### PR TITLE
Add `trtllm` custom AR backend

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/trtllm_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/trtllm_all_reduce.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.utils import is_cuda
+
+logger = logging.getLogger(__name__)
+
+_is_cuda = is_cuda()
+
+
+class TRTLLMAllReduce:
+    """All-reduce backend that dispatches to flashinfer's TRT-LLM
+    ``allreduce_fusion(pattern=kAllReduce)``.
+
+    The communicator owns its own flashinfer workspace, so the same
+    ``GroupCoordinator`` that runs AR+RMSNorm fusion (managed in
+    ``flashinfer_comm_fusion.py``) does not have to share buffers with
+    standalone AR.
+
+    Lifecycle:
+      - ``__init__`` records the group and device but does not allocate
+        IPC buffers.
+      - ``initialize_workspace`` must run once *before* CUDA graph capture.
+        Failure on any rank is broadcast via the cpu_group so all ranks
+        agree to disable; a divergent decision would hang graph capture.
+      - ``should_trtllm_ar`` is the runtime predicate (token-count, dtype,
+        contiguity, hidden_dim match).
+      - ``trtllm_all_reduce`` runs the kernel out-of-place and returns the
+        output tensor.
+    """
+
+    _SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+
+    def __init__(
+        self,
+        cpu_group: ProcessGroup,
+        device_group: Optional[ProcessGroup],
+        device: Union[int, str, torch.device],
+    ) -> None:
+        self.disabled = True
+        self._workspace_manager = None
+        self._flashinfer_comm = None
+
+        if not _is_cuda:
+            return
+
+        try:
+            from sglang.srt.layers.flashinfer_comm_fusion import (
+                FlashInferWorkspaceManager,
+                _flashinfer_comm,
+                is_flashinfer_allreduce_unavailable,
+            )
+        except Exception as e:
+            logger.debug("TRTLLMAllReduce disabled: flashinfer unavailable (%s)", e)
+            return
+
+        if _flashinfer_comm is None or is_flashinfer_allreduce_unavailable():
+            logger.debug(
+                "TRTLLMAllReduce disabled: flashinfer.comm fusion API unavailable"
+            )
+            return
+
+        try:
+            world_size = dist.get_world_size(group=cpu_group)
+            rank = dist.get_rank(group=cpu_group)
+        except Exception as e:
+            logger.warning("TRTLLMAllReduce disabled: %s", e)
+            return
+
+        if world_size <= 1:
+            return
+
+        if isinstance(device, int):
+            device = torch.device(f"cuda:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+
+        self._flashinfer_comm = _flashinfer_comm
+        self._workspace_manager = FlashInferWorkspaceManager()
+        self._cpu_group = cpu_group
+        self._device_group = device_group
+        self._device = device
+        self._world_size = world_size
+        self._rank = rank
+        self._max_token_num: Optional[int] = None
+        self._hidden_dim: Optional[int] = None
+        self._dtype: Optional[torch.dtype] = None
+        # Stays disabled until initialize_workspace succeeds on all ranks.
+
+    def initialize_workspace(
+        self,
+        max_token_num: int,
+        hidden_dim: int,
+        dtype: torch.dtype,
+        use_oneshot: Optional[bool] = None,
+    ) -> bool:
+        """Allocate the IPC workspace. Must run before CUDA graph capture.
+
+        Returns True iff the workspace is ready on all ranks.
+        """
+        if self._workspace_manager is None:
+            return False
+        if dtype not in self._SUPPORTED_DTYPES:
+            logger.debug("TRTLLMAllReduce: dtype %s not supported", dtype)
+            return self._sync_disable()
+
+        local_ok = False
+        try:
+            self._workspace_manager.initialize(
+                world_size=self._world_size,
+                rank=self._rank,
+                max_token_num=max_token_num,
+                hidden_dim=hidden_dim,
+                dtype=dtype,
+                use_oneshot=use_oneshot,
+                device_group=self._device_group,
+                cpu_group=self._cpu_group,
+            )
+            local_ok = bool(self._workspace_manager.initialized)
+        except Exception as e:
+            logger.warning("TRTLLMAllReduce workspace init failed: %s", e)
+            local_ok = False
+
+        # Sync across cpu_group: if any rank failed, all disable.
+        try:
+            flag = torch.tensor([0 if local_ok else 1], dtype=torch.int32)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX, group=self._cpu_group)
+            global_ok = local_ok and flag.item() == 0
+        except Exception as e:
+            logger.warning("TRTLLMAllReduce availability sync failed: %s", e)
+            global_ok = False
+
+        if not global_ok:
+            try:
+                self._workspace_manager.cleanup()
+            except Exception:
+                pass
+            self.disabled = True
+            return False
+
+        self._max_token_num = max_token_num
+        self._hidden_dim = hidden_dim
+        self._dtype = dtype
+        self.disabled = False
+        logger.info(
+            "TRTLLMAllReduce ready (rank=%d world_size=%d hidden_dim=%d "
+            "max_token_num=%d dtype=%s)",
+            self._rank,
+            self._world_size,
+            hidden_dim,
+            max_token_num,
+            dtype,
+        )
+        return True
+
+    def _sync_disable(self) -> bool:
+        try:
+            flag = torch.tensor([1], dtype=torch.int32)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX, group=self._cpu_group)
+        except Exception:
+            pass
+        self.disabled = True
+        return False
+
+    def should_trtllm_ar(self, inp: torch.Tensor) -> bool:
+        if self.disabled:
+            return False
+        if inp.device.type != "cuda":
+            return False
+        if inp.dtype != self._dtype:
+            return False
+        if not inp.is_contiguous():
+            return False
+        if inp.dim() < 1 or inp.shape[-1] != self._hidden_dim:
+            return False
+        token_num = inp.numel() // inp.shape[-1]
+        if token_num <= 0 or token_num > self._max_token_num:
+            return False
+        return True
+
+    def trtllm_all_reduce(self, inp: torch.Tensor) -> torch.Tensor:
+        """Out-of-place TRT-LLM AR. Caller must have passed should_trtllm_ar."""
+        from flashinfer.comm import AllReduceFusionPattern
+
+        token_num = inp.numel() // inp.shape[-1]
+        out = torch.empty_like(inp)
+        inp_2d = inp.view(token_num, inp.shape[-1])
+        out_2d = out.view(token_num, inp.shape[-1])
+        self._flashinfer_comm.allreduce_fusion(
+            input=inp_2d,
+            workspace=self._workspace_manager.workspace,
+            pattern=AllReduceFusionPattern.kAllReduce,
+            launch_with_pdl=True,
+            output=out_2d,
+            fp32_acc=True,
+        )
+        return out
+
+    def close(self) -> None:
+        if self._workspace_manager is not None:
+            try:
+                self._workspace_manager.cleanup()
+            except Exception:
+                pass
+        self.disabled = True
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/python/sglang/srt/distributed/device_communicators/trtllm_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/trtllm_all_reduce.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -40,8 +39,8 @@ class TRTLLMAllReduce:
     def __init__(
         self,
         cpu_group: ProcessGroup,
-        device_group: Optional[ProcessGroup],
-        device: Union[int, str, torch.device],
+        device_group: ProcessGroup | None,
+        device: int | str | torch.device,
     ) -> None:
         self.disabled = True
         self._workspace_manager = None
