### PR TITLE
[PD] Prevent update_status to Failed from cleared entries

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -190,6 +190,12 @@ class CommonKVManager(BaseKVManager):
         ):
             self.req_to_decode_prefix_len.pop(bootstrap_room, None)
         if bootstrap_room not in self.request_status:
+            # Do not resurrect a cleared entry with Failed: once clear() has
+            # popped the room from request_status, any late update_status(Failed)
+            # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
+            # pollute a future request that reuses the same bootstrap_room.
+            if status == KVPoll.Failed:
+                return
             self.request_status[bootstrap_room] = status
         else:
             if status == KVPoll.Failed:


### PR DESCRIPTION
## Motivation
Follow-up to #24522, which added `update_status(self.bootstrap_room, KVPoll.Failed)` to `CommonKVSender.abort()` / `CommonKVReceiver.abort()` so that `Failed` is propagated to the manager-level `request_status` dict (and not just kept in the per-sender `conclude_state` latch).

This could cause two problems:
 - Memory leak. `request_status` grows over time with stale KVFailed entries from late abort / async callbacks that race with clear().
 - Cross-request state pollution. If a future request reuses the same bootstrap_room (random collision is astronomically rare for the built-in 63-bit generator, but user-supplied bootstrap_room is a common pattern via GenerateReqInput), the new request can be observed as Failed from the very first poll.

The local `conclude_state` already correctly shields the aborted request itself from any subsequent Success update on `request_status`, so the only real gap left is the "resurrect after clear" case fixed here.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Do not update status to failed when` bootstrap_room not in self.request_status` (since none of the requests are initialized as failed, so it is safe, and can help us avoid a rare racing case of clear and abort.)
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
