### PR TITLE
[codex] Optimize LTX2.3 HQ denoising split passes

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -1013,7 +1013,7 @@ class LTX2DenoisingStage(DenoisingStage):
         model_kwargs: dict[str, object],
         pass_spec: LTX2GuidancePassSpec,
     ) -> None:
-        """Apply one guidance pass's skips to one model-forward kwargs dict."""
+        """Copy disable-attention options from pass_spec into model_kwargs."""
         if pass_spec.skip_video_self_attn_blocks:
             model_kwargs["skip_video_self_attn_blocks"] = (
                 pass_spec.skip_video_self_attn_blocks
@@ -1487,12 +1487,17 @@ class LTX2DenoisingStage(DenoisingStage):
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
         )
-        # HQ uses split_sizes = [1] * expanded_batch_size below: each model
-        # forward receives one row from the expanded batch, and that row already
-        # represents a concrete guidance pass (cond/neg/perturbed/modality).
-        # Therefore kwargs-level skips match the native forward. TI2V batched
-        # forwards combine multiple guidance-pass rows, so they must keep
-        # per-row perturbation_configs; whole-forward kwargs would change output.
+        # expanded_batch_size = batch_size_local * len(pass_specs). One expanded
+        # item means one local batch element evaluated as cond, neg, perturbed,
+        # or modality. "Perturbation" means disabling selected attention paths
+        # for that item (self-attention blocks or audio/video cross-attention)
+        # to compute STG/modality guidance.
+        #
+        # HQ splits the expanded batch into one-item model calls. Since each
+        # call has only one perturbation setting, pass the disable options
+        # directly as model arguments. TI2V/non-HQ may keep several expanded
+        # items with different settings in one model call, so it needs
+        # perturbation_configs: one config dict per expanded item.
         use_split_pass_kwargs = (
             server_args.pipeline_class_name == "LTX2TwoStageHQPipeline"
         )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -366,8 +366,9 @@ class LTX2DenoisingStage(DenoisingStage):
         eta: float = 0.5,
         terminal: bool = False,
     ) -> torch.Tensor:
-        # Keep terminal checks as host-side booleans; branching on CUDA tensors
-        # here would add a synchronization point to every res2s step.
+        # The caller decides terminal steps from Python scalars before entering
+        # this helper. Keep that branch on host to avoid a CUDA bool sync in
+        # every res2s SDE update.
         if terminal:
             return denoised_sample.to(dtype=sample.dtype)
         alpha_ratio, sigma_down, sigma_up = cls._ltx2_get_sde_coeff(
@@ -984,6 +985,47 @@ class LTX2DenoisingStage(DenoisingStage):
             kwargs["perturbation_configs"] = perturbation_configs
         return kwargs
 
+    @staticmethod
+    def _ltx2_guidance_perturbation_config(
+        pass_spec: LTX2GuidancePassSpec,
+    ) -> dict[str, object]:
+        return {
+            "skip_video_self_attn_blocks": pass_spec.skip_video_self_attn_blocks,
+            "skip_audio_self_attn_blocks": pass_spec.skip_audio_self_attn_blocks,
+            "skip_a2v_cross_attn": pass_spec.disable_a2v_cross_attn,
+            "skip_v2a_cross_attn": pass_spec.disable_v2a_cross_attn,
+        }
+
+    @classmethod
+    def _build_ltx2_guidance_perturbation_configs(
+        cls,
+        pass_specs: list[LTX2GuidancePassSpec],
+        batch_size: int,
+    ) -> tuple[dict[str, object], ...]:
+        return tuple(
+            cls._ltx2_guidance_perturbation_config(pass_spec)
+            for pass_spec in pass_specs
+            for _ in range(batch_size)
+        )
+
+    @staticmethod
+    def _apply_ltx2_guidance_pass_kwargs(
+        model_kwargs: dict[str, object],
+        pass_spec: LTX2GuidancePassSpec,
+    ) -> None:
+        if pass_spec.skip_video_self_attn_blocks:
+            model_kwargs["skip_video_self_attn_blocks"] = (
+                pass_spec.skip_video_self_attn_blocks
+            )
+        if pass_spec.skip_audio_self_attn_blocks:
+            model_kwargs["skip_audio_self_attn_blocks"] = (
+                pass_spec.skip_audio_self_attn_blocks
+            )
+        if pass_spec.disable_a2v_cross_attn:
+            model_kwargs["disable_a2v_cross_attn"] = True
+        if pass_spec.disable_v2a_cross_attn:
+            model_kwargs["disable_v2a_cross_attn"] = True
+
     @classmethod
     def _repeat_ltx2_model_kwargs_batch(
         cls,
@@ -1444,8 +1486,11 @@ class LTX2DenoisingStage(DenoisingStage):
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
         )
-        # HQ split chunks are whole guidance passes, so kwargs-level skips match
-        # native forwards. TI2V keeps per-sample masks to preserve accuracy.
+        # In HQ, each split chunk is one guidance pass for one sample, so
+        # pass-level skips as kwargs match native single-pass forwards and avoid
+        # per-sample masks. TI2V still relies on per-sample masks inside the
+        # batched forward; replacing them with whole-forward kwargs changes
+        # output accuracy.
         use_split_pass_kwargs = (
             server_args.pipeline_class_name == "LTX2TwoStageHQPipeline"
         )
@@ -1628,18 +1673,13 @@ class LTX2DenoisingStage(DenoisingStage):
                             for pass_spec in pass_specs
                             for _ in range(batch_size_local)
                         )
