### PR TITLE
[PD] Export KV transfer telemetry to request and load metrics

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -671,6 +671,12 @@ class SchedulerDisaggregationPrefillMixin:
                     self.kv_transfer_latency_ms = metrics["latency_ms"]
                 if "speed_gb_s" in metrics:
                     self.kv_transfer_speed_gb_s = metrics["speed_gb_s"]
+                if "total_mb" in metrics:
+                    self.kv_transfer_total_mb = metrics["total_mb"]
+                if "bootstrap_ms" in metrics:
+                    self.kv_transfer_bootstrap_ms = metrics["bootstrap_ms"]
+                if "alloc_ms" in metrics:
+                    self.kv_transfer_alloc_ms = metrics["alloc_ms"]
 
         # Stream requests which have finished transfer
         self.stream_output(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1976,6 +1976,15 @@ class DisaggregationMetrics:
     kv_transfer_latency_ms: float = field(
         default=0.0, metadata={"metric": ("gauge", "KV transfer latency in ms")}
     )
+    kv_transfer_total_mb: float = field(
+        default=0.0, metadata={"metric": ("gauge", "KV transfer size in MB")}
+    )
+    kv_transfer_bootstrap_ms: float = field(
+        default=0.0, metadata={"metric": ("gauge", "KV transfer bootstrap time in ms")}
+    )
+    kv_transfer_alloc_ms: float = field(
+        default=0.0, metadata={"metric": ("gauge", "KV transfer allocation time in ms")}
+    )
 
 
 @dataclass

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -120,6 +120,9 @@ class SchedulerStats:
     num_decode_transfer_queue_reqs: QueueCount = field(default_factory=QueueCount)
     kv_transfer_speed_gb_s: float = 0.0
     kv_transfer_latency_ms: float = 0.0
+    kv_transfer_total_mb: float = 0.0
+    kv_transfer_bootstrap_ms: float = 0.0
+    kv_transfer_alloc_ms: float = 0.0
     pending_prealloc_token_usage: float = 0.0
 
     # Utilization

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -850,20 +850,28 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         Returns a dict with latency_ms, total_mb, speed_gb_s if computable, else None.
         """
         result = {}
-        if transfer_metric.transfer_total_bytes is None:
-            return result if result else None
 
         # Transfer latency, size, and speed
-        if transfer_metric.transfer_latency_s is not None:
+        if (
+            transfer_metric.transfer_latency_s is not None
+            and transfer_metric.transfer_total_bytes is not None
+        ):
             transfer_latency_s = transfer_metric.transfer_latency_s
+        elif transfer_metric.transfer_total_bytes is not None:
+            if (
+                self.prefill_transfer_queue_entry_time <= 0
+                or self.prefill_kv_transfer_finish_time <= 0
+            ):
+                transfer_latency_s = None
+            else:
+                transfer_latency_s = (
+                    self.prefill_kv_transfer_finish_time
+                    - self.prefill_transfer_queue_entry_time
+                )
         else:
-            if self.prefill_transfer_queue_entry_time <= 0 or self.completion_time <= 0:
-                return result if result else None
-            transfer_latency_s = (
-                self.completion_time - self.prefill_transfer_queue_entry_time
-            )
+            transfer_latency_s = None
 
-        if transfer_latency_s > 0:
+        if transfer_latency_s is not None and transfer_latency_s > 0:
             latency_ms = transfer_latency_s * 1000
 
             total_bytes = transfer_metric.transfer_total_bytes

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -583,6 +583,7 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
     # other
     transfer_speed_gb_s: float = 0.0
     transfer_total_mb: float = 0.0
+    kv_transfer_metrics: Optional[dict] = None
     # Number of prefill retries for this request
     prefill_retry_count: int = 0
 
@@ -914,7 +915,8 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
                     alloc_ms=alloc_ms,
                 )
 
-        return result if result else None
+        self.kv_transfer_metrics = result if result else None
+        return self.kv_transfer_metrics
 
     def set_quick_finish_time(self, ts=None):
         ts = ts or time.perf_counter()
@@ -1127,6 +1129,8 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
                 "prefill_launch_latency": self.get_prefill_launch_latency(),
             }
         )
+        if self.kv_transfer_metrics:
+            meta_data["kv_transfer"] = self.kv_transfer_metrics
         return meta_data
 
     def format_duration(self, duration: float) -> str:

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -115,6 +115,9 @@ class SchedulerMetricsMixin:
         # For PD disaggregation
         self.kv_transfer_speed_gb_s: float = 0.0
         self.kv_transfer_latency_ms: float = 0.0
+        self.kv_transfer_total_mb: float = 0.0
+        self.kv_transfer_bootstrap_ms: float = 0.0
+        self.kv_transfer_alloc_ms: float = 0.0
 
         # Metrics
         self.enable_metrics = self.server_args.enable_metrics
@@ -460,6 +463,9 @@ class SchedulerMetricsMixin:
                 )
                 self.stats.kv_transfer_speed_gb_s = self.kv_transfer_speed_gb_s
                 self.stats.kv_transfer_latency_ms = self.kv_transfer_latency_ms
+                self.stats.kv_transfer_total_mb = self.kv_transfer_total_mb
+                self.stats.kv_transfer_bootstrap_ms = self.kv_transfer_bootstrap_ms
+                self.stats.kv_transfer_alloc_ms = self.kv_transfer_alloc_ms
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
                 self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
                     self.disagg_decode_prealloc_queue.queue, priority_enabled
@@ -904,6 +910,9 @@ class SchedulerMetricsMixin:
                 decode_retracted_queue_reqs=decode_retracted,
                 kv_transfer_speed_gb_s=self.stats.kv_transfer_speed_gb_s,
                 kv_transfer_latency_ms=self.stats.kv_transfer_latency_ms,
+                kv_transfer_total_mb=self.stats.kv_transfer_total_mb,
+                kv_transfer_bootstrap_ms=self.stats.kv_transfer_bootstrap_ms,
+                kv_transfer_alloc_ms=self.stats.kv_transfer_alloc_ms,
             )
 
         queues = None

--- a/test/registered/unit/observability/test_disaggregation_load_metrics.py
+++ b/test/registered/unit/observability/test_disaggregation_load_metrics.py
@@ -1,0 +1,36 @@
+"""Unit tests for disaggregation load metric payload fields."""
+
+import dataclasses
+import unittest
+
+from sglang.srt.managers.io_struct import DisaggregationMetrics
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestDisaggregationMetrics(CustomTestCase):
+    def test_kv_transfer_load_fields_are_serializable(self):
+        metrics = DisaggregationMetrics(
+            mode="prefill",
+            kv_transfer_latency_ms=100.0,
+            kv_transfer_speed_gb_s=1.5,
+            kv_transfer_total_mb=16.0,
+            kv_transfer_bootstrap_ms=2.5,
+            kv_transfer_alloc_ms=1.0,
+        )
+
+        payload = dataclasses.asdict(metrics)
+
+        self.assertEqual(payload["kv_transfer_latency_ms"], 100.0)
+        self.assertEqual(payload["kv_transfer_speed_gb_s"], 1.5)
+        self.assertEqual(payload["kv_transfer_total_mb"], 16.0)
+        self.assertEqual(payload["kv_transfer_bootstrap_ms"], 2.5)
+        self.assertEqual(payload["kv_transfer_alloc_ms"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/observability/test_req_time_stats_kv_transfer.py
+++ b/test/registered/unit/observability/test_req_time_stats_kv_transfer.py
@@ -1,0 +1,127 @@
+"""Unit tests for disaggregated KV transfer metric computation."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.disaggregation.base.conn import KVTransferMetric
+from sglang.srt.observability.req_time_stats import SchedulerReqTimeStats
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+_TRANSFER_BYTES = 16 * 1024 * 1024
+
+
+def _make_stats(
+    queue_entry: float = 1.0,
+    transfer_finish: float = 1.1,
+    completion: float = 6.1,
+    enable_metrics: bool = False,
+) -> SchedulerReqTimeStats:
+    stats = SchedulerReqTimeStats()
+    stats.prefill_transfer_queue_entry_time = queue_entry
+    stats.prefill_kv_transfer_finish_time = transfer_finish
+    stats.completion_time = completion
+    stats.enable_metrics = enable_metrics
+    return stats
+
+
+class TestKVTransferMetrics(CustomTestCase):
+    def test_backend_latency_is_used_instead_of_completion_time(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.1, completion=6.1)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(
+                transfer_latency_s=0.25,
+                transfer_total_bytes=_TRANSFER_BYTES,
+            )
+        )
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["latency_ms"], 250.0, places=3)
+
+    def test_timestamp_fallback_uses_transfer_finish_not_completion(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.1, completion=6.1)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["latency_ms"], 100.0, places=3)
+        self.assertLess(result["latency_ms"], 200.0)
+
+    def test_timestamp_fallback_does_not_require_completion_time(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.2, completion=0.0)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["latency_ms"], 200.0, places=3)
+
+    def test_missing_transfer_finish_returns_none_for_transfer_metrics(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=0.0, completion=6.0)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        self.assertIsNone(result)
+
+    def test_missing_transfer_bytes_do_not_crash_request_path(self):
+        stats = _make_stats()
+        result = stats.compute_and_observe_kv_transfer_metrics(KVTransferMetric())
+
+        self.assertIsNone(result)
+
+    def test_zero_transfer_bytes_are_reported_without_crashing(self):
+        stats = _make_stats()
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_latency_s=0.1, transfer_total_bytes=0)
+        )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["total_mb"], 0.0)
+        self.assertEqual(result["speed_gb_s"], 0.0)
+
+    def test_speed_uses_selected_latency(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.016, completion=6.016)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        expected_speed = (16.0 / 1024) / 0.016
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result["speed_gb_s"], expected_speed, places=4)
+
+    def test_metrics_observer_called_when_enabled(self):
+        stats = _make_stats(enable_metrics=True)
+        mock_collector = MagicMock()
+        stats.metrics_collector = mock_collector
+
+        stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(
+                transfer_latency_s=0.5, transfer_total_bytes=_TRANSFER_BYTES
+            )
+        )
+
+        mock_collector.observe_kv_transfer_metrics.assert_called_once()
+        call_kwargs = mock_collector.observe_kv_transfer_metrics.call_args.kwargs
+        self.assertAlmostEqual(call_kwargs["latency_ms"], 500.0, places=3)
+
+    def test_metrics_observer_not_called_when_disabled(self):
+        stats = _make_stats(enable_metrics=False)
+        mock_collector = MagicMock()
+        stats.metrics_collector = mock_collector
+
+        stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(
+                transfer_latency_s=0.5, transfer_total_bytes=_TRANSFER_BYTES
+            )
+        )
+
+        mock_collector.observe_kv_transfer_metrics.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/observability/test_req_time_stats_kv_transfer.py
+++ b/test/registered/unit/observability/test_req_time_stats_kv_transfer.py
@@ -122,6 +122,32 @@ class TestKVTransferMetrics(CustomTestCase):
 
         mock_collector.observe_kv_transfer_metrics.assert_not_called()
 
