### PR TITLE
[vlm][deepseek_vl2] support precomputed embeddings

### DIFF
--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -155,6 +155,30 @@ class DeepseekVL2MlpProjector(nn.Module):
         return x
 
 
+def _init_vision_module(
+    vision_config, quant_config: Optional[QuantizationConfig]
+) -> nn.Module:
+    # Module-level helper so the vision tower can be constructed standalone
+    # (outside an Engine). Useful for tests + workflows that pre-compute image
+    # features and feed them via the PRECOMPUTED_EMBEDDING input format.
+    # TODO: refactor vision model through timm wrapper from transformers
+    try:
+        import timm
+    except ImportError:
+        raise ImportError("Please install timm") from ImportError
+
+    model = timm.create_model(
+        "vit_so400m_patch14_siglip_384.webli",
+        pretrained=False,
+        num_classes=0,
+        dynamic_img_size=True,
+        dynamic_img_pad=True,
+    )
+
+    model = model.to(dtype=torch.get_default_dtype())
+    return model
+
+
 class DeepseekVL2ForCausalLM(nn.Module):
 
     def __init__(
@@ -166,7 +190,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
 
         # ----------- vision encoder ------------
         vision_config = config.vision_config
-        self.vision = self._init_vision_module(vision_config, quant_config)
+        self.vision = _init_vision_module(vision_config, quant_config)
 
         # ----------- vl projector ------------
         projector_config = config.projector_config
@@ -195,26 +219,6 @@ class DeepseekVL2ForCausalLM(nn.Module):
         else:
             # deepseek-vl2-tiny forbids mla
             self.language_model = DeepseekForCausalLM(language_config)
-
-    def _init_vision_module(
-        self, vision_config, quant_config: Optional[QuantizationConfig]
-    ) -> nn.Module:
-        # TODO: refactor vision model through timm wrapper from transformers
-        try:
-            import timm
-        except ImportError:
-            raise ImportError("Please install timm") from ImportError
-
-        model = timm.create_model(
-            "vit_so400m_patch14_siglip_384.webli",
-            pretrained=False,
-            num_classes=0,
-            dynamic_img_size=True,
-            dynamic_img_pad=True,
-        )
-
-        model = model.to(dtype=torch.get_default_dtype())
-        return model
 
     def forward(
         self,
@@ -257,22 +261,31 @@ class DeepseekVL2ForCausalLM(nn.Module):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
-    def get_image_feature(self, items: List[MultimodalDataItem]):
+    @staticmethod
+    def build_image_features(
+        items: List[MultimodalDataItem],
+        vision: nn.Module,
+        projector: nn.Module,
+        image_newline: torch.Tensor,
+        view_seperator: torch.Tensor,
+        global_view_pos: str = "head",
+    ) -> torch.Tensor:
+        """Build per-tile image features for the language model.
 
-        images_spatial_crop = torch.cat(
-            [item.images_spatial_crop for item in items], dim=0
-        )
-
-        assert images_spatial_crop.dim() == 3
-
+        Factored out of ``get_image_feature`` so callers that need to pre-compute
+        image embeddings outside the engine — e.g. RL workflows, KV-cache reuse,
+        and standalone tests — can produce the exact embeddings the engine
+        produces and feed them back via the ``PRECOMPUTED_EMBEDDING`` input
+        format.
+        """
         # TODO: can it be batched ?
         images_in_this_batch = []
         for item in items:
             assert item.feature.dim() == 4
-            image_feature = self.vision.forward_features(
-                item.feature.type(next(self.vision.parameters()).dtype)
+            image_feature = vision.forward_features(
+                item.feature.type(next(vision.parameters()).dtype)
             )
-            images_embeds = self.projector(image_feature)
+            images_embeds = projector(image_feature)
             _, hw, n_dim = images_embeds.shape
             h = w = int(hw**0.5)
             tile_index = 0
@@ -297,7 +310,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 global_features = global_features.view(h, w, n_dim)
 
                 # [D]     -> [h, 1, D]
-                new_lines_in_global = repeat(self.image_newline, "d -> h 1 d", h=h)
+                new_lines_in_global = repeat(image_newline, "d -> h 1 d", h=h)
 
                 # cat([h, w, D], [h, 1, D], dim=1) -> [h, w + 1, D]
                 global_features = torch.cat(
@@ -321,7 +334,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
 
                 # [D] -> [num_height_tiles * h, 1, D]
                 new_lines_in_local = repeat(
-                    self.image_newline,
+                    image_newline,
                     "d -> (th h) 1 d",
                     th=num_height_tiles,
                     h=h,
@@ -335,11 +348,11 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 local_features = local_features.view(-1, n_dim)
 
                 # merge global and local tiles
-                if self.global_view_pos == "head":
+                if global_view_pos == "head":
                     global_local_features = torch.cat(
                         [
                             global_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             local_features,
                         ]
                     )
@@ -347,7 +360,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                     global_local_features = torch.cat(
                         [
                             local_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             global_features,
                         ]
                     )
@@ -355,6 +368,23 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 images_in_this_batch.append(global_local_features)
 
         return torch.cat(images_in_this_batch, dim=0)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]):
+
+        images_spatial_crop = torch.cat(
+            [item.images_spatial_crop for item in items], dim=0
+        )
+
+        assert images_spatial_crop.dim() == 3
+
+        return self.build_image_features(
+            items,
+            self.vision,
+            self.projector,
+            self.image_newline,
+            self.view_seperator,
+            self.global_view_pos,
+        )
 
 
 EntryClass = DeepseekVL2ForCausalLM

--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -15,7 +15,11 @@ from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     general_mm_embed_routine,
 )
-from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
+from sglang.srt.managers.schedule_batch import (
+    MultimodalDataItem,
+    MultimodalInputFormat,
+    MultimodalInputs,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.deepseek import DeepseekForCausalLM
@@ -370,6 +374,11 @@ class DeepseekVL2ForCausalLM(nn.Module):
         return torch.cat(images_in_this_batch, dim=0)
 
     def get_image_feature(self, items: List[MultimodalDataItem]):
+        if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
+            return torch.cat(
+                [item.feature.view(-1, item.feature.shape[-1]) for item in items],
+                dim=0,
+            )
 
         images_spatial_crop = torch.cat(
             [item.images_spatial_crop for item in items], dim=0

--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -8,6 +8,7 @@ from torch import nn
 from sglang.srt.configs.deepseekvl2 import (
     DeepseekVL2Config,
     DeepseekVL2MlpProjectorConfig,
+    DeepseekVL2VisionEncoderConfig,
 )
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -206,8 +207,10 @@ class DeepseekVL2ForCausalLM(nn.Module):
             # deepseek-vl2-tiny forbids mla
             self.language_model = DeepseekForCausalLM(language_config)
 
+    @staticmethod
     def _init_vision_module(
-        self, vision_config, quant_config: Optional[QuantizationConfig]
+        vision_config: DeepseekVL2VisionEncoderConfig,
+        quant_config: Optional[QuantizationConfig],
     ) -> nn.Module:
         # TODO: refactor vision model through timm wrapper from transformers
         try:
@@ -267,22 +270,24 @@ class DeepseekVL2ForCausalLM(nn.Module):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
-    def get_image_feature(self, items: List[MultimodalDataItem]):
-
-        images_spatial_crop = torch.cat(
-            [item.images_spatial_crop for item in items], dim=0
-        )
-
-        assert images_spatial_crop.dim() == 3
-
+    @staticmethod
+    def build_image_features(
+        items: List[MultimodalDataItem],
+        vision: nn.Module,
+        projector: nn.Module,
+        image_newline: torch.Tensor,
+        view_seperator: torch.Tensor,
+        global_view_pos: str,
+    ) -> torch.Tensor:
+        """Build the final image features expected by the language model."""
         # TODO: can it be batched ?
         images_in_this_batch = []
         for item in items:
             assert item.feature.dim() == 4
-            image_feature = self.vision.forward_features(
-                item.feature.type(next(self.vision.parameters()).dtype)
+            image_feature = vision.forward_features(
+                item.feature.type(next(vision.parameters()).dtype)
             )
-            images_embeds = self.projector(image_feature)
+            images_embeds = projector(image_feature)
             _, hw, n_dim = images_embeds.shape
             h = w = int(hw**0.5)
             tile_index = 0
@@ -307,7 +312,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 global_features = global_features.view(h, w, n_dim)
 
                 # [D]     -> [h, 1, D]
-                new_lines_in_global = repeat(self.image_newline, "d -> h 1 d", h=h)
+                new_lines_in_global = repeat(image_newline, "d -> h 1 d", h=h)
 
                 # cat([h, w, D], [h, 1, D], dim=1) -> [h, w + 1, D]
                 global_features = torch.cat(
@@ -331,7 +336,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
 
                 # [D] -> [num_height_tiles * h, 1, D]
                 new_lines_in_local = repeat(
-                    self.image_newline,
+                    image_newline,
                     "d -> (th h) 1 d",
                     th=num_height_tiles,
                     h=h,
@@ -345,11 +350,11 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 local_features = local_features.view(-1, n_dim)
 
                 # merge global and local tiles
-                if self.global_view_pos == "head":
+                if global_view_pos == "head":
                     global_local_features = torch.cat(
                         [
                             global_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             local_features,
                         ]
                     )
@@ -357,7 +362,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                     global_local_features = torch.cat(
                         [
                             local_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             global_features,
                         ]
                     )
@@ -365,6 +370,23 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 images_in_this_batch.append(global_local_features)
 
         return torch.cat(images_in_this_batch, dim=0)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+
+        images_spatial_crop = torch.cat(
+            [item.images_spatial_crop for item in items], dim=0
+        )
+
+        assert images_spatial_crop.dim() == 3
+
+        return self.build_image_features(
+            items=items,
+            vision=self.vision,
+            projector=self.projector,
+            image_newline=self.image_newline,
+            view_seperator=self.view_seperator,
+            global_view_pos=self.global_view_pos,
+        )
 
 
 EntryClass = DeepseekVL2ForCausalLM

--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -16,7 +16,11 @@ from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     general_mm_embed_routine,
 )
-from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
+from sglang.srt.managers.schedule_batch import (
+    MultimodalDataItem,
+    MultimodalInputFormat,
+    MultimodalInputs,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.deepseek import DeepseekForCausalLM
@@ -372,6 +376,11 @@ class DeepseekVL2ForCausalLM(nn.Module):
         return torch.cat(images_in_this_batch, dim=0)
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
+            return torch.cat(
+                [item.feature.reshape(-1, item.feature.shape[-1]) for item in items],
+                dim=0,
+            )
 
         images_spatial_crop = torch.cat(
             [item.images_spatial_crop for item in items], dim=0

--- a/test/registered/unit/models/test_deepseek_vl2.py
+++ b/test/registered/unit/models/test_deepseek_vl2.py
@@ -1,0 +1,57 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from sglang.srt.models.deepseek_vl2 import DeepseekVL2ForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _VisionStub(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dtype_anchor = nn.Parameter(torch.zeros(()), requires_grad=False)
+
+    def forward_features(self, features: torch.Tensor) -> torch.Tensor:
+        return features.flatten(start_dim=2) + 1
+
+
+class _ProjectorStub(nn.Module):
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return features * 10
+
+
+class TestDeepseekVL2ImageFeatures(CustomTestCase):
+    def test_global_and_local_views_keep_layout_tokens_in_order(self) -> None:
+        item = SimpleNamespace(
+            feature=torch.arange(3, dtype=torch.float32).reshape(3, 1, 1, 1),
+            images_spatial_crop=torch.tensor([[[2, 1]]]),
+        )
+        expected_by_global_view_pos = {
+            "head": [10, -1, -2, 20, 30, -1],
+            "tail": [20, 30, -1, -2, 10, -1],
+        }
+
+        for global_view_pos, expected in expected_by_global_view_pos.items():
+            with self.subTest(global_view_pos=global_view_pos):
+                image_features = DeepseekVL2ForCausalLM.build_image_features(
+                    items=[item],
+                    vision=_VisionStub(),
+                    projector=_ProjectorStub(),
+                    image_newline=torch.tensor([-1.0]),
+                    view_seperator=torch.tensor([-2.0]),
+                    global_view_pos=global_view_pos,
+                )
+
+                torch.testing.assert_close(
+                    image_features,
+                    torch.tensor(expected, dtype=torch.float32).unsqueeze(1),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_deepseek_vl2_precomputed.py
+++ b/test/registered/unit/models/test_deepseek_vl2_precomputed.py
@@ -1,0 +1,42 @@
+import unittest
+
+import torch
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputFormat,
+)
+from sglang.srt.models.deepseek_vl2 import DeepseekVL2ForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDeepseekVL2PrecomputedEmbedding(CustomTestCase):
+    def test_precomputed_embeddings_bypass_vision_encoder(self) -> None:
+        features = [
+            torch.arange(12, dtype=torch.float32).reshape(2, 2, 3),
+            torch.arange(12, 18, dtype=torch.float32).reshape(2, 3),
+        ]
+        items = [
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                format=MultimodalInputFormat.PRECOMPUTED_EMBEDDING,
+                feature=feature,
+            )
+            for feature in features
+        ]
+        model = DeepseekVL2ForCausalLM.__new__(DeepseekVL2ForCausalLM)
+
+        image_features = model.get_image_feature(items)
+
+        torch.testing.assert_close(
+            image_features,
+            torch.cat([feature.reshape(-1, feature.shape[-1]) for feature in features]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/vlm/test_vlm_input_format.py
+++ b/test/registered/vlm/test_vlm_input_format.py
@@ -710,5 +710,141 @@ class TestMiniCPMVUnderstandsImage(VLMInputTestBase, unittest.IsolatedAsyncioTes
         return dict(processor_output, format="processor_output")
 
 
+class TestDeepseekVL2UnderstandsImage(
+    VLMInputTestBase, unittest.IsolatedAsyncioTestCase
+):
+    model_path = "deepseek-ai/deepseek-vl2-tiny"
+    chat_template = "deepseek-vl2"
+
+    @classmethod
+    def setUpClass(cls):
+        assert cls.model_path is not None
+        assert cls.chat_template is not None
+
+        # The base test sends `image_data` to the engine's async_generate, which
+        # accepts List[Union[str, bytes]] — pass URL/path strings, not PIL.
+        cls.image_urls = [IMAGE_MAN_IRONING_URL, IMAGE_SGL_LOGO_URL]
+        cls.main_image = list(cls.image_urls)
+        cls.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        # PIL list for the offline DeepseekVLV2Processor.__call__(images=...)
+        cls.pil_images = []
+        for image_url in cls.image_urls:
+            response = requests.get(image_url)
+            cls.pil_images.append(Image.open(BytesIO(response.content)).convert("RGB"))
+
+        # sglang ships its own DeepseekVLV2Processor at sglang.srt.configs.deepseekvl2
+        # (registered with AutoProcessor at import). Import directly so we don't
+        # depend on AutoProcessor registration order.
+        from sglang.srt.configs.deepseekvl2 import DeepseekVLV2Processor
+
+        cls.processor = DeepseekVLV2Processor.from_pretrained(
+            cls.model_path, trust_remote_code=True
+        )
+        cls._init_visual()
+
+    @classmethod
+    def _init_visual(cls):
+        # Build a standalone vision tower + projector and load the matching
+        # weights, then call DeepseekVL2ForCausalLM.build_image_features so the
+        # standalone embeddings match what get_image_feature would have produced
+        # — including per-tile newline / view_seperator additions.
+        import glob
+        import os
+
+        from huggingface_hub import snapshot_download
+        from safetensors.torch import load_file
+
+        from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
+        from sglang.srt.models.deepseek_vl2 import (
+            DeepseekVL2ForCausalLM,
+            DeepseekVL2MlpProjector,
+            _init_vision_module,
+        )
+
+        config = DeepseekVL2Config.from_pretrained(cls.model_path)
+        cls.global_view_pos = config.global_view_pos
+        vision = _init_vision_module(config.vision_config, quant_config=None)
+        cls.vision_model = vision.eval().to(cls.device, dtype=torch.bfloat16)
+        cls.projector_model = (
+            DeepseekVL2MlpProjector(config.projector_config, quant_config=None)
+            .eval()
+            .to(cls.device, dtype=torch.bfloat16)
+        )
+
+        cls.image_newline = None
+        cls.view_seperator = None
+
+        local_dir = snapshot_download(cls.model_path, allow_patterns=["*.safetensors"])
+        for f in sorted(glob.glob(os.path.join(local_dir, "*.safetensors"))):
+            shard = load_file(f)
+            vision_sd = {
+                k.removeprefix("vision."): v
+                for k, v in shard.items()
+                if k.startswith("vision.")
+            }
+            projector_sd = {
+                k.removeprefix("projector."): v
+                for k, v in shard.items()
+                if k.startswith("projector.")
+            }
+            cls.vision_model.load_state_dict(vision_sd, strict=False)
+            cls.projector_model.load_state_dict(projector_sd, strict=False)
+            if "image_newline" in shard:
+                cls.image_newline = shard["image_newline"].to(
+                    cls.device, dtype=torch.bfloat16
+                )
+            if "view_seperator" in shard:
+                cls.view_seperator = shard["view_seperator"].to(
+                    cls.device, dtype=torch.bfloat16
+                )
+            del shard
+
+        assert cls.image_newline is not None
+        assert cls.view_seperator is not None
+
+        def visual_func(processor_output):
+            class _Item:
+                pass
+
+            item = _Item()
+            item.feature = processor_output["pixel_values"].to(
+                cls.device, dtype=torch.bfloat16
+            )
+            item.images_spatial_crop = processor_output["images_spatial_crop"]
+            return DeepseekVL2ForCausalLM.build_image_features(
+                [item],
+                cls.vision_model,
+                cls.projector_model,
+                cls.image_newline,
+                cls.view_seperator,
+                cls.global_view_pos,
+            )
+
+        cls.visual = visual_func
+
+    def get_processor_output(self, req=None):
+        # sglang's DeepseekVLV2Processor takes `conversations` as a STRING with
+        # `<image>` tokens (not List[Dict]) and `images` as a PIL list. The
+        # return is a VLChatProcessorOutput; expose it as a plain dict with the
+        # batch dim added so the base test methods can do
+        # processor_output["input_ids"][0].
+        if req is None:
+            req = self.get_completion_request()
+        conv = generate_chat_conv(req, template_name=self.chat_template)
+        text = conv.get_prompt()
+
+        out = self.processor(conversations=text, images=self.pil_images)
+        return {
+            "input_ids": out.input_ids.unsqueeze(0),
+            "pixel_values": out.pixel_values,
+            "images_seq_mask": out.images_seq_mask,
+            "images_spatial_crop": out.images_spatial_crop,
+        }, text
+
+    def _processor_output_image_data(self, processor_output):
+        return dict(processor_output, format="processor_output")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek-VL2 callers can supply an image embedding through the public precomputed-embedding format, but the model still treats that tensor as raw image input. It then reads crop metadata that a precomputed item does not have and fails before inference with:

```text
AttributeError: 'MultimodalDataItem' object has no attribute 'images_spatial_crop'
```

Precomputed items now return their flattened token embeddings without running the vision encoder or projector. Raw image and processor-output requests keep the existing path.

This PR is stacked on https://github.com/sgl-project/sglang/pull/24622.

## Testing

```console
$ MODEL=python/sglang/srt/models/deepseek_vl2.py
$ TEST=test/registered/unit/models/test_deepseek_vl2_precomputed.py
$ git checkout 881a075e7b -- "$MODEL"
$ PYTHONPATH=python python "$TEST" -f
AttributeError: 'MultimodalDataItem' object has no attribute 'images_spatial_crop'
Ran 1 test in 0.004s
FAILED (errors=1)

$ git checkout ab538078a6 -- "$MODEL"
$ PYTHONPATH=python python "$TEST" -f
Ran 1 test in 0.016s
OK
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci)
- [x] Update documentation / docstrings as needed
- [x] Add tests to ensure the change is correctly integrated
- [x] Provide a meaningful PR description
