### PR TITLE
[LoRA] Use deterministic lora_id for --lora-paths so multi-node ranks agree

### DIFF
--- a/python/sglang/srt/lora/lora_registry.py
+++ b/python/sglang/srt/lora/lora_registry.py
@@ -17,7 +17,7 @@ import asyncio
 from collections import OrderedDict
 from dataclasses import dataclass, field, fields
 from typing import Dict, List, Optional, Union
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 from sglang.srt.utils import ConcurrentCounter
 from sglang.srt.utils.aio_rwlock import RWLock
@@ -41,6 +41,16 @@ class LoRARef:
     def __post_init__(self):
         if self.lora_id is None:
             raise ValueError("lora_id cannot be None")
+
+    @staticmethod
+    def deterministic_id(lora_name: str, lora_path: str) -> str:
+        """Stable ``lora_id`` for ``--lora-paths`` adapters.
+
+        Each node in a multi-node launch parses ``--lora-paths`` independently;
+        ``uuid4`` would mint a different id per node for the same adapter,
+        breaking cross-node lookups when the master broadcasts a request id.
+        """
+        return uuid5(NAMESPACE_URL, f"{lora_name}\0{lora_path}").hex
 
     def __str__(self) -> str:
         parts = [

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7011,17 +7011,26 @@ class ServerArgs:
                         if "=" in lora_path:
                             name, path = lora_path.split("=", 1)
                             lora_ref = LoRARef(
-                                lora_name=name, lora_path=path, pinned=False
+                                lora_id=LoRARef.deterministic_id(name, path),
+                                lora_name=name,
+                                lora_path=path,
+                                pinned=False,
                             )
                         else:
                             lora_ref = LoRARef(
-                                lora_name=lora_path, lora_path=lora_path, pinned=False
+                                lora_id=LoRARef.deterministic_id(lora_path, lora_path),
+                                lora_name=lora_path,
+                                lora_path=lora_path,
+                                pinned=False,
                             )
                     elif isinstance(lora_path, dict):
                         assert (
                             "lora_name" in lora_path and "lora_path" in lora_path
                         ), f"When providing LoRA paths as a list of dict, each dict should contain 'lora_name' and 'lora_path' keys. Got: {lora_path}"
                         lora_ref = LoRARef(
+                            lora_id=LoRARef.deterministic_id(
+                                lora_path["lora_name"], lora_path["lora_path"]
+                            ),
                             lora_name=lora_path["lora_name"],
                             lora_path=lora_path["lora_path"],
                             pinned=lora_path.get("pinned", False),
@@ -7034,7 +7043,12 @@ class ServerArgs:
                     self.lora_paths.append(lora_ref)
             elif isinstance(self.lora_paths, dict):
                 self.lora_paths = [
-                    LoRARef(lora_name=k, lora_path=v, pinned=False)
+                    LoRARef(
+                        lora_id=LoRARef.deterministic_id(k, v),
+                        lora_name=k,
+                        lora_path=v,
+                        pinned=False,
+                    )
                     for k, v in self.lora_paths.items()
                 ]
             elif self.lora_paths is None:


### PR DESCRIPTION
## Motivation

`LoRARef.lora_id` is generated with `uuid4()` (see `lora_registry.py`). When `--lora-paths` is parsed in `ServerArgs.check_lora_server_args()`, every node in a multi-node launch parses CLI args independently, so each rank mints a *different* `lora_id` for the same `(lora_name, lora_path)` pair.

The master tokenizer manager broadcasts a request's `lora_id` to all ranks via the TP CPU group. On non-master ranks, that id never matches any local `LoRARef`, so the lookup in `LoRARegistry`/`LoRAMemoryPool` fails (e.g. assertion in `load_lora_weight_to_buffer`, or `KeyError` in the registry). Multi-node `--lora-paths` adapters are effectively unusable.

Concrete repro on `main` (any 2-node launch with the same `--lora-paths`):
```bash
# node 0
python -m sglang.launch_server \
  --model-path /root/Kimi-K2.5-NVFP4 \
  --nnodes 2 --node-rank 0 --dist-init-addr <addr> \
  --tp 16 --ep 16 \
  --enable-lora --max-lora-rank 16 --lora-target-modules all \
  --lora-paths alpha=/root/kimi_k25_lora_alpha
# node 1: same command with --node-rank 1
```
Each node logs a different `LoRARef(lora_id=…, lora_name=alpha, …)` at startup; the first request that targets `alpha` then asserts on the non-master nodes.

This bug surfaces purely at CLI parse time — it is independent of model, quantization, or MoE backend.

## Modifications

- `python/sglang/srt/lora/lora_registry.py`
  - Add `LoRARef.deterministic_id(lora_name, lora_path) -> str`, a static helper that returns `uuid5(NAMESPACE_URL, f"{name}\0{path}").hex`. Same shape (32 hex chars) as `uuid4().hex`, and a NUL byte separator so `("a", "b/c")` ≠ `("a/b", "c")`.

- `python/sglang/srt/server_args.py`
  - In `check_lora_server_args()`, replace the four `LoRARef(lora_name=…, lora_path=…)` constructions in the `--lora-paths` parse block with `LoRARef(lora_id=LoRARef.deterministic_id(name, path), …)`. Covers all four input shapes:
    - `["name=path"]` (list of `name=path` strings)
    - `["/abs/path"]` (list of bare strings)
    - `[{"lora_name": …, "lora_path": …}]` (list of dicts)
    - `{"name": "/abs/path"}` (top-level dict)

The `LoRARef` constructor itself is unchanged — `lora_id` remains a normal field with a `uuid4` default. Only the CLI parse path becomes deterministic; dynamic loads via the `/load_lora_adapter` HTTP endpoint continue to mint a fresh `uuid4` (the loader broadcasts that id to other ranks via the existing IPC, so they don't have the parse-time consistency problem).

## Accuracy Tests

No model-output-affecting changes. The only behavior change is the *value* of `lora_id` for adapters declared via `--lora-paths`, which is an opaque internal identifier — never exposed to the user, never used as a dictionary key in any persisted artifact (radix cache keys hash `lora_id` plus other inputs, but the cache is per-process and doesn't survive a restart, so the change in id is transparent).

Multi-node determinism verified on a 2-pod B200 setup (`sglang-yanbin-0` and `sglang-yanbin-1`):

1. Ran the patched `check_lora_server_args()` on both pods with all four `--lora-paths` shapes. Outputs are byte-exact identical across pods (`diff` empty).
2. Same shapes with the `uuid4()` baseline produce different ids per pod, confirming the bug premise.

```
$ diff /tmp/sa3_pod0.json /tmp/sa3_pod1.json && echo OK
OK
$ jq '."list-of-eq-string"[0].id' /tmp/sa3_pod0.json /tmp/sa3_pod1.json
"4a6ad216c85558e5ba8ad057be37ad8d"
"4a6ad216c85558e5ba8ad057be37ad8d"
```

Existing single-node LoRA accuracy tests are unaffected — the parse path produces a valid 32-hex `lora_id` just like before; only the source of randomness changed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
