### PR TITLE
[NSA PCG] Bring _store_index_k_cache and _get_topk_ragged into the captured region

### DIFF
--- a/python/sglang/jit_kernel/csrc/nsa/fused_store_index_cache.cuh
+++ b/python/sglang/jit_kernel/csrc/nsa/fused_store_index_cache.cuh
@@ -20,6 +20,7 @@ struct FusedStoreCacheParam {
   const void* __restrict__ input;
   void* __restrict__ cache;
   const void* __restrict__ indices;
+  const int32_t* __restrict__ extend_num_tokens;
   uint32_t num_tokens;
 };
 
@@ -42,12 +43,16 @@ __global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCach
   constexpr int64_t kPageBytes = 132 << kPageBits;
 
   // each warp handles 128 elements, each block handles multiple rows
-  const auto& [input, cache, indices, num_tokens] = param;
+  const auto& [input, cache, indices, extend_num_tokens, num_tokens] = param;
   const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
   const auto global_wid = global_tid / 32;
   const auto lane_id = threadIdx.x % 32;
 
   if (global_wid >= num_tokens) return;
+  // Padding-aware bound: under piecewise CUDA graph, num_tokens is the bucket
+  // size baked at capture, while extend_num_tokens is the per-replay count of
+  // real tokens (read from device memory, varies per replay).
+  if (global_wid >= static_cast<uint32_t>(__ldg(extend_num_tokens))) return;
 
   PDLWaitPrimary<kUsePDL>();  // wait for primary kernel
 
