### PR TITLE
fix(server_args): reject outlines grammar backend with speculative decoding

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2812,6 +2812,20 @@ class ServerArgs:
         if self.grammar_backend is None:
             self.grammar_backend = "xgrammar"
 
+        if (
+            self.grammar_backend == "outlines"
+            and self.speculative_algorithm is not None
+        ):
+            raise ValueError(
+                f"Grammar backend 'outlines' is incompatible with speculative decoding "
+                f"(--speculative-algorithm {self.speculative_algorithm}). "
+                f"The Outlines grammar object does not implement rollback() and uses "
+                f"a dense bool mask instead of the packed int32 bitmask that the "
+                f"speculative verifier expects. "
+                f"Please use --grammar-backend xgrammar or --grammar-backend llguidance "
+                f"for grammar-constrained generation with speculative decoding."
+            )
+
     def _handle_mamba_backend(self):
         if self.mamba_backend == "flashinfer":
             if is_flashinfer_available():

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -518,43 +518,46 @@ class TestNgramExternalSamArgs(CustomTestCase):
 class TestGrammarBackendSpeculativeGuard(unittest.TestCase):
     """Tests for _handle_grammar_backend: outlines + speculative → ValueError (issue #24413)."""
 
+    def _make_args(self, **overrides):
+        args = ServerArgs(model_path="dummy")
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
     def test_outlines_with_speculative_raises(self):
         with self.assertRaises(ValueError) as context:
-            ServerArgs(
-                model_path="dummy",
+            self._make_args(
                 grammar_backend="outlines",
                 speculative_algorithm="EAGLE",
-            )
+            )._handle_grammar_backend()
         self.assertIn("outlines", str(context.exception))
         self.assertIn("incompatible with speculative decoding", str(context.exception))
 
     def test_outlines_with_ngram_speculative_raises(self):
         with self.assertRaises(ValueError) as context:
-            ServerArgs(
-                model_path="dummy",
+            self._make_args(
                 grammar_backend="outlines",
                 speculative_algorithm="NGRAM",
-            )
+            )._handle_grammar_backend()
         self.assertIn("outlines", str(context.exception))
 
     def test_xgrammar_with_speculative_allowed(self):
-        server_args = ServerArgs(
-            model_path="dummy",
+        args = self._make_args(
             grammar_backend="xgrammar",
             speculative_algorithm="EAGLE",
         )
-        self.assertEqual(server_args.grammar_backend, "xgrammar")
+        args._handle_grammar_backend()
+        self.assertEqual(args.grammar_backend, "xgrammar")
 
     def test_outlines_without_speculative_allowed(self):
-        server_args = ServerArgs(
-            model_path="dummy",
-            grammar_backend="outlines",
-        )
-        self.assertEqual(server_args.grammar_backend, "outlines")
+        args = self._make_args(grammar_backend="outlines")
+        args._handle_grammar_backend()
+        self.assertEqual(args.grammar_backend, "outlines")
 
     def test_default_grammar_backend_is_xgrammar(self):
-        server_args = ServerArgs(model_path="dummy")
-        self.assertEqual(server_args.grammar_backend, "xgrammar")
+        args = self._make_args()
+        args._handle_grammar_backend()
+        self.assertEqual(args.grammar_backend, "xgrammar")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -515,5 +515,47 @@ class TestNgramExternalSamArgs(CustomTestCase):
         self.assertIn("external-corpus-max-tokens", str(context.exception))
 
 
+class TestGrammarBackendSpeculativeGuard(unittest.TestCase):
+    """Tests for _handle_grammar_backend: outlines + speculative → ValueError (issue #24413)."""
+
+    def test_outlines_with_speculative_raises(self):
+        with self.assertRaises(ValueError) as context:
+            ServerArgs(
+                model_path="dummy",
+                grammar_backend="outlines",
+                speculative_algorithm="EAGLE",
+            )
+        self.assertIn("outlines", str(context.exception))
+        self.assertIn("incompatible with speculative decoding", str(context.exception))
+
+    def test_outlines_with_ngram_speculative_raises(self):
+        with self.assertRaises(ValueError) as context:
+            ServerArgs(
+                model_path="dummy",
+                grammar_backend="outlines",
+                speculative_algorithm="NGRAM",
+            )
+        self.assertIn("outlines", str(context.exception))
+
+    def test_xgrammar_with_speculative_allowed(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            grammar_backend="xgrammar",
+            speculative_algorithm="EAGLE",
+        )
+        self.assertEqual(server_args.grammar_backend, "xgrammar")
+
+    def test_outlines_without_speculative_allowed(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            grammar_backend="outlines",
+        )
+        self.assertEqual(server_args.grammar_backend, "outlines")
+
+    def test_default_grammar_backend_is_xgrammar(self):
+        server_args = ServerArgs(model_path="dummy")
+        self.assertEqual(server_args.grammar_backend, "xgrammar")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #24413

SGLang currently accepts requests that combine speculative decoding with `--grammar-backend outlines`, but this combination crashes at runtime because:

1. `OutlinesGrammar` does not implement `rollback()`, which the speculative DFS verifier requires
2. Outlines uses a dense `torch.bool` mask, but `spec_utils.traverse_tree()` expects packed int32 bitmasks
3. The packed-bit membership check indexes `token_id // 32`, incompatible with Outlines' direct indexing

## Modifications

Add a startup-time guard in `ServerArgs._handle_grammar_backend()` that raises `ValueError` when `--grammar-backend outlines` is used together with any `--speculative-algorithm`. This fails fast at server launch with a clear error message suggesting `xgrammar` or `llguidance` as alternatives.

**Files changed:** 2 files, +56 lines
- `python/sglang/srt/server_args.py` — guard logic (+14 lines)
- `test/registered/unit/server_args/test_server_args.py` — 5 unit tests (+42 lines)

## Tests

Added `TestGrammarBackendSpeculativeGuard` with 5 test cases:
- `outlines` + EAGLE → raises ValueError
- `outlines` + NGRAM → raises ValueError
- `xgrammar` + EAGLE → no error (unaffected)
- `outlines` without speculative → no error
- Default backend (xgrammar) + speculative → no error