### PR TITLE
Add aligned KV buffer allocation for ibv_reg_dmabuf_mr RDMA registration

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -48,6 +48,7 @@ from sglang.srt.layers.attention.nsa.quant_k_cache import (
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.utils import (
+    aligned_zeros,
     get_mla_kv_buffer_triton,
     maybe_init_custom_mem_pool,
     set_mla_kv_buffer_triton,
@@ -895,18 +896,18 @@ class MHATokenToKVPool(KVCache):
                 # [size, head_num, head_dim] for each layer
                 # The padded slot 0 is used for writing dummy outputs from padded tokens.
                 self.k_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (self.size + self.page_size, self.head_num, self.head_dim),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
                 self.v_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (self.size + self.page_size, self.head_num, self.v_head_dim),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
@@ -1142,35 +1143,35 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
                 scale_block_size = 16
                 self.store_dtype = torch.uint8
                 self.k_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (m, n, k // 2),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
                 self.v_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (m, n, k // 2),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
 
                 self.k_scale_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (m, (n * k) // scale_block_size),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
                 self.v_scale_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (m, (n * k) // scale_block_size),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
@@ -1559,10 +1560,10 @@ class MLATokenToKVPool(KVCache):
             ):
                 # The padded slot 0 is used for writing dummy outputs from padded tokens.
                 self.kv_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (self.size + self.page_size, 1, self.kv_cache_dim),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
@@ -1748,19 +1749,19 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
                 self.store_dtype = torch.uint8
 
                 self.kv_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (m, n, k // 2),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]
 
                 self.kv_scale_buffer = [
-                    torch.zeros(
+                    aligned_zeros(
                         (m, k // scale_block_size),
-                        dtype=self.store_dtype,
-                        device=self.device,
+                        self.store_dtype,
+                        self.device,
                     )
                     for _ in range(self.layer_num)
                 ]

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -37,6 +37,7 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     NSATokenToKVPool,
 )
+from sglang.srt.mem_cache.utils import aligned_empty
 from sglang.srt.utils import is_cuda, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
@@ -84,11 +85,15 @@ class HostTensorAllocator(abc.ABC):
         self.dims = None
 
     def allocate(self, dims: tuple, dtype: torch.dtype, device: str) -> torch.Tensor:
-        """Allocate a tensor of given dims and dtype on the memory."""
+        """Allocate a tensor of given dims and dtype on the memory.
+
+        Returns a buffer with ``data_ptr()`` and ``nbytes`` aligned to the
+        host's RDMA registration alignment (kernel page size) so it can be
+        passed directly to ``cudaHostRegister`` / ``ibv_reg_mr``.
+        """
         self.dtype = dtype
         self.dims = dims
-        tensor = torch.empty(dims, dtype=dtype, device=device)
-        return tensor
+        return aligned_empty(dims, dtype=dtype, device=device)
 
 
 def get_allocator_from_storage(allocator_type):
@@ -138,9 +143,12 @@ def alloc_with_pin_memory(
 ) -> torch.Tensor:
     """
     Allocate tensor using PyTorch's built-in pin_memory flag.
+
+    ``data_ptr()`` and ``nbytes`` are aligned to the host's RDMA registration
+    alignment (kernel page size), so the returned buffer is safe to register
+    with ``ibv_reg_mr`` for NIXL/UCX.
     """
-    buffer = torch.empty(dims, dtype=dtype, device=device, pin_memory=pin_memory)
-    return buffer
+    return aligned_empty(dims, dtype=dtype, device=device, pin_memory=pin_memory)
 
 
 ALLOC_MEMORY_FUNCS = defaultdict(

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -14,13 +14,106 @@
 """Common utilities."""
 
 import hashlib
+import math
+import mmap
 from typing import Any, List, Optional, Tuple
 
+import numpy as np
 import torch
 import triton
 import triton.language as tl
 
 from sglang.srt.environ import envs
+
+# CUDA buffer alignment for ibv_reg_dmabuf_mr / GDR registration.
+#
+# Discrete x86: GPU memory is exposed via PCIe BAR1; ``nvidia_p2p_get_pages()``
+# returns 64 KB pages. NVIDIA hardcodes this in NCCL and gdrcopy:
+#   https://github.com/NVIDIA/nccl/blob/1933fdd6360a8bfccaa0166bd71bce363d32e5b6/src/transport/net_ib/gdaki/doca-gpunetio/src/doca_gpunetio_gdrcopy.cpp#L50
+#   https://github.com/NVIDIA/gdrcopy/blob/737708f3b5955cb6ef6b47bba35600a31bce4222/include/gdrapi.h#L42
+#   https://github.com/NVIDIA/nccl/blob/1933fdd6360a8bfccaa0166bd71bce363d32e5b6/src/transport/net_ib/gdaki/doca-gpunetio/include/common/doca_gpunetio_verbs_def.h#L105
+#
+# Unified-memory GB200/GB300: dmabuf registration enforces kernel-page
+# alignment, which is also 64 KB on aarch64 64K kernels.
+#
+# Both regimes land on 64 KB today, so this is a constant.
+CUDA_REG_ALIGN_BYTES = 64 * 1024
+# Host-side ``ibv_reg_mr`` / ``cudaHostRegister`` require kernel-page alignment:
+# 4 KB on x86, 64 KB on aarch64 64K kernels.
+HOST_REG_ALIGN_BYTES = mmap.PAGESIZE
+
+
+def ibv_reg_align_bytes(device) -> int:
+    """Address/length alignment ``ibv_reg_mr``/``ibv_reg_dmabuf_mr`` requires
+    when registering a buffer of `device`'s type for NIXL/UCX RDMA."""
+    if isinstance(device, torch.device):
+        device_type = device.type
+    else:
+        device_type = str(device).split(":", 1)[0]
+    return CUDA_REG_ALIGN_BYTES if device_type == "cuda" else HOST_REG_ALIGN_BYTES
+
+
+def aligned_empty(
+    shape: Tuple[int, ...],
+    dtype: torch.dtype,
+    device,
+    *,
+    pin_memory: bool = False,
+) -> torch.Tensor:
+    """``torch.empty(shape, dtype=dtype, device=device)`` with ``data_ptr()``
+    and ``nbytes`` rounded up to the RDMA registration alignment for `device`
+    (CUDA: 64 KB; host: kernel page size). Pads the leading dim so the
+    returned tensor has shape ``(N', *shape[1:])`` with ``N' >= shape[0]``;
+    callers can ``[idx]`` into it as before — trailing pad rows are unused.
+
+    Required so per-layer KV buffers can be registered with NIXL/UCX
+    (``ibv_reg_dmabuf_mr`` for CUDA, ``ibv_reg_mr`` for host) on aarch64
+    64 KB-page kernels (e.g. GB300), which require page-aligned offset and
+    length. Per-buffer slack is bounded by ``align`` (≤64 KB), negligible
+    against multi-GB KV pools.
+    """
+    if not shape or shape[0] <= 0:
+        return torch.empty(shape, dtype=dtype, device=device, pin_memory=pin_memory)
+
+    align = ibv_reg_align_bytes(device)
+    per_row = int(np.prod(shape[1:])) * dtype.itemsize
+    if per_row <= 0:
+        return torch.empty(shape, dtype=dtype, device=device, pin_memory=pin_memory)
+
+    # The returned tensor must satisfy two constraints simultaneously:
+    #   (1) nbytes % align == 0     -- for ibv_reg_*_mr length.
+    #   (2) nbytes % per_row == 0   -- so .view((N', *shape[1:])) succeeds.
+    # Both hold iff nbytes is a multiple of lcm(align, per_row).
+    chunk = (align // math.gcd(align, per_row)) * per_row  # = lcm(align, per_row)
+    padded_nbytes = ((shape[0] * per_row + chunk - 1) // chunk) * chunk
+    new_dim0 = padded_nbytes // per_row
+
+    # Allocate flat uint8 storage with extra slack, then slice out a region
+    # whose start address lands on an `align`-byte boundary. The slice keeps
+    # the allocation alive via storage refcount.
+    raw = torch.empty(
+        padded_nbytes + align,
+        dtype=torch.uint8,
+        device=device,
+        pin_memory=pin_memory,
+    )
+    shift = (-raw.data_ptr()) & (align - 1)
+    return (
+        raw[shift : shift + padded_nbytes]
+        .view(dtype)
+        .view((new_dim0,) + tuple(shape[1:]))
+    )
+
+
+def aligned_zeros(
+    shape: Tuple[int, ...],
+    dtype: torch.dtype,
+    device,
+    *,
+    pin_memory: bool = False,
+) -> torch.Tensor:
+    """``torch.zeros``-equivalent of :func:`aligned_empty`. See its docstring."""
+    return aligned_empty(shape, dtype, device, pin_memory=pin_memory).zero_()
 
 
 @triton.jit


### PR DESCRIPTION
## Summary
- Introduce `aligned_zeros` and `aligned_empty` helpers in `mem_cache/utils.py` that ensure KV cache buffers have `data_ptr()` and `nbytes` aligned to the RDMA registration boundary (64 KB for CUDA / kernel page size for host).
- Replace all `torch.zeros` / `torch.empty` calls in KV pool allocations (MHA, MLA, FP4 variants, and host allocators) with the aligned versions.
- This allows buffers to be registered directly with `ibv_reg_dmabuf_mr` (GPU) or `ibv_reg_mr` (host) without alignment violations on aarch64 64K-page kernels (e.g. GB300).

## Test plan
- [ ] Existing unit tests pass
- [ ] Verify aligned buffers on CUDA device have `data_ptr() % 65536 == 0` and `nbytes % 65536 == 0`
- [ ] Verify host buffers have page-aligned `data_ptr()` and `nbytes`