@@ -89,7 +94,11 @@ struct FusedStoreCacheIndexerKernel {
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
   static_assert(1 << kLogSize == kPageSize);
 
-  static void run(tvm::ffi::TensorView input, tvm::ffi::TensorView cache, tvm::ffi::TensorView indices) {
+  static void run(
+      tvm::ffi::TensorView input,
+      tvm::ffi::TensorView cache,
+      tvm::ffi::TensorView indices,
+      tvm::ffi::TensorView extend_num_tokens) {
     using namespace host;
 
     auto N = SymbolicSize{"num_tokens"};
@@ -108,11 +117,16 @@ struct FusedStoreCacheIndexerKernel {
         .with_dtype<IndicesT>()
         .with_device(device_)
         .verify(indices);
+    TensorMatcher({1})  // extend_num_tokens (1-elem int32 device tensor)
+        .with_dtype<int32_t>()
+        .with_device(device_)
+        .verify(extend_num_tokens);
     const auto num_tokens = static_cast<uint32_t>(N.unwrap());
     const auto params = FusedStoreCacheParam{
         .input = input.data_ptr(),
         .cache = cache.data_ptr(),
         .indices = indices.data_ptr(),
+        .extend_num_tokens = static_cast<const int32_t*>(extend_num_tokens.data_ptr()),
         .num_tokens = num_tokens,
     };
     const auto kBlockSize = 128;

--- a/python/sglang/jit_kernel/fused_store_index_cache.py
+++ b/python/sglang/jit_kernel/fused_store_index_cache.py
@@ -20,6 +20,7 @@ from sglang.jit_kernel.utils import (
     make_cpp_args,
 )
 from sglang.kernel_api_logging import debug_kernel_api
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -65,41 +66,63 @@ def can_use_nsa_fused_store(
         return False
 
 
+def _fused_store_index_k_cache_fake_impl(
+    key: torch.Tensor,
+    index_k_with_scale: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    extend_num_tokens: torch.Tensor,
+    page_size: int = 64,
+) -> None:
+    return None
+
+
+@register_custom_op(
+    mutates_args=["index_k_with_scale"],
+    fake_impl=_fused_store_index_k_cache_fake_impl,
+)
 @debug_kernel_api
 def fused_store_index_k_cache(
     key: torch.Tensor,
     index_k_with_scale: torch.Tensor,
     out_cache_loc: torch.Tensor,
+    extend_num_tokens: torch.Tensor,
     page_size: int = 64,
 ) -> None:
     """
     Fused: quantize bf16 key (N,128) -> fp8 + fp32 scale and write into NSATokenToKVPool.index_k_with_scale_buffer.
 
-    key:            (num_tokens, 128) bf16 (or reshapeable to it)
-    index_k_with_scale:  (num_pages, 64*(128+4)) uint8
-    out_cache_loc:       (num_tokens,) int64 token indices in TokenToKVPool
+    key:                 (num_tokens, 128) bf16, contiguous
+    index_k_with_scale:  (num_pages, 64*(128+4)) uint8, contiguous
+    out_cache_loc:       (num_tokens,) int64, contiguous; token indices in TokenToKVPool
+    extend_num_tokens:   (1,) int32, contiguous; per-replay real token count.
+                         Under piecewise CUDA graph, num_tokens (= key.shape[0]) is the
+                         bucket size baked at capture, while extend_num_tokens is read
+                         dynamically and bounds the actual writes to skip the padding
+                         region. For non-PCG callers, set this to a 1-elem tensor whose
+                         value equals num_tokens.
     """
-    assert key.is_cuda
-    assert index_k_with_scale.is_cuda
-    assert out_cache_loc.is_cuda
+    assert key.is_cuda and key.is_contiguous(), "key must be contiguous CUDA tensor"
+    assert (
+        index_k_with_scale.is_cuda and index_k_with_scale.is_contiguous()
+    ), "index_k_with_scale must be contiguous CUDA tensor"
+    assert (
+        out_cache_loc.is_cuda and out_cache_loc.is_contiguous()
+    ), "out_cache_loc must be contiguous CUDA tensor"
+    assert (
+        extend_num_tokens.is_cuda and extend_num_tokens.is_contiguous()
+    ), "extend_num_tokens must be contiguous CUDA tensor"
 
-    # 1) normalize shapes
-    if key.dim() != 2:
-        key = key.view(-1, key.shape[-1])
-    assert key.shape[1] == 128, f"expected key last-dim=128, got {key.shape}"
-
-    # 2) dtypes
+    assert (
+        key.dim() == 2 and key.shape[1] == 128
+    ), f"expected key shape (N,128), got {key.shape}"
     assert key.dtype == torch.bfloat16, f"{key.dtype=}"
     assert index_k_with_scale.dtype == torch.uint8, f"{index_k_with_scale.dtype=}"
     assert out_cache_loc.dtype == torch.int64, f"{out_cache_loc.dtype=}"
-
-    # 3) contiguity
-    if not key.is_contiguous():
-        key = key.contiguous()
-    if not out_cache_loc.is_contiguous():
-        out_cache_loc = out_cache_loc.contiguous()
-    if not index_k_with_scale.is_contiguous():
-        index_k_with_scale = index_k_with_scale.contiguous()
+    assert (
+        extend_num_tokens.dtype == torch.int32 and extend_num_tokens.numel() == 1
+    ), f"extend_num_tokens must be a 1-elem int32 tensor, got dtype={extend_num_tokens.dtype} numel={extend_num_tokens.numel()}"
 
     module = _jit_nsa_fused_store_module(key.dtype, out_cache_loc.dtype, page_size)
-    module.fused_store_index_k_cache(key, index_k_with_scale, out_cache_loc)
+    module.fused_store_index_k_cache(
+        key, index_k_with_scale, out_cache_loc, extend_num_tokens
+    )

--- a/python/sglang/jit_kernel/hadamard.py
+++ b/python/sglang/jit_kernel/hadamard.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable
 import torch
 
 from sglang.jit_kernel.utils import KERNEL_PATH, cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -56,6 +57,14 @@ def _hadamard_transform_impl(
     return out.reshape(shapes_og)
 
 
+def _hadamard_transform_fake_impl(
+    x: torch.Tensor,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@register_custom_op(fake_impl=_hadamard_transform_fake_impl)
 def hadamard_transform(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
     module = _jit_hadamard_module(x.dtype)
     return _hadamard_transform_impl(x, scale, 8, module.hadamard_transform)

--- a/python/sglang/srt/compilation/piecewise_context_manager.py
+++ b/python/sglang/srt/compilation/piecewise_context_manager.py
@@ -71,6 +71,7 @@ class ForwardContext:
         self.quant_config = None
         self.moe_layers = None
         self.moe_fusions = None
+        self.nsa_indexers = None
 
     def set_forward_batch(self, forward_batch: ForwardBatch):
         self.forward_batch = forward_batch
@@ -86,6 +87,9 @@ class ForwardContext:
 
     def set_moe_fusions(self, fusions: List[Any]):
         self.moe_fusions = fusions
+
+    def set_nsa_indexers(self, indexers: List[Any]):
+        self.nsa_indexers = indexers
 
 
 _forward_context: Optional[ForwardContext] = None
@@ -104,6 +108,7 @@ def set_forward_context(
     quant_config: Any,
     moe_layers: List[Any],
     moe_fusions: List[Any],
+    nsa_indexers: Optional[List[Any]] = None,
 ):
     global _forward_context
     _forward_context = ForwardContext()
@@ -112,6 +117,8 @@ def set_forward_context(
     _forward_context.set_quant_config(quant_config)
     _forward_context.set_moe_layers(moe_layers)
     _forward_context.set_moe_fusions(moe_fusions)
+    if nsa_indexers is not None:
+        _forward_context.set_nsa_indexers(nsa_indexers)
     try:
         yield
     finally:

--- a/python/sglang/srt/compilation/piecewise_context_manager.py
+++ b/python/sglang/srt/compilation/piecewise_context_manager.py
@@ -72,6 +72,15 @@ class ForwardContext:
         self.moe_layers = None
         self.moe_fusions = None
         self.nsa_indexers = None
+        # 1-elem int32 device tensor holding the per-replay count of real (non-padded)
+        # extend tokens. Bound at a stable address via PrefillInputBuffers and refilled
+        # before each replay, so kernels reading via __ldg see the dynamic value.
+        self.extend_num_tokens_gpu: Optional[torch.Tensor] = None
+        # PCG metadata staging slots for the NSA indexer (see
+        # sglang.srt.layers.attention.nsa.metadata_staging). Stable addresses
+        # populated per-step from the live indexer metadata; read inside the
+        # compiled region as graph-input tensors.
+        self.nsa_metadata_buffers: Optional[Any] = None
 
     def set_forward_batch(self, forward_batch: ForwardBatch):
         self.forward_batch = forward_batch
@@ -91,6 +100,12 @@ class ForwardContext:
     def set_nsa_indexers(self, indexers: List[Any]):
         self.nsa_indexers = indexers
 
+    def set_extend_num_tokens_gpu(self, extend_num_tokens_gpu: torch.Tensor):
+        self.extend_num_tokens_gpu = extend_num_tokens_gpu
+
+    def set_nsa_metadata_buffers(self, buffers: Any):
+        self.nsa_metadata_buffers = buffers
+
 
 _forward_context: Optional[ForwardContext] = None
 
@@ -109,6 +124,8 @@ def set_forward_context(
     moe_layers: List[Any],
     moe_fusions: List[Any],
     nsa_indexers: Optional[List[Any]] = None,
+    extend_num_tokens_gpu: Optional[torch.Tensor] = None,
+    nsa_metadata_buffers: Optional[Any] = None,
 ):
     global _forward_context
     _forward_context = ForwardContext()
@@ -119,6 +136,10 @@ def set_forward_context(
     _forward_context.set_moe_fusions(moe_fusions)
     if nsa_indexers is not None:
         _forward_context.set_nsa_indexers(nsa_indexers)
+    if extend_num_tokens_gpu is not None:
+        _forward_context.set_extend_num_tokens_gpu(extend_num_tokens_gpu)
+    if nsa_metadata_buffers is not None:
+        _forward_context.set_nsa_metadata_buffers(nsa_metadata_buffers)
     try:
         yield
     finally:

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -219,7 +219,6 @@ class ModelConfig:
         self.use_ngram_embedding = getattr(self.hf_config, "use_ngram_embedding", False)
         self.is_piecewise_cuda_graph_disabled_model = (
             is_piecewise_cuda_graph_disabled_model(self.hf_config.architectures)
-            or is_deepseek_nsa(self.hf_text_config)
         )
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
@@ -1394,9 +1393,7 @@ multimodal_model_archs = [
 ]
 
 piecewise_cuda_graph_disabled_model_archs = [
-    "DeepseekV32ForCausalLM",
     "Qwen3NextForCausalLM",
-    "GlmMoeDsaForCausalLM",
     "BailingMoeV2_5ForCausalLM",
     "LLaDAModelLM",
 ]

--- a/python/sglang/srt/layers/attention/nsa/metadata_staging.py
+++ b/python/sglang/srt/layers/attention/nsa/metadata_staging.py
@@ -14,10 +14,8 @@ This module provides:
    live metadata into the staging slots; padded entries are zeroed so stale
    data from a previous step never leaks into the current capture/replay.
 
-Slots are added incrementally as each piece of the indexer is migrated into
-the compiled region. This initial set is what the k-only fast path
-(`_forward_cuda_k_only` PCG branch) needs to construct the per-token topk
-result without reading metadata methods inside the graph.
+Slots are added incrementally as each piece of `_get_topk_ragged` is migrated
+into the compiled region (component C4 of the prefill PCG roadmap).
 """
 from __future__ import annotations
 
@@ -38,15 +36,29 @@ class PrefillNsaMetadataBuffers:
     in `stage_prefill_nsa_metadata_buffers` to avoid stale-data leaks.
     """
 
+    # (max_bs,) int32 — mirror of `metadata.get_indexer_seq_len()`.
+    indexer_seq_len: torch.Tensor
+
+    # (max_num_tokens,) int32 — mirrors of `metadata.get_indexer_kvcache_range()`.
+    ks: torch.Tensor
+    ke: torch.Tensor
+
     # (max_num_tokens,) int32 — mirror of `metadata.get_seqlens_expanded()`.
     seqlens_expanded: torch.Tensor
 
     # (max_num_tokens,) int32 — mirror of `metadata.get_token_to_batch_idx()`.
     token_to_batch_idx: torch.Tensor
 
+    # (max_bs+1,) int32 — mirror of `metadata.attn_metadata.cu_seqlens_q`.
+    cu_seqlens_q: torch.Tensor
+
     # (max_num_tokens,) int32 — mirror of `metadata.attn_metadata.topk_indices_offset`.
     # Only populated under RAGGED topk_transform_method; left zero for PAGED.
     topk_indices_offset: torch.Tensor
+
+    # (max_bs, max_blocks_64) int32 — mirror of `metadata.get_page_table_64()` /
+    # `metadata.attn_metadata.real_page_table`. max_blocks_64 = ceil(max_seq_len/64)+1.
+    page_table_64: torch.Tensor
 
     # (max_bs, max_seq_len) int32 — mirror of `metadata.attn_metadata.page_table_1`.
     page_table_1: torch.Tensor
@@ -69,10 +81,16 @@ def allocate_prefill_nsa_metadata_buffers(
     max_seq_len: int,
     device: torch.device,
 ) -> PrefillNsaMetadataBuffers:
+    max_blocks_64 = (max_seq_len + 63) // 64 + 1
     return PrefillNsaMetadataBuffers(
+        indexer_seq_len=_alloc_static((max_bs,), device),
+        ks=_alloc_static((max_num_tokens,), device),
+        ke=_alloc_static((max_num_tokens,), device),
         seqlens_expanded=_alloc_static((max_num_tokens,), device),
         token_to_batch_idx=_alloc_static((max_num_tokens,), device),
+        cu_seqlens_q=_alloc_static((max_bs + 1,), device),
         topk_indices_offset=_alloc_static((max_num_tokens,), device),
+        page_table_64=_alloc_static((max_bs, max_blocks_64), device),
         page_table_1=_alloc_static((max_bs, max_seq_len), device),
     )
 
@@ -129,6 +147,17 @@ def stage_prefill_nsa_metadata_buffers(
 ) -> None:
     """Per-step copy of live metadata into stable-address staging slots."""
     _stage_1d(
+        buffers.indexer_seq_len,
+        metadata.get_indexer_seq_len(),
+        bs,
+        name="indexer_seq_len",
+    )
+
+    ks_src, ke_src = metadata.get_indexer_kvcache_range()
+    _stage_1d(buffers.ks, ks_src, num_tokens, name="ks")
+    _stage_1d(buffers.ke, ke_src, num_tokens, name="ke")
+
+    _stage_1d(
         buffers.seqlens_expanded,
         metadata.get_seqlens_expanded(),
         num_tokens,
@@ -139,6 +168,11 @@ def stage_prefill_nsa_metadata_buffers(
         metadata.get_token_to_batch_idx(),
         num_tokens,
         name="token_to_batch_idx",
+    )
+
+    cu_seqlens_q_src = metadata.attn_metadata.cu_seqlens_q
+    _stage_1d(
+        buffers.cu_seqlens_q, cu_seqlens_q_src, bs + 1, name="cu_seqlens_q"
     )
 
     # topk_indices_offset is None for PAGED topk_transform_method; leave zeros.
@@ -152,6 +186,15 @@ def stage_prefill_nsa_metadata_buffers(
         )
     else:
         buffers.topk_indices_offset.zero_()
+
+    pt64_src = metadata.get_page_table_64()
+    _stage_2d(
+        buffers.page_table_64,
+        pt64_src,
+        pt64_src.shape[0],
+        pt64_src.shape[1],
+        name="page_table_64",
+    )
 
     pt1_src = metadata.attn_metadata.page_table_1
     _stage_2d(

--- a/python/sglang/srt/layers/attention/nsa/metadata_staging.py
+++ b/python/sglang/srt/layers/attention/nsa/metadata_staging.py
@@ -1,0 +1,173 @@
+"""Stable-address staging buffers for NSA indexer metadata under PCG.
+
+Inside the compiled / CUDA-graph-captured region the indexer cannot reach into
+the Python `BaseIndexerMetadata` object (method dispatch + non-tensor attribute
+walks are not torch.compile-traceable, and the metadata's tensor fields are
+freshly allocated each step so their addresses are not stable across replays).
+
+This module provides:
+ - `PrefillNsaMetadataBuffers`: a dataclass of pre-allocated, stable-address
+   device tensors sized to PCG upper bounds. `mark_static_address` is applied
+   so Dynamo treats them as graph inputs.
+ - `allocate_prefill_nsa_metadata_buffers(...)`: allocator (GPU, int32, zeros).
+ - `stage_prefill_nsa_metadata_buffers(...)`: per-step host-side copy from the
+   live metadata into the staging slots; padded entries are zeroed so stale
+   data from a previous step never leaks into the current capture/replay.
+
+Slots are added incrementally as each piece of the indexer is migrated into
+the compiled region. This initial set is what the k-only fast path
+(`_forward_cuda_k_only` PCG branch) needs to construct the per-token topk
+result without reading metadata methods inside the graph.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import torch
+
+from sglang.srt.layers.attention.nsa.nsa_indexer import BaseIndexerMetadata
+
+
+@dataclass
+class PrefillNsaMetadataBuffers:
+    """Pre-allocated, stable-address NSA indexer metadata staging buffers.
+
+    All slots are sized to PCG upper bounds; the per-step usable region is
+    `[:bs]` (or `[:num_tokens]` for per-token slots). Padded entries are zeroed
+    in `stage_prefill_nsa_metadata_buffers` to avoid stale-data leaks.
+    """
+
+    # (max_num_tokens,) int32 — mirror of `metadata.get_seqlens_expanded()`.
+    seqlens_expanded: torch.Tensor
+
+    # (max_num_tokens,) int32 — mirror of `metadata.get_token_to_batch_idx()`.
+    token_to_batch_idx: torch.Tensor
+
+    # (max_num_tokens,) int32 — mirror of `metadata.attn_metadata.topk_indices_offset`.
+    # Only populated under RAGGED topk_transform_method; left zero for PAGED.
+    topk_indices_offset: torch.Tensor
+
+    # (max_bs, max_seq_len) int32 — mirror of `metadata.attn_metadata.page_table_1`.
+    page_table_1: torch.Tensor
+
+    # `TopkTransformMethod` enum captured on the first `stage_*` call; pinned
+    # thereafter (drift across captures triggers an assertion). Read inside
+    # the compiled region as a Dynamo-specialized Python int.
+    topk_transform_method: Optional[Any] = None
+
+
+def _alloc_static(shape, device: torch.device) -> torch.Tensor:
+    t = torch.zeros(shape, dtype=torch.int32, device=device)
+    torch._dynamo.mark_static_address(t)
+    return t
+
+
+def allocate_prefill_nsa_metadata_buffers(
+    max_bs: int,
+    max_num_tokens: int,
+    max_seq_len: int,
+    device: torch.device,
+) -> PrefillNsaMetadataBuffers:
+    return PrefillNsaMetadataBuffers(
+        seqlens_expanded=_alloc_static((max_num_tokens,), device),
+        token_to_batch_idx=_alloc_static((max_num_tokens,), device),
+        topk_indices_offset=_alloc_static((max_num_tokens,), device),
+        page_table_1=_alloc_static((max_bs, max_seq_len), device),
+    )
+
+
+def _assert_compatible_dtype(slot: torch.Tensor, src: torch.Tensor, name: str) -> None:
+    """Reject mismatches that lose information; allow int<->int casts.
+
+    All staging slots are int32 (sequence lengths and slot indices, well within
+    int32 range). Real metadata may store these as int64 (`forward_batch.seq_lens`),
+    so we permit int64->int32 via `tensor.copy_`'s built-in conversion. Float
+    sources are rejected (would silently truncate)."""
+    if slot.dtype.is_floating_point or src.dtype.is_floating_point:
+        assert src.dtype == slot.dtype, (
+            f"{name} dtype mismatch (float requires exact match): "
+            f"src={src.dtype}, slot={slot.dtype}"
+        )
+
+
+def _stage_1d(slot: torch.Tensor, src: torch.Tensor, n: int, *, name: str) -> None:
+    """Copy `src` (shape `(n,)`) into `slot[:n]`, zero `slot[n:]`."""
+    _assert_compatible_dtype(slot, src, name)
+    assert src.shape == (n,), (
+        f"{name} shape mismatch: src={tuple(src.shape)}, expected ({n},)"
+    )
+    assert n <= slot.shape[0], (
+        f"{name}: n={n} exceeds staging capacity {slot.shape[0]}"
+    )
+    slot[:n].copy_(src, non_blocking=True)
+    if n < slot.shape[0]:
+        slot[n:].zero_()
+
+
+def _stage_2d(
+    slot: torch.Tensor, src: torch.Tensor, n0: int, n1: int, *, name: str
+) -> None:
+    """Copy `src` (shape `(n0, n1)`) into `slot[:n0, :n1]`. Zero everything else."""
+    _assert_compatible_dtype(slot, src, name)
+    assert src.shape == (n0, n1), (
+        f"{name} shape mismatch: src={tuple(src.shape)}, expected ({n0}, {n1})"
+    )
+    assert n0 <= slot.shape[0] and n1 <= slot.shape[1], (
+        f"{name}: ({n0}, {n1}) exceeds staging capacity {tuple(slot.shape)}"
+    )
+    # Wipe the whole slot first to clear stale state outside the (n0, n1) tile.
+    slot.zero_()
+    slot[:n0, :n1].copy_(src, non_blocking=True)
+
+
+def stage_prefill_nsa_metadata_buffers(
+    buffers: PrefillNsaMetadataBuffers,
+    metadata: BaseIndexerMetadata,
+    bs: int,
+    num_tokens: int,
+) -> None:
+    """Per-step copy of live metadata into stable-address staging slots."""
+    _stage_1d(
+        buffers.seqlens_expanded,
+        metadata.get_seqlens_expanded(),
+        num_tokens,
+        name="seqlens_expanded",
+    )
+    _stage_1d(
+        buffers.token_to_batch_idx,
+        metadata.get_token_to_batch_idx(),
+        num_tokens,
+        name="token_to_batch_idx",
+    )
+
+    # topk_indices_offset is None for PAGED topk_transform_method; leave zeros.
+    topk_offset_src = metadata.attn_metadata.topk_indices_offset
+    if topk_offset_src is not None:
+        _stage_1d(
+            buffers.topk_indices_offset,
+            topk_offset_src,
+            num_tokens,
+            name="topk_indices_offset",
+        )
+    else:
+        buffers.topk_indices_offset.zero_()
+
+    pt1_src = metadata.attn_metadata.page_table_1
+    _stage_2d(
+        buffers.page_table_1,
+        pt1_src,
+        pt1_src.shape[0],
+        pt1_src.shape[1],
+        name="page_table_1",
+    )
+
+    # Pin topk_transform_method on first stage; assert stability afterwards.
+    method = getattr(metadata, "topk_transform_method", None)
+    if buffers.topk_transform_method is None:
+        buffers.topk_transform_method = method
+    else:
+        assert buffers.topk_transform_method == method, (
+            f"topk_transform_method drifted: pinned={buffers.topk_transform_method}, "
+            f"observed={method}. PCG requires a fixed topk method per capture."
+        )

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -1178,9 +1178,17 @@ class Indexer(MultiPlatformOp):
         # a tuple like (x_fp8, x_scale[, y]). Use `x_meta` for shape/device queries.
         x_meta = x[0] if isinstance(x, tuple) else x
 
-        metadata = forward_batch.attn_backend.get_indexer_metadata(
-            layer_id, forward_batch
-        )
+        # In PCG mode, metadata is fetched inside split ops via get_forward_context() to
+        # prevent Dynamo from guarding on forward_metadata identity (which changes each
+        # replay when init_forward_metadata creates a new ForwardMetadata object).
+        if not is_in_piecewise_cuda_graph():
+            metadata = forward_batch.attn_backend.get_indexer_metadata(
+                layer_id, forward_batch
+            )
+            if metadata is None:
+                return None
+        else:
+            metadata = None
 
         enable_dual_stream = (
             self.alt_stream is not None
@@ -1188,10 +1196,6 @@ class Indexer(MultiPlatformOp):
             and q_lora.shape[0] > 0
             and q_lora.shape[0] <= DUAL_STREAM_TOKEN_THRESHOLD
         )
-
-        # skip NSA if attention backend choose to skip this batch
-        if metadata is None:
-            return None
 
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -109,6 +109,7 @@ if _is_cuda:
             layer_id=layer_id,
             key=key[:extend_num_tokens],
             act_quant=act_quant,
+            out_cache_loc=forward_batch.out_cache_loc[:extend_num_tokens],
         )
         indexer._get_topk_ragged(
             False,
@@ -1088,21 +1089,28 @@ class Indexer(MultiPlatformOp):
         key: torch.Tensor,
         *,
         act_quant=None,  # fallback only
+        out_cache_loc: Optional[
+            torch.Tensor
+        ] = None,  # override for PCG (sliced to real tokens)
     ) -> None:
         """
         Store NSA indexer K cache for current step.
 
         Preferred: fused_store_index_k_cache(key, cache, out_cache_loc, page_size)
         Fallback : act_quant(key) + token_to_kv_pool.set_index_k_scale_buffer(...)
+
+        out_cahce_loc will default to forward_batch.out_cache_loc if not provided.
         """
 
-        # Fast path: JIT fused store (CUDA, page_size=64, non-fnuz)
+        if out_cache_loc is None:
+            out_cache_loc = forward_batch.out_cache_loc
+
         if (
             _is_cuda
             and (not _is_fp8_fnuz)
             and can_use_nsa_fused_store(
                 key.dtype,
-                forward_batch.out_cache_loc.dtype,
+                out_cache_loc.dtype,
                 forward_batch.token_to_kv_pool.page_size,
             )
         ):
@@ -1113,7 +1121,7 @@ class Indexer(MultiPlatformOp):
             fused_store_index_k_cache(
                 key,
                 buf,
-                forward_batch.out_cache_loc,
+                out_cache_loc,
                 forward_batch.token_to_kv_pool.page_size,
             )
             return
@@ -1138,7 +1146,7 @@ class Indexer(MultiPlatformOp):
         assert act_quant is not None
         k_fp8, k_scale = act_quant(key, self.block_size, self.scale_fmt)
 
-        out_loc = forward_batch.out_cache_loc
+        out_loc = out_cache_loc
         if not out_loc.is_contiguous():
             out_loc = out_loc.contiguous()
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -492,7 +492,8 @@ class Indexer(MultiPlatformOp):
     def _update_rope_guarded(dst: torch.Tensor, src: torch.Tensor) -> None:
         # On AMD with in-place RoPE kernels, self-aliasing can occur;
         # skip write-back when src/dst tensors point to a single memory.
-        if src.data_ptr() == dst.data_ptr():
+        # data_ptr() is not comparable inside torch.compile, so skip the guard there.
+        if not torch.compiler.is_compiling() and src.data_ptr() == dst.data_ptr():
             return
         dst.copy_(src)
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -11,6 +11,11 @@ from sglang.jit_kernel.fused_store_index_cache import (
     can_use_nsa_fused_store,
     fused_store_index_k_cache,
 )
+from sglang.srt.compilation.compilation_config import register_split_op
+from sglang.srt.compilation.piecewise_context_manager import (
+    get_forward_context,
+    is_in_piecewise_cuda_graph,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor
 from sglang.srt.layers.layernorm import LayerNorm
@@ -71,6 +76,49 @@ if TYPE_CHECKING:
 
 
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
+
+
+if _is_cuda:
+    from sglang.srt.utils.custom_op import register_custom_op
+
+    @register_custom_op(mutates_args=["topk_result"])
+    @register_split_op()
+    def k_cache_and_topk_result(
+        layer_id: int,
+        key: torch.Tensor,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+        topk_result: torch.Tensor,
+    ) -> None:
+        assert (
+            _is_cuda
+        ), "Internal error: piecewise cuda graph is only supported on CUDA"
+        from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
+
+        forward_batch = get_forward_context().forward_batch
+        indexer = get_forward_context().nsa_indexers[layer_id]
+        metadata = forward_batch.attn_backend.get_indexer_metadata(
+            layer_id, forward_batch
+        )
+
+        # slice off padding from piecewise cuda graph
+        extend_num_tokens = forward_batch.extend_num_tokens
+
+        indexer._store_index_k_cache(
+            forward_batch=forward_batch,
+            layer_id=layer_id,
+            key=key[:extend_num_tokens],
+            act_quant=act_quant,
+        )
+        indexer._get_topk_ragged(
+            False,
+            forward_batch,
+            layer_id,
+            q_fp8[:extend_num_tokens],
+            weights,
+            metadata,
+            topk_result,
+        )
 
 
 class BaseIndexerMetadata(ABC):
@@ -553,6 +601,7 @@ class Indexer(MultiPlatformOp):
         q_fp8: torch.Tensor,
         weights: torch.Tensor,
         metadata: BaseIndexerMetadata,
+        topk_result: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if TYPE_CHECKING:
             assert isinstance(forward_batch.token_to_kv_pool, NSATokenToKVPool)
@@ -586,9 +635,10 @@ class Indexer(MultiPlatformOp):
         token_nums, _, _ = q_fp8.shape
         device = q_fp8.device
 
-        topk_result = torch.full(
-            (token_nums, self.index_topk), -1, device=device, dtype=torch.int32
-        )
+        if topk_result is None:
+            topk_result = torch.full(
+                (token_nums, self.index_topk), -1, device=device, dtype=torch.int32
+            )
         if batch_size == 0:
             return topk_result
 
@@ -773,6 +823,9 @@ class Indexer(MultiPlatformOp):
         actual_seq_q: int,
         cp_index: List[Tuple[int, int, int]] = None,
     ) -> torch.Tensor:
+        assert (
+            not is_in_piecewise_cuda_graph()
+        ), "NSA CP path (_get_topk_ragged_with_cp) not supported under piecewise CUDA graph"
         if TYPE_CHECKING:
             assert isinstance(forward_batch.token_to_kv_pool, NSATokenToKVPool)
 
@@ -919,6 +972,9 @@ class Indexer(MultiPlatformOp):
         topk: int,
         layer_id: int,
     ) -> Optional[torch.Tensor]:
+        assert (
+            not is_in_piecewise_cuda_graph()
+        ), "NSA forward_indexer (non-CUDA loop path) not supported under piecewise CUDA graph"
         if not _is_npu:
             from sglang.srt.layers.attention.nsa.tilelang_kernel import fp8_index
 
@@ -1101,7 +1157,10 @@ class Indexer(MultiPlatformOp):
         # Determine if should skip topk based on sequence length
         # We can only skip the logits computation if cuda graph is not involved
         skip_logits_computation = False
-        if forward_batch.forward_mode.is_extend_without_speculative():
+        if (
+            not is_in_piecewise_cuda_graph()
+            and forward_batch.forward_mode.is_extend_without_speculative()
+        ):
             if forward_batch.seq_lens_cpu is not None:
                 max_kv_len = forward_batch.seq_lens_cpu.max().item()
                 skip_logits_computation = max_kv_len <= self.index_topk
@@ -1154,7 +1213,7 @@ class Indexer(MultiPlatformOp):
                         act_quant=act_quant,
                     )
                 current_stream.wait_stream(self.alt_stream)
-            else:
+            elif not is_in_piecewise_cuda_graph():
                 q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
@@ -1162,6 +1221,10 @@ class Indexer(MultiPlatformOp):
                     key=key,
                     act_quant=act_quant,
                 )
+            else:
+                # piecewise CUDA graph need to split graph on store_k_cache and mqa_logits,
+                # so cannot use dual stream and delay store_k_cache after weights proj.
+                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
 
             # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
             # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,
@@ -1269,6 +1332,24 @@ class Indexer(MultiPlatformOp):
                         actual_seq_q_next,
                     )
                     return torch.cat([topk_result_prev, topk_result_next], dim=0)
+                elif is_in_piecewise_cuda_graph():
+                    assert (
+                        not enable_dual_stream
+                    ), "Internal error: piecewise CUDA graph should not be enabled with dual stream"
+
+                    topk_result = torch.full(
+                        (q_fp8.shape[0], self.index_topk),
+                        -1,
+                        device=q_fp8.device,
+                        dtype=torch.int32,
+                    )
+                    k_cache_and_topk_result(
+                        layer_id=layer_id,
+                        key=key,
+                        q_fp8=q_fp8,
+                        weights=weights,
+                        topk_result=topk_result,
+                    )
                 else:
                     topk_result = self._get_topk_ragged(
                         enable_dual_stream,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -92,7 +92,7 @@ if _is_cuda:
     ) -> None:
         assert (
             _is_cuda
-        ), "Internal error: piecewise cuda graph is only supported on CUDA"
+        ), "Internal error: piecewise CUDA graph is only supported on CUDA"
         from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 
         forward_batch = get_forward_context().forward_batch
@@ -101,7 +101,7 @@ if _is_cuda:
             layer_id, forward_batch
         )
 
-        # slice off padding from piecewise cuda graph
+        # slice off padding from piecewise CUDA graph
         extend_num_tokens = forward_batch.extend_num_tokens
 
         indexer._store_index_k_cache(
@@ -857,7 +857,7 @@ class Indexer(MultiPlatformOp):
     ) -> torch.Tensor:
         assert (
             not is_in_piecewise_cuda_graph()
-        ), "NSA CP path (_get_topk_ragged_with_cp) not supported under piecewise CUDA graph"
+        ), "NSA context parallel (_get_topk_ragged_with_cp) not supported under piecewise CUDA graph"
         if TYPE_CHECKING:
             assert isinstance(forward_batch.token_to_kv_pool, NSATokenToKVPool)
 
@@ -1089,9 +1089,7 @@ class Indexer(MultiPlatformOp):
         key: torch.Tensor,
         *,
         act_quant=None,  # fallback only
-        out_cache_loc: Optional[
-            torch.Tensor
-        ] = None,  # override for PCG (sliced to real tokens)
+        out_cache_loc: Optional[torch.Tensor] = None,
     ) -> None:
         """
         Store NSA indexer K cache for current step.
@@ -1099,7 +1097,7 @@ class Indexer(MultiPlatformOp):
         Preferred: fused_store_index_k_cache(key, cache, out_cache_loc, page_size)
         Fallback : act_quant(key) + token_to_kv_pool.set_index_k_scale_buffer(...)
 
-        out_cahce_loc will default to forward_batch.out_cache_loc if not provided.
+        out_cache_loc will default to forward_batch.out_cache_loc if not provided.
         """
 
         if out_cache_loc is None:
@@ -1146,13 +1144,12 @@ class Indexer(MultiPlatformOp):
         assert act_quant is not None
         k_fp8, k_scale = act_quant(key, self.block_size, self.scale_fmt)
 
-        out_loc = out_cache_loc
-        if not out_loc.is_contiguous():
-            out_loc = out_loc.contiguous()
+        if not out_cache_loc.is_contiguous():
+            out_cache_loc = out_cache_loc.contiguous()
 
         forward_batch.token_to_kv_pool.set_index_k_scale_buffer(
             layer_id=layer_id,
-            loc=out_loc,
+            loc=out_cache_loc,
             index_k=k_fp8,
             index_k_scale=k_scale,
         )
@@ -1178,7 +1175,7 @@ class Indexer(MultiPlatformOp):
         # a tuple like (x_fp8, x_scale[, y]). Use `x_meta` for shape/device queries.
         x_meta = x[0] if isinstance(x, tuple) else x
 
-        # In PCG mode, metadata is fetched inside split ops via get_forward_context() to
+        # In piecewise CUDA graph mode, metadata is fetched inside custom ops via get_forward_context() to
         # prevent Dynamo from guarding on forward_metadata identity (which changes each
         # replay when init_forward_metadata creates a new ForwardMetadata object).
         if not is_in_piecewise_cuda_graph():
@@ -1266,7 +1263,7 @@ class Indexer(MultiPlatformOp):
                 )
             else:
                 # piecewise CUDA graph need to split graph on store_k_cache and mqa_logits,
-                # so cannot use dual stream and delay store_k_cache after weights proj.
+                # so delay store_k_cache after weights proj.
                 q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
 
             # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
@@ -1322,9 +1319,8 @@ class Indexer(MultiPlatformOp):
                 weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
         if _is_cuda or _is_hip:
-            # In PCG, any access to seq_lens_cpu creates a Dynamo shape guard on
-            # seq_lens_cpu.shape[0] == batch_size, which fails when serving batches
-            # larger than the bs=1 used during capture. PCG never has empty batches.
+            # In piecewise CUDA graph, any access to seq_lens_cpu creates a Dynamo shape guard.
+            # Piecewise CUDA graph never has empty batches.
             if not is_in_piecewise_cuda_graph():
                 assert forward_batch.seq_lens_cpu is not None
                 if len(forward_batch.seq_lens_cpu) == 0:

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -11,7 +11,6 @@ from sglang.jit_kernel.fused_store_index_cache import (
     can_use_nsa_fused_store,
     fused_store_index_k_cache,
 )
-from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.compilation.piecewise_context_manager import (
     get_forward_context,
     is_in_piecewise_cuda_graph,
@@ -79,6 +78,7 @@ DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
 
 
 if _is_cuda:
+    from sglang.srt.compilation.compilation_config import register_split_op
     from sglang.srt.utils.custom_op import register_custom_op
 
     @register_custom_op(mutates_args=["topk_result"])
@@ -119,6 +119,37 @@ if _is_cuda:
             metadata,
             topk_result,
         )
+
+    def _logits_head_gate_pcg_fake_impl(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        n_heads_inv_sqrt: float,
+        softmax_scale: float,
+        q_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.empty(
+            (x.shape[0], weight.shape[0], q_scale.shape[-1]),
+            dtype=torch.float32,
+            device=x.device,
+        )
+
+    @register_custom_op(fake_impl=_logits_head_gate_pcg_fake_impl)
+    def logits_head_gate_pcg(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        n_heads_inv_sqrt: float,
+        softmax_scale: float,
+        q_scale: torch.Tensor,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.deep_gemm_wrapper import entrypoint as deep_gemm_wrapper
+
+        out = torch.empty(
+            (x.shape[0], weight.shape[0]), dtype=torch.float32, device=x.device
+        )
+        deep_gemm_wrapper.gemm_nt_bf16bf16f32(x, weight, out)
+        weights = out * n_heads_inv_sqrt
+        weights = weights.unsqueeze(-1) * q_scale * softmax_scale
+        return weights
 
 
 class BaseIndexerMetadata(ABC):
@@ -1267,7 +1298,16 @@ class Indexer(MultiPlatformOp):
             else:
                 x_for_gate = x
 
-            weights = self._get_logits_head_gate(x_for_gate, q_scale)
+            if is_in_piecewise_cuda_graph():
+                weights = logits_head_gate_pcg(
+                    x_for_gate,
+                    self.weights_proj.weight,
+                    self.n_heads**-0.5,
+                    self.softmax_scale,
+                    q_scale,
+                )
+            else:
+                weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
         if _is_cuda or _is_hip:
             assert forward_batch.seq_lens_cpu is not None

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -1322,19 +1322,18 @@ class Indexer(MultiPlatformOp):
                 weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
         if _is_cuda or _is_hip:
-            assert forward_batch.seq_lens_cpu is not None
-            if len(forward_batch.seq_lens_cpu) == 0:
-                # this seems b/c max-pad, no worries?
-                # if x.shape[0] != 0:
-                #     print(
-                #         "HACK: seq_lens empty but x not empty, hackily return all-invalid topk_result"
-                #     )
-                return torch.full(
-                    (x_meta.shape[0], self.index_topk),
-                    -1,
-                    dtype=torch.int,
-                    device=x_meta.device,
-                )
+            # In PCG, any access to seq_lens_cpu creates a Dynamo shape guard on
+            # seq_lens_cpu.shape[0] == batch_size, which fails when serving batches
+            # larger than the bs=1 used during capture. PCG never has empty batches.
+            if not is_in_piecewise_cuda_graph():
+                assert forward_batch.seq_lens_cpu is not None
+                if len(forward_batch.seq_lens_cpu) == 0:
+                    return torch.full(
+                        (x_meta.shape[0], self.index_topk),
+                        -1,
+                        dtype=torch.int,
+                        device=x_meta.device,
+                    )
 
             if (
                 forward_batch.forward_mode.is_decode_or_idle()

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -83,17 +83,22 @@ if _is_cuda:
 
     @register_custom_op(mutates_args=["topk_result"])
     @register_split_op()
-    def k_cache_and_topk_result(
+    def topk_ragged_pcg(
         layer_id: int,
-        key: torch.Tensor,
         q_fp8: torch.Tensor,
         weights: torch.Tensor,
         topk_result: torch.Tensor,
     ) -> None:
+        """Opaque-op wrapper for `_get_topk_ragged` under piecewise CUDA graph.
+
+        The K-cache store is CUDA-graphable (see fused_store_index_k_cache with
+        extend_num_tokens) and runs inside the compiled region, so it is no
+        longer wrapped here. This op shields only the ragged-topk kernel, whose
+        per-batch metadata + .item() chunking is not torch.compile-traceable.
+        """
         assert (
             _is_cuda
         ), "Internal error: piecewise CUDA graph is only supported on CUDA"
-        from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 
         forward_batch = get_forward_context().forward_batch
         indexer = get_forward_context().nsa_indexers[layer_id]
@@ -104,13 +109,6 @@ if _is_cuda:
         # slice off padding from piecewise CUDA graph
         extend_num_tokens = forward_batch.extend_num_tokens
 
-        indexer._store_index_k_cache(
-            forward_batch=forward_batch,
-            layer_id=layer_id,
-            key=key[:extend_num_tokens],
-            act_quant=act_quant,
-            out_cache_loc=forward_batch.out_cache_loc[:extend_num_tokens],
-        )
         indexer._get_topk_ragged(
             False,
             forward_batch,
@@ -151,6 +149,45 @@ if _is_cuda:
         weights = out * n_heads_inv_sqrt
         weights = weights.unsqueeze(-1) * q_scale * softmax_scale
         return weights
+
+    def topk_construct_k_only_pcg(
+        method: int,
+        seqlens_expanded: torch.Tensor,
+        token_to_batch_idx: torch.Tensor,
+        page_table_1: torch.Tensor,
+        topk_indices_offset: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        """Pure-tensor topk for the PCG-inlined `_forward_cuda_k_only` path.
+
+        For zero-logit inputs the topk kernel's tiebreaker picks the first
+        `seqlens_expanded[i]` indices in position order, which the two
+        `TopkTransformMethod` branches map differently:
+          * PAGED:  topk[i, k] = page_table_1[token_to_batch_idx[i], k]
+          * RAGGED: topk[i, k] = topk_indices_offset[i] + k
+        for `k < seqlens_expanded[i]`, else -1.
+
+        Padded rows beyond `num_tokens` have `seqlens_expanded[i] == 0` (zeroed
+        by `_stage_1d`), so the validity mask collapses them to all -1.
+        """
+        from sglang.srt.layers.attention.nsa_backend import TopkTransformMethod
+
+        device = seqlens_expanded.device
+        k_idx = torch.arange(topk, device=device, dtype=torch.int32)
+        valid = k_idx[None, :] < seqlens_expanded[:, None]
+
+        if method == TopkTransformMethod.PAGED:
+            batch_of_i = token_to_batch_idx.to(torch.long)
+            slots = page_table_1[batch_of_i, :topk]
+        elif method == TopkTransformMethod.RAGGED:
+            slots = topk_indices_offset[:, None] + k_idx[None, :]
+        else:
+            raise AssertionError(
+                f"topk_construct_k_only_pcg: unsupported method={method!r}; "
+                f"expected TopkTransformMethod.PAGED or RAGGED."
+            )
+
+        return torch.where(valid, slots, torch.full_like(slots, -1))
 
 
 class BaseIndexerMetadata(ABC):
@@ -811,7 +848,7 @@ class Indexer(MultiPlatformOp):
         layer_id: int,
         act_quant,
         enable_dual_stream: bool,
-        metadata: BaseIndexerMetadata,
+        metadata: Optional[BaseIndexerMetadata],
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
         assert forward_batch.forward_mode.is_extend_without_speculative()
@@ -820,8 +857,13 @@ class Indexer(MultiPlatformOp):
         # Fast path: only compute and store k cache, skip all q and weights ops
         key = self._get_k_bf16(x, positions, enable_dual_stream)
 
-        if not forward_batch.out_cache_loc.is_contiguous():
-            forward_batch.out_cache_loc = forward_batch.out_cache_loc.contiguous()
+        if not is_in_piecewise_cuda_graph():
+            # Under PCG, out_cache_loc is the runner's pre-allocated contiguous
+            # buffer (slicing it yields a contiguous view); the check itself is
+            # Dynamo-hostile (is_contiguous is a data-dependent tensor call).
+            if not forward_batch.out_cache_loc.is_contiguous():
+                forward_batch.out_cache_loc = forward_batch.out_cache_loc.contiguous()
+        assert forward_batch.out_cache_loc.is_contiguous()
 
         self._store_index_k_cache(
             forward_batch=forward_batch,
@@ -834,7 +876,28 @@ class Indexer(MultiPlatformOp):
         if not return_indices:
             return None
 
-        # MLA: use dummy logits with topk kernel's fast path to generate indices
+        if is_in_piecewise_cuda_graph():
+            bucket = x_meta.shape[0]
+            ctx = get_forward_context()
+            bufs = ctx.nsa_metadata_buffers
+            assert bufs is not None, (
+                "PCG inlined k-only topk requires staged NSA metadata buffers"
+            )
+            method = bufs.topk_transform_method
+            assert method is not None, (
+                "PCG inlined k-only topk requires topk_transform_method to "
+                "have been pinned by stage_prefill_nsa_metadata_buffers"
+            )
+            return topk_construct_k_only_pcg(
+                method=method,
+                seqlens_expanded=bufs.seqlens_expanded[:bucket],
+                token_to_batch_idx=bufs.token_to_batch_idx[:bucket],
+                page_table_1=bufs.page_table_1,
+                topk_indices_offset=bufs.topk_indices_offset[:bucket],
+                topk=self.index_topk,
+            )
+
+        # MLA eager: use dummy logits with topk kernel's fast path to generate indices
         # When length <= 2048, naive_topk_cuda directly generates [0,1,...,length-1,-1,...]
         seq_lens_expanded = metadata.get_seqlens_expanded()
         dummy_logits = torch.zeros(
@@ -1090,19 +1153,20 @@ class Indexer(MultiPlatformOp):
         key: torch.Tensor,
         *,
         act_quant=None,  # fallback only
-        out_cache_loc: Optional[torch.Tensor] = None,
     ) -> None:
         """
         Store NSA indexer K cache for current step.
 
-        Preferred: fused_store_index_k_cache(key, cache, out_cache_loc, page_size)
+        Preferred: fused_store_index_k_cache(key, cache, out_cache_loc,
+                                             extend_num_tokens, page_size)
         Fallback : act_quant(key) + token_to_kv_pool.set_index_k_scale_buffer(...)
 
-        out_cache_loc will default to forward_batch.out_cache_loc if not provided.
+        Always reads out_cache_loc from forward_batch (PCG already plumbs the
+        per-replay value into the forward_batch buffer). Under piecewise CUDA
+        graph, the fused path is mandatory; padding-aware bound is provided by
+        forward_context.extend_num_tokens_gpu (refilled per replay).
         """
-
-        if out_cache_loc is None:
-            out_cache_loc = forward_batch.out_cache_loc
+        out_cache_loc = forward_batch.out_cache_loc
 
         if (
             _is_cuda
@@ -1113,17 +1177,34 @@ class Indexer(MultiPlatformOp):
                 forward_batch.token_to_kv_pool.page_size,
             )
         ):
-            # NOTE: wrapper already normalizes shape/contiguity and asserts dtypes.
             buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
                 layer_id=layer_id
             )
+            ctx = get_forward_context()
+            if ctx is not None and ctx.extend_num_tokens_gpu is not None:
+                # PCG path: padding-aware bound flowing through ForwardContext.
+                extend_num_tokens_gpu = ctx.extend_num_tokens_gpu
+            else:
+                # Non-PCG path (eager prefill, decode CUDA-graph capture): no
+                # padding to worry about; kernel still bound-checks by num_tokens
+                # (== key.shape[0]). Use torch.full so the fill is a device-side
+                # kernel — torch.tensor([...]) would CPU->GPU memcpy and fail
+                # under cuda-graph capture.
+                extend_num_tokens_gpu = torch.full(
+                    (1,), key.shape[0], dtype=torch.int32, device=key.device
+                )
             fused_store_index_k_cache(
                 key,
                 buf,
                 out_cache_loc,
+                extend_num_tokens_gpu,
                 forward_batch.token_to_kv_pool.page_size,
             )
             return
+
+        assert (
+            not is_in_piecewise_cuda_graph()
+        ), "PCG requires the fused NSA store path; AITER / Python fallbacks are not supported"
 
         # Fast path: AITER fused quant + cache store (HIP, page_size=1)
         if _use_aiter:
@@ -1195,14 +1276,17 @@ class Indexer(MultiPlatformOp):
             and q_lora.shape[0] <= DUAL_STREAM_TOKEN_THRESHOLD
         )
 
-        # Determine if should skip topk based on sequence length
-        # We can only skip the logits computation if cuda graph is not involved
+        # Determine if should skip topk based on sequence length.
+        # Under PCG, bucket size == x_meta.shape[0] is a compile-time Python
+        # int; Dynamo specializes per-bucket so each captured graph takes one
+        # branch or the other without runtime dispatch. The pure-tensor
+        # replacement for topk_transform inside _forward_cuda_k_only is valid
+        # for bucket_seq <= index_topk.
         skip_logits_computation = False
-        if (
-            not is_in_piecewise_cuda_graph()
-            and forward_batch.forward_mode.is_extend_without_speculative()
-        ):
-            if forward_batch.seq_lens_cpu is not None:
+        if forward_batch.forward_mode.is_extend_without_speculative():
+            if is_in_piecewise_cuda_graph():
+                skip_logits_computation = x_meta.shape[0] <= self.index_topk
+            elif forward_batch.seq_lens_cpu is not None:
                 max_kv_len = forward_batch.seq_lens_cpu.max().item()
                 skip_logits_computation = max_kv_len <= self.index_topk
 
@@ -1254,7 +1338,11 @@ class Indexer(MultiPlatformOp):
                         act_quant=act_quant,
                     )
                 current_stream.wait_stream(self.alt_stream)
-            elif not is_in_piecewise_cuda_graph():
+            else:
+                # Single path for both eager and piecewise CUDA graph: the
+                # fused store kernel is CUDA-graphable and bound-checks its
+                # writes by forward_context.extend_num_tokens_gpu (refilled
+                # per replay), so padding warps don't scribble at slot 0.
                 q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
                 self._store_index_k_cache(
                     forward_batch=forward_batch,
@@ -1262,10 +1350,6 @@ class Indexer(MultiPlatformOp):
                     key=key,
                     act_quant=act_quant,
                 )
-            else:
-                # piecewise CUDA graph need to split graph on store_k_cache and mqa_logits,
-                # so delay store_k_cache after weights proj.
-                q_fp8, q_scale = act_quant(query, self.block_size, self.scale_fmt)
 
             # aiter (ROCm gfx95): the 3-tuple (fp8, scale, bf16) from
             # fused_rms_fp8_group_quant is passed directly to _get_logits_head_gate,
@@ -1391,9 +1475,8 @@ class Indexer(MultiPlatformOp):
                         device=q_fp8.device,
                         dtype=torch.int32,
                     )
-                    k_cache_and_topk_result(
+                    topk_ragged_pcg(
                         layer_id=layer_id,
-                        key=key,
                         q_fp8=q_fp8,
                         weights=weights,
                         topk_result=topk_result,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -78,45 +78,56 @@ DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
 
 
 if _is_cuda:
-    from sglang.srt.compilation.compilation_config import register_split_op
     from sglang.srt.utils.custom_op import register_custom_op
 
-    @register_custom_op(mutates_args=["topk_result"])
-    @register_split_op()
-    def topk_ragged_pcg(
-        layer_id: int,
-        q_fp8: torch.Tensor,
-        weights: torch.Tensor,
-        topk_result: torch.Tensor,
-    ) -> None:
-        """Opaque-op wrapper for `_get_topk_ragged` under piecewise CUDA graph.
+    # Upper bound on (q_offset * k_offset * 4 bytes) the no-chunk fp8_mqa_logits
+    # path may allocate for its float32 logits tensor under PCG. Picked to leave
+    # ample headroom on H100 80GB / B200 192GB and to cover all current PCG
+    # buckets (8192*8192*4 = 256 MiB << 4 GiB). Tighten if smaller cards are
+    # ever targeted with PCG.
+    _PCG_LOGITS_BUDGET_BYTES = 4 * 1024 * 1024 * 1024  # 4 GiB
 
-        The K-cache store is CUDA-graphable (see fused_store_index_k_cache with
-        extend_num_tokens) and runs inside the compiled region, so it is no
-        longer wrapped here. This op shields only the ragged-topk kernel, whose
-        per-batch metadata + .item() chunking is not torch.compile-traceable.
+    def _assert_pcg_no_chunk_safe(q_offset: int, k_offset: int) -> None:
+        """Validates the no-chunk fp8_mqa_logits path is safe at the given sizes.
+
+        Under PCG the chunking decision is constant-folded to never-chunk, since:
+        - bucket is a Dynamo compile-time constant per capture,
+        - torch.cuda.mem_get_info is host-side and ungraphable,
+        - the chunk path's `while start < q_offset` loop has data-dependent
+          iteration count.
+
+        This assertion fires at trace/replay time and catches any bucket choice
+        whose logits tensor would exceed _PCG_LOGITS_BUDGET_BYTES.
         """
-        assert (
-            _is_cuda
-        ), "Internal error: piecewise CUDA graph is only supported on CUDA"
-
-        forward_batch = get_forward_context().forward_batch
-        indexer = get_forward_context().nsa_indexers[layer_id]
-        metadata = forward_batch.attn_backend.get_indexer_metadata(
-            layer_id, forward_batch
+        logits_bytes = q_offset * k_offset * 4
+        assert logits_bytes <= _PCG_LOGITS_BUDGET_BYTES, (
+            f"PCG no-chunk fp8_mqa_logits would allocate {logits_bytes} bytes "
+            f"for q_offset={q_offset}, k_offset={k_offset}, exceeding the PCG "
+            f"budget of {_PCG_LOGITS_BUDGET_BYTES} bytes. Either lower the bucket "
+            f"size or raise _PCG_LOGITS_BUDGET_BYTES."
         )
 
-        # slice off padding from piecewise CUDA graph
-        extend_num_tokens = forward_batch.extend_num_tokens
+    def _assert_pcg_indexer_sm_count_invariants(indexer: "Indexer") -> None:
+        """PCG-mode invariants for the NSA indexer's deep_gemm SM count:
 
-        indexer._get_topk_ragged(
-            False,
-            forward_batch,
-            layer_id,
-            q_fp8[:extend_num_tokens],
-            weights,
-            metadata,
-            topk_result,
+        (1) PP-recv must be off. With PP-recv on, _with_real_sm_count would
+            mutate deep_gemm SM count per call (host-side, ungraphable), and
+            captured/replayed kernels would see different SM counts than at
+            capture, breaking determinism.
+        (2) deep_gemm.get_num_sms() must match the value cached at indexer
+            __init__ time. Drift would mean some other code path persistently
+            called set_num_sms outside the transient _with_real_sm_count CM.
+        """
+        assert not indexer.logits_with_pp_recv, (
+            "PCG cannot run with PP-recv SM-steal: _with_real_sm_count would "
+            "mutate deep_gemm.set_num_sms() per call, which is host-side and "
+            "non-capturable."
+        )
+        current = deep_gemm.get_num_sms()
+        assert current == indexer.sm_count, (
+            f"deep_gemm SM count drifted since indexer init: "
+            f"cached={indexer.sm_count}, observed={current}. Some other code "
+            f"persistently mutated set_num_sms outside _with_real_sm_count."
         )
 
     def _logits_head_gate_pcg_fake_impl(
@@ -149,6 +160,151 @@ if _is_cuda:
         weights = out * n_heads_inv_sqrt
         weights = weights.unsqueeze(-1) * q_scale * softmax_scale
         return weights
+
+    # deep_gemm.fp8_mqa_logits allocates the output with stride (k_offset + _DG_LOGITS_ROW_PAD, 1)
+    # for alignment. The fake_impl must match exactly or Inductor's assert_size_stride trips.
+    _DG_LOGITS_ROW_PAD = 256
+
+    def _fp8_mqa_logits_pcg_fake_impl(
+        q_fp8: torch.Tensor,
+        k_fp8: torch.Tensor,
+        k_scale: torch.Tensor,
+        weights: torch.Tensor,
+        ks: torch.Tensor,
+        ke: torch.Tensor,
+    ) -> torch.Tensor:
+        q_offset = q_fp8.shape[0]
+        k_offset = k_fp8.shape[0]
+        return torch.empty_strided(
+            (q_offset, k_offset),
+            (k_offset + _DG_LOGITS_ROW_PAD, 1),
+            dtype=torch.float32,
+            device=q_fp8.device,
+        )
+
+    @register_custom_op(fake_impl=_fp8_mqa_logits_pcg_fake_impl)
+    def fp8_mqa_logits_pcg(
+        q_fp8: torch.Tensor,
+        k_fp8: torch.Tensor,
+        k_scale: torch.Tensor,
+        weights: torch.Tensor,
+        ks: torch.Tensor,
+        ke: torch.Tensor,
+    ) -> torch.Tensor:
+        out = deep_gemm.fp8_mqa_logits(
+            q_fp8, (k_fp8, k_scale), weights, ks, ke, clean_logits=False
+        )
+        # Validate the row-pad assumption baked into the fake_impl.
+        assert out.stride() == (k_fp8.shape[0] + _DG_LOGITS_ROW_PAD, 1), (
+            f"deep_gemm.fp8_mqa_logits output stride changed: got {out.stride()}, "
+            f"expected ({k_fp8.shape[0] + _DG_LOGITS_ROW_PAD}, 1). Update _DG_LOGITS_ROW_PAD."
+        )
+        return out
+
+    def _topk_transform_pcg_paged_fake_impl(
+        score: torch.Tensor,
+        seqlens_expanded: torch.Tensor,
+        page_table_1: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        ks: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        return torch.empty(
+            (score.shape[0], topk), dtype=torch.int32, device=score.device
+        )
+
+    @register_custom_op(fake_impl=_topk_transform_pcg_paged_fake_impl)
+    def topk_transform_pcg_paged(
+        score: torch.Tensor,
+        seqlens_expanded: torch.Tensor,
+        page_table_1: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        ks: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        from sgl_kernel import fast_topk_transform_fused
+
+        return fast_topk_transform_fused(
+            score=score,
+            lengths=seqlens_expanded,
+            page_table_size_1=page_table_1,
+            cu_seqlens_q=cu_seqlens_q,
+            topk=topk,
+            row_starts=ks,
+        )
+
+    def _topk_transform_pcg_ragged_fake_impl(
+        score: torch.Tensor,
+        seqlens_expanded: torch.Tensor,
+        topk_indices_offset: torch.Tensor,
+        ks: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        return torch.empty(
+            (score.shape[0], topk), dtype=torch.int32, device=score.device
+        )
+
+    @register_custom_op(fake_impl=_topk_transform_pcg_ragged_fake_impl)
+    def topk_transform_pcg_ragged(
+        score: torch.Tensor,
+        seqlens_expanded: torch.Tensor,
+        topk_indices_offset: torch.Tensor,
+        ks: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        from sgl_kernel import fast_topk_transform_ragged_fused
+
+        return fast_topk_transform_ragged_fused(
+            score=score,
+            lengths=seqlens_expanded,
+            topk_indices_offset=topk_indices_offset,
+            topk=topk,
+            row_starts=ks,
+        )
+
+    def topk_transform_pcg(
+        method: int,
+        score: torch.Tensor,
+        seqlens_expanded: torch.Tensor,
+        page_table_1: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        topk_indices_offset: torch.Tensor,
+        ks: torch.Tensor,
+        topk: int,
+    ) -> torch.Tensor:
+        """Pure-tensor topk transform for the PCG-inlined `_get_topk_ragged` path.
+
+        `method` is a `TopkTransformMethod` int (PAGED=1, RAGGED=2). All other
+        arguments are tensors (no metadata reads), sourced from the staged
+        `PrefillNsaMetadataBuffers` slots. Each branch dispatches to a
+        registered custom op (`topk_transform_pcg_paged` /
+        `topk_transform_pcg_ragged`); Dynamo specializes on `method` at trace
+        time, so only one branch enters the captured graph.
+        """
+        from sglang.srt.layers.attention.nsa_backend import TopkTransformMethod
+
+        if method == TopkTransformMethod.PAGED:
+            return topk_transform_pcg_paged(
+                score=score,
+                seqlens_expanded=seqlens_expanded,
+                page_table_1=page_table_1,
+                cu_seqlens_q=cu_seqlens_q,
+                ks=ks,
+                topk=topk,
+            )
+        elif method == TopkTransformMethod.RAGGED:
+            return topk_transform_pcg_ragged(
+                score=score,
+                seqlens_expanded=seqlens_expanded,
+                topk_indices_offset=topk_indices_offset,
+                ks=ks,
+                topk=topk,
+            )
+        else:
+            raise AssertionError(
+                f"topk_transform_pcg: unsupported method={method!r}; expected "
+                f"TopkTransformMethod.PAGED or RAGGED."
+            )
 
     def topk_construct_k_only_pcg(
         method: int,
@@ -737,7 +893,14 @@ class Indexer(MultiPlatformOp):
         token_to_batch_idx = metadata.get_token_to_batch_idx()
         q_offset = ks.shape[0]
         k_offset = k_fp8.shape[0]
-        need_chunk, free_mem = self._should_chunk_mqa_logits(q_offset, k_offset, device)
+        if is_in_piecewise_cuda_graph():
+            # PCG constant-folds to never-chunk. Validate the bucket fits.
+            _assert_pcg_no_chunk_safe(q_offset, k_offset)
+            need_chunk, free_mem = False, 0
+        else:
+            need_chunk, free_mem = self._should_chunk_mqa_logits(
+                q_offset, k_offset, device
+            )
 
         if not need_chunk:
             assert q_fp8[:q_offset].shape[0] != 0
@@ -839,6 +1002,106 @@ class Indexer(MultiPlatformOp):
             start = end
 
         return topk_result
+
+    def _get_topk_ragged_pcg(
+        self,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        q_fp8: torch.Tensor,
+        weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """Inlined PCG path for ragged topk.
+
+        All metadata is read from the staged `PrefillNsaMetadataBuffers` slots
+        on `ForwardContext`; no `metadata.X()` method calls or `.item()` syncs.
+        Fresh-prefill at any `bs ∈ [1, max_bs]` is supported: every staged
+        buffer is sized to its PCG upper bound and zero-padded beyond the
+        real region by `_stage_1d` / `_stage_2d`, so the K-fetch Triton
+        kernel masks padded batches off via `seq_len == 0`, and the topk
+        kernel short-circuits padded query rows (`seqlens_expanded[i] == 0`)
+        to all -1 before touching `page_table_1` / `topk_indices_offset`.
+        `seq_len_sum` and `max_seq_len` are kept at the bucket as a safe
+        compile-time-constant upper bound on `sum(L_r)` and `max(L_r)`.
+        Prefix-cache (kv_len > qo_len) remains out of scope — it'd break
+        the bucket upper bound. The SM-count + PP-recv invariants are
+        asserted host-side in
+        `PiecewiseCudaGraphRunner._stage_nsa_metadata_if_present` once per
+        step, so no host-side check is needed inside the compiled region.
+        """
+        bucket = q_fp8.shape[0]
+
+        ctx = get_forward_context()
+        bufs = ctx.nsa_metadata_buffers
+        assert bufs is not None, (
+            "PCG inlined ragged topk requires staged NSA metadata buffers"
+        )
+        method = bufs.topk_transform_method
+        assert method is not None, (
+            "PCG inlined ragged topk requires topk_transform_method to have "
+            "been pinned by stage_prefill_nsa_metadata_buffers"
+        )
+
+        # bucket is a compile-time-constant upper bound on both seq_len_sum
+        # (= sum of per-request lengths = num_tokens) and max_seq_len
+        # (= max per-request length) under fresh prefill. The K-fetch
+        # kernel writes `[0:num_tokens)` rows of K and leaves the rest
+        # uninitialized; queries beyond num_tokens have ks=ke=0 (zeroed
+        # by staging) so fp8_mqa_logits never reads those rows.
+        seq_len_sum = bucket
+        max_seq_len = bucket
+
+        # Validate the no-chunk budget for this bucket (compile-time const).
+        _assert_pcg_no_chunk_safe(bucket, bucket)
+
+        # Read staged metadata. Stable addresses (mark_static_address); Dynamo
+        # treats these as graph inputs. Pass full `(max_bs, ...)` /
+        # `(max_bs+1,)` shapes — slicing to `[:bs]` would drop request 1+'s
+        # routing. Padded batches are zero-length and masked off by both
+        # the K-fetch and topk kernels.
+        page_table_64 = bufs.page_table_64
+        page_table_1 = bufs.page_table_1
+        ks = bufs.ks[:bucket]
+        ke = bufs.ke[:bucket]
+        seqlens_expanded = bufs.seqlens_expanded[:bucket]
+        cu_seqlens_q = bufs.cu_seqlens_q
+        topk_indices_offset = bufs.topk_indices_offset[:bucket]
+        indexer_seq_len = bufs.indexer_seq_len
+
+        # weights from forward_cuda is (token_nums, n_heads, 1); squeeze head dim.
+        weights_sq = weights.squeeze(-1)
+
+        # Fetch K cache from the NSA pool. With bucket-as-int sizing this is
+        # a Triton kernel call with compile-time-constant launch params; under
+        # PCG the layer_transfer_counter wait is gated off.
+        k_fp8_raw, k_scale_raw = (
+            forward_batch.token_to_kv_pool.get_index_k_scale_buffer(
+                layer_id,
+                indexer_seq_len,
+                page_table_64,
+                seq_len_sum,
+                max_seq_len,
+            )
+        )
+        k_fp8 = k_fp8_raw.view(torch.float8_e4m3fn)
+        k_scale = k_scale_raw.view(torch.float32).squeeze(-1)
+
+        # MQA logits via the registered custom op (no _with_real_sm_count CM
+        # under PCG; the PP-recv invariant pinned at staging time guarantees
+        # the kernel's SM count is stable).
+        logits = fp8_mqa_logits_pcg(q_fp8, k_fp8, k_scale, weights_sq, ks, ke)
+
+        # Topk transform via the pure-tensor dispatcher (PAGED or RAGGED is
+        # specialized at trace time).
+        return topk_transform_pcg(
+            method=method,
+            score=logits,
+            seqlens_expanded=seqlens_expanded,
+            page_table_1=page_table_1,
+            cu_seqlens_q=cu_seqlens_q,
+            topk_indices_offset=topk_indices_offset,
+            ks=ks,
+            topk=self.index_topk,
+        )
 
     def _forward_cuda_k_only(
         self,
@@ -1469,17 +1732,8 @@ class Indexer(MultiPlatformOp):
                         not enable_dual_stream
                     ), "Internal error: piecewise CUDA graph should not be enabled with dual stream"
 
-                    topk_result = torch.full(
-                        (q_fp8.shape[0], self.index_topk),
-                        -1,
-                        device=q_fp8.device,
-                        dtype=torch.int32,
-                    )
-                    topk_ragged_pcg(
-                        layer_id=layer_id,
-                        q_fp8=q_fp8,
-                        weights=weights,
-                        topk_result=topk_result,
+                    topk_result = self._get_topk_ragged_pcg(
+                        forward_batch, layer_id, q_fp8, weights
                     )
                 else:
                     topk_result = self._get_topk_ragged(

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -2104,24 +2104,7 @@ class NativeSparseAttnBackend(
         block_tables = page_table_1.unsqueeze(1)
         seq_lens = metadata.cache_seqlens_int32 if seq_lens is None else seq_lens
 
-        out = torch.empty(
-            (batch_size, num_heads, self.kv_lora_rank),
-            dtype=torch.bfloat16,
-            device=q.device,
-        )
-        out_kernel = out
-        if forward_batch.forward_mode.is_extend_without_speculative():
-            # Piecewise CUDA graph pads tensors (q, block_tables) to static_num_tokens
-            # but seq_lens covers only the real batch. Slice to real tokens to avoid
-            # invalid block index accesses on padding rows.
-            # out is kept at full batch_size for the caller; out_kernel is the slice the kernel writes into.
-            real_batch_size = seq_lens.shape[0]
-            if real_batch_size < batch_size:
-                q = q[:real_batch_size]
-                block_tables = block_tables[:real_batch_size]
-                out_kernel = out[:real_batch_size]
-
-        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+        out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv,
             workspace_buffer=self.workspace_buffer,
@@ -2132,7 +2115,6 @@ class NativeSparseAttnBackend(
             seq_lens=seq_lens,
             max_seq_len=metadata.max_seq_len_k,
             sparse_mla_top_k=self.nsa_index_topk,
-            out=out_kernel,
             bmm1_scale=bmm1_scale,
             backend="trtllm-gen",
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeAlias
@@ -7,6 +8,8 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, TypeAlia
 import torch
 
 from sglang.srt.configs.model_config import get_nsa_index_topk, is_deepseek_nsa
+
+logger = logging.getLogger(__name__)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.nsa.dequant_k_cache import dequantize_k_cache_paged
@@ -2101,7 +2104,24 @@ class NativeSparseAttnBackend(
         block_tables = page_table_1.unsqueeze(1)
         seq_lens = metadata.cache_seqlens_int32 if seq_lens is None else seq_lens
 
-        out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+        out = torch.empty(
+            (batch_size, num_heads, self.kv_lora_rank),
+            dtype=torch.bfloat16,
+            device=q.device,
+        )
+        out_kernel = out
+        if forward_batch.forward_mode.is_extend_without_speculative():
+            # In piecewise cudagraph, input tensors (q, block_tables) are padded to static_num_tokens
+            # but seq_lens only covers the real token count. Slice to real tokens before the
+            # FMHA kernel to avoid invalid (-1) block index accesses on padding rows.
+            # out is kept at full batch_size for the caller; out_kernel is the slice the kernel writes into.
+            real_batch_size = seq_lens.shape[0]
+            if real_batch_size < batch_size:
+                q = q[:real_batch_size]
+                block_tables = block_tables[:real_batch_size]
+                out_kernel = out[:real_batch_size]
+
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv,
             workspace_buffer=self.workspace_buffer,
@@ -2112,12 +2132,13 @@ class NativeSparseAttnBackend(
             seq_lens=seq_lens,
             max_seq_len=metadata.max_seq_len_k,
             sparse_mla_top_k=self.nsa_index_topk,
+            out=out_kernel,
             bmm1_scale=bmm1_scale,
             backend="trtllm-gen",
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
         )
-        # Output: [batch, q_len=1, heads, v_dim] -> [batch, heads, v_dim]
-        return out.squeeze(1)
+
+        return out
 
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -2111,9 +2111,9 @@ class NativeSparseAttnBackend(
         )
         out_kernel = out
         if forward_batch.forward_mode.is_extend_without_speculative():
-            # In piecewise cudagraph, input tensors (q, block_tables) are padded to static_num_tokens
-            # but seq_lens only covers the real token count. Slice to real tokens before the
-            # FMHA kernel to avoid invalid (-1) block index accesses on padding rows.
+            # Piecewise CUDA graph pads tensors (q, block_tables) to static_num_tokens
+            # but seq_lens covers only the real batch. Slice to real tokens to avoid
+            # invalid block index accesses on padding rows.
             # out is kept at full batch_size for the caller; out_kernel is the slice the kernel writes into.
             real_batch_size = seq_lens.shape[0]
             if real_batch_size < batch_size:

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -51,7 +51,26 @@ _flashinfer_layernorm_available = False
 if _is_cuda or _is_xpu:
     if _is_flashinfer_available:
         try:
-            from flashinfer.norm import layernorm
+            import flashinfer.norm
+
+            from sglang.srt.utils.custom_op import register_custom_op
+
+            def _layernorm_fake_impl(
+                input: torch.Tensor,
+                gamma: torch.Tensor,
+                beta: torch.Tensor,
+                eps: float = 1e-6,
+            ) -> torch.Tensor:
+                return torch.empty_like(input)
+
+            @register_custom_op(fake_impl=_layernorm_fake_impl)
+            def layernorm(
+                input: torch.Tensor,
+                gamma: torch.Tensor,
+                beta: torch.Tensor,
+                eps: float = 1e-6,
+            ) -> torch.Tensor:
+                return flashinfer.norm.layernorm(input, gamma, beta, eps)
 
             _flashinfer_layernorm_available = True
         except (ImportError, AttributeError):

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -179,7 +179,7 @@ def unified_attention_with_output(
     if llama_4_scaling is not None:
         kwargs["llama_4_scaling"] = llama_4_scaling
     if topk_indices is not None:
-        kwargs["topk_indices"] = topk_indices
+        kwargs["topk_indices"] = topk_indices[:real_num_tokens]
 
     original_out_cache_loc = forward_batch.out_cache_loc
     original_out_cache_loc_swa = forward_batch.out_cache_loc_swa

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -148,6 +148,12 @@ def unified_attention_with_output(
     q_rope: Optional[torch.Tensor] = None,
     k_rope: Optional[torch.Tensor] = None,
     sinks: Optional[torch.Tensor] = None,
+    # MLA / TRT-LLM / NSA paths pass these through RadixAttention.forward(**kwargs);
+    # they must appear in the schema when --enforce-piecewise-cuda-graph is on.
+    cos_sin_cache: Optional[torch.Tensor] = None,
+    is_neox: Optional[bool] = None,
+    llama_4_scaling: Optional[torch.Tensor] = None,
+    topk_indices: Optional[torch.Tensor] = None,
 ) -> None:
     context = get_forward_context()
     forward_batch = context.forward_batch
@@ -166,6 +172,14 @@ def unified_attention_with_output(
         kwargs["k_rope"] = k_rope[:real_num_tokens]
     if sinks is not None:
         kwargs["sinks"] = sinks
+    if cos_sin_cache is not None:
+        kwargs["cos_sin_cache"] = cos_sin_cache
+    if is_neox is not None:
+        kwargs["is_neox"] = is_neox
+    if llama_4_scaling is not None:
+        kwargs["llama_4_scaling"] = llama_4_scaling
+    if topk_indices is not None:
+        kwargs["topk_indices"] = topk_indices
 
     original_out_cache_loc = forward_batch.out_cache_loc
     original_out_cache_loc_swa = forward_batch.out_cache_loc_swa

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1920,10 +1920,25 @@ class NSATokenToKVPool(MLATokenToKVPool):
                 )
                 for _ in range(layer_num)
             ]
+            # Mark each slab's address as static for torch.compile / CUDA-graph
+            # capture: the slabs are pool-lifetime, so their data_ptr is invariant.
+            # Without this, Dynamo may re-specialize whenever it re-sees the slab
+            # tensor, defeating piecewise CUDA-graph reuse.
+            for buf in self.index_k_with_scale_buffer:
+                torch._dynamo.mark_static_address(buf)
         self._finalize_allocation_log(size)
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
-        if self.layer_transfer_counter is not None:
+        # Skip the layer-transfer wait under piecewise CUDA graph compile / capture.
+        # Dynamo cannot represent CPU-side waits; the wait either graph-breaks
+        # or, at capture time, runs once and is dropped from the captured graph
+        # (so the "wait" semantically only occurs at warmup). This is safe because
+        # PCG is not used together with disaggregated layer-transfer streaming.
+        from sglang.srt.compilation.piecewise_context_manager import (
+            is_in_piecewise_cuda_graph,
+        )
+
+        if self.layer_transfer_counter is not None and not is_in_piecewise_cuda_graph():
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
         return self.index_k_with_scale_buffer[layer_id - self.start_layer]
 

--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -50,9 +50,13 @@ class ForwardInputBuffers:
 
             if isinstance(buffer, dict):
                 for sub_name, sub_buffer in buffer.items():
-                    assert isinstance(
-                        sub_buffer, torch.Tensor
-                    ), f"Field {name}.{sub_name} is expected to be a torch.Tensor, but got {type(sub_buffer)}."
+                    if sub_buffer is None:
+                        continue
+                    if not isinstance(sub_buffer, torch.Tensor):
+                        # Non-tensor metadata fields (e.g., enums snapshotted at
+                        # staging time on PrefillNsaMetadataBuffers) are managed
+                        # externally and have no shared-pool storage.
+                        continue
                     new_buffer = self._share_one_buffer(
                         f"{name}.{sub_name}", sub_buffer
                     )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2712,7 +2712,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 moe_fusion = layer.mixer
             self.moe_layers.append(moe_block)
             self.moe_fusions.append(moe_fusion)
-            # Collect NSA indexers (None for layers without NSA)
+            # NSA indexers (None for layers without NSA)
             nsa_indexer = None
             if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "indexer"):
                 nsa_indexer = layer.self_attn.indexer

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2659,6 +2659,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.attention_layers = []
         self.moe_layers = []
         self.moe_fusions = []
+        self.nsa_indexers = []
         for layer in language_model.model.layers:
             attn_layer = None
             if hasattr(layer, "self_attn"):
@@ -2711,6 +2712,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 moe_fusion = layer.mixer
             self.moe_layers.append(moe_block)
             self.moe_fusions.append(moe_fusion)
+            # Collect NSA indexers (None for layers without NSA)
+            nsa_indexer = None
+            if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "indexer"):
+                nsa_indexer = layer.self_attn.indexer
+            self.nsa_indexers.append(nsa_indexer)
 
         if len(self.attention_layers) < self.model_config.num_hidden_layers:
             # TODO(yuwei): support Non-Standard GQA

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -273,6 +273,7 @@ class PiecewiseCudaGraphRunner:
         self.attention_layers = self.model_runner.attention_layers
         self.moe_layers = self.model_runner.moe_layers
         self.moe_fusions = self.model_runner.moe_fusions
+        self.nsa_indexers = getattr(self.model_runner, "nsa_indexers", None)
 
         if get_global_graph_memory_pool() is None:
             set_global_graph_memory_pool(self.device_module.graph_pool_handle())
@@ -407,6 +408,7 @@ class PiecewiseCudaGraphRunner:
             self.quant_config,
             self.moe_layers,
             self.moe_fusions,
+            nsa_indexers=self.nsa_indexers,
         ):
             _ = self.model_runner.model.forward(
                 forward_batch.input_ids,
@@ -594,6 +596,7 @@ class PiecewiseCudaGraphRunner:
                 self.quant_config,
                 self.moe_layers,
                 self.moe_fusions,
+                nsa_indexers=self.nsa_indexers,
             ):
                 self.model_runner.model.forward(
                     forward_batch.input_ids,
@@ -788,6 +791,7 @@ class PiecewiseCudaGraphRunner:
                 self.quant_config,
                 self.moe_layers,
                 self.moe_fusions,
+                nsa_indexers=self.nsa_indexers,
             ):
                 # Due to the dispatch kernel for MLA model, we init the metadata with original forward_batch
                 self.model_runner.attn_backend.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -456,12 +456,21 @@ class PiecewiseCudaGraphRunner:
         Called after `attn_backend.init_forward_metadata(forward_batch)` so the
         live metadata is built. The first NSA layer's metadata is used; the
         underlying tensors are shared across layers so any layer_id is fine.
+        Also asserts the SM-count invariant required by the PCG-inlined indexer
+        path (host-side check; cannot live inside the compiled region).
         """
         if self.buffers.nsa_metadata_buffers is None or not self.nsa_indexers:
             return
         from sglang.srt.layers.attention.nsa.metadata_staging import (
             stage_prefill_nsa_metadata_buffers,
         )
+        from sglang.srt.layers.attention.nsa.nsa_indexer import (
+            _assert_pcg_indexer_sm_count_invariants,
+        )
+
+        # SM count must not have drifted; PP-recv must be off. Validated once
+        # per step on the first indexer (deep_gemm SM count is global).
+        _assert_pcg_indexer_sm_count_invariants(self.nsa_indexers[0])
 
         first_layer_id = self.nsa_indexers[0].layer_id
         metadata = forward_batch.attn_backend.get_indexer_metadata(

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -21,7 +21,7 @@ import logging
 import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 import tqdm
@@ -79,6 +79,12 @@ class PrefillInputBuffers(ForwardInputBuffers):
     positions: torch.Tensor
     input_embeds: Optional[torch.Tensor]
     mrope_positions: Optional[torch.Tensor]
+    # 1-elem int32 device tensor; refilled per replay with the real (non-padded)
+    # extend-token count. Address is stable across replays, value is dynamic.
+    extend_num_tokens_gpu: torch.Tensor
+    # NSA indexer metadata staging (PrefillNsaMetadataBuffers); None if model
+    # has no NSA indexers. See sglang.srt.layers.attention.nsa.metadata_staging.
+    nsa_metadata_buffers: Optional[Any] = None
 
 
 @contextmanager
@@ -237,6 +243,22 @@ class PiecewiseCudaGraphRunner:
                 else None
             )
             positions = torch.zeros((self.max_num_tokens,), dtype=torch.int64)
+            extend_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+            # NSA indexer metadata staging slots (only allocated if model uses NSA).
+            nsa_indexers = getattr(self.model_runner, "nsa_indexers", None)
+            if nsa_indexers:
+                from sglang.srt.layers.attention.nsa.metadata_staging import (
+                    allocate_prefill_nsa_metadata_buffers,
+                )
+
+                nsa_metadata_buffers = allocate_prefill_nsa_metadata_buffers(
+                    max_bs=self.max_bs,
+                    max_num_tokens=self.max_num_tokens,
+                    max_seq_len=self.max_num_tokens,
+                    device=torch.device("cuda"),
+                )
+            else:
+                nsa_metadata_buffers = None
 
             self.tbo_plugin = TboCudaGraphRunnerPlugin()
 
@@ -267,6 +289,8 @@ class PiecewiseCudaGraphRunner:
             positions=positions,
             input_embeds=input_embeds,
             mrope_positions=mrope_positions,
+            extend_num_tokens_gpu=extend_num_tokens_gpu,
+            nsa_metadata_buffers=nsa_metadata_buffers,
         )
         self.buffers.share_buffers()
 
@@ -402,6 +426,12 @@ class PiecewiseCudaGraphRunner:
         forward_batch.dp_local_start_pos = forward_batch.dp_local_num_tokens = None
         set_dp_buffer_len(None, num_tokens, forward_batch.dp_padding_mode.is_max_len())
         set_is_extend_in_batch(False)
+        # During warmup, real tokens == bucket size (no padding).
+        self.buffers.extend_num_tokens_gpu.fill_(num_tokens)
+        # Stage live NSA metadata into stable-address slots (no-op if no NSA).
+        self._stage_nsa_metadata_if_present(
+            forward_batch, bs=forward_batch.batch_size, num_tokens=num_tokens
+        )
         with set_forward_context(
             forward_batch,
             self.attention_layers,
@@ -409,12 +439,40 @@ class PiecewiseCudaGraphRunner:
             self.moe_layers,
             self.moe_fusions,
             nsa_indexers=self.nsa_indexers,
+            extend_num_tokens_gpu=self.buffers.extend_num_tokens_gpu,
+            nsa_metadata_buffers=self.buffers.nsa_metadata_buffers,
         ):
             _ = self.model_runner.model.forward(
                 forward_batch.input_ids,
                 forward_batch.positions,
                 forward_batch,
             )
+
+    def _stage_nsa_metadata_if_present(
+        self, forward_batch: ForwardBatch, bs: int, num_tokens: int
+    ) -> None:
+        """Copy live NSA indexer metadata into the stable-address staging slots.
+
+        Called after `attn_backend.init_forward_metadata(forward_batch)` so the
+        live metadata is built. The first NSA layer's metadata is used; the
+        underlying tensors are shared across layers so any layer_id is fine.
+        """
+        if self.buffers.nsa_metadata_buffers is None or not self.nsa_indexers:
+            return
+        from sglang.srt.layers.attention.nsa.metadata_staging import (
+            stage_prefill_nsa_metadata_buffers,
+        )
+
+        first_layer_id = self.nsa_indexers[0].layer_id
+        metadata = forward_batch.attn_backend.get_indexer_metadata(
+            first_layer_id, forward_batch
+        )
+        stage_prefill_nsa_metadata_buffers(
+            self.buffers.nsa_metadata_buffers,
+            metadata,
+            bs=bs,
+            num_tokens=num_tokens,
+        )
 
     def _cache_loc_dtype(self):
         return torch.int64 if not is_npu() else torch.int32
@@ -590,6 +648,14 @@ class PiecewiseCudaGraphRunner:
             set_is_extend_in_batch(False)
 
             kwargs = {}
+            # During capture, real tokens == bucket size (no padding region).
+            self.buffers.extend_num_tokens_gpu.fill_(num_tokens)
+            # Stage live NSA metadata into stable-address slots (no-op if no NSA).
+            self._stage_nsa_metadata_if_present(
+                forward_batch,
+                bs=forward_batch.batch_size,
+                num_tokens=num_tokens,
+            )
             with set_forward_context(
                 forward_batch,
                 self.attention_layers,
@@ -597,6 +663,8 @@ class PiecewiseCudaGraphRunner:
                 self.moe_layers,
                 self.moe_fusions,
                 nsa_indexers=self.nsa_indexers,
+                extend_num_tokens_gpu=self.buffers.extend_num_tokens_gpu,
+                nsa_metadata_buffers=self.buffers.nsa_metadata_buffers,
             ):
                 self.model_runner.model.forward(
                     forward_batch.input_ids,
@@ -641,6 +709,9 @@ class PiecewiseCudaGraphRunner:
         buffers.input_ids[:num_tokens].copy_(forward_batch.input_ids)
         buffers.positions[:num_tokens].copy_(forward_batch.positions)
         buffers.out_cache_loc[:num_tokens].copy_(forward_batch.out_cache_loc)
+        # Stable-address scalar holding the real (non-padded) token count for this
+        # replay; bound NSA store-K kernel writes so padding slots aren't scattered.
+        buffers.extend_num_tokens_gpu.fill_(num_tokens)
         if buffers.out_cache_loc_swa is not None:
             buffers.out_cache_loc_swa[: self.raw_num_tokens].copy_(
                 self.model_runner.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
@@ -792,9 +863,17 @@ class PiecewiseCudaGraphRunner:
                 self.moe_layers,
                 self.moe_fusions,
                 nsa_indexers=self.nsa_indexers,
+                extend_num_tokens_gpu=self.buffers.extend_num_tokens_gpu,
+                nsa_metadata_buffers=self.buffers.nsa_metadata_buffers,
             ):
                 # Due to the dispatch kernel for MLA model, we init the metadata with original forward_batch
                 self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+                # Stage live NSA metadata into stable-address slots (no-op if no NSA).
+                self._stage_nsa_metadata_if_present(
+                    forward_batch,
+                    bs=static_forward_batch.batch_size,
+                    num_tokens=self.raw_num_tokens,
+                )
                 output = self.model_runner.model.forward(
                     static_forward_batch.input_ids,
                     static_forward_batch.positions,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1238,6 +1238,10 @@ class ServerArgs:
         # 18. CUDA Graph debug mode
         if self.debug_cuda_graph:
             self.disable_piecewise_cuda_graph = True
+        # 19. NSA prefill context parallelism (attn_cp_size is set later in
+        # _handle_model_specific_adjustments, so check the flag directly here)
+        if self.enable_nsa_prefill_context_parallel:
+            self.disable_piecewise_cuda_graph = True
 
     def _handle_multi_item_scoring(self):
         """Setup and validate multi-item scoring constraints.
@@ -2947,10 +2951,6 @@ class ServerArgs:
             assert (
                 self.ep_size == 1
             ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
-
-        # flashinfer_trtllm / flashinfer_mxfp4 use BypassedTopKOutput, which is
-        # handled by fused_moe_bypassed_piecewise_cuda_graph_impl (a registered
-        # custom op) — PCG-compatible, no disable needed.
 
     def _handle_a2a_moe(self):
         if self.moe_a2a_backend == "deepep":

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2948,21 +2948,9 @@ class ServerArgs:
                 self.ep_size == 1
             ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
 
-        # TODO(yuwei): Fix piecewise cuda graph support for bypassed topk MoE backends.
-        # Exception: GptOssForCausalLM wraps the entire MoE block in its own
-        # custom op (moe_impl), so bypassed topk is handled inside the op body.
-        if (
-            not self.enforce_piecewise_cuda_graph
-            and self.moe_runner_backend in ("flashinfer_trtllm", "flashinfer_mxfp4")
-            and self.get_model_config().hf_config.architectures[0]
-            != "GptOssForCausalLM"
-        ):
-            self.disable_piecewise_cuda_graph = True
-            logger.info(
-                f"Piecewise cuda graph is disabled for MoE runner backend "
-                f"'{self.moe_runner_backend}' (bypassed topk is incompatible "
-                f"with torch.compile)."
-            )
+        # flashinfer_trtllm / flashinfer_mxfp4 use BypassedTopKOutput, which is
+        # handled by fused_moe_bypassed_piecewise_cuda_graph_impl (a registered
+        # custom op) — PCG-compatible, no disable needed.
 
     def _handle_a2a_moe(self):
         if self.moe_a2a_backend == "deepep":


### PR DESCRIPTION
## Motivation

Stacks on top of #23351, which set up PCG for NSA but explicitly excluded `_store_index_k_cache` and `_get_topk_ragged` from the captured graph (eager fallback). This PR brings the indexer fully into the captured region.

**This is just a PoC that we can get a modest perf improvment by CUDA graphing the indexer fully.**

## Modifications

Both NSA indexer paths — the k-only fast path (`bucket ≤ index_topk`) and the full path (`bucket > index_topk`) — now run entirely inside the captured CUDA graph. Prefill becomes GPU-bound around 8192-token sequences, so in practice CUDA graphs beyond that point aren't useful — bucket-padding overhead would dominate the launch-overhead savings.

Assumptions that make capture safe under typical inference:

- **Logits buffer fits the 4 GiB chunking budget.** The eager chunking decision (`mem_get_info` + while-loop) is constant-folded under PCG to the never-chunk branch via a `q*k*4 ≤ 4 GiB` assertion. Holds comfortably for the bucket sizes we care about (`8192*8192*4 = 256 MiB`).
- **SM count stable across replays.** The eager `_with_real_sm_count` CM — which mutates `deep_gemm.set_num_sms()` per call host-side — is lifted out and replaced by a once-per-step invariant assertion (PP-recv off, cached `get_num_sms()`).
- **Indexer metadata routed through stable-address staging.** New `PrefillNsaMetadataBuffers` provides 9 `mark_static_address` slots refilled per replay, replacing non-traceable `metadata.get_X()` dispatch and per-step fresh allocations.

## Speed Tests

<img width="2084" height="814" alt="image" src="https://github.com/user-attachments/assets/815809da-a1a1-4ca7-83be-56dc476775a7" />


GLM-5-FP8, TP=8, B200, random 1024/1024 (`range_ratio=0.8`). Output TPS/GPU:

| C | This PR | #23351 | Δ |
|--:|--:|--:|--:|
| 1 | 8.81 | 8.82 | -0.1% |
| 2 | 16.77 | 16.73 | +0.2% |
| 4 | 30.76 | 30.45 | +1.0% |
| 8 | 53.12 | 52.25 | +1.7% |
| 16 | 93.17 | 90.61 | +2.8% |
| 32 | 160.15 | 153.35 | +4.4% |
| 64 | 255.03 | 239.40 | +6.5% |
| 128 | 396.54 | 373.51 | +6.2% |

## Accuracy Tests

Same command as #23351:

```
python -m sglang.test.run_eval --base-url http://localhost:8080 \
    --model zai-org/GLM-5-FP8 --num-threads 128 --eval-name gpqa \
    --max-tokens 128000 --num-examples 198 --repeat 8 \
    --top-p 0.95 --temperature 1.0 --thinking-mode glm-45
```

Repeat: 8, mean: 0.851
Scores: `['0.823', '0.874', '0.854', '0.843', '0.843', '0.874', '0.859', '0.838']`

Authored with Claude.