### PR TITLE
extract dsv4 server-args hooks to arg_groups

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -54,22 +54,24 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
 
 def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:
     """Validate DeepSeek V4 context-parallel configuration."""
-    if server_args.enable_nsa_prefill_context_parallel:
-        if server_args.nsa_prefill_cp_mode == "round-robin-split":
-            server_args.moe_dense_tp_size = 1
-            assert (
-                server_args.dp_size == 1
-            ), "For round-robin split mode, dp attention is not supported."
-            assert (
-                server_args.tp_size <= 8
-            ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
-            logger.warning(
-                f"Enable Context Parallel for DeepSeekV4, "
-                f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "
-                f"ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
-            )
-        else:
-            raise ValueError(
-                f"DeepSeekV4 only supports round-robin-split CP mode, "
-                f"got {server_args.nsa_prefill_cp_mode}"
-            )
+    if not server_args.enable_nsa_prefill_context_parallel:
+        return
+
+    if server_args.nsa_prefill_cp_mode != "round-robin-split":
+        raise ValueError(
+            f"DeepSeekV4 only supports round-robin-split CP mode, "
+            f"got {server_args.nsa_prefill_cp_mode}"
+        )
+
+    server_args.moe_dense_tp_size = 1
+    assert (
+        server_args.dp_size == 1
+    ), "For round-robin split mode, dp attention is not supported."
+    assert (
+        server_args.tp_size <= 8
+    ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+    logger.warning(
+        f"Enable Context Parallel for DeepSeekV4, "
+        f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "
+        f"ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
+    )

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -1,0 +1,77 @@
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> None:
+    """Apply DeepSeek V4 model-specific server arg defaults and constraints."""
+    from sglang.srt.environ import envs
+    from sglang.srt.server_args import ServerArgs
+
+    server_args.attention_backend = "compressed"
+    server_args.page_size = 256
+    logger.info(
+        f"Use compressed attention backend for {model_arch}, setting page_size to 256."
+    )
+
+    if server_args.max_running_requests is None:
+        server_args.max_running_requests = 256
+        logger.warning(
+            f"Setting max_running_requests to {server_args.max_running_requests} for {model_arch}."
+        )
+
+    if server_args.kv_cache_dtype == "auto":
+        server_args.kv_cache_dtype = "fp8_e4m3"
+        logger.warning(
+            f"Setting KV cache dtype to {server_args.kv_cache_dtype} for {model_arch}."
+        )
+    assert server_args.kv_cache_dtype in [
+        "fp8_e4m3"
+    ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
+
+    if server_args.speculative_algorithm is not None:
+        assert (
+            server_args.speculative_algorithm == "EAGLE"
+        ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
+        assert (
+            server_args.speculative_eagle_topk == 1
+        ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
+
+        if not envs.SGLANG_ENABLE_SPEC_V2.get():
+            envs.SGLANG_ENABLE_SPEC_V2.set(True)
+            logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
+
+    if server_args.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
+        server_args.swa_full_tokens_ratio = 0.1
+        logger.info(
+            f"Setting swa_full_tokens_ratio to {server_args.swa_full_tokens_ratio} for {model_arch}."
+        )
+
+
+def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:
+    """Validate DeepSeek V4 context-parallel configuration."""
+    if not server_args.enable_nsa_prefill_context_parallel:
+        return
+
+    if server_args.nsa_prefill_cp_mode != "round-robin-split":
+        raise ValueError(
+            f"DeepSeekV4 only supports round-robin-split CP mode, "
+            f"got {server_args.nsa_prefill_cp_mode}"
+        )
+
+    server_args.moe_dense_tp_size = 1
+    assert (
+        server_args.dp_size == 1
+    ), "For round-robin split mode, dp attention is not supported."
+    assert (
+        server_args.tp_size <= 8
+    ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+    logger.warning(
+        f"Enable Context Parallel for DeepSeekV4, "
+        f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "
+        f"ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
+    )

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -54,24 +54,22 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
 
 def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:
     """Validate DeepSeek V4 context-parallel configuration."""
-    if not server_args.enable_nsa_prefill_context_parallel:
-        return
-
-    if server_args.nsa_prefill_cp_mode != "round-robin-split":
-        raise ValueError(
-            f"DeepSeekV4 only supports round-robin-split CP mode, "
-            f"got {server_args.nsa_prefill_cp_mode}"
-        )
-
-    server_args.moe_dense_tp_size = 1
-    assert (
-        server_args.dp_size == 1
-    ), "For round-robin split mode, dp attention is not supported."
-    assert (
-        server_args.tp_size <= 8
-    ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
-    logger.warning(
-        f"Enable Context Parallel for DeepSeekV4, "
-        f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "
-        f"ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
-    )
+    if server_args.enable_nsa_prefill_context_parallel:
+        if server_args.nsa_prefill_cp_mode == "round-robin-split":
+            server_args.moe_dense_tp_size = 1
+            assert (
+                server_args.dp_size == 1
+            ), "For round-robin split mode, dp attention is not supported."
+            assert (
+                server_args.tp_size <= 8
+            ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+            logger.warning(
+                f"Enable Context Parallel for DeepSeekV4, "
+                f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "
+                f"ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
+            )
+        else:
+            raise ValueError(
+                f"DeepSeekV4 only supports round-robin-split CP mode, "
+                f"got {server_args.nsa_prefill_cp_mode}"
+            )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1673,44 +1673,11 @@ class ServerArgs:
         if model_arch in [
             "DeepseekV4ForCausalLM",
         ]:
-            self.attention_backend = "compressed"
-            self.page_size = 256
-            logger.info(
-                f"Use compressed attention backend for {model_arch}, setting page_size to 256."
+            from sglang.srt.arg_groups.deepseek_v4_hook import (
+                apply_deepseek_v4_defaults,
             )
 
-            if self.max_running_requests is None:
-                self.max_running_requests = 256
-                logger.warning(
-                    f"Setting max_running_requests to {self.max_running_requests} for {model_arch}."
-                )
-
-            if self.kv_cache_dtype == "auto":
-                self.kv_cache_dtype = "fp8_e4m3"
-                logger.warning(
-                    f"Setting KV cache dtype to {self.kv_cache_dtype} for {model_arch}."
-                )
-            assert self.kv_cache_dtype in [
-                "fp8_e4m3"
-            ], f"{self.kv_cache_dtype} is not supported for {model_arch}"
-
-            if self.speculative_algorithm is not None:
-                assert (
-                    self.speculative_algorithm == "EAGLE"
-                ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
-                assert (
-                    self.speculative_eagle_topk == 1
-                ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
-
-                if not envs.SGLANG_ENABLE_SPEC_V2.get():
-                    envs.SGLANG_ENABLE_SPEC_V2.set(True)
-                    logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
-
-            if self.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
-                self.swa_full_tokens_ratio = 0.1
-                logger.info(
-                    f"Setting swa_full_tokens_ratio to {self.swa_full_tokens_ratio} for {model_arch}."
-                )
+            apply_deepseek_v4_defaults(self, model_arch)
 
         if model_arch in [
             "DeepseekV3ForCausalLM",
@@ -1917,25 +1884,9 @@ class ServerArgs:
         elif model_arch in [
             "DeepseekV4ForCausalLM",
         ]:
-            if self.enable_nsa_prefill_context_parallel:
-                if self.nsa_prefill_cp_mode == "round-robin-split":
-                    self.moe_dense_tp_size = 1
-                    assert (
-                        self.dp_size == 1
-                    ), "For round-robin split mode, dp attention is not supported."
-                    assert (
-                        self.tp_size <= 8
-                    ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
-                    logger.warning(
-                        f"Enable Context Parallel for DeepSeekV4, "
-                        f"dp_size={self.dp_size}, moe_dense_tp_size={self.moe_dense_tp_size}, "
-                        f"ep_size={self.ep_size}, tp_size={self.tp_size}"
-                    )
-                else:
-                    raise ValueError(
-                        f"DeepSeekV4 only supports round-robin-split CP mode, "
-                        f"got {self.nsa_prefill_cp_mode}"
-                    )
+            from sglang.srt.arg_groups.deepseek_v4_hook import validate_deepseek_v4_cp
+
+            validate_deepseek_v4_cp(self)
 
         elif model_arch in ["GptOssForCausalLM"]:
             # Set attention backend for GPT-OSS


### PR DESCRIPTION
Move DSv4-specific defaults + CP validation out of `server_args.py` into `arg_groups/deepseek_v4_hook.py`. No behavioral change.

Aligned with RFC #20481 (per-arch hook + lazy import), but simplified — flat `arg_groups/<model>_hook.py` instead of the RFC's nested `arg_groups/handlers/model_specific/<model>.py`. The 3-level depth there is over-engineered for the per-arch hook pattern alone, and we may not need that complexity.