-                        split_perturbation_configs = ()
-                        if not use_split_pass_kwargs:
-                            split_perturbation_configs = tuple(
-                                {
-                                    "skip_video_self_attn_blocks": pass_spec.skip_video_self_attn_blocks,
-                                    "skip_audio_self_attn_blocks": pass_spec.skip_audio_self_attn_blocks,
-                                    "skip_a2v_cross_attn": pass_spec.disable_a2v_cross_attn,
-                                    "skip_v2a_cross_attn": pass_spec.disable_v2a_cross_attn,
-                                }
-                                for pass_spec in pass_specs
-                                for _ in range(batch_size_local)
+                        split_perturbation_configs = (
+                            ()
+                            if use_split_pass_kwargs
+                            else self._build_ltx2_guidance_perturbation_configs(
+                                pass_specs, batch_size_local
                             )
+                        )
                         batched_video_chunks = []
                         batched_audio_chunks = []
                         with self._ltx2_model_forward_context(ctx, step):
@@ -1653,22 +1693,9 @@ class LTX2DenoisingStage(DenoisingStage):
                                 )
                             ):
                                 if use_split_pass_kwargs:
-                                    if pass_spec.skip_video_self_attn_blocks:
-                                        model_kwargs_chunk[
-                                            "skip_video_self_attn_blocks"
-                                        ] = pass_spec.skip_video_self_attn_blocks
-                                    if pass_spec.skip_audio_self_attn_blocks:
-                                        model_kwargs_chunk[
-                                            "skip_audio_self_attn_blocks"
-                                        ] = pass_spec.skip_audio_self_attn_blocks
-                                    if pass_spec.disable_a2v_cross_attn:
-                                        model_kwargs_chunk[
-                                            "disable_a2v_cross_attn"
-                                        ] = True
-                                    if pass_spec.disable_v2a_cross_attn:
-                                        model_kwargs_chunk[
-                                            "disable_v2a_cross_attn"
-                                        ] = True
+                                    self._apply_ltx2_guidance_pass_kwargs(
+                                        model_kwargs_chunk, pass_spec
+                                    )
                                 else:
                                     model_kwargs_chunk["perturbation_configs"] = (
                                         split_perturbation_configs[index],
@@ -1682,15 +1709,10 @@ class LTX2DenoisingStage(DenoisingStage):
                         batched_video = torch.cat(batched_video_chunks, dim=0)
                         batched_audio = torch.cat(batched_audio_chunks, dim=0)
                     else:
-                        perturbation_configs = tuple(
-                            {
-                                "skip_video_self_attn_blocks": pass_spec.skip_video_self_attn_blocks,
-                                "skip_audio_self_attn_blocks": pass_spec.skip_audio_self_attn_blocks,
-                                "skip_a2v_cross_attn": pass_spec.disable_a2v_cross_attn,
-                                "skip_v2a_cross_attn": pass_spec.disable_v2a_cross_attn,
-                            }
-                            for pass_spec in pass_specs
-                            for _ in range(batch_size_local)
+                        perturbation_configs = (
+                            self._build_ltx2_guidance_perturbation_configs(
+                                pass_specs, batch_size_local
+                            )
                         )
                         with self._ltx2_model_forward_context(ctx, step):
                             batched_video, batched_audio = step.current_model(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -1487,15 +1487,16 @@ class LTX2DenoisingStage(DenoisingStage):
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
         )
-        # expanded_batch_size = batch_size_local * len(pass_specs). One expanded
-        # item means one local batch element evaluated as cond, neg, perturbed,
-        # or modality. "Perturbation" means disabling selected attention paths
+        # "Perturbation" means disabling selected attention paths
         # for that item (self-attention blocks or audio/video cross-attention)
         # to compute STG/modality guidance.
         #
-        # HQ splits the expanded batch into one-item model calls. Since each
+
+        # Decide whether to use different pass kwargs for split model calls
+        # 1. HQ splits the expanded batch into one-item model calls. Since each
         # call has only one perturbation setting, pass the disable options
-        # directly as model arguments. TI2V/non-HQ may keep several expanded
+        # directly as model arguments.
+        # 2. TI2V/non-HQ may keep several expanded
         # items with different settings in one model call, so it needs
         # perturbation_configs: one config dict per expanded item.
         use_split_pass_kwargs = (

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -364,13 +364,14 @@ class LTX2DenoisingStage(DenoisingStage):
         sigma_next: torch.Tensor,
         noise: torch.Tensor,
         eta: float = 0.5,
+        terminal: bool = False,
     ) -> torch.Tensor:
+        if terminal:
+            return denoised_sample.to(dtype=sample.dtype)
         alpha_ratio, sigma_down, sigma_up = cls._ltx2_get_sde_coeff(
             sigma_next,
             sigma_up=sigma_next * eta,
         )
-        if bool((sigma_up == 0).any()) or bool((sigma_next == 0).any()):
-            return denoised_sample.to(dtype=sample.dtype)
         eps_next = (sample - denoised_sample) / (sigma - sigma_next)
         denoised_next = sample - sigma * eps_next
         x_noised = (
@@ -446,6 +447,7 @@ class LTX2DenoisingStage(DenoisingStage):
             sigma=sigma_d,
             sigma_next=sub_sigma,
             noise=sub_noise_video,
+            terminal=False,
         )
         midpoint_audio_latents = self._ltx2_res2s_sde_step(
             sample=anchor_audio,
@@ -453,6 +455,7 @@ class LTX2DenoisingStage(DenoisingStage):
             sigma=sigma_d,
             sigma_next=sub_sigma,
             noise=sub_noise_audio,
+            terminal=False,
         )
         midpoint_video_latents = self._ltx2_apply_clean_latent_mask(
             midpoint_video_latents.to(dtype=ctx.latents.dtype), ctx
@@ -502,6 +505,7 @@ class LTX2DenoisingStage(DenoisingStage):
             sigma=sigma_d,
             sigma_next=sigma_next_d,
             noise=step_noise_video,
+            terminal=False,
         )
         next_audio = self._ltx2_res2s_sde_step(
             sample=anchor_audio,
@@ -509,6 +513,7 @@ class LTX2DenoisingStage(DenoisingStage):
             sigma=sigma_d,
             sigma_next=sigma_next_d,
             noise=step_noise_audio,
+            terminal=False,
         )
 
         next_video = self._ltx2_apply_clean_latent_mask(
@@ -1210,6 +1215,8 @@ class LTX2DenoisingStage(DenoisingStage):
             device=ctx.latents.device, dtype=torch.float32
         )
         dt = sigma_next - sigma
+        sigma_val = float(sigma.item())
+        sigma_next_val = float(sigma_next.item())
 
         stage1_guider_params = self._get_ltx2_stage1_guider_params(
             batch, server_args, ctx.stage
@@ -1435,6 +1442,9 @@ class LTX2DenoisingStage(DenoisingStage):
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
         )
+        use_split_pass_kwargs = (
+            server_args.pipeline_class_name == "LTX2TwoStageHQPipeline"
+        )
         skip_v2a_cross_attn_for_video_gt = bool(
             batch.extra.get("ltx2_skip_v2a_cross_attn_for_video_gt", False)
         )
@@ -1580,16 +1590,6 @@ class LTX2DenoisingStage(DenoisingStage):
 
                     num_passes = len(pass_specs)
                     expanded_batch_size = batch_size_local * num_passes
-                    perturbation_configs = tuple(
-                        {
-                            "skip_video_self_attn_blocks": pass_spec.skip_video_self_attn_blocks,
-                            "skip_audio_self_attn_blocks": pass_spec.skip_audio_self_attn_blocks,
-                            "skip_a2v_cross_attn": pass_spec.disable_a2v_cross_attn,
-                            "skip_v2a_cross_attn": pass_spec.disable_v2a_cross_attn,
-                        }
-                        for pass_spec in pass_specs
-                        for _ in range(batch_size_local)
-                    )
                     batched_model_kwargs = self._repeat_ltx2_model_kwargs_batch(
                         base_model_kwargs_local, expanded_batch_size
                     )
@@ -1619,19 +1619,56 @@ class LTX2DenoisingStage(DenoisingStage):
                     )
                     if use_split_stage1_guided_passes:
                         split_sizes = [1] * expanded_batch_size
+                        split_pass_specs = tuple(
+                            pass_spec
+                            for pass_spec in pass_specs
+                            for _ in range(batch_size_local)
+                        )
+                        split_perturbation_configs = ()
+                        if not use_split_pass_kwargs:
+                            split_perturbation_configs = tuple(
+                                {
+                                    "skip_video_self_attn_blocks": pass_spec.skip_video_self_attn_blocks,
+                                    "skip_audio_self_attn_blocks": pass_spec.skip_audio_self_attn_blocks,
+                                    "skip_a2v_cross_attn": pass_spec.disable_a2v_cross_attn,
+                                    "skip_v2a_cross_attn": pass_spec.disable_v2a_cross_attn,
+                                }
+                                for pass_spec in pass_specs
+                                for _ in range(batch_size_local)
+                            )
                         batched_video_chunks = []
                         batched_audio_chunks = []
                         with self._ltx2_model_forward_context(ctx, step):
-                            for model_kwargs_chunk, perturbation_config in zip(
-                                self._split_ltx2_model_kwargs(
-                                    batched_model_kwargs, split_sizes
-                                ),
-                                perturbation_configs,
-                                strict=True,
-                            ):
-                                model_kwargs_chunk["perturbation_configs"] = (
-                                    perturbation_config,
+                            for index, (model_kwargs_chunk, pass_spec) in enumerate(
+                                zip(
+                                    self._split_ltx2_model_kwargs(
+                                        batched_model_kwargs, split_sizes
+                                    ),
+                                    split_pass_specs,
+                                    strict=True,
                                 )
+                            ):
+                                if use_split_pass_kwargs:
+                                    if pass_spec.skip_video_self_attn_blocks:
+                                        model_kwargs_chunk[
+                                            "skip_video_self_attn_blocks"
+                                        ] = pass_spec.skip_video_self_attn_blocks
+                                    if pass_spec.skip_audio_self_attn_blocks:
+                                        model_kwargs_chunk[
+                                            "skip_audio_self_attn_blocks"
+                                        ] = pass_spec.skip_audio_self_attn_blocks
+                                    if pass_spec.disable_a2v_cross_attn:
+                                        model_kwargs_chunk[
+                                            "disable_a2v_cross_attn"
+                                        ] = True
+                                    if pass_spec.disable_v2a_cross_attn:
+                                        model_kwargs_chunk[
+                                            "disable_v2a_cross_attn"
+                                        ] = True
+                                else:
+                                    model_kwargs_chunk["perturbation_configs"] = (
+                                        split_perturbation_configs[index],
+                                    )
                                 video_chunk, audio_chunk = step.current_model(
                                     **model_kwargs_chunk
                                 )
@@ -1641,6 +1678,16 @@ class LTX2DenoisingStage(DenoisingStage):
                         batched_video = torch.cat(batched_video_chunks, dim=0)
                         batched_audio = torch.cat(batched_audio_chunks, dim=0)
                     else:
+                        perturbation_configs = tuple(
+                            {
+                                "skip_video_self_attn_blocks": pass_spec.skip_video_self_attn_blocks,
+                                "skip_audio_self_attn_blocks": pass_spec.skip_audio_self_attn_blocks,
+                                "skip_a2v_cross_attn": pass_spec.disable_a2v_cross_attn,
+                                "skip_v2a_cross_attn": pass_spec.disable_v2a_cross_attn,
+                            }
+                            for pass_spec in pass_specs
+                            for _ in range(batch_size_local)
+                        )
                         with self._ltx2_model_forward_context(ctx, step):
                             batched_video, batched_audio = step.current_model(
                                 **batched_model_kwargs,
@@ -1772,7 +1819,6 @@ class LTX2DenoisingStage(DenoisingStage):
                 ctx.latents = original_video_latents
                 ctx.audio_latents = original_audio_latents
 
-        sigma_val = float(sigma.item())
         denoised_video, denoised_audio = evaluate_stage1_guided_x0(
             video_latents=ctx.latents,
             audio_latents=ctx.audio_latents,
@@ -1781,7 +1827,7 @@ class LTX2DenoisingStage(DenoisingStage):
         )
 
         if self.sampler_name == "res2s":
-            if sigma_val == 0.0 or float(sigma_next.item()) == 0.0:
+            if sigma_val == 0.0 or sigma_next_val == 0.0:
                 next_video_latents = denoised_video.to(dtype=ctx.latents.dtype)
                 next_audio_latents = denoised_audio.to(dtype=ctx.audio_latents.dtype)
             else:
@@ -1822,6 +1868,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     sigma=sigma_d,
                     sigma_next=sub_sigma,
                     noise=substep_video_noise,
+                    terminal=False,
                 )
                 midpoint_audio_latents = self._ltx2_res2s_sde_step(
                     sample=anchor_audio,
@@ -1829,6 +1876,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     sigma=sigma_d,
                     sigma_next=sub_sigma,
                     noise=substep_audio_noise,
+                    terminal=False,
                 )
 
                 midpoint_video_latents = self._ltx2_apply_clean_latent_mask(
@@ -1888,6 +1936,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     sigma=sigma_d,
                     sigma_next=sigma_next_d,
                     noise=step_video_noise,
+                    terminal=False,
                 )
                 next_audio_latents = self._ltx2_res2s_sde_step(
                     sample=anchor_audio,
@@ -1895,6 +1944,7 @@ class LTX2DenoisingStage(DenoisingStage):
                     sigma=sigma_d,
                     sigma_next=sigma_next_d,
                     noise=step_audio_noise,
+                    terminal=False,
                 )
 
                 next_video_latents = self._ltx2_apply_clean_latent_mask(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -366,6 +366,8 @@ class LTX2DenoisingStage(DenoisingStage):
         eta: float = 0.5,
         terminal: bool = False,
     ) -> torch.Tensor:
+        # Keep terminal checks as host-side booleans; branching on CUDA tensors
+        # here would add a synchronization point to every res2s step.
         if terminal:
             return denoised_sample.to(dtype=sample.dtype)
         alpha_ratio, sigma_down, sigma_up = cls._ltx2_get_sde_coeff(
@@ -1442,6 +1444,8 @@ class LTX2DenoisingStage(DenoisingStage):
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
         )
+        # HQ split chunks are whole guidance passes, so kwargs-level skips match
+        # native forwards. TI2V keeps per-sample masks to preserve accuracy.
         use_split_pass_kwargs = (
             server_args.pipeline_class_name == "LTX2TwoStageHQPipeline"
         )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/ltx_2_denoising.py
@@ -1013,6 +1013,7 @@ class LTX2DenoisingStage(DenoisingStage):
         model_kwargs: dict[str, object],
         pass_spec: LTX2GuidancePassSpec,
     ) -> None:
+        """Apply one guidance pass's skips to one model-forward kwargs dict."""
         if pass_spec.skip_video_self_attn_blocks:
             model_kwargs["skip_video_self_attn_blocks"] = (
                 pass_spec.skip_video_self_attn_blocks
@@ -1486,11 +1487,12 @@ class LTX2DenoisingStage(DenoisingStage):
                 and int(getattr(batch, "ltx2_num_image_tokens", 0)) > 0
             )
         )
