### PR TITLE
ci(est_time): bump 5 test estimates

### DIFF
--- a/test/registered/hicache/test_hicache_storage_mooncake_backend.py
+++ b/test/registered/hicache/test_hicache_storage_mooncake_backend.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     is_in_ci,
 )
 
-register_cuda_ci(est_time=236, suite="stage-b-test-2-gpu-large")
+register_cuda_ci(est_time=360, suite="stage-b-test-2-gpu-large")
 
 
 class HiCacheStorageMooncakeBackendBaseMixin(HiCacheStorageBaseMixin):

--- a/test/registered/models/test_ministral4_models.py
+++ b/test/registered/models/test_ministral4_models.py
@@ -7,7 +7,7 @@ from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
 register_cuda_ci(
-    est_time=200,
+    est_time=370,
     suite="stage-b-test-2-gpu-large",
 )
 

--- a/test/registered/models/test_nvidia_nemotron_3_nano.py
+++ b/test/registered/models/test_nvidia_nemotron_3_nano.py
@@ -5,7 +5,7 @@ from sglang.test.kits.lm_eval_kit import LMEvalMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
 register_cuda_ci(
-    est_time=564,
+    est_time=640,
     suite="stage-b-test-2-gpu-large",
 )
 

--- a/test/registered/radix_cache/test_unified_radix_cache_kl.py
+++ b/test/registered/radix_cache/test_unified_radix_cache_kl.py
@@ -35,7 +35,7 @@ MAMBA_TRACK_INTERVAL = 128
 SWA_MODEL = "openai/gpt-oss-20b"
 FULL_MODEL = "Qwen/Qwen3-32B"
 
-register_cuda_ci(est_time=760, suite="stage-c-test-4-gpu-h100")
+register_cuda_ci(est_time=930, suite="stage-c-test-4-gpu-h100")
 
 
 class UnifiedRadixTreeTestMixin:

--- a/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py
+++ b/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=420, suite="stage-b-test-4-gpu-b200")
+register_cuda_ci(est_time=540, suite="stage-b-test-4-gpu-b200")
 
 FULL_DEEPSEEK_V3_FP4_MODEL_PATH = "nvidia/DeepSeek-V3-0324-FP4"
 SERVER_LAUNCH_TIMEOUT = 1200


### PR DESCRIPTION
Automated bump of `est_time` on tests that have consistently exceeded their estimate (>3 alerts in the last 72h on the CI failure monitor dashboard).

Suggested values are the average of recent actual elapsed times, rounded up to the next 10s.

| Test | Current | New | Path |
|---|---|---|---|
| `test_ministral4_models.py` | 200s | 370s | `test/registered/models/test_ministral4_models.py` |
| `test_unified_radix_cache_kl.py` | 760s | 930s | `test/registered/radix_cache/test_unified_radix_cache_kl.py` |
| `test_hicache_storage_mooncake_backend.py` | 236s | 360s | `test/registered/hicache/test_hicache_storage_mooncake_backend.py` |
| `test_deepseek_v3_fp4_mtp_small.py` | 420s | 540s | `test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py` |
| `test_nvidia_nemotron_3_nano.py` | 564s | 640s | `test/registered/models/test_nvidia_nemotron_3_nano.py` |


_Opened by ci-monitor / Estimate Update Candidates._