### PR TITLE
Cherry pick weight_checker `_weight_fp32` buffer skip from #22663

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -38,7 +38,7 @@ class WeightChecker:
 
     def _reset_tensors(self):
         for name, param in self._model_state():
-            if "cos_sin_cache" in name or "freqs_cis" in name:
+            if "cos_sin_cache" in name or "freqs_cis" in name or "_weight_fp32" in name:
                 continue
             param.copy_(_random_like(param))
 
@@ -131,6 +131,7 @@ def _postprocess_tensors(
     non_persistent_buffer_patterns = [
         "cos_sin_cache",  # RoPE cache
         "inv_freq",  # RoPE inverse frequency (if it exists as buffer)
+        "_weight_fp32",  # FP32 cache of gate weight (e.g. Glm4MoeGate)
     ]
 
     for name in raw:

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -125,6 +125,21 @@ def _postprocess_tensors(
 
     skip_compare_names = []
 
+    # Skip non-persistent buffers like cos_sin_cache
+    # These buffers are registered with persistent=False and are not saved in checkpoints
+    # They should be recomputed after loading weights, so we don't compare them here
+    non_persistent_buffer_patterns = [
+        "cos_sin_cache",  # RoPE cache
+        "inv_freq",  # RoPE inverse frequency (if it exists as buffer)
+    ]
+
+    for name in raw:
+        for pattern in non_persistent_buffer_patterns:
+            if pattern in name:
+                skip_compare_names.append(name)
+                logger.info(f"[check_tensors] Skipping non-persistent buffer: {name}")
+                break
+
     # dequant fp8
     quant_names = [
         name

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -38,6 +38,8 @@ class WeightChecker:
 
     def _reset_tensors(self):
         for name, param in self._model_state():
+            if "cos_sin_cache" in name or "freqs_cis" in name:
+                continue
             param.copy_(_random_like(param))
 
     def _compare(self):
@@ -131,18 +133,20 @@ def _postprocess_tensors(
         if name.endswith("weight") and name.replace("weight", "weight_scale_inv") in raw
     ]
     skip_compare_names += quant_names
+    skip_compare_names += [
+        name.replace("weight", "weight_scale_inv") for name in quant_names
+    ]
     for name in quant_names:
         w_q = raw[name]
         w_s = raw[name.replace("weight", "weight_scale_inv")]
 
         try:
-            # TODO this is only needed for Blackwell
-            w_s_inverse_transformed = inverse_transform_scale_ue8m0(
-                w_s, mn=w_q.shape[-2]
-            )
+            if w_s.dtype == torch.int32:
+                # UE8M0 packed format (Blackwell DeepGEMM)
+                w_s = inverse_transform_scale_ue8m0(w_s, mn=w_q.shape[-2])
             w_dequant = block_quant_dequant(
                 w_q,
-                w_s_inverse_transformed,
+                w_s,
                 # TODO do not hardcode
                 block_size=[128, 128],
                 dtype=torch.bfloat16,


### PR DESCRIPTION
## Summary

Cherry-picks **only** the `weight_checker.py` portion of #22663 ("[Hotfix] final fixes for P2P Transfer") from `sglang-miles` to `main`. The original PR also touched several unrelated files (model_runner, deepseek_weight_loader, qwen3); those are intentionally **excluded** here.

Original author: @jdguo (JD). I'm only the courier.

## Changes

Adds `"_weight_fp32"` to both:
- the inline skip in `_reset_tensors` (alongside `cos_sin_cache` / `freqs_cis`), and
- the `non_persistent_buffer_patterns` list in `_postprocess_tensors`.

`_weight_fp32` is the FP32 cache of the gate weight (e.g. `Glm4MoeGate`), which is non-persistent and recomputed.

## PR chain

3rd of 3. Stacked on #24533, which is stacked on #24532. After both prior PRs land, this PR's diff will collapse to only this PR's `weight_checker.py` change.

## Test plan

- [ ] CI green after #24532 and #24533 merge