### PR TITLE
[MoE] Add fused MoE auto tune CLI

### DIFF
--- a/benchmark/kernels/fused_moe_triton/README.md
+++ b/benchmark/kernels/fused_moe_triton/README.md
@@ -20,6 +20,46 @@ A specialized tool for separate kernel tuning, optimizing the first and second M
 
 ### Usage Examples
 
+#### User-facing Auto-tune Entrypoint
+```bash
+# Inspect the resolved model/kernel tuning plan without running GPU benchmarks.
+PYTHONPATH=$PWD/python:$PWD:$PYTHONPATH \
+python -m sglang.auto_tune \
+    --model-path mistralai/Mixtral-8x7B-Instruct-v0.1 \
+    --tp 1 \
+    --quick \
+    --dry-run \
+    --output-dir /tmp/sglang-moe-configs
+
+# Run a reduced tuning pass and write configs under
+# /tmp/sglang-moe-configs/configs/triton_<version>/.
+PYTHONPATH=$PWD/python:$PWD:$PYTHONPATH \
+python -m sglang.auto_tune \
+    --model-path mistralai/Mixtral-8x7B-Instruct-v0.1 \
+    --tp 1 \
+    --quick \
+    --batch-size 1,8,32,128 \
+    --output-dir /tmp/sglang-moe-configs
+
+# Reuse the generated configs when launching SGLang.
+SGLANG_MOE_CONFIG_DIR=/tmp/sglang-moe-configs \
+python -m sglang.launch_server \
+    --model-path mistralai/Mixtral-8x7B-Instruct-v0.1 \
+    --tp 1
+```
+
+The `python -m sglang.auto_tune` entrypoint currently wraps the unified
+`fused_moe_triton` tuner in this directory. It resolves the model MoE shape,
+chooses the existing SGLang config filename convention, writes configs in the
+same directory layout read by `SGLANG_MOE_CONFIG_DIR`, and prints a final reuse
+command. Use `--quick` for a smaller candidate search before running a full
+tuning pass. After tuning, the entrypoint validates that the generated JSON is
+loadable through the same runtime `SGLANG_MOE_CONFIG_DIR` path used by
+`get_moe_configs`, which catches misplaced config directories before serving.
+The underlying tuner uses Ray workers, so install SGLang's Ray extra or run
+`pip install 'ray[default]>=2.54.0'` if your environment does not already
+provide Ray.
+
 #### Basic TP Mode Tuning
 ```bash
 # Tune Mixtral-8x7B with default TP settings

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
@@ -3,6 +3,7 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/main/benchmarks/kernels/benchmark_moe.py
 import argparse
 import json
+import os
 import time
 from contextlib import nullcontext
 from datetime import datetime
@@ -11,15 +12,27 @@ from typing import Any, Dict, List, Tuple
 import ray
 import torch
 import triton
-from common_utils import (
-    BenchmarkConfig,
-    get_config_filename,
-    get_configs_compute_bound,
-    get_default_batch_sizes,
-    get_model_config,
-    save_configs,
-    sort_config,
-)
+
+try:
+    from .common_utils import (
+        BenchmarkConfig,
+        get_config_filename,
+        get_configs_compute_bound,
+        get_default_batch_sizes,
+        get_model_config,
+        save_configs,
+        sort_config,
+    )
+except ImportError:
+    from common_utils import (
+        BenchmarkConfig,
+        get_config_filename,
+        get_configs_compute_bound,
+        get_default_batch_sizes,
+        get_model_config,
+        save_configs,
+        sort_config,
+    )
 from ray.experimental.tqdm_ray import tqdm
 
 from sglang.srt.layers.moe.fused_moe_triton import override_config
@@ -36,10 +49,29 @@ from sglang.srt.server_args import (
     set_global_server_args_for_scheduler,
 )
 from sglang.srt.utils import get_device, is_hip, is_xpu
-from sglang.srt.utils.hf_transformers_utils import get_config
 
 _is_hip = is_hip()
 _is_xpu = is_xpu()
+
+
+def get_dtype_flags(dtype: str) -> Dict[str, bool]:
+    return {
+        "use_fp8_w8a8": dtype == "fp8_w8a8",
+        "use_int8_w8a8": dtype == "int8_w8a8",
+        "use_int8_w8a16": dtype == "int8_w8a16",
+        "use_int4_w4a16": dtype == "int4_w4a16",
+    }
+
+
+def filter_search_space_for_model(
+    search_space: List[BenchmarkConfig],
+    block_shape: List[int],
+) -> List[BenchmarkConfig]:
+    if block_shape is None:
+        return search_space
+
+    block_k = block_shape[1]
+    return [config for config in search_space if block_k % config["BLOCK_SIZE_K"] == 0]
 
 
 def benchmark_config(
@@ -56,6 +88,7 @@ def benchmark_config(
     use_int4_w4a16: bool,
     per_channel_quant: bool,
     block_shape: List[int] = None,
+    is_dsv4: bool = False,
     num_iters: int = 100,
 ) -> float:
     init_dtype = torch.float16 if use_fp8_w8a8 else dtype
@@ -176,9 +209,6 @@ def benchmark_config(
         topk_output.router_logits.copy_(new_topk_output.router_logits)
 
     def run():
-        model_config = get_config(args.model, trust_remote_code=True)
-        architecture = model_config.architectures[0]
-        is_dsv4 = architecture == "DeepseekV4ForCausalLM"
         moe_runner_config = MoeRunnerConfig(
             inplace=True,
             swiglu_limit=10.0 if is_dsv4 else None,
@@ -243,10 +273,13 @@ def benchmark_config(
 
 @ray.remote(num_gpus=1)
 class BenchmarkWorker:
-    def __init__(self, seed: int, server_args: ServerArgs) -> None:
+    def __init__(
+        self, seed: int, server_args: ServerArgs, architecture: str
+    ) -> None:
         torch.set_default_device(get_device())
         torch.get_device_module().manual_seed_all(0)
         self.seed = seed
+        self.is_dsv4 = architecture == "DeepseekV4ForCausalLM"
         # Get the device ID to allocate tensors and kernels
         # on the respective GPU. Ray isolates each worker to a single visible
         # GPU via CUDA_VISIBLE_DEVICES, so the local ordinal is always 0. On
@@ -319,6 +352,7 @@ class BenchmarkWorker:
                 use_int4_w4a16,
                 per_channel_quant,
                 block_shape,
+                self.is_dsv4,
             )
         return config, kernel_time
 
@@ -361,6 +395,7 @@ class BenchmarkWorker:
                         use_int4_w4a16,
                         per_channel_quant,
                         block_shape,
+                        self.is_dsv4,
                         num_iters=10,
                     )
                 except (triton.runtime.autotuner.OutOfResources, RuntimeError):
@@ -376,38 +411,66 @@ class BenchmarkWorker:
         return best_config
 
 
-def main(args: argparse.Namespace):
-    server_args = ServerArgs(
-        model_path=args.model, tp_size=args.tp_size, ep_size=args.ep_size
-    )
-
+def resolve_fused_moe_config(
+    model: str,
+    tp_size: int,
+    ep_size: int = 1,
+    disable_shared_experts_fusion: bool = False,
+) -> Dict[str, Any]:
     model_config = get_model_config(
-        args.model, args.tp_size, args.ep_size, args.disable_shared_experts_fusion
+        model,
+        tp_size,
+        ep_size,
+        disable_shared_experts_fusion,
+    )
+    model_config["tp_size"] = tp_size
+    model_config["ep_size"] = ep_size
+    return model_config
+
+
+def tune_fused_moe_triton(
+    model: str,
+    tp_size: int,
+    ep_size: int = 1,
+    dtype: str = "auto",
+    batch_sizes: List[int] = None,
+    seed: int = 0,
+    per_channel_quant: bool = False,
+    disable_shared_experts_fusion: bool = False,
+    tune: bool = True,
+    search_space: List[BenchmarkConfig] = None,
+    output_file: str = None,
+) -> Dict[str, Any]:
+    server_args = ServerArgs(model_path=model, tp_size=tp_size, ep_size=ep_size)
+
+    model_config = resolve_fused_moe_config(
+        model, tp_size, ep_size, disable_shared_experts_fusion
     )
 
     E = model_config["num_experts"]
     topk = model_config["topk"]
     hidden_size = model_config["hidden_size"]
     shard_intermediate_size = model_config["shard_intermediate_size"]
-    dtype = model_config["dtype"]
+    model_dtype = model_config["dtype"]
     block_shape = model_config["block_shape"]
 
-    use_fp8_w8a8 = args.dtype == "fp8_w8a8"
-    use_int8_w8a8 = args.dtype == "int8_w8a8"
-    use_int8_w8a16 = args.dtype == "int8_w8a16"
-    use_int4_w4a16 = args.dtype == "int4_w4a16"
-    per_channel_quant = args.per_channel_quant
+    dtype_flags = get_dtype_flags(dtype)
+    use_fp8_w8a8 = dtype_flags["use_fp8_w8a8"]
+    use_int8_w8a8 = dtype_flags["use_int8_w8a8"]
+    use_int8_w8a16 = dtype_flags["use_int8_w8a16"]
+    use_int4_w4a16 = dtype_flags["use_int4_w4a16"]
 
-    if args.batch_sizes is not None:
-        batch_sizes = args.batch_sizes
-    elif args.batch_size is not None:
-        batch_sizes = [args.batch_size]
-    else:
+    if batch_sizes is None:
         batch_sizes = get_default_batch_sizes()
 
     ray.init()
-    num_gpus = int(ray.available_resources()["GPU"])
-    workers = [BenchmarkWorker.remote(args.seed, server_args) for _ in range(num_gpus)]
+    num_gpus = int(ray.available_resources().get("GPU", 0))
+    if num_gpus <= 0:
+        raise RuntimeError("fused MoE tuning requires at least one GPU visible to Ray")
+    workers = [
+        BenchmarkWorker.remote(seed, server_args, model_config["architecture"])
+        for _ in range(num_gpus)
+    ]
 
     def _distribute(method: str, inputs: List[Any]) -> List[Any]:
         outputs = []
@@ -420,32 +483,17 @@ def main(args: argparse.Namespace):
             worker_idx = (worker_idx + 1) % num_gpus
         return ray.get(outputs)
 
-    if args.tune:
-        if args.search_space_file:
-            with open(args.search_space_file) as f:
-                search_space = json.load(f)
-            if not isinstance(search_space, list) or not all(
-                isinstance(config, dict) for config in search_space
-            ):
-                raise ValueError(
-                    "--search-space-file must contain a JSON list of configs"
-                )
-        else:
+    if tune:
+        if search_space is None:
             search_space = get_configs_compute_bound()
-        if block_shape is not None:
-            block_k = block_shape[1]
-            search_space = [
-                config
-                for config in search_space
-                if block_k % config["BLOCK_SIZE_K"] == 0
-            ]
+        search_space = filter_search_space_for_model(search_space, block_shape)
 
         filename = get_config_filename(
             E,
             shard_intermediate_size,
             hidden_size,
             topk,
-            dtype,
+            model_dtype,
             use_fp8_w8a8,
             use_int8_w8a8,
             use_int8_w8a16,
@@ -453,8 +501,10 @@ def main(args: argparse.Namespace):
             per_channel_quant,
             block_shape,
         )
+        output_file = output_file or filename
         print(
-            f"Start tuning over {len(search_space)} configurations to create {filename}..."
+            f"Start tuning over {len(search_space)} configurations "
+            f"to create {output_file}..."
         )
 
         start = time.perf_counter()
@@ -467,7 +517,7 @@ def main(args: argparse.Namespace):
                     shard_intermediate_size,
                     hidden_size,
                     topk,
-                    dtype,
+                    model_dtype,
                     use_fp8_w8a8,
                     use_int8_w8a8,
                     use_int8_w8a16,
@@ -482,12 +532,24 @@ def main(args: argparse.Namespace):
         best_configs = {
             M: sort_config(config) for M, config in zip(batch_sizes, configs)
         }
+        output_dir = os.path.dirname(output_file)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         save_configs(
             best_configs,
-            filename,
+            output_file,
         )
         end = time.perf_counter()
         print(f"Tuning took {end - start:.2f} seconds")
+        return {
+            "batch_sizes": batch_sizes,
+            "best_configs": best_configs,
+            "elapsed_sec": end - start,
+            "filename": filename,
+            "model_config": model_config,
+            "output_file": output_file,
+            "search_space_size": len(search_space),
+        }
     else:
         outputs = _distribute(
             "benchmark",
@@ -498,7 +560,7 @@ def main(args: argparse.Namespace):
                     shard_intermediate_size,
                     hidden_size,
                     topk,
-                    dtype,
+                    model_dtype,
                     use_fp8_w8a8,
                     use_int8_w8a8,
                     use_int8_w8a16,
@@ -513,6 +575,39 @@ def main(args: argparse.Namespace):
         for batch_size, (config, kernel_time) in zip(batch_sizes, outputs):
             print(f"Batch size: {batch_size}, config: {config}")
             print(f"Kernel time: {kernel_time:.2f} us")
+        return {
+            "batch_sizes": batch_sizes,
+            "model_config": model_config,
+            "outputs": outputs,
+        }
+
+
+def main(args: argparse.Namespace):
+    batch_sizes = args.batch_sizes
+    if batch_sizes is None and args.batch_size is not None:
+        batch_sizes = [args.batch_size]
+
+    search_space = None
+    if args.search_space_file:
+        with open(args.search_space_file, encoding="utf-8") as file:
+            search_space = json.load(file)
+        if not isinstance(search_space, list) or not all(
+            isinstance(config, dict) for config in search_space
+        ):
+            raise ValueError("--search-space-file must contain a JSON list of configs")
+
+    tune_fused_moe_triton(
+        model=args.model,
+        tp_size=args.tp_size,
+        ep_size=args.ep_size,
+        dtype=args.dtype,
+        batch_sizes=batch_sizes,
+        seed=args.seed,
+        per_channel_quant=args.per_channel_quant,
+        disable_shared_experts_fusion=args.disable_shared_experts_fusion,
+        tune=args.tune,
+        search_space=search_space,
+    )
 
 
 if __name__ == "__main__":

--- a/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py
@@ -13,7 +13,7 @@ import ray
 import torch
 import triton
 
-try:
+if __package__:
     from .common_utils import (
         BenchmarkConfig,
         get_config_filename,
@@ -23,7 +23,7 @@ try:
         save_configs,
         sort_config,
     )
-except ImportError:
+else:
     from common_utils import (
         BenchmarkConfig,
         get_config_filename,
@@ -273,9 +273,7 @@ def benchmark_config(
 
 @ray.remote(num_gpus=1)
 class BenchmarkWorker:
-    def __init__(
-        self, seed: int, server_args: ServerArgs, architecture: str
-    ) -> None:
+    def __init__(self, seed: int, server_args: ServerArgs, architecture: str) -> None:
         torch.set_default_device(get_device())
         torch.get_device_module().manual_seed_all(0)
         self.seed = seed

--- a/python/sglang/auto_tune.py
+++ b/python/sglang/auto_tune.py
@@ -1,0 +1,638 @@
+"""User-facing auto-tuning entrypoint for SGLang kernels."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional
+
+DTYPE_CHOICES = ("auto", "fp8_w8a8", "int8_w8a16", "int8_w8a8", "int4_w4a16")
+DEFAULT_BATCH_SIZES = [
+    1,
+    2,
+    4,
+    8,
+    16,
+    24,
+    32,
+    48,
+    64,
+    96,
+    128,
+    256,
+    512,
+    1024,
+    1536,
+    2048,
+    3072,
+    4096,
+]
+DEFAULT_OUTPUT_DIR = "sglang_moe_configs"
+
+
+@dataclass(frozen=True)
+class RuntimeInfo:
+    device_name: str
+    torch_version: str
+    cuda_version: str
+    triton_version: str
+
+
+@dataclass(frozen=True)
+class AutoTunePlan:
+    model_path: str
+    architecture: str
+    tp_size: int
+    ep_size: int
+    dtype: str
+    model_dtype: str
+    batch_sizes: List[int]
+    num_experts: int
+    topk: int
+    hidden_size: int
+    shard_intermediate_size: int
+    block_shape: Optional[List[int]]
+    per_channel_quant: bool
+    filename: str
+    output_root: Path
+    output_file: Path
+    quick: bool
+    search_space_size: Optional[int]
+    runtime: RuntimeInfo
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Auto-tune SGLang kernels for a model. The MVP supports the "
+            "Triton fused MoE kernel."
+        )
+    )
+    parser.add_argument(
+        "--model-path",
+        "--model",
+        dest="model_path",
+        required=True,
+        help="Hugging Face model name or local model path.",
+    )
+    parser.add_argument(
+        "--tp-size",
+        "--tp",
+        dest="tp_size",
+        type=int,
+        default=1,
+        help="Tensor parallel size.",
+    )
+    parser.add_argument(
+        "--ep-size",
+        dest="ep_size",
+        type=int,
+        default=1,
+        help="Expert parallel size.",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=DTYPE_CHOICES,
+        default="auto",
+        help="Kernel dtype mode. 'auto' uses the model config dtype.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        action="append",
+        default=None,
+        help=(
+            "Batch size to tune. May be repeated or comma-separated, e.g. "
+            "--batch-size 1,8 --batch-size 32."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=(
+            "Root directory for generated configs. The CLI writes under "
+            "<output-dir>/configs/triton_<version>/."
+        ),
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Use a reduced candidate search space for a faster tuning pass.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the model/kernel tuning plan without running tuning.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--per-channel-quant", action="store_true")
+    parser.add_argument("--disable-shared-experts-fusion", action="store_true")
+    parser.add_argument(
+        "--skip-load-validation",
+        action="store_true",
+        help=(
+            "Skip the post-tuning check that the generated config is loadable "
+            "through SGLANG_MOE_CONFIG_DIR."
+        ),
+    )
+    return parser
+
+
+def parse_batch_sizes(values: Optional[Iterable[str]]) -> Optional[List[int]]:
+    if values is None:
+        return None
+
+    batch_sizes: List[int] = []
+    seen = set()
+    for value in values:
+        for raw_part in str(value).split(","):
+            part = raw_part.strip()
+            if not part:
+                raise ValueError("empty value in --batch-size")
+            try:
+                batch_size = int(part)
+            except ValueError as exc:
+                raise ValueError(f"invalid batch size: {part}") from exc
+            if batch_size <= 0:
+                raise ValueError("--batch-size values must be positive")
+            if batch_size not in seen:
+                batch_sizes.append(batch_size)
+                seen.add(batch_size)
+
+    return batch_sizes
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.tp_size <= 0:
+        parser.error("--tp-size must be positive")
+    if args.ep_size <= 0:
+        parser.error("--ep-size must be positive")
+    if args.tp_size % args.ep_size != 0:
+        parser.error("--tp-size must be divisible by --ep-size")
+
+    try:
+        args.batch_sizes = parse_batch_sizes(args.batch_size)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    return args
+
+
+def _ensure_source_root_on_path() -> None:
+    source_root = Path(__file__).resolve().parents[2]
+    if (source_root / "benchmark" / "kernels" / "fused_moe_triton").exists():
+        source_root_str = str(source_root)
+        if source_root_str not in sys.path:
+            sys.path.insert(0, source_root_str)
+
+
+def _load_common_utils():
+    _ensure_source_root_on_path()
+    try:
+        return importlib.import_module(
+            "benchmark.kernels.fused_moe_triton.common_utils"
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name == "benchmark":
+            raise RuntimeError(
+                "SGLang auto_tune currently reuses the fused MoE tuner under "
+                "benchmark/kernels/fused_moe_triton. Run it from a source "
+                "checkout or make those benchmark sources importable."
+            ) from exc
+        raise
+
+
+def _load_tuner():
+    _ensure_source_root_on_path()
+    try:
+        return importlib.import_module(
+            "benchmark.kernels.fused_moe_triton.tuning_fused_moe_triton"
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name == "benchmark":
+            raise RuntimeError(
+                "SGLang auto_tune currently reuses the fused MoE tuner under "
+                "benchmark/kernels/fused_moe_triton. Run it from a source "
+                "checkout or make those benchmark sources importable."
+            ) from exc
+        if exc.name == "ray":
+            raise RuntimeError(
+                "SGLang auto_tune reuses the fused MoE tuner, which requires "
+                "Ray. Install the optional Ray dependency, e.g. "
+                "`pip install 'ray[default]>=2.54.0'`, and retry."
+            ) from exc
+        raise
+
+
+def _load_runtime_config_loader():
+    return importlib.import_module(
+        "sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config"
+    )
+
+
+def _install_runtime_server_args(plan: AutoTunePlan):
+    server_args_module = importlib.import_module("sglang.srt.server_args")
+    previous_server_args = getattr(server_args_module, "_global_server_args", None)
+
+    try:
+        server_args_module.get_global_server_args()
+    except ValueError as exc:
+        if "Global server args is not set" not in str(exc):
+            raise
+        server_args_module.set_global_server_args_for_scheduler(
+            server_args_module.ServerArgs(model_path=plan.model_path)
+        )
+
+    def restore() -> None:
+        server_args_module._global_server_args = previous_server_args
+
+    return restore
+
+
+def _dtype_flags(dtype: str) -> dict[str, bool]:
+    return {
+        "use_fp8_w8a8": dtype == "fp8_w8a8",
+        "use_int8_w8a8": dtype == "int8_w8a8",
+        "use_int8_w8a16": dtype == "int8_w8a16",
+        "use_int4_w4a16": dtype == "int4_w4a16",
+    }
+
+
+def _dtype_selector(dtype: Any, dtype_flags: dict[str, bool]) -> Optional[str]:
+    if dtype_flags["use_fp8_w8a8"]:
+        return "fp8_w8a8"
+    if dtype_flags["use_int8_w8a8"]:
+        return "int8_w8a8"
+    if dtype_flags["use_int4_w4a16"]:
+        return "int4_w4a16"
+    if dtype_flags["use_int8_w8a16"]:
+        return "int8_w8a16"
+    if str(dtype) in {"torch.float32", "torch.float"}:
+        return "float32"
+    return None
+
+
+def _build_config_filename(
+    num_experts: int,
+    shard_intermediate_size: int,
+    dtype: Any,
+    dtype_flags: dict[str, bool],
+    block_shape: Optional[List[int]],
+    per_channel_quant: bool,
+    device_name: str,
+) -> str:
+    dtype_str = _dtype_selector(dtype, dtype_flags)
+    dtype_part = "" if dtype_str is None else f",dtype={dtype_str}"
+    block_shape_part = (
+        "" if not block_shape or not all(block_shape) else f",block_shape={block_shape}"
+    )
+    per_channel_quant_part = ",per_channel_quant=True" if per_channel_quant else ""
+    sanitized_device_name = device_name.replace(" ", "_")
+
+    N = shard_intermediate_size // 2
+    if dtype_flags["use_int4_w4a16"]:
+        N = N // 2
+
+    return (
+        f"E={num_experts},N={N},device_name={sanitized_device_name}"
+        f"{dtype_part}{block_shape_part}{per_channel_quant_part}.json"
+    )
+
+
+def _collect_runtime_info() -> RuntimeInfo:
+    torch_version = "unavailable"
+    cuda_version = "unavailable"
+    triton_version = "unavailable"
+    device_name = "unknown_device"
+
+    try:
+        torch = importlib.import_module("torch")
+        torch_version = getattr(torch, "__version__", "unavailable")
+        cuda_version = getattr(getattr(torch, "version", None), "cuda", None) or "none"
+        if hasattr(torch, "cuda") and torch.cuda.is_available():
+            device_name = torch.cuda.get_device_name(0)
+        elif hasattr(torch, "xpu") and torch.xpu.is_available():
+            device_name = torch.xpu.get_device_name(0)
+        elif hasattr(torch, "hpu") and torch.hpu.is_available():
+            device_name = torch.hpu.get_device_name(0)
+        elif hasattr(torch, "npu") and torch.npu.is_available():
+            device_name = torch.npu.get_device_name(0)
+    except Exception:
+        pass
+
+    try:
+        triton = importlib.import_module("triton")
+        triton_version = getattr(triton, "__version__", "unavailable")
+    except Exception:
+        pass
+
+    return RuntimeInfo(
+        device_name=device_name,
+        torch_version=torch_version,
+        cuda_version=cuda_version,
+        triton_version=triton_version,
+    )
+
+
+def _triton_version_dir(triton_version: str) -> str:
+    if not triton_version or triton_version == "unavailable":
+        return "triton_unknown"
+    return f"triton_{triton_version.replace('.', '_')}"
+
+
+def resolve_output_path(
+    output_dir: str | Path, filename: str, triton_version: str
+) -> Path:
+    return (
+        Path(output_dir).expanduser().resolve()
+        / "configs"
+        / _triton_version_dir(triton_version)
+        / filename
+    )
+
+
+def select_quick_search_space(
+    search_space: List[dict[str, int]], max_configs: int = 128
+) -> List[dict[str, int]]:
+    if max_configs <= 0:
+        raise ValueError("max_configs must be positive")
+
+    preferred = [
+        config
+        for config in search_space
+        if config.get("BLOCK_SIZE_M") in {16, 32, 64, 128}
+        and config.get("BLOCK_SIZE_N") in {64, 128, 256}
+        and config.get("BLOCK_SIZE_K") in {64, 128}
+        and config.get("GROUP_SIZE_M") in {1, 16, 32}
+        and config.get("num_warps") in {4, 8}
+        and config.get("num_stages") in {2, 3, 4}
+    ]
+    candidates = preferred or list(search_space)
+
+    if len(candidates) <= max_configs:
+        return candidates
+    if max_configs == 1:
+        return [candidates[0]]
+
+    step = (len(candidates) - 1) / (max_configs - 1)
+    indices = sorted({round(i * step) for i in range(max_configs)})
+    return [candidates[index] for index in indices]
+
+
+def _filter_search_space_for_model(
+    common_utils,
+    search_space: List[dict[str, int]],
+    block_shape: Optional[List[int]],
+) -> List[dict[str, int]]:
+    if hasattr(common_utils, "filter_search_space_for_model"):
+        return common_utils.filter_search_space_for_model(search_space, block_shape)
+    if block_shape is None:
+        return search_space
+    block_k = block_shape[1]
+    return [config for config in search_space if block_k % config["BLOCK_SIZE_K"] == 0]
+
+
+def resolve_tuning_plan(args: argparse.Namespace) -> AutoTunePlan:
+    common_utils = _load_common_utils()
+    runtime = _collect_runtime_info()
+    batch_sizes = args.batch_sizes or DEFAULT_BATCH_SIZES
+
+    model_config = common_utils.get_model_config(
+        args.model_path,
+        args.tp_size,
+        args.ep_size,
+        args.disable_shared_experts_fusion,
+    )
+    dtype_flags = _dtype_flags(args.dtype)
+
+    try:
+        filename = common_utils.get_config_filename(
+            model_config["num_experts"],
+            model_config["shard_intermediate_size"],
+            model_config["hidden_size"],
+            model_config["topk"],
+            model_config["dtype"],
+            dtype_flags["use_fp8_w8a8"],
+            dtype_flags["use_int8_w8a8"],
+            dtype_flags["use_int8_w8a16"],
+            dtype_flags["use_int4_w4a16"],
+            args.per_channel_quant,
+            model_config["block_shape"],
+        )
+    except AttributeError as exc:
+        if "replace" not in str(exc):
+            raise
+        filename = _build_config_filename(
+            model_config["num_experts"],
+            model_config["shard_intermediate_size"],
+            model_config["dtype"],
+            dtype_flags,
+            model_config["block_shape"],
+            args.per_channel_quant,
+            runtime.device_name,
+        )
+
+    output_root = Path(args.output_dir).expanduser().resolve()
+    output_file = resolve_output_path(output_root, filename, runtime.triton_version)
+
+    search_space_size = None
+    try:
+        search_space = common_utils.get_configs_compute_bound()
+        if args.quick:
+            search_space = select_quick_search_space(search_space)
+        search_space = _filter_search_space_for_model(
+            common_utils, search_space, model_config["block_shape"]
+        )
+        search_space_size = len(search_space)
+    except Exception:
+        if not args.dry_run:
+            raise
+
+    return AutoTunePlan(
+        model_path=args.model_path,
+        architecture=model_config["architecture"],
+        tp_size=args.tp_size,
+        ep_size=args.ep_size,
+        dtype=args.dtype,
+        model_dtype=str(model_config["dtype"]),
+        batch_sizes=batch_sizes,
+        num_experts=model_config["num_experts"],
+        topk=model_config["topk"],
+        hidden_size=model_config["hidden_size"],
+        shard_intermediate_size=model_config["shard_intermediate_size"],
+        block_shape=model_config["block_shape"],
+        per_channel_quant=args.per_channel_quant,
+        filename=filename,
+        output_root=output_root,
+        output_file=output_file,
+        quick=args.quick,
+        search_space_size=search_space_size,
+        runtime=runtime,
+    )
+
+
+def _format_list(values: Iterable[Any]) -> str:
+    return ", ".join(str(value) for value in values)
+
+
+def _runtime_config_n(plan: AutoTunePlan) -> int:
+    N = plan.shard_intermediate_size // 2
+    if _dtype_flags(plan.dtype)["use_int4_w4a16"]:
+        N = N // 2
+    return N
+
+
+def print_summary(
+    plan: AutoTunePlan,
+    dry_run: bool = False,
+    load_validated: bool = False,
+) -> None:
+    status = "Dry run" if dry_run else "Completed"
+    print(f"SGLang auto_tune: {status}")
+    print(f"  model: {plan.model_path}")
+    print(f"  architecture: {plan.architecture}")
+    print(
+        "  fused_moe_triton: "
+        f"E={plan.num_experts}, topk={plan.topk}, "
+        f"hidden={plan.hidden_size}, shard_intermediate={plan.shard_intermediate_size}"
+    )
+    print(
+        f"  parallelism: tp={plan.tp_size}, ep={plan.ep_size}; "
+        f"dtype={plan.dtype} (model dtype: {plan.model_dtype})"
+    )
+    print(f"  batch sizes: {_format_list(plan.batch_sizes)}")
+    if plan.search_space_size is not None:
+        mode = "quick" if plan.quick else "full"
+        print(f"  search: {mode}, {plan.search_space_size} candidates")
+    print(
+        f"  device: {plan.runtime.device_name}; CUDA: {plan.runtime.cuda_version}; "
+        f"Triton: {plan.runtime.triton_version}; torch: {plan.runtime.torch_version}"
+    )
+    print("  output config paths:")
+    print(f"    {plan.output_file}")
+    if dry_run:
+        print("  runtime loader validation: skipped (dry run)")
+    elif load_validated:
+        print("  runtime loader validation: passed")
+    print("  reuse with:")
+    print(
+        "    "
+        f"SGLANG_MOE_CONFIG_DIR={shlex.quote(str(plan.output_root))} "
+        f"python -m sglang.launch_server --model-path "
+        f"{shlex.quote(plan.model_path)} --tp {plan.tp_size} "
+        f"--ep-size {plan.ep_size}"
+    )
+
+
+def validate_output_config(plan: AutoTunePlan) -> List[int]:
+    if not plan.output_file.exists():
+        raise RuntimeError(
+            f"tuning completed but output config was not found at {plan.output_file}"
+        )
+
+    with plan.output_file.open(encoding="utf-8") as file:
+        raw_config = json.load(file)
+
+    expected_keys = sorted(int(key) for key in raw_config)
+    runtime_loader = _load_runtime_config_loader()
+    get_moe_configs = runtime_loader.get_moe_configs
+    restore_server_args = _install_runtime_server_args(plan)
+    if hasattr(get_moe_configs, "cache_clear"):
+        get_moe_configs.cache_clear()
+
+    dtype = _dtype_selector(plan.model_dtype, _dtype_flags(plan.dtype))
+    block_n = plan.block_shape[0] if plan.block_shape else 0
+    block_k = plan.block_shape[1] if plan.block_shape else 0
+    previous_config_dir = os.environ.get("SGLANG_MOE_CONFIG_DIR")
+    os.environ["SGLANG_MOE_CONFIG_DIR"] = str(plan.output_root)
+    try:
+        loaded_config = get_moe_configs(
+            plan.num_experts,
+            _runtime_config_n(plan),
+            dtype,
+            block_n=block_n,
+            block_k=block_k,
+            per_channel_quant=plan.per_channel_quant,
+        )
+    finally:
+        if previous_config_dir is None:
+            os.environ.pop("SGLANG_MOE_CONFIG_DIR", None)
+        else:
+            os.environ["SGLANG_MOE_CONFIG_DIR"] = previous_config_dir
+        if hasattr(get_moe_configs, "cache_clear"):
+            get_moe_configs.cache_clear()
+        restore_server_args()
+
+    if loaded_config is None:
+        raise RuntimeError(
+            "generated config was not loadable through SGLANG_MOE_CONFIG_DIR="
+            f"{plan.output_root}"
+        )
+
+    loaded_keys = sorted(int(key) for key in loaded_config)
+    if loaded_keys != expected_keys:
+        raise RuntimeError(
+            "generated config loaded with unexpected batch-size keys: "
+            f"expected {expected_keys}, got {loaded_keys}"
+        )
+
+    return loaded_keys
+
+
+def run_tuning(args: argparse.Namespace, plan: AutoTunePlan) -> dict[str, Any]:
+    tuner = _load_tuner()
+    search_space = None
+    if args.quick:
+        search_space = select_quick_search_space(tuner.get_configs_compute_bound())
+
+    result = tuner.tune_fused_moe_triton(
+        model=args.model_path,
+        tp_size=args.tp_size,
+        ep_size=args.ep_size,
+        dtype=args.dtype,
+        batch_sizes=plan.batch_sizes,
+        seed=args.seed,
+        per_channel_quant=args.per_channel_quant,
+        disable_shared_experts_fusion=args.disable_shared_experts_fusion,
+        tune=True,
+        search_space=search_space,
+        output_file=str(plan.output_file),
+    )
+    if not args.skip_load_validation:
+        result["load_validation_keys"] = validate_output_config(plan)
+        result["load_validated"] = True
+    else:
+        result["load_validated"] = False
+    return result
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    try:
+        args = parse_args(argv)
+        plan = resolve_tuning_plan(args)
+        if args.dry_run:
+            print_summary(plan, dry_run=True)
+            return 0
+
+        result = run_tuning(args, plan)
+        print_summary(
+            plan,
+            dry_run=False,
+            load_validated=bool(result.get("load_validated")),
+        )
+        return 0
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/sglang/auto_tune.py
+++ b/python/sglang/auto_tune.py
@@ -239,22 +239,12 @@ def _load_runtime_config_loader():
 
 
 def _install_runtime_server_args(plan: AutoTunePlan):
-    server_args_module = importlib.import_module("sglang.srt.server_args")
-    previous_server_args = getattr(server_args_module, "_global_server_args", None)
-
-    try:
-        server_args_module.get_global_server_args()
-    except ValueError as exc:
-        if "Global server args is not set" not in str(exc):
-            raise
-        server_args_module.set_global_server_args_for_scheduler(
-            server_args_module.ServerArgs(model_path=plan.model_path)
-        )
-
-    def restore() -> None:
-        server_args_module._global_server_args = previous_server_args
-
-    return restore
+    runtime_context = importlib.import_module("sglang.srt.runtime_context")
+    override = runtime_context.get_context().override_server_args(
+        model_path=plan.model_path
+    )
+    override.install()
+    return override.restore
 
 
 def _dtype_flags(dtype: str) -> dict[str, bool]:

--- a/test/registered/unit/test_auto_tune.py
+++ b/test/registered/unit/test_auto_tune.py
@@ -1,0 +1,339 @@
+import io
+import importlib.util
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    from sglang.test.ci.ci_register import register_cpu_ci
+except ModuleNotFoundError:
+
+    def register_cpu_ci(*args, **kwargs):
+        pass
+
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def load_auto_tune_module():
+    repo_root = Path(__file__).resolve().parents[3]
+    module_path = repo_root / "python" / "sglang" / "auto_tune.py"
+    spec = importlib.util.spec_from_file_location("sglang_auto_tune_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+auto_tune = load_auto_tune_module()
+RuntimeInfo = auto_tune.RuntimeInfo
+main = auto_tune.main
+parse_args = auto_tune.parse_args
+resolve_output_path = auto_tune.resolve_output_path
+run_tuning = auto_tune.run_tuning
+select_quick_search_space = auto_tune.select_quick_search_space
+validate_output_config = auto_tune.validate_output_config
+
+
+class FakeCommonUtils:
+    @staticmethod
+    def get_model_config(
+        model_path, tp_size, ep_size, disable_shared_experts_fusion=False
+    ):
+        return {
+            "architecture": "FakeMoeForCausalLM",
+            "num_experts": 8,
+            "topk": 2,
+            "hidden_size": 1024,
+            "shard_intermediate_size": 2048,
+            "dtype": "torch.bfloat16",
+            "block_shape": None,
+        }
+
+    @staticmethod
+    def get_config_filename(*args, **kwargs):
+        return "E=8,N=1024,device_name=Fake_GPU,dtype=fp8_w8a8.json"
+
+    @staticmethod
+    def get_configs_compute_bound():
+        return [
+            {
+                "BLOCK_SIZE_M": 16,
+                "BLOCK_SIZE_N": 64,
+                "BLOCK_SIZE_K": 64,
+                "GROUP_SIZE_M": 1,
+                "num_warps": 4,
+                "num_stages": 3,
+            },
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": 256,
+                "GROUP_SIZE_M": 64,
+                "num_warps": 8,
+                "num_stages": 5,
+            },
+        ]
+
+
+class FakeTuner:
+    @staticmethod
+    def get_configs_compute_bound():
+        return FakeCommonUtils.get_configs_compute_bound()
+
+    @staticmethod
+    def tune_fused_moe_triton(**kwargs):
+        FakeTuner.kwargs = kwargs
+        return {"output_file": kwargs["output_file"]}
+
+
+class TestAutoTune(unittest.TestCase):
+    def test_parse_tp_aliases_and_batch_sizes(self):
+        args = parse_args(
+            [
+                "--model-path",
+                "fake/model",
+                "--tp",
+                "2",
+                "--batch-size",
+                "1,8",
+                "--batch-size",
+                "32",
+            ]
+        )
+        self.assertEqual(args.tp_size, 2)
+        self.assertEqual(args.batch_sizes, [1, 8, 32])
+
+        args = parse_args(["--model-path", "fake/model", "--tp-size", "4"])
+        self.assertEqual(args.tp_size, 4)
+
+    def test_invalid_tp_ep_fails_clearly(self):
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit):
+            parse_args(
+                ["--model-path", "fake/model", "--tp-size", "3", "--ep-size", "2"]
+            )
+        self.assertIn("--tp-size must be divisible by --ep-size", stderr.getvalue())
+
+    def test_output_path_uses_sglang_config_layout(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = resolve_output_path(tmp_dir, "config.json", "3.4.0")
+
+            self.assertEqual(
+                output_path,
+                Path(tmp_dir).resolve() / "configs" / "triton_3_4_0" / "config.json",
+            )
+
+    def test_quick_search_space_is_reduced_and_deterministic(self):
+        search_space = []
+        for block_m in [16, 32, 64, 128, 256]:
+            search_space.append(
+                {
+                    "BLOCK_SIZE_M": block_m,
+                    "BLOCK_SIZE_N": 64,
+                    "BLOCK_SIZE_K": 64,
+                    "GROUP_SIZE_M": 1,
+                    "num_warps": 4,
+                    "num_stages": 3,
+                }
+            )
+
+        selected = select_quick_search_space(search_space, max_configs=2)
+
+        self.assertEqual(len(selected), 2)
+        self.assertEqual(selected[0]["BLOCK_SIZE_M"], 16)
+        self.assertEqual(selected[1]["BLOCK_SIZE_M"], 128)
+
+    def test_dry_run_resolves_model_config_without_tuning(self):
+        runtime = RuntimeInfo(
+            device_name="Fake GPU",
+            torch_version="2.test",
+            cuda_version="12.test",
+            triton_version="3.4.0",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            stdout = io.StringIO()
+            with (
+                patch.object(
+                    auto_tune, "_load_common_utils", return_value=FakeCommonUtils
+                ),
+                patch.object(auto_tune, "_collect_runtime_info", return_value=runtime),
+                patch.object(
+                    auto_tune,
+                    "run_tuning",
+                    side_effect=AssertionError("dry-run should not tune"),
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = main(
+                    [
+                        "--model-path",
+                        "fake/model",
+                        "--tp",
+                        "1",
+                        "--dtype",
+                        "fp8_w8a8",
+                        "--quick",
+                        "--dry-run",
+                        "--output-dir",
+                        tmp_dir,
+                    ]
+                )
+
+        output = stdout.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Dry run", output)
+        self.assertIn("FakeMoeForCausalLM", output)
+        self.assertIn("search: quick, 1 candidates", output)
+        self.assertIn("runtime loader validation: skipped", output)
+        self.assertIn("SGLANG_MOE_CONFIG_DIR=", output)
+        self.assertIn("configs/triton_3_4_0", output)
+
+    def test_run_tuning_passes_resolved_output_and_quick_search_space(self):
+        runtime = RuntimeInfo(
+            device_name="Fake GPU",
+            torch_version="2.test",
+            cuda_version="12.test",
+            triton_version="3.4.0",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            args = parse_args(
+                [
+                    "--model-path",
+                    "fake/model",
+                    "--tp",
+                    "1",
+                    "--dtype",
+                    "fp8_w8a8",
+                    "--quick",
+                    "--batch-size",
+                    "1,8",
+                    "--output-dir",
+                    tmp_dir,
+                ]
+            )
+            with (
+                patch.object(
+                    auto_tune, "_load_common_utils", return_value=FakeCommonUtils
+                ),
+                patch.object(auto_tune, "_load_tuner", return_value=FakeTuner),
+                patch.object(auto_tune, "_collect_runtime_info", return_value=runtime),
+                patch.object(auto_tune, "validate_output_config", return_value=[1, 8]),
+            ):
+                plan = auto_tune.resolve_tuning_plan(args)
+                result = run_tuning(args, plan)
+
+        self.assertEqual(result["output_file"], str(plan.output_file))
+        self.assertTrue(result["load_validated"])
+        self.assertEqual(result["load_validation_keys"], [1, 8])
+        self.assertEqual(FakeTuner.kwargs["model"], "fake/model")
+        self.assertEqual(FakeTuner.kwargs["batch_sizes"], [1, 8])
+        self.assertEqual(FakeTuner.kwargs["output_file"], str(plan.output_file))
+        self.assertEqual(len(FakeTuner.kwargs["search_space"]), 1)
+        self.assertTrue(FakeTuner.kwargs["tune"])
+
+    def test_validate_output_config_checks_runtime_loader_path(self):
+        runtime = RuntimeInfo(
+            device_name="Fake GPU",
+            torch_version="2.test",
+            cuda_version="12.test",
+            triton_version="3.4.0",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            args = parse_args(
+                [
+                    "--model-path",
+                    "fake/model",
+                    "--tp",
+                    "1",
+                    "--dtype",
+                    "fp8_w8a8",
+                    "--batch-size",
+                    "1,8",
+                    "--output-dir",
+                    tmp_dir,
+                ]
+            )
+            with (
+                patch.object(
+                    auto_tune, "_load_common_utils", return_value=FakeCommonUtils
+                ),
+                patch.object(auto_tune, "_collect_runtime_info", return_value=runtime),
+            ):
+                plan = auto_tune.resolve_tuning_plan(args)
+
+            plan.output_file.parent.mkdir(parents=True, exist_ok=True)
+            plan.output_file.write_text(
+                '{"1": {"BLOCK_SIZE_M": 16}, "8": {"BLOCK_SIZE_M": 32}}'
+            )
+
+            captured = {}
+
+            def fake_get_moe_configs(*args, **kwargs):
+                captured["args"] = args
+                captured["kwargs"] = kwargs
+                captured["config_dir"] = auto_tune.os.environ.get(
+                    "SGLANG_MOE_CONFIG_DIR"
+                )
+                return {1: {"BLOCK_SIZE_M": 16}, 8: {"BLOCK_SIZE_M": 32}}
+
+            def cache_clear():
+                captured["cache_clears"] = captured.get("cache_clears", 0) + 1
+
+            fake_get_moe_configs.cache_clear = cache_clear
+
+            class FakeRuntimeLoader:
+                get_moe_configs = staticmethod(fake_get_moe_configs)
+
+            with (
+                patch.object(
+                    auto_tune,
+                    "_load_runtime_config_loader",
+                    return_value=FakeRuntimeLoader,
+                ),
+                patch.object(
+                    auto_tune,
+                    "_install_runtime_server_args",
+                    return_value=lambda: None,
+                ),
+            ):
+                keys = validate_output_config(plan)
+
+        self.assertEqual(keys, [1, 8])
+        self.assertEqual(captured["config_dir"], str(plan.output_root))
+        self.assertEqual(captured["args"][:3], (8, 1024, "fp8_w8a8"))
+        self.assertEqual(captured["kwargs"]["per_channel_quant"], False)
+        self.assertGreaterEqual(captured["cache_clears"], 2)
+
+    def test_missing_ray_dependency_has_actionable_error(self):
+        missing_ray = ModuleNotFoundError("No module named 'ray'", name="ray")
+
+        with (
+            patch.object(auto_tune.importlib, "import_module", side_effect=missing_ray),
+            self.assertRaisesRegex(RuntimeError, "requires Ray"),
+        ):
+            auto_tune._load_tuner()
+
+    def test_runtime_error_is_reported_without_traceback(self):
+        stderr = io.StringIO()
+        with (
+            patch.object(
+                auto_tune, "resolve_tuning_plan", side_effect=RuntimeError("boom")
+            ),
+            redirect_stderr(stderr),
+        ):
+            exit_code = main(["--model-path", "fake/model"])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("error: boom", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_auto_tune.py
+++ b/test/registered/unit/test_auto_tune.py
@@ -30,6 +30,7 @@ def load_auto_tune_module():
 
 auto_tune = load_auto_tune_module()
 RuntimeInfo = auto_tune.RuntimeInfo
+install_runtime_server_args = auto_tune._install_runtime_server_args
 main = auto_tune.main
 parse_args = auto_tune.parse_args
 resolve_output_path = auto_tune.resolve_output_path
@@ -310,6 +311,39 @@ class TestAutoTune(unittest.TestCase):
         self.assertEqual(captured["args"][:3], (8, 1024, "fp8_w8a8"))
         self.assertEqual(captured["kwargs"]["per_channel_quant"], False)
         self.assertGreaterEqual(captured["cache_clears"], 2)
+
+    def test_runtime_loader_validation_uses_scoped_server_args(self):
+        captured = {}
+
+        class FakeOverride:
+            def install(self):
+                captured["installed"] = True
+
+            def restore(self):
+                captured["restored"] = True
+
+        class FakeContext:
+            def override_server_args(self, **kwargs):
+                captured["override_kwargs"] = kwargs
+                return FakeOverride()
+
+        class FakeRuntimeContext:
+            @staticmethod
+            def get_context():
+                return FakeContext()
+
+        plan = type("Plan", (), {"model_path": "fake/model"})()
+        with patch.object(
+            auto_tune.importlib,
+            "import_module",
+            return_value=FakeRuntimeContext,
+        ):
+            restore = install_runtime_server_args(plan)
+
+        self.assertTrue(captured["installed"])
+        self.assertEqual(captured["override_kwargs"], {"model_path": "fake/model"})
+        restore()
+        self.assertTrue(captured["restored"])
 
     def test_missing_ray_dependency_has_actionable_error(self):
         missing_ray = ModuleNotFoundError("No module named 'ray'", name="ray")

--- a/test/registered/unit/test_auto_tune.py
+++ b/test/registered/unit/test_auto_tune.py
@@ -1,5 +1,5 @@
-import io
 import importlib.util
+import io
 import sys
 import tempfile
 import unittest


### PR DESCRIPTION
## Summary

This adds a narrow first `python -m sglang.auto_tune` entrypoint for the auto tuner roadmap in #13363.

The MVP scope is intentionally limited to Triton fused MoE tuning:

- resolves the model MoE shape from `--model-path`, `--tp`, `--ep-size`, and `--dtype`
- reuses `benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py` instead of duplicating benchmark logic
- writes tuned JSON files under the runtime `SGLANG_MOE_CONFIG_DIR` layout: `configs/triton_<version>/...json`
- supports `--dry-run`, `--quick`, repeatable/comma-separated `--batch-size`, `--output-dir`, and existing dtype/quant flags
- validates after tuning that the generated config is loadable through the runtime `get_moe_configs()` path

Out of scope: allreduce selection, attention backend selection, CUTLASS GEMM tuning, speculative decoding parameters, and separate `_down` MoE tuning.

## Current-main refresh

This branch is now rebased onto current `main` (`b98a577fb`). The refresh also:

- preserves the newer DeepSeek-V4 `swiglu_limit` behavior without relying on a module-global CLI `args` object when the tuner is imported as a library
- passes the resolved model architecture explicitly to Ray workers
- distinguishes package imports from direct-script imports with `__package__`, so nested dependency errors are no longer masked as a misleading `common_utils` import failure
- uses the current scoped runtime-context override for post-tuning config-loader validation
- reads generated JSON explicitly as UTF-8

## Validation on current main

Local CPU/static checks:

- `python3 test/registered/unit/test_auto_tune.py -f` — 10 passed
- `python3 scripts/ci/check_registered_tests.py`
- `python3 -m py_compile ...`
- Ruff 0.15.1, Black 26.1.0, and isort 7.0.0 checks

DGX Spark / NVIDIA GB10 checks with PyTorch 2.9.1+cu130 and Triton 3.5.1:

- imported the tuner as `benchmark.kernels.fused_moe_triton.tuning_fused_moe_triton` and verified the reusable API has no global `args` dependency
- current-main dry run for `Qwen/Qwen1.5-MoE-A2.7B-Chat` resolved `E=60`, `topk=4`, `hidden=2048`, and `shard_intermediate=2816`
- minimal real Ray tuning with one batch size and one candidate completed, wrote a JSON config, and returned `search_space_size=1`
- runtime loader validation found the generated config through `SGLANG_MOE_CONFIG_DIR` and returned batch-size keys `[1]`

The earlier full GB10 validation remains representative of the complete search path: 128 candidates across batch sizes `[1, 8, 32, 128]`, followed by a server health/completion smoke using the generated config. The current-main refresh specifically revalidated the changed import, Ray-worker, tuning, and loader paths above.

## Environment note

The base `lmsysorg/sglang:dev-cu13` image does not include Ray, so the CLI reports an actionable installation hint. For current-main validation I installed `ray[default]>=2.54.0` in an ephemeral container.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30008366935](https://github.com/sgl-project/sglang/actions/runs/30008366935)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30008366621](https://github.com/sgl-project/sglang/actions/runs/30008366621)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->