### PR TITLE
amd/deepseek_v4 integration 11/N Compressor element-wise kernel fusion 0505

### DIFF
--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -16,6 +16,13 @@ from sglang.jit_kernel.utils import (
 from sglang.srt.debug_utils.deepseek_v4_debug_utils import (
     deepseek_v4_moe_code_path_checker,
 )
+from sglang.srt.utils import get_bool_env_var, is_hip
+
+_is_hip = is_hip()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+
+if _use_aiter:
+    from aiter.tuned_gemm import tgemm
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -750,6 +757,8 @@ def linear_bf16_fp32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         z = x.new_empty(x.size(0), y.size(0), dtype=torch.float32)
         deep_gemm.bf16_gemm_nt(x, y, z)
         return z
+    elif _use_aiter:
+        return tgemm.mm(x, y, otype=x.dtype).float()
     else:  # fall back to torch fp32 GEMM
         return torch.nn.functional.linear(x.float(), y.float())
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2221,6 +2221,11 @@ class DeepseekV4Model(nn.Module):
             hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
 
+        # Reset Compressor's per-step freqs_cis cache from any previous step.
+        for _attr in ("freqs_cis_c4", "freqs_cis_c128"):
+            if hasattr(forward_batch, _attr):
+                delattr(forward_batch, _attr)
+
         for i in range(self.start_layer, self.end_layer):
             # TODO: ctx?
             layer = self.layers[i]

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1052,8 +1052,8 @@ class Compressor(nn.Module):
                 pool_kv=kv_and_score_states_pool.kv,
                 kv_score_input_kv=kv_and_scores.kv,
                 ape=self.ape,
-                seq_lens=seq_lens.to(torch.int32),
-                req_pool_indices=req_pool_indices.to(torch.int32),
+                seq_lens=seq_lens,
+                req_pool_indices=req_pool_indices,
                 head_dim=self.head_dim,
             )
         elif self.use_hip_fused_compress and self.ratio == 128 and not self.overlap:
@@ -1065,8 +1065,8 @@ class Compressor(nn.Module):
                 pool_kv=kv_and_score_states_pool.kv,
                 kv_score_input_kv=kv_and_scores.kv,
                 ape=self.ape,
-                seq_lens=seq_lens.to(torch.int32),
-                req_pool_indices=req_pool_indices.to(torch.int32),
+                seq_lens=seq_lens,
+                req_pool_indices=req_pool_indices,
                 head_dim=self.head_dim,
             )
         else:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -563,7 +563,8 @@ class Compressor(nn.Module):
         ).sum(dim=1)
         self.print_tensor(kv_compressed, "kv_before_norm")
         if self.use_hip_fused_compress:
-            freqs_cis = self.freqs_cis[(seq_lens - 1) // self.ratio * self.ratio]
+            # HIP-only: share the per-step freqs_cis gather across layers.
+            freqs_cis = self._init_freqs_cis_per_decode_step(forward_batch, seq_lens)
             fused_norm_rope_inplace_triton(
                 kv_compressed, self.norm.weight, self.norm.eps, freqs_cis
             )
@@ -789,7 +790,8 @@ class Compressor(nn.Module):
         ).sum(dim=1)
         self.print_tensor(kv_compressed, "kv_before_norm")
         if self.use_hip_fused_compress:
-            freqs_cis = self.freqs_cis[(seq_lens - 1) // self.ratio * self.ratio]
+            # HIP-only: share the per-step freqs_cis gather across layers.
+            freqs_cis = self._init_freqs_cis_per_decode_step(forward_batch, seq_lens)
             fused_norm_rope_inplace_triton(
                 kv_compressed, self.norm.weight, self.norm.eps, freqs_cis
             )
@@ -1030,6 +1032,19 @@ class Compressor(nn.Module):
 
         return compressed_kv_output
 
+    def _init_freqs_cis_per_decode_step(
+        self,
+        forward_batch: ForwardBatch,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        attr = f"freqs_cis_c{self.ratio}"
+        cached = getattr(forward_batch, attr, None)
+        if cached is not None:
+            return cached
+        decoded = self.freqs_cis[(seq_lens - 1) // self.ratio * self.ratio]
+        setattr(forward_batch, attr, decoded)
+        return decoded
+
     def compress_decode_old(
         self,
         kv_and_scores: KVAndScore,
@@ -1127,7 +1142,8 @@ class Compressor(nn.Module):
             ).sum(dim=1)
         self.print_tensor(kv_compressed, "kv_before_norm")
         if self.use_hip_fused_compress:
-            freqs_cis = self.freqs_cis[(seq_lens - 1) // self.ratio * self.ratio]
+            # HIP-only: share the per-step freqs_cis gather across layers.
+            freqs_cis = self._init_freqs_cis_per_decode_step(forward_batch, seq_lens)
             fused_norm_rope_inplace_triton(
                 kv_compressed, self.norm.weight, self.norm.eps, freqs_cis
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Update amd/deepseek_v4 integration branch

Following PRs have large set of conflict, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608

This PR cleans up some redundant element-wise kernels around Compressor.forward.
- In linear_bf16_fp32(), use tgemm instead of the torch fallback to avoid unnecessary .float() casts. Saves 2 kernels per layer.
- In fused_compress_c*_decode_old_triton(), drop the redundant .to(torch.int32) on triton args; the kernel handles dtype internally. Saves 2 kernels per layer.
- Move freqs_cis computation from per-layer to per-step. Saves 4 kernels per layer.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
