### PR TITLE
[glm5/dsv32 nsa ] Fuse RoPE + Hadamard transform

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh
@@ -1,0 +1,305 @@
+/******************************************************************************
+ * Fused RoPE + Hadamard for the NSA Lightning Indexer
+ *
+ *   Replaces the chain
+ *     apply_rope_with_cos_sin_cache_inplace(q_rope, k_rope, ...)   // 1 launch
+ *     hadamard_transform(query, scale=1/sqrt(head_dim))            // 1 launch
+ *     hadamard_transform(key,   scale=1/sqrt(head_dim))            // 1 launch
+ *   with a single in-place kernel that:
+ *     - reads `query` and `key` once (full head_dim columns),
+ *     - applies neox-style RoPE on the rope-half (first kRopeDim dims) per head
+ *       using `cos_sin_cache[positions[token]]`,
+ *     - applies a kHeadDim-wide Hadamard butterfly on the full per-head row,
+ *     - stores back in place with the orthogonal scale 1 / sqrt(kHeadDim).
+ *
+ *   Per-thread layout (one CTA covers `kBlockSize / kWorkThreads` workers, where
+ *   each worker = one (token, head) pair):
+ *     - kWorkThreads = kHeadDim / kNElts  (e.g. 16 for kHeadDim=128 bf16)
+ *     - kNElts       = 16 / sizeof(DType) (8 for bf16/fp16; 4 for fp32)
+ *     - kLogNElts    = log2(kNElts)
+ *     - kLogWorkThreads = log2(kWorkThreads)
+ *
+ *   Hadamard butterfly composition (reuses fast-hadamard-transform helpers):
+ *     - kLogNElts in-thread stages           (`hadamard_mult_thread`)
+ *     - kLogWorkThreads warp-shuffle stages  (`hadamard_mult_warp`)
+ *     - Total stages = log2(kHeadDim).
+ *
+ *   RoPE pairing inside the worker:
+ *     - threads [0, kRopeXThreads)            hold q_x  = head[0          : kRopeDim/2)
+ *     - threads [kRopeXThreads, kRopeYThreads)hold q_y  = head[kRopeDim/2 : kRopeDim)
+ *     - threads [kRopeYThreads, kWorkThreads) hold the nope half (no RoPE)
+ *     - pair partner = lane ^ kRopeXThreads (warp-shuffle within width=kWorkThreads)
+ *
+ *   Architecture gating:
+ *     - The kernel uses warp shuffles + 128-bit vec loads only; portable from
+ *       SM70+. PDL hooks are gated by kUsePDL, which the Python wrapper sets
+ *       from is_arch_support_pdl() (SM90+, covers SM100/SM103).
+ ******************************************************************************/
+#pragma once
+
+#include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDType, SymbolicDevice
+#include <sgl_kernel/utils.h>   // For RuntimeCheck, div_ceil
+
+#include <sgl_kernel/runtime.cuh>  // For runtime::get_blocks_per_sm, get_sm_count
+#include <sgl_kernel/type.cuh>     // For dtype_trait, fp16_t, bf16_t, fp32_t, packed_t, cast
+#include <sgl_kernel/utils.cuh>    // For SGL_DEVICE, LaunchKernel, PDLWait/Trigger
+#include <sgl_kernel/vec.cuh>      // For AlignedVector
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include "fast_hadamard_transform_common.h"  // For hadamard_mult_thread, hadamard_mult_warp, cilog2
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+
+namespace {
+
+struct FusedRopeHadamardParams {
+  void* __restrict__ q_ptr;
+  // NOTE: pre-offset by `-num_qo_heads * head_stride_bytes` so that index math
+  // can use a unified head_id range [0, num_qo_heads + num_kv_heads).
+  void* __restrict__ k_ptr;
+  const void* __restrict__ cos_sin_cache_ptr;
+  const void* __restrict__ positions;
+  int64_t q_stride_bytes;     // byte stride between tokens for q
+  int64_t k_stride_bytes;     // byte stride between tokens for k
+  int64_t head_stride_bytes;  // byte stride between heads (same for q and k by validation)
+  uint32_t num_qo_heads;
+  uint32_t num_kv_heads;
+  uint32_t num_tokens;
+  float had_scale;  // 1 / sqrt(kHeadDim)
+};
+
+constexpr uint32_t kBlockSize = 128;
+
+template <
+    bool kIsNeox,
+    int kHeadDim,
+    int kRopeDim,
+    bool kUsePDL,
+    typename DType,
+    typename IdType>
+__global__ __launch_bounds__(kBlockSize)  //
+    void fused_rope_hadamard_kernel(const __grid_constant__ FusedRopeHadamardParams params) {
+  using namespace device;
+
+  // ---- compile-time geometry ------------------------------------------------
+  static_assert(sizeof(DType) == 2, "fused_rope_hadamard: only fp16/bf16 supported in this version");
+  static_assert(kIsNeox, "fused_rope_hadamard: only neox-style RoPE supported in this version");
+
+  constexpr int kNElts = 16 / sizeof(DType);             // 8 for bf16/fp16
+  constexpr int kWorkThreads = kHeadDim / kNElts;        // 16 for head_dim=128
+  constexpr int kLogNElts = cilog2(kNElts);              // 3
+  constexpr int kLogWorkThreads = cilog2(kWorkThreads);  // 4
+  constexpr int kNChunks = 1;
+  constexpr int kWorkersPerBlock = kBlockSize / kWorkThreads;
+
+  static_assert(kHeadDim > 0 && (kHeadDim & (kHeadDim - 1)) == 0, "kHeadDim must be a power of 2");
+  static_assert(kRopeDim > 0 && kRopeDim <= kHeadDim);
+  static_assert(
+      kRopeDim % (2 * kNElts) == 0,
+      "kRopeDim must be divisible by 2 * kNElts so the rope/nope split aligns to vector lanes");
+  static_assert(
+      kWorkThreads >= 4 && kWorkThreads <= 32,
+      "kWorkThreads in [4, 32]; larger head_dim needs cross-warp Hadamard staging");
+  static_assert(kBlockSize % kWorkThreads == 0);
+  static_assert((1 << kLogNElts) == kNElts);
+  static_assert((1 << kLogWorkThreads) == kWorkThreads);
+
+  // RoPE rope-half partitioning (within a worker):
+  constexpr int kRopeHalf = kRopeDim / 2;            // dims [0, kRopeHalf) and [kRopeHalf, kRopeDim)
+  constexpr int kRopeXThreads = kRopeHalf / kNElts;  // first  kRopeHalf dims live in these lanes
+  constexpr int kRopeYThreads =
+      kRopeDim / kNElts;  // second kRopeHalf dims live in lanes [kRopeXThreads, kRopeYThreads)
+
+  // ---- worker / lane identity ----------------------------------------------
+  const uint32_t lane_id = threadIdx.x % kWorkThreads;
+  const uint32_t worker_in_block = threadIdx.x / kWorkThreads;
+  const uint32_t start_worker_id = blockIdx.x * kWorkersPerBlock + worker_in_block;
+  const uint32_t total_workers = (params.num_qo_heads + params.num_kv_heads) * params.num_tokens;
+  const uint32_t worker_stride = gridDim.x * kWorkersPerBlock;
+
+  PDLWaitPrimary<kUsePDL>();
+
+  for (uint32_t work_id = start_worker_id; work_id < total_workers; work_id += worker_stride) {
+    const uint32_t num_q_and_k_heads = params.num_qo_heads + params.num_kv_heads;
+    const uint32_t token_id = work_id / num_q_and_k_heads;
+    const uint32_t head_id = work_id % num_q_and_k_heads;
+    const bool load_q = head_id < params.num_qo_heads;
+
+    // Compute base row pointer. params.k_ptr has been pre-offset by
+    // `-num_qo_heads * head_stride_bytes` on the host so the kernel can index
+    // both q and k with the same `head_id` running over [0, num_q_and_k_heads).
+    void* row_ptr = pointer::offset(
+        load_q ? params.q_ptr : params.k_ptr,
+        token_id * (load_q ? params.q_stride_bytes : params.k_stride_bytes),
+        head_id * params.head_stride_bytes);
+
+    // ---- Step 1: vec-load 128-bit per thread, cast to fp32 -----------------
+    using vec_t = AlignedVector<DType, kNElts>;
+    float x_vals[kNChunks][kNElts];
+    {
+      auto v = load_as<vec_t>(row_ptr, lane_id);
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        x_vals[0][i] = static_cast<float>(v[i]);
+      }
+    }
+
+    // ---- Step 2: in-register neox RoPE on the rope-half --------------------
+    //
+    //   For lane t in [0, kRopeXThreads): holds q_x slice = head[lane_in_rope * kNElts ..]
+    //     pairs with lane (t ^ kRopeXThreads) which holds q_y at the same offset.
+    //   Both lanes load the same (cos[i], sin[i]) since neox couples (i, i+kRopeHalf).
+    //
+    //   `__shfl_xor_sync` is called by all kWorkThreads lanes uniformly (no
+    //   intra-warp divergence); only rope-half lanes use the result.
+    {
+      const auto pos = static_cast<const IdType*>(params.positions)[token_id];
+      const float* cos_cache = static_cast<const float*>(params.cos_sin_cache_ptr);
+      const float* sin_cache = cos_cache + kRopeHalf;
+      const int64_t pos_offset = static_cast<int64_t>(pos) * static_cast<int64_t>(kRopeDim);
+
+      float cos_vals[kNElts] = {0};
+      float sin_vals[kNElts] = {0};
+      if (lane_id < kRopeYThreads) {
+        const uint32_t lane_in_rope = lane_id & (kRopeXThreads - 1);  // 0..kRopeXThreads-1
+        const int64_t base = pos_offset + static_cast<int64_t>(lane_in_rope) * kNElts;
+#pragma unroll
+        for (int i = 0; i < kNElts; ++i) {
+          cos_vals[i] = cos_cache[base + i];
+          sin_vals[i] = sin_cache[base + i];
+        }
+      }
+
+      // Width = kWorkThreads keeps shuffles confined to one worker's lanes when
+      // multiple workers share a warp (kBlockSize / kWorkThreads workers/warp).
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        const float my_val = x_vals[0][i];
+        const float pair_val = __shfl_xor_sync(0xFFFFFFFFu, my_val, kRopeXThreads, kWorkThreads);
+        if (lane_id < kRopeXThreads) {
+          // q_x lane: my=x, pair=y → new_x = x*cos − y*sin
+          x_vals[0][i] = my_val * cos_vals[i] - pair_val * sin_vals[i];
+        } else if (lane_id < kRopeYThreads) {
+          // q_y lane: my=y, pair=x → new_y = x*sin + y*cos = pair*sin + my*cos
+          x_vals[0][i] = pair_val * sin_vals[i] + my_val * cos_vals[i];
+        }
+        // lane_id >= kRopeYThreads: nope, leave x_vals unchanged.
+      }
+    }
+
+    // ---- Step 3: in-register kHeadDim-wide Hadamard butterfly --------------
+    //   kLogNElts in-thread stages, then kLogWorkThreads warp-shuffle stages.
+    //   At kHeadDim=128 / kWorkThreads=16 there are no cross-warp stages.
+    //   Width inside `hadamard_mult_warp` is kWorkThreads (matches our worker).
+    hadamard_mult_thread<kLogNElts, kNChunks>(x_vals);
+    hadamard_mult_warp<kLogWorkThreads, 0, kNChunks, kNElts>(x_vals);
+
+    // ---- Step 4: cast back to DType, apply scale, store in place -----------
+    {
+      vec_t v;
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        v[i] = static_cast<DType>(x_vals[0][i] * params.had_scale);
+      }
+      store_as<vec_t>(row_ptr, v, lane_id);
+    }
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+template <bool kIsNeox, int kHeadDim, int kRopeDim, bool kUsePDL, typename DType>
+struct FusedRopeHadamardKernel {
+  static constexpr int kNElts = 16 / sizeof(DType);
+  static constexpr int kWorkThreads = kHeadDim / kNElts;
+
+  template <typename IdType>
+  static constexpr auto _kernel = fused_rope_hadamard_kernel<kIsNeox, kHeadDim, kRopeDim, kUsePDL, DType, IdType>;
+
+  static auto get_num_sm(DLDevice device) {
+    static const auto kNumSM = host::runtime::get_sm_count(device.device_id);
+    return kNumSM;
+  }
+
+  static void
+  run(const tvm::ffi::TensorView q,
+      const tvm::ffi::TensorView k,
+      const tvm::ffi::TensorView cos_sin_cache,
+      const tvm::ffi::TensorView positions) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_tokens"};
+    auto Q = SymbolicSize{"num_qo_heads"};
+    auto K = SymbolicSize{"num_kv_heads"};
+    auto Hd = SymbolicSize{"head_dim"};
+    auto Rd = SymbolicSize{"rope_dim"};
+    auto Dq = SymbolicSize{"q_token_stride"};
+    auto Dk = SymbolicSize{"k_token_stride"};
+    auto Dh = SymbolicSize{"head_stride"};
+    Hd.set_value(kHeadDim);
+    Rd.set_value(kRopeDim);
+
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    auto id_type = SymbolicDType{};
+
+    // q : [N, Q, kHeadDim], in-place
+    TensorMatcher({N, Q, Hd}).with_strides({Dq, Dh, 1}).with_dtype<DType>().with_device(device).verify(q);
+    // k : [N, K, kHeadDim], in-place; head stride must match q's
+    TensorMatcher({N, K, Hd}).with_strides({Dk, Dh, 1}).with_dtype<DType>().with_device(device).verify(k);
+    // cos_sin_cache : [max_pos, kRopeDim], fp32; first kRopeDim/2 = cos, second = sin
+    TensorMatcher({-1, Rd}).with_dtype<float>().with_device(device).verify(cos_sin_cache);
+    // positions : [N], int32 or int64
+    TensorMatcher({N}).with_dtype<int32_t, int64_t>(id_type).with_device(device).verify(positions);
+
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto num_qo_heads = static_cast<uint32_t>(Q.unwrap());
+    const auto num_kv_heads = static_cast<uint32_t>(K.unwrap());
+    const auto q_stride_bytes = static_cast<int64_t>(Dq.unwrap()) * sizeof(DType);
+    const auto k_stride_bytes = static_cast<int64_t>(Dk.unwrap()) * sizeof(DType);
+    const auto head_stride_bytes = static_cast<int64_t>(Dh.unwrap()) * sizeof(DType);
+
+    // Pre-offset k pointer so the kernel can index q/k uniformly via head_id ∈ [0, Q+K).
+    const int64_t k_offset = static_cast<int64_t>(num_qo_heads) * head_stride_bytes;
+
+    FusedRopeHadamardParams params;
+    std::memset(&params, 0, sizeof(params));
+    params.q_ptr = const_cast<void*>(q.data_ptr());
+    params.k_ptr = pointer::offset(const_cast<void*>(k.data_ptr()), -k_offset);
+    params.cos_sin_cache_ptr = cos_sin_cache.data_ptr();
+    params.positions = positions.data_ptr();
+    params.q_stride_bytes = q_stride_bytes;
+    params.k_stride_bytes = k_stride_bytes;
+    params.head_stride_bytes = head_stride_bytes;
+    params.num_qo_heads = num_qo_heads;
+    params.num_kv_heads = num_kv_heads;
+    params.num_tokens = num_tokens;
+    params.had_scale = 1.0f / std::sqrt(static_cast<float>(kHeadDim));
+
+    const DLDevice dev = device.unwrap();
+    const auto is_int32 = id_type.is_type<int32_t>();
+    const auto kernel = is_int32 ? _kernel<int32_t> : _kernel<int64_t>;
+
+    // Persistent grid sized to occupancy × SM count, capped by needed workers.
+    static const uint32_t kOccupancy[2] = {
+        runtime::get_blocks_per_sm(_kernel<int32_t>, kBlockSize),
+        runtime::get_blocks_per_sm(_kernel<int64_t>, kBlockSize),
+    };
+    const uint32_t num_sm = get_num_sm(dev);
+    const uint32_t max_blocks = num_sm * kOccupancy[is_int32 ? 0 : 1];
+    const uint32_t total_workers = (num_qo_heads + num_kv_heads) * num_tokens;
+    constexpr uint32_t kWorkersPerBlock = kBlockSize / kWorkThreads;
+    const uint32_t needed_blocks = div_ceil(total_workers, kWorkersPerBlock);
+    const uint32_t num_blocks = std::min(max_blocks, needed_blocks);
+
+    LaunchKernel(num_blocks, kBlockSize, dev)  //
+        .enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh
@@ -88,7 +88,6 @@ __global__ __launch_bounds__(kBlockSize)  //
 
   // ---- compile-time geometry ------------------------------------------------
   static_assert(sizeof(DType) == 2, "fused_rope_hadamard: only fp16/bf16 supported in this version");
-  static_assert(kIsNeox, "fused_rope_hadamard: only neox-style RoPE supported in this version");
 
   constexpr int kNElts = 16 / sizeof(DType);             // 8 for bf16/fp16
   constexpr int kWorkThreads = kHeadDim / kNElts;        // 16 for head_dim=128
@@ -98,7 +97,7 @@ __global__ __launch_bounds__(kBlockSize)  //
   constexpr int kWorkersPerBlock = kBlockSize / kWorkThreads;
 
   static_assert(kHeadDim > 0 && (kHeadDim & (kHeadDim - 1)) == 0, "kHeadDim must be a power of 2");
-  static_assert(kRopeDim > 0 && kRopeDim <= kHeadDim);
+  static_assert(kRopeDim > 0 && kRopeDim <= kHeadDim, "kRopeDim must be in (0, kHeadDim]");
   static_assert(
       kRopeDim % (2 * kNElts) == 0,
       "kRopeDim must be divisible by 2 * kNElts so the rope/nope split aligns to vector lanes");
@@ -149,44 +148,76 @@ __global__ __launch_bounds__(kBlockSize)  //
       }
     }
 
