### PR TITLE
[diffusion] CI: pin diffusion consistency GT revision

### DIFF
--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -35,6 +35,7 @@ from sglang.multimodal_gen.test.server.testcase_configs import (
     ScenarioConfig,
 )
 from sglang.multimodal_gen.test.test_utils import (
+    SGL_TEST_FILES_CI_DATA_REVISION,
     _consistency_gt_filenames,
     _get_consistency_gt_dir,
     compare_with_gt,
@@ -569,6 +570,7 @@ Add the expected file(s) to sgl-project/ci-data in diffusion-ci/consistency_gt/s
 For this case, expected file(s): {names}
 
 Repository: https://github.com/sgl-project/ci-data (path: diffusion-ci/consistency_gt/sglang_generated/)
+Pinned revision used by this check: {SGL_TEST_FILES_CI_DATA_REVISION}
 
 (Optional) Per-case override in consistency_threshold.json:
   "cases": {{

--- a/python/sglang/multimodal_gen/test/test_consistency_metrics.py
+++ b/python/sglang/multimodal_gen/test/test_consistency_metrics.py
@@ -18,6 +18,14 @@ def _solid_image(value: int, size: int = 32) -> np.ndarray:
     return np.full((size, size, 3), value, dtype=np.uint8)
 
 
+def test_consistency_gt_urls_are_pinned_to_ci_data_revision():
+    revision_path = f"/ci-data/{test_utils.SGL_TEST_FILES_CI_DATA_REVISION}/"
+
+    assert "/ci-data/main/" not in test_utils.SGL_TEST_FILES_CONSISTENCY_GT_ROOT
+    assert revision_path in test_utils.SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_BASE
+    assert revision_path in test_utils.SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE
+
+
 def test_pixel_metrics_identical_image():
     image = _solid_image(128)
 

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "35e022eee6c7e082724494ebb5771d605c76749d"
+SGL_TEST_FILES_CI_DATA_REVISION = "437539b330592b1421d239b22d7d76b4a6d08fda"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,8 +33,18 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_BASE = "https://raw.githubusercontent.com/sgl-project/ci-data/main/diffusion-ci/consistency_gt/official_generated"
-SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE = "https://raw.githubusercontent.com/sgl-project/ci-data/main/diffusion-ci/consistency_gt/sglang_generated"
+SGL_TEST_FILES_CI_DATA_REVISION = "35e022eee6c7e082724494ebb5771d605c76749d"
+SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
+    "https://raw.githubusercontent.com/"
+    f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"
+    "diffusion-ci/consistency_gt"
+)
+SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_BASE = (
+    f"{SGL_TEST_FILES_CONSISTENCY_GT_ROOT}/official_generated"
+)
+SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE = (
+    f"{SGL_TEST_FILES_CONSISTENCY_GT_ROOT}/sglang_generated"
+)
 SGL_TEST_FILES_CONSISTENCY_GT_BASE = SGL_TEST_FILES_SGLANG_CONSISTENCY_GT_BASE
 SGL_TEST_FILES_CONSISTENCY_GT_BASES = (
     SGL_TEST_FILES_OFFICIAL_CONSISTENCY_GT_BASE,


### PR DESCRIPTION
## Summary
- Pin diffusion consistency GT raw URLs to `sgl-project/ci-data@437539b330592b1421d239b22d7d76b4a6d08fda` instead of floating `main`.
- Surface the pinned ci-data revision in the missing-GT error message.
- Add a unit check that the consistency GT URLs do not point at `/ci-data/main/`.

## Motivation
The diffusion consistency check was reading GT assets from the latest `ci-data/main`, so unrelated ci-data updates could change PR test behavior without a matching sglang code revision. Binding the default GT source to a concrete ci-data commit makes the check reproducible.

## Validation
- GitHub connector confirmed `437539b330592b1421d239b22d7d76b4a6d08fda` exists in `sgl-project/ci-data`.
- `git diff --check -- python/sglang/multimodal_gen/test/test_utils.py python/sglang/multimodal_gen/test/server/test_server_common.py python/sglang/multimodal_gen/test/test_consistency_metrics.py`
- `rg` confirmed no remaining diffusion test GT URL points at `raw.githubusercontent.com/sgl-project/ci-data/main` or `/ci-data/main/`.
- Attempted `python -m pytest python/sglang/multimodal_gen/test/test_consistency_metrics.py -q`, but local collection fails before tests due to the existing local torch/sglang import mismatch: `cannot import name '_cuda_beginAllocateCurrentThreadToPool' from 'torch.cuda.memory'`.