### PR TITLE
[diffusion] Use direct all-to-all for USP collectives

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -37,13 +37,12 @@ def _usp_all_to_all_single(x: torch.Tensor) -> torch.Tensor:
     ulysses_pg = get_sp_group().ulysses_group
     assert ulysses_pg is not None, "Ulysses process group is not initialized."
     x_shape = x.shape
-    x = x.flatten()
-    x = ft_c.all_to_all_single(
-        x, output_split_sizes=None, input_split_sizes=None, group=ulysses_pg
-    )
-    x = _maybe_wait(x)
-    x = x.reshape(x_shape)
-    return x
+    x = x.flatten().contiguous()
+    output = torch.empty_like(x)
+    # USP calls this collective many times per denoising step and waits
+    # immediately, so avoid the extra wrapper overhead of functional collectives.
+    torch.distributed.all_to_all_single(output, x, group=ulysses_pg)
+    return output.reshape(x_shape)
 
 
 def _usp_input_all_to_all(x: torch.Tensor, head_dim: int = 1) -> torch.Tensor:


### PR DESCRIPTION
## Summary

Use `torch.distributed.all_to_all_single` directly for USP all-to-all collectives instead of routing through `torch.distributed._functional_collectives.all_to_all_single` and immediately waiting on the async wrapper.

The tensor layout and sharding semantics are unchanged: USP still flattens the same contiguous buffer, runs all-to-all on the same Ulysses process group, and reshapes back to the original shape. The existing `_maybe_wait` helper is kept, but this hot path no longer calls it.

## Root Cause

LTX 2.3 one-stage TI2V on 2 GPUs regressed after the torch 2.11 dependency update. Profiling narrowed the slowdown to USP collective overhead rather than FA3 attention compute. USP calls this collective many times per denoising step, so the additional functional-collective wrapper overhead accumulates across 48 transformer blocks and multiple guidance passes.

## Performance

Remote H100/H200 dev container, same SGLang repo path, same LTX 2.3 one-stage TI2V 2GPU server test.

New dependency stack (`torch 2.11.0+cu130`, `sglang-kernel 0.4.2`, NCCL `2.28.9`):

- Before: `808.3ms/step` to `821.4ms/step` average denoise, semantic consistency pass.
- After: `657.1ms/step` average denoise, semantic consistency pass.
- Result: roughly `18.7%` faster vs the same-run unpatched `808.3ms/step` sample, and back in line with the pre-regression `~647-669ms/step` range.

Older dependency stack (`torch 2.9.1+cu130`, `sglang-kernel 0.4.1.post1+cu130`, NCCL `2.27.7`):

- Before: `647.3ms/step` to `668.9ms/step` average denoise, semantic consistency pass.
- After: `601.8ms/step` average denoise, semantic consistency pass.
- Result: no observed denoise regression on the older stack; this run also improved. The pytest process still failed on the already-known VAE decode stage threshold (`884.9ms > 689.9ms`), not on denoise or consistency.

## Validation

- `sglang/multimodal_gen/test/server/test_server_2_gpu.py::TestDiffusionServerTwoGpu::test_diffusion_generation[ltx_2.3_one_stage_ti2v]`
  - New deps after patch: passed, average denoise `657.12ms`, semantic consistency pass.
  - Old deps after patch: semantic consistency pass, average denoise `601.79ms`; pytest failed only the unrelated VAE decode stage threshold.

Precision note: these are CI semantic consistency checks, not bit-exact comparisons.
