### PR TITLE
Remove dsv4 compress_state dead code

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -22,79 +22,15 @@ class KVAndScore:
     def score(self) -> torch.Tensor:
         return self.kv_score[..., self._item_size :]
 
-    @property
-    def shape(self):
-        return self.kv_score.shape
-
     def __post_init__(self):
         self._item_size = self.kv_score.shape[-1] // 2
-
-    def new_empty(self, new_shape) -> KVAndScore:
-        assert new_shape[-1] == self._item_size
-        new_shape = list(new_shape)
-        new_shape[-1] = 2 * self._item_size
-        return KVAndScore(self.kv_score.new_empty(new_shape, requires_grad=False))
 
     def __getitem__(self, index) -> KVAndScore:
         return KVAndScore(self.kv_score[index])
 
-    def __setitem__(self, index, value: KVAndScore):
-        self.kv_score[index] = value.kv_score
-
     def clear(self):
         self.kv.zero_()
         self.score.fill_(float("-inf"))
-
-    def view(self, *args):
-        args = list(args)
-        if isinstance(args[-1], int) and args[-1] != -1:
-            args[-1] = 2 * self._item_size
-        return KVAndScore(self.kv_score.view(*args))
-
-    def clone(self) -> KVAndScore:
-        return KVAndScore(self.kv_score.clone())
-
-    @staticmethod
-    def cat(tensors: list[KVAndScore], dim: int) -> KVAndScore:
-        assert dim != -1, "Concatenation along last dim is not supported."
-        assert len(tensors) > 0, "At least one tensor is required for concatenation."
-        item_size = tensors[0]._item_size
-        for v in tensors:
-            assert (
-                v._item_size == item_size
-            ), "All tensors must have the same item size."
-
-        return KVAndScore(torch.cat([v.kv_score for v in tensors], dim=dim))
-
-
-class DeepSeekV4CompressState:
-    def __init__(
-        self,
-        max_num_reqs: int,
-        ratio: int,
-        overlap: bool,
-        head_dim: int,
-        device: str,
-        dtype: torch.dtype,
-        enable_memory_saver: bool = True,
-    ):
-        self.max_num_reqs = max_num_reqs
-        self.ratio = ratio
-        self.overlap = overlap
-        self.head_dim = head_dim
-        self.device = device
-        self.dtype = dtype
-        coff = 1 + self.overlap
-
-        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=enable_memory_saver
-        )
-        state_shape = (max_num_reqs, ratio * coff, 2 * head_dim * coff)
-        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
-            self.kv_score_state = torch.empty(state_shape, dtype=dtype, device=device)
-
-    def get_state(self) -> KVAndScore:
-        return KVAndScore(self.kv_score_state)
 
 
 class CompressStatePool:


### PR DESCRIPTION
Drop unused `DeepSeekV4CompressState` class and unused `KVAndScore` methods (`shape`, `new_empty`, `__setitem__`, `view`, `clone`, `cat`). All call sites verified.