### PR TITLE
Cherry pick weight_checker fp8 dequant fix and non-persistent buffer skip from #21494

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -38,6 +38,8 @@ class WeightChecker:
 
     def _reset_tensors(self):
         for name, param in self._model_state():
+            if "cos_sin_cache" in name or "freqs_cis" in name:
+                continue
             param.copy_(_random_like(param))
 
     def _compare(self):
@@ -131,18 +133,20 @@ def _postprocess_tensors(
         if name.endswith("weight") and name.replace("weight", "weight_scale_inv") in raw
     ]
     skip_compare_names += quant_names
+    skip_compare_names += [
+        name.replace("weight", "weight_scale_inv") for name in quant_names
+    ]
     for name in quant_names:
         w_q = raw[name]
         w_s = raw[name.replace("weight", "weight_scale_inv")]
 
         try:
-            # TODO this is only needed for Blackwell
-            w_s_inverse_transformed = inverse_transform_scale_ue8m0(
-                w_s, mn=w_q.shape[-2]
-            )
+            if w_s.dtype == torch.int32:
+                # UE8M0 packed format (Blackwell DeepGEMM)
+                w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
             w_dequant = block_quant_dequant(
                 w_q,
-                w_s_inverse_transformed,
+                w_s,
                 # TODO do not hardcode
                 block_size=[128, 128],
                 dtype=torch.bfloat16,


### PR DESCRIPTION
## Summary

Cherry-picks the `weight_checker.py` change from #21494 (originally landed on the `sglang-miles` branch) onto `main`.

Original author: @yym022502 (Yueming Yuan). I'm only the courier.

## Changes

- Skip `cos_sin_cache` / `freqs_cis` buffers in `_reset_tensors` (non-persistent, get recomputed after weight load).
- Add `weight_scale_inv` names to `skip_compare_names` so fp8 scale tensors aren't double-compared.
- Make `inverse_transform_scale_ue8m0` conditional on `w_s.dtype == torch.int32` (UE8M0 packed format / Blackwell DeepGEMM only); other paths now feed `w_s` directly to `block_quant_dequant`.

## PR chain

First of 3 PRs, all touching `weight_checker.py` only, cherry-picking weight_checker-related changes from `sglang-miles` to `main`:

1. **This PR** — cherry-pick of #21494
2. Cherry-pick of weight_checker portion of #21278
3. Cherry-pick of weight_checker portion of #22663

The next two PRs each cherry-pick only the `weight_checker.py` slice of their source PR (the originals also touched many unrelated files). Please merge in order.

## Test plan

- [ ] CI green