### PR TITLE
Align `triton_kernels` with Triton 3.6.0 and fix SM120 MXFP4 MoE performance

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py
@@ -9,11 +9,13 @@ from triton_kernels.matmul_ogs import (
     FlexCtx,
     FnSpecs,
     FusedActivation,
+    GatherIndx,
     PrecisionConfig,
+    RoutingData,
+    ScatterIndx,
     matmul_ogs,
 )
 from triton_kernels.numerics import InFlexData
-from triton_kernels.routing import GatherIndx, RoutingData, ScatterIndx
 from triton_kernels.swiglu import swiglu_fn
 
 from sglang.srt.utils import is_cuda
@@ -295,9 +297,8 @@ def triton_kernel_fused_experts_with_bias(
         w2_pcg = PrecisionConfig(flex_ctx=FlexCtx(rhs_data=w2_flex))
 
     act = FusedActivation(
-        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")),
+        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2),
         (gemm1_alpha, gemm1_clamp_limit),
-        2,
     )
 
     intermediate_cache = torch.empty(

--- a/python/sglang/srt/layers/moe/moe_runner/triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_kernels.py
@@ -19,8 +19,12 @@ from sglang.srt.layers.moe.moe_runner.base import (
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 
 if TYPE_CHECKING:
-    from triton_kernels.matmul_ogs import PrecisionConfig
-    from triton_kernels.routing import GatherIndx, RoutingData, ScatterIndx
+    from triton_kernels.matmul_ogs import (
+        GatherIndx,
+        PrecisionConfig,
+        RoutingData,
+        ScatterIndx,
+    )
 
     from sglang.srt.layers.moe.token_dispatcher.standard import (
         StandardCombineInput,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -32,7 +32,50 @@ import torch
 import torch.nn.functional as F
 
 try:
-    from triton_kernels.routing import GatherIndx, RoutingData, ScatterIndx, routing
+    from triton_kernels.matmul_ogs import GatherIndx, RoutingData, ScatterIndx
+    from triton_kernels.tensor import make_ragged_tensor_metadata
+    from triton_kernels.topk import topk as triton_kernels_topk
+
+    def routing(
+        logits,
+        n_expts_act,
+        sm_first=False,
+        expt_indx=None,
+        simulated_ep=1,
+        n_rows=None,
+    ):
+        if simulated_ep != 1:
+            raise NotImplementedError(
+                "simulated_ep routing is not supported with triton_kernels 3.6.0"
+            )
+
+        if sm_first:
+            logits = torch.softmax(logits, dim=-1)
+
+        sparse_logits = triton_kernels_topk(
+            logits,
+            n_expts_act,
+            apply_softmax=not sm_first,
+            y_indx=expt_indx,
+            n_rows=n_rows,
+        )
+        dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
+        combine_indx = sparse_logits.mask_metadata.col_sorted_indx
+        ragged_metadata = make_ragged_tensor_metadata(
+            sparse_logits.mask_metadata.col_sum, dispatch_indx.shape[0]
+        )
+        gate_scal = sparse_logits.vals.flatten()[combine_indx]
+        routing_data = RoutingData(
+            gate_scal,
+            ragged_metadata.slice_sizes,
+            logits.shape[-1],
+            n_expts_act,
+            ragged_metadata,
+        )
+        gather_indx = GatherIndx(combine_indx, dispatch_indx)
+        scatter_indx = ScatterIndx(dispatch_indx, combine_indx)
+        return routing_data, gather_indx, scatter_indx
+
 except ImportError:
     pass
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -113,6 +113,7 @@ if TYPE_CHECKING:
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
+_sm120_mxfp4_min_warps_patched = False
 
 if _is_hip:
     # import aiter
@@ -128,6 +129,49 @@ if _is_hip:
         dynamic_mxfp4_quant = e8m0_shuffle = err
 
 
+def _patch_sm120_mxfp4_min_warps():
+    global _sm120_mxfp4_min_warps_patched
+    if _sm120_mxfp4_min_warps_patched:
+        return
+
+    import inspect
+
+    from triton_kernels.matmul_ogs_details.opt_flags_details import opt_flags_nvidia
+    from triton_kernels.tensor import get_layout
+    from triton_kernels.tensor_details.layout import StridedLayout
+
+    compute_num_warps = opt_flags_nvidia.compute_num_warps
+    params = inspect.signature(compute_num_warps).parameters
+
+    if "is_persistent" in params and not getattr(
+        compute_num_warps, "_sglang_sm120_mxfp4_patch", False
+    ):
+
+        def _compute_num_warps_sm120_mxfp4(
+            block_m, block_n, is_persistent, precision_config
+        ):
+            selected_num_warps = compute_num_warps(
+                block_m, block_n, is_persistent, precision_config
+            )
+            weight_scale = getattr(precision_config, "weight_scale", None)
+            weight_scale_layout = get_layout(weight_scale)
+            if (
+                not is_persistent
+                and weight_scale is not None
+                and (
+                    weight_scale_layout is StridedLayout
+                    or isinstance(weight_scale_layout, StridedLayout)
+                )
+            ):
+                return max(selected_num_warps, 4)
+            return selected_num_warps
+
+        _compute_num_warps_sm120_mxfp4._sglang_sm120_mxfp4_patch = True
+        opt_flags_nvidia.compute_num_warps = _compute_num_warps_sm120_mxfp4
+
+    _sm120_mxfp4_min_warps_patched = True
+
+
 def _swizzle_mxfp4(quant_tensor, scale, num_warps):
     """weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel"""
     import triton_kernels.matmul_ogs_details.opt_flags as opt_flags
@@ -137,8 +181,8 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
 
     if is_sm120_supported():
         # SM120 desktop Blackwell does not support the persistent/TMA MXFP4 path.
-        # This MXFP4 path uses StridedLayout and the non-persistent kernel with
-        # block_k=128 so the selected tile stays within the per-block shared-memory budget.
+        # This MXFP4 path uses StridedLayout and the non-persistent kernel.
+        _patch_sm120_mxfp4_min_warps()
         from triton_kernels.tensor_details.layout import StridedLayout
 
         value_layout = StridedLayout
@@ -147,7 +191,6 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         scale_layout_opts = {}
         constraints = {
             "is_persistent": False,
-            "block_k": 128,
             "num_stages": 1,
         }
         opt_flags.update_opt_flags_constraints(constraints)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3602,7 +3602,11 @@ class ConcurrentCounter:
 
 @lru_cache(maxsize=1)
 def is_triton_kernels_available() -> bool:
-    return importlib.util.find_spec("triton_kernels") is not None
+    triton_kernels_spec = importlib.util.find_spec("triton_kernels")
+    ragged_metadata_spec = importlib.util.find_spec(
+        "triton_kernels.tensor_details.ragged_tensor"
+    )
+    return triton_kernels_spec is not None and ragged_metadata_spec is not None
 
 
 @lru_cache(maxsize=1)

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -285,11 +285,15 @@ install_sglang_kernel() {
         $PIP_CMD install "torch==${TORCH_VER}" "torchaudio==${TORCHAUDIO_VER}" "torchvision==${TORCHVISION_VER}" --index-url "https://download.pytorch.org/whl/${CU_VERSION}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
 
-    # install_sglang above pulls sglang-kernel from PyPI, whose default wheel
-    # tracks one CUDA version (currently cu130). Force-reinstall from the
-    # CU_VERSION-matched sglang wheel index so runners on a different CUDA
-    # (e.g. h20 / cu129) get a wheel linked against the right libnvrtc.
-    $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+    if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" != "true" ]; then
+        # install_sglang above pulls sglang-kernel from PyPI, whose default wheel
+        # tracks one CUDA version (currently cu130). Force-reinstall from the
+        # CU_VERSION-matched sglang wheel index so runners on a different CUDA
+        # (e.g. h20 / cu129) get a wheel linked against the right libnvrtc.
+        $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+    else
+        echo "CUSTOM_BUILD_SGL_KERNEL=true: keeping freshly built sgl-kernel wheel."
+    fi
 
     mark_step_done "${FUNCNAME[0]}"
 }

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -74,7 +74,7 @@ FetchContent_Populate(repo-fmt)
 FetchContent_Declare(
     repo-triton
     GIT_REPOSITORY "https://github.com/triton-lang/triton"
-    GIT_TAG        v3.5.1
+    GIT_TAG        v3.6.0
     GIT_SHALLOW    OFF
 )
 FetchContent_Populate(repo-triton)


### PR DESCRIPTION
## Summary

- Following the Torch 2.11 upgrade in #21247, align the bundled `triton_kernels` source with the Triton 3.6.0 version shipped by Torch.
- Update SGLang's `triton_kernels` MoE integration for Triton 3.6.0 API changes:
  - `GatherIndx`, `RoutingData`, and `ScatterIndx` moved from `triton_kernels.routing` to `triton_kernels.matmul_ogs`.
  - `triton_kernels.routing` is no longer exposed, so SGLang now rebuilds routing from `triton_kernels.topk` and ragged tensor metadata.
  - `swiglu` fused activation now passes `reduction_n=2` through `FnSpecs`.
- Tighten `is_triton_kernels_available()` so stale pre-3.6 installs are not treated as compatible.
- Fix severe SM120 GPT-OSS MXFP4 decode slowdown after the Triton 3.6.0 update.

The SM120 performance issue comes from this `triton_kernels` heuristic change:

```py
# Triton 3.5.1
return max(block_m * block_n // 4096, 4)

# Triton 3.6.0
return max(block_m * block_n // 4096, 4 if is_persistent else 1)
```

For small decode/ragged MoE batches on SM120 this can select `num_warps=1`, which makes throughput very slow. Without this patch, I was seeing SM120 decode around 35-36 token/s. This patch restores the old 4-warp floor only for SM120 non-persistent `StridedLayout` MXFP4 matmuls.

This also removes the explicit SM120 `block_k=128` override added in #20040. That override was added because the older `triton_kernels` path could hit `assert num_stages >= 1` during GPT-OSS startup on SM120. I think this was most likely being tripped during PCG warmup/capture. With the Triton 3.6.0 `triton_kernels` path, I can no longer reproduce that failure without the override, so this PR lets Triton choose its default `block_k` again, which is currently 256 for this path.

The SM120 `num_warps` patch is ugly, but I think this is the only practical way to restore SM120 performance from SGLang right now. `triton_kernels` does not expose `num_warps` as an opt-flag constraint, so this patch narrowly adjusts the heuristic only for the SM120 non-persistent `StridedLayout` MXFP4 path.

## Accuracy Tests

### H200 (MXFP4):

```shell
python -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 256 --reasoning-effort low --base-url http://127.0.0.1:30000/v1

Writing report to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_212928.html
{'chars': np.float64(52.16729797979798), 'chars:std': np.float64(218.80938828184415), 'score': np.float64(0.5744949494949495), 'score:std': np.float64(0.494419358945162)}
Writing results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_212928.json
Writing all results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_212928_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-20b-low_temp1.0_20260502_212928', 'metric': 0.5744949494949495}]
```

### GB300 (MXFP4):

```shell
python -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 512 --reasoning-effort low --base-url http://127.0.0.1:30000/v1

Writing report to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_214250.html
{'chars': np.float64(52.530934343434346), 'chars:std': np.float64(200.0052121862134), 'score': np.float64(0.5549242424242424), 'score:std': np.float64(0.4969741719587881)}
Writing results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_214250.json
Writing all results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_214250_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-20b-low_temp1.0_20260502_214250', 'metric': 0.5549242424242424}]
```

### GB300 (BF16):

```shell
python -m gpt_oss.evals --model lmsys/gpt-oss-20b-bf16 --eval gpqa --n-threads 512 --reasoning-effort low --base-url http://127.0.0.1:30000/v1

Writing report to /tmp/gpqa_lmsys__gpt-oss-20b-bf16-low_temp1.0_20260502_214425.html
{'chars': np.float64(50.92550505050505), 'chars:std': np.float64(214.67684371696978), 'score': np.float64(0.5568181818181818), 'score:std': np.float64(0.4967612044180544)}
Writing results to /tmp/gpqa_lmsys__gpt-oss-20b-bf16-low_temp1.0_20260502_214425.json
Writing all results to /tmp/gpqa_lmsys__gpt-oss-20b-bf16-low_temp1.0_20260502_214425_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'lmsys__gpt-oss-20b-bf16-low_temp1.0_20260502_214425', 'metric': 0.5568181818181818}]
```

### RTX PRO 6000 (MXFP4):

```shell
python -m gpt_oss.evals --model openai/gpt-oss-20b --eval gpqa --n-threads 256 --reasoning-effort low --base-url http://127.0.0.1:30000/v1

Writing report to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_223913.html
{'chars': np.float64(52.41856060606061), 'chars:std': np.float64(206.45098944881033), 'score': np.float64(0.553030303030303), 'score:std': np.float64(0.4971798336221153)}
Writing results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_223913.json
Writing all results to /tmp/gpqa_openai__gpt-oss-20b-low_temp1.0_20260502_223913_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-20b-low_temp1.0_20260502_223913', 'metric': 0.553030303030303}]
```