### PR TITLE
Fix HiCache short bigram page lookup

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1318,13 +1318,13 @@ class HiRadixCache(RadixCache):
         self, node: TreeNode, key: RadixKey, host_value, hash_value
     ):
         node.last_access_time = time.monotonic()
-        if len(key) == 0:
+        if len(key) < self.page_size:
             return 0
 
         child_key = key.child_key(self.page_size)
 
         matched_length = 0
-        while len(key) > 0 and child_key in node.children.keys():
+        while len(key) >= self.page_size and child_key in node.children.keys():
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
             prefix_len = node.key.match(key, page_size=self.page_size)
@@ -1337,7 +1337,7 @@ class HiRadixCache(RadixCache):
                 new_node = self._split_node(node.key, node, prefix_len)
                 node = new_node
 
-            if len(key):
+            if len(key) >= self.page_size:
                 child_key = key.child_key(self.page_size)
 
         if len(key):
@@ -1359,10 +1359,12 @@ class HiRadixCache(RadixCache):
 
     def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
         node.last_access_time = time.monotonic()
+        if len(key) < self.page_size:
+            return [], node
         child_key = key.child_key(self.page_size)
         value = []
 
-        while len(key) > 0 and child_key in node.children.keys():
+        while len(key) >= self.page_size and child_key in node.children.keys():
             child = node.children[child_key]
             child.last_access_time = time.monotonic()
             prefix_len = child.key.match(key, page_size=self.page_size)
@@ -1378,7 +1380,7 @@ class HiRadixCache(RadixCache):
                 node = child
                 key = key[prefix_len:]
 
-                if len(key):
+                if len(key) >= self.page_size:
                     child_key = key.child_key(self.page_size)
 
         return value, node
@@ -1425,14 +1427,14 @@ class HiRadixCache(RadixCache):
         if value is not None:
             value = value[: len(key)]
 
-        if len(key) == 0:
+        if len(key) < self.page_size:
             return InsertResult(prefix_len=0)
 
         node = self.root_node
         child_key = key.child_key(self.page_size)
         total_prefix_length = 0
 
-        while len(key) > 0 and child_key in node.children.keys():
+        while len(key) >= self.page_size and child_key in node.children.keys():
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
             node.priority = max(node.priority, priority)
@@ -1471,7 +1473,7 @@ class HiRadixCache(RadixCache):
             key = key[prefix_len:]
             value = value[prefix_len:]
 
-            if len(key):
+            if len(key) >= self.page_size:
                 child_key = key.child_key(self.page_size)
 
         if len(key):

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -38,6 +38,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
 # Test constants
@@ -233,6 +234,21 @@ class TestTreeNode(unittest.TestCase):
 
         self.assertTrue(node1 < node2)
         self.assertFalse(node2 < node1)
+
+
+class TestHiRadixCache(unittest.TestCase):
+    """Test cases for HiRadixCache-specific tree handling."""
+
+    def test_match_prefix_helper_skips_short_bigram_page(self):
+        """Short page-aligned EAGLE keys should not compute a full-page child key."""
+        root = TreeNode()
+        key = RadixKey([1, 2, 3], is_bigram=True).page_aligned(DEFAULT_PAGE_SIZE)
+        cache = type("FakeHiRadixCache", (), {"page_size": DEFAULT_PAGE_SIZE})()
+
+        value, last_node = HiRadixCache._match_prefix_helper(cache, root, key)
+
+        self.assertEqual(value, [])
+        self.assertIs(last_node, root)
 
 
 class TestRadixCache(unittest.TestCase):


### PR DESCRIPTION
## Bug
- HiRadixCache computed `child_key(page_size)` whenever a remaining key was non-empty, but paged lookup requires at least one full page.
- In EAGLE bigram mode, a full page of 64 logical bigrams needs 65 raw tokens, so short page-aligned keys could index past the token list and crash.

## Fix
- Guard HiRadixCache traversal and insert paths with `len(key) >= page_size` before computing child keys.
- Add a regression test covering short page-aligned EAGLE bigram keys.
