### PR TITLE
model_runner: bind init_weights_update_group's NCCL comm to worker gpu_id

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1828,6 +1828,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 world_size=world_size,
                 rank=rank,
                 group_name=group_name,
+                device_id=torch.device("cuda", self.gpu_id),
             )
             return True, "Succeeded to initialize custom process group."
         except Exception as e:


### PR DESCRIPTION
## Motivation

\`init_weights_update_group\` calls \`init_custom_process_group\` without
passing \`device_id=\`, so the resulting \`_model_update_group\` NCCL
communicator isn't bound to a cuda device at init time. Torch's NCCL
backend defers binding to the first collective and uses
\`torch.cuda.current_device()\` at that moment.

In practice this forces callers to set \`--base-gpu-id=rank_offset\` on
the inference engine so the worker's current cuda device happens to
equal its rank in the \`_model_update_group\` when the comm materializes.
With multi-GPU inference at a non-zero \`rank_offset\` (typical RL setup
where rank 0 is the external trainer/sender and the engine TP ranks
fill 1..tp_size), this leaves \`cuda:0..rank_offset-1\` visible-but-unused
— one GPU wasted per inference engine, regardless of \`tp_size\`.

\`init_weights_send_group_for_remote_instance\` right next door already
passes \`device_id\` (\`model_runner.py:1732\`); this PR makes
\`init_weights_update_group\` consistent.

## Modifications

One line in \`init_weights_update_group\`: pass
\`device_id=torch.device("cuda", self.gpu_id)\` into
\`init_custom_process_group\` so the \`_model_update_group\` comm binds
to the worker's actual configured cuda device explicitly.

After this change, launchers can use \`--base-gpu-id=0\` +
\`--gpus=tp_size\`, reclaiming the previously-wasted GPU. Constant 1-GPU
saving per inference engine.

No behavior change for callers that already align \`base_gpu_id\` with
\`rank_offset\`: \`gpu_id\` and \`current_device()\` were already equal
in that path; the explicit \`device_id\` just makes the binding
deterministic rather than relying on first-collective ordering.

## Accuracy Tests

Not applicable — no kernel or model forward path is touched. The patch
only affects which cuda device the \`_model_update_group\` NCCL
communicator binds to at init.

## Speed Tests and Profiling

Not applicable — no inference-path code is touched.

## Verification

Tested end-to-end with TP=2 inference at \`rank_offset=1\` (3-rank
update group: 1 external sender + 2 engine TP ranks). Without the
patch the bringup requires \`--base-gpu-id=1\` and \`--gpus=3\` (cuda:0
visible-but-unused). With the patch \`--base-gpu-id=0\` and \`--gpus=2\`
work end-to-end: each TP worker's \`_model_update_group\` comm binds
to its own \`gpu_id\`, the cross-host weight broadcast and the
subsequent \`update_weights_from_distributed\` reload both succeed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).