### PR TITLE
[Fix] Handle nixlRemoteDisconnectError in NixlKVSender

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1077,7 +1077,7 @@ class NixlKVSender(CommonKVSender):
                 self.aux_index,
                 state_indices,
             )
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(
                 f"KVSender transfer request failed for room {self.bootstrap_room}: {e}"
             )
@@ -1098,7 +1098,7 @@ class NixlKVSender(CommonKVSender):
             return self.kv_mgr.check_status(self.bootstrap_room)
         try:
             states = [self.kv_mgr.agent.check_xfer_state(x) for x in self.xfer_handles]
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(
                 f"KVSender check_xfer_state failed for room {self.bootstrap_room}: {e}"
             )

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1108,6 +1108,10 @@ class NixlKVSender(CommonKVSender):
         if all(x == "DONE" for x in states):
             return KVPoll.Success  # type: ignore
         if any(x == "ERR" for x in states):
+            self._send_failed = True
+            self._send_error = RuntimeError(
+                f"NIXL transfer error for room {self.bootstrap_room}"
+            )
             return KVPoll.Failed  # type: ignore
         return KVPoll.WaitingForInput  # type: ignore
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1038,12 +1038,17 @@ class NixlKVSender(CommonKVSender):
         self.xfer_handles = []
         self.has_sent = False
         self.chunk_id = 0
+        self._send_failed = False
+        self._send_error: Optional[Exception] = None
 
     def send(
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List[int]] = None,
     ):
+        if self._send_failed:
+            return
+
         index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))
         self.curr_idx += len(kv_indices)
         is_last = self.curr_idx == self.num_kv_indices
@@ -1062,15 +1067,24 @@ class NixlKVSender(CommonKVSender):
                 self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
                 return
 
-        new_xfer_handles = self.kv_mgr.add_transfer_request(
-            self.bootstrap_room,
-            kv_indices,
-            index_slice,
-            is_last,
-            self.chunk_id,
-            self.aux_index,
-            state_indices,
-        )
+        try:
+            new_xfer_handles = self.kv_mgr.add_transfer_request(
+                self.bootstrap_room,
+                kv_indices,
+                index_slice,
+                is_last,
+                self.chunk_id,
+                self.aux_index,
+                state_indices,
+            )
+        except Exception as e:
+            logger.warning(
+                f"KVSender transfer request failed for room {self.bootstrap_room}: {e}"
+            )
+            self._send_failed = True
+            self._send_error = e
+            return
+
         self.xfer_handles.extend(new_xfer_handles)
         self.chunk_id += 1
         if is_last:
@@ -1078,16 +1092,26 @@ class NixlKVSender(CommonKVSender):
             del self.kv_mgr.request_status[self.bootstrap_room]
 
     def poll(self) -> KVPoll:
+        if self._send_failed:
+            return KVPoll.Failed  # type: ignore
         if not self.has_sent:
             return self.kv_mgr.check_status(self.bootstrap_room)
-        states = [self.kv_mgr.agent.check_xfer_state(x) for x in self.xfer_handles]
-        if all([x == "DONE" for x in states]):
+        try:
+            states = [self.kv_mgr.agent.check_xfer_state(x) for x in self.xfer_handles]
+        except Exception as e:
+            logger.warning(
+                f"KVSender check_xfer_state failed for room {self.bootstrap_room}: {e}"
+            )
+            return KVPoll.Failed  # type: ignore
+        if all(x == "DONE" for x in states):
             return KVPoll.Success  # type: ignore
-        if any([x == "ERR" for x in states]):
-            raise Exception("KVSender transfer encountered an error.")
+        if any(x == "ERR" for x in states):
+            return KVPoll.Failed  # type: ignore
         return KVPoll.WaitingForInput  # type: ignore
 
     def failure_exception(self):
+        if self._send_error is not None:
+            raise self._send_error
         raise RuntimeError("NIXL KVSender Exception")
 
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -27,6 +27,21 @@ from sglang.srt.disaggregation.utils import (
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 
+try:
+    from nixl._bindings import (
+        nixlBackendError,
+        nixlCancelledError,
+        nixlRemoteDisconnectError,
+    )
+
+    _NIXL_TRANSPORT_ERRORS = (
+        nixlRemoteDisconnectError,
+        nixlBackendError,
+        nixlCancelledError,
+    )
+except ImportError:
+    _NIXL_TRANSPORT_ERRORS = (RuntimeError,)
+
 logger = logging.getLogger(__name__)
 
 GUARD = "NixlMsgGuard".encode("ascii")
@@ -1077,7 +1092,7 @@ class NixlKVSender(CommonKVSender):
                 self.aux_index,
                 state_indices,
             )
-        except RuntimeError as e:
+        except _NIXL_TRANSPORT_ERRORS as e:
             logger.warning(
                 f"KVSender transfer request failed for room {self.bootstrap_room}: {e}"
             )
@@ -1098,7 +1113,7 @@ class NixlKVSender(CommonKVSender):
             return self.kv_mgr.check_status(self.bootstrap_room)
         try:
             states = [self.kv_mgr.agent.check_xfer_state(x) for x in self.xfer_handles]
-        except RuntimeError as e:
+        except _NIXL_TRANSPORT_ERRORS as e:
             logger.warning(
                 f"KVSender check_xfer_state failed for room {self.bootstrap_room}: {e}"
             )

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1102,6 +1102,8 @@ class NixlKVSender(CommonKVSender):
             logger.warning(
                 f"KVSender check_xfer_state failed for room {self.bootstrap_room}: {e}"
             )
+            self._send_failed = True
+            self._send_error = e
             return KVPoll.Failed  # type: ignore
         if all(x == "DONE" for x in states):
             return KVPoll.Success  # type: ignore


### PR DESCRIPTION
## The problem

`nixlRemoteDisconnectError` is raised by the NIXL library when the remote RDMA peer disconnects. It maps from UCX errors: `UCS_ERR_NOT_CONNECTED`, `UCS_ERR_CONNECTION_RESET`, `UCS_ERR_ENDPOINT_TIMEOUT`, `UCS_ERR_CANCELED`. Without this fix, any decode-side crash or network drop during KV transfer crashes the prefill scheduler.

## The fix

- Catch `nixlRemoteDisconnectError` (and other NIXL exceptions) in `NixlKVSender.send()` and `poll()`  so it is reflected as `KVPoll.Failed` 


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).