### PR TITLE
fp8: support TP-rank-interleaved qkv_proj layout for asymmetric K/V

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1002,6 +1002,29 @@ class QKVParallelLinear(ColumnParallelLinear):
         }
         return shard_size_mapping.get(loaded_shard_id)
 
+    def _is_tp_interleaved_qkv_layout(self) -> bool:
+        # When the model has asymmetric K/V heads (head_size != v_head_size)
+        # AND per-rank merged-QKV output is not divisible by the FP8 block_n,
+        # the checkpoint can't store fp8 scales in the natural flat
+        # [Q | K | V] layout: each rank's K (or V) crosses a block boundary,
+        # so a flat scale tensor would either need to encode mid-block
+        # transitions or be misaligned. Some checkpoints (e.g. MiMo-V2.5-Pro
+        # at TP=8 with head_size=192, v_head_size=128, block_n=128) work
+        # around this by storing both qkv_proj.weight and
+        # qkv_proj.weight_scale_inv in TP-rank-INTERLEAVED layout: each
+        # rank's contiguous Q | K | V slab is laid out back-to-back, and
+        # each rank's scale is padded up to a multiple of block_n.
+        try:
+            block_n = self.quant_method.quant_config.weight_block_size[0]
+        except Exception:
+            return False
+        per_rank_size = (
+            self.total_num_heads * self.head_size
+            + self.total_num_kv_heads * self.head_size
+            + self.total_num_kv_heads * self.v_head_size
+        ) // self.tp_size
+        return per_rank_size % block_n != 0
+
     def _load_fused_module_from_checkpoint(
         self, param: BasevLLMParameter, loaded_weight: torch.Tensor
     ):
