### PR TITLE
deepseek_v4: route mega-MoE through DeepGEMM mega_moe_pre_dispatch + FP4 acts opt-in

### DIFF
--- a/docker/deepseek_v4_b300_fp4.Dockerfile
+++ b/docker/deepseek_v4_b300_fp4.Dockerfile
@@ -1,0 +1,53 @@
+FROM lmsysorg/sglang:v0.5.7-cu130-runtime
+
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+# tilelang's bundled libtvm.so depends on libz3.so (no version suffix).
+# Base image ships nothing matching, and apt's libz3-4 only installs libz3.so.4.
+RUN apt-get update && apt-get install -y --no-install-recommends libz3-4 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libz3.so.4 /usr/lib/x86_64-linux-gnu/libz3.so && \
+    ldconfig && rm -rf /var/lib/apt/lists/*
+
+# sglang: our fork branch with FP4-acts opt-in + deep_gemm.mega_moe_pre_dispatch wiring.
+RUN mkdir -p /workspace && cd /workspace && rm -rf sglang && \
+    git clone -b fp4-acts-pre-dispatch https://github.com/pranjalssh/sglang.git
+
+RUN pip install cuda-python --upgrade
+RUN pip install flashinfer-jit-cache==0.6.8 --index-url https://flashinfer.ai/whl/cu130
+
+
+RUN pip install https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21+cu130-cp310-abi3-manylinux2014_x86_64.whl
+
+# DeepGEMM: our local tree (subtree of pranjalssh/kernels) with FP4 acts +
+# MXF4 kind + the new fused mega_moe_pre_dispatch kernel.
+# DG_USE_LOCAL_VERSION=0 tells setup.py to skip the working-tree-clean check
+# (the install runs inside the parent kernels repo, not a clean DeepGEMM clone).
+RUN pip uninstall -y deep-gemm deep_gemm 2>/dev/null; \
+    cd /tmp && rm -rf kernels && \
+    git clone --depth 1 -b worktree-hazy-noodling-giraffe \
+        https://github.com/pranjalssh/kernels.git && \
+    cd kernels/DeepGEMM && \
+    ln -sf $(pwd)/third-party/cutlass/include/cutlass $(pwd)/deep_gemm/include/cutlass && \
+    ln -sf $(pwd)/third-party/cutlass/include/cute $(pwd)/deep_gemm/include/cute && \
+    DG_USE_LOCAL_VERSION=0 bash install.sh
+
+RUN pip install -e /workspace/sglang/python/
+
+
+RUN pip install --force-reinstall --no-deps tilelang==0.1.8
+
+RUN pip install nvidia-cuda-cccl && \
+    CCCL_INC=$(find /usr/local/lib -path "*/include/cccl/cuda/std" -type d 2>/dev/null | head -1 | sed 's|/cuda/std$||') && \
+    ln -sf $CCCL_INC/cuda /usr/local/cuda/include/cuda && \
+    mv /usr/local/cuda/targets/x86_64-linux/include/cccl /usr/local/cuda/targets/x86_64-linux/include/cccl.bak && \
+    ln -sf $CCCL_INC /usr/local/cuda/targets/x86_64-linux/include/cccl
+# FlashMLA — required by deepseek_v4_backend_radix.py
+RUN cd /tmp && rm -rf flash-mla && \
+    git clone https://github.com/deepseek-ai/FlashMLA.git flash-mla && \
+    cd flash-mla && git submodule update --init --recursive && \
+    pip install --no-build-isolation .
+# fast_hadamard_transform — sgl_kernel 0.3.21 lacks hadamard_transform on B300
+RUN pip install --no-build-isolation git+https://github.com/Dao-AILab/fast-hadamard-transform.git
+
+# Install mooncake
+RUN pip install mooncake-transfer-engine-cuda13

