### PR TITLE
[Fix] NGRAMWorker.update_weights_from_tensor — delegate to target worker

### DIFF
--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -83,6 +83,15 @@ class NGRAMWorker:
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
 
+    def update_weights_from_tensor(self, recv_req):
+        # NGRAM has no draft weights of its own — the n-gram corpus is a CPU
+        # lookup structure built from request token streams — and its
+        # `model_runner` is shared with the target worker. The scheduler
+        # mixin dispatches via `self.draft_worker or self.tp_worker`, so
+        # without this method any caller of `update_weights_from_tensor`
+        # under `--speculative-algorithm NGRAM` raises AttributeError.
+        return self.target_worker.update_weights_from_tensor(recv_req)
+
     def add_external_corpus(self, corpus_id: str, token_chunks: list[list[int]]) -> int:
         return self.ngram_corpus.load_external_corpus_named(corpus_id, token_chunks)
 


### PR DESCRIPTION
## Motivation

Fixes #24343.

When sglang is launched with `--speculative-algorithm NGRAM`, any caller of `update_weights_from_tensor` (e.g. RL frameworks doing online actor → rollout weight sync — slime, OpenRLHF, verl, etc.) crashes with:

```
AttributeError: 'NGRAMWorker' object has no attribute 'update_weights_from_tensor'
```

`scheduler_update_weights_mixin.py` dispatches this single weight-update method through `self.draft_worker or self.tp_worker` (all the other `update_weights_*` entry points go through `self.tp_worker` directly). `EAGLEWorker` implements the method; `NGRAMWorker` does not, so the dispatch fails on the first call.

## Modifications

Adds a 1-line delegation on `NGRAMWorker` in `python/sglang/srt/speculative/ngram_worker.py`:

```python
def update_weights_from_tensor(self, recv_req):
    return self.target_worker.update_weights_from_tensor(recv_req)
```

Why delegation is the semantically correct fix:

1. **NGRAM has no draft weights.** `NgramCorpus` is a CPU lookup structure built from request token streams (`self.ngram_corpus.batch_put(...)` in `_update_ngram_corpus`). There is nothing tensor-shaped to update.
2. **`NGRAMWorker.model_runner` *is* `target_worker.model_runner`** (`__init__` line 41: `self.model_runner = target_worker.model_runner`). Even a direct call would be the same object — delegating one layer up to `target_worker.update_weights_from_tensor` reuses the existing deserialize + update path verbatim.
3. **Contract matches.** `TpModelWorker.update_weights_from_tensor` (`tp_worker.py:157`) already returns `(success, message)`, which is what the scheduler unpacks at the dispatch site.
4. **Mirrors EAGLE.** `EAGLEWorker.update_weights_from_tensor` (`eagle_worker.py:1205`) does `self.target_worker.model_runner.update_weights_from_tensor(...)` for its target half; this is the same pattern, one method up.

No NGRAM-corpus invalidation is added on weight update: the corpus stores token streams from past requests, and new weights produce new requests that update the corpus organically. Happy to add `self.ngram_corpus.reset()` here if maintainers prefer stricter cache-coherency semantics.

The other weight-update entry points (`update_weights_from_disk`, `update_weights_from_distributed`, `init_weights_update_group`, `destroy_weights_update_group`) all dispatch through `self.tp_worker` directly in the scheduler mixin, so they are unaffected by this change.

## Accuracy Tests

Not applicable — this PR adds a missing dispatch path. Model forward / kernel code is untouched. Manual smoke check: after `update_weights_from_tensor(...)` succeeds, `/generate` returns coherent output under `--speculative-algorithm NGRAM`.

## Speed Tests and Profiling

Not applicable — no hot-path code changed.

For context, in our internal eval against a non-speculative baseline (Qwen2.5-32B SFT, agentic SWE-style trajectories), NGRAM gave ~3.2× mean `gen_throughput`, p95 latency −21–33%, sample-timeout 4%/2% → 0%. This bug currently forces RL workflows off NGRAM despite those wins.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

> Note on tests: I checked `test/srt/speculative/` and didn't find existing `update_weights_from_tensor` coverage for EAGLE either, so there's no obvious template to mirror. Happy to add one of:
> - A regression test that constructs a fake `target_worker` and asserts `NGRAMWorker.update_weights_from_tensor` returns the target's `(success, message)` tuple.
> - An end-to-end test that launches an NGRAM engine, calls `update_weights_from_tensor`, and verifies subsequent `/generate` works.
>
> Please advise which fits the project's style and I'll add it before merge.

cc speculative codeowners: @Ying1123 @merrymercy @hnyls2002 @Qiaolin-Yu
````