### PR TITLE
fix(gateway): use http1_only() on health check client

### DIFF
--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -34,6 +34,7 @@ pub const DEFAULT_WORKER_HTTP_TIMEOUT_SECS: u64 = 30;
 
 static WORKER_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
+        .http1_only()
         .timeout(Duration::from_secs(DEFAULT_WORKER_HTTP_TIMEOUT_SECS))
         .build()
         .expect("Failed to create worker HTTP client")


### PR DESCRIPTION
## Problem

The `WORKER_CLIENT` static (used for health checks in `worker.rs:35`) creates a bare `reqwest::Client` that defaults to HTTP/2 prior knowledge (h2c) on cleartext connections. When workers run behind ASGI servers that don't support h2c (e.g. uvicorn, which is extremely common), the health probe sends an HTTP/2 connection preface, the server responds with HTTP/1.1, and reqwest's h2 parser rejects it:

```
Remote peer returned unexpected data while we expected SETTINGS frame.
```

This causes every health check to fail, workers get marked unhealthy after 3 consecutive failures, and the `worker_removal` workflow evicts them from the registry. The result is a tight add/remove loop where the reconciler keeps POST'ing workers and the gateway keeps removing them.

## Fix

Add `.http1_only()` to the health check client builder. HTTP/1.1 is universally supported by all backends (uvicorn, hypercorn, gunicorn, nginx, etc). The main proxy client (`AppContext`) already has more careful HTTP configuration — this aligns the health check client with best practice.

## Reproduction

```bash
# Start any uvicorn-based worker on port 8080
# Then test with h2c prior knowledge (what reqwest does):
curl --http2-prior-knowledge http://worker:8080/health
# Result: connection error (peer returned unexpected data)

# HTTP/1.1 works fine:
curl --http1.1 http://worker:8080/health  
# Result: 200 OK
```