--- a/python/sglang/srt/_vendor/README.md
+++ b/python/sglang/srt/_vendor/README.md
@@ -1,0 +1,54 @@
+# Vendored DeepGEMM wheel
+
+`deep_gemm-2.5.0-cp312-cp312-linux_x86_64.whl` is a custom build of DeepGEMM
+that ships with this `fp4-acts-pre-dispatch` branch. It contains:
+
+- The FP4 acts + MXF4 kind code paths (kernel headers `sm100_fp8_fp4_mega_moe.cuh`
+  with `kUseFp4Acts` / `kUseMxf4Kind` template flags).
+- A new fused `mega_moe_pre_dispatch` kernel that replaces the unfused
+  BF16 → quant + topk-copy + pad-fill chain in the deepseek_v4 forward path.
+- A heuristic fix bumping `block_m=16 → 32` when `kUseMxf4Kind=true` to
+  satisfy the 1024-byte smem alignment static_assert at small batches.
+- Cherry-pick of upstream sgl-project/DeepGEMM `003ed71b` (relax NVLink
+  barrier timeout 30s → 180s).
+
+## Install
+
+```bash
+pip install /path/to/sglang/python/sglang/srt/_vendor/deep_gemm-2.5.0-cp312-cp312-linux_x86_64.whl \
+    --force-reinstall --no-deps
+```
+
+The `--force-reinstall --no-deps` is important: another package's transitive
+deps may have installed a different DeepGEMM. Without `--force-reinstall`, pip
+will skip our wheel; without `--no-deps`, pip may pull a different version
+of torch/cuda libs.
+
+## Verify
+
+```bash
+python -c "import deep_gemm; print(hasattr(deep_gemm, 'mega_moe_pre_dispatch'))"
+```
+
+Should print `True`. If `False`, the wheel didn't install correctly — check
+that no other Python install path shadows it.
+
+## Compatibility
+
+- Python: cp312 only (3.12)
+- CUDA: 13.0+ (uses `nvidia-cuda-cccl` headers via the system cuda symlinks
+  that the deepseek_v4 dockerfile sets up).
+- GPU: `sm_100` (B100/B200/B300). Other archs untested.
+
+## Source
+
+The wheel is built from `pranjalssh/kernels@worktree-hazy-noodling-giraffe`,
+specifically the `DeepGEMM/` subtree. To rebuild from source:
+
+```bash
+git clone -b worktree-hazy-noodling-giraffe https://github.com/pranjalssh/kernels.git
+cd kernels/DeepGEMM
+ln -sf $(pwd)/third-party/cutlass/include/cutlass $(pwd)/deep_gemm/include/cutlass
+ln -sf $(pwd)/third-party/cutlass/include/cute    $(pwd)/deep_gemm/include/cute
+DG_USE_LOCAL_VERSION=0 bash install.sh
+```

--- a/python/sglang/srt/_vendor/install.sh
+++ b/python/sglang/srt/_vendor/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install the vendored DeepGEMM wheel that this branch needs for the
+# FP4 acts + MXF4 kind + mega_moe_pre_dispatch path. Run once after
+# `pip install -e python/`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHEEL="$(ls "$HERE"/deep_gemm-*.whl | head -1)"
+if [[ -z "$WHEEL" ]]; then
+    echo "No deep_gemm wheel found in $HERE" >&2
+    exit 1
+fi
+
+echo "Installing $WHEEL"
+pip install "$WHEEL" --force-reinstall --no-deps
+
+python - <<'PY'
+import deep_gemm
+need = ("mega_moe_pre_dispatch", "fp8_fp4_mega_moe",
+        "transform_weights_for_mega_moe", "get_symm_buffer_for_mega_moe")
+missing = [s for s in need if not hasattr(deep_gemm, s)]
+if missing:
+    raise SystemExit(f"deep_gemm install incomplete; missing: {missing}")
+print("deep_gemm install OK; all required symbols present")
+PY

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -520,6 +520,16 @@ class Envs:
     SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE = EnvBool(False)
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK = EnvInt(1024)
     SGLANG_OPT_MEGA_MOE_FUSED_PRE_DISPATCH = EnvBool(True)
+    # When set, the mega-MoE x slot is packed E2M1 (FP4) instead of FP8 E4M3.
+    # Halves symm-buffer footprint and unlocks the MXF4 mainloop downstream.
+    # Setting this also exports DG_USE_FP4_ACTS=1 so DeepGEMM's symm-buffer
+    # sizing + fp8_fp4_mega_moe pick up the FP4 layout.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS = EnvBool(False)
+    # Switches the L1+L2 mainloops from kind::mxf8f6f4 (K=32 with-padding) to
+    # kind::mxf4 (K=64 dense) inside fp8_fp4_mega_moe. No effect unless
+    # SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS is also set; DeepGEMM asserts
+    # this combination on the host side.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND = EnvBool(False)
     SGLANG_OPT_FUSE_WQA_WKV = EnvBool(True)
     SGLANG_OPT_USE_JIT_NORM = EnvBool(False)
     SGLANG_OPT_FIX_HASH_MEGA_MOE = EnvBool(False)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -378,6 +378,26 @@ class MoEGate(nn.Module):
 
 
 _MEGA_MOE_SYMM_BUFFER: dict = {}