@@ -88,9 +87,9 @@ class TRTLLMAllReduce:
         self._device = device
         self._world_size = world_size
         self._rank = rank
-        self._max_token_num: Optional[int] = None
-        self._hidden_dim: Optional[int] = None
-        self._dtype: Optional[torch.dtype] = None
+        self._max_token_num: int | None = None
+        self._hidden_dim: int | None = None
+        self._dtype: torch.dtype | None = None
         # Stays disabled until initialize_workspace succeeds on all ranks.
 
     def initialize_workspace(
@@ -98,7 +97,7 @@ class TRTLLMAllReduce:
         max_token_num: int,
         hidden_dim: int,
         dtype: torch.dtype,
-        use_oneshot: Optional[bool] = None,
+        use_oneshot: bool | None = None,
     ) -> bool:
         """Allocate the IPC workspace. Must run before CUDA graph capture.
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -226,6 +226,7 @@ class GroupCoordinator:
     use_torch_symm_mem_all_reduce: (
         bool  # a hint of whether to use TorchSymmMemAllReduce
     )
+    use_trtllm_all_reduce: bool  # a hint of whether to use TRTLLMAllReduce
     use_message_queue_broadcaster: (
         bool  # a hint of whether to use message queue broadcaster
     )
@@ -233,6 +234,7 @@ class GroupCoordinator:
     pynccl_comm: Optional[Any]  # PyNccl communicator
     ca_comm: Optional[Any]  # Custom allreduce communicator
     torch_symm_mem_comm: Optional[Any]  # Torch symm mem communicator
+    trtllm_comm: Optional[Any]  # TRTLLM allreduce communicator
     mq_broadcaster: Optional[Any]  # shared memory broadcaster
 
     def __init__(
@@ -247,6 +249,7 @@ class GroupCoordinator:
         use_hpu_communicator: bool,
         use_xpu_communicator: bool,
         use_npu_communicator: bool,
+        use_trtllm_all_reduce: bool = False,
         use_message_queue_broadcaster: bool = False,
         group_name: Optional[str] = None,
         gloo_timeout: timedelta = timedelta(seconds=120 * 60),
@@ -328,6 +331,7 @@ class GroupCoordinator:
         self.use_pymscclpp = use_pymscclpp
         self.use_custom_allreduce = use_custom_allreduce
         self.use_torch_symm_mem_all_reduce = use_torch_symm_mem_all_reduce
+        self.use_trtllm_all_reduce = use_trtllm_all_reduce
         self.use_hpu_communicator = use_hpu_communicator
         self.use_xpu_communicator = use_xpu_communicator
         self.use_npu_communicator = use_npu_communicator
@@ -414,6 +418,26 @@ class GroupCoordinator:
                 group=self.cpu_group,
                 device=self.device,
             )
+
+        self.trtllm_comm: Optional[Any] = None
+        if self.use_trtllm_all_reduce and self.world_size > 1:
+            from sglang.srt.distributed.device_communicators.trtllm_all_reduce import (
+                TRTLLMAllReduce,
+            )
+
+            try:
+                self.trtllm_comm = TRTLLMAllReduce(
+                    cpu_group=self.cpu_group,
+                    device_group=self.device_group,
+                    device=self.device,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Setup TRTLLMAllReduce failed with %s; falling back to "
+                    "the standard AR backend chain.",
+                    e,
+                )
+                self.trtllm_comm = None
 
         # Create communicator for other hardware backends
         from sglang.srt.distributed.device_communicators.hpu_communicator import (
@@ -597,6 +621,12 @@ class GroupCoordinator:
 
         outplace_all_reduce_method = None
         if (
+            self.trtllm_comm is not None
+            and not self.trtllm_comm.disabled
+            and self.trtllm_comm.should_trtllm_ar(input_)
+        ):
+            outplace_all_reduce_method = "trtllm"
+        elif (
             self.ca_comm is not None
             and not self.ca_comm.disabled
             and self.ca_comm.should_custom_ar(input_)
@@ -701,8 +731,21 @@ class GroupCoordinator:
         pymscclpp_comm = self.pymscclpp_comm
         torch_symm_mem_comm = self.torch_symm_mem_comm
         pynccl_comm = self.pynccl_comm
-        assert any([qr_comm, ca_comm, pymscclpp_comm, torch_symm_mem_comm, pynccl_comm])
-        if outplace_all_reduce_method == "ca":
+        trtllm_comm = self.trtllm_comm
+        assert any(
+            [
+                qr_comm,
+                ca_comm,
+                pymscclpp_comm,
+                torch_symm_mem_comm,
+                pynccl_comm,
+                trtllm_comm,
+            ]
+        )
+        if outplace_all_reduce_method == "trtllm":
+            assert not trtllm_comm.disabled
+            out = trtllm_comm.trtllm_all_reduce(input_)
+        elif outplace_all_reduce_method == "ca":
             assert not ca_comm.disabled
             out = ca_comm.custom_all_reduce(input_)
         elif outplace_all_reduce_method == "qr":
@@ -1388,6 +1431,12 @@ class GroupCoordinator:
             self.pynccl_comm = None
         if self.ca_comm is not None:
             self.ca_comm = None
+        if self.trtllm_comm is not None:
+            try:
+                self.trtllm_comm.close()
+            except Exception:
+                pass
+            self.trtllm_comm = None
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 
@@ -1414,6 +1463,7 @@ def init_world_group(
         use_hpu_communicator=False,
         use_xpu_communicator=False,
         use_npu_communicator=False,
+        use_trtllm_all_reduce=False,
         group_name="world",
         recovered_rank=recovered_rank,
     )
@@ -1429,6 +1479,7 @@ def init_model_parallel_group(
     group_name: Optional[str] = None,
     use_mscclpp_allreduce: Optional[bool] = None,
     use_torch_symm_mem_allreduce: Optional[bool] = None,
+    use_trtllm_allreduce: Optional[bool] = None,
     recovered_rank: bool = False,
 ) -> GroupCoordinator:
     if use_custom_allreduce is None:
@@ -1437,6 +1488,8 @@ def init_model_parallel_group(
         use_mscclpp_allreduce = _ENABLE_MSCCLPP_ALL_REDUCE
     if use_torch_symm_mem_allreduce is None:
         use_torch_symm_mem_allreduce = _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE
+    if use_trtllm_allreduce is None:
+        use_trtllm_allreduce = _ENABLE_TRTLLM_ALL_REDUCE
     return GroupCoordinator(
         group_ranks=group_ranks,
         local_rank=local_rank,
@@ -1449,6 +1502,7 @@ def init_model_parallel_group(
         use_pymscclpp=use_mscclpp_allreduce,
         use_custom_allreduce=use_custom_allreduce,
         use_torch_symm_mem_all_reduce=use_torch_symm_mem_allreduce,
+        use_trtllm_all_reduce=use_trtllm_allreduce,
         use_hpu_communicator=True,
         use_xpu_communicator=True,
         use_npu_communicator=True,
@@ -1576,6 +1630,7 @@ logger = logging.getLogger(__name__)
 _ENABLE_CUSTOM_ALL_REDUCE = True
 _ENABLE_MSCCLPP_ALL_REDUCE = False
 _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = False
+_ENABLE_TRTLLM_ALL_REDUCE = False
 
 
 def set_custom_all_reduce(enable: bool):
@@ -1591,6 +1646,11 @@ def set_mscclpp_all_reduce(enable: bool):
 def set_torch_symm_mem_all_reduce(enable: bool):
     global _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE
     _ENABLE_TORCH_SYMM_MEM_ALL_REDUCE = enable
+
+
+def set_trtllm_all_reduce(enable: bool):
+    global _ENABLE_TRTLLM_ALL_REDUCE
+    _ENABLE_TRTLLM_ALL_REDUCE = enable
 
 
 _DEVICE_TO_DISTRIBUTED_BACKEND = {

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -70,6 +70,7 @@ from sglang.srt.distributed import (
     set_custom_all_reduce,
     set_mscclpp_all_reduce,
     set_torch_symm_mem_all_reduce,
+    set_trtllm_all_reduce,
 )
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
@@ -1147,6 +1148,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         set_custom_all_reduce(not self.server_args.disable_custom_all_reduce)
         set_mscclpp_all_reduce(self.server_args.enable_mscclpp)
         set_torch_symm_mem_all_reduce(self.server_args.enable_torch_symm_mem)
+        set_trtllm_all_reduce(self.server_args.enable_trtllm_allreduce)
 
         if not self.is_draft_worker:
             if self.device == "cpu":
@@ -2362,19 +2364,35 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         (broadcasts, barriers) inside the graph capture context, which can
         deadlock with custom_all_reduce.register_graph_buffers.
         """
