### PR TITLE
Eliminate per-layer torch.cat in attn-tp post-MoE re-gather

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1186,14 +1186,10 @@ class DeepseekV4DecoderLayer(nn.Module):
             hidden_states, local_hidden_states = get_global_dp_buffer(), hidden_states
             dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
         _a2a_scatter_chunks: Optional[List[torch.Tensor]] = None
-        _a2a_equal_scatter: bool = False
         _a2a_full_token_count: int = 0
         if _use_tp_attn_a2a_scatter:
             s, r = get_attention_tp_size(), get_attention_tp_rank()
             _a2a_scatter_chunks = list(hidden_states.tensor_split(s))
-            _a2a_equal_scatter = (
-                _a2a_scatter_chunks[0].shape[0] == _a2a_scatter_chunks[-1].shape[0]
-            )
             _a2a_full_token_count = hidden_states.shape[0]
             hidden_states = _a2a_scatter_chunks[r].contiguous()
             input_ids = input_ids.tensor_split(s)[r].contiguous()
@@ -1210,17 +1206,12 @@ class DeepseekV4DecoderLayer(nn.Module):
         if _use_tp_attn_a2a_scatter:
             assert _a2a_scatter_chunks is not None
             local_contig = hidden_states.contiguous()
-            if _a2a_equal_scatter:
-                hidden_states = torch.empty(
-                    (_a2a_full_token_count, *local_contig.shape[1:]),
-                    dtype=local_contig.dtype,
-                    device=local_contig.device,
-                )
-                attn_tp_all_gather_into_tensor(hidden_states, local_contig)
-            else:
-                gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]
-                attn_tp_all_gather(gathered, local_contig)
-                hidden_states = torch.cat(gathered)
+            hidden_states = torch.empty(
+                (_a2a_full_token_count, *local_contig.shape[1:]),
+                dtype=local_contig.dtype,
+                device=local_contig.device,
+            )
+            attn_tp_all_gather_into_tensor(hidden_states, local_contig)
 
         hidden_states = self.hc_post(hidden_states, residual, post, comb)
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -52,6 +52,7 @@ from sglang.srt.layers.communicator import LayerScatterModes, get_attn_tp_contex
 from sglang.srt.layers.dp_attention import (
     _DpGatheredBufferWrapper,
     attn_tp_all_gather,
+    attn_tp_all_gather_into_tensor,
     dp_gather_partial,
     dp_scatter,
     get_attention_dp_size,
@@ -1185,9 +1186,15 @@ class DeepseekV4DecoderLayer(nn.Module):
             hidden_states, local_hidden_states = get_global_dp_buffer(), hidden_states
             dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
         _a2a_scatter_chunks: Optional[List[torch.Tensor]] = None
+        _a2a_equal_scatter: bool = False
+        _a2a_full_token_count: int = 0
         if _use_tp_attn_a2a_scatter:
             s, r = get_attention_tp_size(), get_attention_tp_rank()
             _a2a_scatter_chunks = list(hidden_states.tensor_split(s))
+            _a2a_equal_scatter = (
+                _a2a_scatter_chunks[0].shape[0] == _a2a_scatter_chunks[-1].shape[0]
+            )
+            _a2a_full_token_count = hidden_states.shape[0]
             hidden_states = _a2a_scatter_chunks[r].contiguous()
             input_ids = input_ids.tensor_split(s)[r].contiguous()
             input_ids_global = input_ids_global.tensor_split(s)[r].contiguous()
@@ -1202,9 +1209,18 @@ class DeepseekV4DecoderLayer(nn.Module):
             dp_scatter(hidden_states, global_hidden_states, forward_batch)
         if _use_tp_attn_a2a_scatter:
             assert _a2a_scatter_chunks is not None
-            gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]
-            attn_tp_all_gather(gathered, hidden_states.contiguous())
-            hidden_states = torch.cat(gathered)
+            local_contig = hidden_states.contiguous()
+            if _a2a_equal_scatter:
+                hidden_states = torch.empty(
+                    (_a2a_full_token_count, *local_contig.shape[1:]),
+                    dtype=local_contig.dtype,
+                    device=local_contig.device,
+                )
+                attn_tp_all_gather_into_tensor(hidden_states, local_contig)
+            else:
+                gathered = [torch.empty_like(t) for t in _a2a_scatter_chunks]
+                attn_tp_all_gather(gathered, local_contig)
+                hidden_states = torch.cat(gathered)
 
         hidden_states = self.hc_post(hidden_states, residual, post, comb)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Replaces the post-MoE `attn_tp_all_gather` (list output) + `torch.cat` with a single `attn_tp_all_gather_into_tensor` writing directly into a contiguous [S, H] buffer when shards are equal-sized. 

Profiling DeepSeek V4 prefill (B=1, in=8192, out=1024, B200×8, 61 layers) showed 61 calls to `at::native::CatArrayBatchedCopy_alignedK_contig` totalling 3.29ms. This kernel calls were removed after this pr.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
root@sglang-dsv4-chunan:/workspace/sglang# python3 -m sglang.test.few_shot_gsm8k     --num-shots 64     --num-questions 1319     --parallel 1319
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:49<00:00, 26.46it/s]
Accuracy: 0.958
Invalid: 0.000
Latency: 49.997 s
Output throughput: 2497.183 token/s
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
Reduced 3.29ms by removing this kernel from trace `void at::native::(anonymous namespace)::CatArrayBatchedCopy_alignedK_contig`
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
