### PR TITLE
[diffusion] fix: fix RowParallel LoRA merged forwarding

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -513,6 +513,9 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
         super().__init__(base_layer, lora_rank, lora_alpha)
 
     def forward(self, input_: torch.Tensor):
+        if self.merged or self.disable_lora:
+            return self.base_layer(input_)
+
         lora_A = self.lora_A
         lora_B = self.lora_B
         if isinstance(self.lora_B, DTensor):

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "4ec556d5716a071071861fa372bf200935107e44"
+SGL_TEST_FILES_CI_DATA_REVISION = "4d9eff3b05b0ffe1d3529e8bb148b63af11a4b92"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "3f50cfcc0abf70b851370551d2dd86a74c149fdb"
+SGL_TEST_FILES_CI_DATA_REVISION = "df245c17bd99f8e205ce3d299fe341a723b6e2d6"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "df245c17bd99f8e205ce3d299fe341a723b6e2d6"
+SGL_TEST_FILES_CI_DATA_REVISION = "4ec556d5716a071071861fa372bf200935107e44"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "437539b330592b1421d239b22d7d76b4a6d08fda"
+SGL_TEST_FILES_CI_DATA_REVISION = "3f50cfcc0abf70b851370551d2dd86a74c149fdb"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"


### PR DESCRIPTION
## Summary

Fix `RowParallelLinearWithLoRA` so the wrapper is transparent when no runtime LoRA delta needs to be applied:

- `disable_lora=True` now directly calls `base_layer(input)`.
- `merged=True` now directly calls `base_layer(input)` because the LoRA delta has already been folded into `base_layer.weight`.
- Pin diffusion consistency GT to the ci-data revision containing the refreshed Wan / Z-Image LoRA outputs.

## Root Cause

`RowParallelLinearWithLoRA.forward()` previously kept using its hand-written RowParallel path even when LoRA was already merged or disabled. That path is algebraically equivalent to the base layer path, but it is not the same implementation path:

- old wrapper path: GEMM without the base-layer bias in the quantized linear call, TP reduce, then add base-layer bias in Python/Torch;
- base layer path: preserve `RowParallelLinear.forward()` behavior, including its bias handling inside the base quant method / epilogue path where applicable.

For `merged=True`, the LoRA delta is already part of `base_layer.weight`, so the wrapper should not alter the base layer's forward semantics. For `disable_lora=True`, the wrapper should also be a transparent pass-through.

## Impact

This intentionally changes the numerical path for merged/disabled RowParallel LoRA layers. The math is the same, but diffusion outputs can amplify small floating-point differences. Existing Wan / Z-Image LoRA consistency GT was generated from the old wrapper-specific numerical path, so the affected GT has been regenerated.

This does not change the active unmerged LoRA path (`not merged and not disable_lora`), and it does not change LoRA merge/unmerge logic.

Expected performance impact:

- merged/disabled RowParallel LoRA: neutral to slightly faster, because the wrapper now delegates to the base RowParallel implementation instead of duplicating its forward logic;
- active unmerged LoRA: unchanged.

## Ground Truth Update

Ran `diffusion-ci-gt-gen.yml` for the affected case IDs:

- `zimage_image_t2i_multi_lora`
- `wan2_1_t2v_1_3b_lora_1gpu`
- `wan2_1_i2v_14b_lora_2gpu`
- `wan2_2_t2v_a14b_lora_2gpu`

Workflow: https://github.com/sgl-project/sglang/actions/runs/25361072314

Final ci-data revision pinned by this PR:

- `3f50cfcc0abf70b851370551d2dd86a74c149fdb`

Verified the refreshed GT files exist at that revision for all four cases.

## Validation

- `git diff --check`
- `diffusion-ci-gt-gen.yml` completed successfully and published refreshed GT images.
- Attempted local `python -m pytest python/sglang/multimodal_gen/test/test_consistency_metrics.py -q`, but local Mac environment failed during collection due to Torch/CUDA API mismatch: `torch.cuda.memory` missing `_cuda_beginAllocateCurrentThreadToPool`.