+    def test_kv_transfer_metrics_are_exported_in_meta_info(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=1.2, completion=6.0)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        meta_info = stats.convert_to_output_meta_info()
+
+        self.assertIsNotNone(result)
+        self.assertIn("kv_transfer", meta_info)
+        self.assertEqual(meta_info["kv_transfer"], result)
+        self.assertAlmostEqual(
+            meta_info["kv_transfer"]["latency_ms"], 200.0, places=3
+        )
+
+    def test_kv_transfer_meta_info_is_omitted_when_metrics_missing(self):
+        stats = _make_stats(queue_entry=1.0, transfer_finish=0.0, completion=6.0)
+        result = stats.compute_and_observe_kv_transfer_metrics(
+            KVTransferMetric(transfer_total_bytes=_TRANSFER_BYTES)
+        )
+
+        meta_info = stats.convert_to_output_meta_info()
+
+        self.assertIsNone(result)
+        self.assertNotIn("kv_transfer", meta_info)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/registered/unit/observability/test_request_metrics_exporter.py
+++ b/test/registered/unit/observability/test_request_metrics_exporter.py
@@ -190,6 +190,25 @@ class TestFormatOutputData(unittest.TestCase):
         self.assertIn("latency", result)
         self.assertNotIn("secret", result)
 
