### PR TITLE
fix(http): apply SGLANG_TIMEOUT_KEEP_ALIVE in common.py

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2555,7 +2555,7 @@ def launch_dummy_health_check_server(host, port, enable_metrics):
         app,
         host=host,
         port=port,
-        timeout_keep_alive=5,
+        timeout_keep_alive=envs.SGLANG_TIMEOUT_KEEP_ALIVE.get(),
         loop="auto",
         log_config=None,
         log_level="warning",


### PR DESCRIPTION
## Why

PR #19847 made SGLANG_TIMEOUT_KEEP_ALIVE configurable across the uvicorn launch sites in srt/entrypoints/http_server.py. The dummy health-check server helper in srt/utils/common.py still used a hard-coded 5s keep-alive timeout, so that path ignored the environment variable.

## What

Replace the literal timeout_keep_alive=5 in utils/common.py with envs.SGLANG_TIMEOUT_KEEP_ALIVE.get(), matching the existing http_server.py pattern. Default behavior is preserved because SGLANG_TIMEOUT_KEEP_ALIVE still defaults to 5.

## Tests

- python3 -m compileall -q python/sglang/srt/utils/common.py

No new unit test added. This is a mechanical consistency change using the existing envs.<NAME>.get() pattern already used in this file; default behavior is unchanged.

Refs #19847.