-        if not self.server_args.enable_flashinfer_allreduce_fusion:
+        if not (
+            self.server_args.enable_flashinfer_allreduce_fusion
+            or self.server_args.enable_trtllm_allreduce
+        ):
             return
 
         from sglang.srt.layers.communicator import FUSE_ALLREDUCE_MAX_BATCH_SIZE
-        from sglang.srt.layers.flashinfer_comm_fusion import (
-            pre_initialize_workspaces,
-        )
 
-        pre_initialize_workspaces(
-            max_token_num=FUSE_ALLREDUCE_MAX_BATCH_SIZE,
-            hidden_dim=self.model_config.hidden_size,
-            dtype=self.dtype,
-        )
+        if self.server_args.enable_flashinfer_allreduce_fusion:
+            from sglang.srt.layers.flashinfer_comm_fusion import (
+                pre_initialize_workspaces,
+            )
+
+            pre_initialize_workspaces(
+                max_token_num=FUSE_ALLREDUCE_MAX_BATCH_SIZE,
+                hidden_dim=self.model_config.hidden_size,
+                dtype=self.dtype,
+            )
+
+        if self.server_args.enable_trtllm_allreduce:
+            from sglang.srt.distributed import get_tp_group
+
+            tp_group = get_tp_group()
+            if tp_group.trtllm_comm is not None:
+                tp_group.trtllm_comm.initialize_workspace(
+                    max_token_num=FUSE_ALLREDUCE_MAX_BATCH_SIZE,
+                    hidden_dim=self.model_config.hidden_size,
+                    dtype=self.dtype,
+                )
 
     def _should_run_flashinfer_autotune(self) -> bool:
         """Check if flashinfer autotune should be run."""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -651,6 +651,7 @@ class ServerArgs:
     disable_custom_all_reduce: bool = False
     enable_mscclpp: bool = False
     enable_torch_symm_mem: bool = False
