### PR TITLE
[PD] Fix missing update_status call in abort() across all KV backends

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -544,7 +544,7 @@ class CommonKVSender(BaseKVSender):
             self.bootstrap_room,
             "Aborted by AbortReq.",
         )
-        # Explicitly set the status to failure since this request has been aborted
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.conclude_state = KVPoll.Failed
 
 
@@ -739,7 +739,7 @@ class CommonKVReceiver(BaseKVReceiver):
             self.bootstrap_room,
             "Aborted by AbortReq.",
         )
-        # Explicitly set the status to failure since this request has been aborted
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.conclude_state = KVPoll.Failed
 
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1753,13 +1753,6 @@ class MooncakeKVSender(CommonKVSender):
             )
         raise KVTransferError(self.bootstrap_room, failure_reason)
 
-    def abort(self):
-        self.kv_mgr.record_failure(
-            self.bootstrap_room,
-            "Aborted by AbortReq.",
-        )
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
-        self.conclude_state = KVPoll.Failed
 
 
 class MooncakeKVReceiver(CommonKVReceiver):
@@ -1942,13 +1935,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
             )
         raise KVTransferError(self.bootstrap_room, failure_reason)
 
-    def abort(self):
-        self.kv_mgr.record_failure(
-            self.bootstrap_room,
-            "Aborted by AbortReq.",
-        )
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
-        self.conclude_state = KVPoll.Failed
 
 
 class MooncakeKVBootstrapServer(CommonKVBootstrapServer):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1758,7 +1758,7 @@ class MooncakeKVSender(CommonKVSender):
             self.bootstrap_room,
             "Aborted by AbortReq.",
         )
-        # Explicitly set the status to failure since this request has been aborted
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.conclude_state = KVPoll.Failed
 
 
@@ -1947,7 +1947,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
             self.bootstrap_room,
             "Aborted by AbortReq.",
         )
-        # Explicitly set the status to failure since this request has been aborted
+        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.conclude_state = KVPoll.Failed
 
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1754,7 +1754,6 @@ class MooncakeKVSender(CommonKVSender):
         raise KVTransferError(self.bootstrap_room, failure_reason)
 
 
-
 class MooncakeKVReceiver(CommonKVReceiver):
     def __init__(
         self,
@@ -1934,7 +1933,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
                 self.bootstrap_room, "Failed due to an unknown reason from another rank"
             )
         raise KVTransferError(self.bootstrap_room, failure_reason)
-
 
 
 class MooncakeKVBootstrapServer(CommonKVBootstrapServer):

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1107,7 +1107,6 @@ class MoriKVReceiver(CommonKVReceiver):
         if self.bootstrap_room is None:
             return
         super().abort()
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         self.clear()
 
 

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -859,6 +859,7 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         else:
             if self.prefill_transfer_queue_entry_time <= 0 or self.completion_time <= 0:
                 return result if result else None
+            # Note: This only capture the last chunk time
             transfer_latency_s = (
                 self.completion_time - self.prefill_transfer_queue_entry_time
             )


### PR DESCRIPTION
## Summary
- All `abort()` methods across KV sender/receiver implementations should call `update_status(Failed)` to propagate failure to the manager's shared `request_status` dictionary — not just set the local `conclude_state` latch.
- **Common** (`CommonKVSender`, `CommonKVReceiver`): replaced dangling comments with actual `update_status()` calls. Nixl inherits these.
- **Mooncake** (`MooncakeKVSender`, `MooncakeKVReceiver`): removed redundant `abort()` overrides that were identical to the parent. They now inherit the fixed Common implementation. Ascend inherits from Mooncake so it gets the fix too.
- **Mori** (`MoriKVReceiver`): removed redundant `update_status()` call since `super().abort()` already does it.
- Also adds a clarifying comment in `req_time_stats.py`.

## Test plan
- [ ] Existing PD disaggregation tests pass
- [ ] Verify abort behavior in Nixl/Mooncake/Mori PD setups