### PR TITLE
[diffusion] Fuse LTX2 split rotary embedding

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/ltx2_rotary.py
+++ b/python/sglang/jit_kernel/diffusion/triton/ltx2_rotary.py
@@ -37,8 +37,14 @@ def _ltx2_split_rotary_kernel(
     cos = tl.load(cos_ptr + cos_base + offsets, mask=mask, other=0.0)
     sin = tl.load(sin_ptr + sin_base + offsets, mask=mask, other=0.0)
 
-    out_first = x_first * cos - x_second * sin
-    out_second = x_second * cos + x_first * sin
+    # Match the original PyTorch order: x * cos is written as BF16 first, then
+    # addcmul_ computes the sine product in FP32 before the final BF16 store.
+    out_first = (x_first * cos).to(tl.bfloat16).to(tl.float32) + (
+        -x_second.to(tl.float32) * sin.to(tl.float32)
+    )
+    out_second = (x_second * cos).to(tl.bfloat16).to(tl.float32) + (
+        x_first.to(tl.float32) * sin.to(tl.float32)
+    )
 
     tl.store(out_ptr + x_base + offsets, out_first, mask=mask)
     tl.store(out_ptr + x_base + half_dim + offsets, out_second, mask=mask)

--- a/python/sglang/jit_kernel/diffusion/triton/ltx2_rotary.py
+++ b/python/sglang/jit_kernel/diffusion/triton/ltx2_rotary.py
@@ -1,0 +1,84 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _ltx2_split_rotary_kernel(
+    out_ptr,
+    x_ptr,
+    cos_ptr,
+    sin_ptr,
+    seq_len: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    half_dim: tl.constexpr,
+    stride_cos_b: tl.constexpr,
+    stride_cos_h: tl.constexpr,
+    stride_cos_t: tl.constexpr,
+    stride_sin_b: tl.constexpr,
+    stride_sin_h: tl.constexpr,
+    stride_sin_t: tl.constexpr,
+    BLOCK_HALF: tl.constexpr,
+):
+    pid_bt = tl.program_id(0)
+    head = tl.program_id(1)
+    batch = pid_bt // seq_len
+    token = pid_bt - batch * seq_len
+    offsets = tl.arange(0, BLOCK_HALF)
+    mask = offsets < half_dim
+
+    x_base = ((batch * seq_len + token) * num_heads + head) * head_dim
+    cos_base = batch * stride_cos_b + head * stride_cos_h + token * stride_cos_t
+    sin_base = batch * stride_sin_b + head * stride_sin_h + token * stride_sin_t
+
+    x_first = tl.load(x_ptr + x_base + offsets, mask=mask, other=0.0)
+    x_second = tl.load(x_ptr + x_base + half_dim + offsets, mask=mask, other=0.0)
+    cos = tl.load(cos_ptr + cos_base + offsets, mask=mask, other=0.0)
+    sin = tl.load(sin_ptr + sin_base + offsets, mask=mask, other=0.0)
+
+    out_first = x_first * cos - x_second * sin
+    out_second = x_second * cos + x_first * sin
+
+    tl.store(out_ptr + x_base + offsets, out_first, mask=mask)
+    tl.store(out_ptr + x_base + half_dim + offsets, out_second, mask=mask)
+
+
+def apply_ltx2_split_rotary_emb(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> torch.Tensor:
+    batch, seq_len, inner_dim = x.shape
+    cos_batch, num_heads, cos_seq_len, half_dim = cos.shape
+    head_dim = half_dim * 2
+    if (
+        cos_batch != batch
+        or cos_seq_len != seq_len
+        or inner_dim != num_heads * head_dim
+        or sin.shape != cos.shape
+    ):
+        raise ValueError(
+            "LTX2 split RoPE shape mismatch: "
+            f"x={tuple(x.shape)}, cos={tuple(cos.shape)}, sin={tuple(sin.shape)}"
+        )
+
+    out = torch.empty_like(x)
+    block_half = triton.next_power_of_2(half_dim)
+    _ltx2_split_rotary_kernel[(batch * seq_len, num_heads)](
+        out,
+        x,
+        cos,
+        sin,
+        seq_len,
+        num_heads,
+        head_dim,
+        half_dim,
+        cos.stride(0),
+        cos.stride(1),
+        cos.stride(2),
+        sin.stride(0),
+        sin.stride(1),
+        sin.stride(2),
+        BLOCK_HALF=block_half,
+        num_warps=1,
+    )
+    return out

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -102,6 +102,21 @@ def apply_split_rotary_emb(
     x: torch.Tensor, freqs: Tuple[torch.Tensor, torch.Tensor]
 ) -> torch.Tensor:
     cos, sin = freqs
+    if (
+        x.ndim == 3
+        and cos.ndim == 4
+        and sin.ndim == 4
+        and x.is_cuda
+        and x.is_contiguous()
+        and cos.is_cuda
+        and sin.is_cuda
+    ):
+        from sglang.jit_kernel.diffusion.triton.ltx2_rotary import (
+            apply_ltx2_split_rotary_emb,
+        )
+
+        return apply_ltx2_split_rotary_emb(x, cos, sin)
+
     x_dtype = x.dtype
     needs_reshape = False
     if x.ndim != 4 and cos.ndim == 4:

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -106,6 +106,9 @@ def apply_split_rotary_emb(
         x.ndim == 3
         and cos.ndim == 4
         and sin.ndim == 4
+        and x.dtype == torch.bfloat16
+        and cos.dtype == torch.bfloat16
+        and sin.dtype == torch.bfloat16
         and x.is_cuda
         and x.is_contiguous()
         and cos.is_cuda


### PR DESCRIPTION
## Summary
- add a Triton kernel for the LTX2 split rotary embedding layout used by the DiT path
- route the CUDA BF16 3D contiguous LTX2 split-RoPE case through the fused kernel
- keep the existing PyTorch path for other dtypes, layouts, and shapes

## Background
Before this PR there was no LTX2-specific fused kernel for this split-RoPE layout. The existing path used PyTorch reshape/broadcast/elementwise ops:

```python
split_x = x.reshape(*x.shape[:-1], 2, r)
first_x = split_x[..., :1, :]
second_x = split_x[..., 1:, :]

cos_u = cos.unsqueeze(-2)
sin_u = sin.unsqueeze(-2)

out = split_x * cos_u
first_out = out[..., :1, :]
second_out = out[..., 1:, :]
first_out.addcmul_(-sin_u, second_x)
second_out.addcmul_(sin_u, first_x)
```

This PR only replaces the common LTX2 CUDA BF16 hot path where `x` is a contiguous 3D tensor and `cos/sin` are 4D tensors. Other cases continue to use the PyTorch implementation above.

## Accuracy
The kernel preserves the original PyTorch operation order for BF16: the `x * cos` term is rounded to BF16 before adding the sine product, matching the existing `addcmul_` behavior.

Remote kernel checks on the LTX2 target shapes showed bit-exact results:
- `(4, 1152, 32, 128)`: `max_abs=0.0`
- `(4, 25, 32, 64)`: `max_abs=0.0`

Precision alignment: 100% for the checked kernel shapes.

## Performance
E2E experiment on one H100 80GB, `Lightricks/LTX-2.3`, `LTX2TwoStageHQPipeline`, snapshot device mode, `1024x1024`, 24 frames, after warmup. Command shape:

```bash
SGLANG_GEN_BASELINE=1 SGLANG_SKIP_CONSISTENCY=1 CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=<worktree>/python \
python -m pytest -s \
  python/sglang/multimodal_gen/test/server/test_server_1_gpu.py \
  -k ltx_2_3_hq_pipeline --tb=short
```

| Metric | Base `6279aee716` | This PR `5a7d6c6785` | Delta |
| --- | ---: | ---: | ---: |
| E2E pixel generation | 28.50s | 28.19s | -1.1% |
| Stage 1 denoise total | 9.5370s | 9.4211s | -1.2% |
| Stage 1 denoise avg step | 585.7ms | 577.7ms | -1.4% |
| Stage 2 refinement total | 1.6825s | 1.6564s | -1.6% |
| Stage 2 refinement avg step | 496.8ms | 485.1ms | -2.4% |
| Peak memory | 74384 MB | 74384 MB | no change |

This is a small but measurable request-level win; the main value is removing repeated PyTorch reshape/broadcast/elementwise work from the LTX2 split-RoPE hot path without changing numerics.