### PR TITLE
[DIAGNOSTIC, DO NOT MERGE] Pin test_prefill_logits to marco/mcdse-2b-v1 to reproduce the 5090 failure

### DIFF
--- a/test/registered/prefill_only/test_embedding_models.py
+++ b/test/registered/prefill_only/test_embedding_models.py
@@ -45,7 +45,12 @@ MODEL_TO_CONFIG = {
     # Temporarily disable before this model is fixed
     # "jason9693/Qwen2.5-1.5B-apeach": (1, 1e-5),
 }
-MODELS = [(key, *MODEL_TO_CONFIG[key]) for key in MODEL_TO_CONFIG]
+# DIAGNOSTIC ONLY — DO NOT MERGE.
+# Pin test_prefill_logits to only marco/mcdse-2b-v1 to confirm reproducibility
+# of the 5090 (sm_120) flashinfer divergence we identified in PR #24279. If
+# this branch's CI shows the ~0.30 cosine diff failure on stage-b-test-1-gpu-small,
+# that confirms mcdse is the offender and the skip in #24279 is the correct fix.
+MODELS = [("marco/mcdse-2b-v1", *MODEL_TO_CONFIG["marco/mcdse-2b-v1"])]
 
 TORCH_DTYPES = [torch.float16]
 


### PR DESCRIPTION
## Status

**DRAFT — DO NOT MERGE.** Diagnostic-only PR.

## Companion to #24279

PR #24279 removes \`marco/mcdse-2b-v1\` from \`random.choice(MODELS)\` to unblock the scheduled \`main\` PR Test pipeline. This PR does the **inverse** — pins \`test_prefill_logits\` to **only** mcdse — so that we can deterministically reproduce the failure on the 5090 (sm_120) runner and verify our hypothesis that mcdse is the offender.

## Hypothesis under test

Per #24279, on **A100 (sm_80) + sglang 0.5.10.post1 + fp16 + flashinfer + transformers 5.3.0** with byte-identical inputs, mcdse agrees with the HF reference to ~\`1e-6\` cosine. The CI failure (~0.30 cosine diff) only manifests on the **5090 (sm_120)** runner, suggesting a structural sm_120 kernel issue (most likely flashinfer) for mcdse's specific shape (head_dim=128, GQA 6:1, Qwen2-VL backbone).

If this PR's \`stage-b-test-1-gpu-small\` job fails with the \`embeddings are not all close\` assertion and \`similarity diff tensor(0.~)\` lines, that confirms:

1. mcdse is the failing model (since this PR forces \`random.choice\` to land on it).
2. The skip in #24279 is the correct, minimal fix.
3. The underlying issue is real and needs a follow-up kernel investigation.

If this PR passes, that means the failure is intermittent across runs — also useful data for #24279, and would suggest random.choice unluckily picked mcdse on a flaky run.

## Modifications

Single line in \`test/registered/prefill_only/test_embedding_models.py\`:
\`MODELS\` is replaced with a list containing only mcdse. \`MODEL_TO_CONFIG\` is left intact so \`test_matryoshka_embedding\` (which references \`Alibaba-NLP/gte-Qwen2-1.5B-instruct\` directly) keeps working.

## Accuracy / Speed / Profiling

N/A — diagnostic-only. Once we have the CI signal, this PR will be closed without merging.