### PR TITLE
ci: bump test_mimo_models.py est_time 330 → 610

### DIFF
--- a/test/registered/8-gpu-models/test_mimo_models.py
+++ b/test/registered/8-gpu-models/test_mimo_models.py
@@ -6,7 +6,7 @@ from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
-register_cuda_ci(est_time=330, suite="stage-c-test-8-gpu-h200")
+register_cuda_ci(est_time=610, suite="stage-c-test-8-gpu-h200")
 
 
 class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):


### PR DESCRIPTION
## Summary
- PR #23811 added a second test class (`TestMiMoV2` — `XiaomiMiMo/MiMo-V2.5`, TP=8 DP=2, MMMU + GSM8K + EAGLE spec) to `test_mimo_models.py` without bumping `est_time`.
- The file now runs ~500-640 s on h200 vs the unchanged `est_time=330`, which causes the auto-partitioner to consistently overload shard 0 of `stage-c-test-8-gpu-h200` and hit the 30-min `Run test` wall (e.g. runs `25428444359`, `25411981650`).
## Test plan
- [ ] Trigger a scheduled-style run on `main` and confirm `stage-c-test-8-gpu-h200 (0)` no longer hits the 30-min wall.