### PR TITLE
Lazy-load sglang.srt.configs via PEP-562 __getattr__

### DIFF
--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -1,72 +1,75 @@
-from sglang.srt.configs.afmoe import AfmoeConfig
-from sglang.srt.configs.bailing_hybrid import BailingHybridConfig
-from sglang.srt.configs.chatglm import ChatGLMConfig
-from sglang.srt.configs.dbrx import DbrxConfig
-from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
-from sglang.srt.configs.dots_ocr import DotsOCRConfig
-from sglang.srt.configs.dots_vlm import DotsVLMConfig
-from sglang.srt.configs.exaone import ExaoneConfig
-from sglang.srt.configs.falcon_h1 import FalconH1Config
-from sglang.srt.configs.granitemoehybrid import GraniteMoeHybridConfig
-from sglang.srt.configs.janus_pro import MultiModalityConfig
-from sglang.srt.configs.jet_nemotron import JetNemotronConfig
-from sglang.srt.configs.jet_vlm import JetVLMConfig
-from sglang.srt.configs.kimi_k25 import KimiK25Config
-from sglang.srt.configs.kimi_linear import KimiLinearConfig
-from sglang.srt.configs.kimi_vl import KimiVLConfig
-from sglang.srt.configs.kimi_vl_moonvit import MoonViTConfig
-from sglang.srt.configs.lfm2 import Lfm2Config
-from sglang.srt.configs.lfm2_moe import Lfm2MoeConfig
-from sglang.srt.configs.lfm2_vl import Lfm2VlConfig
-from sglang.srt.configs.longcat_flash import LongcatFlashConfig
-from sglang.srt.configs.nano_nemotron_vl import (
-    NemotronH_Nano_Omni_Reasoning_V3_Config,
-    NemotronH_Nano_VL_V2_Config,
-)
-from sglang.srt.configs.nemotron_h import NemotronHConfig
-from sglang.srt.configs.olmo3 import Olmo3Config
-from sglang.srt.configs.qwen3_5 import Qwen3_5Config, Qwen3_5MoeConfig
-from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig
-from sglang.srt.configs.qwen3_next import Qwen3NextConfig
-from sglang.srt.configs.step3_vl import (
-    Step3TextConfig,
-    Step3VisionEncoderConfig,
-    Step3VLConfig,
-)
-from sglang.srt.configs.step3p5 import Step3p5Config
+"""Lazy re-exports for sglang.srt.configs.
 
-__all__ = [
-    "AfmoeConfig",
-    "BailingHybridConfig",
-    "ExaoneConfig",
-    "ChatGLMConfig",
-    "DbrxConfig",
-    "DeepseekVL2Config",
-    "LongcatFlashConfig",
-    "MultiModalityConfig",
-    "KimiVLConfig",
-    "MoonViTConfig",
-    "Step3VLConfig",
-    "Step3TextConfig",
-    "Step3VisionEncoderConfig",
-    "Olmo3Config",
-    "KimiLinearConfig",
-    "KimiK25Config",
-    "Qwen3NextConfig",
-    "Qwen3_5Config",
-    "Qwen3_5MoeConfig",
-    "DotsVLMConfig",
-    "DotsOCRConfig",
-    "FalconH1Config",
-    "GraniteMoeHybridConfig",
-    "Lfm2Config",
-    "Lfm2MoeConfig",
-    "Lfm2VlConfig",
-    "NemotronHConfig",
-    "NemotronH_Nano_VL_V2_Config",
-    "NemotronH_Nano_Omni_Reasoning_V3_Config",
-    "JetNemotronConfig",
-    "JetVLMConfig",
-    "Step3p5Config",
-    "Qwen3ASRConfig",
-]
+Previously this module eagerly imported 30+ model-specific config submodules
+at package-load time. Many of those drag transformers internals with them
+(e.g. ``sglang.srt.configs.bailing_hybrid`` and
+``sglang.srt.configs.deepseekvl2`` together account for ~9s of transformers
+eager loads). Since most callers only need one config, switch to PEP-562
+``__getattr__`` so submodules are loaded on first access.
+
+Existing code can still do ``from sglang.srt.configs import ChatGLMConfig``;
+only the touched submodule is loaded.
+"""
+
+from __future__ import annotations
+
+# Map of attribute name -> (submodule, attr) for lazy loading.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    "AfmoeConfig": ("afmoe", "AfmoeConfig"),
+    "BailingHybridConfig": ("bailing_hybrid", "BailingHybridConfig"),
+    "ChatGLMConfig": ("chatglm", "ChatGLMConfig"),
+    "DbrxConfig": ("dbrx", "DbrxConfig"),
+    "DeepseekVL2Config": ("deepseekvl2", "DeepseekVL2Config"),
+    "DotsOCRConfig": ("dots_ocr", "DotsOCRConfig"),
+    "DotsVLMConfig": ("dots_vlm", "DotsVLMConfig"),
+    "ExaoneConfig": ("exaone", "ExaoneConfig"),
+    "FalconH1Config": ("falcon_h1", "FalconH1Config"),
+    "GraniteMoeHybridConfig": ("granitemoehybrid", "GraniteMoeHybridConfig"),
+    "MultiModalityConfig": ("janus_pro", "MultiModalityConfig"),
+    "JetNemotronConfig": ("jet_nemotron", "JetNemotronConfig"),
+    "JetVLMConfig": ("jet_vlm", "JetVLMConfig"),
+    "KimiK25Config": ("kimi_k25", "KimiK25Config"),
+    "KimiLinearConfig": ("kimi_linear", "KimiLinearConfig"),
+    "KimiVLConfig": ("kimi_vl", "KimiVLConfig"),
+    "MoonViTConfig": ("kimi_vl_moonvit", "MoonViTConfig"),
+    "Lfm2Config": ("lfm2", "Lfm2Config"),
+    "Lfm2MoeConfig": ("lfm2_moe", "Lfm2MoeConfig"),
+    "Lfm2VlConfig": ("lfm2_vl", "Lfm2VlConfig"),
+    "LongcatFlashConfig": ("longcat_flash", "LongcatFlashConfig"),
+    "NemotronH_Nano_Omni_Reasoning_V3_Config": (
+        "nano_nemotron_vl",
+        "NemotronH_Nano_Omni_Reasoning_V3_Config",
+    ),
+    "NemotronH_Nano_VL_V2_Config": (
+        "nano_nemotron_vl",
+        "NemotronH_Nano_VL_V2_Config",
+    ),
+    "NemotronHConfig": ("nemotron_h", "NemotronHConfig"),
+    "Olmo3Config": ("olmo3", "Olmo3Config"),
+    "Qwen3_5Config": ("qwen3_5", "Qwen3_5Config"),
+    "Qwen3_5MoeConfig": ("qwen3_5", "Qwen3_5MoeConfig"),
+    "Qwen3ASRConfig": ("qwen3_asr", "Qwen3ASRConfig"),
+    "Qwen3NextConfig": ("qwen3_next", "Qwen3NextConfig"),
+    "Step3TextConfig": ("step3_vl", "Step3TextConfig"),
+    "Step3VisionEncoderConfig": ("step3_vl", "Step3VisionEncoderConfig"),
+    "Step3VLConfig": ("step3_vl", "Step3VLConfig"),
+    "Step3p5Config": ("step3p5", "Step3p5Config"),
+}
+
+__all__ = sorted(_LAZY_ATTRS.keys())
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_ATTRS:
+        raise AttributeError(f"module 'sglang.srt.configs' has no attribute {name!r}")
+    submodule_name, attr_name = _LAZY_ATTRS[name]
+    import importlib
+
+    module = importlib.import_module(f"sglang.srt.configs.{submodule_name}")
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__) | set(globals().keys()))


