### PR TITLE
misc: add marlin to moe runner choices; drop dead env var doc

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -44,11 +44,6 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_DISABLE_REQUEST_LOGGING`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Disable request logging</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
-    </tr>
-    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_LOG_REQUEST_HEADERS</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Comma-separated list of additional HTTP headers to log when <code>--log-requests</code> is enabled. Appends to the default <code>x-smg-routing-key</code>.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set</td>

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -188,6 +188,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cutedsl",
     "cutlass",
     "aiter",
+    "marlin",
 ]
 
 MOE_A2A_BACKEND_CHOICES = [


### PR DESCRIPTION
Two unrelated tiny cleanups bundled:

1. `server_args.py`: `MOE_RUNNER_BACKEND_CHOICES` was missing `marlin` even though `MoeRunnerBackend.MARLIN` enum exists since #14554. `docs_new/.../deepseek-v4-deployment.jsx` already instructs users to pass `--moe-runner-backend marlin`, but argparse rejects it.
2. `docs_new/.../environment_variables.mdx`: drop the `SGLANG_DISABLE_REQUEST_LOGGING` row -- the env var has no reader anywhere in the codebase.