### PR TITLE
[PD] Add KV transfer metric fallback tests

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, List, Optional
 
@@ -10,6 +11,13 @@ from sglang.srt.server_args import ServerArgs
 
 if TYPE_CHECKING:
     from sglang.srt.disaggregation.utils import DisaggregationMode
+
+
+@dataclasses.dataclass
+class KVTransferMetric:
+    # Backends that cannot isolate transfer latency can leave this as None.
+    transfer_latency_s: Optional[float] = None
+    transfer_total_bytes: Optional[int] = None
 
 
 class KVArgs:
@@ -100,6 +108,11 @@ class BaseKVSender(ABC):
 
     def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
         return num_pages > 0
+
+    @abstractmethod
+    def get_transfer_metric(self) -> KVTransferMetric:
+        """Return backend-specific transfer metrics for this sender."""
+        ...
 
     @abstractmethod
     def poll(self) -> KVPoll:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -22,6 +22,7 @@ from sglang.srt.disaggregation.base.conn import (
     BaseKVSender,
     KVArgs,
     KVPoll,
+    KVTransferMetric,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.distributed import get_pp_group
@@ -442,6 +443,10 @@ class CommonKVSender(BaseKVSender):
         self.bootstrap_room = bootstrap_room
         self.aux_index = None
         self.bootstrap_server_url = bootstrap_addr
+        self.conclude_state: Optional[KVPoll] = None
+        self._transfer_metric = KVTransferMetric()
+        self._transfer_num_kv_indices = 0
+        self._transfer_num_state_indices = 0
         # inner state
         self.curr_idx = 0
         if self.kv_mgr.is_dummy_cp_rank:
@@ -501,6 +506,25 @@ class CommonKVSender(BaseKVSender):
 
     def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
         return num_pages > 0
+
+    def get_transfer_metric(self) -> KVTransferMetric:
+        total_bytes = self._transfer_num_kv_indices * sum(
+            self.kv_mgr.kv_args.kv_item_lens
+        )
+        total_bytes += self._transfer_num_state_indices * sum(
+            self.kv_mgr.kv_args.state_item_lens
+        )
+        self._transfer_metric.transfer_total_bytes = total_bytes
+        return self._transfer_metric
+
+    def _record_transfer_indices(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List[int]],
+    ):
+        self._transfer_num_kv_indices += len(kv_indices)
+        if state_indices is not None:
+            self._transfer_num_state_indices += len(state_indices)
 
     def send(
         self,

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -10,6 +10,7 @@ from sglang.srt.disaggregation.base.conn import (
     BaseKVSender,
     KVArgs,
     KVPoll,
+    KVTransferMetric,
 )
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.server_args import ServerArgs
@@ -53,6 +54,9 @@ class FakeKVSender(BaseKVSender):
             # Assume transfer completed instantly
             logger.debug("FakeKVSender poll success")
             return KVPoll.Success
+
+    def get_transfer_metric(self) -> KVTransferMetric:
+        return KVTransferMetric()
 
     def init(
         self,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -21,6 +21,12 @@ from sglang.srt.disaggregation.common.conn import (
     CommonKVReceiver,
     CommonKVSender,
 )
+from sglang.srt.disaggregation.common.staging_handler import (
+    DecodeStagingContext,
+    PrefillStagingContext,
+    StagingRegisterInfo,
+    StagingTransferInfo,
+)
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
     group_concurrent_contiguous,
@@ -59,14 +65,6 @@ class TransferKVChunk:
     is_last_chunk: bool
     prefill_aux_index: Optional[int]
     state_indices: Optional[List[int]]
-
-
-from sglang.srt.disaggregation.common.staging_handler import (
-    DecodeStagingContext,
-    PrefillStagingContext,
-    StagingRegisterInfo,
-    StagingTransferInfo,
-)
 
 
 # decode
@@ -1710,6 +1708,7 @@ class MooncakeKVSender(CommonKVSender):
                 aux_index=self.aux_index,
                 state_indices=state_indices,
             )
+        self._record_transfer_indices(kv_indices, state_indices)
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -882,6 +882,7 @@ class MoriKVSender(CommonKVSender):
             aux_index=self.aux_index if is_last else None,
         )
         self.transfer_statuses.extend(statuses)
