### PR TITLE
Return the caller's embedding for Llama 4 precomputed image input

### DIFF
--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -30,6 +30,7 @@ from sglang.srt.managers.mm_utils import (
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
+    MultimodalInputFormat,
     MultimodalInputs,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -542,13 +543,15 @@ class Llama4ForConditionalGeneration(nn.Module):
         self,
         items: List[MultimodalDataItem],
     ) -> torch.Tensor:
-        from sglang.srt.managers.schedule_batch import MultimodalInputFormat
 
         # Pre-projected embeddings supplied by the caller (e.g. RL workflows,
         # disaggregated serving): skip the vision tower + projector entirely.
         if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
-            return torch.cat(
-                [item.feature.view(-1, item.feature.shape[-1]) for item in items],
+            return torch.concat(
+                [
+                    torch.as_tensor(item.feature).view(-1, item.feature.shape[-1])
+                    for item in items
+                ],
                 dim=0,
             )
 

--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -542,6 +542,16 @@ class Llama4ForConditionalGeneration(nn.Module):
         self,
         items: List[MultimodalDataItem],
     ) -> torch.Tensor:
+        from sglang.srt.managers.schedule_batch import MultimodalInputFormat
+
+        # Pre-projected embeddings supplied by the caller (e.g. RL workflows,
+        # disaggregated serving): skip the vision tower + projector entirely.
+        if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
+            return torch.cat(
+                [item.feature.view(-1, item.feature.shape[-1]) for item in items],
+                dim=0,
+            )
+
         # For text-only models, return None or raise an error
         if not self.has_vision or self.vision_model is None:
             raise ValueError("Vision model not available for text-only checkpoint")

--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -30,6 +30,7 @@ from sglang.srt.managers.mm_utils import (
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
+    MultimodalInputFormat,
     MultimodalInputs,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -575,6 +576,9 @@ class Llama4ForConditionalGeneration(nn.Module):
         # For text-only models, return None or raise an error
         if not self.has_vision or self.vision_model is None:
             raise ValueError("Vision model not available for text-only checkpoint")
+        if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
+            result = torch.cat([item.feature for item in items])
+            return result.reshape(-1, result.shape[-1])
         pixel_values = (
             torch.concat([item.feature for item in items])
             .to(next(self.vision_model.parameters()).device)

--- a/test/registered/unit/models/test_mllama4_precomputed_embedding.py
+++ b/test/registered/unit/models/test_mllama4_precomputed_embedding.py
@@ -1,0 +1,109 @@
+"""CPU-only coverage for Llama 4 precomputed embedding inputs."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputFormat,
+)
+from sglang.srt.models.mllama4 import Llama4ForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _VisionTower(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+        self.weight = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+    def forward(self, pixel_values):
+        self.calls.append(pixel_values)
+        return pixel_values.unsqueeze(0)
+
+
+class _Projector(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    def forward(self, vision_flat):
+        self.calls.append(vision_flat)
+        return vision_flat
+
+
+def _bare_model():
+    model = Llama4ForConditionalGeneration.__new__(Llama4ForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.has_vision = True
+    model.vision_model = _VisionTower()
+    model.multi_modal_projector = _Projector()
+    return model
+
+
+def _precomputed_item(feature):
+    return MultimodalDataItem(
+        modality=Modality.IMAGE,
+        offsets=[(0, feature.shape[0] - 1)],
+        feature=feature,
+        format=MultimodalInputFormat.PRECOMPUTED_EMBEDDING,
+    )
+
+
+class TestLlama4PrecomputedEmbedding(CustomTestCase):
+    def test_returns_embedding_without_entering_vision_tower(self):
+        model = _bare_model()
+        embedding = torch.arange(24, dtype=torch.float32).reshape(3, 8)
+
+        out = model.get_image_feature([_precomputed_item(embedding)])
+
+        self.assertTrue(torch.equal(out, embedding))
+        self.assertEqual(model.vision_model.calls, [])
+        self.assertEqual(model.multi_modal_projector.calls, [])
+
+    def test_concatenates_multiple_items(self):
+        model = _bare_model()
+        first = torch.ones(2, 8)
+        second = torch.full((3, 8), 2.0)
+
+        out = model.get_image_feature(
+            [_precomputed_item(first), _precomputed_item(second)]
+        )
+
+        self.assertEqual(out.shape, (5, 8))
+        self.assertTrue(torch.equal(out, torch.cat([first, second])))
+        self.assertEqual(model.vision_model.calls, [])
+
+    def test_flattens_batched_embedding_to_two_dims(self):
+        model = _bare_model()
+        embedding = torch.arange(48, dtype=torch.float32).reshape(2, 3, 8)
+
+        out = model.get_image_feature([_precomputed_item(embedding)])
+
+        self.assertEqual(out.shape, (6, 8))
+        self.assertTrue(torch.equal(out, embedding.reshape(6, 8)))
+        self.assertEqual(model.vision_model.calls, [])
+
+    def test_pixel_values_still_go_through_vision_tower(self):
+        model = _bare_model()
+        pixel_values = torch.ones(2, 8)
+        item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 1)],
+            feature=pixel_values,
+        )
+
+        out = model.get_image_feature([item])
+
+        self.assertEqual(len(model.vision_model.calls), 1)
+        self.assertEqual(len(model.multi_modal_projector.calls), 1)
+        self.assertEqual(out.shape, (2, 8))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

A caller can skip the vision tower by passing an already-computed image embedding
as image data, using the public precomputed-embedding input format. On Llama 4
that embedding was re-encoded instead of used.

The multimodal processor stores the supplied embedding under the item's `feature`
attribute and tags the item as precomputed. It leaves the older
`precomputed_embeddings` attribute unset, and the scheduler's central bypass only
short-circuits on that older attribute. The item therefore falls through to the
model, and Llama 4's image-feature hook had no precomputed branch to catch it.

**Before:** the embedding is run through the vision tower and projector.
**After:** it is returned unchanged; the vision tower is never entered.

This is the Llama 4 entry in #6483. #8156 moved Llama 4 onto generic processor
handling but did not bridge the two attributes.

## Modifications

The early return already used by the MiniCPM-V and MiniCPM-o models, unchanged:

```python
if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
    result = torch.cat([item.feature for item in items])
    return result.reshape(-1, result.shape[-1])
```

As in both references the branch is chosen from the first item, so a single encode
batch mixing precomputed and raw items is unsupported. That comes from the shared
scheduler batching path, not from this change.

## Accuracy Tests

The raw-pixel path is untouched. Restoring only the changed source file turns the
new test red, showing the vision tower being entered:

```
$ SRC=python/sglang/srt/models/mllama4.py
$ TEST=test/registered/unit/models/test_mllama4_precomputed_embedding.py

$ git checkout origin/main -- $SRC && pytest $TEST
E AssertionError: Lists differ: [tensor([[1., 1., ...]])] != []   # tower entered
3 failed, 1 passed

$ git checkout HEAD -- $SRC && pytest $TEST
4 passed
```

Run on CPU; no GPU was available, so this is not a live generation.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
