### PR TITLE
Register deepseek_v32 alias instead of rewriting config.json

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -343,6 +343,7 @@ class ModelConfig:
 
         if is_draft_model and self.hf_config.architectures[0] in [
             "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
             "GlmMoeDsaForCausalLM",
         ]:
             self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1673,6 +1673,7 @@ class ServerArgs:
 
         if model_arch in [
             "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
             "KimiK25ForConditionalGeneration",
             "MistralLarge3ForCausalLM",
             "PixtralForConditionalGeneration",

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -100,6 +100,15 @@ _CONFIG_REGISTRY: Dict[str, Type[PretrainedConfig]] = {
     ]
 }
 
+# DeepSeek V3.2 reuses the V3 config schema. Alias to the upstream
+# transformers class so AutoConfig / AutoTokenizer dispatch works natively.
+try:
+    from transformers import DeepseekV3Config as _HFDeepseekV3Config
+
+    _CONFIG_REGISTRY["deepseek_v32"] = _HFDeepseekV3Config
+except ImportError:
+    pass
+
 for name, cls in _CONFIG_REGISTRY.items():
     try:
         AutoConfig.register(name, cls)
@@ -312,37 +321,6 @@ def _override_v_head_dim_if_zero(config: PretrainedConfig, patch: int = 128) -> 
         logger.warning(
             f"Overriding v_head_dim from 0 to {patch} to avoid potential issues."
         )
-
-
-def _load_deepseek_v32_model(
-    model_path: str,
-    trust_remote_code: bool = False,
-    revision: Optional[str] = None,
-    **kwargs,
-):
-    import tempfile
-
-    local_path = download_from_hf(model_path)
-    config_file = os.path.join(local_path, "config.json")
-    if not os.path.exists(config_file):
-        raise RuntimeError(f"Can't find config file in {local_path}.")
-
-    with open(config_file, "r") as f:
-        config_json = json.load(f)
-
-    config_json["architectures"] = ["DeepseekV3ForCausalLM"]
-    config_json["model_type"] = "deepseek_v3"
-
-    tmp_path = os.path.join(tempfile.gettempdir(), "_tmp_config_folder")
-    os.makedirs(tmp_path, exist_ok=True)
-
-    unique_path = os.path.join(tmp_path, f"deepseek_v32_{os.getpid()}")
-    with open(unique_path, "w") as f:
-        json.dump(config_json, f)
-
-    return AutoConfig.from_pretrained(
-        unique_path, trust_remote_code=trust_remote_code, revision=revision, **kwargs
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -100,12 +100,16 @@ _CONFIG_REGISTRY: Dict[str, Type[PretrainedConfig]] = {
     ]
 }
 
-# DeepSeek V3.2 reuses the V3 config schema. Alias to the upstream
-# transformers class so AutoConfig / AutoTokenizer dispatch works natively.
+# DeepSeek V3.2 reuses the V3 config schema. Subclass the upstream transformers
+# class with the V3.2 model_type so AutoConfig.register passes its consistency
+# check (which requires class.model_type == registered key).
 try:
     from transformers import DeepseekV3Config as _HFDeepseekV3Config
 
-    _CONFIG_REGISTRY["deepseek_v32"] = _HFDeepseekV3Config
+    class _DeepseekV32ConfigAlias(_HFDeepseekV3Config):
+        model_type = "deepseek_v32"
+
+    _CONFIG_REGISTRY["deepseek_v32"] = _DeepseekV32ConfigAlias
 except ImportError:
     pass
 

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -16,11 +16,10 @@
 from pathlib import Path
 from typing import Optional
 
-from transformers import PretrainedConfig
 from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
 from sglang.srt.connector import create_remote_connector
-from sglang.srt.utils import is_remote_url, logger, lru_cache_frozenset
+from sglang.srt.utils import is_remote_url, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
 from ..hf_transformers_patches import _ensure_gguf_version
@@ -30,7 +29,6 @@ from .common import (
     DeepseekVLV2Config,
     _is_deepseek_ocr2_model,
     _is_deepseek_ocr_model,
-    _load_deepseek_v32_model,
     _override_v_head_dim_if_zero,
     check_gguf_file,
     get_hf_text_config,
@@ -75,39 +73,9 @@ def get_config(
             model, trust_remote_code=trust_remote_code, revision=revision
         )
     else:
-        try:
-            config = AutoConfig.from_pretrained(
-                model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
-            )
-        except (ValueError, KeyError) as e:
-            if "deepseek_v32" in str(e):
-                config = _load_deepseek_v32_model(
-                    model,
-                    trust_remote_code=trust_remote_code,
-                    revision=revision,
-                    **kwargs,
-                )
-            elif isinstance(e, ValueError):
-                raise
-            else:
-                logger.warning(
-                    "AutoConfig.from_pretrained raised KeyError for %s: %s. "
-                    "Falling back to config registry lookup.",
-                    model,
-                    e,
-                )
-                config_dict, _ = PretrainedConfig.get_config_dict(
-                    model,
-                    trust_remote_code=trust_remote_code,
-                    revision=revision,
-                    **kwargs,
-                )
-                model_type = config_dict.get("model_type")
-                if model_type in _CONFIG_REGISTRY:
-                    config = _CONFIG_REGISTRY[model_type].from_dict(config_dict)
-                    config._name_or_path = model
-                else:
-                    raise
+        config = AutoConfig.from_pretrained(
+            model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
+        )
 
     if (
         config.architectures is not None


### PR DESCRIPTION
Replaces the temp-folder hack that rewrote config.json with a registry-time alias, so AutoConfig / AutoTokenizer dispatch works natively.