+        self._record_transfer_indices(kv_indices, None)
         if infos is not None:
             self.pending_infos = infos
             self.sent_last_chunk = True

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1098,6 +1098,7 @@ class NixlKVSender(CommonKVSender):
         self.xfer_handles = []
         self.has_sent = False
         self.chunk_id = 0
+        self._transfer_start_time: Optional[float] = None
 
     def pop_decode_prefix_len(self) -> int:
         return self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, 0)
@@ -1128,6 +1129,11 @@ class NixlKVSender(CommonKVSender):
                 self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
                 return
 
+        if self._transfer_start_time is None and (
+            len(kv_indices) > 0 or state_indices is not None
+        ):
+            self._transfer_start_time = time.perf_counter()
+
         new_xfer_handles = self.kv_mgr.add_transfer_request(
             self.bootstrap_room,
             kv_indices,
@@ -1137,6 +1143,7 @@ class NixlKVSender(CommonKVSender):
             self.aux_index,
             state_indices,
         )
+        self._record_transfer_indices(kv_indices, state_indices)
         self.xfer_handles.extend(new_xfer_handles)
         self.chunk_id += 1
         if is_last:
@@ -1148,6 +1155,13 @@ class NixlKVSender(CommonKVSender):
             return self.kv_mgr.check_status(self.bootstrap_room)
         states = [self.kv_mgr.agent.check_xfer_state(x) for x in self.xfer_handles]
         if all([x == "DONE" for x in states]):
+            if (
+                self._transfer_start_time is not None
+                and self._transfer_metric.transfer_latency_s is None
+            ):
+                self._transfer_metric.transfer_latency_s = (
+                    time.perf_counter() - self._transfer_start_time
+                )
             return KVPoll.Success  # type: ignore
         if any([x == "ERR" for x in states]):
             raise Exception("KVSender transfer encountered an error.")

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -651,19 +651,15 @@ class SchedulerDisaggregationPrefillMixin:
         for req in done_reqs:
             req.time_stats.set_completion_time()
 
-        page_size = self.token_to_kv_pool_allocator.page_size
-        kv_item_lens = (
-            self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.kv_item_lens
-        )
-        bytes_per_page_all_layers = sum(kv_item_lens)
-
         for req in done_reqs:
             if isinstance(req.finished_reason, FINISH_ABORT):
                 continue
