### PR TITLE
[AMD] fix(docker): unbreak nightly when archive.ubuntu.com:80 is unreachable

### DIFF
--- a/.github/workflows/release-docker-amd-nightly.yml
+++ b/.github/workflows/release-docker-amd-nightly.yml
@@ -85,7 +85,9 @@ jobs:
           echo "IMAGE_TAG=${tag}-${{ env.DATE }}" >> $GITHUB_ENV
 
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
+          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local

--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -95,7 +95,9 @@ jobs:
           echo "IMAGE_TAG=${tag}-${{ env.DATE }}" >> $GITHUB_ENV
 
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
+          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local
@@ -248,12 +250,15 @@ jobs:
           echo "IMAGE_TAG=${image_tag}" >> "$GITHUB_ENV"
           echo "Building rocm/sgl-dev:${image_tag} from amd/deepseek_v4 @ ${{ steps.version.outputs.commit_sha }}"
 
+          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
+          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
           docker build . -f docker/rocm.Dockerfile \
             --build-arg SGL_BRANCH=${{ steps.version.outputs.commit_sha }} \
             --build-arg BUILD_TYPE=${{ matrix.build_type }} \
             --build-arg GPU_ARCH=${{ matrix.gpu_arch }} \
             --build-arg ENABLE_MORI=1 \
             --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} \
+            --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com \
             -t rocm/sgl-dev:${image_tag} \
             --no-cache
           docker push rocm/sgl-dev:${image_tag}

--- a/.github/workflows/release-docker-amd.yml
+++ b/.github/workflows/release-docker-amd.yml
@@ -85,5 +85,7 @@ jobs:
 
           # rocm.Dockerfile expects SGL_BRANCH with 'v' prefix for git tag checkout
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
-          docker build . -f docker/rocm.Dockerfile --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }}${gpu_arch_suffix} --build-arg SGL_BRANCH=v${version} --build-arg ENABLE_MORI=1 -t lmsysorg/sglang:${tag} --no-cache
+          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
+          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
+          docker build . -f docker/rocm.Dockerfile --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }}${gpu_arch_suffix} --build-arg SGL_BRANCH=v${version} --build-arg ENABLE_MORI=1 --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t lmsysorg/sglang:${tag} --no-cache
           docker push lmsysorg/sglang:${tag}

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -109,7 +109,30 @@ ARG MORI_COMMIT="v1.1.1"
 # AMD AINIC apt repo settings
 ARG AINIC_VERSION=1.117.5-a-38
 ARG UBUNTU_CODENAME=jammy
+
+# Optional Ubuntu mirror override + apt hardening.
+# - UBUNTU_MIRROR is empty by default (no behaviour change for local builds).
+#   When set (typically in CI), all http://*archive.ubuntu.com and
+#   http://*security.ubuntu.com entries in /etc/apt/sources.list are rewritten
+#   to point at the given base URL, e.g.
+#     --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com
+#     --build-arg UBUNTU_MIRROR=https://tw.archive.ubuntu.com
+#     --build-arg UBUNTU_MIRROR=http://internal-cache.example.com
+#   This mirrors the pattern already used in docker/Dockerfile (NVIDIA) and
+#   docker/npu.Dockerfile, and lets CI runners that cannot reach Canonical's
+#   port-80 mirror IPs still complete `apt-get update`.
+# - The 80-net-hardening apt config adds retries + per-request timeout so that
+#   transient mirror flakes don't immediately fail a build (apt's default is 0
+#   retries).
+ARG UBUNTU_MIRROR=
 USER root
+
+RUN if [ -n "$UBUNTU_MIRROR" ]; then \
+        sed -i "s|http://[^[:space:]/]*archive.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list && \
+        sed -i "s|http://[^[:space:]/]*security.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list; \
+    fi && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+        > /etc/apt/apt.conf.d/80-net-hardening
 
 # Fix hipDeviceGetName returning empty string in ROCm 7.0 docker images.
 # The ROCm 7.0 base image is missing libdrm-amdgpu-common which provides the


### PR DESCRIPTION
## Motivation
The Release Docker Images Nightly ROCm7.2 (AMD) build is failing on the
TileLang stage when the `amd-docker-scale` runner cannot reach Canonical's
`archive.ubuntu.com` mirror IPs over port 80.
### Failure chain (from a recent nightly run)

24 214.2 Get:1 https://repo.radeon.com/amdgpu/30.30/ubuntu jammy InRelease     OK
24 214.4 Get:8 https://repo.radeon.com/rocm/apt/7.2 jammy/main amd64 Packages   OK
24 214.6 Get:5 https://apt.llvm.org/jammy llvm-toolchain-jammy-18 InRelease     OK
24 240.6 Get:12 http://security.ubuntu.com/ubuntu jammy-security InRelease      OK
24 314.9 Err:14 http://archive.ubuntu.com/ubuntu jammy InRelease
            Connection failed [IP: 185.125.190.81 80]
24 314.9 Err:18 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
            Could not connect to archive.ubuntu.com:80 (91.189.92.24), connection timed out
            Could not connect to archive.ubuntu.com:80 (185.125.190.82), ...
            [all 8 archive.ubuntu.com IPs time out]
24 314.9 Err:19 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
            Unable to connect to archive.ubuntu.com:http
...
24 315.5 The following packages have unmet dependencies:
24 315.5  llvm-18 : Depends: libpfm4 but it is not installable
24 315.5 E: Unable to correct problems, you have held broken packages.
24 ERROR: process "...install -y --no-install-recommends llvm-18..." did not complete successfully: exit code: 100

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<img width="331" height="118" alt="image" src="https://github.com/user-attachments/assets/a4db6db3-2821-40f7-bb92-51b8fd911654" />
https://github.com/sgl-project/sglang/actions/runs/25358834624/job/74353667371

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
