### PR TITLE
Silence noisy health-check race log in TokenizerManager

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -40,6 +40,7 @@ import zmq.asyncio
 from fastapi import BackgroundTasks
 
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.disaggregation.encode_receiver import create_mm_receiver
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
@@ -1653,6 +1654,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         for i, rid in enumerate(recv_obj.rids):
             state = self.rid_to_state.get(rid, None)
             if state is None:
+                # Known race: /health_generate pops its rid as soon as ANY message bumps last_receive_tstamp.
+                if rid.startswith(HEALTH_CHECK_RID_PREFIX):
+                    continue
                 logger.error(
                     f"Received output for {rid=} but the state was deleted in TokenizerManager."
                 )


### PR DESCRIPTION
## Motivation
In `/health_generate` endpoint,  healthcheck requests do not wait for the final output but return as soon as any response is received from the scheduler/detokenizer.

As noted in the code:
```
# As long as we receive any response from the detokenizer/scheduler, we consider the server is healthy.
```

Therefore under high load the healthcheck response often arrives after its rid has been removed, and `_handle_batch_output` warns:

```
Received output for rid='HEALTH_CHECK_…' but the state was deleted in TokenizerManager.
```

This is benign but very noisy on busy pods.

## Modifications

In `_handle_batch_output`, treat missing-state lookups for `HEALTH_CHECK_*` rids as expected and skip the error log. All other rids still log as before. Same pattern is already used by `_handle_abort_req`.