### PR TITLE
Add fwd_occupancy metric to SchedulerStats and Prometheus collector

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -124,6 +124,7 @@ class SchedulerStats:
 
     # Utilization
     utilization: float = 0.0
+    fwd_occupancy: float = float("nan")
 
     # Scheduler policy
     new_token_ratio: float = 0.0
@@ -465,6 +466,12 @@ class SchedulerMetricsCollector:
         self.utilization = Gauge(
             name="sglang:utilization",
             documentation="The utilization.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.fwd_occupancy = Gauge(
+            name="sglang:fwd_occupancy",
+            documentation="Forward pass GPU occupancy percentage.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1147,6 +1154,7 @@ class SchedulerMetricsCollector:
 
         # Utilization
         self._log_gauge(self.utilization, stats.utilization)
+        self._log_gauge(self.fwd_occupancy, stats.fwd_occupancy)
 
         # Scheduler policy
         self._log_gauge(self.new_token_ratio, stats.new_token_ratio)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -157,11 +157,12 @@ class SchedulerMetricsMixin:
                 self._mfu_log_read_bytes = 0.0
                 self._mfu_log_write_bytes = 0.0
 
+        self.fwd_occupancy = float("nan")
+
         if ENABLE_METRICS_DEVICE_TIMER:
             self._device_timer_window_batch_count = 0
             self._device_timer_window_gpu_time = 0.0
             self._device_timer_window_start = None
-            self.fwd_occupancy = float("nan")
 
             def _wrap_execution_reporter(**kwargs):
                 self._device_timer_window_gpu_time += kwargs["t"]
@@ -469,7 +470,7 @@ class SchedulerMetricsMixin:
 
             # Utilization / LoRA / HiCache
             self.calculate_utilization()
-            self.stats.fwd_occupancy = getattr(self, "fwd_occupancy", float("nan"))
+            self.stats.fwd_occupancy = self.fwd_occupancy
             self.update_lora_metrics()
             self._log_hicache_stats()
             self.metrics_collector.log_stats(self.stats)
@@ -662,7 +663,7 @@ class SchedulerMetricsMixin:
 
             # Utilization / LoRA / HiCache
             self.calculate_utilization()
-            self.stats.fwd_occupancy = getattr(self, "fwd_occupancy", float("nan"))
+            self.stats.fwd_occupancy = self.fwd_occupancy
             self.update_lora_metrics()
             self._log_hicache_stats()
             self.metrics_collector.log_stats(self.stats)

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -469,6 +469,7 @@ class SchedulerMetricsMixin:
 
             # Utilization / LoRA / HiCache
             self.calculate_utilization()
+            self.stats.fwd_occupancy = getattr(self, "fwd_occupancy", float("nan"))
             self.update_lora_metrics()
             self._log_hicache_stats()
             self.metrics_collector.log_stats(self.stats)
@@ -661,6 +662,7 @@ class SchedulerMetricsMixin:
 
             # Utilization / LoRA / HiCache
             self.calculate_utilization()
+            self.stats.fwd_occupancy = getattr(self, "fwd_occupancy", float("nan"))
             self.update_lora_metrics()
             self._log_hicache_stats()
             self.metrics_collector.log_stats(self.stats)


### PR DESCRIPTION
## Summary
- Add `fwd_occupancy` field to `SchedulerStats` dataclass
- Add `sglang:fwd_occupancy` Prometheus Gauge in `SchedulerMetricsCollector`
- Log `fwd_occupancy` in both `report_prefill_stats` and `report_decode_stats`

## Original commits

- `d59980bd5`

## Test plan
- [ ] Verify `/metrics` endpoint includes `sglang:fwd_occupancy` gauge
- [ ] Verify no regression in scheduler stats logging
