### PR TITLE
[CI] Fix nightly NV jobs cancelling each other via shared concurrency groups

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -57,9 +57,6 @@ jobs:
   nightly-test-general-1-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-1-gpu-h100')
     runs-on: 1-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,9 +84,6 @@ jobs:
   nightly-test-kernel-1-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-kernel-1-gpu-h100')
     runs-on: 1-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     timeout-minutes: 60
     env:
       # Full jit_kernel test grids (see sglang.jit_kernel.utils.should_run_full_tests)
@@ -123,9 +117,6 @@ jobs:
   nightly-test-kernel-8-gpu-h200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-kernel-8-gpu-h200')
     runs-on: 8-gpu-h200
-    concurrency:
-      group: nightly-hw-h200
-      cancel-in-progress: false
     timeout-minutes: 240
     env:
       SGLANG_JIT_KERNEL_RUN_FULL_TESTS: "1"
@@ -157,9 +148,6 @@ jobs:
   nightly-test-general-4-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-4-gpu-h100')
     runs-on: 4-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -185,9 +173,6 @@ jobs:
   nightly-test-general-8-gpu-h200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h200')
     runs-on: 8-gpu-h200
-    concurrency:
-      group: nightly-hw-h200
-      cancel-in-progress: false
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -275,9 +260,6 @@ jobs:
   nightly-test-general-8-gpu-h20:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h20')
     runs-on: 8-gpu-h20
-    concurrency:
-      group: nightly-hw-h20
-      cancel-in-progress: false
     env:
       SGLANG_CI_RDMA_ALL_DEVICES: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
     steps:
@@ -307,9 +289,6 @@ jobs:
   nightly-test-general-8-gpu-b200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-b200')
     runs-on: 8-gpu-b200
-    concurrency:
-      group: nightly-hw-b200
-      cancel-in-progress: false
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -386,9 +365,6 @@ jobs:
   nightly-test-text-accuracy-2-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-text-accuracy-2-gpu-h100')
     runs-on: 2-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -414,9 +390,6 @@ jobs:
   nightly-test-text-perf-2-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-text-perf-2-gpu-h100')
     runs-on: 2-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -455,9 +428,6 @@ jobs:
   nightly-test-vlm-accuracy-2-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-vlm-accuracy-2-gpu-h100')
     runs-on: 2-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -483,9 +453,6 @@ jobs:
   nightly-test-vlm-perf-2-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-vlm-perf-2-gpu-h100')
     runs-on: 2-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -524,9 +491,6 @@ jobs:
   nightly-test-multimodal-server-1-gpu:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-multimodal-server-1-gpu')
     runs-on: 1-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -585,9 +549,6 @@ jobs:
   nightly-test-multimodal-server-2-gpu:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-multimodal-server-2-gpu')
     runs-on: 2-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -647,9 +608,6 @@ jobs:
   nightly-test-perf-4-gpu-b200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-4-gpu-b200')
     runs-on: 4-gpu-b200
-    concurrency:
-      group: nightly-hw-b200
-      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -675,9 +633,6 @@ jobs:
   nightly-test-specialized-8-gpu-b200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-perf-8-gpu-b200' || inputs.job_filter == 'nightly-test-specialized-8-gpu-b200')
     runs-on: 8-gpu-b200
-    concurrency:
-      group: nightly-hw-b200
-      cancel-in-progress: false
     env:
       RUNNER_LABELS: 8-gpu-b200
     steps:
@@ -707,9 +662,6 @@ jobs:
   nightly-test-diffusion-comparison:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-diffusion-comparison')
     runs-on: 4-gpu-h100
-    concurrency:
-      group: nightly-hw-h100
-      cancel-in-progress: false
     timeout-minutes: 300
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Each per-job `concurrency.group` in `nightly-test-nvidia.yml` (`nightly-hw-{h100,h200,h20,b200}`) was shared across many jobs. GitHub Actions only keeps **one pending job** per concurrency group: when a second job tries to queue while one is already pending, the previously pending one is cancelled — regardless of `cancel-in-progress: false`, which only protects the running job.

So when a nightly run fans out N jobs targeting the same group, only one runs, one survives as the last queued, and the rest are cancelled within ~2 seconds with no runner assigned and no steps executed.

### Concrete repro

[Release Branch Cut run #25261510384](https://github.com/sgl-project/sglang/actions/runs/25261510384) — 18 of 24 NVIDIA jobs cancelled at workflow start. Cancelled jobs all share the same fingerprint:

```
started_at:  2026-05-02T20:47:36Z
completed_at:2026-05-02T20:47:37Z   # 1 second
runner_name: ""                      # never assigned
steps_count: 0                       # never ran
```

| Group | Total jobs queued | Outcome |
|---|---|---|
| `nightly-hw-h100` | 12 | 1 ran, 1 survived as last-queued and ran later, 10 cancelled |
| `nightly-hw-h200` | 5 | 2 ran (one immediately, one after queueing), 3 cancelled |
| `nightly-hw-b200` | 6 | 1 ran, 1 still pending, 4 cancelled |
| `nightly-hw-h20` | 1 | 1 ran |

Same pattern affects every recent scheduled nightly run (e.g. 25239610196, 24944658760, 24866511893 — all `cancelled`).

### Why concurrency groups can't fix this

Per [GitHub docs](https://docs.github.com/en/actions/using-jobs/using-concurrency):

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be **pending**. Any **previously pending** job or workflow in the concurrency group will be **canceled**.

`cancel-in-progress: false` only protects the *running* job. The pending slot is always single-occupancy; new arrivals always evict prior pending entries. So a group of N>2 jobs cannot serialize via concurrency groups — only via `needs:` chains.

### Fix

Drop the shared per-job concurrency blocks. Hardware contention is already serialized by:

- **Runner-label scarcity** — each `<N>-gpu-h100` / `<N>-gpu-h200` / `<N>-gpu-b200` label has limited capacity, jobs queue naturally on runner availability.
- **`max-parallel: 2`** on the four matrix jobs (`general-8-gpu-h200`, `general-8-gpu-b200`, `multimodal-server-{1,2}-gpu`) — preserved.
- **Top-level workflow concurrency** at line 45 (keyed on ref) — preserved.

If strict "1 job per hardware family at a time" is needed beyond what runner labels enforce, follow up with `needs:` chains (the only mechanism in GH Actions that can actually queue more than 2 jobs).

This reverts the per-job groups added in #23314 while keeping the matrix `max-parallel` and timeout adjustments from that PR.

## Test plan

- [ ] Trigger `Nightly Test (Nvidia)` via `workflow_dispatch` and verify all jobs are scheduled (not cancelled at start).
- [ ] Confirm matrix jobs still cap at `max-parallel: 2`.
- [ ] Confirm `workflow_dispatch` with `job_filter=<single>` still dispatches a single job.
- [ ] Watch next scheduled nightly to confirm no spurious cancellations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)