### PR TITLE
ci: drop 1-gpu-h100-h200 shared label

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -830,10 +830,7 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    # `1-gpu-h100-h200` is a shared label advertised by both the 1-GPU H100 and
-    # 1-GPU H200 runner pools, so this job can land on either. Multimodal_gen
-    # jobs in pr-test-multimodal-gen.yml continue to pin to `1-gpu-h100`.
-    runs-on: 1-gpu-h100-h200
+    runs-on: 1-gpu-h100
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -14,7 +14,6 @@ on:
         type: choice
         options:
           - 1-gpu-h100
-          - 1-gpu-h100-h200
           - 1-gpu-5090
           - 2-gpu-h100
           - 4-gpu-h100

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -478,7 +478,7 @@ CUDA_SUITE_TO_RUNNER = {
     "stage-a-test-1-gpu-small": "1-gpu-5090",
     "stage-a-test-cpu": "ubuntu-latest",
     "stage-b-test-1-gpu-small": "1-gpu-5090",
-    "stage-b-test-1-gpu-large": "1-gpu-h100-h200",
+    "stage-b-test-1-gpu-large": "1-gpu-h100",
     "stage-b-test-2-gpu-large": "2-gpu-h100",
     "stage-b-test-4-gpu-b200": "4-gpu-b200",
     "stage-c-test-4-gpu-h100": "4-gpu-h100",


### PR DESCRIPTION
## Summary
- `1-gpu-h100-h200` was a shared label advertised across both the 1-GPU H100 and 1-GPU H200 runner pools. The 1-GPU H200 pool has been retired, so the shared alias no longer has a second backing pool.
- Without this change, `stage-b-test-1-gpu-large` was bottlenecked on the 8 runners that still carried the legacy shared label, instead of dispatching across the full ~32-runner 1-GPU H100 fleet.
- Switches `stage-b-test-1-gpu-large` to `runs-on: 1-gpu-h100`, drops the label from the `rerun-test` workflow input choices, and updates `CUDA_SUITE_TO_RUNNER` in `slash_command_handler.py`.
- Runner-side: the label has already been removed from all 8 runners that advertised it.

## Test plan
- [ ] Trigger a PR run and confirm `stage-b-test-1-gpu-large` partitions distribute across the full 1-GPU H100 fleet.
- [ ] Confirm `/rerun-test` no longer offers `1-gpu-h100-h200` in the runner-label dropdown.