### PR TITLE
Add zRzRzRzRzRzRzR to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1301,6 +1301,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "zRzRzRzRzRzRzR": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "top contributor"
+    },
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- add @zRzRzRzRzRzRzR to CI_PERMISSIONS.json as a top contributor
- grant CI label, failed-CI rerun, and stage rerun permissions

## Testing
- python3 .github/update_ci_permission.py --sort-only
- jq -e '."zRzRzRzRzRzRzR".can_tag_run_ci_label == true and ."zRzRzRzRzRzRzR".can_rerun_failed_ci == true and ."zRzRzRzRzRzRzR".can_rerun_stage == true' .github/CI_PERMISSIONS.json\n- git diff --check