+    enable_trtllm_allreduce: bool = False
     pre_warm_nccl: bool = dataclasses.field(
         default_factory=lambda: is_hip()
     )  # Pre-warm NCCL/RCCL to reduce P99 TTFT cold-start latency (default: True for AMD/HIP, False for others)
@@ -6052,6 +6053,14 @@ class ServerArgs:
             "--enable-torch-symm-mem",
             action="store_true",
             help="Enable using torch symm mem for all-reduce kernel and fall back to NCCL. Only supports CUDA device SM90 and above. SM90 supports world size 4, 6, 8. SM100 supports world size 6, 8.",
+        )
+        parser.add_argument(
+            "--enable-trtllm-allreduce",
+            action="store_true",
+            help="Route TP all-reduce through flashinfer's TRT-LLM AR kernel "
+            "(allreduce_fusion(pattern=kAllReduce)). Pre-initializes an IPC "
+            "workspace before CUDA graph capture; falls back to the standard "
+            "AR backend chain when the input exceeds the workspace budget.",
         )
         parser.add_argument(
             "--pre-warm-nccl",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Not sure why `cross_device_reduce_2stage` of `sgl-kernel` allreduce will be extremely slow for input embedding when in TP mode (so no DP `lm_head`). First I thought it was a torch profiler bug (i.e, it has a mistake in measuring comm kernel), but it seem both Nsight also agree on it.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

When doing `embed_tokens → AR → first_norm`, use TRTLLM one instead.

## Accuracy Tests

Use FP32 acc like custom AR, no drop in accuracy.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

```
CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server \
  --model-path nvidia/GLM-5-NVFP4 \
  --tp 4 \
  --ep 4 \
  --trust-remote-code \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --quantization modelopt_fp4
```

```
python3 -m sglang.bench_one_batch_server \
  --model baseten-admin/glm-4.7-fp8-attn-fp4-mlp \
  --base-url http://localhost:30000 \
  --batch-size 16 \
  --input-len 16000 \
  --output-len 64 \
  --profile \
  --profile-activities CUDA_PROFILER \
  --profile-steps 10 \
  --show-report \
  --profile-by-stage \
  --profile-output-dir /sgl-workspace/sglang
```

## Before:
<img width="1277" height="798" alt="Screenshot 2026-05-03 at 8 23 10 AM" src="https://github.com/user-attachments/assets/dd3f7d16-6171-490f-a3bb-f0d90bae4f01" />


## After:
<img width="723" height="467" alt="Screenshot 2026-05-04 at 8 51 06 AM" src="https://github.com/user-attachments/assets/cc8061c9-b9b8-47bd-ae1a-00b140f257b6" />

# **Edit**: 
89.25 -> 89.90 TPS for BS = 1


