### PR TITLE
[v0.5.11] Cherry-pick #24369: fix(docker): restore nixl stub alongside cu12/cu13 binary

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -540,10 +540,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # it with --no-deps and pair it with the matching nixl-cu12 / nixl-cu13 binary
 # to avoid shipping wrong-CUDA libs on cu13 images.
 RUN --mount=type=cache,target=/root/.cache/pip if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
-    python3 -m pip install nixl-cu12 --no-deps ; \
+    python3 -m pip install nixl nixl-cu12 --no-deps ; \
     python3 -m pip install cuda-python==12.9 ; \
 elif [ "${CUDA_VERSION%%.*}" = "13" ]; then \
-    python3 -m pip install nixl-cu13 --no-deps ; \
+    python3 -m pip install nixl nixl-cu13 --no-deps ; \
     python3 -m pip install cuda-python==13.2.0 ; \
 fi
 


### PR DESCRIPTION
Cherry-pick of #24369 to `release/v0.5.11`.

Original commit: `1aefd4dfed490be0336ae2d3cfcce765434e7c11`

## Summary
- Restores the `nixl` Python stub package alongside the `nixl-cu12`/`nixl-cu13` binary in `docker/Dockerfile` so that imports of `from nixl._api import ...` keep working on cu13 images.
- `--no-deps` is preserved to prevent the stub's unconditional `nixl-cu12>=1.0.1` requirement from pulling cu12 binaries onto cu13 images.
- Applies cleanly via auto-merge; no functional change beyond the upstream PR.

## Test plan
- [ ] Build `lmsysorg/sglang:dev-cu13` from this branch and verify `python3 -c "from nixl._api import nixl_agent"` succeeds.
- [ ] Verify `python3 -c "import sglang.srt.mem_cache.storage.nixl.hicache_nixl"` imports cleanly on the resulting image.
- [ ] Same checks on the cu12 image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)