@@ -1014,6 +1037,26 @@ class QKVParallelLinear(ColumnParallelLinear):
         An example of a model with these fused layers:
         https://huggingface.co/microsoft/Phi-3-mini-4k-instruct
         """
+        # If the per-rank output is not block-aligned (asymmetric K/V where
+        # head_size and v_head_size differ enough to break alignment), the
+        # checkpoint stores the qkv_proj weight in TP-rank-INTERLEAVED layout
+        # rather than flat [Q | K | V]. Detect and copy the rank's slab.
+        if self._is_tp_interleaved_qkv_layout():
+            per_rank_size = (
+                self.total_num_heads * self.head_size
+                + self.total_num_kv_heads * self.head_size
+                + self.total_num_kv_heads * self.v_head_size
+            ) // self.tp_size
+            rank_slice = loaded_weight.narrow(
+                param.output_dim, self.tp_rank * per_rank_size, per_rank_size
+            )
+            assert rank_slice.shape == param.data.shape, (
+                f"interleaved qkv weight shape mismatch: "
+                f"{rank_slice.shape} vs {param.data.shape}"
+            )
+            param.data.copy_(rank_slice)
+            return
+
         shard_offsets = [
             # (shard_id, shard_offset, shard_size)
             ("q", 0, self.total_num_heads * self.head_size),
@@ -1051,6 +1094,29 @@ class QKVParallelLinear(ColumnParallelLinear):
         self, param: BasevLLMParameter, loaded_weight: torch.Tensor
     ):
         block_n, _ = self.quant_method.quant_config.weight_block_size
+        # Mirror the weight loader: when the per-rank output is not
+        # block-aligned, the scale is stored in TP-rank-INTERLEAVED layout
+        # with each rank's chunk padded up to a multiple of block_n. The
+        # flat-layout total predicts (Q + K + V) // block_n rows; the
+        # checkpoint actually has tp_size * ceil(per_rank/block_n) rows.
+        # That difference is the smoking gun.
+        flat_total = (
+            self.total_num_heads * self.head_size
+            + self.total_num_kv_heads * self.head_size
+            + self.total_num_kv_heads * self.v_head_size
+        ) // block_n
+        if loaded_weight.shape[param.output_dim] != flat_total:
+            per_rank_blocks = loaded_weight.shape[param.output_dim] // self.tp_size
+            rank_slice = loaded_weight.narrow(
+                param.output_dim, self.tp_rank * per_rank_blocks, per_rank_blocks
+            )
+            assert rank_slice.shape == param.data.shape, (
+                f"interleaved qkv scale shape mismatch: "
+                f"{rank_slice.shape} vs {param.data.shape}"
+            )
+            param.data.copy_(rank_slice)
+            return
+
         q_size = self.total_num_heads * self.head_size // block_n
         k_size = self.total_num_kv_heads * self.head_size // block_n
         v_size = self.total_num_kv_heads * self.v_head_size // block_n

--- a/test/registered/unit/layers/test_qkv_interleaved_layout.py
+++ b/test/registered/unit/layers/test_qkv_interleaved_layout.py
@@ -1,0 +1,215 @@
+"""Unit tests for the TP-rank-interleaved qkv_proj layout detection used by
+QKVParallelLinear's FP8 weight and weight-scale loaders.
+
+Background: when a model has asymmetric K/V (head_size != v_head_size) AND the
+per-rank merged-QKV output is not divisible by the FP8 quantization block_n,
+some checkpoints (e.g. MiMo-V2.5-Pro at TP=8 with head_size=192,
+v_head_size=128, block_n=128) store qkv_proj.weight and
+qkv_proj.weight_scale_inv in TP-rank-INTERLEAVED layout rather than flat
+[Q | K | V]. The loader's heuristic must (a) detect this case for asymmetric
+checkpoints, (b) NOT fire for symmetric/aligned checkpoints, and (c) split the
+checkpoint correctly when it does fire.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="stage-a-test-cpu")
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.layers.linear import QKVParallelLinear
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_layer(
+    *,
+    total_num_heads,
+    total_num_kv_heads,
+    head_size,
+    v_head_size,
+    tp_size,
+    tp_rank,
+    block_n,
+):
+    """Construct a minimal QKVParallelLinear-like object that bypasses the
+    full __init__ but exposes the attributes the loader heuristic reads."""
+    layer = QKVParallelLinear.__new__(QKVParallelLinear)
+    layer.total_num_heads = total_num_heads
+    layer.total_num_kv_heads = total_num_kv_heads
+    layer.head_size = head_size
+    layer.v_head_size = v_head_size
+    layer.tp_size = tp_size
+    layer.tp_rank = tp_rank
+
+    quant_config = types.SimpleNamespace(weight_block_size=(block_n, block_n))
+    layer.quant_method = types.SimpleNamespace(quant_config=quant_config)
+    return layer
+
+
+class _Param:
+    """Minimal stand-in for a vLLMParameter — exposes data and output_dim."""
+
+    def __init__(self, shape, output_dim=0, dtype=torch.float32):
+        self.data = torch.zeros(*shape, dtype=dtype)
+        self.output_dim = output_dim
+
+
+class TestInterleavedQKVLayoutHeuristic(CustomTestCase):
+    """The _is_tp_interleaved_qkv_layout helper must fire only for cases
+    where per-rank merged-QKV output is not divisible by block_n."""
+
+    def test_mimo_v25_pro_tp8_triggers(self):
+        # MiMo-V2.5-Pro at TP=8: per-rank = 16*192 + 1*192 + 1*128 = 3392,
+        # 3392 % 128 = 64. Asymmetric K/V — must trigger.
+        layer = _make_layer(
+            total_num_heads=128,
+            total_num_kv_heads=8,
+            head_size=192,
+            v_head_size=128,
+            tp_size=8,
+            tp_rank=0,
+            block_n=128,
+        )
+        self.assertTrue(layer._is_tp_interleaved_qkv_layout())
+
+    def test_symmetric_kv_aligned_does_not_trigger(self):
+        # DeepSeek-V3-style: head_size == v_head_size, all dims block-aligned.
+        layer = _make_layer(
+            total_num_heads=128,
+            total_num_kv_heads=8,
+            head_size=128,
+            v_head_size=128,
+            tp_size=8,
+            tp_rank=0,
+            block_n=128,
+        )
+        self.assertFalse(layer._is_tp_interleaved_qkv_layout())
+
+    def test_llama_style_does_not_trigger(self):
+        # Llama-3-style: 32 heads, 8 kv heads, head_size 128, TP=4.
+        # per-rank = 8*128 + 2*128 + 2*128 = 1536, divisible by 128.
+        layer = _make_layer(
+            total_num_heads=32,
+            total_num_kv_heads=8,
+            head_size=128,
+            v_head_size=128,
+            tp_size=4,
+            tp_rank=0,
+            block_n=128,
+        )
+        self.assertFalse(layer._is_tp_interleaved_qkv_layout())
+
+    def test_no_quant_config_returns_false(self):
+        # Models without an FP8 block-scale quant config must not trigger.
+        layer = QKVParallelLinear.__new__(QKVParallelLinear)
+        layer.total_num_heads = 128
+        layer.total_num_kv_heads = 8
+        layer.head_size = 192
+        layer.v_head_size = 128
+        layer.tp_size = 8
+        layer.tp_rank = 0
+        layer.quant_method = types.SimpleNamespace(quant_config=None)
+        self.assertFalse(layer._is_tp_interleaved_qkv_layout())
+
+
+class TestInterleavedQKVScaleLoading(CustomTestCase):
+    """When the scale checkpoint is in TP-rank-interleaved layout (more rows
+    than the flat layout would predict), the loader must copy this rank's
+    contiguous chunk into the parameter."""
+
+    def _setup(self, tp_rank):
+        # MiMo-V2.5-Pro shape: per-rank scale is (27, 48), total scale rows
+        # are 8 * 27 = 216 (vs the 212 flat layout would predict).
+        layer = _make_layer(
+            total_num_heads=128,
+            total_num_kv_heads=8,
+            head_size=192,
+            v_head_size=128,
+            tp_size=8,
+            tp_rank=tp_rank,
+            block_n=128,
+        )
+        per_rank_blocks = 27
+        in_blocks = 48
+        # Synthetic checkpoint whose value at each row equals the row index, so
+        # we can assert exactly which rows ended up in the rank's parameter.
+        loaded = (
+            torch.arange(8 * per_rank_blocks, dtype=torch.float32)
+            .view(-1, 1)
+            .expand(-1, in_blocks)
+            .contiguous()
+        )
+        param = _Param((per_rank_blocks, in_blocks), output_dim=0)
+        return layer, param, loaded, per_rank_blocks
+
+    def test_rank0_loads_first_27_blocks(self):
+        layer, param, loaded, per_rank_blocks = self._setup(tp_rank=0)
+        layer._load_qkv_block_scale(param, loaded)
+        # Rank 0 must end up with rows [0, 1, ..., 26].
+        expected = torch.arange(per_rank_blocks, dtype=torch.float32)
+        self.assertTrue(torch.equal(param.data[:, 0], expected))
+
+    def test_rank4_loads_correct_chunk(self):
+        layer, param, loaded, per_rank_blocks = self._setup(tp_rank=4)
+        layer._load_qkv_block_scale(param, loaded)
+        # Rank 4's chunk is rows [4*27, ..., 5*27 - 1] = [108, ..., 134].
+        expected = torch.arange(
+            4 * per_rank_blocks, 5 * per_rank_blocks, dtype=torch.float32
+        )
+        self.assertTrue(torch.equal(param.data[:, 0], expected))
+
+    def test_rank7_loads_last_chunk(self):
+        layer, param, loaded, per_rank_blocks = self._setup(tp_rank=7)
+        layer._load_qkv_block_scale(param, loaded)
+        expected = torch.arange(
+            7 * per_rank_blocks, 8 * per_rank_blocks, dtype=torch.float32
+        )
+        self.assertTrue(torch.equal(param.data[:, 0], expected))
+
+
+class TestInterleavedQKVWeightLoading(CustomTestCase):
+    """When per-rank output isn't block-aligned, the weight checkpoint is
+    also TP-rank-interleaved. _load_fused_module_from_checkpoint must copy
+    this rank's slab directly rather than splitting flat [Q | K | V]."""
+
+    def _setup(self, tp_rank):
+        layer = _make_layer(
+            total_num_heads=128,
+            total_num_kv_heads=8,
+            head_size=192,
+            v_head_size=128,
+            tp_size=8,
+            tp_rank=tp_rank,
+            block_n=128,
+        )
+        per_rank_size = 16 * 192 + 1 * 192 + 1 * 128  # 3392
+        hidden_size = 6144
+        loaded = (
+            torch.arange(8 * per_rank_size, dtype=torch.float32)
+            .view(-1, 1)
+            .expand(-1, hidden_size)
+            .contiguous()
+        )
+        param = _Param((per_rank_size, hidden_size), output_dim=0)
+        return layer, param, loaded, per_rank_size
+
+    def test_rank0_loads_first_slab(self):
+        layer, param, loaded, per_rank_size = self._setup(tp_rank=0)
+        layer._load_fused_module_from_checkpoint(param, loaded)
+        expected = torch.arange(per_rank_size, dtype=torch.float32)
+        self.assertTrue(torch.equal(param.data[:, 0], expected))
+
+    def test_rank3_loads_correct_slab(self):
+        layer, param, loaded, per_rank_size = self._setup(tp_rank=3)
+        layer._load_fused_module_from_checkpoint(param, loaded)
+        expected = torch.arange(
+            3 * per_rank_size, 4 * per_rank_size, dtype=torch.float32
+        )
+        self.assertTrue(torch.equal(param.data[:, 0], expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When a model has asymmetric K/V (head_size != v_head_size) AND the per-rank merged-QKV output is not divisible by the FP8 quantization block_n, the natural flat [Q | K | V] layout for qkv_proj.weight and qkv_proj.weight_scale_inv is no longer expressible: each rank's K (or V) crosses a block boundary, so a flat scale tensor would either need to encode mid-block transitions or be misaligned with the GEMM kernel's per-block-scale arithmetic.

Some checkpoints (e.g. MiMo-V2.5-Pro at TP=8 with head_size=192, v_head_size=128, block_n=128, where per-rank output = 16*192 + 1*192 + 1*128 = 3392 is not divisible by 128) work around this by storing both qkv_proj.weight and qkv_proj.weight_scale_inv in TP-rank- INTERLEAVED layout: each rank's contiguous Q | K | V slab is laid out back-to-back, and each rank's scale is padded to a multiple of block_n. Total scale rows = tp_size * ceil(per_rank / block_n) (216 for MiMo) vs the (Q + K + V) // block_n the flat layout would predict (212 for MiMo).

The existing _load_fused_module_from_checkpoint and _load_qkv_block_scale assume the flat layout. With the buggy V scale being read from the wrong checkpoint offset, V dequantizes ~3x too large and overflows to NaN through the residual stack; with the buggy weight loader, V weights for ranks 0..N-2 are read from mid-rank-Q/K rows entirely. Together, /v1/completions returns '!!!!!!!!!!!!!!!!' (uniform-logit argmax to the lowest-id token).

This patch adds a TP-interleaved fast path to both loaders:

- _load_qkv_block_scale: detect via loaded_weight.shape[output_dim] != flat_total. The mismatch is unambiguous because the flat-layout total can only equal the interleaved-padded total when per-rank output is already block-aligned (in which case both layouts produce identical contents and the original code path runs unchanged).

- _load_fused_module_from_checkpoint: detect via per_rank_size % block_n != 0. The weight tensor itself doesn't need padding so the row count alone can't distinguish the two layouts, but if the scale needs interleaved-with-padding to make the rows fit, the weight must be in the same layout for the GEMM kernel's per-block-scale arithmetic to line up.

For symmetric K/V models the heuristic never fires and the original code path runs unchanged.

Verified end-to-end on MiMo-V2.5-Pro FP8 / TP=8 across two GB200 pods: /v1/completions previously returned '!!!!!!!!!!!!!!!!' for any prompt; now returns coherent text:
  "The capital of France is" -> " one of the most popular tourist
   destinations in the world. The city is known for its art,
   culture, fashion, and"
  "Hello, my name is" -> " **Judas Gutenberg** and this is my
   blaag (pronounced as you would the vomit ..."
  "1 + 1 =" -> " 2\n+    assert 1 + 1 == 2\n+    assert 1 + 1 =="

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
