### PR TITLE
[NemotronH] Fix expert scale weight loading

### DIFF
--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -972,6 +972,8 @@ class NemotronHForCausalLM(nn.Module):
                         continue
                     is_expert_weight = True
                     name_mapped = name.replace(weight_name, param_name)
+                    if name_mapped not in params_dict:
+                        continue
                     param = params_dict[name_mapped]
                     param.weight_loader(
                         param,

--- a/test/registered/unit/models/test_nemotron_h_weight_loading.py
+++ b/test/registered/unit/models/test_nemotron_h_weight_loading.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for NemotronHForCausalLM.load_weights.
+
+Regression test for Nemotron-H expert scale checkpoint tensors that map to
+parameters absent from the current runtime model.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.models.nemotron_h import NemotronHForCausalLM
+
+
+class _FakePPGroup:
+    is_first_rank = True
+    is_last_rank = True
+
+
+class _FakeParam:
+    def __init__(self):
+        self.loaded = None
+
+    def weight_loader(
+        self, param, loaded_weight, name, *, shard_id=None, expert_id=None
+    ):
+        self.loaded = (param, loaded_weight, name, shard_id, expert_id)
+
+
+class TestNemotronHWeightLoading(unittest.TestCase):
+    def _make_minimal_model(self, named_parameters=()):
+        model = object.__new__(NemotronHForCausalLM)
+        model.config = SimpleNamespace(n_routed_experts=2)
+        model.model = SimpleNamespace()
+        model.pp_group = _FakePPGroup()
+        model.remap_prefix = {}
+        model.remap_substr = {}
+        model.stacked_params_mapping = []
+        model.named_parameters = lambda: iter(named_parameters)
+        return model
+
+    def test_expert_input_scale_without_target_parameter_is_skipped(self):
+        """Expert scale weights absent from params_dict should not raise KeyError."""
+        model = self._make_minimal_model()
+        weights = [
+            (
+                "model.layers.1.mixer.experts.0.down_proj.input_scale",
+                torch.ones(1),
+            )
+        ]
+
+        model.load_weights(weights)
+
+    def test_expert_weight_with_target_parameter_is_loaded(self):
+        param = _FakeParam()
+        model = self._make_minimal_model(
+            [("model.layers.1.mixer.experts.w2_weight", param)]
+        )
+        loaded_weight = torch.ones(1)
+        weights = [
+            (
+                "model.layers.1.mixer.experts.0.down_proj.weight",
+                loaded_weight,
+            )
+        ]
+
+        model.load_weights(weights)
+
+        self.assertEqual(
+            param.loaded,
+            (
+                param,
+                loaded_weight,
+                "model.layers.1.mixer.experts.w2_weight",
+                "w2",
+                0,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #24137

When loading NVFP4 checkpoints for Nemotron-H, expert scale weights like `down_proj.input_scale` match the expert mapping rule and get transformed to `experts.w2_input_scale`. If this key is not registered in `params_dict`, the bare `params_dict[name_mapped]` raises a `KeyError` and crashes the server on startup.

Every other branch in `load_weights` already has an existence check — stacked params does `if name not in params_dict: continue`, and the default path falls back to `logger.warning`. The expert branch was the only one missing it.

## Modifications

In `nemotron_h.py` `load_weights()`, added an existence check before accessing `params_dict[name_mapped]` in the expert mapping branch:

```python
if name_mapped not in params_dict:
    continue
```

## Accuracy Tests

N/A — this change only affects the weight loading error path. No model forward logic is modified.

## Speed Tests and Profiling

N/A — skipping a missing key during checkpoint loading has no impact on inference speed.

## Testing

Unit tests covering the skip path (regression) and the happy path (expert weight successfully loaded):

```bash
CUDA_VISIBLE_DEVICES= FLASHINFER_WORKSPACE_BASE=/tmp PYTHONPATH=python \
python -m pytest test/registered/unit/models/test_nemotron_h_weight_loading.py -q
```

```
2 passed
```

`CUDA_VISIBLE_DEVICES=` is used because this test only exercises Python weight-loading name mapping and does not require CUDA kernels.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required because this is an internal weight-loading fix.
- [x] Accuracy and speed benchmarks are not required because this does not change model forward logic or inference kernels.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