+_MEGA_MOE_DG_ENV_APPLIED = False
+
+
+def _apply_mega_moe_dg_env() -> None:
+    """Forward sglang's FP4/MXF4 opt-in flags to DeepGEMM via env vars.
+
+    DeepGEMM reads `DG_USE_FP4_ACTS` (and `DG_USE_MXF4_KIND`) at host-function
+    call time — both `get_symm_buffer_for_mega_moe` and `fp8_fp4_mega_moe`.
+    Forwarding once at first use is sufficient (these are static config
+    flags, not per-request state) and matches the `setdefault` pattern so
+    explicit `DG_USE_*` overrides from outside still win.
+    """
+    global _MEGA_MOE_DG_ENV_APPLIED
+    if _MEGA_MOE_DG_ENV_APPLIED:
+        return
+    if envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get():
+        os.environ.setdefault("DG_USE_FP4_ACTS", "1")
+    if envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND.get():
+        os.environ.setdefault("DG_USE_MXF4_KIND", "1")
+    _MEGA_MOE_DG_ENV_APPLIED = True
 
 
 def _get_mega_moe_symm_buffer(
@@ -389,6 +409,8 @@ def _get_mega_moe_symm_buffer(
     intermediate_hidden: int,
 ) -> SymmBuffer:
     import deep_gemm
+
+    _apply_mega_moe_dg_env()
 
     key = (
         id(group),
@@ -1218,9 +1240,8 @@ class DeepseekV2MoE(nn.Module):
         )
 
         padded_max = buf.topk_idx.shape[0]
+        use_fp4_acts = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get()
         if envs.SGLANG_OPT_MEGA_MOE_FUSED_PRE_DISPATCH.get():
-            from sglang.jit_kernel.deepseek_v4 import mega_moe_pre_dispatch
-
             if num_tokens > 0:
                 topk_ids_in = topk_ids
                 topk_weights_in = topk_weights
@@ -1229,7 +1250,7 @@ class DeepseekV2MoE(nn.Module):
                 topk_weights_in = hidden_states.new_empty(
                     (0, top_k), dtype=torch.float32
                 )
-            mega_moe_pre_dispatch(
+            deep_gemm.mega_moe_pre_dispatch(
                 hidden_states,
                 topk_ids_in,
                 topk_weights_in,
@@ -1237,14 +1258,23 @@ class DeepseekV2MoE(nn.Module):
                 buf.x_sf,
                 buf.topk_idx,
                 buf.topk_weights,
-                quant_group_size=32,
+                num_tokens=num_tokens,
+                group_size=32,
+                use_fp4_acts=use_fp4_acts,
             )
         else:
             if num_tokens > 0:
-                x_fp8, x_sf = sglang_per_token_group_quant_fp8_ue8m0(
-                    hidden_states, group_size=32
-                )
-                buf.x[:num_tokens].copy_(x_fp8)
+                if use_fp4_acts:
+                    from deep_gemm.utils import per_token_cast_to_fp4
+                    x_q, x_sf = per_token_cast_to_fp4(
+                        hidden_states, use_ue8m0=True, gran_k=32,
+                        use_packed_ue8m0=True,
+                    )
+                else:
+                    x_q, x_sf = sglang_per_token_group_quant_fp8_ue8m0(
+                        hidden_states, group_size=32
+                    )
+                buf.x[:num_tokens].copy_(x_q)
                 buf.x_sf[:num_tokens].copy_(x_sf)
                 buf.topk_idx[:num_tokens].copy_(topk_ids)
                 buf.topk_weights[:num_tokens].copy_(topk_weights)


### PR DESCRIPTION
## Summary

Adds two opt-in env flags that flip DeepSeek-V4 inference onto a fused FP4 MoE
path through DeepGEMM:

- `SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS` → exports `DG_USE_FP4_ACTS=1`,
  flipping the mega-MoE \`x\` symm-buffer slot from FP8 (E4M3) to packed FP4
  (E2M1) and halving the per-rank symm buffer footprint.
- `SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND` → exports `DG_USE_MXF4_KIND=1`,
  switching the L1+L2 mainloops from `kind::mxf8f6f4` (K=32 with-padding)
  to `kind::mxf4` (K=64 dense, 2× MMA throughput).

Also routes the existing pre-dispatch kernel through DeepGEMM's new
`deep_gemm.mega_moe_pre_dispatch` (instead of the sgl-kernel JIT'd
`mega_moe_pre_dispatch.cuh`), unifying the FP4/UE8M0 contract behind the
same library that owns the symm buffer layout.

The bundled DeepGEMM wheel under `python/sglang/srt/_vendor/` carries:
- The FP4 acts + MXF4 kind code paths
- The new fused `mega_moe_pre_dispatch` kernel
- A heuristic fix bumping `block_m=16 → 32` when `kind::mxf4` is on,
  avoiding the 1024-byte smem alignment static_assert at small batches
- Cherry-pick of upstream sgl-project/DeepGEMM
  [`003ed71`](https://github.com/sgl-project/DeepGEMM/commit/003ed71b9cf9bca6a9edef85fa32bdb757cc13e2)
  (relax NVLink barrier timeout 30s → 180s)

No sgl-kernel changes; the existing 0.3.21+cu130 wheel works.

## Measurements (DeepSeek-V4-Pro on B300 ×8)

### GSM8K accuracy (1319q, 8-shot, parallel=256, 3 warm reps each)

| Config       | accuracy           | output tok/s | wall (s)     |
|--------------|---------------------|--------------|--------------|
| FP4+MXF4     | 95.60% ± 0.53      | 4587 ± 102   | 26.70 ± 0.64 |
| FP8 baseline | 95.80% ± 0.30      | 4404 ± 123   | 28.00 ± 0.79 |
| Δ (FP4-FP8)  | **−0.20 pp** (< noise) | **+4.2%** | **−4.6%** |

Accuracy gap is well within run-to-run variance (max stdev 0.53 pp).
**FP4+MXF4 does not measurably hurt GSM8K reasoning.**

### bench_serving sweep, 8192-input × 256-output (single warm run each)

| conc | FP8 TTFT | FP4 TTFT | Δ      | FP8 total tok/s | FP4 total tok/s | Δ     |
|------|----------|----------|--------|-----------------|------------------|-------|
| 64   | 983 ms   | 921 ms   | −6.3%  | 29110           | 31411            | +7.9% |
| 128  | 971 ms   | 919 ms   | −5.4%  | 39412           | 42648            | +8.2% |
| 256  | 1080 ms  | 974 ms   | −9.8%  | 47422           | 51333            | +8.2% |
| 512  | 1342 ms  | 1313 ms  | −2.2%  | 52113           | 56240            | +7.9% |

**FP4 wins on every metric at production prefill length** — TTFT down
2-10%, total throughput up ~8% across the conc range.

### bench_serving 1024-input × 256-output, conc=128 (5 reps FP4)

| Metric | FP4 mean ± stdev | FP8 (single) |
|--------|------------------|---------------|
| Output throughput | 2598 ± 74 tok/s | 2365 tok/s (+10%) |
| Median TTFT | 516 ± 67 ms (range 438-620) | 512 ms (≈0%) |

The single-rep "+41% TTFT regression" reported earlier was a one-run outlier;
across 5 reps mean TTFT ≈ FP8 baseline.

## InferenceX CI integration

The benchmark script
[`benchmarks/single_node/dsv4_fp4_b300_sglang.sh`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/benchmarks/single_node/dsv4_fp4_b300_sglang.sh)
already sets `SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1` for high-concurrency
configs (CONC ∈ {2048, 4096, 8192}). To enable the FP4+MXF4 path, two
extra envs are needed alongside the existing config:

\`\`\`bash
export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1
export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1
\`\`\`

Image-build steps:
1. Use `pranjalssh/sglang@fp4-acts-pre-dispatch` as the sglang source
   (instead of upstream `sgl-project/sglang@deepseek_v4`).
2. After `pip install -e python/`, run
   \`bash python/sglang/srt/_vendor/install.sh\` to install the bundled
   DeepGEMM wheel — replaces whatever was installed at base-image time.

The included `docker/deepseek_v4_b300_fp4.Dockerfile` is a drop-in
replacement that demonstrates this; either reference it directly or
copy the relevant install steps into the existing
`deepseek_v4_b300.Dockerfile`.

## Test plan

- [x] Bytewise unit test for `mega_moe_pre_dispatch` (FP8 + FP4 paths) at
  production shape (M=8192 H=7168 K=6 G=32, num_experts=384). Passes
  bytewise vs `deep_gemm.utils.per_token_cast_to_fp4` /
  `per_token_cast_to_fp8` reference.
- [x] sglang server boots end-to-end on DeepSeek-V4-Pro B300 ×8 with
  FP4+MXF4 envs set. Health = 200, generation works.
- [x] GSM8K 1319q accuracy = 95.6% (3 warm reps), within noise of FP8 95.8%.
- [x] bench_serving 8192/256 sweep at conc {64,128,256,512}: FP4 better
  than FP8 on every metric.
- [ ] InferenceX CI sweep (delegated to follow-up; this PR adds the
  wiring needed for it).

## Risk / Rollback

- Both new envs default to **off**. If left unset, behavior is identical
  to the existing `deepseek_v4` branch (modulo the swap from sgl-kernel's
  `mega_moe_pre_dispatch` to `deep_gemm.mega_moe_pre_dispatch`, which is
  bytewise-identical for the FP8 path).
- Rollback: revert this PR or set both envs to 0.
- The bundled DeepGEMM wheel only takes effect after explicit
  `python/sglang/srt/_vendor/install.sh`. Without that step, the
  base-image's DeepGEMM is used and the new symbols
  (`mega_moe_pre_dispatch`, `transform_weights_for_mega_moe` re-exports)
  may be missing — server will fail to import in `forward_mega_moe`.