### PR TITLE
feat(multimodal_gen): add --max-queued-requests backpressure

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -213,7 +213,7 @@ async def forward_to_scheduler(
     try:
         response = await async_scheduler_client.forward(req_obj)
         if response.output is None and response.output_file_paths is None:
-            raise RuntimeError("Model generation returned no output.")
+            raise RuntimeError(response.error or "Model generation returned no output.")
 
         if response.output_file_paths:
             output_file_path = response.output_file_paths[0]

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
@@ -165,7 +165,9 @@ async def list_loras():
         if output.error is None:
             return output.output or {}
         else:
-            raise HTTPException(status_code=500, detail=output.error)
+            raise HTTPException(
+                status_code=output.status_code or 500, detail=output.error
+            )
     except Exception as e:
         if isinstance(e, HTTPException):
             raise

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from typing import Any, Generator, List, Optional, Union
 
 import httpx
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 
 from sglang.multimodal_gen.configs.sample.sampling_params import (
     DataType,
@@ -327,6 +327,12 @@ async def process_generation_batch(
     total_start_time = time.perf_counter()
     with trace_req(batch.trace_ctx), log_generation_timer(logger, batch.prompt):
         result = await scheduler_client.forward([batch])
+
+        if result.status_code is not None:
+            raise HTTPException(
+                status_code=result.status_code,
+                detail=result.error or "Request rejected by scheduler.",
+            )
 
         if result.output is None and result.output_file_paths is None:
             error_msg = result.error or "Unknown error"

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -992,13 +992,24 @@ class Scheduler(SchedulerDisaggMixin):
                 cap,
                 len(self.waiting_queue) + len(admitted),
             )
-            self.return_result(
-                OutputBatch(
-                    error="The request queue is full.",
-                    status_code=503,
-                ),
-                identity,
-            )
+            try:
+                self.return_result(
+                    OutputBatch(
+                        error="The request queue is full.",
+                        status_code=503,
+                    ),
+                    identity,
+                )
+            except zmq.ZMQError as e:
+                # Don't let a transient ZMQ failure on the rejection reply
+                # trip the outer event_loop's _consecutive_error_count and
+                # tear down the scheduler — the rejected req is already lost,
+                # we just want to keep serving.
+                logger.error(
+                    "Failed to send queue-full rejection over ZMQ to identity=%r: %s",
+                    identity,
+                    e,
+                )
         return admitted
 
     def process_received_reqs_with_req_based_warmup(

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -960,6 +960,47 @@ class Scheduler(SchedulerDisaggMixin):
 
         return input_path
 
+    def _enforce_queue_cap(
+        self, new_reqs: List[tuple[bytes, Any]]
+    ) -> List[tuple[bytes, Any]]:
+        """Reject incoming generation reqs once the waiting queue is full.
+
+        Rejected reqs get an OutputBatch with status_code=503 sent back over the
+        ZMQ ROUTER and never enter the waiting queue. Warmup reqs and
+        control-plane reqs (SetLoraReq, ShutdownReq, etc.) bypass the cap and
+        are admitted unconditionally — they are rare/internal and may transiently
+        push the queue depth above the cap.
+        """
+        cap = self.server_args.max_queued_requests
+        if cap is None:
+            return new_reqs
+
+        admitted: list[tuple[bytes, Any]] = []
+        available = max(0, cap - len(self.waiting_queue))
+        for identity, req_or_group in new_reqs:
+            is_generation = self._first_generation_req(req_or_group) is not None
+            is_warmup = self._is_warmup_item(req_or_group)
+            if not is_generation or is_warmup:
+                admitted.append((identity, req_or_group))
+                continue
+            if available > 0:
+                admitted.append((identity, req_or_group))
+                available -= 1
+                continue
+            logger.warning(
+                "Rejecting request: waiting queue full (cap=%d, depth=%d).",
+                cap,
+                len(self.waiting_queue) + len(admitted),
+            )
+            self.return_result(
+                OutputBatch(
+                    error="The request queue is full.",
+                    status_code=503,
+                ),
+                identity,
+            )
+        return admitted
+
     def process_received_reqs_with_req_based_warmup(
         self, recv_reqs: List[tuple[bytes, Any]]
     ) -> List[tuple[bytes, Any]]:
@@ -1083,6 +1124,7 @@ class Scheduler(SchedulerDisaggMixin):
             try:
                 new_reqs = self.recv_reqs()
                 new_reqs = self.process_received_reqs_with_req_based_warmup(new_reqs)
+                new_reqs = self._enforce_queue_cap(new_reqs)
                 now = time.monotonic()
                 self.waiting_queue.extend(
                     [(identity, req, now) for identity, req in new_reqs]

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -391,6 +391,7 @@ class OutputBatch:
     rollout_trajectory_data: RolloutTrajectoryData | None = None
     trajectory_decoded: list[torch.Tensor] | None = None
     error: str | None = None
+    status_code: int | None = None
     output_file_paths: list[str] | None = None
 
     # logged metrics info, directly from Req.timings

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -230,6 +230,7 @@ class ServerArgs(DisaggArgsMixin):
     batching_delay_ms: float = 0.0
     batching_config: str | None = None
     enable_batching_metrics: bool = False
+    max_queued_requests: int | None = None
 
     # Strict port mode: fail if requested port is unavailable instead of auto-selecting
     strict_ports: bool = False
@@ -1058,6 +1059,16 @@ class ServerArgs(DisaggArgsMixin):
             help="Log periodic batch efficiency metrics such as realized batch size and queue wait time.",
         )
         parser.add_argument(
+            "--max-queued-requests",
+            type=int,
+            default=ServerArgs.max_queued_requests,
+            help=(
+                "Maximum number of generation requests allowed to wait in the "
+                "scheduler queue. Additional requests are rejected with HTTP 503. "
+                "Defaults to unlimited. Ignored when using --disagg-mode."
+            ),
+        )
+        parser.add_argument(
             "--host",
             type=str,
             default=ServerArgs.host,
@@ -1505,6 +1516,8 @@ class ServerArgs(DisaggArgsMixin):
             raise ValueError("batching_max_size must be >= 1")
         if self.batching_delay_ms < 0:
             raise ValueError("batching_delay_ms must be >= 0")
+        if self.max_queued_requests is not None and self.max_queued_requests < 1:
+            raise ValueError("max_queued_requests must be >= 1 when set")
 
     def _set_default_attention_backend(self) -> None:
         """Configure ROCm defaults when users do not specify an attention backend."""

--- a/python/sglang/multimodal_gen/test/unit/test_max_queued_requests.py
+++ b/python/sglang/multimodal_gen/test/unit/test_max_queued_requests.py
@@ -1,0 +1,135 @@
+"""Unit tests for Scheduler._enforce_queue_cap (max_queued_requests backpressure)."""
+
+import types
+import unittest
+from collections import deque
+
+from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+
+
+class _GenReq:
+    """Stand-in for a generation Req. Detected as generation, not warmup."""
+
+    def __init__(self, name: str, is_warmup: bool = False):
+        self.name = name
+        self.is_warmup = is_warmup
+
+
+class _ControlReq:
+    """Stand-in for a control-plane req (e.g., ShutdownReq)."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _DummyScheduler:
+    """Minimal duck-typed scheduler for exercising _enforce_queue_cap."""
+
+    def __init__(self, max_queued_requests, queue_depth: int = 0):
+        self.server_args = types.SimpleNamespace(
+            max_queued_requests=max_queued_requests
+        )
+        self.waiting_queue: deque = deque(
+            (None, _GenReq(f"prefilled-{i}"), 0.0) for i in range(queue_depth)
+        )
+        self.rejected: list[tuple[OutputBatch, bytes | None]] = []
+
+    @staticmethod
+    def _first_generation_req(req_or_group):
+        if isinstance(req_or_group, _GenReq):
+            return req_or_group
+        if isinstance(req_or_group, list) and req_or_group:
+            first = req_or_group[0]
+            if isinstance(first, _GenReq):
+                return first
+        return None
+
+    @classmethod
+    def _is_warmup_item(cls, req_or_group):
+        req = cls._first_generation_req(req_or_group)
+        return req.is_warmup if req is not None else False
+
+    def return_result(self, output_batch, identity=None, is_warmup=False):
+        self.rejected.append((output_batch, identity))
+
+
+def _enforce(dummy: _DummyScheduler, new_reqs):
+    return Scheduler._enforce_queue_cap(dummy, new_reqs)
+
+
+class TestEnforceQueueCap(unittest.TestCase):
+    def test_unlimited_admits_all(self):
+        dummy = _DummyScheduler(max_queued_requests=None)
+        new_reqs = [(b"a", _GenReq("r1")), (b"b", _GenReq("r2"))]
+        admitted = _enforce(dummy, new_reqs)
+        self.assertEqual(admitted, new_reqs)
+        self.assertEqual(dummy.rejected, [])
+
+    def test_cap_admits_up_to_limit_then_rejects(self):
+        dummy = _DummyScheduler(max_queued_requests=2)
+        new_reqs = [
+            (b"a", _GenReq("r1")),
+            (b"b", _GenReq("r2")),
+            (b"c", _GenReq("r3")),
+        ]
+        admitted = _enforce(dummy, new_reqs)
+
+        self.assertEqual([item[0] for item in admitted], [b"a", b"b"])
+        self.assertEqual(len(dummy.rejected), 1)
+        rejected_batch, rejected_id = dummy.rejected[0]
+        self.assertEqual(rejected_id, b"c")
+        self.assertEqual(rejected_batch.status_code, 503)
+        self.assertEqual(rejected_batch.error, "The request queue is full.")
+
+    def test_cap_counts_existing_queue_depth(self):
+        dummy = _DummyScheduler(max_queued_requests=2, queue_depth=2)
+        new_reqs = [(b"x", _GenReq("r1"))]
+        admitted = _enforce(dummy, new_reqs)
+
+        self.assertEqual(admitted, [])
+        self.assertEqual(len(dummy.rejected), 1)
+        self.assertEqual(dummy.rejected[0][0].status_code, 503)
+
+    def test_control_reqs_bypass_cap(self):
+        dummy = _DummyScheduler(max_queued_requests=1, queue_depth=1)
+        shutdown = _ControlReq("shutdown")
+        admitted = _enforce(dummy, [(b"s", shutdown)])
+        self.assertEqual(admitted, [(b"s", shutdown)])
+        self.assertEqual(dummy.rejected, [])
+
+    def test_warmup_reqs_bypass_cap(self):
+        dummy = _DummyScheduler(max_queued_requests=1, queue_depth=1)
+        warmup_req = _GenReq("warmup", is_warmup=True)
+        admitted = _enforce(dummy, [(b"w", warmup_req)])
+        self.assertEqual(admitted, [(b"w", warmup_req)])
+        self.assertEqual(dummy.rejected, [])
+
+    def test_mixed_batch_only_generation_overflow_rejected(self):
+        dummy = _DummyScheduler(max_queued_requests=1)
+        gen1 = _GenReq("r1")
+        ctrl = _ControlReq("set_lora")
+        gen2 = _GenReq("r2")
+        new_reqs = [(b"a", gen1), (b"b", ctrl), (b"c", gen2)]
+
+        admitted = _enforce(dummy, new_reqs)
+
+        self.assertEqual(admitted, [(b"a", gen1), (b"b", ctrl)])
+        self.assertEqual(len(dummy.rejected), 1)
+        self.assertEqual(dummy.rejected[0][1], b"c")
+        self.assertEqual(dummy.rejected[0][0].status_code, 503)
+
+    def test_grouped_list_req_counts_as_one(self):
+        dummy = _DummyScheduler(max_queued_requests=1)
+        group = [_GenReq("r1a"), _GenReq("r1b")]
+        new_reqs = [(b"a", group), (b"b", _GenReq("r2"))]
+
+        admitted = _enforce(dummy, new_reqs)
+
+        self.assertEqual(admitted, [(b"a", group)])
+        self.assertEqual(len(dummy.rejected), 1)
+        self.assertEqual(dummy.rejected[0][1], b"b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_max_queued_requests.py
+++ b/python/sglang/multimodal_gen/test/unit/test_max_queued_requests.py
@@ -1,31 +1,35 @@
-"""Unit tests for Scheduler._enforce_queue_cap (max_queued_requests backpressure)."""
+"""Unit tests for max_queued_requests backpressure: Scheduler._enforce_queue_cap,
+HTTP 503 propagation through process_generation_batch, and ServerArgs validation.
+"""
 
 import types
 import unittest
 from collections import deque
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+from fastapi import HTTPException
+
+from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
+    process_generation_batch,
+)
 from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
 
 
 class _GenReq:
-    """Stand-in for a generation Req. Detected as generation, not warmup."""
-
     def __init__(self, name: str, is_warmup: bool = False):
         self.name = name
         self.is_warmup = is_warmup
 
 
 class _ControlReq:
-    """Stand-in for a control-plane req (e.g., ShutdownReq)."""
-
     def __init__(self, name: str):
         self.name = name
 
 
 class _DummyScheduler:
-    """Minimal duck-typed scheduler for exercising _enforce_queue_cap."""
-
     def __init__(self, max_queued_requests, queue_depth: int = 0):
         self.server_args = types.SimpleNamespace(
             max_queued_requests=max_queued_requests
@@ -129,6 +133,69 @@ class TestEnforceQueueCap(unittest.TestCase):
         self.assertEqual(admitted, [(b"a", group)])
         self.assertEqual(len(dummy.rejected), 1)
         self.assertEqual(dummy.rejected[0][1], b"b")
+
+
+class TestProcessGenerationBatchPropagatesStatusCode(unittest.IsolatedAsyncioTestCase):
+    async def test_status_code_raises_http_exception(self):
+        scheduler_client = SimpleNamespace(
+            forward=AsyncMock(
+                return_value=OutputBatch(
+                    error="The request queue is full.",
+                    status_code=503,
+                )
+            )
+        )
+        batch = SimpleNamespace(
+            trace_ctx=SimpleNamespace(trace_req_finish=lambda: None),
+            prompt="test",
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await process_generation_batch(scheduler_client, batch)
+
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertEqual(ctx.exception.detail, "The request queue is full.")
+
+    async def test_no_status_code_falls_through_to_no_output_check(self):
+        scheduler_client = SimpleNamespace(
+            forward=AsyncMock(
+                return_value=OutputBatch(error="pipeline crashed", status_code=None)
+            )
+        )
+        batch = SimpleNamespace(
+            trace_ctx=SimpleNamespace(trace_req_finish=lambda: None),
+            prompt="test",
+        )
+
+        with self.assertRaises(RuntimeError):
+            await process_generation_batch(scheduler_client, batch)
+
+
+class TestValidateMaxQueuedRequests(unittest.TestCase):
+    @staticmethod
+    def _fake(**overrides):
+        defaults = dict(
+            batching_mode="dynamic",
+            batching_max_size=1,
+            batching_delay_ms=0.0,
+            max_queued_requests=None,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_none_is_valid(self):
+        ServerArgs._validate_batching(self._fake(max_queued_requests=None))
+
+    def test_one_is_valid(self):
+        ServerArgs._validate_batching(self._fake(max_queued_requests=1))
+
+    def test_zero_is_rejected(self):
+        with self.assertRaises(ValueError):
+            ServerArgs._validate_batching(self._fake(max_queued_requests=0))
+
+    def test_negative_is_rejected(self):
+        with self.assertRaises(ValueError):
+            ServerArgs._validate_batching(self._fake(max_queued_requests=-5))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a `--max-queued-requests` flag to the diffusion runtime (`multimodal_gen`) that bounds the scheduler's `waiting_queue` and rejects overflow generation requests with HTTP 503. Mirrors the existing behavior in the LLM `srt` runtime (`srt/server_args.py:363`, `srt/managers/scheduler.py:2245`).

- **Default**: `None` (unlimited) — backwards compatible.
- **Scope**: monolithic mode only. Disagg mode (`--disagg-role` non-MONOLITHIC) is documented as ignored — `event_loop` early-returns into `_disagg_event_loop` before `_enforce_queue_cap` is reached.
- **Bypasses**: warmup reqs and control-plane reqs (`SetLoraReq`, `ShutdownReq`, weight updates, etc.) are admitted unconditionally.
- **HTTP path**: `process_generation_batch` (image/video/mesh OpenAI APIs) raises `HTTPException(status_code=503)`. Vertex `/predict` keeps its per-instance error semantics — the rich rejection reason (`response.error`) is now preserved through `forward_to_scheduler` instead of being replaced with a generic "no output" string.
- **Hardening**: rejection `return_result` is wrapped in `zmq.ZMQError` so a flaky client during overload cannot trip the scheduler's `_consecutive_error_count` and tear down the loop.

## Commits

1. `b474c5041` schema: `OutputBatch.status_code` field + `ServerArgs.max_queued_requests` + CLI flag + validation (no behavior change)
2. `6fe477caa` enforcement: `_enforce_queue_cap` helper in scheduler event loop
3. `5fc7d6107` HTTP wiring: surface 503 from `process_generation_batch` + unit tests
4. `6ab34cc82` review fixes: ZMQ error guard on rejection path, Vertex error passthrough, async/validation tests

## Test plan

- [x] `pre-commit run` on all changed files — clean
- [x] **Unit tests**: 13/13 pass on H100 (`lmsysorg/sglang:dev`):
  ```
  TestEnforceQueueCap (7 cases): unlimited, exact-cap, prefilled-queue, control-bypass, warmup-bypass, mixed-batch, grouped-list
  TestProcessGenerationBatchPropagatesStatusCode (2 cases): status_code -> HTTPException(503), no status_code -> RuntimeError
  TestValidateMaxQueuedRequests (4 cases): None, 1, 0 (rejected), -5 (rejected)
  ```
- [x] **E2E integration on H100** with `Wan-AI/Wan2.1-T2V-1.3B-Diffusers --max-queued-requests 1`:
  - Started server, fired 3 concurrent `POST /v1/videos` requests
  - Scheduler logged exactly 1 rejection: `Rejecting request: waiting queue full (cap=1, depth=1).`
  - 3rd video's status object contained `error: "503: The request queue is full."` — confirming end-to-end propagation: scheduler `_enforce_queue_cap` -> `OutputBatch(status_code=503)` over ZMQ -> `process_generation_batch` raises `HTTPException(503)` -> recorded in the video job's error field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)