### PR TITLE
[Docker] fix: install nixl stub alongside nixl-cuXX binary

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -540,10 +540,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # it with --no-deps and pair it with the matching nixl-cu12 / nixl-cu13 binary
 # to avoid shipping wrong-CUDA libs on cu13 images.
 RUN --mount=type=cache,target=/root/.cache/pip if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
-    python3 -m pip install nixl-cu12 --no-deps ; \
+    python3 -m pip install nixl nixl-cu12 --no-deps ; \
     python3 -m pip install cuda-python==12.9 ; \
 elif [ "${CUDA_VERSION%%.*}" = "13" ]; then \
-    python3 -m pip install nixl-cu13 --no-deps ; \
+    python3 -m pip install nixl nixl-cu13 --no-deps ; \
     python3 -m pip install cuda-python==13.2.0 ; \
 fi
 


### PR DESCRIPTION
## Motivation

Follow-up to #23593. That PR dropped the `nixl` Python stub package because its wheel METADATA carries an unconditional `Requires-Dist: nixl-cu12>=1.0.1` — installing plain `nixl` would pull cu12 binaries onto cu13 images. The cleanup went one step too far: sglang code still imports `from nixl._api import nixl_agent, nixl_agent_config`, and that import path is owned **only** by the stub package, not by `nixl-cu12` / `nixl-cu13`.

### Repro on `lmsysorg/sglang-staging:dev-cu13`

```text
$ python3 -c "from nixl._api import nixl_agent"
ModuleNotFoundError: No module named 'nixl'

$ python3 -c "import sglang.srt.mem_cache.storage.nixl.hicache_nixl"
ImportError: Please install NIXL by following the instructions at
  https://github.com/ai-dynamo/nixl/blob/main/README.md
  to use HiCacheNixl storage backend.
```

Affected sglang call sites:
- `python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py:24` — module raises at import time → HiCacheNixl backend unusable on cu13.
- `python/sglang/srt/disaggregation/nixl/conn.py:191` — guarded inside `__init__`, module imports fine but the NIXL disagg transport will fail when actually instantiated.
- `python/sglang/srt/layers/moe/token_dispatcher/nixl.py:29` uses `nixl_ep` (provided by `nixl-cuXX`), so this one is unaffected.

## Modifications

`docker/Dockerfile` — install `nixl` (stub) together with `nixl-cu12` / `nixl-cu13` (binary) using `--no-deps`. `--no-deps` is what makes this safe: it blocks the stub's unconditional `nixl-cu12` requirement, so cu12 binaries are never pulled onto a cu13 image (and vice versa).

```diff
-    python3 -m pip install nixl-cu12 --no-deps ; \
+    python3 -m pip install nixl nixl-cu12 --no-deps ; \
 ...
-    python3 -m pip install nixl-cu13 --no-deps ; \
+    python3 -m pip install nixl nixl-cu13 --no-deps ; \
```

This matches the form suggested in the reviewer comment on #23593 ([`#discussion_r3137949623`](https://github.com/sgl-project/sglang/pull/23593/files#r3137949623)).

### Why not `pip install nixl[cu13] --no-deps`?

Two follow-up review suggestions on #23593 proposed the extras form ([r3177204892](https://github.com/sgl-project/sglang/pull/23593/files#r3177204892), [r3177205349](https://github.com/sgl-project/sglang/pull/23593/files#r3177205349)). Empirically, neither shape works — verified with `pip install --dry-run` inside the staging image:

| Command | What pip would install |
|---|---|
| `pip install nixl[cu12] --no-deps` | only `nixl-1.0.1` — **no cu12 binary** |
| `pip install nixl[cu13] --no-deps` | only `nixl-1.0.1` — **no cu13 binary** |
| `pip install nixl[cu13]` (no `--no-deps`) | `nixl-1.0.1` + **`nixl-cu12-1.0.1`** — wrong-cuda on cu13 |

Two reasons: (1) `--no-deps` suppresses extras alongside regular deps (extras resolve through pip's normal dep machinery); (2) the `nixl` 1.0.1 wheel still has the unconditional `Requires-Dist: nixl-cu12>=1.0.1` regardless of which extra is requested, so `nixl[cu13]` ends up resolving cu12 via the unconditional path. Naming both packages explicitly is the only form that works.

## Verification

Verified end-to-end on **both** `lmsysorg/sglang-staging:dev-cu13` and `lmsysorg/sglang-staging:dev-cu12` by simulating the patched install (`pip install nixl --no-deps` on top of the existing image, since the binary is already present).

### `dev-cu13`

```text
$ pip install nixl --no-deps
$ pip list | grep -i nixl
nixl                  1.0.1
nixl-cu13             1.0.1                    # cu12 NOT pulled in
$ python3 -c "from nixl._api import nixl_agent; print(nixl_agent)"
<class 'nixl_cu13._api.nixl_agent'>
$ python3 -c "import sglang.srt.mem_cache.storage.nixl.hicache_nixl; print('OK')"
OK
```

### `dev-cu12`

| | before | after `pip install nixl --no-deps` |
|---|---|---|
| `nixl` stub | missing | `1.0.1` |
| `nixl-cu12` binary | `1.0.1` | `1.0.1` (no cu13 leak) |
| `from nixl._api import nixl_agent` | `ModuleNotFoundError` | `<class 'nixl_cu12._api.nixl_agent'>` |
| `sglang...hicache_nixl` import | `ImportError: Please install NIXL...` | OK |
| `sglang...disaggregation.nixl.conn` import | OK (guarded) | OK |
| `sglang...moe.token_dispatcher.nixl` import | OK (uses `nixl_ep`) | OK |

Also reconfirmed on cu12 that `pip install --dry-run "nixl[cu12]" --no-deps` would install only the stub (no cu12 binary), matching the cu13 behavior — so the alternative `nixl[cuXX] --no-deps` form is wrong on both variants.

The stub auto-detects which `nixl-cuXX` is installed and delegates to it (cu12 → `nixl_cu12._api.nixl_agent`, cu13 → `nixl_cu13._api.nixl_agent`).

## Accuracy Tests

N/A — Dockerfile-only change.

## Speed Tests and Profiling

N/A — Dockerfile-only change.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — `pre-commit run` passes
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) — covered by post-build image validator (smoke-imports `nixl`); recommend running it against the rebuilt cu13 image to confirm
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
