### PR TITLE
[CI] Keep custom sgl-kernel wheel in CUDA CI

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -285,11 +285,15 @@ install_sglang_kernel() {
         $PIP_CMD install "torch==${TORCH_VER}" "torchaudio==${TORCHAUDIO_VER}" "torchvision==${TORCHVISION_VER}" --index-url "https://download.pytorch.org/whl/${CU_VERSION}" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
 
-    # install_sglang above pulls sglang-kernel from PyPI, whose default wheel
-    # tracks one CUDA version (currently cu130). Force-reinstall from the
-    # CU_VERSION-matched sglang wheel index so runners on a different CUDA
-    # (e.g. h20 / cu129) get a wheel linked against the right libnvrtc.
-    $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+    if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" != "true" ]; then
+        # install_sglang above pulls sglang-kernel from PyPI, whose default wheel
+        # tracks one CUDA version (currently cu130). Force-reinstall from the
+        # CU_VERSION-matched sglang wheel index so runners on a different CUDA
+        # (e.g. h20 / cu129) get a wheel linked against the right libnvrtc.
+        $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+    else
+        echo "CUSTOM_BUILD_SGL_KERNEL=true: keeping freshly built sgl-kernel wheel."
+    fi
 
     mark_step_done "${FUNCNAME[0]}"
 }


### PR DESCRIPTION
## Summary

Fixes a regression from #21247 where CUDA CI always force-reinstalled `sglang-kernel` from the public wheel index, which could overwrite a freshly built PR `sgl-kernel` wheel when `CUSTOM_BUILD_SGL_KERNEL=true`.

Keep the custom-built wheel in that path so CI actually tests kernel changes from the PR.

See https://github.com/sgl-project/sglang/actions/runs/25264102281/job/74077130931?pr=24281#step:6:380.

cc @Kangyan-Zhou 