### PR TITLE
[AMD] Replace naive triton RMSNorm with aiter RMSNorm for diffusion model

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -28,10 +28,12 @@ from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.common import get_bool_env_var
 
 _is_cuda = current_platform.is_cuda()
+_is_hip = current_platform.is_hip()
 _is_npu = current_platform.is_npu()
 _is_musa = current_platform.is_musa()
 _is_cpu = current_platform.is_cpu()
 _is_xpu = current_platform.is_xpu()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_cuda or _is_xpu:
     from sgl_kernel import fused_add_rmsnorm, rmsnorm
@@ -41,6 +43,11 @@ if _is_npu:
 
 if _is_musa:
     from sgl_kernel import fused_add_rmsnorm
+
+if _use_aiter:
+    from aiter import rmsnorm2d_fwd as rms_norm
+    from aiter import rmsnorm2d_fwd_with_add as fused_add_rms_norm
+
 if not _is_cpu:
     from sglang.jit_kernel.diffusion.triton.norm import norm_infer, rms_norm_fn
 
@@ -70,6 +77,8 @@ class RMSNorm(CustomOp):
         )
         if get_bool_env_var("SGLANG_ENABLE_DETERMINISTIC_INFERENCE"):
             self._forward_method = self.forward_native
+        elif _use_aiter:
+            self._forward_method = self.forward_aiter
 
     def forward_triton(self, x: torch.Tensor, residual: Optional[torch.Tensor] = None):
         return rms_norm_fn(
@@ -176,6 +185,47 @@ class RMSNorm(CustomOp):
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         # ROCm builds of sgl-kernel do not expose rmsnorm custom ops yet.
         return self.forward_native(x, residual)
+
+    def forward_aiter(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        # Fall back to the native fp32 path for cases aiter cannot serve:
+        #   - fp32 input  (CK kernel is templated on fp16/bf16 only;
+        #                  out.dtype check rejects fp32 with "not support output type: float")
+        if (
+            x.dtype not in (torch.float16, torch.bfloat16)
+            or self.variance_size_override is not None
+        ):
+            return self.forward_native(x, residual)
+
+        weight = self._get_weight(x.dtype)
+
+        shape = x.shape
+        x_2d = x.reshape(
+            -1, shape[-1]
+        )  # (bs, seq_len, hidden_size) -> (bs*seq_len, hidden_size)
+        if not x_2d.is_contiguous():
+            x_2d = x_2d.contiguous()
+
+        if residual is not None:
+            residual_shape = residual.shape
+            residual_2d = residual.reshape(-1, shape[-1])
+            if not residual_2d.is_contiguous():
+                residual_2d = residual_2d.contiguous()
+            output = torch.empty_like(x_2d)
+            residual_out = torch.empty_like(x_2d)
+            fused_add_rms_norm(
+                output,
+                x_2d,
+                residual_2d,
+                residual_out,
+                weight,
+                self.variance_epsilon,
+            )
+            return output.view(shape), residual_out.view(residual_shape)
+        return rms_norm(x_2d, weight, self.variance_epsilon).view(shape)
 
     def _get_weight(self, dtype: torch.dtype) -> torch.Tensor:
         """Return weight matched to *dtype*.


### PR DESCRIPTION
## Motivation
Replace the default Triton-based RMSNorm with aiter's optimized HIP RMSNorm kernel in the diffusion multimodal_gen path on ROCm, reducing per-kernel RMSNorm time by ~30% (430 us → 290 us, ~0.2% of denoise total time).

## Modifications

Key changes in `layernorm.py`:
- Add `forward_aiter` method to `RMSNorm` that dispatches to `aiter.rmsnorm2d_fwd` (plain) or `aiter.rmsnorm2d_fwd_with_add` (fused residual-add variant).
- Reshape 3-D inputs to 2-D before calling aiter, since the underlying C++ op (`rmsnorm_quant_kernels.cu`) interprets `input.size(1)` as hidden_size.  Without the reshape a 3-D tensor like (1, 90000, 5120) causes the dispatch macro to reject n=90000 with "not support n: 90000".
- Guard on dtype (fp16/bf16 only) and `variance_size_override` to fall back to the native path when aiter cannot serve.

## Accuracy Tests


## Speed Tests and Profiling
| | Kernel | Time (us) | Reduction |
| --- | --- | --- | --- |
| **Before** | `triton_red_fused__to_copy_add_addmm_mean_mul_pow_rsqrt_view_2` | 430.6 | — |
| **After**  | `_ZN5aiter24add_rmsnorm_quant_kernelID...` | 291.4 | **−139.2 us (−32.3%)** |
| --- | --- | --- | *0.2% of total time in denoise stage* |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