+            if req.bootstrap_host == FAKE_BOOTSTRAP_HOST:
+                continue
+            if getattr(req.disagg_kv_sender.kv_mgr, "is_dummy_cp_rank", False):
+                continue
             metrics = req.time_stats.compute_and_observe_kv_transfer_metrics(
-                num_tokens=len(req.origin_input_ids),
-                page_size=page_size,
-                bytes_per_page_all_layers=bytes_per_page_all_layers,
+                req.disagg_kv_sender.get_transfer_metric()
             )
             if metrics:
                 # Update last-value for REST API

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -850,19 +850,28 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         Returns a dict with latency_ms, total_mb, speed_gb_s if computable, else None.
         """
         result = {}
-        assert transfer_metric.transfer_total_bytes is not None
 
         # Transfer latency, size, and speed
-        if transfer_metric.transfer_latency_s is not None:
+        if (
+            transfer_metric.transfer_latency_s is not None
+            and transfer_metric.transfer_total_bytes is not None
+        ):
             transfer_latency_s = transfer_metric.transfer_latency_s
+        elif transfer_metric.transfer_total_bytes is not None:
+            if (
+                self.prefill_transfer_queue_entry_time <= 0
+                or self.prefill_kv_transfer_finish_time <= 0
+            ):
+                transfer_latency_s = None
+            else:
+                transfer_latency_s = (
+                    self.prefill_kv_transfer_finish_time
+                    - self.prefill_transfer_queue_entry_time
+                )
         else:
-            if self.prefill_transfer_queue_entry_time <= 0 or self.completion_time <= 0:
-                return result if result else None
-            transfer_latency_s = (
-                self.completion_time - self.prefill_transfer_queue_entry_time
-            )
+            transfer_latency_s = None
 
-        if transfer_latency_s > 0:
+        if transfer_latency_s is not None and transfer_latency_s > 0:
             latency_ms = transfer_latency_s * 1000
 
             total_bytes = transfer_metric.transfer_total_bytes

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -37,6 +37,7 @@ from sglang.srt.observability.trace import (
 from sglang.srt.utils import get_bool_env_var
 
 if TYPE_CHECKING:
+    from sglang.srt.disaggregation.base.conn import KVTransferMetric
     from sglang.srt.managers.schedule_batch import ScheduleBatch
 
 SGLANG_TEST_REQUEST_TIME_STATS = get_bool_env_var("SGLANG_TEST_REQUEST_TIME_STATS")
@@ -842,27 +843,29 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
     def compute_and_observe_kv_transfer_metrics(
         self,
-        num_tokens: int,
-        page_size: int,
-        bytes_per_page_all_layers: int,
+        transfer_metric: KVTransferMetric,
     ) -> Optional[dict]:
         """Compute KV transfer metrics and observe them via the metrics collector.
 
         Returns a dict with latency_ms, total_mb, speed_gb_s if computable, else None.
         """
-        from sglang.srt.mem_cache.common import kv_to_page_num
-
         result = {}
+        assert transfer_metric.transfer_total_bytes is not None
 
         # Transfer latency, size, and speed
-        if self.prefill_transfer_queue_entry_time > 0 and self.completion_time > 0:
+        if transfer_metric.transfer_latency_s is not None:
+            transfer_latency_s = transfer_metric.transfer_latency_s
+        else:
+            if self.prefill_transfer_queue_entry_time <= 0 or self.completion_time <= 0:
+                return result if result else None
             transfer_latency_s = (
                 self.completion_time - self.prefill_transfer_queue_entry_time
             )
+
+        if transfer_latency_s > 0:
             latency_ms = transfer_latency_s * 1000
 
-            num_pages = kv_to_page_num(num_tokens, page_size)
-            total_bytes = bytes_per_page_all_layers * num_pages
+            total_bytes = transfer_metric.transfer_total_bytes
             total_mb = total_bytes / (1024 * 1024)
             self.transfer_total_mb = total_mb
 
@@ -980,8 +983,12 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
     def convert_to_duration(self) -> str:
         if self.disagg_mode == DisaggregationMode.NULL:
-            queue_duration = self.forward_entry_time - self.wait_queue_entry_time
-            forward_duration = self.completion_time - self.forward_entry_time
+            queue_duration = self.duration_between(
+                self.wait_queue_entry_time, self.forward_entry_time
+            )
+            forward_duration = self.duration_between(
+                self.forward_entry_time, self.completion_time
+            )
 
             if SGLANG_TEST_REQUEST_TIME_STATS:
                 assert (
@@ -990,11 +997,15 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
             return f"queue_duration={self.format_duration(queue_duration)}, forward_duration={self.format_duration(forward_duration)}, start_time={self.wait_queue_entry_time:.3f}"
         elif self.disagg_mode == DisaggregationMode.PREFILL:
-            bootstrap_queue_duration = (
-                self.wait_queue_entry_time - self.prefill_bootstrap_queue_entry_time
+            bootstrap_queue_duration = self.duration_between(
+                self.prefill_bootstrap_queue_entry_time, self.wait_queue_entry_time
             )
-            queue_duration = self.forward_entry_time - self.wait_queue_entry_time
-            forward_duration = self.completion_time - self.forward_entry_time
+            queue_duration = self.duration_between(
+                self.wait_queue_entry_time, self.forward_entry_time
+            )
+            forward_duration = self.duration_between(
+                self.forward_entry_time, self.completion_time
+            )
 
             if SGLANG_TEST_REQUEST_TIME_STATS:
                 if self.wait_queue_entry_time > 0:
@@ -1006,11 +1017,11 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
             # Break down bootstrap_queue_duration into sub-phases
             if self.bootstrap_done_time > 0:
-                bootstrap_duration = (
-                    self.bootstrap_done_time - self.prefill_bootstrap_queue_entry_time
+                bootstrap_duration = self.duration_between(
+                    self.prefill_bootstrap_queue_entry_time, self.bootstrap_done_time
                 )
-                alloc_wait_duration = (
-                    self.wait_queue_entry_time - self.bootstrap_done_time
+                alloc_wait_duration = self.duration_between(
+                    self.bootstrap_done_time, self.wait_queue_entry_time
                 )
                 if SGLANG_TEST_REQUEST_TIME_STATS:
                     assert (
@@ -1034,15 +1045,22 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
                 f"#retries={self.prefill_retry_count}"
             )
         elif self.disagg_mode == DisaggregationMode.DECODE:
-            prealloc_duration = (
-                self.decode_transfer_queue_entry_time
-                - self.decode_prealloc_queue_entry_time
+            prealloc_duration = self.duration_between(
+                self.decode_prealloc_queue_entry_time,
+                self.decode_transfer_queue_entry_time,
             )
-            transfer_duration = (
-                self.wait_queue_entry_time - self.decode_transfer_queue_entry_time
+            transfer_duration = self.duration_between(
+                self.decode_transfer_queue_entry_time,
+                self.wait_queue_entry_time,
             )
-            queue_duration = self.forward_entry_time - self.wait_queue_entry_time
-            forward_duration = self.completion_time - self.forward_entry_time
+            queue_duration = self.duration_between(
+                self.wait_queue_entry_time,
+                self.forward_entry_time,
+            )
+            forward_duration = self.duration_between(
+                self.forward_entry_time,
+                self.completion_time,
+            )
 
             if SGLANG_TEST_REQUEST_TIME_STATS:
                 if self.wait_queue_entry_time > 0:
@@ -1055,11 +1073,11 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
             # Break down prealloc_duration into sub-phases
             if self.bootstrap_done_time > 0:
-                bootstrap_duration = (
-                    self.bootstrap_done_time - self.decode_prealloc_queue_entry_time
+                bootstrap_duration = self.duration_between(
+                    self.decode_prealloc_queue_entry_time, self.bootstrap_done_time
                 )
-                alloc_wait_duration = (
-                    self.decode_transfer_queue_entry_time - self.bootstrap_done_time
+                alloc_wait_duration = self.duration_between(
+                    self.bootstrap_done_time, self.decode_transfer_queue_entry_time
                 )
                 if SGLANG_TEST_REQUEST_TIME_STATS:
                     assert (
@@ -1104,6 +1122,11 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
     def format_duration(self, duration: float) -> str:
         return f"{duration * 1e3:.2f}ms"
+
+    def duration_between(self, start: float, end: float) -> float:
+        if start <= 0 or end <= 0:
+            return 0.0
+        return end - start
 
 
 def set_schedule_time_batch(batch: ScheduleBatch):

--- a/test/registered/unit/observability/test_req_time_stats_kv_transfer.py
+++ b/test/registered/unit/observability/test_req_time_stats_kv_transfer.py
@@ -1,0 +1,127 @@
+"""Unit tests for disaggregated KV transfer metric computation."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.disaggregation.base.conn import KVTransferMetric
+from sglang.srt.observability.req_time_stats import SchedulerReqTimeStats
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+_TRANSFER_BYTES = 16 * 1024 * 1024
+
+
+def _make_stats(
+    queue_entry: float = 1.0,
+    transfer_finish: float = 1.1,
+    completion: float = 6.1,
+    enable_metrics: bool = False,
+) -> SchedulerReqTimeStats:
+    stats = SchedulerReqTimeStats()
+    stats.prefill_transfer_queue_entry_time = queue_entry
+    stats.prefill_kv_transfer_finish_time = transfer_finish
+    stats.completion_time = completion
+    stats.enable_metrics = enable_metrics
+    return stats
+
+
+class TestKVTransferMetrics(CustomTestCase):
+    def test_backend_latency_is_used_instead_of_completion_time(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.1, completion=6.1)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(
+                transfer_latency_s=0.25,
+                transfer_total_bytes=_TRANSFER_BYTES,
+            )
+        )
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["latency_ms"], 250.0, places=3)
+
+    def test_timestamp_fallback_uses_transfer_finish_not_completion(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.1, completion=6.1)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["latency_ms"], 100.0, places=3)
+        self.assertLess(result["latency_ms"], 200.0)
+
+    def test_timestamp_fallback_does_not_require_completion_time(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.2, completion=0.0)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["latency_ms"], 200.0, places=3)
+
+    def test_missing_transfer_finish_returns_none_for_transfer_metrics(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=0.0, completion=6.0)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        self.assertIsNone(result)
+
+    def test_missing_transfer_bytes_do_not_crash_request_path(self):
+        stats = _make_stats()
+        result = stats.compute_and_observe_kv_transfer_metrics(KVTransferMetric())
+
+        self.assertIsNone(result)
+
+    def test_zero_transfer_bytes_are_reported_without_crashing(self):
+        stats = _make_stats()
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_latency_s=0.1, transfer_total_bytes=0)
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["total_mb"], 0.0)
+        self.assertEqual(result["speed_gb_s"], 0.0)
+
+    def test_speed_uses_selected_latency(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.016, completion=6.016)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        expected_speed = (16.0 / 1024) / 0.016
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["speed_gb_s"], expected_speed, places=4)
+
+    def test_metrics_observer_called_when_enabled(self):
+        stats = _make_stats(enable_metrics=True)
+        mock_collector = MagicMock()
+        stats.metrics_collector = mock_collector
+
+        stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(
+                transfer_latency_s=0.5, transfer_total_bytes=_TRANSFER_BYTES
+            )
+        )
+
+        mock_collector.observe_kv_transfer_metrics.assert_called_once()
+        call_kwargs = mock_collector.observe_kv_transfer_metrics.call_args.kwargs
+        self.assertAlmostEqual(call_kwargs["latency_ms"], 500.0, places=3)
+
+    def test_metrics_observer_not_called_when_disabled(self):
+        stats = _make_stats(enable_metrics=False)
+        mock_collector = MagicMock()
+        stats.metrics_collector = mock_collector
+
+        stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(
+                transfer_latency_s=0.5, transfer_total_bytes=_TRANSFER_BYTES
+            )
+        )
+
+        mock_collector.observe_kv_transfer_metrics.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This is a stacked support PR for #24416 / #23937.