-    // ---- Step 2: in-register neox RoPE on the rope-half --------------------
+    // ---- Step 2: in-register RoPE on the rope-half -------------------------
     //
-    //   For lane t in [0, kRopeXThreads): holds q_x slice = head[lane_in_rope * kNElts ..]
-    //     pairs with lane (t ^ kRopeXThreads) which holds q_y at the same offset.
-    //   Both lanes load the same (cos[i], sin[i]) since neox couples (i, i+kRopeHalf).
+    //   Two layouts (selected at compile time by kIsNeox):
     //
-    //   `__shfl_xor_sync` is called by all kWorkThreads lanes uniformly (no
-    //   intra-warp divergence); only rope-half lanes use the result.
+    //   Neox (split-half pairing): pair (head[i], head[i + kRopeHalf]) for
+    //     i in [0, kRopeHalf). Lanes [0, kRopeXThreads) hold q_x; lanes
+    //     [kRopeXThreads, kRopeYThreads) hold q_y. Pair partner via
+    //     __shfl_xor_sync(_, _, kRopeXThreads, kWorkThreads). Both x-lane and
+    //     y-lane in a pair load the SAME (cos[i], sin[i]).
+    //
+    //   Non-neox (interleaved pairing): pair (head[2i], head[2i+1]) for
+    //     i in [0, kRopeHalf). Each lane holds kPairsPerThread = kNElts/2
+    //     full pairs in its own 8 elements; no cross-lane shuffle is needed.
+    //     Lanes [0, kRopeYThreads) participate; lane t loads cos[t * kPairs ..]
+    //     and sin[t * kPairs ..] from the cos / sin halves of cos_sin_cache.
     {
       const auto pos = static_cast<const IdType*>(params.positions)[token_id];
       const float* cos_cache = static_cast<const float*>(params.cos_sin_cache_ptr);
       const float* sin_cache = cos_cache + kRopeHalf;
       const int64_t pos_offset = static_cast<int64_t>(pos) * static_cast<int64_t>(kRopeDim);
 
-      float cos_vals[kNElts] = {0};
-      float sin_vals[kNElts] = {0};
-      if (lane_id < kRopeYThreads) {
-        const uint32_t lane_in_rope = lane_id & (kRopeXThreads - 1);  // 0..kRopeXThreads-1
-        const int64_t base = pos_offset + static_cast<int64_t>(lane_in_rope) * kNElts;
+      if constexpr (kIsNeox) {
+        float cos_vals[kNElts] = {0};
+        float sin_vals[kNElts] = {0};
+        if (lane_id < kRopeYThreads) {
+          const uint32_t lane_in_rope = lane_id & (kRopeXThreads - 1);  // 0..kRopeXThreads-1
+          const int64_t base = pos_offset + static_cast<int64_t>(lane_in_rope) * kNElts;
+#pragma unroll
+          for (int i = 0; i < kNElts; ++i) {
+            cos_vals[i] = cos_cache[base + i];
+            sin_vals[i] = sin_cache[base + i];
+          }
+        }
+
+        // Width = kWorkThreads keeps shuffles confined to one worker's lanes
+        // when multiple workers share a warp (kBlockSize / kWorkThreads
+        // workers/warp). All kWorkThreads lanes call shfl uniformly.
 #pragma unroll
         for (int i = 0; i < kNElts; ++i) {
-          cos_vals[i] = cos_cache[base + i];
-          sin_vals[i] = sin_cache[base + i];
+          const float my_val = x_vals[0][i];
+          const float pair_val = __shfl_xor_sync(0xFFFFFFFFu, my_val, kRopeXThreads, kWorkThreads);
+          if (lane_id < kRopeXThreads) {
+            // q_x lane: my=x, pair=y → new_x = x*cos − y*sin
+            x_vals[0][i] = my_val * cos_vals[i] - pair_val * sin_vals[i];
+          } else if (lane_id < kRopeYThreads) {
+            // q_y lane: my=y, pair=x → new_y = x*sin + y*cos = pair*sin + my*cos
+            x_vals[0][i] = pair_val * sin_vals[i] + my_val * cos_vals[i];
+          }
+          // lane_id >= kRopeYThreads: nope, leave x_vals unchanged.
         }
-      }
-
-      // Width = kWorkThreads keeps shuffles confined to one worker's lanes when
-      // multiple workers share a warp (kBlockSize / kWorkThreads workers/warp).
+      } else {
+        // Non-neox: pairs are adjacent inside each lane, all in registers.
+        constexpr int kPairsPerThread = kNElts / 2;  // 4 for kNElts=8
+        static_assert(kNElts % 2 == 0, "non-neox requires kNElts to be even");
+        if (lane_id < kRopeYThreads) {
+          const int64_t base = pos_offset + static_cast<int64_t>(lane_id) * kPairsPerThread;
+          float cos_vals[kPairsPerThread];
+          float sin_vals[kPairsPerThread];
 #pragma unroll
-      for (int i = 0; i < kNElts; ++i) {
-        const float my_val = x_vals[0][i];
-        const float pair_val = __shfl_xor_sync(0xFFFFFFFFu, my_val, kRopeXThreads, kWorkThreads);
-        if (lane_id < kRopeXThreads) {
-          // q_x lane: my=x, pair=y → new_x = x*cos − y*sin
-          x_vals[0][i] = my_val * cos_vals[i] - pair_val * sin_vals[i];
-        } else if (lane_id < kRopeYThreads) {
-          // q_y lane: my=y, pair=x → new_y = x*sin + y*cos = pair*sin + my*cos
-          x_vals[0][i] = pair_val * sin_vals[i] + my_val * cos_vals[i];
+          for (int m = 0; m < kPairsPerThread; ++m) {
+            cos_vals[m] = cos_cache[base + m];
+            sin_vals[m] = sin_cache[base + m];
+          }
+#pragma unroll
+          for (int m = 0; m < kPairsPerThread; ++m) {
+            const float x = x_vals[0][2 * m];
+            const float y = x_vals[0][2 * m + 1];
+            x_vals[0][2 * m] = x * cos_vals[m] - y * sin_vals[m];
+            x_vals[0][2 * m + 1] = x * sin_vals[m] + y * cos_vals[m];
+          }
         }
         // lane_id >= kRopeYThreads: nope, leave x_vals unchanged.
       }

--- a/python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh
@@ -1,40 +1,3 @@
-/******************************************************************************
- * Fused RoPE + Hadamard for the NSA Lightning Indexer
- *
- *   Replaces the chain
- *     apply_rope_with_cos_sin_cache_inplace(q_rope, k_rope, ...)   // 1 launch
- *     hadamard_transform(query, scale=1/sqrt(head_dim))            // 1 launch
- *     hadamard_transform(key,   scale=1/sqrt(head_dim))            // 1 launch
- *   with a single in-place kernel that:
- *     - reads `query` and `key` once (full head_dim columns),
- *     - applies neox-style RoPE on the rope-half (first kRopeDim dims) per head
- *       using `cos_sin_cache[positions[token]]`,
- *     - applies a kHeadDim-wide Hadamard butterfly on the full per-head row,
- *     - stores back in place with the orthogonal scale 1 / sqrt(kHeadDim).
- *
- *   Per-thread layout (one CTA covers `kBlockSize / kWorkThreads` workers, where
- *   each worker = one (token, head) pair):
- *     - kWorkThreads = kHeadDim / kNElts  (e.g. 16 for kHeadDim=128 bf16)
- *     - kNElts       = 16 / sizeof(DType) (8 for bf16/fp16; 4 for fp32)
- *     - kLogNElts    = log2(kNElts)
- *     - kLogWorkThreads = log2(kWorkThreads)
- *
- *   Hadamard butterfly composition (reuses fast-hadamard-transform helpers):
- *     - kLogNElts in-thread stages           (`hadamard_mult_thread`)
- *     - kLogWorkThreads warp-shuffle stages  (`hadamard_mult_warp`)
- *     - Total stages = log2(kHeadDim).
- *
- *   RoPE pairing inside the worker:
- *     - threads [0, kRopeXThreads)            hold q_x  = head[0          : kRopeDim/2)
- *     - threads [kRopeXThreads, kRopeYThreads)hold q_y  = head[kRopeDim/2 : kRopeDim)
- *     - threads [kRopeYThreads, kWorkThreads) hold the nope half (no RoPE)
- *     - pair partner = lane ^ kRopeXThreads (warp-shuffle within width=kWorkThreads)
- *
- *   Architecture gating:
- *     - The kernel uses warp shuffles + 128-bit vec loads only; portable from
- *       SM70+. PDL hooks are gated by kUsePDL, which the Python wrapper sets
- *       from is_arch_support_pdl() (SM90+, covers SM100/SM103).
- ******************************************************************************/
 #pragma once
 
 #include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDType, SymbolicDevice
@@ -53,73 +16,64 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <numeric>
 
 namespace {
 
 struct FusedRopeHadamardParams {
   void* __restrict__ q_ptr;
-  // NOTE: pre-offset by `-num_qo_heads * head_stride_bytes` so that index math
-  // can use a unified head_id range [0, num_qo_heads + num_kv_heads).
-  void* __restrict__ k_ptr;
+  void* __restrict__ k_ptr;  // NOTE: this k is pre-offset in host code to reduce computation in kernel
   const void* __restrict__ cos_sin_cache_ptr;
   const void* __restrict__ positions;
-  int64_t q_stride_bytes;     // byte stride between tokens for q
-  int64_t k_stride_bytes;     // byte stride between tokens for k
-  int64_t head_stride_bytes;  // byte stride between heads (same for q and k by validation)
+  int64_t q_stride_bytes;
+  int64_t k_stride_bytes;
+  int64_t head_stride_bytes;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
   uint32_t num_tokens;
-  float had_scale;  // 1 / sqrt(kHeadDim)
+  float had_scale;
 };
 
 constexpr uint32_t kBlockSize = 128;
 
-template <
-    bool kIsNeox,
-    int kHeadDim,
-    int kRopeDim,
-    bool kUsePDL,
-    typename DType,
-    typename IdType>
+template <bool kIsNeox, int kHeadDim, int kRopeDim, bool kUsePDL, typename DType, typename IdType>
 __global__ __launch_bounds__(kBlockSize)  //
     void fused_rope_hadamard_kernel(const __grid_constant__ FusedRopeHadamardParams params) {
   using namespace device;
 
-  // ---- compile-time geometry ------------------------------------------------
-  static_assert(sizeof(DType) == 2, "fused_rope_hadamard: only fp16/bf16 supported in this version");
+  static_assert(sizeof(DType) == 2, "fused_rope_hadamard: only fp16/bf16 supported");
 
-  constexpr int kNElts = 16 / sizeof(DType);             // 8 for bf16/fp16
-  constexpr int kWorkThreads = kHeadDim / kNElts;        // 16 for head_dim=128
-  constexpr int kLogNElts = cilog2(kNElts);              // 3
-  constexpr int kLogWorkThreads = cilog2(kWorkThreads);  // 4
+  constexpr int kNElts = 16 / sizeof(DType);
+  constexpr int kWorkThreads = kHeadDim / kNElts;
+  constexpr int kLogNElts = cilog2(kNElts);
+  constexpr int kLogWorkThreads = cilog2(kWorkThreads);
   constexpr int kNChunks = 1;
+  constexpr int kVecSize = kNElts / 2;
+  constexpr int kRopeHalf = kRopeDim / 2;
+  constexpr int kRopeXThreads = kRopeHalf / kNElts;
+  constexpr int kRopeYThreads = kRopeDim / kNElts;
   constexpr int kWorkersPerBlock = kBlockSize / kWorkThreads;
+  constexpr int64_t kCosSinStrideBytes = kRopeDim * sizeof(float);
 
   static_assert(kHeadDim > 0 && (kHeadDim & (kHeadDim - 1)) == 0, "kHeadDim must be a power of 2");
   static_assert(kRopeDim > 0 && kRopeDim <= kHeadDim, "kRopeDim must be in (0, kHeadDim]");
-  static_assert(
-      kRopeDim % (2 * kNElts) == 0,
-      "kRopeDim must be divisible by 2 * kNElts so the rope/nope split aligns to vector lanes");
-  static_assert(
-      kWorkThreads >= 4 && kWorkThreads <= 32,
-      "kWorkThreads in [4, 32]; larger head_dim needs cross-warp Hadamard staging");
+  static_assert(kRopeDim % (2 * kNElts) == 0);
+  static_assert(kWorkThreads >= 4 && kWorkThreads <= 32);
   static_assert(kBlockSize % kWorkThreads == 0);
   static_assert((1 << kLogNElts) == kNElts);
   static_assert((1 << kLogWorkThreads) == kWorkThreads);
+  static_assert(kVecSize >= 1);
 
-  // RoPE rope-half partitioning (within a worker):
-  constexpr int kRopeHalf = kRopeDim / 2;            // dims [0, kRopeHalf) and [kRopeHalf, kRopeDim)
-  constexpr int kRopeXThreads = kRopeHalf / kNElts;  // first  kRopeHalf dims live in these lanes
-  constexpr int kRopeYThreads =
-      kRopeDim / kNElts;  // second kRopeHalf dims live in lanes [kRopeXThreads, kRopeYThreads)
+  using DType2 = packed_t<DType>;
+  using InputStorage = AlignedVector<DType2, kVecSize>;
 
-  // ---- worker / lane identity ----------------------------------------------
   const uint32_t lane_id = threadIdx.x % kWorkThreads;
   const uint32_t worker_in_block = threadIdx.x / kWorkThreads;
   const uint32_t start_worker_id = blockIdx.x * kWorkersPerBlock + worker_in_block;
   const uint32_t total_workers = (params.num_qo_heads + params.num_kv_heads) * params.num_tokens;
   const uint32_t worker_stride = gridDim.x * kWorkersPerBlock;
+
+  const auto cos_cache_ptr = params.cos_sin_cache_ptr;
+  const auto sin_cache_ptr = pointer::offset(cos_cache_ptr, kCosSinStrideBytes / 2);
 
   PDLWaitPrimary<kUsePDL>();
 
@@ -128,117 +82,73 @@ __global__ __launch_bounds__(kBlockSize)  //
     const uint32_t token_id = work_id / num_q_and_k_heads;
     const uint32_t head_id = work_id % num_q_and_k_heads;
     const bool load_q = head_id < params.num_qo_heads;
+    const auto pos = static_cast<const IdType*>(params.positions)[token_id];
 
-    // Compute base row pointer. params.k_ptr has been pre-offset by
-    // `-num_qo_heads * head_stride_bytes` on the host so the kernel can index
-    // both q and k with the same `head_id` running over [0, num_q_and_k_heads).
-    void* row_ptr = pointer::offset(
+    const auto input = pointer::offset(
         load_q ? params.q_ptr : params.k_ptr,
         token_id * (load_q ? params.q_stride_bytes : params.k_stride_bytes),
         head_id * params.head_stride_bytes);
+    const auto cos_ptr = pointer::offset(cos_cache_ptr, pos * kCosSinStrideBytes);
+    const auto sin_ptr = pointer::offset(sin_cache_ptr, pos * kCosSinStrideBytes);
 
-    // ---- Step 1: vec-load 128-bit per thread, cast to fp32 -----------------
-    using vec_t = AlignedVector<DType, kNElts>;
+    auto input_vec = load_as<InputStorage>(input, lane_id);
     float x_vals[kNChunks][kNElts];
-    {
-      auto v = load_as<vec_t>(row_ptr, lane_id);
 #pragma unroll
-      for (int i = 0; i < kNElts; ++i) {
-        x_vals[0][i] = static_cast<float>(v[i]);
-      }
+    for (int j = 0; j < kVecSize; ++j) {
+      const auto [a, b] = cast<fp32x2_t>(input_vec[j]);
+      x_vals[0][2 * j] = a;
+      x_vals[0][2 * j + 1] = b;
     }
 
-    // ---- Step 2: in-register RoPE on the rope-half -------------------------
-    //
-    //   Two layouts (selected at compile time by kIsNeox):
-    //
-    //   Neox (split-half pairing): pair (head[i], head[i + kRopeHalf]) for
-    //     i in [0, kRopeHalf). Lanes [0, kRopeXThreads) hold q_x; lanes
-    //     [kRopeXThreads, kRopeYThreads) hold q_y. Pair partner via
-    //     __shfl_xor_sync(_, _, kRopeXThreads, kWorkThreads). Both x-lane and
-    //     y-lane in a pair load the SAME (cos[i], sin[i]).
-    //
-    //   Non-neox (interleaved pairing): pair (head[2i], head[2i+1]) for
-    //     i in [0, kRopeHalf). Each lane holds kPairsPerThread = kNElts/2
-    //     full pairs in its own 8 elements; no cross-lane shuffle is needed.
-    //     Lanes [0, kRopeYThreads) participate; lane t loads cos[t * kPairs ..]
-    //     and sin[t * kPairs ..] from the cos / sin halves of cos_sin_cache.
-    {
-      const auto pos = static_cast<const IdType*>(params.positions)[token_id];
-      const float* cos_cache = static_cast<const float*>(params.cos_sin_cache_ptr);
-      const float* sin_cache = cos_cache + kRopeHalf;
-      const int64_t pos_offset = static_cast<int64_t>(pos) * static_cast<int64_t>(kRopeDim);
-
-      if constexpr (kIsNeox) {
-        float cos_vals[kNElts] = {0};
-        float sin_vals[kNElts] = {0};
-        if (lane_id < kRopeYThreads) {
-          const uint32_t lane_in_rope = lane_id & (kRopeXThreads - 1);  // 0..kRopeXThreads-1
-          const int64_t base = pos_offset + static_cast<int64_t>(lane_in_rope) * kNElts;
+    if constexpr (kIsNeox) {
+      using CacheStorage = AlignedVector<fp32x2_t, kVecSize>;
+      const uint32_t lane_in_rope = lane_id & (kRopeXThreads - 1);
+      const auto cos_pair = load_as<CacheStorage>(cos_ptr, lane_in_rope);
+      const auto sin_pair = load_as<CacheStorage>(sin_ptr, lane_in_rope);
 #pragma unroll
-          for (int i = 0; i < kNElts; ++i) {
-            cos_vals[i] = cos_cache[base + i];
-            sin_vals[i] = sin_cache[base + i];
-          }
-        }
-
-        // Width = kWorkThreads keeps shuffles confined to one worker's lanes
-        // when multiple workers share a warp (kBlockSize / kWorkThreads
-        // workers/warp). All kWorkThreads lanes call shfl uniformly.
-#pragma unroll
-        for (int i = 0; i < kNElts; ++i) {
-          const float my_val = x_vals[0][i];
+      for (int j = 0; j < kVecSize; ++j) {
+        const auto [cos_0, cos_1] = cos_pair[j];
+        const auto [sin_0, sin_1] = sin_pair[j];
+        for (int sub = 0; sub < 2; ++sub) {
+          const float cos_v = (sub == 0) ? cos_0 : cos_1;
+          const float sin_v = (sub == 0) ? sin_0 : sin_1;
+          const int idx = 2 * j + sub;
+          const float my_val = x_vals[0][idx];
           const float pair_val = __shfl_xor_sync(0xFFFFFFFFu, my_val, kRopeXThreads, kWorkThreads);
           if (lane_id < kRopeXThreads) {
-            // q_x lane: my=x, pair=y → new_x = x*cos − y*sin
-            x_vals[0][i] = my_val * cos_vals[i] - pair_val * sin_vals[i];
+            x_vals[0][idx] = my_val * cos_v - pair_val * sin_v;
           } else if (lane_id < kRopeYThreads) {
-            // q_y lane: my=y, pair=x → new_y = x*sin + y*cos = pair*sin + my*cos
-            x_vals[0][i] = pair_val * sin_vals[i] + my_val * cos_vals[i];
-          }
-          // lane_id >= kRopeYThreads: nope, leave x_vals unchanged.
-        }
-      } else {
-        // Non-neox: pairs are adjacent inside each lane, all in registers.
-        constexpr int kPairsPerThread = kNElts / 2;  // 4 for kNElts=8
-        static_assert(kNElts % 2 == 0, "non-neox requires kNElts to be even");
-        if (lane_id < kRopeYThreads) {
-          const int64_t base = pos_offset + static_cast<int64_t>(lane_id) * kPairsPerThread;
-          float cos_vals[kPairsPerThread];
-          float sin_vals[kPairsPerThread];
-#pragma unroll
-          for (int m = 0; m < kPairsPerThread; ++m) {
-            cos_vals[m] = cos_cache[base + m];
-            sin_vals[m] = sin_cache[base + m];
-          }
-#pragma unroll
-          for (int m = 0; m < kPairsPerThread; ++m) {
-            const float x = x_vals[0][2 * m];
-            const float y = x_vals[0][2 * m + 1];
-            x_vals[0][2 * m] = x * cos_vals[m] - y * sin_vals[m];
-            x_vals[0][2 * m + 1] = x * sin_vals[m] + y * cos_vals[m];
+            x_vals[0][idx] = pair_val * sin_v + my_val * cos_v;
           }
         }
-        // lane_id >= kRopeYThreads: nope, leave x_vals unchanged.
+      }
+    } else {
+      using CacheStorage = AlignedVector<float, kVecSize>;
+      if (lane_id < kRopeYThreads) {
+        const auto cos_vec = load_as<CacheStorage>(cos_ptr, lane_id);
+        const auto sin_vec = load_as<CacheStorage>(sin_ptr, lane_id);
+#pragma unroll
+        for (int j = 0; j < kVecSize; ++j) {
+          const float x = x_vals[0][2 * j];
+          const float y = x_vals[0][2 * j + 1];
+          const float cos = cos_vec[j];
+          const float sin = sin_vec[j];
+          x_vals[0][2 * j] = x * cos - y * sin;
+          x_vals[0][2 * j + 1] = x * sin + y * cos;
+        }
       }
     }
 
-    // ---- Step 3: in-register kHeadDim-wide Hadamard butterfly --------------
-    //   kLogNElts in-thread stages, then kLogWorkThreads warp-shuffle stages.
-    //   At kHeadDim=128 / kWorkThreads=16 there are no cross-warp stages.
-    //   Width inside `hadamard_mult_warp` is kWorkThreads (matches our worker).
     hadamard_mult_thread<kLogNElts, kNChunks>(x_vals);
     hadamard_mult_warp<kLogWorkThreads, 0, kNChunks, kNElts>(x_vals);
 
-    // ---- Step 4: cast back to DType, apply scale, store in place -----------
-    {
-      vec_t v;
+    InputStorage out_vec;
 #pragma unroll
-      for (int i = 0; i < kNElts; ++i) {
-        v[i] = static_cast<DType>(x_vals[0][i] * params.had_scale);
-      }
-      store_as<vec_t>(row_ptr, v, lane_id);
+    for (int j = 0; j < kVecSize; ++j) {
+      out_vec[j] =
+          cast<DType2, fp32x2_t>({x_vals[0][2 * j] * params.had_scale, x_vals[0][2 * j + 1] * params.had_scale});
     }
+    store_as<InputStorage>(input, out_vec, lane_id);
   }
 
   PDLTriggerSecondary<kUsePDL>();
@@ -269,24 +179,33 @@ struct FusedRopeHadamardKernel {
     auto K = SymbolicSize{"num_kv_heads"};
     auto Hd = SymbolicSize{"head_dim"};
     auto Rd = SymbolicSize{"rope_dim"};
-    auto Dq = SymbolicSize{"q_token_stride"};
-    auto Dk = SymbolicSize{"k_token_stride"};
+    auto Dq = SymbolicSize{"q_stride"};
+    auto Dk = SymbolicSize{"k_stride"};
     auto Dh = SymbolicSize{"head_stride"};
+    auto device = SymbolicDevice{};
+    auto id_type = SymbolicDType{};
     Hd.set_value(kHeadDim);
     Rd.set_value(kRopeDim);
-
-    auto device = SymbolicDevice{};
     device.set_options<kDLCUDA>();
-    auto id_type = SymbolicDType{};
 
-    // q : [N, Q, kHeadDim], in-place
-    TensorMatcher({N, Q, Hd}).with_strides({Dq, Dh, 1}).with_dtype<DType>().with_device(device).verify(q);
-    // k : [N, K, kHeadDim], in-place; head stride must match q's
-    TensorMatcher({N, K, Hd}).with_strides({Dk, Dh, 1}).with_dtype<DType>().with_device(device).verify(k);
-    // cos_sin_cache : [max_pos, kRopeDim], fp32; first kRopeDim/2 = cos, second = sin
-    TensorMatcher({-1, Rd}).with_dtype<float>().with_device(device).verify(cos_sin_cache);
-    // positions : [N], int32 or int64
-    TensorMatcher({N}).with_dtype<int32_t, int64_t>(id_type).with_device(device).verify(positions);
+    TensorMatcher({N, Q, Hd})  // q input
+        .with_strides({Dq, Dh, 1})
+        .with_dtype<DType>()
+        .with_device(device)
+        .verify(q);
+    TensorMatcher({N, K, Hd})  // k input
+        .with_strides({Dk, Dh, 1})
+        .with_dtype<DType>()
+        .with_device(device)
+        .verify(k);
+    TensorMatcher({-1, Rd})  // cos_sin_cache
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(cos_sin_cache);
+    TensorMatcher({N})  // positions
+        .with_dtype<int32_t, int64_t>(id_type)
+        .with_device(device)
+        .verify(positions);
 
     const auto num_tokens = static_cast<uint32_t>(N.unwrap());
     const auto num_qo_heads = static_cast<uint32_t>(Q.unwrap());
@@ -295,7 +214,7 @@ struct FusedRopeHadamardKernel {
     const auto k_stride_bytes = static_cast<int64_t>(Dk.unwrap()) * sizeof(DType);
     const auto head_stride_bytes = static_cast<int64_t>(Dh.unwrap()) * sizeof(DType);
 
-    // Pre-offset k pointer so the kernel can index q/k uniformly via head_id ∈ [0, Q+K).
+    // NOTE: we offset the k here to reduce computation cost in the kernel
     const int64_t k_offset = static_cast<int64_t>(num_qo_heads) * head_stride_bytes;
 
     FusedRopeHadamardParams params;
@@ -316,7 +235,6 @@ struct FusedRopeHadamardKernel {
     const auto is_int32 = id_type.is_type<int32_t>();
     const auto kernel = is_int32 ? _kernel<int32_t> : _kernel<int64_t>;
 
-    // Persistent grid sized to occupancy × SM count, capped by needed workers.
     static const uint32_t kOccupancy[2] = {
         runtime::get_blocks_per_sm(_kernel<int32_t>, kBlockSize),
         runtime::get_blocks_per_sm(_kernel<int64_t>, kBlockSize),

--- a/python/sglang/jit_kernel/fused_rope_hadamard.py
+++ b/python/sglang/jit_kernel/fused_rope_hadamard.py
@@ -1,0 +1,147 @@
+"""Fused RoPE + Hadamard for the NSA Lightning Indexer.
+
+Replaces the chain
+  ``apply_rope_with_cos_sin_cache_inplace(q_rope, k_rope, ...)`` (1 launch)
+  ``hadamard_transform(query, scale=1/sqrt(head_dim))``           (1 launch)
+  ``hadamard_transform(key,   scale=1/sqrt(head_dim))``           (1 launch)
+with a single in-place launch that handles both ``q`` and ``k``.
+
+Public entrypoint: :func:`fused_rope_hadamard`.
+
+Architecture: portable from SM70+ (warp shuffles + 128-bit vec loads); PDL hooks
+gate to SM90+ via :func:`is_arch_support_pdl`, which covers SM90 (Hopper),
+SM100 (B200), and SM103 (B300).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import (
+    KERNEL_PATH,
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+logger = logging.getLogger(__name__)
+
+
+@cache_once
+def _jit_fused_rope_hadamard_module(
+    is_neox: bool,
+    head_dim: int,
+    rope_dim: int,
+    dtype: torch.dtype,
+) -> Module:
+    """JIT-compile (and cache) one specialization per (is_neox, head_dim, rope_dim, dtype).
+
+    PDL is folded into the cache key indirectly: ``is_arch_support_pdl()`` returns
+    a per-process constant, so each architecture lane gets its own specialization.
+    """
+    pdl = is_arch_support_pdl()
+    args = make_cpp_args(
+        is_neox,
+        head_dim,
+        rope_dim,
+        pdl,
+        dtype,
+    )
+    hadamard_include_dir = (KERNEL_PATH / "csrc" / "fast-hadamard-transform").resolve()
+    logger.info(
+        "[NSA] JIT-compiling fused_rope_hadamard "
+        "(is_neox=%s, head_dim=%d, rope_dim=%d, dtype=%s, pdl=%s)",
+        is_neox,
+        head_dim,
+        rope_dim,
+        dtype,
+        pdl,
+    )
+    module = load_jit(
+        "fused_rope_hadamard",
+        *args,
+        cuda_files=["elementwise/fused_rope_hadamard.cuh"],
+        cuda_wrappers=[
+            ("run", f"FusedRopeHadamardKernel<{args}>::run"),
+        ],
+        extra_include_paths=[str(hadamard_include_dir)],
+    )
+    logger.info(
+        "[NSA] fused_rope_hadamard JIT compile complete "
+        "(is_neox=%s, head_dim=%d, rope_dim=%d, dtype=%s)",
+        is_neox,
+        head_dim,
+        rope_dim,
+        dtype,
+    )
+    return module
+
+
+@register_custom_op(
+    op_name="nsa_fused_rope_hadamard",
+    mutates_args=["q", "k"],
+)
+def fused_rope_hadamard(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    is_neox: bool = True,
+    rope_dim: int = 0,
+) -> None:
+    """Fused in-place RoPE (rope-half) + per-head Hadamard (full head_dim).
+
+    Args:
+        q: Query tensor of shape ``[num_tokens, num_qo_heads, head_dim]``, fp16/bf16.
+            The first ``rope_dim`` columns of each head are RoPE-rotated; the full
+            ``head_dim`` is then Hadamard-transformed and scaled by ``1/sqrt(head_dim)``.
+            Modified in place.
+        k: Key tensor of shape ``[num_tokens, num_kv_heads, head_dim]``, same dtype/device
+            as ``q``. Same per-head treatment. Modified in place.
+        cos_sin_cache: ``[max_position, rope_dim]`` fp32. The first ``rope_dim/2``
+            columns are cos values; the second ``rope_dim/2`` are sin values
+            (matching :mod:`sglang.jit_kernel.rope`'s layout).
+        positions: ``[num_tokens]`` int32 or int64 position indices.
+        is_neox: True for GPT-NeoX-style (paired rotation across the rope-half
+            midpoint). False is not yet supported (asserted in the kernel).
+        rope_dim: rope dimension; defaults to ``cos_sin_cache.size(-1)``.
+
+    Notes:
+        * ``head_dim`` must be a power of two and equal between ``q`` and ``k``.
+        * ``rope_dim`` must satisfy ``rope_dim % (2 * (16 / sizeof(dtype))) == 0``
+          (so the rope/nope split aligns to vector lanes; e.g. multiple of 16 for bf16).
+        * ``head_dim / (16 / sizeof(dtype))`` must be in ``[4, 32]``: the kernel
+          uses sub-warp/warp Hadamard butterflies and does not stage across warps
+          in this version. For bf16/fp16 this covers ``head_dim ∈ {32, 64, 128, 256}``.
+        * ``q`` and ``k`` must share the same per-head stride.
+
+    Example:
+        >>> # In nsa_indexer._get_q_k_bf16, replace:
+        >>> #   q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
+        >>> #   self._update_rope_guarded(query[..., :rope_head_dim], q_rope)
+        >>> #   self._update_rope_guarded(key[..., :rope_head_dim], k_rope)
+        >>> #   query = rotate_activation(query)
+        >>> #   key   = rotate_activation(key)
+        >>> # with:
+        >>> fused_rope_hadamard(
+        ...     q=query,
+        ...     k=key,
+        ...     cos_sin_cache=self.rotary_emb.cos_sin_cache,
+        ...     positions=positions,
+        ...     is_neox=self.rotary_emb.is_neox_style,
+        ...     rope_dim=self.rope_head_dim,
+        ... )
+    """
+    rope_dim = rope_dim or cos_sin_cache.size(-1)
+    head_dim = q.size(-1)
+    module = _jit_fused_rope_hadamard_module(is_neox, head_dim, rope_dim, q.dtype)
+    module.run(q, k, cos_sin_cache, positions)

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from einops import rearrange
 
+from sglang.jit_kernel.fused_rope_hadamard import fused_rope_hadamard
 from sglang.jit_kernel.fused_store_index_cache import (
     can_use_nsa_fused_store,
     fused_store_index_k_cache,
@@ -68,6 +70,11 @@ from sglang.srt.server_args import get_global_server_args
 _use_ag_after_qlora = envs.SGLANG_USE_AG_AFTER_QLORA.get()
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
+
+logger = logging.getLogger(__name__)
+
+# Logged once per process, on the first call that takes the fused fast path.
+_FUSED_ROPE_HAD_FIRST_HIT_LOGGED: bool = False
 
 
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
@@ -241,6 +248,56 @@ class Indexer(MultiPlatformOp):
         self.scale_fmt = scale_fmt
         self.softmax_scale = self.head_dim**-0.5
 
+        # Static eligibility for the fused RoPE+Hadamard JIT kernel.
+        # Combines into one launch the chain
+        #   rotary_emb (q + k)  →  Hadamard(q)  →  Hadamard(k).
+        # The kernel's internal asserts require:
+        #   - kHeadDim is a power of 2 in [32, 256] (kWorkThreads in [4, 32])
+        #   - kRopeDim divisible by 2 * (16 / sizeof(DType)); for bf16/fp16 that is 16
+        #   - neox-style RoPE
+        # Runtime checks the dtype is bf16/fp16 and the device is CUDA / non-fnuz FP8.
+        self._fused_rope_had_eligible = (
+            _is_cuda
+            and not _is_fp8_fnuz
+            and self.head_dim in (32, 64, 128, 256)
+            and 0 < self.rope_head_dim <= self.head_dim
+            and self.rope_head_dim % 16 == 0
+            and is_neox_style
+        )
+        # Log once per process (gate on layer_id==0) so we can confirm at server
+        # startup whether the fast path is reachable for this model config.
+        if self.layer_id == 0:
+            if self._fused_rope_had_eligible:
+                logger.info(
+                    "[NSA] fused_rope_hadamard fast path ELIGIBLE "
+                    "(head_dim=%d, rope_head_dim=%d, neox=%s); "
+                    "JIT compile happens on the first forward.",
+                    self.head_dim,
+                    self.rope_head_dim,
+                    is_neox_style,
+                )
+            else:
+                reasons = []
+                if not _is_cuda:
+                    reasons.append("not CUDA")
+                if _is_fp8_fnuz:
+                    reasons.append("FP8-fnuz device")
+                if self.head_dim not in (32, 64, 128, 256):
+                    reasons.append(f"head_dim={self.head_dim} unsupported")
+                if not (0 < self.rope_head_dim <= self.head_dim):
+                    reasons.append(f"rope_head_dim={self.rope_head_dim} out of range")
+                if self.rope_head_dim % 16 != 0:
+                    reasons.append(
+                        f"rope_head_dim={self.rope_head_dim} not divisible by 16"
+                    )
+                if not is_neox_style:
+                    reasons.append("non-neox RoPE")
+                logger.info(
+                    "[NSA] fused_rope_hadamard fast path DISABLED, "
+                    "falling back to (rotary_emb + Hadamard×2): %s",
+                    "; ".join(reasons) if reasons else "unknown",
+                )
+
     @contextlib.contextmanager
     def _with_real_sm_count(self):
         # When pipeline parallelism is enabled, each PP rank initiates a recv operation after the _pp_launch_batch
@@ -343,6 +400,65 @@ class Indexer(MultiPlatformOp):
                 key, [self.rope_head_dim, self.head_dim - self.rope_head_dim], dim=-1
             )
 
+        # Fused fast path: one launch that does RoPE on the rope-half + the
+        # kHeadDim-wide Hadamard on the full per-head row, in place on q and k.
+        # Replaces the (rotary_emb + 2× _update_rope_guarded + 2× rotate_activation)
+        # chain. See sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh.
+        if self._fused_rope_had_eligible and query.dtype in (
+            torch.bfloat16,
+            torch.float16,
+        ):
+            global _FUSED_ROPE_HAD_FIRST_HIT_LOGGED
+            if not _FUSED_ROPE_HAD_FIRST_HIT_LOGGED:
+                _FUSED_ROPE_HAD_FIRST_HIT_LOGGED = True
+                logger.info(
+                    "[NSA] fused_rope_hadamard fast path ACTIVE "
+                    "(layer_id=%d, num_tokens=%d, num_qo_heads=%d, "
+                    "num_kv_heads=%d, head_dim=%d, rope_dim=%d, dtype=%s)",
+                    self.layer_id,
+                    query.size(0),
+                    query.size(1),
+                    key.size(1),
+                    self.head_dim,
+                    self.rope_head_dim,
+                    query.dtype,
+                )
+            fused_rope_hadamard(
+                q=query,
+                k=key,
+                cos_sin_cache=self.rotary_emb.cos_sin_cache,
+                positions=positions,
+                is_neox=self.rotary_emb.is_neox_style,
+                rope_dim=self.rope_head_dim,
+            )
+            # CP path still needs the all-gather; overlap it on alt_stream when
+            # available so the next kernel on the main stream can start sooner.
+            if (
+                forward_batch.attn_cp_metadata is not None
+                and self.nsa_enable_prefill_cp
+            ):
+                if self.alt_stream is not None:
+                    current_stream = torch.cuda.current_stream()
+                    self.alt_stream.wait_stream(current_stream)
+                    with torch.cuda.stream(self.alt_stream):
+                        key = cp_all_gather_rerange_output(
+                            key.contiguous(),
+                            self.cp_size,
+                            forward_batch,
+                            torch.cuda.current_stream(),
+                        )
+                    current_stream.wait_stream(self.alt_stream)
+                else:
+                    key = cp_all_gather_rerange_output(
+                        key.contiguous(),
+                        self.cp_size,
+                        forward_batch,
+                        torch.cuda.current_stream(),
+                    )
+            return query, key
+
+        # Fallback: original RoPE + per-side Hadamard chain. Used on AMD/HIP,
+        # NPU, FP8-fnuz, non-neox RoPE, or unsupported head_dim/rope_dim shapes.
         q_rope, k_rope = self.rotary_emb(positions, q_rope, k_rope)
 
         self._update_rope_guarded(query[..., : self.rope_head_dim], q_rope)

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -256,17 +256,19 @@ class Indexer(MultiPlatformOp):
         #   - kRopeDim divisible by 2 * (16 / sizeof(DType)); for bf16/fp16 that is 16
         #   - neox-style RoPE
         # Runtime checks the dtype is bf16/fp16 and the device is CUDA / non-fnuz FP8.
+        # Both neox and non-neox RoPE are supported; the kernel branches on
+        # `is_neox` at compile time and is templated separately per JIT-cache key.
         self._fused_rope_had_eligible = (
             _is_cuda
             and not _is_fp8_fnuz
             and self.head_dim in (32, 64, 128, 256)
             and 0 < self.rope_head_dim <= self.head_dim
             and self.rope_head_dim % 16 == 0
-            and is_neox_style
         )
         # Log once per process (gate on layer_id==0) so we can confirm at server
         # startup whether the fast path is reachable for this model config.
         if self.layer_id == 0:
+            rope_neox = bool(getattr(self.rotary_emb, "is_neox_style", is_neox_style))
             if self._fused_rope_had_eligible:
                 logger.info(
                     "[NSA] fused_rope_hadamard fast path ELIGIBLE "
@@ -274,7 +276,7 @@ class Indexer(MultiPlatformOp):
                     "JIT compile happens on the first forward.",
                     self.head_dim,
                     self.rope_head_dim,
-                    is_neox_style,
+                    rope_neox,
                 )
             else:
                 reasons = []
@@ -290,8 +292,6 @@ class Indexer(MultiPlatformOp):
                     reasons.append(
                         f"rope_head_dim={self.rope_head_dim} not divisible by 16"
                     )
-                if not is_neox_style:
-                    reasons.append("non-neox RoPE")
                 logger.info(
                     "[NSA] fused_rope_hadamard fast path DISABLED, "
                     "falling back to (rotary_emb + Hadamard×2): %s",
@@ -404,10 +404,12 @@ class Indexer(MultiPlatformOp):
         # kHeadDim-wide Hadamard on the full per-head row, in place on q and k.
         # Replaces the (rotary_emb + 2× _update_rope_guarded + 2× rotate_activation)
         # chain. See sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh.
-        if self._fused_rope_had_eligible and query.dtype in (
-            torch.bfloat16,
-            torch.float16,
-        ):
+        if self._fused_rope_had_eligible and query.dtype == torch.bfloat16:
+            # `key` comes out of `self.wk(x) → self.k_norm(...)` as 2-D `[L, head_dim]`
+            # (MQA, single kv head). The fused kernel's TensorMatcher requires a
+            # 3-D layout `[L, num_kv_heads, head_dim]`, so reshape to a same-storage
+            # 3-D view here. Mutations through `key_3d` are visible on `key`.
+            key_3d = key.view(key.size(0), 1, self.head_dim)
             global _FUSED_ROPE_HAD_FIRST_HIT_LOGGED
             if not _FUSED_ROPE_HAD_FIRST_HIT_LOGGED:
                 _FUSED_ROPE_HAD_FIRST_HIT_LOGGED = True
@@ -418,14 +420,14 @@ class Indexer(MultiPlatformOp):
                     self.layer_id,
                     query.size(0),
                     query.size(1),
-                    key.size(1),
+                    key_3d.size(1),
                     self.head_dim,
                     self.rope_head_dim,
                     query.dtype,
                 )
             fused_rope_hadamard(
                 q=query,
-                k=key,
+                k=key_3d,
                 cos_sin_cache=self.rotary_emb.cos_sin_cache,
                 positions=positions,
                 is_neox=self.rotary_emb.is_neox_style,


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The NSA Lightning Indexer's `_get_q_k_bf16` issues three CUDA kernels per layer per forward to apply RoPE on the rope-half of `q`/`k` and a per-head Hadamard transform on the full head:

1. `apply_rope_with_cos_sin_cache_inplace(q, k, ...)` — one in-place kernel for both `q` and `k`.
2. `hadamard_transform(query, scale=1/sqrt(head_dim))` — one kernel for `q`.
3. `hadamard_transform(key,   scale=1/sqrt(head_dim))` — one kernel for `k`.

This PR collapses the three kernels into one fused op.

Compatible with: bf16/fp16, head_dim ∈ {32, 64, 128, 256}, both neox and non-neox RoPE (NON neox dsv32/glm5, CUDA only (non-FNUZ FP8). Other paths are untouched.

Model for test:`nvidia/GLM-5-NVFP4` (TP=4, EP=4, EAGLE-3 speculative) on B300.

## Modifications

Create (`fused_rope_hadamard`) for replace the existing `apply_rope_with_cos_sin_cache_inplace` + 2× `hadamard_transform` chain inside `nsa_indexer._get_q_k_bf16`.

<!-- for llms.

### 1. New fused kernel — `python/sglang/jit_kernel/csrc/elementwise/fused_rope_hadamard.cuh`

A single block-tiled kernel that walks every `(token, head)` pair across **both** q and k heads. For each work item it loads the head into registers, applies RoPE on the first `rope_dim` elements (warp-shuffle for the paired element), then applies Hadamard via `hadamard_mult_thread` + `hadamard_mult_warp`, scales by `1/sqrt(head_dim)`, and stores back in place.

Key design points:

- **Unified worker loop over q ∪ k.** `total_workers = (Hq + Hk) * num_tokens`; `head_id = work_id % (Hq + Hk)`; `load_q = head_id < Hq`. One grid covers both tensors.
- **Pre-offset k pointer trick.** Host code sets `params.k_ptr = k.data_ptr() - Hq * head_stride_bytes`. Inside the kernel the address calc is just `base + token*stride + head_id*head_stride` for both q and k — no branch, no extra subtract.
- **bf16/fp16 vectorization.** `kNElts = 16/sizeof(DType)` (8 for bf16); `kWorkThreads = head_dim/kNElts` (16 for `head_dim=128`). `kBlockSize=128` ⇒ 8 heads/block. Each head lives in one warp's registers, so `hadamard_mult_warp` suffices — zero shared memory.
- **RoPE.** Neox uses `__shfl_xor_sync(..., kRopeXThreads, kWorkThreads)` to fetch the paired element across the rope-half midpoint within the sub-warp. Non-neox is the standard pairwise (cos, sin) form. Both branches are templated and JIT-cached separately.
- **PDL.** `PDLWaitPrimary` / `PDLTriggerSecondary` gated on `is_arch_support_pdl()` (SM90/SM100/SM103). Per-arch is folded into the JIT cache key indirectly via a per-process constant.

### 2. Python wrapper — `python/sglang/jit_kernel/fused_rope_hadamard.py`

`fused_rope_hadamard(q, k, cos_sin_cache, positions, *, is_neox, rope_dim)`:
- Registered as a custom op (`nsa_fused_rope_hadamard`) with `mutates_args=["q", "k"]` so torch.compile/inductor see the in-place semantics.
- `_jit_fused_rope_hadamard_module` keys on `(is_neox, head_dim, rope_dim, dtype)` and uses `cache_once`. PDL falls in via the per-process arch constant.

### 3. Wire-up in `python/sglang/srt/layers/attention/nsa/nsa_indexer.py`

- `Indexer.__init__` computes `self._fused_rope_had_eligible` from the static config (CUDA, non-FNUZ FP8, `head_dim ∈ {32,64,128,256}`, `0 < rope_head_dim ≤ head_dim`, `rope_head_dim % 16 == 0`). Logs `ELIGIBLE` or `DISABLED` (with reasons) once per process at `layer_id == 0` so it's easy to confirm at server startup whether the fast path is reachable for a given model config.
- `_get_q_k_bf16` calls the fused op when eligible and `query.dtype == torch.bfloat16`. Reshapes `key` from 2-D `[L, head_dim]` (MQA, single kv head) to a 3-D view `[L, 1, head_dim]` to match the kernel's `TensorMatcher` — same storage, mutations visible on `key`.
- CP path (`forward_batch.attn_cp_metadata is not None and self.nsa_enable_prefill_cp`) preserves the existing alt-stream all-gather overlap.
- One-shot `[NSA] fused_rope_hadamard fast path ACTIVE` log on the first call so the actual hit is visible in the server log (gated on a process-local boolean — fine for an info log under TP/PP).
- The original `(rotary_emb + 2× _update_rope_guarded + 2× rotate_activation)` chain is kept verbatim as the fallback.

### Before / after

```
Before                                      After
──────                                      ─────
apply_rope_with_cos_sin_cache_inplace       fused_rope_hadamard
  (1 kernel: q+k together)                    (1 kernel: q+k, RoPE+Hadamard, in place)
_update_rope_guarded(q)  # no-op when in-place
_update_rope_guarded(k)  # no-op when in-place
hadamard_transform(q)                       
  (1 kernel)                                
hadamard_transform(k)                       
  (1 kernel)                                
──────                                      ─────
3 launches per layer per forward            1 launch per layer per forward
```

### Kernel-launch validation (torch profiler, 10 steps, profile-by-stage, TP-0)

| Stage | Kernel | main | this PR |
|---|---|---:|---:|
| EXTEND | `apply_rope*` | 79 | 0 |
| EXTEND | `hadamard*`   | 158 | 0 |
| EXTEND | `fused_rope_hadamard` | 0 | **79** |
| EXTEND | **total launches** | **237** | **79** |
| DECODE | `apply_rope*` | 810 | 0 |
| DECODE | `hadamard*`   | 1620 | 0 |
| DECODE | `fused_rope_hadamard` | 0 | **810** |
| DECODE | **total launches** | **2430** | **810** |

The `1 : 2` ratio of `apply_rope : hadamard` on `main` is exactly the expected `1 RoPE : 2 Hadamard (q+k separately)` chain. The PR collapses every group of three to one. Dual-stream overlap on the two Hadamards already hides part of this on the GPU side; the remaining wins are per-call CPU launch overhead and the q/k HBM round-trips that the separate Hadamard kernels would have done.

-->

## Accuracy Tests

aime25 eval:

```bash
python -m sglang.test.run_eval \
  --port 30021 --eval-name aime25 \
  --temperature 1.0 --top-p 0.95 --max-tokens 131072 \
  --thinking-mode glm-45 --repeat 4
```

| Branch | Per-repeat scores | Mean |
|---|---|---:|
| `main` (baseline) | `0.633, 0.733, 0.767, 0.767` | **0.725** |
| this PR (fusion)  | `0.733, 0.833, 0.700, 0.733` | **0.750** |

## Benchmarking and Profiling

### End-to-end serving (`bench_serving`, 32k input → 8k output)

`nvidia/GLM-5-NVFP4`, TP=4 EP=4, EAGLE-3 (`steps=3 topk=1 draft_tokens=4`), `--quantization modelopt_fp4`, B300. Same launch command and `bench_serving` invocation on both branches; warmup-3 + `--flush-cache` before the timed run on every config.

```bash
python -m sglang.bench_serving \
  --backend sglang --base-url http://127.0.0.1:30021 \
  --model nvidia/GLM-5-NVFP4 --dataset-name random \
  --random-input-len 32000 --random-output-len 8192 --random-range-ratio 1.0 \
  --num-prompts <N> --max-concurrency <C> --request-rate inf \
  --warmup-requests 3 --flush-cache --output-details
```

**1 prompt (sequential)**

| Metric | `main` | this PR | Δ |
|---|---:|---:|---:|
| Output throughput (tok/s) | 226.49 | **230.00** | **+1.55%** |
| TPOT (ms) | 4.22 | **4.16** | **−1.42%** |
| Median ITL (ms) | 4.22 | 4.16 | −0.06 |
| TTFT (ms) | 1561.31 | 1535.15 | −26 (−1.68%) |
| E2E latency (ms) | 36 154 | 35 604 | −549 (−1.52%) |
| Accept length | 4.00 | 4.00 | identical |

**32 prompts × max-concurrency 16 (`--request-rate inf`)**

| Metric | `main` | this PR | Δ |
|---|---:|---:|---:|
| Output throughput (tok/s) | 1 439.47 | **1 474.87** | **+2.46%** |
| TPOT (ms) | 9.66 | **9.55** | **−1.14%** |
| Median ITL (ms) | 7.79 | 7.73 | −0.06 |
| Mean TTFT (ms) | 10 065 | 9 348 | **−717 (−7.12%)** |
| Median TTFT (ms) | 8 430 | 8 060 | −370 (−4.39%) |
| Mean E2E (ms) | 89 207 | 87 609 | −1 598 (−1.79%) |
| Accept length | 3.98 | 3.98 | identical |


### torch trace.

#### `main` (baseline)

<img width="1688" height="1794" alt="CleanShot 2026-05-03 at 17 06 53@2x" src="https://github.com/user-attachments/assets/5adbeb0b-55ec-47d6-866d-8901ec1bb59c" />

q / k is on the other stream.

#### this PR (fused)

<img width="1644" height="1046" alt="CleanShot 2026-05-03 at 17 07 44@2x" src="https://github.com/user-attachments/assets/6caccd95-6962-42e4-9633-ffd7bd11622e" />

so about 4.2 to 2.5mus


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