### PR DESCRIPTION
## Motivation

\`sglang/srt/configs/__init__.py\` eagerly imports 30+ model-specific config submodules at package-load time. Many of those drag heavy transformers internals with them:

- \`bailing_hybrid\`: ~4.75s
- \`deepseekvl2\` -> \`transformers.utils\`: ~4.5s

A caller that only needs one config — for example \`from sglang.srt.configs.mamba_utils import BaseLinearStateParams\` — still pays the full ~9s cumulative cost because Python loads the package's \`__init__.py\` before any submodule.

This is a meaningful chunk of \`from sglang.private.launch_server import ...\` latency (~25s total) on TML deployments. Profiling with \`python -X importtime\` showed \`sglang.srt.configs\` at 9.35s self+children, with \`sglang.srt.configs.bailing_hybrid\` and \`sglang.srt.configs.deepseekvl2\` accounting for most of it.

## Modification

Replace the eager imports with a \`_LAZY_ATTRS\` map and PEP-562 \`__getattr__\`. \`from sglang.srt.configs import ChatGLMConfig\` continues to work; it now only loads the \`chatglm\` submodule on first access. Direct submodule imports (\`from sglang.srt.configs.X import Y\`) skip the package init's eager loads entirely.

\`__all__\` is preserved (alphabetized for stability). \`__dir__\` is added so IDE autocomplete still discovers the lazy attrs.

## Smoke test

\`\`\`python
import time
t = time.time()
from sglang.srt.configs import ChatGLMConfig
print(f'ChatGLMConfig: {time.time()-t:.2f}s')
# Before: dragged in all 30 configs + their transformers internals.
# After: only loads sglang.srt.configs.chatglm.
\`\`\`

## Checklist

- [x] No public API surface change.
- [x] \`__all__\` preserved.
- [x] PEP-562 \`__getattr__\` (Python 3.7+).