### PR TITLE
rerun-test: route deepep h200 suite to deepep runner

### DIFF
--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -21,6 +21,7 @@ on:
           - 4-gpu-a10
           - 4-gpu-b200
           - 8-gpu-h200
+          - 8-gpu-h200-deepep
           - 8-gpu-h20
           - 8-gpu-b200
           - ubuntu-latest

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -50,6 +50,8 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
+  # TEMP: rebuild deepep against the new torch for torch-211-merge PR only — revert before merging to main.
+  FORCE_REBUILD_DEEPEP: '1'
 
 permissions:
   actions: write

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -486,7 +486,7 @@ CUDA_SUITE_TO_RUNNER = {
     "stage-c-test-8-gpu-h20": "8-gpu-h20",
     "stage-c-test-4-gpu-b200": "4-gpu-b200",
     "stage-c-test-deepep-4-gpu-h100": "4-gpu-h100",
-    "stage-c-test-deepep-8-gpu-h200": "8-gpu-h200",
+    "stage-c-test-deepep-8-gpu-h200": "8-gpu-h200-deepep",
     # Nightly test suites (NVIDIA)
     "nightly-1-gpu": "1-gpu-h100",
     "nightly-4-gpu": "4-gpu-h100",


### PR DESCRIPTION
Match the runner that pr-test.yml uses for stage-c-test-deepep-8-gpu-h200 (8-gpu-h200-deepep), so /rerun-test on this suite lands on the same hardware as the original PR job.