-        # In HQ, each split chunk is one guidance pass for one sample, so
-        # pass-level skips as kwargs match native single-pass forwards and avoid
-        # per-sample masks. TI2V still relies on per-sample masks inside the
-        # batched forward; replacing them with whole-forward kwargs changes
-        # output accuracy.
+        # HQ uses split_sizes = [1] * expanded_batch_size below: each model
+        # forward receives one row from the expanded batch, and that row already
+        # represents a concrete guidance pass (cond/neg/perturbed/modality).
+        # Therefore kwargs-level skips match the native forward. TI2V batched
+        # forwards combine multiple guidance-pass rows, so they must keep
+        # per-row perturbation_configs; whole-forward kwargs would change output.
         use_split_pass_kwargs = (
             server_args.pipeline_class_name == "LTX2TwoStageHQPipeline"
         )


### PR DESCRIPTION
## Summary

- Optimize LTX2.3 HQ guided denoising by passing disable-attention options directly to the model when each forward contains only one expanded-batch item.
- Avoid an internal CUDA bool sync in the res2s SDE terminal path.
- Keep TI2V/non-HQ on `perturbation_configs`, which stores one disable-attention config per expanded-batch item; changing this path previously affected accuracy.

## Motivation

`pass_specs` defines the denoising results we need from the model: `cond`, `neg`, optional `perturbed`, and optional `modality`. The code builds an expanded batch of size `batch_size_local * len(pass_specs)`. Each expanded-batch item is one local batch element evaluated under one of those pass specs.

