### PR TITLE
[AMD] fix tbo specv2 seq_lens_cpu NoneType error

### DIFF
--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -279,6 +279,12 @@ class EagleVerifyInputV2Mixin:
                 batch.mamba_track_mask = None
                 batch.mamba_track_seqlens = None
 
+        # Populate seq_lens_cpu/seq_lens_sum on the verify input so that
+        # TBO's split_spec_info can slice the custom_mask correctly.
+        if not batch.forward_mode.is_idle():
+            self.seq_lens_cpu = batch.seq_lens_cpu
+            self.seq_lens_sum = batch.seq_lens_sum
+
         # Get a forward batch
         batch.forward_mode = (
             ForwardMode.IDLE

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -279,9 +279,8 @@ class EagleVerifyInputV2Mixin:
                 batch.mamba_track_mask = None
                 batch.mamba_track_seqlens = None
 
-        # Populate seq_lens_cpu/seq_lens_sum on the verify input so that
-        # TBO's split_spec_info can slice the custom_mask correctly.
-        if not batch.forward_mode.is_idle():
+            # Populate seq_lens_cpu/seq_lens_sum on the verify input so that
+            # TBO's split_spec_info can slice the custom_mask correctly.
             self.seq_lens_cpu = batch.seq_lens_cpu
             self.seq_lens_sum = batch.seq_lens_sum
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The issue is identified in CI task https://github.com/sgl-project/sglang/actions/runs/25151525365/job/73798865426#step:7:16755
and workaround https://github.com/sgl-project/sglang/pull/24205
and issue tracker https://github.com/sgl-project/sglang/issues/24212

cc @HaiShaw @hubertlu-tw @bingxche 

This patch is to fix the crash when SpecV2 is enabled (now the default) together with TBO, `TestMTPwithTBOLowLatency`. The trace is as following:

```
File "/sgl-workspace/sglang/python/sglang/srt/batch_overlap/two_batch_overlap.py", line 208, in split_spec_info
    if end_seq_index == spec_info.seq_lens_cpu.shape[0]:
AttributeError: 'NoneType' object has no attribute 'shape'
```

at `two_batch_overlap.py:208` in `split_spec_info`, because `spec_info.seq_lens_cpu` is `None`.

In the v2 draft path (`eagle_worker_v2.py:390`), `EagleVerifyInput` is created with `seq_lens_cpu=None` and `seq_lens_sum=None`. The v1 path (`eagle_worker.py:800`) correctly passes `forward_batch.seq_lens_cpu`. Later, `prepare_for_v2_verify` updates `batch.seq_lens_cpu` but never writes it back to the `EagleVerifyInput` object itself. When TBO calls `split_spec_info(forward_batch.spec_info, ...)`, it reads `spec_info.seq_lens_cpu` which is still `None`.

The same issue applies to `multi_layer_eagle_worker_v2.py:283`, but both paths share the `EagleVerifyInputV2Mixin`, so the fix covers both.

## Modifications

- `python/sglang/srt/speculative/eagle_info_v2.py`: In `prepare_for_v2_verify`, populate `self.seq_lens_cpu` and `self.seq_lens_sum` from `batch` before `ForwardBatch.init_new()` is called.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

TestMTPwithTBOLowLatency passed

<img width="1503" height="224" alt="image" src="https://github.com/user-attachments/assets/67637b35-c90d-454d-a3ba-36731d81682d" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
