### PR TITLE
[vlm] declarative HF_KEY_RENAMES on the base mm processor

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1030,7 +1030,26 @@ class BaseMultimodalProcessor(ABC):
         these are later split into per-image/video items by get_new_expanded_mm_items.
 
         Note that the data_dict can be passed via offline engine api
+
+        Subclasses can declare a ``HF_KEY_RENAMES`` mapping to translate model-
+        specific HF processor output keys to sglang-standard names before the
+        ATTR_NAME_TO_MODALITY lookup. Example::
+
+            class Phi4MMMultimodalProcessor(BaseMultimodalProcessor):
+                HF_KEY_RENAMES = {
+                    "input_image_embeds": "pixel_values",
+                    "input_audio_embeds": "audio_features",
+                    "audio_embed_sizes": "audio_feature_lens",
+                }
+
+        Without the rename, HF-native keys outside ATTR_NAME_TO_MODALITY are
+        silently dropped — the per-modality mm_item is then created without
+        ``feature`` set, and the model's get_*_feature blows up downstream.
         """
+
+        renames = getattr(self, "HF_KEY_RENAMES", None)
+        if renames:
+            data_dict = {renames.get(k, k): v for k, v in data_dict.items()}
 
         items: dict[Modality, MultimodalDataItem] = {}
         for attr_name, value in data_dict.items():

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -192,6 +192,7 @@ class MultimodalSpecialTokens:
 
 class BaseMultimodalProcessor(ABC):
     models = []
+    HF_KEY_RENAMES: dict[str, str] = {}
     gpu_image_decode = True  # Enable GPU decoding by default
     prefer_tokenized_input = False
     precompute_hash_before_cpu_transfer = False
@@ -1364,6 +1365,12 @@ class BaseMultimodalProcessor(ABC):
         Args:
             modality: if provided, force the data into a single MultimodalDataItem of that modality
         """