A perturbation config tells the transformer which attention paths to disable for one expanded-batch item: selected video/audio self-attention blocks and A2V/V2A cross-attention. The perturbed and modality results use those disabled attention paths for STG/modality guidance.

In the HQ path, `_split_ltx2_model_kwargs(..., [1] * expanded_batch_size)` makes one model call per expanded-batch item. Because that call has only one perturbation config, we can pass the disable-attention options directly as normal model arguments and avoid the per-item config list.

In TI2V/non-HQ, one model call may contain multiple expanded-batch items with different perturbation configs. That path must keep `perturbation_configs`, one config per item; otherwise the model would apply one setting to the whole call and change the output.

## Performance

Benchmark: H100 80GB, snapshot mode, `ltx_2_3_hq_pipeline`, parent `28238d5b1` vs optimized validation commit `aeea82a08f`.

| Metric | Parent | Optimized | Delta |
| --- | ---: | ---: | ---: |
| `LTX2AVDenoisingStage` | 10054.60 ms | 9737.69 ms | +3.15% |
| Avg denoise step | 601.32 ms | 582.47 ms | +3.13% |
| Median denoise step | 636.53 ms | 617.63 ms | +2.97% |
| E2E baseline dump | 15468.94 ms | 15192.81 ms | +1.78% |

## Validation

- `ltx_2_3_hq_pipeline` consistency passed: min clip `0.8043`, min SSIM `0.4844`, min PSNR `12.1561`, max mean abs diff `46.4682`.
- Full pytest still fails only the unrelated `LTX2AVDecodingStage` perf threshold (`actual 1474 ms`, threshold `1053 ms`); this PR does not touch decode.
- 2-GPU two-stage TI2V comparison: optimized and parent both fail consistency with identical metrics (`clip 0.8993`, `SSIM 0.5444`, `PSNR 16.8427`, `mean_abs_diff 21.9915`), so this is not a new regression from the patch.
