### PR TITLE
[diffusion] feat: support post-response component cleanup tasks

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/component_manager.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import lru_cache
 from typing import Mapping, MutableMapping, Protocol, Sequence, TypeVar
 
@@ -20,6 +20,7 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 _T = TypeVar("_T")
+PostResponseTask = tuple[str, Callable[[], None]]
 
 
 @dataclass(slots=True)
@@ -49,6 +50,9 @@ class ComponentUse:
     # Some components are intentionally kept ready between warmup and the first
     # real request to avoid measuring a cold H2D in the user-visible request.
     keep_ready_after_warmup: bool = False
+    # Finish this use after the response is sent. The scheduler waits for pending
+    # post-response tasks before executing the next request, avoiding module races.
+    finish_after_response: bool = False
 
 
 @dataclass(slots=True)
@@ -183,6 +187,7 @@ class ComponentResidencyManager:
             pipeline.component_residency_strategies
         )
         self._uses_seen: dict[str, ComponentUse] = {}
+        self._deferred_finish_uses: dict[str, tuple[ComponentUse, nn.Module]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -196,6 +201,7 @@ class ComponentResidencyManager:
             self._active_use = None
             self._active_use_module = None
             self._uses_seen.clear()
+            self._deferred_finish_uses.clear()
             self._prefetched_use_keys.clear()
         elif custom_strategies != self._custom_strategies:
             self.strategy_for.cache_clear()
@@ -233,6 +239,7 @@ class ComponentResidencyManager:
         self._current_use_index = -1
         self._prefetched_use_keys.clear()
         self._uses_seen.clear()
+        self._deferred_finish_uses.clear()
         if self.enabled:
             self._stage_uses_by_index = [
                 tuple(stage.component_uses(server_args, self.stage_name(stage)))
@@ -451,13 +458,24 @@ class ComponentResidencyManager:
                 module,
             )
             return
+        if use.finish_after_response:
+            self._trace(
+                "defer_finish",
+                use,
+                self.strategy_for(use.component_name, module),
+                module,
+                detail="post_response",
+            )
+            self._deferred_finish_uses[use.component_name] = (use, module)
+            return
         strategy = self.strategy_for(use.component_name, module)
         self._trace("finish", use, strategy, module)
         strategy.finish_use(module, use, self.state)
 
-    def finish_request(self) -> None:
+    def finish_request(self) -> list[PostResponseTask]:
+        post_response_tasks: list[PostResponseTask] = []
         if not self.enabled and not self._uses_seen and self._active_use is None:
-            return
+            return post_response_tasks
         # 1. Close the currently active sequential use.
         self.finish_active_use(prefetch_next=False)
         # 2. Pick components that should be ready for the next request.
@@ -489,11 +507,51 @@ class ComponentResidencyManager:
             if preferred and not self.state.batch_is_warmup:
                 self._trace("request_prefetch", use, strategy, module)
                 strategy.prepare_after_request(module, use, self.state)
+            elif use.finish_after_response and not self.state.batch_is_warmup:
+                deferred = self._deferred_finish_uses.pop(component_name, None)
+                deferred_use, deferred_module = deferred or (use, module)
+                self._trace(
+                    "request_defer_finish",
+                    deferred_use,
+                    strategy,
+                    deferred_module,
+                    detail="post_response",
+                )
+                post_response_tasks.append(
+                    self._make_finish_request_task(
+                        component_name,
+                        deferred_use,
+                        deferred_module,
+                        strategy,
+                        preferred=False,
+                    )
+                )
             else:
                 action = "request_resident" if preferred else "request_finish"
                 self._trace(action, use, strategy, module)
                 strategy.finish_request(module, use, self.state, preferred=preferred)
+        self._deferred_finish_uses.clear()
         self._trace("request_end")
+        return post_response_tasks
+
+    def _make_finish_request_task(
+        self,
+        component_name: str,
+        use: ComponentUse,
+        module: nn.Module,
+        strategy: ComponentResidencyStrategy,
+        *,
+        preferred: bool,
+    ) -> PostResponseTask:
+        state = replace(self.state)
+
+        def finish_component() -> None:
+            strategy.finish_request(module, use, state, preferred=preferred)
+
+        return (
+            f"component_residency.finish_request.{component_name}",
+            finish_component,
+        )
 
     def stage_name(self, stage: ComponentResidencyStage) -> str:
         return self._stage_names_by_id.get(id(stage), stage.__class__.__name__)

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -41,6 +41,9 @@ from sglang.multimodal_gen.runtime.managers.layerwise_offload import (
     OffloadableDiTMixin,
     iter_materialized_weights,
 )
+from sglang.multimodal_gen.runtime.managers.post_response_tasks import (
+    PostResponseTaskRunner,
+)
 from sglang.multimodal_gen.runtime.pipelines_core import (
     ComposedPipelineBase,
     LoRAPipeline,
@@ -105,6 +108,10 @@ class GPUWorker:
         # FIXME: should we use tcp as distribute init method?
         self.server_args = server_args
         self.pipeline: ComposedPipelineBase = None
+        self.post_response_task_runner = PostResponseTaskRunner(
+            f"sgl_diffusion_post_response_{rank}"
+        )
+        self._post_response_tasks: list[tuple[str, Callable[[], None]]] = []
 
         self.init_device_and_model()
         self.sp_group = get_sp_group()
@@ -329,7 +336,11 @@ class GPUWorker:
                     stack.enter_context(
                         trace_slice(item.trace_ctx, DiffStage.GPU_FORWARD)
                     )
-                result = forward_fn()
+                try:
+                    result = forward_fn()
+                finally:
+                    if not return_req:
+                        self._collect_pipeline_post_response_tasks()
 
             # disagg roles return raw Req so callers can keep and transfer intermediate tensors
             # before converting it to OutputBatch
@@ -397,6 +408,35 @@ class GPUWorker:
                 output_batch = OutputBatch()
             output_batch.error = f"Error executing {error_context}: {e}"
         return output_batch
+
+    def _collect_pipeline_post_response_tasks(self) -> None:
+        executor = getattr(self.pipeline, "executor", None)
+        if executor is None:
+            return
+        self._post_response_tasks.extend(executor.pop_post_response_tasks())
+
+    def submit_post_response_tasks(self) -> None:
+        tasks = self._post_response_tasks
+        self._post_response_tasks = []
+        for name, task in tasks:
+            self.post_response_task_runner.submit(
+                name,
+                self._wrap_post_response_task(task),
+            )
+
+    def wait_post_response_tasks(self) -> None:
+        self.post_response_task_runner.wait_pending()
+
+    def shutdown_post_response_tasks(self) -> None:
+        self.post_response_task_runner.shutdown()
+
+    def _wrap_post_response_task(self, task: Callable[[], None]) -> Callable[[], None]:
+        def run_task() -> None:
+            if current_platform.is_cuda():
+                torch.get_device_module().set_device(self.local_rank)
+            task()
+
+        return run_task
 
     def _forward_group(self, batch: list[Req]) -> OutputBatch:
         assert self.pipeline is not None

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -66,6 +66,14 @@ from sglang.srt.utils.network import NetworkAddress
 
 logger = init_logger(__name__)
 
+OFFLOAD_DISABLE_RECOMMENDATION_ORDER = (
+    "vae",
+    "image_encoder",
+    "text_encoder",
+    "text_encoder_2",
+    "transformer",
+)
+
 
 @dataclass
 class _ExpandedOutputParts:
@@ -192,25 +200,8 @@ class GPUWorker:
             current_platform.get_device_total_memory() / (1024**3) - peak_reserved_gb
         )
         can_stay_resident = self.get_can_stay_resident_components(remaining_gpu_mem_gb)
-        suggested_args = set()
-        component_to_arg = {
-            "vae": "--vae-cpu-offload",
-            "text_encoder": "--text-encoder-cpu-offload",
-            "text_encoder_2": "--text-encoder-cpu-offload",
-            "image_encoder": "--image-encoder-cpu-offload",
-        }
-
-        for component in can_stay_resident:
-            if component == "transformer":
-                if self.server_args.dit_layerwise_offload:
-                    suggested_args.add("--dit-layerwise-offload")
-                elif self.server_args.dit_cpu_offload:
-                    suggested_args.add("--dit-cpu-offload")
-            elif component in component_to_arg:
-                suggested_args.add(component_to_arg[component])
-
-        suggested_args_str = (
-            ", ".join(sorted(suggested_args)) if suggested_args else "None"
+        suggested_args_str = self._format_offload_disable_suggestions(
+            can_stay_resident
         )
 
         pool_overhead_gb = peak_reserved_gb - peak_allocated_gb
@@ -223,6 +214,34 @@ class GPUWorker:
             f"Components that could stay resident (based on the last request workload): {can_stay_resident}. "
             f"Related offload server args to disable: {suggested_args_str}"
         )
+
+    def _format_offload_disable_suggestions(self, components: List[str]) -> str:
+        component_set = set(components)
+        suggestions = []
+        seen_args = set()
+
+        for component in OFFLOAD_DISABLE_RECOMMENDATION_ORDER:
+            if component not in component_set:
+                continue
+
+            arg = None
+            if component == "vae":
+                arg = "--vae-cpu-offload"
+            elif component == "image_encoder":
+                arg = "--image-encoder-cpu-offload"
+            elif component in ("text_encoder", "text_encoder_2"):
+                arg = "--text-encoder-cpu-offload"
+            elif component == "transformer":
+                if self.server_args.dit_layerwise_offload:
+                    arg = "--dit-layerwise-offload"
+                elif self.server_args.dit_cpu_offload:
+                    arg = "--dit-cpu-offload"
+
+            if arg is not None and arg not in seen_args:
+                suggestions.append(arg)
+                seen_args.add(arg)
+
+        return ", ".join(suggestions) if suggestions else "None"
 
     def execute_forward(
         self, batch: List[Req], return_req: bool = False
@@ -613,9 +632,9 @@ class GPUWorker:
         if not self.pipeline:
             return can_stay_resident
 
-        # Map memory_usage keys to server_args offload flags
-        # If the flag is False, the component is ALREADY resident, so we don't suggest it.
-        # If the flag is True, it is currently offloaded, so it's a candidate to "stay resident".
+        # Map memory_usage keys to server_args offload flags.
+        # If the flag is False, the component is already resident, so we do not suggest it.
+        # If the flag is True, it is currently offloaded, so it is a candidate to stay resident.
         offload_flags = {
             "transformer": self.server_args.dit_cpu_offload
             or self.server_args.dit_layerwise_offload,
@@ -625,10 +644,14 @@ class GPUWorker:
             "image_encoder": self.server_args.image_encoder_cpu_offload,
         }
 
-        for name, usage in self.pipeline.memory_usages.items():
+        for name in OFFLOAD_DISABLE_RECOMMENDATION_ORDER:
             # Only consider components that are currently configured to be offloaded
             is_offload_configured = offload_flags.get(name, False)
             if not is_offload_configured:
+                continue
+
+            usage = self.pipeline.memory_usages.get(name)
+            if usage is None:
                 continue
 
             if usage <= remaining_gpu_mem_gb:

--- a/python/sglang/multimodal_gen/runtime/managers/post_response_tasks.py
+++ b/python/sglang/multimodal_gen/runtime/managers/post_response_tasks.py
@@ -1,0 +1,58 @@
+"""Post-response task utilities.
+
+Unlike post-process (for example, output tensor/image/video formatting, file
+saving, and response payload construction), post-response is runtime
+maintenance after the result is returned (for example, component cleanup, CPU
+offload, next-request prefetch, and cache cleanup).
+
+Performance concern:
+1. When request frequency is high, the next request may wait for unfinished
+   post-response work, so the maintenance cost moves to the next request.
+2. When request frequency is low, post-response work usually finishes in the
+   idle gap and has little user-visible impact.
+"""
+
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from threading import Lock
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class PostResponseTaskRunner:
+    """Runs maintenance tasks after a response has been sent.
+
+    The scheduler waits for pending tasks before executing the next request, so
+    tasks can use model modules without racing the next forward pass.
+    """
+
+    def __init__(self, name: str) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=name)
+        self._lock = Lock()
+        self._pending: list[Future[None]] = []
+
+    def submit(self, name: str, fn: Callable[[], None]) -> None:
+        with self._lock:
+            self._pending.append(self._executor.submit(self._run, name, fn))
+
+    def wait_pending(self) -> None:
+        with self._lock:
+            pending = self._pending
+            self._pending = []
+
+        for future in pending:
+            future.result()
+
+    def shutdown(self) -> None:
+        self.wait_pending()
+        self._executor.shutdown(wait=True)
+
+    @staticmethod
+    def _run(name: str, fn: Callable[[], None]) -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception("Post-response task failed: %s", name)
+            raise

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -520,9 +520,10 @@ class Scheduler(SchedulerDisaggMixin):
             identities = [item[0] for item in items]
             reqs = [item[1] for item in items]
 
+            req_or_group = reqs[0]
+            is_warmup = self._is_warmup_item(req_or_group)
             try:
-                req_or_group = reqs[0]
-                is_warmup = self._is_warmup_item(req_or_group)
+                self.worker.wait_post_response_tasks()
                 output_batch = self._dispatch_request(reqs)
             except Exception as e:
                 logger.error(
@@ -541,9 +542,12 @@ class Scheduler(SchedulerDisaggMixin):
                 # Reply failed; log and keep loop alive to accept future requests
                 logger.error(f"ZMQ error sending reply: {e}")
                 continue
+            finally:
+                self.worker.submit_post_response_tasks()
 
         if self.receiver is not None:
             self.receiver.close()
+        self.worker.shutdown_post_response_tasks()
         self._cleanup_disagg()
         self.context.destroy(linger=0)
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -46,6 +46,7 @@ class PipelineExecutor(ABC):
     def __init__(self, server_args):
         self.server_args = server_args
         self.component_residency_manager = None
+        self._post_response_tasks = []
 
     def begin_component_residency_request(
         self,
@@ -71,7 +72,14 @@ class PipelineExecutor(ABC):
         self.component_residency_manager.after_stage(stage_index)
 
     def finish_component_residency_request(self) -> None:
-        self.component_residency_manager.finish_request()
+        self._post_response_tasks.extend(
+            self.component_residency_manager.finish_request()
+        )
+
+    def pop_post_response_tasks(self):
+        tasks = self._post_response_tasks
+        self._post_response_tasks = []
+        return tasks
 
     def execute_with_profiling(
         self,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -80,6 +80,7 @@ class DecodingStage(PipelineStage):
                 self.component_name,
                 target_dtype=vae_dtype,
                 keep_ready_after_warmup=True,
+                finish_after_response=server_args.vae_cpu_offload,
             )
         ]
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding_av.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding_av.py
@@ -31,9 +31,22 @@ class LTX2AVDecodingStage(DecodingStage):
     ) -> list[ComponentUse]:
         stage_name = self._component_stage_name(stage_name)
         return [
-            ComponentUse(stage_name, "vae", target_dtype=torch.bfloat16),
-            ComponentUse(stage_name, "audio_vae"),
-            ComponentUse(stage_name, "vocoder"),
+            ComponentUse(
+                stage_name,
+                "vae",
+                target_dtype=torch.bfloat16,
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
+            ComponentUse(
+                stage_name,
+                "audio_vae",
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
+            ComponentUse(
+                stage_name,
+                "vocoder",
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
         ]
 
     @staticmethod

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -948,8 +948,17 @@ class MOVADecodingStage(PipelineStage):
         stage_name = self._component_stage_name(stage_name)
         vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
         return [
-            ComponentUse(stage_name, "video_vae", target_dtype=vae_dtype),
-            ComponentUse(stage_name, "audio_vae"),
+            ComponentUse(
+                stage_name,
+                "video_vae",
+                target_dtype=vae_dtype,
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
+            ComponentUse(
+                stage_name,
+                "audio_vae",
+                finish_after_response=server_args.vae_cpu_offload,
+            ),
         ]
 
     @property

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -190,7 +190,7 @@ class ServerArgs(DisaggArgsMixin):
     dit_offload_prefetch_size: float = 0.0
     text_encoder_cpu_offload: bool | None = None
     image_encoder_cpu_offload: bool | None = None
-    vae_cpu_offload: bool | None = None
+    vae_cpu_offload: bool | None = False
     use_fsdp_inference: bool = False
     pin_cpu_memory: bool = True
     ltx2_two_stage_device_mode: str | None = None
@@ -376,7 +376,9 @@ class ServerArgs(DisaggArgsMixin):
 
         # TODO: to be handled by each platform
         if current_platform.get_device_total_memory() / BYTES_PER_GB < 30:
-            logger.info("Enabling all offloading for GPU with low device memory")
+            logger.info(
+                "Enabling large component offloading for GPU with low device memory"
+            )
             if self.dit_cpu_offload is None:
                 self.dit_cpu_offload = True
             if self.text_encoder_cpu_offload is None:
@@ -384,7 +386,7 @@ class ServerArgs(DisaggArgsMixin):
             if self.image_encoder_cpu_offload is None:
                 self.image_encoder_cpu_offload = True
             if self.vae_cpu_offload is None:
-                self.vae_cpu_offload = True
+                self.vae_cpu_offload = False
         elif self.pipeline_config.task_type.is_image_gen():
             logger.info(
                 "Disabling some offloading (except dit, text_encoder) for image generation model"
@@ -405,7 +407,7 @@ class ServerArgs(DisaggArgsMixin):
             if self.image_encoder_cpu_offload is None:
                 self.image_encoder_cpu_offload = True
             if self.vae_cpu_offload is None:
-                self.vae_cpu_offload = True
+                self.vae_cpu_offload = False
 
     def _adjust_ltx2_two_stage_device_mode(self):
         if not self._is_ltx23_two_stage_pipeline():

--- a/python/sglang/multimodal_gen/test/unit/test_component_residency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_residency.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+import unittest
+
+import torch.nn as nn
+
+from sglang.multimodal_gen.runtime.managers.component_manager import (
+    ComponentResidencyManager,
+    ComponentUse,
+)
+from sglang.multimodal_gen.runtime.managers.component_resident_strategies import (
+    ComponentResidencyStrategy,
+)
+
+
+class _CountingStrategy(ComponentResidencyStrategy):
+    def __init__(self):
+        self.finish_use_count = 0
+        self.finish_request_count = 0
+
+    def finish_use(self, module, use, state):
+        self.finish_use_count += 1
+
+    def finish_request(self, module, use, state, *, preferred):
+        self.finish_request_count += 1
+        super().finish_request(module, use, state, preferred=preferred)
+
+
+class _FakeStage:
+    def __init__(self, uses):
+        self._uses = uses
+
+    def component_uses(self, _server_args, stage_name=None):
+        return self._uses
+
+
+class _FakePipeline:
+    def __init__(self, module, strategy):
+        self.modules = {"vae": module}
+        self._stage_name_mapping = {}
+        self.component_residency_strategies = {"vae": strategy}
+
+
+class ComponentResidencyTests(unittest.TestCase):
+    def _make_manager(self, use):
+        strategy = _CountingStrategy()
+        manager = ComponentResidencyManager(
+            _FakePipeline(nn.Linear(1, 1), strategy),
+            SimpleNamespace(),
+        )
+        manager.begin_request(
+            [_FakeStage([use])],
+            SimpleNamespace(is_warmup=False),
+            SimpleNamespace(),
+        )
+        return manager, strategy
+
+    def test_finish_after_response_defers_until_task_runs(self):
+        use = ComponentUse("DecodingStage", "vae", finish_after_response=True)
+        manager, strategy = self._make_manager(use)
+
+        with manager.use_component(use):
+            pass
+
+        self.assertEqual(strategy.finish_use_count, 0)
+
+        tasks = manager.finish_request()
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(strategy.finish_request_count, 0)
+        self.assertEqual(strategy.finish_use_count, 0)
+
+        tasks[0][1]()
+
+        self.assertEqual(strategy.finish_request_count, 1)
+        self.assertEqual(strategy.finish_use_count, 1)
+
+    def test_regular_use_finishes_before_response(self):
+        use = ComponentUse("DecodingStage", "vae")
+        manager, strategy = self._make_manager(use)
+
+        with manager.use_component(use):
+            pass
+
+        self.assertEqual(strategy.finish_use_count, 1)
+        self.assertEqual(manager.finish_request(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -3,7 +3,10 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from sglang.multimodal_gen.configs.pipeline_configs.base import PipelineConfig
+from sglang.multimodal_gen.configs.pipeline_configs.base import (
+    ModelTaskType,
+    PipelineConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
     QwenImagePipelineConfig,
 )
@@ -44,6 +47,51 @@ class TestServerArgsPathExpansion(unittest.TestCase):
         self.assertEqual(
             args.component_paths["vae"], os.path.expanduser("~/fake/local/vae")
         )
+
+
+class TestOffloadDefaults(unittest.TestCase):
+    def _from_dict_with_task_type(
+        self,
+        task_type,
+        *,
+        memory_gb=80,
+        kwargs=None,
+    ):
+        pipeline_config = PipelineConfig()
+        pipeline_config.task_type = task_type
+        with (
+            patch.object(PipelineConfig, "from_kwargs", return_value=pipeline_config),
+            patch(
+                "sglang.multimodal_gen.runtime.server_args.current_platform.is_cpu",
+                return_value=False,
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.server_args.current_platform.get_device_total_memory",
+                return_value=memory_gb * 1024**3,
+            ),
+        ):
+            return ServerArgs.from_dict({"model_path": "/fake", **(kwargs or {})})
+
+    def test_vae_cpu_offload_defaults_false_for_video_generation(self):
+        args = self._from_dict_with_task_type(ModelTaskType.T2V)
+
+        self.assertFalse(args.vae_cpu_offload)
+
+    def test_vae_cpu_offload_defaults_false_on_low_memory_gpu(self):
+        args = self._from_dict_with_task_type(ModelTaskType.T2V, memory_gb=16)
+
+        self.assertFalse(args.vae_cpu_offload)
+        self.assertTrue(args.dit_cpu_offload)
+        self.assertTrue(args.text_encoder_cpu_offload)
+        self.assertTrue(args.image_encoder_cpu_offload)
+
+    def test_explicit_vae_cpu_offload_true_is_preserved(self):
+        args = self._from_dict_with_task_type(
+            ModelTaskType.T2V,
+            kwargs={"vae_cpu_offload": True},
+        )
+
+        self.assertTrue(args.vae_cpu_offload)
 
 
 class TestModelIdResolution(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add a post-response task runner for runtime maintenance that can run after a response is sent.
- Have the scheduler submit post-response tasks after sending a reply and wait for pending tasks before dispatching the next request, so background module mutation does not race the next forward pass.
- Let component residency defer selected component finish work into post-response tasks.
- Use that path for terminal VAE/audio VAE/vocoder cleanup when `--vae-cpu-offload` is explicitly enabled.
- Add unit coverage for deferred component residency cleanup.

## Design Notes

Post-process remains part of the current request: it transforms model outputs into the response payload and must finish before the response can be sent. Post-response tasks are different: they are runtime maintenance after the response is already sendable, such as component residency cleanup.

The scheduler waits for pending post-response tasks before executing the next request. This gives idle gaps a chance to absorb VAE D2H work while avoiding concurrent module mutation if the next request arrives immediately.

## Validation

- Attempted: `PYTHONPATH=/Users/mick/repos/sglang-vae-offload-pr/python python -m pytest -q python/sglang/multimodal_gen/test/unit/test_component_residency.py python/sglang/multimodal_gen/test/unit/test_server_args.py::TestOffloadDefaults`
- Blocked locally on macOS during collection by an existing torch/cuda import compatibility issue: `ImportError: cannot import name '_cuda_beginAllocateCurrentThreadToPool' from 'torch.cuda.memory'`.