### PR TITLE
[Bug] Fix: \n between </tool_call> and <tool_call> incorrectly emitted as normal_text

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -50,6 +50,8 @@ class Qwen3CoderDetector(BaseFormatDetector):
 
         # [FIX] New state flag: mark whether inside tool_call structure block
         self.is_inside_tool_call: bool = False
+        self.pending_post_tool_call: str = ""
+        self.just_exited_tool_call: bool = False
 
         # Initialize attributes that were missing in the original PR
         self.current_func_name: Optional[str] = None
@@ -264,6 +266,10 @@ class Qwen3CoderDetector(BaseFormatDetector):
             # 1. Priority detection: check if it's the start of Tool Call
             # -------------------------------------------------------
             if current_slice.startswith(self.tool_call_start_token):
+                # [FIX] Discard the whitespace characters in the middle of </tool_call> and <tool_call>, usually \n
+                if self.just_exited_tool_call:
+                    self.pending_post_tool_call = ""
+                    self.just_exited_tool_call = False
                 self.parsed_pos += len(self.tool_call_start_token)
                 self.is_inside_tool_call = True
                 continue
@@ -403,6 +409,8 @@ class Qwen3CoderDetector(BaseFormatDetector):
             if current_slice.startswith(self.tool_call_end_token):
                 self.parsed_pos += len(self.tool_call_end_token)
                 self.is_inside_tool_call = False  # [FIX] Exit tool call region
+                self.just_exited_tool_call = True
+                self.pending_post_tool_call = ""
                 continue
 
             # -------------------------------------------------------
@@ -416,7 +424,17 @@ class Qwen3CoderDetector(BaseFormatDetector):
 
             if next_open_angle == -1:
                 # This entire segment is plain text
-                if not self.is_inside_tool_call:
+                # [FIX] If just exited </tool_call>, buffer whitespace for delayed emission
+                if self.just_exited_tool_call:
+                    if current_slice.strip() == "":
+                        self.pending_post_tool_call += current_slice
+                    else:
+                        normal_text_chunks.append(
+                            self.pending_post_tool_call + current_slice
+                        )
+                        self.pending_post_tool_call = ""
+                        self.just_exited_tool_call = False
+                elif not self.is_inside_tool_call:
                     normal_text_chunks.append(current_slice)
                 # [FIX] If inside tool call, discard this text (usually \n), don't append
                 self.parsed_pos += len(current_slice)
@@ -444,7 +462,12 @@ class Qwen3CoderDetector(BaseFormatDetector):
                     break  # Wait for more
                 else:
                     # Just a plain '<' symbol
-                    if not self.is_inside_tool_call:
+                    # [FIX] If the whitespace character is not between </tool_call> and <tool_call>, it is preserved
+                    if self.just_exited_tool_call:
+                        normal_text_chunks.append(self.pending_post_tool_call + "<")
+                        self.pending_post_tool_call = ""
+                        self.just_exited_tool_call = False
+                    elif not self.is_inside_tool_call:
                         normal_text_chunks.append("<")
                     self.parsed_pos += 1
                     continue
@@ -452,7 +475,17 @@ class Qwen3CoderDetector(BaseFormatDetector):
             else:
                 # '<' is in the middle
                 text_segment = current_slice[:next_open_angle]
-                if not self.is_inside_tool_call:
+                # [FIX] If just exited </tool_call>, buffer/flush pending whitespace
+                if self.just_exited_tool_call:
+                    if text_segment.strip() == "":
+                        self.pending_post_tool_call += text_segment
+                    else:
+                        normal_text_chunks.append(
+                            self.pending_post_tool_call + text_segment
+                        )
+                        self.pending_post_tool_call = ""
+                        self.just_exited_tool_call = False
+                elif not self.is_inside_tool_call:
                     normal_text_chunks.append(text_segment)
                 # [FIX] If inside tool call, discard whitespace/text before Tag
                 self.parsed_pos += next_open_angle