+    def test_preserves_nested_kv_transfer_meta_info(self):
+        server_args = _make_server_args("/tmp/unused")
+        exporter = _ConcreteExporter(
+            server_args, obj_skip_names=None, out_skip_names=None
+        )
+
+        obj = _GenerateReqInput(rid="req-1")
+        kv_transfer = {
+            "latency_ms": 125.0,
+            "total_mb": 16.0,
+            "speed_gb_s": 0.125,
+            "bootstrap_ms": 3.0,
+            "alloc_ms": 2.0,
+        }
+        out_dict = {"meta_info": {"kv_transfer": kv_transfer}}
+        result = exporter._format_output_data(obj, out_dict)
+
+        self.assertEqual(result["kv_transfer"], kv_transfer)
+
 
 class TestFileRequestMetricsExporter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

This is a small stacked follow-up to #24416 / #23937.

It keeps the backend-owned `KVTransferMetric` direction from #24416 and makes the corrected transfer metrics easier to consume from request-level and load-metric surfaces:

- use backend-provided `transfer_latency_s` when available
- fall back to `prefill_transfer_queue_entry_time -> prefill_kv_transfer_finish_time`, not request completion time
- avoid asserting when optional backend metrics omit `transfer_total_bytes`
- add request-level `meta_info["kv_transfer"]` when transfer metrics are available
- preserve nested KV transfer metadata in request metrics export
- expose last-observed transfer size, bootstrap time, and allocation time in disaggregation load metrics
- add CPU unit coverage for fallback timing, missing values, exporter serialization, and load metric payloads

## Why

#23937 is about KV transfer latency and speed including non-transfer request time. #24416 fixes the core metric contract by letting backends provide transfer metrics.

This follow-up makes those corrected values visible to benchmark tools and operators without changing the backend metric contract.

## Validation

- `rtk git diff --check`
- `rtk env PYTHONPYCACHEPREFIX=/tmp/sglang-pycache python3 -m py_compile python/sglang/srt/disaggregation/prefill.py python/sglang/srt/managers/io_struct.py python/sglang/srt/observability/metrics_collector.py python/sglang/srt/observability/req_time_stats.py python/sglang/srt/observability/scheduler_metrics_mixin.py test/registered/unit/observability/test_req_time_stats_kv_transfer.py test/registered/unit/observability/test_disaggregation_load_metrics.py test/registered/unit/observability/test_request_metrics_exporter.py`

Attempted targeted pytest locally:

```bash
PYTHONPATH=python python3 -m pytest \
  test/registered/unit/observability/test_req_time_stats_kv_transfer.py \
  test/registered/unit/observability/test_disaggregation_load_metrics.py \
  test/registered/unit/observability/test_request_metrics_exporter.py -q
```

The local system Python environment is missing SGLang runtime dependency `orjson`, so collection cannot run outside the SGLang dev/CI environment here.
