### PR TITLE
revert rocm artifacts from dsv4-rebase (cuda-only scope)

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -71,9 +71,6 @@ _use_ag_after_qlora = envs.SGLANG_USE_AG_AFTER_QLORA.get()
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
 
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
 
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
 
@@ -844,7 +841,7 @@ class Indexer(MultiPlatformOp):
                 actual_seq_q_list.append(actual_seq_q)
                 batch_idx_list.append(batch_idx)
 
-            k_fp8 = torch.cat(k_fp8_list, dim=0).view(fp8_dtype)
+            k_fp8 = torch.cat(k_fp8_list, dim=0).view(torch.float8_e4m3fn)
             k_scale = torch.cat(k_scale_list, dim=0).view(torch.float32).squeeze(-1)
             kv_fp8 = (k_fp8, k_scale)
             ks = torch.cat(ks_list, dim=0)
@@ -885,7 +882,7 @@ class Indexer(MultiPlatformOp):
                 block_tables[0],
             )
 
-            k_fp8 = k_fp8.view(fp8_dtype)
+            k_fp8 = k_fp8.view(torch.float8_e4m3fn)
             k_scale = k_scale.view(torch.float32).squeeze(-1)
             kv_fp8 = (k_fp8, k_scale)
             ks = torch.full((actual_seq_q,), offset, dtype=torch.int32, device="cuda")
@@ -978,7 +975,7 @@ class Indexer(MultiPlatformOp):
                 block_tables[i],
             )
 
-            k_fp8 = k_fp8.view(fp8_dtype).unsqueeze(0).contiguous()
+            k_fp8 = k_fp8.view(torch.float8_e4m3fn).unsqueeze(0).contiguous()
             k_scale = k_scale.view(torch.float32).squeeze(-1).unsqueeze(0).contiguous()
 
             index_score = fp8_index(

--- a/python/sglang/srt/layers/attention/nsa/quant_k_cache.py
+++ b/python/sglang/srt/layers/attention/nsa/quant_k_cache.py
@@ -2,10 +2,6 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-
 
 def quantize_k_cache(cache_k):
     return _quantize_k_cache_fast_wrapped(cache_k)
@@ -79,7 +75,7 @@ def _quantize_k_cache_ref(
 
     result = torch.empty(
         (num_blocks, block_size, dv + num_tiles * 4 + input_elem_size * (d - dv)),
-        dtype=fp8_dtype,
+        dtype=torch.float8_e4m3fn,
         device=input_k_cache.device,
     )
     result_k_nope_part = result[..., :dv]
@@ -104,7 +100,7 @@ def _quantize_k_cache_ref(
                 ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
             ].float()
             / cur_scale_factors_inv.float()
-        ).to(fp8_dtype)
+        ).to(torch.float8_e4m3fn)
         result_k_nope_part[..., tile_idx * tile_size : (tile_idx + 1) * tile_size] = (
             cur_quantized_nope
         )
@@ -156,7 +152,7 @@ def _quantize_k_cache_fast(k_nope, k_rope, group_size: int = 128):
 
     output = torch.empty(
         (num_tokens, dim_nope + num_tiles * 4 + k_rope.element_size() * dim_rope),
-        dtype=fp8_dtype,
+        dtype=torch.float8_e4m3fn,
         device=k_nope.device,
     )
     output_nope_q = output[..., :dim_nope]
@@ -184,8 +180,8 @@ def _quantize_k_cache_fast(k_nope, k_rope, group_size: int = 128):
         GROUP_SIZE=group_size,
         DIM_NOPE=dim_nope,
         DIM_ROPE=dim_rope,
-        FP8_MIN=torch.finfo(fp8_dtype).min,
-        FP8_MAX=torch.finfo(fp8_dtype).max,
+        FP8_MIN=torch.finfo(torch.float8_e4m3fn).min,
+        FP8_MAX=torch.finfo(torch.float8_e4m3fn).max,
     )
 
     return output
@@ -236,7 +232,7 @@ def _quantize_k_cache_fast_separate(k_nope, k_rope, group_size: int = 128):
     # Create typed views for the kernel to write into
     # Fixed byte layout for nope_part: [nope_fp8 (dim_nope bytes) | scales_fp32 (num_tiles*4 bytes)]
     # Fixed byte layout for rope_part: [rope_bf16 (dim_rope*2 bytes)]
-    nope_q_view = nope_part_u8[:, :dim_nope].view(fp8_dtype)
+    nope_q_view = nope_part_u8[:, :dim_nope].view(torch.float8_e4m3fn)
     nope_s_view = nope_part_u8[:, dim_nope:].view(torch.float32)
     rope_view = rope_part_u8.view(torch.bfloat16)
 