### PR DESCRIPTION
Clear if whitespace occurs between </tool_call> and <tool_call>, otherwise retain

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using `--tool-call-parser qwen3_coder`, the Qwen3CoderDetector streaming parser incorrectly emits the trailing `\n` after `</tool_call>` as `normal_text` when followed by `<tool_call>`.
**Example raw delta:**

chunk data
```
\n\n<tool_call>
\n<function=read>\n
<parameter=path>\nC
:\\Users\\l\\Desktop\\
weibo\\main
.go\n</parameter>\n
</function>\n</tool_call>\n
<tool_call>\n<function=read>
```

openai api data
```
data: {"id":"fe48d3a2d241459f9467b9076aabdf46","object":"chat.completion.chunk","created":1777751005,"model":"qwen3.6-27b","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"id":"call_2a1994a5f265419094877b17","index":0,"type":"function","function":{"name":"read","arguments":""}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}

data: {"id":"fe48d3a2d241459f9467b9076aabdf46","object":"chat.completion.chunk","created":1777751005,"model":"qwen3.6-27b","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"{"}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}

data: {"id":"fe48d3a2d241459f9467b9076aabdf46","object":"chat.completion.chunk","created":1777751005,"model":"qwen3.6-27b","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"\"path\": \"C:\\\\Users\\\\l\\\\Desktop\\\\weibo\\\\main.go\""}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}

data: {"id":"fe48d3a2d241459f9467b9076aabdf46","object":"chat.completion.chunk","created":1777751005,"model":"qwen3.6-27b","choices":[{"index":0,"delta":{"role":null,"content":"\n","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}

data: {"id":"fe48d3a2d241459f9467b9076aabdf46","object":"chat.completion.chunk","created":1777751005,"model":"qwen3.6-27b","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":"}"}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}

data: {"id":"fe48d3a2d241459f9467b9076aabdf46","object":"chat.completion.chunk","created":1777751005,"model":"qwen3.6-27b","choices":[{"index":0,"delta":{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"id":"call_50d12abdb4694a0b8623fbb0","index":1,"type":"function","function":{"name":"read","arguments":""}}]},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}
```

The `\n` after `</tool_call>` is a structural delimiter separating tool calls, not real text. However, because `is_inside_tool_call` is set to `False` immediately after matching `</tool_call>`, this whitespace gets appended to `normal_text`. This causes the openai api to output text content before the end of the tool call parameter, causing agent to report errors

**Root cause:** The parser cannot know whether the `\n` after `</tool_call>` is a delimiter or real text without looking ahead.

## Modifications

Added a `pending_post_tool_call` buffer and `just_exited_tool_call` flag in `Qwen3CoderDetector` to delay emitting whitespace after `</tool_call>` until its nature is confirmed:

1. After matching `</tool_call>`, set `just_exited_tool_call = True` and clear buffer
2. When encountering whitespace → store in `pending_post_tool_call` (do not emit yet)
3. When encountering the next tag:
   - If `<tool_call>` → pending is a delimiter, discard it
   - If any other tag → flush pending + continue
4. When encountering real text → emit `pending + text` (no data loss)
5. Keep state across chunks via instance variables

**Changed files:**
- `sglang/srt/function_call/qwen3_coder_detector.py` — `Qwen3CoderDetector.__init__`, `parse_streaming_increment()`

## Accuracy Tests

| Scenario | Before | After |
|---|---|---|
| `</tool_call>\n<tool_call>` | `\n` emitted as normal_text | `\n` discarded (delimiter) |
| `</tool_call>\n<tool_call>` (cross-chunk) | `\n` emitted as normal_text | `\n` discarded (delimiter) |
| `</tool_call>\nReal text` | `\n` emitted, then text separately | `\nReal text` emitted together |
| `</tool_call>\n` (last chunk) | `\n` emitted as normal_text | `\n` discarded (delimiter) |
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