+
+        if self.HF_KEY_RENAMES:
+            data_dict = dict(data_dict)
+            for hf_key, attr_name in self.HF_KEY_RENAMES.items():
+                if hf_key in data_dict:
+                    data_dict[attr_name] = data_dict.pop(hf_key)
 
         # universal getter for data_dict
         get_data_value = (

--- a/python/sglang/srt/multimodal/processors/phi4mm.py
+++ b/python/sglang/srt/multimodal/processors/phi4mm.py
@@ -22,20 +22,11 @@ class Phi4MMProcessorAdapter(ProcessorMixin):
     def __call__(self, **kwargs):
         result = self._processor(**kwargs)
 
-        # Map HuggingFace output keys to sglang standard keys
-        key_mapping = {
-            "input_image_embeds": "pixel_values",
-            "input_audio_embeds": "audio_features",
-            "audio_embed_sizes": "audio_feature_lens",
-        }
-        for hf_key, sglang_key in key_mapping.items():
-            if hf_key in result:
-                result[sglang_key] = result[hf_key]
-                del result[hf_key]
-
         # Filter out None or empty tensors from the result.
         # This prevents the sglang function base_processor.collect_mm_items_from_processor_output()
         # from misclassifying audio content as image content, and vice versa.
+        # (HF Phi-4-native key names like input_image_embeds are translated to
+        # sglang-standard names by the base class via HF_KEY_RENAMES below.)
         filtered_result = {
             k: v
             for k, v in result.items()
@@ -46,6 +37,16 @@ class Phi4MMProcessorAdapter(ProcessorMixin):
 
 class Phi4MMMultimodalProcessor(BaseMultimodalProcessor):
     models = [Phi4MMForCausalLM]
+
+    # HF Phi-4-native processor keys → sglang-standard names. Applied by the
+    # base class in collect_mm_items_from_processor_output before the
+    # ATTR_NAME_TO_MODALITY lookup; without this, the IMAGE / AUDIO mm_items
+    # come out without `feature` set and the model crashes downstream.
+    HF_KEY_RENAMES = {
+        "input_image_embeds": "pixel_values",
+        "input_audio_embeds": "audio_features",
+        "audio_embed_sizes": "audio_feature_lens",
+    }
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         self.processor = Phi4MMProcessorAdapter(_processor)

--- a/python/sglang/srt/multimodal/processors/phi4mm.py
+++ b/python/sglang/srt/multimodal/processors/phi4mm.py
@@ -22,17 +22,6 @@ class Phi4MMProcessorAdapter(ProcessorMixin):
     def __call__(self, **kwargs):
         result = self._processor(**kwargs)
 
-        # Map HuggingFace output keys to sglang standard keys
-        key_mapping = {
-            "input_image_embeds": "pixel_values",
-            "input_audio_embeds": "audio_features",
-            "audio_embed_sizes": "audio_feature_lens",
-        }
-        for hf_key, sglang_key in key_mapping.items():
-            if hf_key in result:
-                result[sglang_key] = result[hf_key]
-                del result[hf_key]
-
         # Filter out None or empty tensors from the result.
         # This prevents the sglang function base_processor.collect_mm_items_from_processor_output()
         # from misclassifying audio content as image content, and vice versa.
@@ -46,6 +35,12 @@ class Phi4MMProcessorAdapter(ProcessorMixin):
 
 class Phi4MMMultimodalProcessor(BaseMultimodalProcessor):
     models = [Phi4MMForCausalLM]
+
+    HF_KEY_RENAMES: dict[str, str] = {
+        "input_image_embeds": "pixel_values",
+        "input_audio_embeds": "audio_features",
+        "audio_embed_sizes": "audio_feature_lens",
+    }
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         self.processor = Phi4MMProcessorAdapter(_processor)

--- a/test/registered/unit/multimodal/test_phi4mm_processor.py
+++ b/test/registered/unit/multimodal/test_phi4mm_processor.py
@@ -1,0 +1,73 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Modality, MultimodalInputFormat
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultiModalProcessorOutput,
+    MultimodalSpecialTokens,
+)
+from sglang.srt.multimodal.processors.phi4mm import Phi4MMMultimodalProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPhi4MMProcessorOutput(unittest.TestCase):
+    @staticmethod
+    def _make_processor() -> Phi4MMMultimodalProcessor:
+        processor = object.__new__(Phi4MMMultimodalProcessor)
+        processor.ATTR_NAME_TO_MODALITY = {
+            "pixel_values": Modality.IMAGE,
+            "audio_features": Modality.AUDIO,
+            "audio_feature_lens": Modality.AUDIO,
+        }
+        processor.FEATURE_NAMES = ["pixel_values", "audio_features"]
+        processor._processor = object()
+        processor._tokenizer = lambda *args, **kwargs: SimpleNamespace(
+            input_ids=torch.tensor([200010, 200011])
+        )
+        processor.use_cuda_ipc = False
+        processor.precompute_hash_before_cpu_transfer = False
+        return processor
+
+    def test_offline_processor_output_uses_hf_key_renames(self) -> None:
+        image_features = torch.arange(4).reshape(1, 4)
+        audio_features = torch.arange(6).reshape(1, 6)
+        audio_feature_lens = torch.tensor([6])
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": [200010, 200011],
+            "input_image_embeds": image_features,
+            "input_audio_embeds": audio_features,
+            "audio_embed_sizes": audio_feature_lens,
+        }
+        processor = self._make_processor()
+
+        items, input_ids, _ = processor.process_and_combine_mm_data(
+            base_output=BaseMultiModalProcessorOutput(
+                input_text="",
+                images=[processor_output],
+            ),
+            mm_tokens=MultimodalSpecialTokens(
+                image_token_id=200010,
+                audio_token_id=200011,
+            ),
+        )
+        items_by_modality = {item.modality: item for item in items}
+        self.assertEqual(input_ids.tolist(), [200010, 200011])
+        self.assertEqual(
+            items_by_modality[Modality.IMAGE].format,
+            MultimodalInputFormat.PROCESSOR_OUTPUT,
+        )
+        self.assertIs(items_by_modality[Modality.IMAGE].feature, image_features)
+        self.assertIs(items_by_modality[Modality.AUDIO].feature, audio_features)
+        self.assertIs(
+            items_by_modality[Modality.AUDIO].audio_feature_lens,
+            audio_feature_lens,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Some VLMs' HF processors return model-specific keys (Phi-4 returns `input_image_embeds`, `input_audio_embeds`, `audio_embed_sizes`) that aren't in `ATTR_NAME_TO_MODALITY`. The PROCESSOR_OUTPUT input-format path hands the raw HF dict to `BaseMultimodalProcessor.collect_mm_items_from_processor_output`, which silently drops keys it doesn't recognize. The IMAGE / AUDIO mm_item is then created without `feature` set, and `get_image_feature` crashes with `expected Tensor ... got NoneType`.

The Phi-4 adapter renamed these in `__call__` for the NORMAL path (sglang-drives-the-processor), but PROCESSOR_OUTPUT skips that. Lift the rename to a declarative `HF_KEY_RENAMES` class attribute the base class applies before walking `ATTR_NAME_TO_MODALITY`, so both paths converge.

Future trust_remote_code processors with non-standard HF keys can opt in by declaring `HF_KEY_RENAMES = {...}` on their subclass.

Companion to #24469 (phi4mm input-format support). Sibling pattern surfaced during the phi4mm investigation; this is the structural fix while #24469 carries the localized version. Once both land, #24469 can be rebased to drop the override in favor of the declaration.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci)
- [x] Update documentation / docstrings as needed
- [x] Add tests to ensure the change is correctly integrated.
- [x] Provide a meaningful PR description

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32777834253](https://github.com/sgl-project/sglang/actions/runs/32777834253)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32777833628](https://github.com/sgl-project/sglang/actions/runs/32777833628)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32777833913](https://github.com/sgl-project/sglang/actions/runs/32777833913)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->