### PR TITLE
[CI] Exclude flaky h20 stage from check-stage-health root cause set

### DIFF
--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -56,6 +56,12 @@ runs:
           // Find jobs that failed from a real error, not from fast-fail cascade
           const rootCauseFailures = jobs.filter(j => {
             if (j.status !== 'completed' || j.conclusion !== 'failure') return false;
+            // h20 runners are flaky (dirty GPU state from prior runs); their failures
+            // should not cascade fast-fail to other stages. Exact match avoids
+            // accidentally matching the h200 job names.
+            if (j.name === 'stage-c-test-8-gpu-h20') {
+              return false;
+            }
             // If the failing step is the health check, it's a cascade — skip it
             const failedStep = (j.steps || []).find(s => s.conclusion === 'failure');
             if (failedStep && (failedStep.name.includes('check-stage-health') || failedStep.name.includes('Check stage health'))) {


### PR DESCRIPTION
## Summary

- The `8-gpu-h20` runners regularly enter jobs with leftover GPU memory from a prior run that cleanup can't reclaim, so `stage-c-test-8-gpu-h20` fails at `Install dependencies` before any test runs (see [run 25316228022](https://github.com/sgl-project/sglang/actions/runs/25316228022/job/74268805394) — `ERROR: memory >=10%` across all 8 GPUs, 8 unkillable PIDs).
- When that happens, every other stage-c job (h200, b200, deepep, …) fast-fails via `check-stage-health` because h20 is treated as a root-cause failure — even though the failure is purely a runner-state issue unrelated to the PR. Example cascade: [job 74268805495 (h200)](https://github.com/sgl-project/sglang/actions/runs/25316228022/job/74268805495).
- Exclude the `stage-c-test-8-gpu-h20` job (exact name match, so `h200` is unaffected) from the root-cause filter so its failure no longer cascades. The h20 job will still fail and report itself.

## Test plan

- [ ] Verify on this PR's CI that `check-stage-health` no longer fast-fails when an h20 job fails.
- [ ] Confirm h200 / b200 / deepep stage-c jobs still cascade correctly when one of *them* is the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)