@@ -260,8 +256,8 @@ def _quantize_k_cache_fast_separate(k_nope, k_rope, group_size: int = 128):
         GROUP_SIZE=group_size,
         DIM_NOPE=dim_nope,
         DIM_ROPE=dim_rope,
-        FP8_MIN=torch.finfo(fp8_dtype).min,
-        FP8_MAX=torch.finfo(fp8_dtype).max,
+        FP8_MIN=torch.finfo(torch.float8_e4m3fn).min,
+        FP8_MAX=torch.finfo(torch.float8_e4m3fn).max,
     )
 
     # Add middle dimension for compatibility with set_mla_kv_buffer_triton

--- a/python/sglang/srt/layers/attention/nsa/triton_kernel.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_kernel.py
@@ -5,15 +5,6 @@ import triton
 import triton.language as tl
 
 
-def _is_hip() -> bool:
-    return hasattr(torch.version, "hip") and torch.version.hip is not None
-
-
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-
-
 # Triton implementation
 @triton.jit
 def _act_quant_kernel(
@@ -118,7 +109,7 @@ def act_quant(
     M = x_flat.size(0)
 
     # Allocate output tensors
-    y = torch.empty_like(x, dtype=fp8_dtype)
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
     y_flat = y.view(-1, N)
     s = x.new_empty(*x.size()[:-1], N // block_size, dtype=torch.float32)
     s_flat = s.view(-1, N // block_size)
@@ -128,11 +119,6 @@ def act_quant(
     BLOCK_N = block_size
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, block_size))
     round_scale = scale_fmt is not None
-
-    if round_scale:
-        num_stages = 1 if _is_hip() else 0
-    else:
-        num_stages = 2
 
     _act_quant_kernel[grid](
         x_flat,
@@ -144,7 +130,7 @@ def act_quant(
         round_scale=round_scale,
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
-        num_stages=num_stages,
+        num_stages=0 if round_scale else 2,
     )
 
     return y, s

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -14,10 +14,6 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.fixup_zero_kv import fixup_zero_kv_rows
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-
-fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.flashinfer_mla_backend import (
@@ -203,7 +199,7 @@ def unpad_draft_extend_output_kernel(
 
 
 def _quantize_fp8_qkv(q, k, v, layer):
-    q = q.to(fp8_dtype)
+    q = q.to(torch.float8_e4m3fn)
 
     k_scale = getattr(layer, "k_scale_float", None)
     if k_scale is None:
@@ -215,7 +211,7 @@ def _quantize_fp8_qkv(q, k, v, layer):
         )
         k = k_2d.reshape(k.shape)
     else:
-        k = k.to(fp8_dtype)
+        k = k.to(torch.float8_e4m3fn)
 
     v_scale = getattr(layer, "v_scale_float", None)
     if v_scale is None:
@@ -227,7 +223,7 @@ def _quantize_fp8_qkv(q, k, v, layer):
         )
         v = v_2d.reshape(v.shape)
     else:
-        v = v.to(fp8_dtype)
+        v = v.to(torch.float8_e4m3fn)
 
     return q, k, v, k_scale, v_scale
 
@@ -775,7 +771,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
     ) -> torch.Tensor:
         """Run forward for decode using TRTLLM MLA kernel."""
         merge_query = q_rope is not None
-        if self.data_type == fp8_dtype:
+        if self.data_type == torch.float8_e4m3fn:
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
             assert all(
@@ -914,7 +910,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         # TODO refactor to avoid code duplication
         merge_query = q_rope is not None
         if (
-            self.data_type == fp8_dtype
+            self.data_type == torch.float8_e4m3fn
         ) and forward_batch.forward_mode.is_target_verify():
             # For FP8 path, we quantize the query and rope parts and merge them into a single tensor
             # Note: rope application in deepseek_v2.py:forward_absorb_prepare is skipped for FP8 decode path of this trtllm_mla backend
@@ -1092,7 +1088,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         v = v.view(-1, layer.tp_k_head_num, layer.v_head_dim)
 
         q_scale = k_scale = v_scale = 1.0
-        if self.data_type == fp8_dtype:
+        if self.data_type == torch.float8_e4m3fn:
             q, k, v, k_scale, v_scale = _quantize_fp8_qkv(q, k, v, layer)
 
         common_trtllm_args = {

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -288,12 +288,6 @@ class RMSNorm(MultiPlatformOp):
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        if _is_hip:
-            if x.shape[0] == 0:
-                if residual is not None:
-                    return x, residual
-                return x
-
         # Aiter's RMSNorm kernels expect 2D contiguous inputs. Keep the
         # already-safe layout as a zero-copy path, and only normalize strided or
         # higher-rank views such as Q/K slices from packed QKV projections.


### PR DESCRIPTION
Revert ROCm-only hunks to keep PR #23882 CUDA-only. See individual commits.