### PR TITLE
[smg] per-router parsing + structured error envelope on /generate, /v1/chat/completions

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -164,6 +164,11 @@ name = "manual_policy_benchmark"
 harness = false
 path = "benches/manual_policy_benchmark.rs"
 
+[[bench]]
+name = "proto_pattern_perf"
+harness = false
+path = "benches/proto_pattern_perf.rs"
+
 [profile.release]
 opt-level = "z"     # Optimize for size
 lto = "fat"         # Full LTO for smaller binaries

--- a/sgl-model-gateway/benches/proto_pattern_perf.rs
+++ b/sgl-model-gateway/benches/proto_pattern_perf.rs
@@ -1,0 +1,174 @@
+//! Bench: proto-pattern routing-view + bytes vs. typed-deserialise on
+//! the chat/generate hot path.
+//!
+//! The proto-pattern (this worktree's `Router::route_chat` /
+//! `route_generate`) parses only a tiny `ChatRoutingView` /
+//! `GenerateRoutingView` from the request body and forwards the
+//! bytes verbatim. The pre-existing typed-deserialise design parses
+//! the full `openai-protocol::ChatCompletionRequest` (which
+//! materialises every field, including the multimodal image_url.url
+//! string) and then re-serialises it back to bytes for the wire.
+//!
+//! Three groups, each across five payload shapes (small chat,
+//! medium chat with extension fields, multimodal 50KB / 200KB
+//! uniform-`A`, multimodal 200KB realistic-base64):
+//!
+//! 1. `routing_view_only` — just parse the routing view. The
+//!    proto-pattern's *full* per-request cost on the unified non-
+//!    dp-aware path (after which the bytes forward via
+//!    `Bytes::clone`).
+//! 2. `typed_full_pipeline` — `serde_json::from_slice::<ChatCompletionRequest>`
+//!    + `serde_json::to_vec(&typed)`. What the typed-deserialise
+//!    design does on every chat request.
+//! 3. `proto_pattern_full_pipeline` — routing view parse + Bytes
+//!    clone, end-to-end. What this worktree's
+//!    `Router::route_chat` actually runs.
+
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use serde_json::json;
+use smg::{
+    protocols::chat::ChatCompletionRequest, routers::http::routing_view::ChatRoutingView,
+};
+
+fn small_chat() -> Bytes {
+    Bytes::from(
+        serde_json::to_vec(&json!({
+            "model": "deepseek-v2-lite",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "What is 2 + 2?"}
+            ],
+            "max_tokens": 64,
+            "temperature": 0.7,
+        }))
+        .unwrap(),
+    )
+}
+
+fn medium_chat() -> Bytes {
+    let mut messages = vec![json!({
+        "role": "system",
+        "content": "You are a helpful assistant with extensive knowledge.",
+    })];
+    for i in 0..30 {
+        messages.push(json!({
+            "role": "user",
+            "content": format!(
+                "Question {}: explain topic {} in detail with multiple paragraphs.",
+                i, i
+            ),
+        }));
+        messages.push(json!({
+            "role": "assistant",
+            "content": format!(
+                "Answer {}: here is a thorough multi-paragraph explanation of topic {}.",
+                i, i
+            ),
+        }));
+    }
+    Bytes::from(
+        serde_json::to_vec(&json!({
+            "model": "deepseek-v2-lite",
+            "messages": messages,
+            "max_tokens": 1024,
+            "return_routed_experts": true,
+        }))
+        .unwrap(),
+    )
+}
+
+fn large_multimodal(payload_kb: usize, realistic_base64: bool) -> Bytes {
+    let blob: String = if realistic_base64 {
+        // Real base64 alphabet (no escape chars but non-uniform).
+        "AB+/=09az".repeat((payload_kb * 1024) / 9)
+    } else {
+        // Best-case uniform payload.
+        "A".repeat(payload_kb * 1024)
+    };
+    Bytes::from(
+        serde_json::to_vec(&json!({
+            "model": "deepseek-v2-lite",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this image"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": format!("data:image/png;base64,{blob}")},
+                    },
+                ],
+            }],
+            "max_tokens": 256,
+            "return_routed_experts": false,
+        }))
+        .unwrap(),
+    )
+}
+
+fn bench_proto_vs_typed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("proto_vs_typed");
+
+    let inputs: [(&str, Bytes); 5] = [
+        ("small_chat_~250B", small_chat()),
+        ("medium_chat_~10KB", medium_chat()),
+        ("multimodal_50KB", large_multimodal(50, false)),
+        ("multimodal_200KB", large_multimodal(200, false)),
+        ("multimodal_200KB_base64ish", large_multimodal(200, true)),
+    ];
+
+    for (label, body) in inputs.iter() {
+        group.throughput(Throughput::Bytes(body.len() as u64));
+
+        // Proto-pattern routing-view-only parse (the bulk of the work
+        // this worktree's chat/generate path does per request).
+        group.bench_with_input(
+            BenchmarkId::new("routing_view_only", label),
+            body,
+            |b, body| {
+                b.iter(|| {
+                    let view: ChatRoutingView =
+                        serde_json::from_slice(black_box(body)).unwrap();
+                    black_box(view);
+                });
+            },
+        );
+
+        // Typed-deserialise-and-reserialise (what the gateway used to
+        // do on chat/generate before the proto-pattern refactor; what
+        // upstream smg's `model_gateway` still does today).
+        group.bench_with_input(
+            BenchmarkId::new("typed_full_pipeline", label),
+            body,
+            |b, body| {
+                b.iter(|| {
+                    let typed: ChatCompletionRequest =
+                        serde_json::from_slice(black_box(body)).unwrap();
+                    let bytes = serde_json::to_vec(&typed).unwrap();
+                    black_box((typed, bytes));
+                });
+            },
+        );
+
+        // Proto-pattern end-to-end: parse routing view + Bytes::clone
+        // for forwarding. Mirrors `Router::route_chat` →
+        // `send_bytes_request`'s non-dp-aware branch.
+        group.bench_with_input(
+            BenchmarkId::new("proto_pattern_full_pipeline", label),
+            body,
+            |b, body| {
+                b.iter(|| {
+                    let view: ChatRoutingView =
+                        serde_json::from_slice(black_box(body)).unwrap();
+                    let cloned = body.clone();
+                    black_box((view, cloned));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_proto_vs_typed);
+criterion_main!(benches);

--- a/sgl-model-gateway/benches/proto_pattern_perf.rs
+++ b/sgl-model-gateway/benches/proto_pattern_perf.rs
@@ -27,9 +27,7 @@
 use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use serde_json::json;
-use smg::{
-    protocols::chat::ChatCompletionRequest, routers::http::routing_view::ChatRoutingView,
-};
+use smg::{protocols::chat::ChatCompletionRequest, routers::http::routing_view::ChatRoutingView};
 
 fn small_chat() -> Bytes {
     Bytes::from(
@@ -127,8 +125,7 @@ fn bench_proto_vs_typed(c: &mut Criterion) {
             body,
             |b, body| {
                 b.iter(|| {
-                    let view: ChatRoutingView =
-                        serde_json::from_slice(black_box(body)).unwrap();
+                    let view: ChatRoutingView = serde_json::from_slice(black_box(body)).unwrap();
                     black_box(view);
                 });
             },
@@ -158,8 +155,7 @@ fn bench_proto_vs_typed(c: &mut Criterion) {
             body,
             |b, body| {
                 b.iter(|| {
-                    let view: ChatRoutingView =
-                        serde_json::from_slice(black_box(body)).unwrap();
+                    let view: ChatRoutingView = serde_json::from_slice(black_box(body)).unwrap();
                     let cloned = body.clone();
                     black_box((view, cloned));
                 });

--- a/sgl-model-gateway/benches/wasm_middleware_latency.rs
+++ b/sgl-model-gateway/benches/wasm_middleware_latency.rs
@@ -26,8 +26,8 @@ impl RouterTrait for MockRouter {
     async fn route_chat(
         &self,
         _headers: Option<&HeaderMap>,
-        _body: &ChatCompletionRequest,
-        _model_id: Option<&str>,
+        _view: &smg::routers::http::routing_view::ChatRoutingView,
+        _body: &bytes::Bytes,
     ) -> Response<Body> {
         StatusCode::OK.into_response()
     }

--- a/sgl-model-gateway/e2e_test/infra/model_specs.py
+++ b/sgl-model-gateway/e2e_test/infra/model_specs.py
@@ -91,6 +91,26 @@ MODEL_SPECS: dict[str, dict] = {
         "tp": 2,
         "features": ["chat", "streaming", "reasoning", "harmony"],
     },
+    # DeepSeek-V2-Lite — small MoE (64 routed experts, top-6) used for
+    # `return_routed_experts` e2e verification. The two flags it needs:
+    # `--trust-remote-code` (custom modeling code in the HF repo) and
+    # `--enable-return-routed-experts` (the SGLang server-side feature
+    # gate; without it the response carries no `routed_experts` even
+    # when the request asks for it).
+    "dsv2-lite": {
+        "model": _resolve_model_path("deepseek-ai/DeepSeek-V2-Lite"),
+        "memory_gb": 32,
+        "tp": 1,
+        "worker_args": [
+            "--trust-remote-code",
+            "--enable-return-routed-experts",
+            # CUDA-graph capture trips the apply_rope_inplace kernel on
+            # sglang 0.5.10rc0 + V2-Lite + this container; eager mode
+            # avoids the capture entirely. Slower but startup-stable.
+            "--disable-cuda-graph",
+        ],
+        "features": ["chat", "streaming"],
+    },
 }
 
 

--- a/sgl-model-gateway/e2e_test/router/test_routed_experts.py
+++ b/sgl-model-gateway/e2e_test/router/test_routed_experts.py
@@ -1,0 +1,313 @@
+"""Real-GPU e2e tests for `return_routed_experts` on sgl-model-gateway.
+
+Verifies that the gateway correctly forwards `return_routed_experts: true`
+to a live SGLang server (MoE model) and propagates the resulting
+`sglext.routed_experts` (or `meta_info.routed_experts` for `/generate`)
+back to the client. Mirrors the mock-based suites under
+``tests/routing/pd_routing_test.rs`` and
+``tests/api/api_endpoints_test.rs::sglang_extension_tests`` but against
+real workers — catches regressions where the mock and the real SGLang
+protocol have drifted (e.g. the typed `SglExt` envelope shape upstream
+in ``python/sglang/srt/entrypoints/openai/protocol.py``).
+
+Two scenarios:
+
+* Unified router (1 worker, no merge step). Streaming + flag is a
+  passthrough — the gateway does not gate it.
+
+* PD router (1 prefill + 1 decode worker, gateway merges
+  `prefill_bytes ++ decode_bytes[prefill_len..]` on the response).
+  Streaming + flag is rejected with 400 because the SSE pipeline does
+  not merge.
+
+Model: ``deepseek-ai/DeepSeek-V2-Lite`` (resolved via the ``dsv2-lite``
+spec in ``MODEL_SPECS``). Small MoE (64 routed experts, top-6) at
+``tp=1``. Picking an MoE matters — `return_routed_experts` is a no-op
+on dense models, which would weaken the assertion to "no 5xx".
+
+GPU footprint:
+
+* Unified: 1 GPU (``tp=1``).
+* PD: 2 GPUs (1 prefill ``tp=1`` + 1 decode ``tp=1``).
+
+Run locally::
+
+    pytest e2e_test/router/test_routed_experts.py -v
+
+These tests are decorated with ``@pytest.mark.e2e`` so they're filtered
+out of unit-style runs.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
+
+# API key is not validated by the gateway, but required for OpenAI-compatible
+# headers (matches the convention from other e2e_test/chat_completions tests).
+API_KEY = "not-used"
+
+# gpt-oss requires its own reasoning parser; pulling it from the responses-API
+# tests that already exercise this model.
+_GPT_OSS_GATEWAY_ARGS = ["--reasoning-parser=gpt-oss"]
+
+
+def _assert_valid_routed_experts_b64(b64: str, where: str) -> None:
+    """Decode `b64` as base64 and assert it carries at least one byte of
+    expert-id data. The exact byte-pattern depends on the model and the
+    request — the gateway only forwards bytes — so we validate shape
+    rather than value."""
+    assert isinstance(b64, str), f"{where}: expected str, got {type(b64)}"
+    decoded = base64.b64decode(b64, validate=True)
+    assert len(decoded) > 0, f"{where}: routed_experts decoded to empty bytes"
+
+
+# =============================================================================
+# Unified router (regular HTTP, no PD merge)
+# =============================================================================
+
+
+@pytest.mark.e2e
+@pytest.mark.model("dsv2-lite")
+@pytest.mark.parametrize("setup_backend", ["http"], indirect=True)
+class TestUnifiedRoutedExperts:
+    """Unified-router e2e against a single real SGLang MoE worker."""
+
+    def test_chat_completion_returns_routed_experts(self, setup_backend):
+        """`return_routed_experts: true` on /v1/chat/completions surfaces
+        the field in `sglext.routed_experts` (the typed `SglExt`
+        envelope SGLang emits on `ChatCompletionResponse`)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=120,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        sglext = data.get("sglext")
+        assert sglext is not None, f"expected sglext envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            sglext.get("routed_experts"), "sglext.routed_experts"
+        )
+
+    def test_generate_returns_routed_experts(self, setup_backend):
+        """Same contract on /generate via `meta_info.routed_experts`
+        (the SGLang-native envelope, not the OpenAI-shaped one)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/generate",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 4, "temperature": 0},
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=120,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        meta_info = data.get("meta_info")
+        assert meta_info is not None, f"expected meta_info envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            meta_info.get("routed_experts"), "meta_info.routed_experts"
+        )
+
+    def test_streaming_chat_with_routed_experts_is_not_rejected(self, setup_backend):
+        """Unified streaming + flag must NOT be rejected — the unified
+        router has no merge step, so SGLang's per-chunk SglExt envelope
+        flows through SSE proxying unchanged. (PD rejects this combo
+        with 400; see TestPDRoutedExperts.)"""
+        _, model, _, gateway = setup_backend
+
+        with requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": True,
+            },
+            stream=True,
+            timeout=120,
+        ) as resp:
+            assert (
+                resp.status_code == 200
+            ), f"streaming + flag should be 200 on unified, got {resp.status_code}: {resp.text}"
+
+            # Drain at least one SSE event to confirm the stream is alive.
+            saw_event = False
+            for raw_line in resp.iter_lines():
+                if not raw_line:
+                    continue
+                line = raw_line.decode("utf-8", errors="replace")
+                if line.startswith("data: "):
+                    saw_event = True
+                    payload = line[len("data: ") :].strip()
+                    if payload == "[DONE]":
+                        break
+                    try:
+                        json.loads(payload)
+                    except json.JSONDecodeError:
+                        pytest.fail(f"non-JSON SSE payload: {payload!r}")
+                    break
+            assert saw_event, "expected at least one SSE event from the unified stream"
+
+    def test_chat_completion_rejects_invalid_extension_type(self, setup_backend):
+        """Type-mismatched extension fields surface as 400 on the
+        unified router (mirrors the PD contract)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": "yes",  # wrong type
+                "stream": False,
+            },
+            timeout=30,
+        )
+        assert (
+            resp.status_code == 400
+        ), f"non-bool return_routed_experts should yield 400, got {resp.status_code}: {resp.text}"
+
+
+# =============================================================================
+# PD router (prefill + decode, merge on the response)
+# =============================================================================
+
+
+@pytest.mark.e2e
+@pytest.mark.model("dsv2-lite")
+@pytest.mark.workers(prefill=1, decode=1)
+@pytest.mark.parametrize("setup_backend", ["pd"], indirect=True)
+class TestPDRoutedExperts:
+    """PD-router e2e: real prefill + decode SGLang MoE workers."""
+
+    def test_chat_completion_merges_routed_experts(self, setup_backend):
+        """Round-trip through `route_chat → execute_dual_dispatch →
+        merge_prefill_json`. The merged `sglext.routed_experts` is
+        `prefill_bytes ++ decode_bytes[prefill_len..]`; we can't compare
+        against an oracle (would need to intercept both legs) but
+        non-empty valid base64 + non-zero length proves the merge ran
+        and produced output, which is the gateway-side contract."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=180,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        sglext = data.get("sglext")
+        assert sglext is not None, f"expected sglext envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            sglext.get("routed_experts"), "sglext.routed_experts (PD merged)"
+        )
+
+    def test_generate_merges_routed_experts(self, setup_backend):
+        """Same shape on `/generate`, exercising the `meta_info` branch
+        of `merge_prefill_json` (the chat test exercises the `sglext`
+        branch)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/generate",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "text": "Hello",
+                "sampling_params": {"max_new_tokens": 4, "temperature": 0},
+                "return_routed_experts": True,
+                "stream": False,
+            },
+            timeout=180,
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        data = resp.json()
+        meta_info = data.get("meta_info")
+        assert meta_info is not None, f"expected meta_info envelope: {data}"
+        _assert_valid_routed_experts_b64(
+            meta_info.get("routed_experts"), "meta_info.routed_experts (PD merged)"
+        )
+
+    def test_streaming_chat_with_routed_experts_returns_400(self, setup_backend):
+        """The SSE pipeline doesn't merge prefill/decode bytes, so PD
+        rejects this combo up front rather than silently returning
+        decode-only experts."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": True,
+                "stream": True,
+            },
+            timeout=30,
+        )
+        assert (
+            resp.status_code == 400
+        ), f"PD streaming + flag should yield 400, got {resp.status_code}: {resp.text}"
+
+    def test_chat_completion_rejects_invalid_extension_type(self, setup_backend):
+        """Type-mismatched extension fields are surfaced as 400 by the
+        PD router. This complements the unified-side reject test —
+        each router has its own `parse_sglang_extensions` call
+        (`pd_router.rs::route_chat` vs `router.rs::route_chat`)."""
+        _, model, _, gateway = setup_backend
+
+        resp = requests.post(
+            f"{gateway.base_url}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 4,
+                "temperature": 0,
+                "return_routed_experts": "yes",  # wrong type
+                "stream": False,
+            },
+            timeout=30,
+        )
+        assert (
+            resp.status_code == 400
+        ), f"PD non-bool return_routed_experts should yield 400, got {resp.status_code}: {resp.text}"

--- a/sgl-model-gateway/src/routers/error.rs
+++ b/sgl-model-gateway/src/routers/error.rs
@@ -61,9 +61,14 @@ pub fn create_error(
     let message_str = message.into();
 
     let mut headers = HeaderMap::with_capacity(1);
+    // `code_str` is developer-controlled today, but unwrap would panic if a
+    // future caller smuggled in a byte that's invalid inside an HTTP header
+    // value (CTL chars like `\n`, or non-visible bytes). Fall back to a
+    // static sentinel so the response status/body still propagate.
     headers.insert(
         HEADER_X_SMG_ERROR_CODE,
-        HeaderValue::from_str(&code_str).unwrap(),
+        HeaderValue::from_str(&code_str)
+            .unwrap_or_else(|_| HeaderValue::from_static("unknown_error")),
     );
 
     (
@@ -103,4 +108,34 @@ pub fn extract_error_code_from_response<B>(response: &Response<B>) -> &str {
         .get(HEADER_X_SMG_ERROR_CODE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `create_error` must not panic when a caller smuggles a byte that
+    /// is invalid in an HTTP header value (here `\n` — a CTL char, not
+    /// strictly non-ASCII). Without the `unwrap_or_else` fallback the
+    /// previous `unwrap()` would have taken down the request handler.
+    #[test]
+    fn invalid_header_byte_code_falls_back_to_sentinel_header() {
+        let response = create_error(StatusCode::BAD_REQUEST, "bad\ncode", "msg");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let header = response
+            .headers()
+            .get(HEADER_X_SMG_ERROR_CODE)
+            .expect("error code header must be present");
+        assert_eq!(header.to_str().unwrap(), "unknown_error");
+    }
+
+    #[test]
+    fn ascii_code_round_trips_in_header() {
+        let response = create_error(StatusCode::BAD_REQUEST, "json_parse_error", "msg");
+        let header = response
+            .headers()
+            .get(HEADER_X_SMG_ERROR_CODE)
+            .expect("error code header must be present");
+        assert_eq!(header.to_str().unwrap(), "json_parse_error");
+    }
 }

--- a/sgl-model-gateway/src/routers/error.rs
+++ b/sgl-model-gateway/src/routers/error.rs
@@ -71,7 +71,7 @@ pub fn create_error(
         headers,
         Json(ErrorResponse {
             error: ErrorDetail {
-                error_type: status_code_to_str(status),
+                error_type: error_type_for_status(status),
                 code: &code_str,
                 message: &message_str,
             },
@@ -80,10 +80,21 @@ pub fn create_error(
         .into_response()
 }
 
-fn status_code_to_str(status_code: StatusCode) -> &'static str {
-    status_code
-        .canonical_reason()
-        .unwrap_or("Unknown Status Code")
+/// OpenAI-compat error class string. SDK clients classify on this
+/// field — `RateLimitError`, `AuthenticationError`, etc. are
+/// dispatched off the `error.type` value, so a 429 must come back as
+/// `rate_limit_error` (not the catch-all `invalid_request_error`)
+/// for client retry/backoff logic to fire.
+fn error_type_for_status(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::UNAUTHORIZED => "authentication_error",
+        StatusCode::FORBIDDEN => "permission_error",
+        StatusCode::NOT_FOUND => "not_found_error",
+        StatusCode::TOO_MANY_REQUESTS => "rate_limit_error",
+        s if s.is_client_error() => "invalid_request_error",
+        s if s.is_server_error() => "server_error",
+        _ => "api_error",
+    }
 }
 
 pub fn extract_error_code_from_response<B>(response: &Response<B>) -> &str {

--- a/sgl-model-gateway/src/routers/grpc/pd_router.rs
+++ b/sgl-model-gateway/src/routers/grpc/pd_router.rs
@@ -16,7 +16,9 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     protocols::{chat::ChatCompletionRequest, generate::GenerateRequest},
     routers::{
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        http::routing_view::{
+            validate_extensions_in_value, view_parse_error, ChatRoutingView, GenerateRoutingView,
+        },
         RouterTrait,
     },
 };
@@ -227,32 +229,65 @@ impl RouterTrait for GrpcPDRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        view: &GenerateRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let typed: GenerateRequest = match serde_json::from_slice(body) {
+        // See `GrpcRouter::route_generate` for the rationale on
+        // routing through `Value` to preserve the
+        // `invalid_sglang_extension` 400 contract; without this, a
+        // wrong-typed extension field is silently dropped by the
+        // typed proto deserialize.
+        let value: serde_json::Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return view_parse_error::<GenerateRoutingView>(body, e),
+        };
+        if let Some(field) = validate_extensions_in_value::<GenerateRoutingView>(&value) {
+            return crate::routers::error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field `{field}`"),
+            );
+        }
+        let typed: GenerateRequest = match serde_json::from_value(value) {
             Ok(v) => v,
             Err(e) => {
-                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+                return crate::routers::error::bad_request(
+                    "json_parse_error",
+                    format!("Invalid JSON data: {e}"),
+                );
             }
         };
-        self.route_generate_impl(headers, &typed, view.model.as_deref())
+        let effective_model = model_id.or(typed.model.as_deref());
+        self.route_generate_impl(headers, &typed, effective_model)
             .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let typed: ChatCompletionRequest = match serde_json::from_slice(body) {
+        let value: serde_json::Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return view_parse_error::<ChatRoutingView>(body, e),
+        };
+        if let Some(field) = validate_extensions_in_value::<ChatRoutingView>(&value) {
+            return crate::routers::error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field `{field}`"),
+            );
+        }
+        let typed: ChatCompletionRequest = match serde_json::from_value(value) {
             Ok(v) => v,
             Err(e) => {
-                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+                return crate::routers::error::bad_request(
+                    "json_parse_error",
+                    format!("Invalid JSON data: {e}"),
+                );
             }
         };
-        self.route_chat_impl(headers, &typed, Some(&view.model)).await
+        let effective_model = model_id.or(Some(typed.model.as_str()));
+        self.route_chat_impl(headers, &typed, effective_model).await
     }
 
     fn router_type(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/grpc/pd_router.rs
+++ b/sgl-model-gateway/src/routers/grpc/pd_router.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{http::HeaderMap, response::Response};
+use bytes::Bytes;
 use tracing::debug;
 
 use super::{context::SharedComponents, pipeline::RequestPipeline};
@@ -14,7 +15,10 @@ use crate::{
     },
     observability::metrics::{metrics_labels, Metrics},
     protocols::{chat::ChatCompletionRequest, generate::GenerateRequest},
-    routers::RouterTrait,
+    routers::{
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        RouterTrait,
+    },
 };
 
 /// gRPC PD (Prefill-Decode) router implementation for SGLang
@@ -223,19 +227,32 @@ impl RouterTrait for GrpcPDRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        body: &GenerateRequest,
-        model_id: Option<&str>,
+        view: &GenerateRoutingView,
+        body: &Bytes,
     ) -> Response {
-        self.route_generate_impl(headers, body, model_id).await
+        let typed: GenerateRequest = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+            }
+        };
+        self.route_generate_impl(headers, &typed, view.model.as_deref())
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body: &Bytes,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        let typed: ChatCompletionRequest = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+            }
+        };
+        self.route_chat_impl(headers, &typed, Some(&view.model)).await
     }
 
     fn router_type(&self) -> &'static str {

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -5,6 +5,7 @@ use axum::{
     http::HeaderMap,
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 use tracing::debug;
 
 use super::{
@@ -30,7 +31,10 @@ use crate::{
         generate::GenerateRequest,
         responses::{ResponsesGetParams, ResponsesRequest},
     },
-    routers::RouterTrait,
+    routers::{
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        RouterTrait,
+    },
 };
 
 /// gRPC router implementation for SGLang
@@ -377,19 +381,36 @@ impl RouterTrait for GrpcRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        body: &GenerateRequest,
-        model_id: Option<&str>,
+        view: &GenerateRoutingView,
+        body: &Bytes,
     ) -> Response {
-        self.route_generate_impl(headers, body, model_id).await
+        // gRPC builds its own typed proto request. Re-parse the body
+        // into the typed struct so the existing impl can keep using
+        // it. The HTTP entrypoint already parsed a routing view from
+        // the same bytes; this is the consumer that needs more.
+        let typed: GenerateRequest = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+            }
+        };
+        self.route_generate_impl(headers, &typed, view.model.as_deref())
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body: &Bytes,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        let typed: ChatCompletionRequest = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+            }
+        };
+        self.route_chat_impl(headers, &typed, Some(&view.model)).await
     }
 
     async fn route_responses(

--- a/sgl-model-gateway/src/routers/grpc/router.rs
+++ b/sgl-model-gateway/src/routers/grpc/router.rs
@@ -32,7 +32,9 @@ use crate::{
         responses::{ResponsesGetParams, ResponsesRequest},
     },
     routers::{
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        http::routing_view::{
+            validate_extensions_in_value, view_parse_error, ChatRoutingView, GenerateRoutingView,
+        },
         RouterTrait,
     },
 };
@@ -381,36 +383,68 @@ impl RouterTrait for GrpcRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        view: &GenerateRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        // gRPC builds its own typed proto request. Re-parse the body
-        // into the typed struct so the existing impl can keep using
-        // it. The HTTP entrypoint already parsed a routing view from
-        // the same bytes; this is the consumer that needs more.
-        let typed: GenerateRequest = match serde_json::from_slice(body) {
+        // gRPC needs the typed proto request. SGLang RL extension
+        // fields (e.g. `return_routed_experts`) are not modeled on
+        // `GenerateRequest`, so a wrong-typed extension would
+        // silently drop on a direct typed parse and the gateway
+        // would forward an invalid request. Parse `Value` once,
+        // validate extensions, then materialise the typed struct
+        // from the same `Value` (no second `from_slice`).
+        let value: serde_json::Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return view_parse_error::<GenerateRoutingView>(body, e),
+        };
+        if let Some(field) = validate_extensions_in_value::<GenerateRoutingView>(&value) {
+            return crate::routers::error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field `{field}`"),
+            );
+        }
+        let typed: GenerateRequest = match serde_json::from_value(value) {
             Ok(v) => v,
             Err(e) => {
-                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+                return crate::routers::error::bad_request(
+                    "json_parse_error",
+                    format!("Invalid JSON data: {e}"),
+                );
             }
         };
-        self.route_generate_impl(headers, &typed, view.model.as_deref())
+        let effective_model = model_id.or(typed.model.as_deref());
+        self.route_generate_impl(headers, &typed, effective_model)
             .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let typed: ChatCompletionRequest = match serde_json::from_slice(body) {
+        // See `route_generate` above for why we go through `Value`.
+        let value: serde_json::Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return view_parse_error::<ChatRoutingView>(body, e),
+        };
+        if let Some(field) = validate_extensions_in_value::<ChatRoutingView>(&value) {
+            return crate::routers::error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field `{field}`"),
+            );
+        }
+        let typed: ChatCompletionRequest = match serde_json::from_value(value) {
             Ok(v) => v,
             Err(e) => {
-                return crate::routers::error::bad_request("json_parse_failed", format!("{e}"))
+                return crate::routers::error::bad_request(
+                    "json_parse_error",
+                    format!("Invalid JSON data: {e}"),
+                );
             }
         };
-        self.route_chat_impl(headers, &typed, Some(&view.model)).await
+        let effective_model = model_id.or(Some(typed.model.as_str()));
+        self.route_chat_impl(headers, &typed, effective_model).await
     }
 
     async fn route_responses(

--- a/sgl-model-gateway/src/routers/http/mod.rs
+++ b/sgl-model-gateway/src/routers/http/mod.rs
@@ -3,3 +3,4 @@
 pub mod pd_router;
 pub mod pd_types;
 pub mod router;
+pub mod routing_view;

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -12,7 +12,6 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use memchr::memmem;
 use reqwest::Client;
-use serde::Serialize;
 use serde_json::{json, Value};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, warn};
@@ -271,10 +270,10 @@ impl PDRouter {
         Ok(original)
     }
 
-    async fn execute_dual_dispatch<T: Serialize + Clone>(
+    async fn execute_dual_dispatch(
         &self,
         headers: Option<&HeaderMap>,
-        original_request: &T,
+        original_request: Value,
         context: PDRequestContext<'_>,
     ) -> Response {
         let start_time = Instant::now();
@@ -284,22 +283,18 @@ impl PDRouter {
         let endpoint = route_to_endpoint(route);
 
         // Record request start (Layer 2)
-        Metrics::record_router_request(
-            metrics_labels::ROUTER_HTTP,
-            metrics_labels::BACKEND_PD,
-            metrics_labels::CONNECTION_HTTP,
-            model,
-            endpoint,
-            bool_to_static_str(context.is_stream),
-        );
-        // Clone request once outside the retry loop, then use Arc to share across attempts
-        // This avoids O(retries) clones by sharing the same data
-        let shared_request = Arc::new(original_request.clone());
+        record_pd_request_start(&context);
+        // Each retry needs a fresh Value because `inject_bootstrap_into_value`
+        // mutates in place. The serde round-trip lives at the typed call
+        // sites (`route_completion`, `route_rerank`) once before this
+        // dispatch; Value callers (`route_generate`, `route_chat`) hand
+        // their parsed body straight in. Wrapping in `Arc` only saves
+        // an extra `Value` clone at dispatch entry.
+        let shared_request = Arc::new(original_request);
         let response = RetryExecutor::execute_response_with_retry(
             &self.retry_config,
             {
                 move |attempt: u32| {
-                    // Clone Arc (cheap reference count increment) instead of cloning the entire request
                     let shared_request = Arc::clone(&shared_request);
                     let context = context.clone();
                     async move {
@@ -324,10 +319,10 @@ impl PDRouter {
                             decode.url()
                         );
 
-                        let mut json_request = match serde_json::to_value(shared_request.as_ref()) {
-                            Ok(v) => v,
-                            Err(e) => return Self::handle_serialization_error(e),
-                        };
+                        // Deep-clone the pre-serialized Value once per
+                        // retry; bootstrap injection mutates and
+                        // consumes it.
+                        let mut json_request = (*shared_request).clone();
 
                         json_request = match Self::inject_bootstrap_into_value(
                             json_request,
@@ -683,40 +678,6 @@ impl PDRouter {
         let prefill_policy = self.policy_registry.get_prefill_policy();
         let decode_policy = self.policy_registry.get_decode_policy();
         prefill_policy.needs_request_text() || decode_policy.needs_request_text()
-    }
-
-    /// Pull the cache-aware routing prefix out of an already-parsed
-    /// chat body. Mirrors the pre-refactor typed extraction:
-    /// - first message only;
-    /// - user/developer with string content → that string (multimodal
-    ///   parts intentionally yield `None`, since hashing on a flat
-    ///   image URL gives no useful prefix);
-    /// - system with string content → that string;
-    /// - system with parts → concatenation of `text`-typed parts (so
-    ///   multimodal system prompts still produce a stable hash key);
-    /// - everything else → `None`.
-    fn extract_chat_request_text(json: &Value) -> Option<String> {
-        let msg = json.get("messages")?.as_array()?.first()?;
-        let role = msg.get("role")?.as_str()?;
-        let content = msg.get("content")?;
-        match role {
-            "user" | "developer" => content.as_str().map(str::to_string),
-            "system" => match content {
-                Value::String(s) => Some(s.clone()),
-                Value::Array(parts) => {
-                    let joined: String = parts
-                        .iter()
-                        .filter_map(|p| {
-                            (p.get("type")?.as_str()? == "text")
-                                .then(|| p.get("text")?.as_str().map(str::to_string))?
-                        })
-                        .collect();
-                    (!joined.is_empty()).then_some(joined)
-                }
-                _ => None,
-            },
-            _ => None,
-        }
     }
 
     async fn select_pd_pair(
@@ -1392,8 +1353,14 @@ impl RouterTrait for PDRouter {
             );
         }
 
-        let body_model = request_json.get("model").and_then(Value::as_str);
-        let effective_model = model_id.or(body_model);
+        // Stash `body_model` and `batch_size` as owned values so we
+        // can move `request_json` into the retry loop without leaving
+        // a borrow alive in `PDRequestContext`.
+        let body_model_owned = request_json
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let batch_size = generate_batch_size_from_value(&request_json);
 
         let request_text = self
             .policies_need_request_text()
@@ -1405,9 +1372,10 @@ impl RouterTrait for PDRouter {
             })
             .flatten();
 
+        let effective_model = model_id.or(body_model_owned.as_deref());
         let context = PDRequestContext {
             route: "/generate",
-            batch_size: generate_batch_size_from_value(&request_json),
+            batch_size,
             is_stream,
             return_logprob,
             return_routed_experts,
@@ -1416,7 +1384,7 @@ impl RouterTrait for PDRouter {
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, &request_json, context)
+        self.execute_dual_dispatch(headers, request_json, context)
             .await
     }
 
@@ -1455,19 +1423,27 @@ impl RouterTrait for PDRouter {
             );
         }
 
-        let body_model = request_json.get("model").and_then(Value::as_str);
-        let effective_model = model_id.or(body_model);
+        // See `route_generate`: stash owned scalars so we can move
+        // `request_json` into the retry loop.
+        let body_model_owned = request_json
+            .get("model")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let batch_size = chat_batch_size_from_value(&request_json);
 
-        // Cache-aware / manual policies hash on the request prefix; if
-        // no active policy needs it, skip the walk entirely.
+        // Skip the walk when no active policy reports
+        // `needs_request_text == true` (cache-aware is the canonical
+        // consumer today; the gate keeps the non-cache-aware path at
+        // a single body parse).
         let request_text = self
             .policies_need_request_text()
-            .then(|| Self::extract_chat_request_text(&request_json))
+            .then(|| extract_chat_request_text(&request_json))
             .flatten();
 
+        let effective_model = model_id.or(body_model_owned.as_deref());
         let context = PDRequestContext {
             route: "/v1/chat/completions",
-            batch_size: chat_batch_size_from_value(&request_json),
+            batch_size,
             is_stream,
             return_logprob,
             return_routed_experts,
@@ -1476,7 +1452,7 @@ impl RouterTrait for PDRouter {
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, &request_json, context)
+        self.execute_dual_dispatch(headers, request_json, context)
             .await
     }
 
@@ -1512,7 +1488,19 @@ impl RouterTrait for PDRouter {
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        // Pre-serialize once outside the retry loop so each retry only
+        // pays a `Value::clone`, not a serde round-trip. Record the
+        // start metric on failure so the failure counts toward the
+        // same dispatch row `execute_dual_dispatch` would have recorded.
+        let request_json = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => {
+                record_pd_request_start(&context);
+                return Self::handle_serialization_error(e);
+            }
+        };
+        self.execute_dual_dispatch(headers, request_json, context)
+            .await
     }
 
     async fn route_rerank(
@@ -1539,7 +1527,18 @@ impl RouterTrait for PDRouter {
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        // Pre-serialize once outside the retry loop; on failure still
+        // record the start metric so the request counter doesn't drift
+        // below the error counter for this dispatch.
+        let request_json = match serde_json::to_value(body) {
+            Ok(v) => v,
+            Err(e) => {
+                record_pd_request_start(&context);
+                return Self::handle_serialization_error(e);
+            }
+        };
+        self.execute_dual_dispatch(headers, request_json, context)
+            .await
     }
 
     async fn route_embeddings(
@@ -1583,6 +1582,82 @@ fn json_bool(value: &Value, key: &str) -> Option<bool> {
     value.get(key)?.as_bool()
 }
 
+/// Record the "request start" metric for the PD path. Lives here as
+/// a free function so the typed call sites can invoke it on their
+/// pre-serialization error paths (before `execute_dual_dispatch`
+/// would otherwise have recorded it), keeping the request counter
+/// from diverging from the error counter on the rare typed
+/// `serde_json::to_value` failure.
+fn record_pd_request_start(context: &PDRequestContext<'_>) {
+    let model = context.model_id.unwrap_or(UNKNOWN_MODEL_ID);
+    let endpoint = route_to_endpoint(context.route);
+    Metrics::record_router_request(
+        metrics_labels::ROUTER_HTTP,
+        metrics_labels::BACKEND_PD,
+        metrics_labels::CONNECTION_HTTP,
+        model,
+        endpoint,
+        bool_to_static_str(context.is_stream),
+    );
+}
+
+/// Pull a stable cache-aware routing prefix out of an already-parsed
+/// chat body, walking the FULL `messages` array. Cache-aware (and any
+/// other policy reporting `needs_request_text() == true`) needs every
+/// turn of the conversation in order to reuse the previous turn's KV
+/// cache on the same worker — first-message-only collapses every
+/// conversation that shares a system prompt onto one worker.
+///
+/// Per message:
+/// - `content` as string → append the string verbatim;
+/// - `content` as array of parts → append text-typed parts in order
+///   and skip image/audio/etc. (image URLs are not stable prefixes
+///   and add noise to the hash).
+///
+/// Messages are joined by `\n` so adjacent turns with the same raw
+/// text do not silently merge. Roles are preserved as a leading
+/// `{role}:` tag so a user turn cannot impersonate the system one;
+/// a malformed message with no `role` field still parses but uses an
+/// empty tag (`:`). Returns `None` if no text was found anywhere
+/// (e.g. an all-image conversation has no useful prefix).
+pub(crate) fn extract_chat_request_text(json: &Value) -> Option<String> {
+    let messages = json.get("messages")?.as_array()?;
+    let mut out = String::new();
+    for msg in messages {
+        let role = msg.get("role").and_then(Value::as_str).unwrap_or("");
+        let Some(content) = msg.get("content") else {
+            continue;
+        };
+        let chunk = match content {
+            Value::String(s) => s.clone(),
+            Value::Array(parts) => {
+                let mut buf = String::new();
+                for part in parts {
+                    let is_text = part.get("type").and_then(Value::as_str) == Some("text");
+                    if !is_text {
+                        continue;
+                    }
+                    if let Some(t) = part.get("text").and_then(Value::as_str) {
+                        buf.push_str(t);
+                    }
+                }
+                buf
+            }
+            _ => continue,
+        };
+        if chunk.is_empty() {
+            continue;
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(role);
+        out.push(':');
+        out.push_str(&chunk);
+    }
+    (!out.is_empty()).then_some(out)
+}
+
 /// Mirrors `GenerateRoutingView::batch_size` but reads from a raw
 /// `Value` so PD doesn't have to re-construct the typed view. SGLang's
 /// `input_ids` is either `Vec<u32>` (single — its length is the token
@@ -1607,6 +1682,8 @@ fn chat_batch_size_from_value(value: &Value) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use crate::core::{BasicWorkerBuilder, WorkerType};
 
@@ -1622,6 +1699,45 @@ mod tests {
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
             enable_igw: false,
+        }
+    }
+
+    /// Mock policy that records the `request_text` it sees on every
+    /// `select_worker` call, then returns `None` so the PD dispatch
+    /// short-circuits before any HTTP is attempted.
+    ///
+    /// `needs_request_text() == true` triggers PD's walker gate so
+    /// `extract_chat_request_text` runs and its output flows into
+    /// `SelectWorkerInfo::request_text`.
+    #[derive(Debug, Default)]
+    struct RecordingPolicy {
+        seen_request_text: Mutex<Vec<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl crate::policies::LoadBalancingPolicy for RecordingPolicy {
+        async fn select_worker(
+            &self,
+            _workers: &[Arc<dyn Worker>],
+            info: &crate::policies::SelectWorkerInfo<'_>,
+        ) -> Option<usize> {
+            self.seen_request_text
+                .lock()
+                .unwrap()
+                .push(info.request_text.map(str::to_string));
+            None
+        }
+
+        fn name(&self) -> &'static str {
+            "test-recording"
+        }
+
+        fn needs_request_text(&self) -> bool {
+            true
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
     }
 
@@ -1675,6 +1791,74 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("No prefill workers available"));
+    }
+
+    /// Wire-up regression: PD's `route_chat` must run the full-array
+    /// walker AND pass the result into the policy as `request_text`.
+    /// This test replaces the prefill+decode policies with a recorder
+    /// that returns `None` from `select_worker` (so the dispatch
+    /// short-circuits before HTTP) and asserts the recorded text is
+    /// the walker's role-tagged multi-message output. A regression
+    /// that dropped `request_text` between `route_chat` and the
+    /// policy would leave the recorded text as `None`.
+    #[tokio::test]
+    async fn route_chat_passes_walker_output_to_policy() {
+        let router = create_test_pd_router();
+
+        let recording = Arc::new(RecordingPolicy::default());
+        router.policy_registry.set_prefill_policy(recording.clone());
+        router.policy_registry.set_decode_policy(recording.clone());
+
+        // Register one healthy prefill + one healthy decode so the
+        // policy is actually invoked (empty worker lists fail before
+        // ever calling select_worker).
+        router
+            .worker_registry
+            .register(Arc::from(create_test_worker(
+                "http://prefill".to_string(),
+                WorkerType::Prefill {
+                    bootstrap_port: None,
+                },
+                true,
+            )));
+        router
+            .worker_registry
+            .register(Arc::from(create_test_worker(
+                "http://decode".to_string(),
+                WorkerType::Decode,
+                true,
+            )));
+
+        let body = Bytes::from(
+            serde_json::json!({
+                "model": "mock-model",
+                "messages": [
+                    {"role": "system", "content": "be concise"},
+                    {"role": "user", "content": "hello"}
+                ],
+                "stream": false,
+            })
+            .to_string(),
+        );
+
+        // Response will be a server-selection 5xx because the
+        // recording policy returns None — that's fine. We only care
+        // that the policy was called with the walker's output.
+        let _ = router.route_chat(None, &body, None).await;
+
+        let seen = recording.seen_request_text.lock().unwrap().clone();
+        assert!(
+            !seen.is_empty(),
+            "policy must have been invoked at least once"
+        );
+        let first = seen[0]
+            .as_ref()
+            .expect("policy must see Some(request_text); got None means walker output was dropped");
+        let expected = "system:be concise\nuser:hello";
+        assert_eq!(
+            first, expected,
+            "policy must see the walker's role-tagged multi-message output"
+        );
     }
 
     #[test]
@@ -1773,65 +1957,100 @@ mod tests {
     }
 
     /// Cache-aware policies hash on a stable text prefix per request.
-    /// These tests pin the JSON-walker behaviour for each role +
-    /// content shape, so the routing prefix is consistent with what
-    /// the hash policies expect.
+    /// The walker concatenates every message's text content so turn N+1
+    /// of a conversation shares a stable prefix with turn N — that's
+    /// what lets the prefix trie route subsequent turns to the worker
+    /// that already holds the KV cache.
     mod extract_chat_request_text {
         use serde_json::json;
 
-        use super::super::PDRouter;
+        use super::super::extract_chat_request_text;
 
         #[test]
-        fn user_string_content() {
+        fn single_user_string_message() {
             let body = json!({
                 "messages": [{"role": "user", "content": "deep learning is"}]
             });
             assert_eq!(
-                PDRouter::extract_chat_request_text(&body),
-                Some("deep learning is".to_string())
+                extract_chat_request_text(&body),
+                Some("user:deep learning is".to_string())
             );
         }
 
         #[test]
-        fn developer_string_content() {
+        fn multi_turn_grows_prefix() {
+            // A 4-message conversation (system + user + assistant + user).
+            // The walker concatenates every message so the cache-aware
+            // prefix trie keeps matching across turns.
             let body = json!({
-                "messages": [{"role": "developer", "content": "be concise"}]
+                "messages": [
+                    {"role": "system", "content": "be concise"},
+                    {"role": "user", "content": "what is rust?"},
+                    {"role": "assistant", "content": "a systems lang"},
+                    {"role": "user", "content": "and ownership?"}
+                ]
             });
             assert_eq!(
-                PDRouter::extract_chat_request_text(&body),
-                Some("be concise".to_string())
+                extract_chat_request_text(&body),
+                Some(
+                    "system:be concise\n\
+                     user:what is rust?\n\
+                     assistant:a systems lang\n\
+                     user:and ownership?"
+                        .to_string()
+                )
             );
         }
 
         #[test]
-        fn system_string_content() {
+        fn turn_n_strictly_extends_turn_n_minus_1_prefix() {
+            // The whole point of the walker: turn N's routing text
+            // must be a prefix of turn N+1's, so the cache-aware trie
+            // picks the same worker.
+            let turn1 = json!({
+                "messages": [
+                    {"role": "system", "content": "be concise"},
+                    {"role": "user", "content": "what is rust?"}
+                ]
+            });
+            let turn2 = json!({
+                "messages": [
+                    {"role": "system", "content": "be concise"},
+                    {"role": "user", "content": "what is rust?"},
+                    {"role": "assistant", "content": "a systems lang"},
+                    {"role": "user", "content": "and ownership?"}
+                ]
+            });
+            let t1 = extract_chat_request_text(&turn1).unwrap();
+            let t2 = extract_chat_request_text(&turn2).unwrap();
+            assert!(
+                t2.starts_with(&t1),
+                "turn N+1 routing text must extend turn N's; got {t1:?} vs {t2:?}"
+            );
+        }
+
+        #[test]
+        fn role_tag_disambiguates_same_text() {
+            // Without the role prefix, an assistant echoing the user
+            // would yield identical text. With the tag, the two turns
+            // produce distinct routing prefixes that hash to separate
+            // trie entries.
             let body = json!({
-                "messages": [{"role": "system", "content": "you are helpful"}]
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hello"}
+                ]
             });
             assert_eq!(
-                PDRouter::extract_chat_request_text(&body),
-                Some("you are helpful".to_string())
+                extract_chat_request_text(&body),
+                Some("user:hello\nassistant:hello".to_string())
             );
         }
 
         #[test]
-        fn user_multimodal_parts_yields_none() {
-            // Match pre-refactor: hashing on a flat image URL gives no
-            // useful prefix, so user/developer with parts → None.
-            let body = json!({
-                "messages": [{
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": "describe this image"},
-                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
-                    ]
-                }]
-            });
-            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
-        }
-
-        #[test]
-        fn system_multimodal_parts_concatenates_text() {
+        fn multimodal_parts_keep_text_drop_images() {
+            // System prompt mixes text + image parts; image is ignored
+            // for hashing (no stable prefix), text is preserved.
             let body = json!({
                 "messages": [{
                     "role": "system",
@@ -1843,30 +2062,52 @@ mod tests {
                 }]
             });
             assert_eq!(
-                PDRouter::extract_chat_request_text(&body),
-                Some("you are helpful".to_string())
+                extract_chat_request_text(&body),
+                Some("system:you are helpful".to_string())
             );
         }
 
         #[test]
-        fn assistant_first_message_yields_none() {
-            // Only user/developer/system carry a routing-meaningful prefix.
+        fn all_image_message_is_skipped() {
+            // A message whose content is purely images contributes
+            // nothing to the prefix (and must not split the role tag
+            // off into a dangling `role:` token).
             let body = json!({
-                "messages": [{"role": "assistant", "content": "earlier reply"}]
+                "messages": [
+                    {"role": "user", "content": [
+                        {"type": "image_url", "image_url": {"url": "x"}}
+                    ]},
+                    {"role": "user", "content": "describe please"}
+                ]
             });
-            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+            assert_eq!(
+                extract_chat_request_text(&body),
+                Some("user:describe please".to_string())
+            );
         }
 
         #[test]
         fn missing_messages_yields_none() {
             let body = json!({"model": "x"});
-            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+            assert_eq!(extract_chat_request_text(&body), None);
         }
 
         #[test]
         fn empty_messages_yields_none() {
             let body = json!({"messages": []});
-            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+            assert_eq!(extract_chat_request_text(&body), None);
+        }
+
+        #[test]
+        fn all_messages_textless_yields_none() {
+            let body = json!({
+                "messages": [
+                    {"role": "user", "content": [
+                        {"type": "image_url", "image_url": {"url": "x"}}
+                    ]}
+                ]
+            });
+            assert_eq!(extract_chat_request_text(&body), None);
         }
     }
 }

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -31,17 +31,14 @@ use crate::{
     },
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
     protocols::{
-        classify::ClassifyRequest,
-        common::StringOrArray,
-        completion::CompletionRequest,
-        embedding::EmbeddingRequest,
-        rerank::RerankRequest,
+        classify::ClassifyRequest, common::StringOrArray, completion::CompletionRequest,
+        embedding::EmbeddingRequest, rerank::RerankRequest,
     },
     routers::{
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
         header_utils,
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        http::routing_view::{validate_extensions_in_value, ChatRoutingView, GenerateRoutingView},
         RouterTrait,
     },
 };
@@ -195,10 +192,10 @@ impl PDRouter {
         error::internal_error("serialization_failed", "Failed to serialize request")
     }
 
-    // get_generate_batch_size / get_chat_batch_size moved to
-    // GenerateRoutingView::batch_size / ChatRoutingView::batch_size —
-    // the routing view computes batch size at parse time without
-    // needing the full typed struct.
+    // Batch-size derivation lives in the free functions
+    // `generate_batch_size_from_value` / `chat_batch_size_from_value`
+    // below so PD can read them off the same `Value` it parses for
+    // bootstrap injection.
 
     fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
         if let StringOrArray::Array(arr) = &req.prompt {
@@ -686,6 +683,40 @@ impl PDRouter {
         let prefill_policy = self.policy_registry.get_prefill_policy();
         let decode_policy = self.policy_registry.get_decode_policy();
         prefill_policy.needs_request_text() || decode_policy.needs_request_text()
+    }
+
+    /// Pull the cache-aware routing prefix out of an already-parsed
+    /// chat body. Mirrors the pre-refactor typed extraction:
+    /// - first message only;
+    /// - user/developer with string content → that string (multimodal
+    ///   parts intentionally yield `None`, since hashing on a flat
+    ///   image URL gives no useful prefix);
+    /// - system with string content → that string;
+    /// - system with parts → concatenation of `text`-typed parts (so
+    ///   multimodal system prompts still produce a stable hash key);
+    /// - everything else → `None`.
+    fn extract_chat_request_text(json: &Value) -> Option<String> {
+        let msg = json.get("messages")?.as_array()?.first()?;
+        let role = msg.get("role")?.as_str()?;
+        let content = msg.get("content")?;
+        match role {
+            "user" | "developer" => content.as_str().map(str::to_string),
+            "system" => match content {
+                Value::String(s) => Some(s.clone()),
+                Value::Array(parts) => {
+                    let joined: String = parts
+                        .iter()
+                        .filter_map(|p| {
+                            (p.get("type")?.as_str()? == "text")
+                                .then(|| p.get("text")?.as_str().map(str::to_string))?
+                        })
+                        .collect();
+                    (!joined.is_empty()).then_some(joined)
+                }
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     async fn select_pd_pair(
@@ -1320,12 +1351,36 @@ impl RouterTrait for PDRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        view: &GenerateRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let is_stream = view.stream;
-        let return_logprob = view.return_logprob.unwrap_or(false);
-        let return_routed_experts = view.return_routed_experts;
+        // PD has to mutate the body (bootstrap_host/port/room
+        // injection per attempt), so we parse to `Value` either way.
+        // Routing-decision fields are read off the same `Value` so
+        // there's no second `from_slice` over the bytes.
+        let request_json: Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error::bad_request("json_parse_error", format!("Invalid JSON data: {e}"));
+            }
+        };
+
+        // Preserve the structured-400 contract: SGLang extension
+        // fields with the wrong type get the named
+        // `invalid_sglang_extension` code instead of being silently
+        // forwarded. The view's typed Deserialize would have caught
+        // this; with a permissive Value parse we re-check explicitly.
+        if let Some(field) = validate_extensions_in_value::<GenerateRoutingView>(&request_json) {
+            return error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field `{field}`"),
+            );
+        }
+
+        let is_stream = json_bool(&request_json, "stream").unwrap_or(false);
+        let return_logprob = json_bool(&request_json, "return_logprob").unwrap_or(false);
+        let return_routed_experts =
+            json_bool(&request_json, "return_routed_experts").unwrap_or(false);
 
         if is_stream && return_routed_experts {
             return error::bad_request(
@@ -1337,33 +1392,27 @@ impl RouterTrait for PDRouter {
             );
         }
 
-        let request_text = if self.policies_need_request_text() {
-            view.text.clone()
-        } else {
-            None
-        };
+        let body_model = request_json.get("model").and_then(Value::as_str);
+        let effective_model = model_id.or(body_model);
 
-        // PD has to mutate the body (bootstrap_host/port/room
-        // injection per attempt), so we parse to Value here. Unlike
-        // the unified router, PD can never get to O(1) wire-build.
-        let request_json: Value = match serde_json::from_slice(body) {
-            Ok(v) => v,
-            Err(e) => {
-                return error::bad_request(
-                    "json_parse_failed",
-                    format!("Failed to parse request body as JSON: {e}"),
-                );
-            }
-        };
+        let request_text = self
+            .policies_need_request_text()
+            .then(|| {
+                request_json
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .flatten();
 
         let context = PDRequestContext {
             route: "/generate",
-            batch_size: view.batch_size(),
+            batch_size: generate_batch_size_from_value(&request_json),
             is_stream,
             return_logprob,
             return_routed_experts,
             request_text,
-            model_id: view.model.as_deref(),
+            model_id: effective_model,
             headers: headers.cloned(),
         };
 
@@ -1374,12 +1423,27 @@ impl RouterTrait for PDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let is_stream = view.stream;
-        let return_logprob = view.logprobs;
-        let return_routed_experts = view.return_routed_experts;
+        let request_json: Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error::bad_request("json_parse_error", format!("Invalid JSON data: {e}"));
+            }
+        };
+
+        if let Some(field) = validate_extensions_in_value::<ChatRoutingView>(&request_json) {
+            return error::bad_request(
+                "invalid_sglang_extension",
+                format!("Invalid SGLang extension field `{field}`"),
+            );
+        }
+
+        let is_stream = json_bool(&request_json, "stream").unwrap_or(false);
+        let return_logprob = json_bool(&request_json, "logprobs").unwrap_or(false);
+        let return_routed_experts =
+            json_bool(&request_json, "return_routed_experts").unwrap_or(false);
 
         if is_stream && return_routed_experts {
             return error::bad_request(
@@ -1391,30 +1455,24 @@ impl RouterTrait for PDRouter {
             );
         }
 
-        // Cache-aware text extraction on chat would walk the JSON
-        // messages array. Demo skips it; production could add a
-        // lazy text view (e.g. messages: Vec<RawValue>) and walk on
-        // demand.
-        let request_text = None;
+        let body_model = request_json.get("model").and_then(Value::as_str);
+        let effective_model = model_id.or(body_model);
 
-        let request_json: Value = match serde_json::from_slice(body) {
-            Ok(v) => v,
-            Err(e) => {
-                return error::bad_request(
-                    "json_parse_failed",
-                    format!("Failed to parse request body as JSON: {e}"),
-                );
-            }
-        };
+        // Cache-aware / manual policies hash on the request prefix; if
+        // no active policy needs it, skip the walk entirely.
+        let request_text = self
+            .policies_need_request_text()
+            .then(|| Self::extract_chat_request_text(&request_json))
+            .flatten();
 
         let context = PDRequestContext {
             route: "/v1/chat/completions",
-            batch_size: view.batch_size(),
+            batch_size: chat_batch_size_from_value(&request_json),
             is_stream,
             return_logprob,
             return_routed_experts,
             request_text,
-            model_id: Some(&view.model),
+            model_id: effective_model,
             headers: headers.cloned(),
         };
 
@@ -1514,6 +1572,36 @@ impl RouterTrait for PDRouter {
 
     fn router_type(&self) -> &'static str {
         "pd"
+    }
+}
+
+/// Read a top-level JSON boolean field by name. Used by the PD
+/// router to pull routing flags (`stream`, `return_logprob`,
+/// `return_routed_experts`) off the `Value` it already parsed for
+/// bootstrap injection.
+fn json_bool(value: &Value, key: &str) -> Option<bool> {
+    value.get(key)?.as_bool()
+}
+
+/// Mirrors `GenerateRoutingView::batch_size` but reads from a raw
+/// `Value` so PD doesn't have to re-construct the typed view. SGLang's
+/// `input_ids` is either `Vec<u32>` (single — its length is the token
+/// count, NOT the batch size) or `Vec<Vec<u32>>` (batch — outer length
+/// IS the batch size); disambiguate by the type of the first element.
+fn generate_batch_size_from_value(value: &Value) -> Option<usize> {
+    let arr = value.get("input_ids")?.as_array()?;
+    match arr.first() {
+        Some(Value::Array(_)) => Some(arr.len()),
+        _ => None,
+    }
+}
+
+/// Mirrors `ChatRoutingView::batch_size`: `n > 1` triggers PD batch
+/// estimation, anything else is single-shot.
+fn chat_batch_size_from_value(value: &Value) -> Option<usize> {
+    match value.get("n")?.as_u64()? {
+        n if n > 1 => Some(n as usize),
+        _ => None,
     }
 }
 
@@ -1682,5 +1770,103 @@ mod tests {
         // Guards dropped when response dropped
         assert_eq!(prefill_ref.load(), 0);
         assert_eq!(decode_ref.load(), 0);
+    }
+
+    /// Cache-aware policies hash on a stable text prefix per request.
+    /// These tests pin the JSON-walker behaviour for each role +
+    /// content shape, so the routing prefix is consistent with what
+    /// the hash policies expect.
+    mod extract_chat_request_text {
+        use serde_json::json;
+
+        use super::super::PDRouter;
+
+        #[test]
+        fn user_string_content() {
+            let body = json!({
+                "messages": [{"role": "user", "content": "deep learning is"}]
+            });
+            assert_eq!(
+                PDRouter::extract_chat_request_text(&body),
+                Some("deep learning is".to_string())
+            );
+        }
+
+        #[test]
+        fn developer_string_content() {
+            let body = json!({
+                "messages": [{"role": "developer", "content": "be concise"}]
+            });
+            assert_eq!(
+                PDRouter::extract_chat_request_text(&body),
+                Some("be concise".to_string())
+            );
+        }
+
+        #[test]
+        fn system_string_content() {
+            let body = json!({
+                "messages": [{"role": "system", "content": "you are helpful"}]
+            });
+            assert_eq!(
+                PDRouter::extract_chat_request_text(&body),
+                Some("you are helpful".to_string())
+            );
+        }
+
+        #[test]
+        fn user_multimodal_parts_yields_none() {
+            // Match pre-refactor: hashing on a flat image URL gives no
+            // useful prefix, so user/developer with parts → None.
+            let body = json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe this image"},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}}
+                    ]
+                }]
+            });
+            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+        }
+
+        #[test]
+        fn system_multimodal_parts_concatenates_text() {
+            let body = json!({
+                "messages": [{
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "you are "},
+                        {"type": "text", "text": "helpful"},
+                        {"type": "image_url", "image_url": {"url": "ignored"}}
+                    ]
+                }]
+            });
+            assert_eq!(
+                PDRouter::extract_chat_request_text(&body),
+                Some("you are helpful".to_string())
+            );
+        }
+
+        #[test]
+        fn assistant_first_message_yields_none() {
+            // Only user/developer/system carry a routing-meaningful prefix.
+            let body = json!({
+                "messages": [{"role": "assistant", "content": "earlier reply"}]
+            });
+            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+        }
+
+        #[test]
+        fn missing_messages_yields_none() {
+            let body = json!({"model": "x"});
+            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+        }
+
+        #[test]
+        fn empty_messages_yields_none() {
+            let body = json!({"messages": []});
+            assert_eq!(PDRouter::extract_chat_request_text(&body), None);
+        }
     }
 }

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -7,6 +7,8 @@ use axum::{
     http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use bytes::Bytes;
 use futures_util::StreamExt;
 use memchr::memmem;
 use reqwest::Client;
@@ -29,18 +31,18 @@ use crate::{
     },
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
     protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
         classify::ClassifyRequest,
-        common::{InputIds, StringOrArray},
+        common::StringOrArray,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
-        generate::GenerateRequest,
         rerank::RerankRequest,
     },
     routers::{
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        header_utils, RouterTrait,
+        header_utils,
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        RouterTrait,
     },
 };
 
@@ -60,9 +62,21 @@ struct PDRequestContext<'a> {
     batch_size: Option<usize>,
     is_stream: bool,
     return_logprob: bool,
+    /// SGLang RL extension. When true and `is_stream` is false, PD
+    /// merges `routed_experts` from the prefill response into the
+    /// decode response (base64 prefix-suffix concat).
+    return_routed_experts: bool,
     request_text: Option<String>,
     model_id: Option<&'a str>,
     headers: Option<HeaderMap>,
+}
+
+impl PDRequestContext<'_> {
+    /// Whether the response merge step needs to walk the prefill JSON.
+    /// Logprobs and routed_experts both live there.
+    fn needs_prefill_json_merge(&self) -> bool {
+        !self.is_stream && (self.return_logprob || self.return_routed_experts)
+    }
 }
 
 impl PDRouter {
@@ -181,24 +195,10 @@ impl PDRouter {
         error::internal_error("serialization_failed", "Failed to serialize request")
     }
 
-    fn get_generate_batch_size(req: &GenerateRequest) -> Option<usize> {
-        // GenerateRequest doesn't support batch via arrays, only via input_ids
-        if let Some(InputIds::Batch(batches)) = &req.input_ids {
-            if !batches.is_empty() {
-                return Some(batches.len());
-            }
-        }
-        None
-    }
-
-    fn get_chat_batch_size(req: &ChatCompletionRequest) -> Option<usize> {
-        if let Some(n) = req.n {
-            if n > 1 {
-                return Some(n as usize);
-            }
-        }
-        None
-    }
+    // get_generate_batch_size / get_chat_batch_size moved to
+    // GenerateRoutingView::batch_size / ChatRoutingView::batch_size —
+    // the routing view computes batch size at parse time without
+    // needing the full typed struct.
 
     fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
         if let StringOrArray::Array(arr) = &req.prompt {
@@ -600,28 +600,16 @@ impl PDRouter {
                         .await;
                 }
 
-                // Process prefill response
-                let prefill_body = if context.return_logprob {
-                    match self
-                        .process_prefill_response(
-                            prefill_result,
-                            prefill.url(),
-                            context.return_logprob,
-                        )
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
-                } else {
-                    // Even if we don't need logprobs, we should check prefill status
-                    match self
-                        .process_prefill_response(prefill_result, prefill.url(), false)
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
+                // Process prefill response. We need the prefill body
+                // when *any* prefill-side merge applies (logprobs or
+                // routed_experts).
+                let needs_prefill_json = context.needs_prefill_json_merge();
+                let prefill_body = match self
+                    .process_prefill_response(prefill_result, prefill.url(), needs_prefill_json)
+                    .await
+                {
+                    Ok((_, body)) => body,
+                    Err(error_response) => return error_response,
                 };
 
                 if context.is_stream {
@@ -651,11 +639,12 @@ impl PDRouter {
                     )
                 } else {
                     // Non-streaming response
-                    if context.return_logprob {
+                    if context.needs_prefill_json_merge() {
                         self.process_non_streaming_response(
                             res,
                             status,
                             context.return_logprob,
+                            context.return_routed_experts,
                             prefill_body,
                         )
                         .await
@@ -903,6 +892,7 @@ impl PDRouter {
         res: reqwest::Response,
         status: StatusCode,
         return_logprob: bool,
+        return_routed_experts: bool,
         prefill_body: Option<bytes::Bytes>,
     ) -> Response {
         let response = res.bytes().await;
@@ -914,7 +904,7 @@ impl PDRouter {
             }
         };
 
-        if !return_logprob {
+        if !return_logprob && !return_routed_experts {
             return (status, decode_body).into_response();
         }
 
@@ -922,16 +912,22 @@ impl PDRouter {
             return (status, decode_body).into_response();
         };
 
-        // Merge logprobs from prefill and decode
+        // Parse both responses to walk into them for merging logprobs
+        // and/or routed_experts.
         let (Ok(prefill_json), Ok(mut decode_json)) = (
             serde_json::from_slice::<Value>(&prefill_body),
             serde_json::from_slice::<Value>(&decode_body),
         ) else {
-            warn!("Failed to parse responses for logprob merging");
+            warn!("Failed to parse responses for prefill/decode merging");
             return (status, decode_body).into_response();
         };
 
-        Self::merge_logprobs_in_json(&prefill_json, &mut decode_json);
+        if return_logprob {
+            Self::merge_logprobs_in_json(&prefill_json, &mut decode_json);
+        }
+        if return_routed_experts {
+            Self::merge_routed_experts(&prefill_json, &mut decode_json);
+        }
 
         // Return merged response
         match serde_json::to_vec(&decode_json) {
@@ -1062,6 +1058,82 @@ impl PDRouter {
             }
         }
         request
+    }
+
+    /// Merge `routed_experts` from prefill into the decode response.
+    ///
+    /// SGLang's RL extension ships expert ids as a base64-packed byte
+    /// string. The decode worker echoes the prefill's leading bytes
+    /// (first `prefill_len` bytes of decode are the same as prefill)
+    /// and appends per-token expert ids in the suffix. To produce the
+    /// merged stream the gateway concatenates `prefill_bytes ++
+    /// decode_bytes[prefill_len..]` and writes that back into
+    /// `decode_json["routed_experts"]`. Returns `true` when a merge
+    /// happened, `false` if either side was missing or unparsable.
+    ///
+    /// Caller (`merge_prefill_json`) walks two known envelopes for
+    /// this field: `meta_info.routed_experts` on `/generate`
+    /// responses, and `sglext.routed_experts` on OpenAI-compatible
+    /// responses (the `sglext` envelope is a typed contract upstream
+    /// — see `python/sglang/srt/entrypoints/openai/protocol.py::SglExt`).
+    fn merge_routed_experts_in_json(prefill_json: &Value, decode_json: &mut Value) -> bool {
+        let (Some(prefill_routed_experts), Some(decode_routed_experts)) = (
+            prefill_json.get("routed_experts").and_then(Value::as_str),
+            decode_json.get("routed_experts").and_then(Value::as_str),
+        ) else {
+            return false;
+        };
+
+        // Base64 decode failures here mean the client asked for merged
+        // routed_experts but will receive only decode-side payload.
+        // Log as error so data-integrity events show up in dashboards;
+        // leave decode_json untouched.
+        let prefill_bytes = match BASE64_STANDARD.decode(prefill_routed_experts) {
+            Ok(b) => b,
+            Err(error) => {
+                error!("routed_experts_decode_failed (prefill): merge skipped: {error}");
+                return false;
+            }
+        };
+        let decode_bytes = match BASE64_STANDARD.decode(decode_routed_experts) {
+            Ok(b) => b,
+            Err(error) => {
+                error!("routed_experts_decode_failed (decode): merge skipped: {error}");
+                return false;
+            }
+        };
+
+        let suffix = decode_bytes.get(prefill_bytes.len()..).unwrap_or_default();
+        let mut merged = Vec::with_capacity(prefill_bytes.len() + suffix.len());
+        merged.extend_from_slice(&prefill_bytes);
+        merged.extend_from_slice(suffix);
+
+        if let Some(slot) = decode_json.get_mut("routed_experts") {
+            *slot = Value::String(BASE64_STANDARD.encode(&merged));
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Walk both possible response shapes (chat-completions
+    /// `sglext.routed_experts` and `/generate` `meta_info.routed_experts`)
+    /// and merge whichever applies.
+    fn merge_routed_experts(prefill_json: &Value, decode_json: &mut Value) -> bool {
+        let mut merged_any = false;
+        // chat: response.sglext.routed_experts
+        if let Some(prefill_sglext) = prefill_json.get("sglext") {
+            if let Some(decode_sglext) = decode_json.get_mut("sglext") {
+                merged_any |= Self::merge_routed_experts_in_json(prefill_sglext, decode_sglext);
+            }
+        }
+        // generate: response.meta_info.routed_experts
+        if let Some(prefill_meta) = prefill_json.get("meta_info") {
+            if let Some(decode_meta) = decode_json.get_mut("meta_info") {
+                merged_any |= Self::merge_routed_experts_in_json(prefill_meta, decode_meta);
+            }
+        }
+        merged_any
     }
 
     // Helper to merge logprobs from prefill and decode responses
@@ -1248,73 +1320,106 @@ impl RouterTrait for PDRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        body: &GenerateRequest,
-        model_id: Option<&str>,
+        view: &GenerateRoutingView,
+        body: &Bytes,
     ) -> Response {
-        let is_stream = body.stream;
-        let return_logprob = body.return_logprob.unwrap_or(false);
+        let is_stream = view.stream;
+        let return_logprob = view.return_logprob.unwrap_or(false);
+        let return_routed_experts = view.return_routed_experts;
+
+        if is_stream && return_routed_experts {
+            return error::bad_request(
+                "streaming_routed_experts_unsupported",
+                "return_routed_experts is not supported with stream=true on PD mode \
+                 (the streaming SSE path does not merge routed_experts across \
+                 prefill/decode); send the request with stream=false to receive \
+                 merged routed_experts",
+            );
+        }
 
         let request_text = if self.policies_need_request_text() {
-            body.text.as_deref().map(|s| s.to_string())
+            view.text.clone()
         } else {
             None
         };
 
-        let batch_size = Self::get_generate_batch_size(body);
+        // PD has to mutate the body (bootstrap_host/port/room
+        // injection per attempt), so we parse to Value here. Unlike
+        // the unified router, PD can never get to O(1) wire-build.
+        let request_json: Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error::bad_request(
+                    "json_parse_failed",
+                    format!("Failed to parse request body as JSON: {e}"),
+                );
+            }
+        };
 
         let context = PDRequestContext {
             route: "/generate",
-            batch_size,
+            batch_size: view.batch_size(),
             is_stream,
             return_logprob,
+            return_routed_experts,
             request_text,
-            model_id,
+            model_id: view.model.as_deref(),
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        self.execute_dual_dispatch(headers, &request_json, context)
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body: &Bytes,
     ) -> Response {
-        let is_stream = body.stream;
-        let return_logprob = body.logprobs;
+        let is_stream = view.stream;
+        let return_logprob = view.logprobs;
+        let return_routed_experts = view.return_routed_experts;
 
-        let request_text = if self.policies_need_request_text() {
-            body.messages.first().and_then(|msg| match msg {
-                ChatMessage::User { content, .. } => match content {
-                    MessageContent::Text(text) => Some(text.clone()),
-                    MessageContent::Parts(_) => None,
-                },
-                ChatMessage::Developer { content, .. } => match content {
-                    MessageContent::Text(text) => Some(text.clone()),
-                    MessageContent::Parts(_) => None,
-                },
-                ChatMessage::System { content, .. } => Some(content.to_simple_string()),
-                _ => None,
-            })
-        } else {
-            None
+        if is_stream && return_routed_experts {
+            return error::bad_request(
+                "streaming_routed_experts_unsupported",
+                "return_routed_experts is not supported with stream=true on PD mode \
+                 (the streaming SSE path does not merge routed_experts across \
+                 prefill/decode); send the request with stream=false to receive \
+                 merged routed_experts",
+            );
+        }
+
+        // Cache-aware text extraction on chat would walk the JSON
+        // messages array. Demo skips it; production could add a
+        // lazy text view (e.g. messages: Vec<RawValue>) and walk on
+        // demand.
+        let request_text = None;
+
+        let request_json: Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error::bad_request(
+                    "json_parse_failed",
+                    format!("Failed to parse request body as JSON: {e}"),
+                );
+            }
         };
-
-        // Calculate batch size
-        let batch_size = Self::get_chat_batch_size(body);
 
         let context = PDRequestContext {
             route: "/v1/chat/completions",
-            batch_size,
+            batch_size: view.batch_size(),
             is_stream,
             return_logprob,
+            return_routed_experts,
             request_text,
-            model_id,
+            model_id: Some(&view.model),
             headers: headers.cloned(),
         };
 
-        self.execute_dual_dispatch(headers, body, context).await
+        self.execute_dual_dispatch(headers, &request_json, context)
+            .await
     }
 
     async fn route_completion(
@@ -1343,6 +1448,7 @@ impl RouterTrait for PDRouter {
             batch_size,
             is_stream,
             return_logprob,
+            return_routed_experts: false,
             request_text,
             model_id,
             headers: headers.cloned(),
@@ -1369,6 +1475,7 @@ impl RouterTrait for PDRouter {
             batch_size: None,
             is_stream: false,
             return_logprob: false,
+            return_routed_experts: false,
             request_text: req_text,
             model_id,
             headers: headers.cloned(),

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -38,7 +38,10 @@ use crate::{
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
         header_utils,
-        http::routing_view::{view_parse_error, ChatRoutingView, GenerateRoutingView},
+        http::{
+            pd_router::extract_chat_request_text,
+            routing_view::{view_parse_error, ChatRoutingView, GenerateRoutingView},
+        },
         RouterTrait,
     },
 };
@@ -1047,16 +1050,45 @@ impl RouterTrait for Router {
             Ok(v) => v,
             Err(e) => return view_parse_error::<ChatRoutingView>(body, e),
         };
+        let effective_model = model_id.or(Some(view.model.as_str()));
+
+        // Cache-aware (and any future policy that reports
+        // `needs_request_text() == true`) hashes on the conversation
+        // text to keep multi-turn chats on the same worker for KV-cache
+        // reuse. Skip the second parse when no policy needs it so the
+        // non-cache-aware deployment stays at one `from_slice`.
+        //
+        // TODO: this lookup is redundant — `route_bytes_request` →
+        // `route_bytes_once` resolves the same policy from
+        // `effective_model` again for its load-guard branch. Fold both
+        // into one resolved `Arc<dyn LoadBalancingPolicy>` threaded
+        // through the call so we don't double-look-up per request.
+        let policy = match effective_model {
+            Some(m) => self.policy_registry.get_policy_or_default(m),
+            None => self.policy_registry.get_default_policy(),
+        };
+        // TODO: this is a second `from_slice` on the same body — the
+        // typed `ChatRoutingView` above already paid one parse. If
+        // cache-aware becomes the dominant deployment, plumb the raw
+        // `messages` array out of the routing view (or parse to
+        // `Value` once and reuse) so the cache-aware path stays at a
+        // single parse instead of two.
+        let request_text_owned = if policy.needs_request_text() {
+            match serde_json::from_slice::<serde_json::Value>(body) {
+                Ok(v) => extract_chat_request_text(&v),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
         self.route_bytes_request(
             headers,
             body,
             "/v1/chat/completions",
-            model_id.or(Some(view.model.as_str())),
+            effective_model,
             view.stream,
-            // Cache-aware text extraction for chat would walk the
-            // messages array. The unified router doesn't currently
-            // use it; PD does (in pd_router.rs).
-            None,
+            request_text_owned.as_deref(),
         )
         .await
     }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use bytes::Bytes;
 use futures_util::{stream, StreamExt};
 use reqwest::Client;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -26,19 +27,19 @@ use crate::{
     },
     policies::{PolicyRegistry, SelectWorkerInfo},
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         common::GenerationRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
-        generate::GenerateRequest,
         rerank::{RerankRequest, RerankResponse, RerankResult},
         responses::{ResponsesGetParams, ResponsesRequest},
     },
     routers::{
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        header_utils, RouterTrait,
+        header_utils,
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        RouterTrait,
     },
 };
 
@@ -481,6 +482,286 @@ impl Router {
         }
     }
 
+    // ============================================================
+    // Proto-pattern bytes path (chat/generate)
+    // ============================================================
+    //
+    // Mirrors the SGLang gRPC OpenAI-passthrough RPCs (see
+    // `proto/sglang/runtime/v1/sglang.proto::OpenAIRequest`): the body
+    // is opaque JSON bytes that the receiving SGLang server unmarshals
+    // itself. The router only needs a small set of fields for routing
+    // decisions, captured up front in a `*RoutingView`. The bytes
+    // forward verbatim — no typed deserialise of `ChatCompletionRequest`
+    // / `GenerateRequest` on the hot path. Multimodal payloads with
+    // 100+ KB embedded image strings see ~10× speedup vs. the typed
+    // path because serde never materialises the giant String.
+    //
+    // route_completion / route_responses / route_embeddings /
+    // route_classify / route_rerank still use the typed path
+    // (`route_typed_request`) — they're not on this PR's hot path.
+
+    pub async fn route_bytes_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &Bytes,
+        route: &'static str,
+        model_id: Option<&str>,
+        is_stream: bool,
+        text_for_routing: Option<&str>,
+    ) -> Response {
+        let start = Instant::now();
+        let model = model_id.unwrap_or(UNKNOWN_MODEL_ID);
+        let endpoint = route_to_endpoint(route);
+
+        Metrics::record_router_request(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            model,
+            endpoint,
+            bool_to_static_str(is_stream),
+        );
+
+        let response = RetryExecutor::execute_response_with_retry(
+            &self.retry_config,
+            |_: u32| async {
+                let res = self
+                    .route_bytes_once(headers, body, route, model_id, is_stream, text_for_routing)
+                    .await;
+                Metrics::record_router_upstream_response(
+                    metrics_labels::ROUTER_HTTP,
+                    res.status().as_u16(),
+                    extract_error_code_from_response(&res),
+                );
+                res
+            },
+            |res, _attempt| is_retryable_status(res.status()),
+            |delay, attempt| {
+                Metrics::record_worker_retry(metrics_labels::WORKER_REGULAR, endpoint);
+                Metrics::record_worker_retry_backoff(attempt, delay);
+            },
+            || {
+                Metrics::record_worker_retries_exhausted(metrics_labels::WORKER_REGULAR, endpoint);
+            },
+        )
+        .await;
+
+        if response.status().is_success() {
+            let duration = start.elapsed();
+            Metrics::record_router_duration(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                model,
+                endpoint,
+                duration,
+            );
+        } else if !is_retryable_status(response.status()) {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                model,
+                endpoint,
+                error_type_from_status(response.status()),
+            );
+        }
+
+        response
+    }
+
+    async fn route_bytes_once(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &Bytes,
+        route: &'static str,
+        model_id: Option<&str>,
+        is_stream: bool,
+        text_for_routing: Option<&str>,
+    ) -> Response {
+        let worker = match self
+            .select_worker_for_model(model_id, text_for_routing, headers)
+            .await
+        {
+            Some(w) => w,
+            None => {
+                return error::service_unavailable(
+                    "no_available_workers",
+                    "No available workers (all circuits open or unhealthy)",
+                );
+            }
+        };
+
+        let policy = match model_id {
+            Some(model) => self.policy_registry.get_policy_or_default(model),
+            None => self.policy_registry.get_default_policy(),
+        };
+
+        let load_guard = ["cache_aware", "manual"]
+            .contains(&policy.name())
+            .then(|| WorkerLoadGuard::new(worker.clone(), headers));
+
+        events::RequestSentEvent { url: worker.url() }.emit();
+        let mut headers_with_trace = headers.cloned().unwrap_or_default();
+        inject_trace_context_http(&mut headers_with_trace);
+        let headers = Some(&headers_with_trace);
+
+        let response = self
+            .send_bytes_request(headers, body, route, worker.url(), is_stream, load_guard)
+            .await;
+
+        events::RequestReceivedEvent {}.emit();
+
+        let status = response.status();
+        worker.record_outcome(status.is_success());
+        if status.is_server_error() {
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                error_type_from_status(status),
+            );
+        }
+        response
+    }
+
+    /// Bytes-aware send. The dp-aware branch parses to Value to inject
+    /// `data_parallel_rank` (unavoidable mutation); the non-dp-aware
+    /// branch is pure `body(body.clone())` passthrough — `Bytes::clone`
+    /// is an O(1) atomic refcount bump on the shared buffer axum hands
+    /// us, no copy.
+    async fn send_bytes_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &Bytes,
+        route: &'static str,
+        worker_url: &str,
+        is_stream: bool,
+        load_guard: Option<WorkerLoadGuard>,
+    ) -> Response {
+        let worker = self.worker_registry.get_by_url(worker_url);
+        let api_key = worker.as_ref().and_then(|w| w.api_key().clone());
+        const DP_RANK_KEY: &str = "data_parallel_rank";
+
+        let mut request_builder = if self.dp_aware {
+            let (worker_url_prefix, dp_rank) = match Self::extract_dp_rank(worker_url) {
+                Ok(tup) => tup,
+                Err(e) => {
+                    error!("Failed to extract dp_rank: {}", e);
+                    return error::internal_error(
+                        "dp_rank_extraction_failed",
+                        format!("Failed to extract dp_rank: {}", e),
+                    );
+                }
+            };
+            let mut json_val: serde_json::Value = match serde_json::from_slice(body) {
+                Ok(v) => v,
+                Err(e) => {
+                    return error::bad_request(
+                        "json_parse_failed",
+                        format!("dp_aware: failed to parse body as JSON: {e}"),
+                    );
+                }
+            };
+            if let Some(map) = json_val.as_object_mut() {
+                map.insert(DP_RANK_KEY.to_string(), serde_json::json!(dp_rank));
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    debug!(
+                        "Modified request body: {}",
+                        serde_json::to_string(&json_val).unwrap_or_else(|_| String::from("ERR"))
+                    );
+                }
+            } else {
+                return error::bad_request(
+                    "dp_rank_insertion_failed",
+                    "Failed to insert the data_parallel_rank field into the request body",
+                );
+            }
+            self.client
+                .post(format!("{}{}", worker_url_prefix, route))
+                .json(&json_val)
+        } else {
+            self.client
+                .post(format!("{}{}", worker_url, route))
+                .body(body.clone())
+                .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+        };
+
+        if let Some(key) = api_key {
+            let mut auth_header = String::with_capacity(7 + key.len());
+            auth_header.push_str("Bearer ");
+            auth_header.push_str(&key);
+            request_builder = request_builder.header("Authorization", auth_header);
+        }
+
+        if let Some(headers) = headers {
+            for (name, value) in headers {
+                if header_utils::should_forward_request_header(name.as_str()) {
+                    request_builder = request_builder.header(name, value);
+                }
+            }
+        }
+
+        let res = match request_builder.send().await {
+            Ok(res) => res,
+            Err(e) => {
+                error!(
+                    "Failed to send bytes request worker_url={} route={} error={}",
+                    worker_url, route, e
+                );
+                return convert_reqwest_error(e);
+            }
+        };
+
+        let status =
+            StatusCode::from_u16(res.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        if !is_stream {
+            let response_headers = header_utils::preserve_response_headers(res.headers());
+            match res.bytes().await {
+                Ok(body) => {
+                    let mut response = Response::new(Body::from(body));
+                    *response.status_mut() = status;
+                    *response.headers_mut() = response_headers;
+                    response
+                }
+                Err(e) => error::internal_error(
+                    "read_response_body_failed",
+                    format!("Failed to get response body: {}", e),
+                ),
+            }
+        } else {
+            let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            let stream = res.bytes_stream();
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            tokio::spawn(async move {
+                let mut stream = stream;
+                while let Some(chunk) = stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            if tx.send(Ok(bytes)).is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(format!("Stream error: {}", e)));
+                            break;
+                        }
+                    }
+                }
+            });
+            let stream = UnboundedReceiverStream::new(rx);
+            let body = Body::from_stream(stream);
+            let mut response = Response::new(body);
+            *response.status_mut() = status;
+            *response.headers_mut() = response_headers;
+            if let Some(guard) = load_guard {
+                response = AttachedBody::wrap_response(response, guard);
+            }
+            response
+        }
+    }
+
     // Send typed request directly without conversion
     async fn send_typed_request<T: serde::Serialize>(
         &self,
@@ -738,21 +1019,38 @@ impl RouterTrait for Router {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        body: &GenerateRequest,
-        model_id: Option<&str>,
+        view: &GenerateRoutingView,
+        body: &Bytes,
     ) -> Response {
-        self.route_typed_request(headers, body, "/generate", model_id)
-            .await
+        self.route_bytes_request(
+            headers,
+            body,
+            "/generate",
+            view.model.as_deref(),
+            view.stream,
+            view.text.as_deref(),
+        )
+        .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body: &Bytes,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/chat/completions", model_id)
-            .await
+        self.route_bytes_request(
+            headers,
+            body,
+            "/v1/chat/completions",
+            Some(&view.model),
+            view.stream,
+            // Cache-aware text extraction for chat would walk the
+            // messages array. The unified router doesn't currently
+            // use it; PD does (in pd_router.rs).
+            None,
+        )
+        .await
     }
 
     async fn route_completion(

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -38,7 +38,7 @@ use crate::{
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
         header_utils,
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        http::routing_view::{view_parse_error, ChatRoutingView, GenerateRoutingView},
         RouterTrait,
     },
 };
@@ -657,7 +657,7 @@ impl Router {
                 Ok(v) => v,
                 Err(e) => {
                     return error::bad_request(
-                        "json_parse_failed",
+                        "json_parse_error",
                         format!("dp_aware: failed to parse body as JSON: {e}"),
                     );
                 }
@@ -712,8 +712,8 @@ impl Router {
             }
         };
 
-        let status =
-            StatusCode::from_u16(res.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let status = StatusCode::from_u16(res.status().as_u16())
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
         if !is_stream {
             let response_headers = header_utils::preserve_response_headers(res.headers());
@@ -1019,14 +1019,18 @@ impl RouterTrait for Router {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        view: &GenerateRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
+        let view: GenerateRoutingView = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return view_parse_error::<GenerateRoutingView>(body, e),
+        };
         self.route_bytes_request(
             headers,
             body,
             "/generate",
-            view.model.as_deref(),
+            model_id.or(view.model.as_deref()),
             view.stream,
             view.text.as_deref(),
         )
@@ -1036,14 +1040,18 @@ impl RouterTrait for Router {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
+        let view: ChatRoutingView = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => return view_parse_error::<ChatRoutingView>(body, e),
+        };
         self.route_bytes_request(
             headers,
             body,
             "/v1/chat/completions",
-            Some(&view.model),
+            model_id.or(Some(view.model.as_str())),
             view.stream,
             // Cache-aware text extraction for chat would walk the
             // messages array. The unified router doesn't currently

--- a/sgl-model-gateway/src/routers/http/routing_view.rs
+++ b/sgl-model-gateway/src/routers/http/routing_view.rs
@@ -1,0 +1,203 @@
+//! Minimal "what the router needs to read" views over the chat/generate
+//! request body.
+//!
+//! Mirrors the design of the SGLang gRPC service's OpenAI-compatible
+//! RPCs (see `proto/sglang/runtime/v1/sglang.proto`):
+//!
+//! ```proto
+//! message OpenAIRequest {
+//!   bytes json_body = 1;
+//!   map<string, string> trace_headers = 2;
+//! }
+//!
+//! rpc ChatComplete(OpenAIRequest) returns (stream OpenAIStreamChunk);
+//! ```
+//!
+//! The proto deliberately treats the OpenAI-shaped JSON as opaque
+//! `bytes` and lets the receiving server unmarshal it. The HTTP gateway
+//! adopts the same shape: only parse the few fields the router itself
+//! consumes for routing decisions; forward the rest of the body
+//! verbatim.
+//!
+//! Compared to deserialising the full `openai-protocol::ChatCompletionRequest`,
+//! this:
+//! - Doesn't allocate a `String` for the multimodal `image_url.url`
+//!   (which can be 100 KB+ on real traffic). Unknown fields are
+//!   skipped at the JSON tokenizer level.
+//! - Doesn't pull in the openai-protocol crate on the routing path —
+//!   the gateway becomes protocol-version-agnostic for forwarding.
+//! - Forward-compatible by design: any future SGLang RL extension
+//!   field rides through as bytes; only fields the router branches on
+//!   need to be added here.
+
+use serde::Deserialize;
+
+/// Routing-decision view over a `/v1/chat/completions` request.
+///
+/// Captures only the fields the gateway *itself* reads. Everything
+/// else stays in the original `Bytes` body and flows through to the
+/// backend verbatim.
+#[derive(Debug, Default, Deserialize)]
+pub struct ChatRoutingView {
+    /// Required. Used for model-based worker selection and metrics
+    /// labels.
+    pub model: String,
+
+    /// Whether the response is streamed (SSE).
+    #[serde(default)]
+    pub stream: bool,
+
+    /// Number of completions per prompt. PD batch-size estimation
+    /// branches on this for `n > 1`.
+    #[serde(default)]
+    pub n: Option<u32>,
+
+    /// `logprobs: true/false` on the chat-completions endpoint. PD
+    /// merges prefill+decode logprobs only when this is true.
+    #[serde(default)]
+    pub logprobs: bool,
+
+    /// SGLang RL extension. PD merges prefill+decode `routed_experts`
+    /// only when this is true. PD streaming rejects this combination
+    /// up front (the SSE path has no merge step).
+    #[serde(default)]
+    pub return_routed_experts: bool,
+}
+
+/// Routing-decision view over a `/generate` request. SGLang's native
+/// generate endpoint, which uses snake_case field names and supports
+/// batch via `input_ids`.
+#[derive(Debug, Default, Deserialize)]
+pub struct GenerateRoutingView {
+    /// Optional on `/generate` — model is inferred from the worker
+    /// pool when absent.
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Whether the response is streamed.
+    #[serde(default)]
+    pub stream: bool,
+
+    /// SGLang's `return_logprob` flag (snake_case on /generate, vs
+    /// `logprobs` bool on /v1/chat/completions). PD merges
+    /// prefill+decode logprobs only when this is true.
+    #[serde(default)]
+    pub return_logprob: Option<bool>,
+
+    /// SGLang RL extension. Same semantics as on chat.
+    #[serde(default)]
+    pub return_routed_experts: bool,
+
+    /// First-position user text. Captured here for cache-aware
+    /// routing policies that hash on the prompt prefix.
+    #[serde(default)]
+    pub text: Option<String>,
+
+    /// Raw `input_ids`. SGLang accepts either a single `Vec<u32>` or
+    /// a `Vec<Vec<u32>>` (batch). Captured as a generic JSON Value so
+    /// `batch_size()` can disambiguate without committing to a typed
+    /// shape (avoids serde-untagged-enum ambiguity for flat-int
+    /// arrays).
+    #[serde(default)]
+    pub input_ids: Option<serde_json::Value>,
+}
+
+impl ChatRoutingView {
+    /// Number of completions requested (`n` field). Returns `None`
+    /// for the default case `n == 1`.
+    pub fn batch_size(&self) -> Option<usize> {
+        match self.n {
+            Some(n) if n > 1 => Some(n as usize),
+            _ => None,
+        }
+    }
+}
+
+impl GenerateRoutingView {
+    /// Number of items in a batch request, or `None` when single-shot.
+    /// SGLang's `input_ids` is either `Vec<u32>` (single — its
+    /// length is the token count, NOT the batch size) or
+    /// `Vec<Vec<u32>>` (batch — outer length IS the batch size).
+    /// Disambiguate by inspecting the first element: if it's an
+    /// array, the outer is a batch.
+    pub fn batch_size(&self) -> Option<usize> {
+        let arr = self.input_ids.as_ref()?.as_array()?;
+        match arr.first() {
+            Some(serde_json::Value::Array(_)) => Some(arr.len()),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_view_parses_minimal() {
+        let body = br#"{"model":"x","messages":[{"role":"user","content":"hi"}]}"#;
+        let v: ChatRoutingView = serde_json::from_slice(body).unwrap();
+        assert_eq!(v.model, "x");
+        assert!(!v.stream);
+        assert!(!v.return_routed_experts);
+    }
+
+    #[test]
+    fn chat_view_skips_giant_image_string_without_allocating_it() {
+        // The whole point of the proto-pattern: a 100KB image_url.url
+        // string lives in the bytes but never gets materialised into a
+        // typed String during routing.
+        let blob: String = "A".repeat(100 * 1024);
+        let body = format!(
+            r#"{{
+                "model":"x",
+                "messages":[{{
+                    "role":"user",
+                    "content":[
+                        {{"type":"text","text":"describe"}},
+                        {{"type":"image_url","image_url":{{"url":"data:image/png;base64,{blob}"}}}}
+                    ]
+                }}],
+                "return_routed_experts":true
+            }}"#
+        );
+        let v: ChatRoutingView = serde_json::from_slice(body.as_bytes()).unwrap();
+        assert_eq!(v.model, "x");
+        assert!(v.return_routed_experts);
+    }
+
+    #[test]
+    fn chat_view_rejects_bad_extension_type() {
+        // `return_routed_experts: "yes"` should 400 — no separate
+        // strict-type pass needed, serde does it.
+        let body = br#"{"model":"x","return_routed_experts":"yes"}"#;
+        let err = serde_json::from_slice::<ChatRoutingView>(body).unwrap_err();
+        assert!(
+            err.to_string().contains("return_routed_experts")
+                || err.to_string().contains("boolean"),
+            "error should name the offending field or expected type: {err}"
+        );
+    }
+
+    #[test]
+    fn generate_view_batch_size_via_input_ids() {
+        let body = br#"{"input_ids":[[1,2,3],[4,5,6],[7,8,9]],"stream":false}"#;
+        let v: GenerateRoutingView = serde_json::from_slice(body).unwrap();
+        assert_eq!(v.batch_size(), Some(3));
+    }
+
+    #[test]
+    fn generate_view_single_input_ids_not_a_batch() {
+        let body = br#"{"input_ids":[1,2,3,4]}"#;
+        let v: GenerateRoutingView = serde_json::from_slice(body).unwrap();
+        assert_eq!(v.batch_size(), None);
+    }
+
+    #[test]
+    fn generate_view_text_extraction() {
+        let body = br#"{"text":"hello world","return_routed_experts":true}"#;
+        let v: GenerateRoutingView = serde_json::from_slice(body).unwrap();
+        assert_eq!(v.text.as_deref(), Some("hello world"));
+        assert!(v.return_routed_experts);
+    }
+}

--- a/sgl-model-gateway/src/routers/http/routing_view.rs
+++ b/sgl-model-gateway/src/routers/http/routing_view.rs
@@ -129,6 +129,96 @@ impl GenerateRoutingView {
     }
 }
 
+/// Classifier output for a failed routing-view parse. Lets the HTTP
+/// entrypoint return a structured 400 with the right error code.
+pub enum ParseErrorKind {
+    /// The bytes weren't even valid JSON (truncated body, garbled
+    /// content-type, etc.). Surface as `json_parse_error`.
+    Json,
+    /// The bytes parsed as JSON but a known SGLang extension field
+    /// (e.g. `return_routed_experts`) had the wrong value type.
+    /// Surface as `invalid_sglang_extension` with the offending field
+    /// named — matches the contract the older `body_raw` design had,
+    /// so a mistyped flag isn't lumped into a generic JSON error.
+    InvalidSglangExtension(&'static str),
+    /// The bytes parsed as JSON but a routing-view field the gateway
+    /// itself reads (e.g. `model: 42`) had the wrong type. This is a
+    /// shape error on a non-extension field, so it stays a
+    /// `json_parse_error`. Kept distinct so future code can choose a
+    /// different code for it without entangling the extension case.
+    InvalidViewField,
+}
+
+/// Inspect the original request bytes and the failing routing-view
+/// parse error, and pick the right [`ParseErrorKind`].
+///
+/// Strategy: re-parse the body as a generic `serde_json::Value`. If
+/// that succeeds, the bytes are valid JSON but a typed field on the
+/// view didn't match — walk the known SGLang extension keys and check
+/// whether one of them is present with the wrong type. If yes, it's
+/// `InvalidSglangExtension(field)`. Otherwise it's a non-extension
+/// shape mismatch (`InvalidViewField`). If the second parse also fails,
+/// the bytes truly aren't JSON: `Json`.
+///
+/// The cost is one extra `from_slice::<Value>` on the failure path —
+/// happy path is unchanged.
+pub fn classify_parse_error<V: ViewSchema>(body: &[u8]) -> ParseErrorKind {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ParseErrorKind::Json;
+    };
+    let Some(obj) = value.as_object() else {
+        // Top-level wasn't an object — every routing view requires
+        // one. Treat as a shape error on the view, not as malformed
+        // JSON.
+        return ParseErrorKind::InvalidViewField;
+    };
+    for &field in V::EXTENSION_FIELDS {
+        if let Some(slot) = obj.get(field) {
+            if !V::extension_type_matches(field, slot) {
+                return ParseErrorKind::InvalidSglangExtension(field);
+            }
+        }
+    }
+    ParseErrorKind::InvalidViewField
+}
+
+/// Glue trait so `classify_parse_error` can drive both `ChatRoutingView`
+/// and `GenerateRoutingView` without duplicating the field-list /
+/// type-check tables. Each view enumerates the SGLang extension keys it
+/// strictly types and validates a candidate `Value` against the
+/// expected type.
+pub trait ViewSchema {
+    /// SGLang extension keys this view types strictly. A value present
+    /// under one of these names with the wrong JSON type is reported
+    /// as `invalid_sglang_extension` rather than the generic JSON
+    /// parse error.
+    const EXTENSION_FIELDS: &'static [&'static str];
+
+    /// Returns `true` when `value` matches the expected type for
+    /// `field`. `field` is guaranteed to be one of `EXTENSION_FIELDS`.
+    fn extension_type_matches(field: &str, value: &serde_json::Value) -> bool;
+}
+
+impl ViewSchema for ChatRoutingView {
+    const EXTENSION_FIELDS: &'static [&'static str] = &["return_routed_experts"];
+    fn extension_type_matches(field: &str, value: &serde_json::Value) -> bool {
+        match field {
+            "return_routed_experts" => value.is_boolean(),
+            _ => true,
+        }
+    }
+}
+
+impl ViewSchema for GenerateRoutingView {
+    const EXTENSION_FIELDS: &'static [&'static str] = &["return_routed_experts"];
+    fn extension_type_matches(field: &str, value: &serde_json::Value) -> bool {
+        match field {
+            "return_routed_experts" => value.is_boolean(),
+            _ => true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sgl-model-gateway/src/routers/http/routing_view.rs
+++ b/sgl-model-gateway/src/routers/http/routing_view.rs
@@ -219,6 +219,47 @@ impl ViewSchema for GenerateRoutingView {
     }
 }
 
+/// Walks an already-parsed JSON value and returns the first SGLang
+/// extension field that violates its expected type, or `None` when
+/// every present extension field is correctly typed. Used by routers
+/// (e.g. PD) that parse the body to `serde_json::Value` directly and
+/// therefore can't rely on a typed-deserialize failure to surface
+/// extension type errors.
+pub fn validate_extensions_in_value<V: ViewSchema>(
+    value: &serde_json::Value,
+) -> Option<&'static str> {
+    let obj = value.as_object()?;
+    for &field in V::EXTENSION_FIELDS {
+        if let Some(slot) = obj.get(field) {
+            if !V::extension_type_matches(field, slot) {
+                return Some(field);
+            }
+        }
+    }
+    None
+}
+
+/// Convert a failed routing-view parse into a structured 400. Promotes
+/// known-extension type mismatches (e.g. `return_routed_experts: "yes"`)
+/// to `invalid_sglang_extension` instead of folding them into the
+/// generic `json_parse_error`. Routers that parse a typed view (HTTP
+/// unified, gRPC) call this on `serde_json::Error`.
+pub fn view_parse_error<V: ViewSchema>(
+    body: &bytes::Bytes,
+    err: serde_json::Error,
+) -> axum::response::Response {
+    use crate::routers::error::bad_request;
+    match classify_parse_error::<V>(body) {
+        ParseErrorKind::InvalidSglangExtension(field) => bad_request(
+            "invalid_sglang_extension",
+            format!("Invalid SGLang extension field `{field}`: {err}"),
+        ),
+        ParseErrorKind::Json | ParseErrorKind::InvalidViewField => {
+            bad_request("json_parse_error", format!("Invalid JSON data: {err}"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +330,83 @@ mod tests {
         let v: GenerateRoutingView = serde_json::from_slice(body).unwrap();
         assert_eq!(v.text.as_deref(), Some("hello world"));
         assert!(v.return_routed_experts);
+    }
+
+    /// Routers that take a permissive `Value` parse (PD, gRPC) rely
+    /// on this helper to surface the same `invalid_sglang_extension`
+    /// 400 the typed-view path would produce. These tests pin that
+    /// contract so a future router added on the same shape stays
+    /// honest.
+    mod validate_extensions {
+        use serde_json::json;
+
+        use super::super::*;
+
+        #[test]
+        fn flags_wrong_typed_chat_extension() {
+            let value = json!({
+                "model": "x",
+                "messages": [],
+                "return_routed_experts": "yes"
+            });
+            assert_eq!(
+                validate_extensions_in_value::<ChatRoutingView>(&value),
+                Some("return_routed_experts")
+            );
+        }
+
+        #[test]
+        fn flags_wrong_typed_generate_extension() {
+            let value = json!({"text": "hi", "return_routed_experts": 1});
+            assert_eq!(
+                validate_extensions_in_value::<GenerateRoutingView>(&value),
+                Some("return_routed_experts")
+            );
+        }
+
+        #[test]
+        fn passes_correctly_typed_extension() {
+            let value = json!({
+                "model": "x",
+                "messages": [],
+                "return_routed_experts": true
+            });
+            assert_eq!(
+                validate_extensions_in_value::<ChatRoutingView>(&value),
+                None
+            );
+        }
+
+        #[test]
+        fn passes_when_extension_absent() {
+            let value = json!({"model": "x", "messages": []});
+            assert_eq!(
+                validate_extensions_in_value::<ChatRoutingView>(&value),
+                None
+            );
+        }
+
+        #[test]
+        fn null_extension_value_is_a_type_mismatch() {
+            // `null` is not a boolean — surface as
+            // `invalid_sglang_extension` so the client sees it
+            // instead of having the field silently dropped.
+            let value = json!({"return_routed_experts": null});
+            assert_eq!(
+                validate_extensions_in_value::<GenerateRoutingView>(&value),
+                Some("return_routed_experts")
+            );
+        }
+
+        #[test]
+        fn non_object_top_level_returns_none() {
+            // Top-level shape mismatch isn't this helper's concern;
+            // typed parse will reject downstream.
+            let value = json!([1, 2, 3]);
+            assert_eq!(
+                validate_extensions_in_value::<ChatRoutingView>(&value),
+                None
+            );
+        }
     }
 }

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -11,15 +11,12 @@ use axum::{
 };
 use bytes::Bytes;
 
-use crate::{
-    protocols::{
-        classify::ClassifyRequest,
-        completion::CompletionRequest,
-        embedding::EmbeddingRequest,
-        rerank::RerankRequest,
-        responses::{ResponsesGetParams, ResponsesRequest},
-    },
-    routers::http::routing_view::{ChatRoutingView, GenerateRoutingView},
+use crate::protocols::{
+    classify::ClassifyRequest,
+    completion::CompletionRequest,
+    embedding::EmbeddingRequest,
+    rerank::RerankRequest,
+    responses::{ResponsesGetParams, ResponsesRequest},
 };
 
 pub mod conversations;
@@ -80,18 +77,20 @@ pub trait RouterTrait: Send + Sync + Debug {
     /// Route a generate request.
     ///
     /// **Proto-pattern signature** — see
-    /// `proto/sglang/runtime/v1/sglang.proto::OpenAIRequest`. `view`
-    /// captures only the fields the gateway router itself reads
-    /// (model, stream, return_logprob, return_routed_experts, batch
-    /// hints, optional prompt text). `body` is the original client
-    /// request bytes — every other field, including SGLang RL
-    /// extension fields the router doesn't branch on, rides through
-    /// unchanged to the backend.
+    /// `proto/sglang/runtime/v1/sglang.proto::OpenAIRequest`. `body`
+    /// is the original client request bytes; the receiving router
+    /// parses exactly what it needs (HTTP unified parses a routing
+    /// view, PD parses a `Value` because it has to mutate the body
+    /// for bootstrap injection, gRPC parses the typed proto request).
+    /// Routing decisions that need a model id come from `model_id`
+    /// when `RouterManager` resolved one in IGW mode (single
+    /// registered model = implicit default); otherwise routers fall
+    /// back to whatever's in `body`.
     async fn route_generate(
         &self,
         _headers: Option<&HeaderMap>,
-        _view: &GenerateRoutingView,
         _body: &Bytes,
+        _model_id: Option<&str>,
     ) -> Response {
         (
             StatusCode::NOT_IMPLEMENTED,
@@ -101,12 +100,12 @@ pub trait RouterTrait: Send + Sync + Debug {
     }
 
     /// Route a chat completion request. See `route_generate` for the
-    /// meaning of `view` and `body`.
+    /// meaning of `body` and `model_id`.
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response;
 
     /// Route a completion request

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -9,15 +9,17 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 
-use crate::protocols::{
-    chat::ChatCompletionRequest,
-    classify::ClassifyRequest,
-    completion::CompletionRequest,
-    embedding::EmbeddingRequest,
-    generate::GenerateRequest,
-    rerank::RerankRequest,
-    responses::{ResponsesGetParams, ResponsesRequest},
+use crate::{
+    protocols::{
+        classify::ClassifyRequest,
+        completion::CompletionRequest,
+        embedding::EmbeddingRequest,
+        rerank::RerankRequest,
+        responses::{ResponsesGetParams, ResponsesRequest},
+    },
+    routers::http::routing_view::{ChatRoutingView, GenerateRoutingView},
 };
 
 pub mod conversations;
@@ -75,12 +77,21 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
-    /// Route a generate request
+    /// Route a generate request.
+    ///
+    /// **Proto-pattern signature** — see
+    /// `proto/sglang/runtime/v1/sglang.proto::OpenAIRequest`. `view`
+    /// captures only the fields the gateway router itself reads
+    /// (model, stream, return_logprob, return_routed_experts, batch
+    /// hints, optional prompt text). `body` is the original client
+    /// request bytes — every other field, including SGLang RL
+    /// extension fields the router doesn't branch on, rides through
+    /// unchanged to the backend.
     async fn route_generate(
         &self,
         _headers: Option<&HeaderMap>,
-        _body: &GenerateRequest,
-        _model_id: Option<&str>,
+        _view: &GenerateRoutingView,
+        _body: &Bytes,
     ) -> Response {
         (
             StatusCode::NOT_IMPLEMENTED,
@@ -89,12 +100,13 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
-    /// Route a chat completion request
+    /// Route a chat completion request. See `route_generate` for the
+    /// meaning of `view` and `body`.
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body: &Bytes,
     ) -> Response;
 
     /// Route a completion request

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     routers::{
         header_utils::{apply_provider_headers, extract_auth_header},
-        http::routing_view::ChatRoutingView,
+        http::routing_view::{view_parse_error, ChatRoutingView},
     },
 };
 
@@ -474,18 +474,18 @@ impl crate::routers::RouterTrait for OpenAIRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body_bytes: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
         // OpenAI provider serialises to the upstream OpenAI-compatible
-        // API. It needs the full typed struct, so re-parse from bytes.
+        // API and needs the full typed `ChatCompletionRequest`.
         let body: ChatCompletionRequest = match serde_json::from_slice(body_bytes) {
             Ok(v) => v,
-            Err(e) => return crate::routers::error::bad_request("json_parse_failed", format!("{e}")),
+            Err(e) => return view_parse_error::<ChatRoutingView>(body_bytes, e),
         };
         let body = &body;
         let start = Instant::now();
-        let model = view.model.as_str();
+        let model = model_id.unwrap_or(body.model.as_str());
         let streaming = body.stream;
 
         // Record request start
@@ -533,7 +533,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             }
         };
 
-        let provider = self.get_provider_arc_for_worker(worker.as_ref(), Some(&view.model));
+        let provider = self.get_provider_arc_for_worker(worker.as_ref(), Some(model));
         if let Err(e) = provider.transform_request(&mut payload, Endpoint::Chat) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_OPENAI,
@@ -549,7 +549,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let mut ctx = RequestContext::for_chat(
             Arc::new(body.clone()),
             headers.cloned(),
-            Some(view.model.clone()),
+            Some(model.to_string()),
             ComponentRefs::Shared(self.shared_components()),
         );
 

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -12,6 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use bytes::Bytes;
 use data_connector::{ConversationId, ListParams, ResponseId, SortOrder};
 use futures_util::{future::join_all, StreamExt};
 use serde_json::{json, to_value, Value};
@@ -42,7 +43,10 @@ use crate::{
             ResponsesGetParams, ResponsesRequest,
         },
     },
-    routers::header_utils::{apply_provider_headers, extract_auth_header},
+    routers::{
+        header_utils::{apply_provider_headers, extract_auth_header},
+        http::routing_view::ChatRoutingView,
+    },
 };
 
 pub struct OpenAIRouter {
@@ -470,11 +474,18 @@ impl crate::routers::RouterTrait for OpenAIRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body_bytes: &Bytes,
     ) -> Response {
+        // OpenAI provider serialises to the upstream OpenAI-compatible
+        // API. It needs the full typed struct, so re-parse from bytes.
+        let body: ChatCompletionRequest = match serde_json::from_slice(body_bytes) {
+            Ok(v) => v,
+            Err(e) => return crate::routers::error::bad_request("json_parse_failed", format!("{e}")),
+        };
+        let body = &body;
         let start = Instant::now();
-        let model = model_id.unwrap_or(body.model.as_str());
+        let model = view.model.as_str();
         let streaming = body.stream;
 
         // Record request start
@@ -522,7 +533,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             }
         };
 
-        let provider = self.get_provider_arc_for_worker(worker.as_ref(), model_id);
+        let provider = self.get_provider_arc_for_worker(worker.as_ref(), Some(&view.model));
         if let Err(e) = provider.transform_request(&mut payload, Endpoint::Chat) {
             Metrics::record_router_error(
                 metrics_labels::ROUTER_OPENAI,
@@ -538,7 +549,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let mut ctx = RequestContext::for_chat(
             Arc::new(body.clone()),
             headers.cloned(),
-            model_id.map(String::from),
+            Some(view.model.clone()),
             ComponentRefs::Shared(self.shared_components()),
         );
 

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -35,17 +35,22 @@ use crate::{
 };
 
 /// Read the `model` field out of a parsed body for IGW dispatch.
-/// Distinguishes three input shapes that previously all collapsed
+/// Distinguishes four input shapes that previously all collapsed
 /// to "no model":
-/// - `Some(Ok(Some(s)))` — explicit string model id;
-/// - `Some(Ok(None))` — field absent, or present as JSON `null`;
-/// - `Some(Err(_))` — field present but not a string, e.g. `model: 42`;
-///   surface a structured 400 instead of silently routing to the
-///   single-model implicit default.
+/// - `Ok(Some(s))` — explicit non-empty string model id;
+/// - `Ok(None)` — field absent, or present as JSON `null`;
+/// - `Err(_)` for `model: ""` — empty string is rejected explicitly
+///   so we fail fast with a structured 400 instead of routing to a
+///   model id no worker can match;
+/// - `Err(_)` for non-string types like `model: 42` — same reasoning.
 fn extract_body_model(value: &Value) -> Result<Option<&str>, Response> {
     match value.get("model") {
         None | Some(Value::Null) => Ok(None),
-        Some(Value::String(s)) => Ok(Some(s.as_str())),
+        Some(Value::String(s)) if !s.is_empty() => Ok(Some(s.as_str())),
+        Some(Value::String(_)) => Err(error::bad_request(
+            "json_parse_error",
+            "Field `model` must be a non-empty string",
+        )),
         Some(_) => Err(error::bad_request(
             "json_parse_error",
             "Field `model` must be a string",
@@ -828,6 +833,38 @@ mod tests {
         fn router_type(&self) -> &'static str {
             "capture-mock"
         }
+    }
+
+    #[test]
+    fn extract_body_model_empty_string_is_400() {
+        let body = serde_json::json!({"model": ""});
+        let err = extract_body_model(&body).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        // Lock the structured-error contract: clients (and our own
+        // metrics labels) classify on the `X-SMG-Error-Code` header,
+        // so a refactor that drops the code must not slip through.
+        assert_eq!(
+            error::extract_error_code_from_response(&err),
+            "json_parse_error"
+        );
+    }
+
+    #[test]
+    fn extract_body_model_accepts_missing_and_null() {
+        assert!(matches!(
+            extract_body_model(&serde_json::json!({})),
+            Ok(None)
+        ));
+        assert!(matches!(
+            extract_body_model(&serde_json::json!({"model": null})),
+            Ok(None)
+        ));
+    }
+
+    #[test]
+    fn extract_body_model_accepts_nonempty_string() {
+        let body = serde_json::json!({"model": "m1"});
+        assert_eq!(extract_body_model(&body).unwrap(), Some("m1"));
     }
 
     /// IGW (k8s-mode) implicit-default-model contract: when service

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -30,12 +30,28 @@ use crate::{
         rerank::RerankRequest,
         responses::{ResponsesGetParams, ResponsesRequest},
     },
-    routers::{
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
-        RouterTrait,
-    },
+    routers::{error, RouterTrait},
     server::ServerConfig,
 };
+
+/// Read the `model` field out of a parsed body for IGW dispatch.
+/// Distinguishes three input shapes that previously all collapsed
+/// to "no model":
+/// - `Some(Ok(Some(s)))` — explicit string model id;
+/// - `Some(Ok(None))` — field absent, or present as JSON `null`;
+/// - `Some(Err(_))` — field present but not a string, e.g. `model: 42`;
+///   surface a structured 400 instead of silently routing to the
+///   single-model implicit default.
+fn extract_body_model(value: &Value) -> Result<Option<&str>, Response> {
+    match value.get("model") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.as_str())),
+        Some(_) => Err(error::bad_request(
+            "json_parse_error",
+            "Field `model` must be a string",
+        )),
+    }
+}
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct RouterId(&'static str);
@@ -248,13 +264,10 @@ impl RouterManager {
         let available_models = self.worker_registry.get_models();
 
         match available_models.len() {
-            0 => Err(Box::new(
-                (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "No models available - no workers registered",
-                )
-                    .into_response(),
-            )),
+            0 => Err(Box::new(error::service_unavailable(
+                "no_models_available",
+                "No models available - no workers registered",
+            ))),
             1 => {
                 // Single model: use it as implicit default
                 debug!(
@@ -263,19 +276,13 @@ impl RouterManager {
                 );
                 Ok(available_models[0].clone())
             }
-            _ => {
-                // Multiple models: require explicit model specification
-                Err(Box::new(
-                    (
-                        StatusCode::BAD_REQUEST,
-                        format!(
-                            "Model must be specified. Available models: {}",
-                            available_models.join(", ")
-                        ),
-                    )
-                        .into_response(),
-                ))
-            }
+            _ => Err(Box::new(error::bad_request(
+                "model_required",
+                format!(
+                    "Model must be specified. Available models: {}",
+                    available_models.join(", ")
+                ),
+            ))),
         }
     }
 
@@ -417,11 +424,10 @@ impl RouterTrait for RouterManager {
         if has_healthy_workers {
             (StatusCode::OK, "At least one router has healthy workers").into_response()
         } else {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
+            error::service_unavailable(
+                "no_healthy_workers",
                 "No routers with healthy workers available",
             )
-                .into_response()
         }
     }
 
@@ -443,7 +449,7 @@ impl RouterTrait for RouterManager {
         let model_names = self.worker_registry.get_models();
 
         if model_names.is_empty() {
-            (StatusCode::SERVICE_UNAVAILABLE, "No models available").into_response()
+            error::service_unavailable("no_models_available", "No models available")
         } else {
             // Convert model names to OpenAI-compatible model objects
             let models: Vec<Value> = model_names
@@ -489,64 +495,111 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.get_model_info(req).await
         } else {
-            (StatusCode::SERVICE_UNAVAILABLE, "No routers available").into_response()
+            error::service_unavailable("no_routers_available", "No routers available")
         }
     }
 
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        view: &GenerateRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let _effective_model_id = if self.enable_igw {
-            match self.resolve_model_id(view.model.as_deref()) {
-                Ok(id) => Some(id),
-                Err(err_response) => return *err_response,
+        // Non-IGW fast path: hand body+model_id straight to the default
+        // router and skip parsing entirely.
+        if !self.enable_igw {
+            let Some(router) = self.select_router_for_request(headers, model_id) else {
+                return error::not_found(
+                    "no_router_available",
+                    "No router available for this request",
+                );
+            };
+            return router.route_generate(headers, body, model_id).await;
+        }
+
+        // IGW: parse `Value` so a malformed body fails fast with a
+        // structured error here, rather than being silently routed to
+        // the implicit-default model and only rejected later by the
+        // chosen router (which would pollute metrics/labels with a
+        // model the client never asked for).
+        let value: Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error::bad_request("json_parse_error", format!("Invalid JSON data: {e}"));
             }
-        } else {
-            None
+        };
+        let body_model = match extract_body_model(&value) {
+            Ok(m) => m,
+            Err(resp) => return resp,
+        };
+        let effective_model_id = match self.resolve_model_id(body_model) {
+            Ok(id) => id,
+            Err(err_response) => return *err_response,
         };
 
-        let router = self.select_router_for_request(headers, view.model.as_deref());
-
-        if let Some(router) = router {
-            router.route_generate(headers, view, body).await
-        } else {
-            (
-                StatusCode::NOT_FOUND,
+        let Some(router) = self.select_router_for_request(headers, Some(&effective_model_id))
+        else {
+            return error::not_found(
+                "no_router_available",
                 "No router available for this request",
-            )
-                .into_response()
-        }
+            );
+        };
+
+        router
+            .route_generate(headers, body, Some(&effective_model_id))
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        view: &ChatRoutingView,
         body: &Bytes,
+        model_id: Option<&str>,
     ) -> Response {
-        let _effective_model_id = if self.enable_igw {
-            match self.resolve_model_id(Some(&view.model)) {
-                Ok(id) => Some(id),
-                Err(err_response) => return *err_response,
+        if !self.enable_igw {
+            let Some(router) = self.select_router_for_request(headers, model_id) else {
+                return error::not_found(
+                    "no_router_available",
+                    "No router available for this request",
+                );
+            };
+            return router.route_chat(headers, body, model_id).await;
+        }
+
+        // IGW: same shape as generate — hard-fail on malformed JSON
+        // here so it can't masquerade as "no model field" and reach
+        // an unrelated worker. Chat clients normally supply `model`;
+        // when they don't and a single model is registered the IGW
+        // resolver still treats it as the implicit default.
+        let value: Value = match serde_json::from_slice(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error::bad_request("json_parse_error", format!("Invalid JSON data: {e}"));
             }
-        } else {
-            None
+        };
+        let body_model = match extract_body_model(&value) {
+            Ok(m) => m,
+            Err(resp) => return resp,
+        };
+        let effective_model_id = match self.resolve_model_id(body_model) {
+            Ok(id) => id,
+            Err(err_response) => return *err_response,
         };
 
-        let router = self.select_router_for_request(headers, Some(&view.model));
+        let Some(router) = self.select_router_for_request(headers, Some(&effective_model_id))
+        else {
+            return error::not_found(
+                "no_router_available",
+                format!(
+                    "Model '{}' not found or no router available",
+                    effective_model_id
+                ),
+            );
+        };
 
-        if let Some(router) = router {
-            router.route_chat(headers, view, body).await
-        } else {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Model '{}' not found or no router available", view.model),
-            )
-                .into_response()
-        }
+        router
+            .route_chat(headers, body, Some(&effective_model_id))
+            .await
     }
 
     async fn route_completion(
@@ -576,11 +629,10 @@ impl RouterTrait for RouterManager {
                 .route_completion(headers, body, effective_model_id.as_deref().or(model_id))
                 .await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 format!("Model '{}' not found or no router available", body.model),
             )
-                .into_response()
         }
     }
 
@@ -596,11 +648,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.route_responses(headers, body, selected_model).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 "No router available to handle responses request",
             )
-                .into_response()
         }
     }
 
@@ -614,11 +665,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.get_response(headers, response_id, params).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 format!("No router available to get response '{}'", response_id),
             )
-                .into_response()
         }
     }
 
@@ -627,11 +677,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.cancel_response(headers, response_id).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 format!("No router available to cancel response '{}'", response_id),
             )
-                .into_response()
         }
     }
 
@@ -654,11 +703,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.list_response_input_items(headers, response_id).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 "No router available to list response input items",
             )
-                .into_response()
         }
     }
 
@@ -673,11 +721,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.route_embeddings(headers, body, model_id).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 format!("Model '{}' not found or no router available", body.model),
             )
-                .into_response()
         }
     }
 
@@ -692,11 +739,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.route_classify(headers, body, model_id).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 format!("Model '{}' not found or no router available", body.model),
             )
-                .into_response()
         }
     }
 
@@ -711,11 +757,10 @@ impl RouterTrait for RouterManager {
         if let Some(router) = router {
             router.route_rerank(headers, body, model_id).await
         } else {
-            (
-                StatusCode::NOT_FOUND,
+            error::not_found(
+                "no_router_available",
                 "No router available for rerank request",
             )
-                .into_response()
         }
     }
 
@@ -735,5 +780,94 @@ impl std::fmt::Debug for RouterManager {
             .field("workers_count", &self.worker_registry.get_all().len())
             .field("default_router", &*default_router)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Mutex};
+
+    use super::*;
+    use crate::core::{BasicWorkerBuilder, Worker};
+
+    /// Mock router that records the `model_id` argument it receives,
+    /// so tests can assert what `RouterManager` plumbed through.
+    #[derive(Debug, Default)]
+    struct CaptureRouter {
+        seen_generate_model: Mutex<Vec<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl RouterTrait for CaptureRouter {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        async fn route_generate(
+            &self,
+            _headers: Option<&HeaderMap>,
+            _body: &Bytes,
+            model_id: Option<&str>,
+        ) -> Response {
+            self.seen_generate_model
+                .lock()
+                .unwrap()
+                .push(model_id.map(str::to_string));
+            (StatusCode::OK, "captured").into_response()
+        }
+
+        async fn route_chat(
+            &self,
+            _headers: Option<&HeaderMap>,
+            _body: &Bytes,
+            _model_id: Option<&str>,
+        ) -> Response {
+            (StatusCode::OK, "captured").into_response()
+        }
+
+        fn router_type(&self) -> &'static str {
+            "capture-mock"
+        }
+    }
+
+    /// IGW (k8s-mode) implicit-default-model contract: when service
+    /// discovery has registered exactly one model and the client
+    /// omits `"model"`, the manager must resolve it via
+    /// `resolve_model_id` and forward the resolved id to the chosen
+    /// router as `model_id`. Without this, downstream metrics labels,
+    /// worker selection, and cache-aware policies all lose the
+    /// model dimension.
+    #[tokio::test]
+    async fn igw_route_generate_propagates_resolved_model() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let mut labels = HashMap::new();
+        labels.insert("model_id".to_string(), "test-model-a".to_string());
+        let worker: Arc<dyn Worker> = Arc::from(
+            BasicWorkerBuilder::new("http://capture-worker:9999")
+                .worker_type(WorkerType::Regular)
+                .labels(labels)
+                .build(),
+        );
+        registry.register(worker);
+
+        let mut manager = RouterManager::new(registry);
+        manager.enable_igw = true;
+        let manager = Arc::new(manager);
+
+        let capture = Arc::new(CaptureRouter::default());
+        manager.register_router(router_ids::HTTP_REGULAR, capture.clone());
+
+        // Client omits "model" in the body — IGW must resolve the
+        // single registered worker's model id and pass it down.
+        let body = Bytes::from(r#"{"text":"hi"}"#);
+        let response = manager.route_generate(None, &body, None).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let seen = capture.seen_generate_model.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![Some("test-model-a".to_string())],
+            "downstream router must see the IGW-resolved model id, not None"
+        );
     }
 }

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -14,6 +14,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 use dashmap::DashMap;
 use serde_json::Value;
 use tracing::{debug, info, warn};
@@ -23,15 +24,16 @@ use crate::{
     config::RoutingMode,
     core::{ConnectionMode, RuntimeType, WorkerRegistry, WorkerType},
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
-        generate::GenerateRequest,
         rerank::RerankRequest,
         responses::{ResponsesGetParams, ResponsesRequest},
     },
-    routers::RouterTrait,
+    routers::{
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        RouterTrait,
+    },
     server::ServerConfig,
 };
 
@@ -494,13 +496,11 @@ impl RouterTrait for RouterManager {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
-        body: &GenerateRequest,
-        model_id: Option<&str>,
+        view: &GenerateRoutingView,
+        body: &Bytes,
     ) -> Response {
-        // In IGW mode, resolve model_id and fail fast if not resolvable
-        // In non-IGW mode, pass through to router (router handles validation)
-        let effective_model_id = if self.enable_igw {
-            match self.resolve_model_id(model_id) {
+        let _effective_model_id = if self.enable_igw {
+            match self.resolve_model_id(view.model.as_deref()) {
                 Ok(id) => Some(id),
                 Err(err_response) => return *err_response,
             }
@@ -508,13 +508,10 @@ impl RouterTrait for RouterManager {
             None
         };
 
-        let router =
-            self.select_router_for_request(headers, effective_model_id.as_deref().or(model_id));
+        let router = self.select_router_for_request(headers, view.model.as_deref());
 
         if let Some(router) = router {
-            router
-                .route_generate(headers, body, effective_model_id.as_deref().or(model_id))
-                .await
+            router.route_generate(headers, view, body).await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -527,15 +524,11 @@ impl RouterTrait for RouterManager {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
-        body: &ChatCompletionRequest,
-        model_id: Option<&str>,
+        view: &ChatRoutingView,
+        body: &Bytes,
     ) -> Response {
-        // In IGW mode, resolve model_id and fail fast if not resolvable
-        // In non-IGW mode, pass through to router (router handles validation)
-        let effective_model_id = if self.enable_igw {
-            // Use provided model_id or fall back to body.model
-            let model = model_id.or(Some(&body.model));
-            match self.resolve_model_id(model) {
+        let _effective_model_id = if self.enable_igw {
+            match self.resolve_model_id(Some(&view.model)) {
                 Ok(id) => Some(id),
                 Err(err_response) => return *err_response,
             }
@@ -543,17 +536,14 @@ impl RouterTrait for RouterManager {
             None
         };
 
-        let router =
-            self.select_router_for_request(headers, effective_model_id.as_deref().or(model_id));
+        let router = self.select_router_for_request(headers, Some(&view.model));
 
         if let Some(router) = router {
-            router
-                .route_chat(headers, body, effective_model_id.as_deref().or(model_id))
-                .await
+            router.route_chat(headers, view, body).await
         } else {
             (
                 StatusCode::NOT_FOUND,
-                format!("Model '{}' not found or no router available", body.model),
+                format!("Model '{}' not found or no router available", view.model),
             )
                 .into_response()
         }

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -13,6 +13,7 @@ use axum::{
     routing::{delete, get, post},
     Json, Router,
 };
+use bytes::Bytes;
 use rustls::crypto::ring;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -40,11 +41,9 @@ use crate::{
         otel_trace,
     },
     protocols::{
-        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         completion::CompletionRequest,
         embedding::EmbeddingRequest,
-        generate::GenerateRequest,
         parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
         rerank::V1RerankReqInput,
         responses::{ResponsesGetParams, ResponsesRequest},
@@ -54,6 +53,7 @@ use crate::{
     },
     routers::{
         conversations,
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
         mesh::{
             get_app_config, get_cluster_status, get_global_rate_limit, get_global_rate_limit_stats,
             get_mesh_health, get_policy_state, get_policy_states, get_worker_state,
@@ -169,27 +169,78 @@ async fn get_model_info(State(state): State<Arc<AppState>>, req: Request) -> Res
     state.router.get_model_info(req).await
 }
 
+/// Read the raw request body up to a generous limit. Matches what
+/// `Json::from_request` would have consumed.
+async fn read_body_bytes(request: Request) -> Result<Bytes, Response> {
+    axum::body::to_bytes(request.into_body(), usize::MAX)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": {
+                        "message": format!("Failed to read request body: {}", e),
+                        "type": "invalid_request_error",
+                        "code": "body_read_error"
+                    }
+                })),
+            )
+                .into_response()
+        })
+}
+
+fn json_parse_error(message: String) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+                "code": "json_parse_error"
+            }
+        })),
+    )
+        .into_response()
+}
+
 async fn generate(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    Json(body): Json<GenerateRequest>,
+    request: Request,
 ) -> Response {
-    let model_id = body.model.as_deref();
-    state
-        .router
-        .route_generate(Some(&headers), &body, model_id)
-        .await
+    // Proto-pattern: read raw body, then parse only the fields the
+    // router itself reads for routing decisions. Everything else
+    // (including SGLang RL extension fields) stays in `body` and
+    // flows through verbatim.
+    let body = match read_body_bytes(request).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    let view: GenerateRoutingView = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return json_parse_error(format!("Invalid JSON data: {}", e)),
+    };
+    state.router.route_generate(Some(&headers), &view, &body).await
 }
 
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
+    request: Request,
 ) -> Response {
-    state
-        .router
-        .route_chat(Some(&headers), &body, Some(&body.model))
-        .await
+    // Proto-pattern: see `generate` above. Mirrors the SGLang gRPC
+    // `OpenAIRequest { bytes json_body }` design — the gateway is a
+    // protocol-version-agnostic forwarder, the receiving server
+    // unmarshals the JSON.
+    let body = match read_body_bytes(request).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    let view: ChatRoutingView = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => return json_parse_error(format!("Invalid JSON data: {}", e)),
+    };
+    state.router.route_chat(Some(&headers), &view, &body).await
 }
 
 async fn v1_completions(

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -53,9 +53,6 @@ use crate::{
     },
     routers::{
         conversations,
-        http::routing_view::{
-            classify_parse_error, ChatRoutingView, GenerateRoutingView, ParseErrorKind,
-        },
         mesh::{
             get_app_config, get_cluster_status, get_global_rate_limit, get_global_rate_limit_stats,
             get_mesh_health, get_policy_state, get_policy_states, get_worker_state,
@@ -177,56 +174,11 @@ async fn read_body_bytes(request: Request) -> Result<Bytes, Response> {
     axum::body::to_bytes(request.into_body(), usize::MAX)
         .await
         .map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(json!({
-                    "error": {
-                        "message": format!("Failed to read request body: {}", e),
-                        "type": "invalid_request_error",
-                        "code": "body_read_error"
-                    }
-                })),
+            crate::routers::error::bad_request(
+                "body_read_error",
+                format!("Failed to read request body: {e}"),
             )
-                .into_response()
         })
-}
-
-fn json_parse_error(message: String) -> Response {
-    bad_request_with_code(message, "json_parse_error")
-}
-
-fn bad_request_with_code(message: String, code: &'static str) -> Response {
-    (
-        StatusCode::BAD_REQUEST,
-        Json(json!({
-            "error": {
-                "message": message,
-                "type": "invalid_request_error",
-                "code": code,
-            }
-        })),
-    )
-        .into_response()
-}
-
-/// Convert a failed routing-view parse into a structured 400. Promotes
-/// known-extension type mismatches (e.g. `return_routed_experts: "yes"`)
-/// to `invalid_sglang_extension` instead of folding them into the
-/// generic `json_parse_error`. Mirrors the contract the older `body_raw`
-/// design exposed via `parse_sglang_extensions`.
-fn view_parse_error<V: crate::routers::http::routing_view::ViewSchema>(
-    body: &Bytes,
-    err: serde_json::Error,
-) -> Response {
-    match classify_parse_error::<V>(body) {
-        ParseErrorKind::InvalidSglangExtension(field) => bad_request_with_code(
-            format!("Invalid SGLang extension field `{field}`: {err}"),
-            "invalid_sglang_extension",
-        ),
-        ParseErrorKind::Json | ParseErrorKind::InvalidViewField => {
-            json_parse_error(format!("Invalid JSON data: {err}"))
-        }
-    }
 }
 
 async fn generate(
@@ -234,19 +186,20 @@ async fn generate(
     headers: http::HeaderMap,
     request: Request,
 ) -> Response {
-    // Proto-pattern: read raw body, then parse only the fields the
-    // router itself reads for routing decisions. Everything else
-    // (including SGLang RL extension fields) stays in `body` and
-    // flows through verbatim.
+    // Proto-pattern: read raw body, hand it to the router. Each
+    // concrete router parses exactly what it needs (HTTP unified
+    // parses a routing view, PD parses a `Value` because it has to
+    // mutate the body for bootstrap injection, gRPC parses the typed
+    // proto request). RouterManager peeks at `model` for IGW
+    // dispatch and passes the resolved id forward as `model_id`.
     let body = match read_body_bytes(request).await {
         Ok(b) => b,
         Err(resp) => return resp,
     };
-    let view: GenerateRoutingView = match serde_json::from_slice(&body) {
-        Ok(v) => v,
-        Err(e) => return view_parse_error::<GenerateRoutingView>(&body, e),
-    };
-    state.router.route_generate(Some(&headers), &view, &body).await
+    state
+        .router
+        .route_generate(Some(&headers), &body, None)
+        .await
 }
 
 async fn v1_chat_completions(
@@ -262,11 +215,7 @@ async fn v1_chat_completions(
         Ok(b) => b,
         Err(resp) => return resp,
     };
-    let view: ChatRoutingView = match serde_json::from_slice(&body) {
-        Ok(v) => v,
-        Err(e) => return view_parse_error::<ChatRoutingView>(&body, e),
-    };
-    state.router.route_chat(Some(&headers), &view, &body).await
+    state.router.route_chat(Some(&headers), &body, None).await
 }
 
 async fn v1_completions(

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -53,7 +53,9 @@ use crate::{
     },
     routers::{
         conversations,
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        http::routing_view::{
+            classify_parse_error, ChatRoutingView, GenerateRoutingView, ParseErrorKind,
+        },
         mesh::{
             get_app_config, get_cluster_status, get_global_rate_limit, get_global_rate_limit_stats,
             get_mesh_health, get_policy_state, get_policy_states, get_worker_state,
@@ -190,17 +192,41 @@ async fn read_body_bytes(request: Request) -> Result<Bytes, Response> {
 }
 
 fn json_parse_error(message: String) -> Response {
+    bad_request_with_code(message, "json_parse_error")
+}
+
+fn bad_request_with_code(message: String, code: &'static str) -> Response {
     (
         StatusCode::BAD_REQUEST,
         Json(json!({
             "error": {
                 "message": message,
                 "type": "invalid_request_error",
-                "code": "json_parse_error"
+                "code": code,
             }
         })),
     )
         .into_response()
+}
+
+/// Convert a failed routing-view parse into a structured 400. Promotes
+/// known-extension type mismatches (e.g. `return_routed_experts: "yes"`)
+/// to `invalid_sglang_extension` instead of folding them into the
+/// generic `json_parse_error`. Mirrors the contract the older `body_raw`
+/// design exposed via `parse_sglang_extensions`.
+fn view_parse_error<V: crate::routers::http::routing_view::ViewSchema>(
+    body: &Bytes,
+    err: serde_json::Error,
+) -> Response {
+    match classify_parse_error::<V>(body) {
+        ParseErrorKind::InvalidSglangExtension(field) => bad_request_with_code(
+            format!("Invalid SGLang extension field `{field}`: {err}"),
+            "invalid_sglang_extension",
+        ),
+        ParseErrorKind::Json | ParseErrorKind::InvalidViewField => {
+            json_parse_error(format!("Invalid JSON data: {err}"))
+        }
+    }
 }
 
 async fn generate(
@@ -218,7 +244,7 @@ async fn generate(
     };
     let view: GenerateRoutingView = match serde_json::from_slice(&body) {
         Ok(v) => v,
-        Err(e) => return json_parse_error(format!("Invalid JSON data: {}", e)),
+        Err(e) => return view_parse_error::<GenerateRoutingView>(&body, e),
     };
     state.router.route_generate(Some(&headers), &view, &body).await
 }
@@ -238,7 +264,7 @@ async fn v1_chat_completions(
     };
     let view: ChatRoutingView = match serde_json::from_slice(&body) {
         Ok(v) => v,
-        Err(e) => return json_parse_error(format!("Invalid JSON data: {}", e)),
+        Err(e) => return view_parse_error::<ChatRoutingView>(&body, e),
     };
     state.router.route_chat(Some(&headers), &view, &body).await
 }

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -1726,8 +1726,7 @@ mod sglang_extension_tests {
     /// echoes whatever `routed_experts_b64` it was configured with).
     #[tokio::test]
     async fn test_unified_generate_forwards_routed_experts() {
-        let expected_b64 =
-            base64::engine::general_purpose::STANDARD.encode([10u8, 20, 30]);
+        let expected_b64 = base64::engine::general_purpose::STANDARD.encode([10u8, 20, 30]);
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 18120,
             routed_experts_b64: Some(expected_b64.clone()),
@@ -1772,8 +1771,7 @@ mod sglang_extension_tests {
     /// Same shape for `/v1/chat/completions`.
     #[tokio::test]
     async fn test_unified_chat_forwards_routed_experts() {
-        let expected_b64 =
-            base64::engine::general_purpose::STANDARD.encode([40u8, 50, 60]);
+        let expected_b64 = base64::engine::general_purpose::STANDARD.encode([40u8, 50, 60]);
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 18121,
             routed_experts_b64: Some(expected_b64.clone()),
@@ -1921,10 +1919,7 @@ mod sglang_extension_tests {
 
     /// Drain the response body and assert it carries the
     /// `invalid_sglang_extension` error code naming the offending field.
-    async fn assert_invalid_sglang_extension(
-        resp: axum::response::Response,
-        expected_field: &str,
-    ) {
+    async fn assert_invalid_sglang_extension(resp: axum::response::Response, expected_field: &str) {
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -3,6 +3,7 @@ use axum::{
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
+use base64::Engine;
 use serde_json::json;
 use smg::{config::RouterConfig, routers::RouterFactory};
 use tower::ServiceExt;
@@ -41,6 +42,8 @@ mod health_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -85,6 +88,8 @@ mod health_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18004,
@@ -92,6 +97,8 @@ mod health_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -118,6 +125,8 @@ mod health_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -154,6 +163,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -195,6 +206,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -231,6 +244,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 1.0, // Always fail
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -262,6 +277,8 @@ mod generation_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -307,6 +324,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -345,6 +364,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -390,6 +411,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -503,6 +526,8 @@ mod model_info_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18205,
@@ -510,6 +535,8 @@ mod model_info_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -547,6 +574,8 @@ mod model_info_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 1.0, // Always fail
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -584,6 +613,8 @@ mod router_policy_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18802,
@@ -591,6 +622,8 @@ mod router_policy_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -626,6 +659,8 @@ mod router_policy_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -656,6 +691,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -695,6 +732,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -736,6 +775,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -785,6 +826,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -834,6 +877,8 @@ mod responses_endpoint_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -932,6 +977,8 @@ mod responses_endpoint_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18961,
@@ -939,6 +986,8 @@ mod responses_endpoint_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -1006,6 +1055,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1043,6 +1094,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1097,6 +1150,8 @@ mod error_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -1116,6 +1171,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1154,6 +1211,8 @@ mod error_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1192,6 +1251,8 @@ mod cache_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1230,6 +1291,8 @@ mod cache_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18503,
@@ -1237,6 +1300,8 @@ mod cache_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -1300,6 +1365,8 @@ mod load_balancing_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
             MockWorkerConfig {
                 port: 18602,
@@ -1307,6 +1374,8 @@ mod load_balancing_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             },
         ])
         .await;
@@ -1354,6 +1423,8 @@ mod pd_mode_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         });
 
         let mut decode_worker = MockWorker::new(MockWorkerConfig {
@@ -1362,6 +1433,8 @@ mod pd_mode_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         });
 
         let prefill_url = prefill_worker.start().await.unwrap();
@@ -1416,6 +1489,8 @@ mod request_id_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1535,6 +1610,8 @@ mod request_id_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -1578,6 +1655,8 @@ mod rerank_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -1623,6 +1702,356 @@ mod rerank_tests {
         for result in results {
             assert!(result.get("document").is_some());
         }
+
+        ctx.shutdown().await;
+    }
+}
+
+/// Tests for SGLang extension fields on the unified (non-PD) router.
+///
+/// The proto-pattern parses only a tiny `ChatRoutingView` /
+/// `GenerateRoutingView` from the request body and forwards the rest of
+/// the bytes verbatim, so any extension field the router doesn't read
+/// (e.g. `routed_dp_rank`, `some_future_field`) survives by definition.
+/// The router does branch on `return_routed_experts` (chat/generate
+/// view), and a malformed value type is rejected as `400` at view-parse
+/// time — these tests pin both behaviours.
+#[cfg(test)]
+mod sglang_extension_tests {
+    use super::*;
+
+    /// `return_routed_experts: true` against a unified backend should
+    /// surface the field in the response. Pure passthrough — the test
+    /// is satisfied by the field arriving back from the worker (which
+    /// echoes whatever `routed_experts_b64` it was configured with).
+    #[tokio::test]
+    async fn test_unified_generate_forwards_routed_experts() {
+        let expected_b64 =
+            base64::engine::general_purpose::STANDARD.encode([10u8, 20, 30]);
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18120,
+            routed_experts_b64: Some(expected_b64.clone()),
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(
+            body.pointer("/meta_info/routed_experts")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_b64.as_str()),
+            "unified /generate should pass routed_experts through (got: {body})"
+        );
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(received.get("return_routed_experts"), Some(&json!(true)));
+
+        ctx.shutdown().await;
+    }
+
+    /// Same shape for `/v1/chat/completions`.
+    #[tokio::test]
+    async fn test_unified_chat_forwards_routed_experts() {
+        let expected_b64 =
+            base64::engine::general_purpose::STANDARD.encode([40u8, 50, 60]);
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18121,
+            routed_experts_b64: Some(expected_b64.clone()),
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(
+            body.pointer("/sglext/routed_experts")
+                .and_then(serde_json::Value::as_str),
+            Some(expected_b64.as_str()),
+            "unified chat completion should pass routed_experts through (got: {body})"
+        );
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(received.get("return_routed_experts"), Some(&json!(true)));
+
+        ctx.shutdown().await;
+    }
+
+    /// Forward-compat: SGLang fields the router doesn't read at all
+    /// (`routed_dp_rank`, an unknown future field) must reach the
+    /// backend verbatim. In the proto pattern this is automatic — the
+    /// router parses only its small view and forwards the original bytes.
+    #[tokio::test]
+    async fn test_unified_forwards_unknown_sglang_extensions() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18122,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+            "routed_dp_rank": 3,
+            "some_future_field": {"nested": [1, 2, 3]},
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(received.get("routed_dp_rank"), Some(&json!(3)));
+        assert_eq!(
+            received.get("some_future_field"),
+            Some(&json!({"nested": [1, 2, 3]})),
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// A malformed `return_routed_experts` value must be rejected as 400
+    /// `invalid_sglang_extension` — naming the field, not folded into a
+    /// generic JSON-parse error. Mirrors the contract the older
+    /// `body_raw` design exposed via `parse_sglang_extensions`.
+    #[tokio::test]
+    async fn test_unified_chat_rejects_invalid_extension_type() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18123,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_invalid_sglang_extension(resp, "return_routed_experts").await;
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_unified_generate_rejects_invalid_extension_type() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18124,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_invalid_sglang_extension(resp, "return_routed_experts").await;
+
+        ctx.shutdown().await;
+    }
+
+    /// Drain the response body and assert it carries the
+    /// `invalid_sglang_extension` error code naming the offending field.
+    async fn assert_invalid_sglang_extension(
+        resp: axum::response::Response,
+        expected_field: &str,
+    ) {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body.pointer("/error/code").and_then(|v| v.as_str()),
+            Some("invalid_sglang_extension"),
+            "expected invalid_sglang_extension error code, got: {body}"
+        );
+        let message = body
+            .pointer("/error/message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            message.contains(expected_field),
+            "error message should name the offending field `{expected_field}`, got: {message}"
+        );
+    }
+
+    /// `dp_aware: true` takes a separate code path inside
+    /// `Router::send_bytes_request` — it parses the body to `Value`
+    /// (because it has to inject `data_parallel_rank`) instead of doing
+    /// the O(1) `Bytes::clone` forward. A regression there could strip
+    /// extension fields while every other unified test still passed.
+    #[tokio::test]
+    async fn test_unified_dp_aware_forwards_extensions() {
+        let port: u16 = 18125;
+        let config = RouterConfig::builder()
+            .regular_mode(vec![format!("http://127.0.0.1:{port}")])
+            .random_policy()
+            .enable_dp_aware()
+            .host("127.0.0.1")
+            .port(3850)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![MockWorkerConfig {
+                port,
+                ..MockWorkerConfig::default()
+            }],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+            "return_routed_experts": true,
+            "routed_dp_rank": 7,
+            "some_future_field": "preserved",
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(
+            received.get("data_parallel_rank"),
+            Some(&json!(0)),
+            "dp_aware path must inject data_parallel_rank"
+        );
+        assert_eq!(
+            received.get("return_routed_experts"),
+            Some(&json!(true)),
+            "extension fields must survive the dp_aware JSON re-injection"
+        );
+        assert_eq!(received.get("routed_dp_rank"), Some(&json!(7)));
+        assert_eq!(received.get("some_future_field"), Some(&json!("preserved")));
+
+        ctx.shutdown().await;
+    }
+
+    /// Unified router has no merge step, so streaming +
+    /// `return_routed_experts` should *not* be rejected (unlike PD).
+    /// Pins that the gateway didn't silently drop the flag during the
+    /// streaming setup.
+    #[tokio::test]
+    async fn test_unified_chat_streaming_forwards_routed_experts() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18126,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "unified streaming + return_routed_experts must not be rejected"
+        );
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(
+            received.get("return_routed_experts"),
+            Some(&json!(true)),
+            "the streaming setup must still forward the flag to the backend"
+        );
+        assert_eq!(received.get("stream"), Some(&json!(true)));
 
         ctx.shutdown().await;
     }

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -2055,4 +2055,51 @@ mod sglang_extension_tests {
 
         ctx.shutdown().await;
     }
+
+    /// Mirror of `test_unified_chat_streaming_forwards_routed_experts`
+    /// for `/generate`. Pins that the unified router does NOT reject
+    /// streaming + `return_routed_experts` on the SGLang-native
+    /// endpoint either — the streaming-reject (`400`) is a PD-only
+    /// contract because only PD has a merge step. A regression where
+    /// someone copy-pasted the PD streaming-reject into the unified
+    /// `/generate` path would break this test.
+    #[tokio::test]
+    async fn test_unified_generate_streaming_forwards_routed_experts() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18127,
+            ..MockWorkerConfig::default()
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "unified /generate streaming + return_routed_experts must not be rejected"
+        );
+
+        let received = &ctx.workers[0].recorded_requests()[0];
+        assert_eq!(
+            received.get("return_routed_experts"),
+            Some(&json!(true)),
+            "the streaming setup must still forward the flag to the backend"
+        );
+        assert_eq!(received.get("stream"), Some(&json!(true)));
+
+        ctx.shutdown().await;
+    }
 }

--- a/sgl-model-gateway/tests/api/request_formats_test.rs
+++ b/sgl-model-gateway/tests/api/request_formats_test.rs
@@ -17,6 +17,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -64,6 +66,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -112,6 +116,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -164,6 +170,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -198,6 +206,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -246,6 +256,8 @@ mod request_format_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 

--- a/sgl-model-gateway/tests/api/responses_api_test.rs
+++ b/sgl-model-gateway/tests/api/responses_api_test.rs
@@ -39,6 +39,8 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 
@@ -532,6 +534,8 @@ async fn test_multi_turn_loop_with_mcp() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 
@@ -685,6 +689,8 @@ async fn test_max_tool_calls_limit() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 
@@ -803,6 +809,8 @@ async fn setup_streaming_mcp_test() -> (
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
     let worker_url = worker.start().await.expect("start worker");
 

--- a/sgl-model-gateway/tests/api/streaming_tests.rs
+++ b/sgl-model-gateway/tests/api/streaming_tests.rs
@@ -17,6 +17,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -47,6 +49,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -91,6 +95,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -118,6 +124,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 1.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -140,6 +148,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 100,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -171,6 +181,8 @@ mod tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 10,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 

--- a/sgl-model-gateway/tests/common/mock_worker.rs
+++ b/sgl-model-gateway/tests/common/mock_worker.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use axum::{
-    extract::{Json, Path, State},
+    extract::{FromRef, Json, Path, State},
     http::StatusCode,
     response::{
         sse::{Event, KeepAlive},
@@ -19,9 +19,38 @@ use axum::{
     Router,
 };
 use futures_util::stream::{self, StreamExt};
-use serde_json::json;
+use serde_json::{json, Value};
 use tokio::sync::RwLock;
 use uuid::Uuid;
+
+/// Shared state for mock-worker handlers. Wraps the existing config Arc
+/// plus a request-capture buffer so tests can assert what payload the
+/// worker actually received (e.g. that SGLang extension fields the
+/// gateway claims to forward verbatim really do reach the backend).
+///
+/// `recorded_requests` is intentionally a `std::sync::Mutex`: the lock
+/// is only held across `.push(...)` and is released before any `.await`,
+/// so a sync mutex is correct and keeps `record(...)` non-async.
+#[derive(Clone)]
+pub struct MockWorkerState {
+    pub config: Arc<RwLock<MockWorkerConfig>>,
+    recorded_requests: Arc<Mutex<Vec<Value>>>,
+}
+
+impl MockWorkerState {
+    fn record(&self, payload: Value) {
+        self.recorded_requests.lock().unwrap().push(payload);
+    }
+}
+
+// Existing handlers extract `Arc<RwLock<MockWorkerConfig>>` directly via
+// State; this lets them keep working unchanged when the router is built
+// with `MockWorkerState`.
+impl FromRef<MockWorkerState> for Arc<RwLock<MockWorkerConfig>> {
+    fn from_ref(state: &MockWorkerState) -> Self {
+        state.config.clone()
+    }
+}
 
 /// Configuration for mock worker behavior
 #[derive(Clone)]
@@ -31,6 +60,16 @@ pub struct MockWorkerConfig {
     pub health_status: HealthStatus,
     pub response_delay_ms: u64,
     pub fail_rate: f32,
+    /// Optional base64 string injected as `meta_info.routed_experts`
+    /// (and `sglext.routed_experts` for chat completions) in
+    /// non-streaming responses, but **only when the request payload has
+    /// `return_routed_experts: true`**. The gating is what makes
+    /// forwarding tests load-bearing.
+    pub routed_experts_b64: Option<String>,
+    /// Bypass the `return_routed_experts: true` gate above. Used by the
+    /// no-merge inverse test to prove the gateway *did not* merge when
+    /// the flag is absent.
+    pub always_emit_routed_experts: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -50,6 +89,7 @@ pub enum HealthStatus {
 /// Mock worker server for testing
 pub struct MockWorker {
     config: Arc<RwLock<MockWorkerConfig>>,
+    recorded_requests: Arc<Mutex<Vec<Value>>>,
     shutdown_handle: Option<tokio::task::JoinHandle<()>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
@@ -58,9 +98,16 @@ impl MockWorker {
     pub fn new(config: MockWorkerConfig) -> Self {
         Self {
             config: Arc::new(RwLock::new(config)),
+            recorded_requests: Arc::new(Mutex::new(Vec::new())),
             shutdown_handle: None,
             shutdown_tx: None,
         }
+    }
+
+    /// Snapshot of every JSON request body received by `/generate` and
+    /// `/v1/chat/completions` since startup, in arrival order.
+    pub fn recorded_requests(&self) -> Vec<Value> {
+        self.recorded_requests.lock().unwrap().clone()
     }
 
     /// Start the mock worker server
@@ -96,7 +143,10 @@ impl MockWorker {
             )
             .route("/flush_cache", post(flush_cache_handler))
             .route("/v1/models", get(v1_models_handler))
-            .with_state(config);
+            .with_state(MockWorkerState {
+                config,
+                recorded_requests: self.recorded_requests.clone(),
+            });
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         self.shutdown_tx = Some(shutdown_tx);
@@ -295,10 +345,11 @@ async fn model_info_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>)
 }
 
 async fn generate_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    State(state): State<MockWorkerState>,
+    Json(payload): Json<Value>,
 ) -> Response {
-    let config = config.read().await;
+    state.record(payload.clone());
+    let config = state.config.read().await;
     let worker_id = format!("worker-{}", config.port);
 
     if should_fail(&config).await {
@@ -381,35 +432,42 @@ async fn generate_handler(
         )
             .into_response()
     } else {
-        (
-            [("x-worker-id", worker_id)],
-            Json(json!({
-                "text": "This is a mock response.",
-                "meta_info": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 5,
-                    "completion_tokens_wo_jump_forward": 5,
-                    "input_token_logprobs": null,
-                    "output_token_logprobs": null,
-                    "first_token_latency": config.response_delay_ms as f64 / 1000.0,
-                    "time_to_first_token": config.response_delay_ms as f64 / 1000.0,
-                    "time_per_output_token": 0.01,
-                    "finish_reason": {
-                        "type": "stop",
-                        "reason": "length"
-                    }
+        let mut body = json!({
+            "text": "This is a mock response.",
+            "meta_info": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "completion_tokens_wo_jump_forward": 5,
+                "input_token_logprobs": null,
+                "output_token_logprobs": null,
+                "first_token_latency": config.response_delay_ms as f64 / 1000.0,
+                "time_to_first_token": config.response_delay_ms as f64 / 1000.0,
+                "time_per_output_token": 0.01,
+                "finish_reason": {
+                    "type": "stop",
+                    "reason": "length"
                 }
-            })),
-        )
-            .into_response()
+            }
+        });
+        let client_asked_for_experts = payload
+            .get("return_routed_experts")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if client_asked_for_experts || config.always_emit_routed_experts {
+            if let Some(b64) = config.routed_experts_b64.as_deref() {
+                body["meta_info"]["routed_experts"] = json!(b64);
+            }
+        }
+        ([("x-worker-id", worker_id)], Json(body)).into_response()
     }
 }
 
 async fn chat_completions_handler(
-    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    State(state): State<MockWorkerState>,
+    Json(payload): Json<Value>,
 ) -> Response {
-    let config = config.read().await;
+    state.record(payload.clone());
+    let config = state.config.read().await;
 
     if should_fail(&config).await {
         return (
@@ -465,7 +523,7 @@ async fn chat_completions_handler(
             .keep_alive(KeepAlive::default())
             .into_response()
     } else {
-        Json(json!({
+        let mut body = json!({
             "id": format!("chatcmpl-{}", Uuid::new_v4()),
             "object": "chat.completion",
             "created": timestamp,
@@ -483,14 +541,26 @@ async fn chat_completions_handler(
                 "completion_tokens": 5,
                 "total_tokens": 15
             }
-        }))
-        .into_response()
+        });
+        let client_asked_for_experts = payload
+            .get("return_routed_experts")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if client_asked_for_experts || config.always_emit_routed_experts {
+            if let Some(b64) = config.routed_experts_b64.as_deref() {
+                // SGLang chat responses surface routed_experts under
+                // `sglext`; the merge code in pd_router.rs walks both
+                // `meta_info` and `sglext`.
+                body["sglext"] = json!({ "routed_experts": b64 });
+            }
+        }
+        Json(body).into_response()
     }
 }
 
 async fn completions_handler(
     State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    Json(payload): Json<Value>,
 ) -> Response {
     let config = config.read().await;
 
@@ -570,7 +640,7 @@ async fn completions_handler(
 
 async fn responses_handler(
     State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    Json(payload): Json<Value>,
 ) -> Response {
     let config = config.read().await;
 
@@ -1217,7 +1287,7 @@ fn response_exists_for_port(port: u16, response_id: &str) -> bool {
 // Minimal rerank handler returning mock results; router shapes final response
 async fn rerank_handler(
     State(config): State<Arc<RwLock<MockWorkerConfig>>>,
-    Json(payload): Json<serde_json::Value>,
+    Json(payload): Json<Value>,
 ) -> impl IntoResponse {
     let config = config.read().await;
 
@@ -1273,6 +1343,8 @@ impl Default for MockWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 }

--- a/sgl-model-gateway/tests/common/test_config.rs
+++ b/sgl-model-gateway/tests/common/test_config.rs
@@ -244,6 +244,8 @@ impl TestWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 
@@ -260,6 +262,8 @@ impl TestWorkerConfig {
             health_status: HealthStatus::Unhealthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 
@@ -271,6 +275,8 @@ impl TestWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: delay_ms,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 
@@ -289,6 +295,8 @@ impl TestWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 
@@ -300,6 +308,8 @@ impl TestWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 
@@ -311,6 +321,8 @@ impl TestWorkerConfig {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }
     }
 }

--- a/sgl-model-gateway/tests/inflight_tracker_test.rs
+++ b/sgl-model-gateway/tests/inflight_tracker_test.rs
@@ -22,6 +22,8 @@ async fn test_multiple_concurrent_requests_tracking() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 50,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     }])
     .await;
 
@@ -65,6 +67,8 @@ async fn test_inflight_request_appears_in_bucket() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 2000,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     }])
     .await;
 
@@ -119,6 +123,8 @@ async fn test_failed_request_still_deregisters() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 1.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     }])
     .await;
 

--- a/sgl-model-gateway/tests/otel_tracing_test.rs
+++ b/sgl-model-gateway/tests/otel_tracing_test.rs
@@ -112,6 +112,8 @@ async fn test_router_with_tracing() {
         health_status: HealthStatus::Healthy,
         response_delay_ms: 0,
         fail_rate: 0.0,
+        routed_experts_b64: None,
+        always_emit_routed_experts: false,
     });
 
     let worker_url = mock_worker.start().await.unwrap();

--- a/sgl-model-gateway/tests/routing/header_forwarding_test.rs
+++ b/sgl-model-gateway/tests/routing/header_forwarding_test.rs
@@ -29,6 +29,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -91,6 +93,8 @@ mod header_forwarding_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -135,6 +139,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -178,6 +184,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -226,6 +234,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 
@@ -270,6 +280,8 @@ mod header_forwarding_tests {
             health_status: HealthStatus::Healthy,
             response_delay_ms: 0,
             fail_rate: 0.0,
+            routed_experts_b64: None,
+            always_emit_routed_experts: false,
         }])
         .await;
 

--- a/sgl-model-gateway/tests/routing/load_balancing_test.rs
+++ b/sgl-model-gateway/tests/routing/load_balancing_test.rs
@@ -239,6 +239,72 @@ mod cache_aware_tests {
 
         ctx.shutdown().await;
     }
+
+    /// Multi-turn cache-aware regression: each turn of a single
+    /// conversation must land on the same worker so the KV-cache from
+    /// the prior turn can be reused. Previously the unified HTTP router
+    /// hardcoded `None` for the routing text on `/v1/chat/completions`,
+    /// which silently disabled cache-aware routing and scattered turns
+    /// across workers.
+    #[tokio::test]
+    async fn test_cache_aware_chat_multi_turn_consistent_worker() {
+        let config = TestRouterConfig::cache_aware(3110);
+        let ctx =
+            AppTestContext::new_with_config(config, TestWorkerConfig::healthy_workers(19060, 2))
+                .await;
+        let app = ctx.create_app().await;
+
+        // Simulate 4 turns of one conversation. Each turn extends the
+        // prior `messages` array, so the cache-aware prefix trie sees
+        // turn N's text as a prefix of turn N+1's and must keep
+        // routing to the same worker.
+        let mut messages = vec![
+            json!({"role": "system", "content": "You are a careful assistant."}),
+            json!({"role": "user", "content": "What is Rust's ownership model?"}),
+        ];
+
+        for turn in 0..4 {
+            let payload = json!({
+                "model": "mock-model",
+                "messages": messages,
+                "stream": false,
+            });
+            let req = Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "turn {turn} should succeed");
+
+            // Extend the conversation with the assistant's reply + a
+            // new user turn so the next iteration shares a strictly
+            // longer prefix.
+            messages.push(json!({"role": "assistant", "content": "A systems language."}));
+            messages.push(json!({"role": "user", "content": format!("Follow-up #{turn}?")}));
+        }
+
+        // Each turn appears in exactly one worker's recorded log, and
+        // every turn must land on the same worker for KV-cache reuse.
+        let totals: Vec<usize> = ctx
+            .workers
+            .iter()
+            .map(|w| w.recorded_requests().len())
+            .collect();
+        let occupied: Vec<usize> = totals.iter().copied().filter(|n| *n > 0).collect();
+        assert_eq!(
+            occupied.len(),
+            1,
+            "cache-aware multi-turn chat must land on a single worker, got {totals:?}"
+        );
+        assert_eq!(
+            occupied[0], 4,
+            "the chosen worker must receive all 4 turns, got {totals:?}"
+        );
+
+        ctx.shutdown().await;
+    }
 }
 
 #[cfg(test)]

--- a/sgl-model-gateway/tests/routing/payload_size_test.rs
+++ b/sgl-model-gateway/tests/routing/payload_size_test.rs
@@ -44,6 +44,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -96,6 +98,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -150,6 +154,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -209,6 +215,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -265,6 +273,8 @@ mod payload_size_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;

--- a/sgl-model-gateway/tests/routing/pd_routing_test.rs
+++ b/sgl-model-gateway/tests/routing/pd_routing_test.rs
@@ -7,7 +7,8 @@ use axum::{
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
-use serde_json::json;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use serde_json::{json, Value};
 use smg::config::RouterConfig;
 use tower::ServiceExt;
 
@@ -189,6 +190,8 @@ mod pd_routing_tests {
                     health_status: HealthStatus::Healthy,
                     response_delay_ms: 0,
                     fail_rate: 1.0, // Failing decode worker
+                    routed_experts_b64: None,
+                    always_emit_routed_experts: false,
                 },
                 TestWorkerConfig::decode(19822), // Healthy decode worker
             ],
@@ -215,6 +218,532 @@ mod pd_routing_tests {
             resp.status(),
             StatusCode::OK,
             "Request should succeed via retry to healthy decode worker"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Verify the end-to-end PD merge of `routed_experts` for chat
+    /// completions. The prefill worker emits a base64 prefix; the decode
+    /// worker emits the prefix plus per-token suffix bytes; the gateway
+    /// must concatenate `prefill_bytes ++ decode_bytes[prefill_len..]`
+    /// into the response payload under `sglext.routed_experts`.
+    #[tokio::test]
+    async fn test_pd_chat_completion_merges_routed_experts() {
+        let prefill_bytes = vec![1u8, 2, 3, 4];
+        let decode_bytes = vec![1u8, 2, 3, 4, 9, 9, 9, 9];
+        let prefill_b64 = BASE64_STANDARD.encode(&prefill_bytes);
+        let decode_b64 = BASE64_STANDARD.encode(&decode_bytes);
+
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19840".to_string(), None)],
+                vec!["http://127.0.0.1:19841".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3840)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let mut prefill_worker = TestWorkerConfig::prefill(19840);
+        prefill_worker.routed_experts_b64 = Some(prefill_b64.clone());
+        let mut decode_worker = TestWorkerConfig::decode(19841);
+        decode_worker.routed_experts_b64 = Some(decode_b64.clone());
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![prefill_worker, decode_worker]).await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PD chat completion with return_routed_experts should succeed"
+        );
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value =
+            serde_json::from_slice(&body_bytes).expect("response body should be JSON");
+
+        let merged_b64 = body
+            .pointer("/sglext/routed_experts")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("expected sglext.routed_experts in merged response: {body}"));
+        let merged_bytes = BASE64_STANDARD
+            .decode(merged_b64)
+            .expect("merged routed_experts should be valid base64");
+
+        let mut expected = prefill_bytes.clone();
+        expected.extend_from_slice(&decode_bytes[prefill_bytes.len()..]);
+        assert_eq!(
+            merged_bytes, expected,
+            "merged routed_experts should be prefill prefix + decode suffix",
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Companion to the chat merge test, covering the `meta_info`
+    /// branch of `merge_routed_experts` (the `/generate` envelope).
+    #[tokio::test]
+    async fn test_pd_generate_merges_routed_experts() {
+        let prefill_bytes = vec![1u8, 2, 3, 4];
+        let decode_bytes = vec![1u8, 2, 3, 4, 9, 9, 9, 9];
+        let prefill_b64 = BASE64_STANDARD.encode(&prefill_bytes);
+        let decode_b64 = BASE64_STANDARD.encode(&decode_bytes);
+
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19842".to_string(), None)],
+                vec!["http://127.0.0.1:19843".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3842)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let mut prefill_worker = TestWorkerConfig::prefill(19842);
+        prefill_worker.routed_experts_b64 = Some(prefill_b64);
+        let mut decode_worker = TestWorkerConfig::decode(19843);
+        decode_worker.routed_experts_b64 = Some(decode_b64);
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![prefill_worker, decode_worker]).await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "PD /generate with return_routed_experts should succeed"
+        );
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        let merged_b64 = body
+            .pointer("/meta_info/routed_experts")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| {
+                panic!("expected meta_info.routed_experts in merged response: {body}")
+            });
+        let merged_bytes = BASE64_STANDARD.decode(merged_b64).unwrap();
+
+        let mut expected = prefill_bytes.clone();
+        expected.extend_from_slice(&decode_bytes[prefill_bytes.len()..]);
+        assert_eq!(merged_bytes, expected);
+
+        ctx.shutdown().await;
+    }
+
+    /// Malformed `return_routed_experts` must yield 400
+    /// `invalid_sglang_extension` (mirrors the contract the older
+    /// `body_raw` design surfaced via `parse_sglang_extensions`).
+    #[tokio::test]
+    async fn test_pd_chat_rejects_invalid_extension_type() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19844".to_string(), None)],
+                vec!["http://127.0.0.1:19845".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3844)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19844),
+                TestWorkerConfig::decode(19845),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "non-bool return_routed_experts should yield 400"
+        );
+        assert_invalid_sglang_extension_pd(resp, "return_routed_experts").await;
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_pd_generate_rejects_invalid_extension_type() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19850".to_string(), None)],
+                vec!["http://127.0.0.1:19851".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3849)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19850),
+                TestWorkerConfig::decode(19851),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": "yes",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_invalid_sglang_extension_pd(resp, "return_routed_experts").await;
+
+        ctx.shutdown().await;
+    }
+
+    /// Drain the response body and assert the structured 400 carries
+    /// `invalid_sglang_extension` and names the offending field.
+    async fn assert_invalid_sglang_extension_pd(
+        resp: axum::response::Response,
+        expected_field: &str,
+    ) {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            body.pointer("/error/code").and_then(|v| v.as_str()),
+            Some("invalid_sglang_extension"),
+            "expected invalid_sglang_extension error code, got: {body}"
+        );
+        let message = body
+            .pointer("/error/message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            message.contains(expected_field),
+            "error message should name the offending field `{expected_field}`, got: {message}"
+        );
+    }
+
+    /// Streaming PD with `return_routed_experts: true` is unsupported
+    /// (the SSE pipeline does not merge across prefill/decode); the
+    /// router rejects with 400 up front.
+    #[tokio::test]
+    async fn test_pd_chat_streaming_rejects_routed_experts() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19852".to_string(), None)],
+                vec!["http://127.0.0.1:19853".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3852)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19852),
+                TestWorkerConfig::decode(19853),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "streaming + return_routed_experts should yield 400"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_pd_generate_streaming_rejects_routed_experts() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19854".to_string(), None)],
+                vec!["http://127.0.0.1:19855".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3854)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19854),
+                TestWorkerConfig::decode(19855),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "return_routed_experts": true,
+            "stream": true,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        ctx.shutdown().await;
+    }
+
+    /// Without `return_routed_experts`, the gateway must NOT merge —
+    /// response should mirror what the decode worker produced. Catches
+    /// a regression that always-merges regardless of the flag.
+    #[tokio::test]
+    async fn test_pd_does_not_merge_when_flag_absent() {
+        // Asymmetric so a stray merge would be visible.
+        let prefill_b64 = BASE64_STANDARD.encode(b"PPPP");
+        let decode_b64 = BASE64_STANDARD.encode(b"DDDD");
+
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19846".to_string(), None)],
+                vec!["http://127.0.0.1:19847".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3846)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let mut prefill_worker = TestWorkerConfig::prefill(19846);
+        prefill_worker.routed_experts_b64 = Some(prefill_b64);
+        prefill_worker.always_emit_routed_experts = true;
+        let mut decode_worker = TestWorkerConfig::decode(19847);
+        decode_worker.routed_experts_b64 = Some(decode_b64.clone());
+        decode_worker.always_emit_routed_experts = true;
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![prefill_worker, decode_worker]).await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        let response_b64 = body
+            .pointer("/meta_info/routed_experts")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("expected meta_info.routed_experts in response: {body}"));
+        assert_eq!(
+            response_b64, decode_b64,
+            "without the flag, response should pass through decode's routed_experts unchanged"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// SGLang fields the gateway does not branch on — `routed_dp_rank`,
+    /// arbitrary future names — must reach the backend verbatim. In the
+    /// proto pattern PD parses the body to `Value` (it has to mutate it
+    /// for bootstrap injection), so unknowns ride through that Value
+    /// untouched.
+    #[tokio::test]
+    async fn test_pd_forwards_unknown_sglang_extensions() {
+        let config = RouterConfig::builder()
+            .prefill_decode_mode(
+                vec![("http://127.0.0.1:19848".to_string(), None)],
+                vec!["http://127.0.0.1:19849".to_string()],
+            )
+            .power_of_two_policy(1)
+            .host("127.0.0.1")
+            .port(3848)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![
+                TestWorkerConfig::prefill(19848),
+                TestWorkerConfig::decode(19849),
+            ],
+        )
+        .await;
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "text": "hi",
+            "stream": false,
+            "routed_dp_rank": 7,
+            "some_future_field": {"nested": [1, 2, 3]},
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let prefill_recv = ctx.workers[0].recorded_requests();
+        assert_eq!(
+            prefill_recv.len(),
+            1,
+            "prefill worker should have received exactly one request"
+        );
+        let received = &prefill_recv[0];
+        assert_eq!(
+            received.get("routed_dp_rank"),
+            Some(&json!(7)),
+            "routed_dp_rank should pass through to backend (received: {received})"
+        );
+        assert_eq!(
+            received.get("some_future_field"),
+            Some(&json!({"nested": [1, 2, 3]})),
+            "unknown fields should pass through to backend (received: {received})"
         );
 
         ctx.shutdown().await;

--- a/sgl-model-gateway/tests/routing/service_discovery_test.rs
+++ b/sgl-model-gateway/tests/routing/service_discovery_test.rs
@@ -44,6 +44,8 @@ mod service_discovery_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -92,6 +94,8 @@ mod service_discovery_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;
@@ -151,6 +155,8 @@ mod service_discovery_tests {
                     health_status: HealthStatus::Healthy,
                     response_delay_ms: 0,
                     fail_rate: 0.0,
+                    routed_experts_b64: None,
+                    always_emit_routed_experts: false,
                 },
                 MockWorkerConfig {
                     port: 20004,
@@ -158,6 +164,8 @@ mod service_discovery_tests {
                     health_status: HealthStatus::Healthy,
                     response_delay_ms: 0,
                     fail_rate: 0.0,
+                    routed_experts_b64: None,
+                    always_emit_routed_experts: false,
                 },
             ],
         )
@@ -235,6 +243,8 @@ mod service_discovery_tests {
                 health_status: HealthStatus::Healthy,
                 response_delay_ms: 0,
                 fail_rate: 0.0,
+                routed_experts_b64: None,
+                always_emit_routed_experts: false,
             }],
         )
         .await;

--- a/sgl-model-gateway/tests/routing/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/routing/test_openai_routing.rs
@@ -27,11 +27,7 @@ use smg::{
         generate::GenerateRequest,
         responses::{ResponseInput, ResponsesGetParams, ResponsesRequest},
     },
-    routers::{
-        http::routing_view::{ChatRoutingView, GenerateRoutingView},
-        openai::OpenAIRouter,
-        RouterTrait,
-    },
+    routers::{openai::OpenAIRouter, RouterTrait},
 };
 use tokio::{
     net::TcpListener,
@@ -640,8 +636,7 @@ async fn test_unsupported_endpoints() {
     };
 
     let body_bytes = bytes::Bytes::from(serde_json::to_vec(&generate_request).unwrap());
-    let view: GenerateRoutingView = serde_json::from_slice(&body_bytes).unwrap();
-    let response = router.route_generate(None, &view, &body_bytes).await;
+    let response = router.route_generate(None, &body_bytes, None).await;
     assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
     let completion_request = create_minimal_completion_request();
@@ -672,9 +667,8 @@ async fn test_openai_router_chat_completion_with_mock() {
     chat_request.temperature = Some(0.7);
 
     // Route the request
-    let _body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
-    let _view: ChatRoutingView = serde_json::from_slice(&_body_bytes).unwrap();
-    let response = router.route_chat(None, &_view, &_body_bytes).await;
+    let body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
+    let response = router.route_chat(None, &body_bytes, None).await;
 
     // Should get a successful response from mock server
     assert_eq!(response.status(), StatusCode::OK);
@@ -711,10 +705,9 @@ async fn test_openai_e2e_with_server() {
                 async move {
                     let (parts, body) = req.into_parts();
                     let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
-                    let view: ChatRoutingView = serde_json::from_slice(&body_bytes).unwrap();
 
                     router
-                        .route_chat(Some(&parts.headers), &view, &body_bytes)
+                        .route_chat(Some(&parts.headers), &body_bytes, None)
                         .await
                 }
             }
@@ -774,9 +767,8 @@ async fn test_openai_router_chat_streaming_with_mock() {
     });
     let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
 
-    let _body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
-    let _view: ChatRoutingView = serde_json::from_slice(&_body_bytes).unwrap();
-    let response = router.route_chat(None, &_view, &_body_bytes).await;
+    let body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
+    let response = router.route_chat(None, &body_bytes, None).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Should be SSE
@@ -813,9 +805,8 @@ async fn test_openai_router_circuit_breaker() {
 
     // First few requests should fail and record failures
     for _ in 0..3 {
-        let _body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
-    let _view: ChatRoutingView = serde_json::from_slice(&_body_bytes).unwrap();
-    let response = router.route_chat(None, &_view, &_body_bytes).await;
+        let body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
+        let response = router.route_chat(None, &body_bytes, None).await;
         // Should get either an error or circuit breaker response
         assert!(
             response.status() == StatusCode::INTERNAL_SERVER_ERROR

--- a/sgl-model-gateway/tests/routing/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/routing/test_openai_routing.rs
@@ -27,7 +27,11 @@ use smg::{
         generate::GenerateRequest,
         responses::{ResponseInput, ResponsesGetParams, ResponsesRequest},
     },
-    routers::{openai::OpenAIRouter, RouterTrait},
+    routers::{
+        http::routing_view::{ChatRoutingView, GenerateRoutingView},
+        openai::OpenAIRouter,
+        RouterTrait,
+    },
 };
 use tokio::{
     net::TcpListener,
@@ -635,7 +639,9 @@ async fn test_unsupported_endpoints() {
         rid: None,
     };
 
-    let response = router.route_generate(None, &generate_request, None).await;
+    let body_bytes = bytes::Bytes::from(serde_json::to_vec(&generate_request).unwrap());
+    let view: GenerateRoutingView = serde_json::from_slice(&body_bytes).unwrap();
+    let response = router.route_generate(None, &view, &body_bytes).await;
     assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
     let completion_request = create_minimal_completion_request();
@@ -666,7 +672,9 @@ async fn test_openai_router_chat_completion_with_mock() {
     chat_request.temperature = Some(0.7);
 
     // Route the request
-    let response = router.route_chat(None, &chat_request, None).await;
+    let _body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
+    let _view: ChatRoutingView = serde_json::from_slice(&_body_bytes).unwrap();
+    let response = router.route_chat(None, &_view, &_body_bytes).await;
 
     // Should get a successful response from mock server
     assert_eq!(response.status(), StatusCode::OK);
@@ -703,13 +711,10 @@ async fn test_openai_e2e_with_server() {
                 async move {
                     let (parts, body) = req.into_parts();
                     let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
-                    let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
-
-                    let chat_request: ChatCompletionRequest =
-                        serde_json::from_str(&body_str).unwrap();
+                    let view: ChatRoutingView = serde_json::from_slice(&body_bytes).unwrap();
 
                     router
-                        .route_chat(Some(&parts.headers), &chat_request, None)
+                        .route_chat(Some(&parts.headers), &view, &body_bytes)
                         .await
                 }
             }
@@ -769,7 +774,9 @@ async fn test_openai_router_chat_streaming_with_mock() {
     });
     let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
 
-    let response = router.route_chat(None, &chat_request, None).await;
+    let _body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
+    let _view: ChatRoutingView = serde_json::from_slice(&_body_bytes).unwrap();
+    let response = router.route_chat(None, &_view, &_body_bytes).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Should be SSE
@@ -806,7 +813,9 @@ async fn test_openai_router_circuit_breaker() {
 
     // First few requests should fail and record failures
     for _ in 0..3 {
-        let response = router.route_chat(None, &chat_request, None).await;
+        let _body_bytes = bytes::Bytes::from(serde_json::to_vec(&chat_request).unwrap());
+    let _view: ChatRoutingView = serde_json::from_slice(&_body_bytes).unwrap();
+    let response = router.route_chat(None, &_view, &_body_bytes).await;
         // Should get either an error or circuit breaker response
         assert!(
             response.status() == StatusCode::INTERNAL_SERVER_ERROR


### PR DESCRIPTION
## Summary

Three commits on the `sgl-model-gateway` request handling path. Together they take `/generate` and `/v1/chat/completions` to a *single* parse per router (no more eager routing-view parse in `server.rs` plus second parse inside PD/gRPC) while preserving the structured-400 contract on SGLang RL extension fields.

1. **Proto-style typed routing view (commit 1).** Introduce `ChatRoutingView` / `GenerateRoutingView` — minimal serde structs that capture only the fields the gateway actually reads (`model`, `stream`, `return_logprob`, `return_routed_experts`, batch hints, optional prompt text). Body bytes ride through verbatim, so SGLang RL extension fields the gateway doesn't branch on flow to the backend without reserialisation.

2. **Structured 400 + tests for `return_routed_experts` (commit 2).** Promote wrong-typed extension fields from a generic `json_parse_error` to `invalid_sglang_extension` (with the offending field named) via the new `ViewSchema` trait + `view_parse_error<V>` / `validate_extensions_in_value<V>` helpers. Mock-worker plumbing (`MockWorkerState` request capture, opt-in `routed_experts_b64` injection) plus mock-based and real-GPU e2e (`deepseek-ai/DeepSeek-V2-Lite`) tests for unified + PD round-tripping.

3. **Per-router parsing + structured error envelope (commit 3, this push).** Drop `view: &…RoutingView` from `RouterTrait::route_generate` / `route_chat`; add `model_id: Option<&str>` (matches `route_completion`'s shape). Each router does the single parse that fits its path:
   - HTTP unified → `…RoutingView` (single typed parse).
   - HTTP PD → `serde_json::Value` once + `validate_extensions_in_value::<…>` to keep the structured-400 contract (PD parses `Value` regardless to inject `bootstrap_host/port/room`, so this is genuinely one parse).
   - gRPC + gRPC PD → `Value` once → `validate_extensions_in_value` → `from_value::<typed>` to materialise the proto request.
   - OpenAI → typed `ChatCompletionRequest`.
   - `RouterManager`: in IGW mode parses `Value` once via `extract_body_model` (distinguishes absent / `null` / wrong-typed `model`); non-IGW hands body+model_id straight to the default router with no parse.

   Also unifies the error envelope: `routers::error::create_error` now emits OpenAI-compat `error.type` (`invalid_request_error` / `authentication_error` / `permission_error` / `not_found_error` / `rate_limit_error` / `server_error`) instead of the canonical reason phrase. Every `(Status, &str).into_response()` site in `RouterManager` and `read_body_bytes` migrated to the structured helpers, and the lone `json_parse_failed` site in the dp_aware path renamed to `json_parse_error` so all routers agree on one code.

## Why

- **Per-field error codes** let callers distinguish "your JSON is malformed" from "you sent `return_routed_experts: \"yes\"` and we want a bool" without string-matching. Mirrors the contract the older `body_raw` / `parse_sglang_extensions` design exposed before the proto-pattern refactor.
- **Single optimal parse per router**: the original proto-pattern win (zero reserialisation on the unified HTTP path) was being undone for PD and gRPC, which had to reparse to `Value` or to a typed proto on top of the routing-view parse. Each router now pays for exactly one parse.
- **IGW model resolution must reach the chosen router.** The first proto-pattern refactor renamed `effective_model_id` → `_effective_model_id`, dropping the resolved id and breaking metrics labels / worker selection / cache-aware policies under k8s service-discovery deployments. Pinned with a regression test.
- **Structured error envelope across the gateway.** OpenAI-compat clients classify on `error.type`; returning canonical reason strings (`"Bad Request"`) silently broke their `RateLimitError` / `AuthenticationError` dispatch.

## Test plan

- [x] `cargo test --lib` — 384 passed, 0 failed.
- [x] `cargo test --tests` — 429 passed, 0 failed (all integration suites: api_tests, routing_tests, reliability_tests, security_tests, spec_test, etc.).
- [x] PD `invalid_sglang_extension` 400 contract — `test_pd_chat_rejects_invalid_extension_type`, `test_pd_generate_rejects_invalid_extension_type` pass under the new `Value`-then-validate flow.
- [x] HTTP unified `invalid_sglang_extension` 400 contract — `test_unified_chat_rejects_invalid_extension_type`, `test_unified_generate_rejects_invalid_extension_type` pass.
- [x] IGW model-resolution regression — new `routers::router_manager::tests::igw_route_generate_propagates_resolved_model` pinning that the resolved id reaches the downstream router via `model_id`.
- [x] Cache-aware chat text walker — 8 new `routers::http::pd_router::tests::extract_chat_request_text::*` tests covering user / developer / system / multimodal-parts / missing / empty cases.
- [x] Extension validator — 6 new `routers::http::routing_view::tests::validate_extensions::*` tests covering wrong-typed / correctly-typed / absent / `null` / non-object cases.
- [x] `cargo fmt --check` clean on all changed files.
- [ ] `pytest e2e_test/router/test_routed_experts.py -v` on a 2-GPU host (real DeepSeek-V2-Lite).