It keeps the backend-owned `KVTransferMetric` direction from #24416, then adds the regression coverage and request-path hardening that make the metric contract safer for operators:

- use backend-provided `transfer_latency_s` when available
- fall back to `prefill_transfer_queue_entry_time -> prefill_kv_transfer_finish_time`, not request completion time
- avoid asserting when an optional backend metric omits `transfer_total_bytes`
- add CPU unit tests for backend latency, timestamp fallback, completion-time independence, missing timestamps, missing bytes, zero-byte transfers, speed calculation, and observer calls

## Why

#23937 is about KV transfer latency and speed including non-transfer request time. If fallback logic uses request completion time, decode time can still contaminate `kv_transfer_latency_ms` and derived GB/s when backend latency is unavailable.

Metric collection should also not crash a request path because an optional backend metric was missing.

## Validation

- `rtk git diff --check`
- `rtk env PYTHONPYCACHEPREFIX=/tmp/sglang-pycache python3 -m py_compile python/sglang/srt/observability/req_time_stats.py test/registered/unit/observability/test_req_time_stats_kv_transfer.py`

Attempted targeted pytest locally:

```bash
PYTHONPATH=python python3 -m pytest test/registered/unit/observability/test_req_time_stats_kv_transfer.py -q
```

The local system Python environment is missing SGLang runtime dependency `orjson`, so collection cannot run outside the SGLang dev/CI environment here.
