### PR TITLE
Cherry pick weight_checker non-persistent buffer pattern list from #21278

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -125,6 +125,21 @@ def _postprocess_tensors(
 
     skip_compare_names = []
 
+    # Skip non-persistent buffers like cos_sin_cache
+    # These buffers are registered with persistent=False and are not saved in checkpoints
+    # They should be recomputed after loading weights, so we don't compare them here
+    non_persistent_buffer_patterns = [
+        "cos_sin_cache",  # RoPE cache
+        "inv_freq",  # RoPE inverse frequency (if it exists as buffer)
+    ]
+
+    for name in raw:
+        for pattern in non_persistent_buffer_patterns:
+            if pattern in name:
+                skip_compare_names.append(name)
+                logger.info(f"[check_tensors] Skipping non-persistent buffer: {name}")
+                break
+
     # dequant fp8
     quant_names = [
         name

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -38,6 +38,8 @@ class WeightChecker:
 
     def _reset_tensors(self):
         for name, param in self._model_state():
+            if "cos_sin_cache" in name or "freqs_cis" in name:
+                continue
             param.copy_(_random_like(param))
 
     def _compare(self):
@@ -131,18 +133,20 @@ def _postprocess_tensors(
         if name.endswith("weight") and name.replace("weight", "weight_scale_inv") in raw
     ]
     skip_compare_names += quant_names
+    skip_compare_names += [
+        name.replace("weight", "weight_scale_inv") for name in quant_names
+    ]
     for name in quant_names:
         w_q = raw[name]
         w_s = raw[name.replace("weight", "weight_scale_inv")]
 
         try:
-            # TODO this is only needed for Blackwell
-            w_s_inverse_transformed = inverse_transform_scale_ue8m0(
-                w_s, mn=w_q.shape[-2]
-            )
+            if w_s.dtype == torch.int32:
+                # UE8M0 packed format (Blackwell DeepGEMM)
+                w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
             w_dequant = block_quant_dequant(
                 w_q,
-                w_s_inverse_transformed,
+                w_s,
                 # TODO do not hardcode
                 block_size=[128, 128],
                 dtype=torch.bfloat16,


### PR DESCRIPTION
## Summary

Cherry-picks **only** the `weight_checker.py` portion of #21278 ("P2P Weight Update features for miles") from `sglang-miles` to `main`. The original PR also touched many unrelated files (qwen3_moe model, integration tests, etc.); those are intentionally **excluded** here.

Original author: @jdguo (JD). I'm only the courier.

## Changes

In `_postprocess_tensors`, adds a `non_persistent_buffer_patterns = ["cos_sin_cache", "inv_freq"]` list and pre-populates `skip_compare_names` with raw tensor names matching those patterns. Reasoning (kept as a code comment): these buffers are registered with `persistent=False`, are not saved in checkpoints, and are recomputed after loading weights — so they must not be compared.

Also one auto-formatter line wrap on the `skip_compare_names += [...]` list comprehension.

## PR chain

2nd of 3. Stacked on #24532. After #24532 lands, this PR's diff will collapse to only this PR's `weight_checker.py` change.

## Test plan

- [ ] CI green after #24532 merges