### PR TITLE
Fix weight_checker e2e OOM on 32GB GPU + move to nightly

### DIFF
--- a/test/registered/rl/test_weight_checker_e2e.py
+++ b/test/registered/rl/test_weight_checker_e2e.py
@@ -34,7 +34,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=150, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=150, suite="nightly-1-gpu", nightly=True)
 
 _MODEL_NAME = "Qwen/Qwen3-0.6B"
 # We address the up half via the HF-style unfused name "up_proj.weight". sglang's
@@ -55,10 +55,17 @@ class TestWeightCheckerE2E(CustomTestCase):
     @classmethod
     def setUpClass(cls):
         cls.url = DEFAULT_URL_FOR_TEST
+        # --mem-fraction-static 0.7 leaves enough free GPU for _check_tensors's
+        # CPU->GPU round trip: snapshot lives on CPU, then _compare moves each
+        # snapshot tensor back to GPU for byte equality. With the default 0.88,
+        # sglang holds ~29GB on a 32GB GPU and only ~200MB is free, so the
+        # vocab-embedding round-trip (~600MB) OOMs the snapshot/reset/compare
+        # cycle in test_z_*.
         cls.process = popen_launch_server(
             _MODEL_NAME,
             cls.url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--mem-fraction-static", "0.7"],
         )
 
     @classmethod

--- a/test/registered/rl/test_weight_checker_e2e.py
+++ b/test/registered/rl/test_weight_checker_e2e.py
@@ -34,7 +34,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=150, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=150, suite="nightly-1-gpu", nightly=True)
 
 _MODEL_NAME = "Qwen/Qwen3-0.6B"
 # We address the up half via the HF-style unfused name "up_proj.weight". sglang's

--- a/test/registered/rl/test_weight_checker_e2e.py
+++ b/test/registered/rl/test_weight_checker_e2e.py
@@ -34,7 +34,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=150, suite="nightly-1-gpu", nightly=True)
+register_cuda_ci(est_time=150, suite="stage-b-test-1-gpu-small")
 
 _MODEL_NAME = "Qwen/Qwen3-0.6B"
 # We address the up half via the HF-style unfused name "up_proj.weight". sglang's


### PR DESCRIPTION
## Motivation

`test_weight_checker_e2e.py` was OOM-ing on the 32GB 5090 per-commit runner (see [the failing run on stage-b-test-1-gpu-small (3)](https://github.com/sgl-project/sglang/actions/runs/25451250096/job/74668796303)). #24553 sidestepped it by switching the suite to `*-large` (H100 80GB), but that still occupies the per-commit pool with a 150s end-to-end test (server boot + Qwen3-0.6B + `update_weights_from_tensor` cycle).

This PR fixes the actual root cause and moves the test off the per-commit pool.

## Root cause of the 32GB OOM

The OOM is not in the new `checksum` action — it's in the legacy `_check_tensors` (`weight_checker.py:169`) during `test_z_snapshot_reset_compare_detects_diff` (snapshot → reset → compare):

```
[2026-05-06 17:51:30] check_weights see error: CUDA out of memory.
Tried to allocate 594.00 MiB. GPU 0 has a total capacity of 31.36 GiB
of which 207.12 MiB is free. ... 29.43 GiB is allocated by PyTorch
File "weight_checker.py", line 169, in _check_tensors
File "test_weight_checker_e2e.py", line 218, in test_z_snapshot_reset_compare_detects_diff
```

Mechanics:
1. `_snapshot()` moves all params to CPU (~1.2GB) — no GPU growth.
2. `_reset_tensors()` randomizes in place — no allocation.
3. `_compare()` iterates pairs and calls `_check_tensors`, which does `expect = expect.cuda()` to round-trip each CPU snapshot tensor back to GPU for byte equality.
4. With the default `--mem-fraction-static=0.88`, sglang already holds ~29.43GB on the 31.36GB GPU; only ~207MB is free. The vocab-embedding round-trip (~600MB) OOMs.

## Steps

### Step 1 — verify the mem-fraction fix on the small (32GB) machine

Commit [`503494da97`](https://github.com/fzyzcjy/sglang/commit/503494da97): switch suite back to `stage-b-test-1-gpu-small` and add `--mem-fraction-static 0.7` to `popen_launch_server`. This leaves ~9GB free on a 32GB GPU — comfortably above the 600MB round-trip footprint.

Triggered via `/rerun-test test_weight_checker_e2e.py` ([comment](https://github.com/sgl-project/sglang/pull/24559#issuecomment-4393051459)).

**Result: ✅ pass** on `1-gpu-5090` (32GB), workflow run [25467844547](https://github.com/sgl-project/sglang/actions/runs/25467844547):

| Job | Conclusion | Started | Completed | Duration |
| --- | --- | --- | --- | --- |
| `rerun-test-cuda` | success | 2026-05-07T00:06:14Z | 2026-05-07T00:08:09Z | ~115s |

All 9 test methods executed (including `test_z_snapshot_reset_compare_detects_diff`), no `OutOfMemoryError`. The `max_abs_err` lines in the log are the expected output of the destructive snapshot/reset/compare test, not failures.

→ `--mem-fraction-static 0.7` alone fixes the 32GB OOM.

### Step 2 — move to the nightly suite

Commit [`c1c7b74097`](https://github.com/fzyzcjy/sglang/commit/c1c7b74097): re-register as `suite="nightly-1-gpu", nightly=True`. The 150s test should not occupy the per-commit pool when its semantics (load model + update_weights round-trip) are stable enough for daily coverage.

`--mem-fraction-static 0.7` is kept as defense — the `_check_tensors` CPU↔GPU round trip is memory-fragile and worth bounding even on H100.

Triggered via a second `/rerun-test test_weight_checker_e2e.py` ([comment](https://github.com/sgl-project/sglang/pull/24559#issuecomment-4393114951)).

**Result: ✅ pass** on `1-gpu-h100` (nightly runner, 80GB), workflow run [25468395960](https://github.com/sgl-project/sglang/actions/runs/25468395960):

| Job | Conclusion | Started | Completed | Duration |
| --- | --- | --- | --- | --- |
| `rerun-test-cuda` | success | 2026-05-07T00:13:15Z | 2026-05-07T00:16:25Z | ~190s |

## Modifications

- `test/registered/rl/test_weight_checker_e2e.py`:
  - `suite="stage-b-test-1-gpu-large"` → `suite="nightly-1-gpu", nightly=True`
  - `popen_launch_server(...)` gains `other_args=["--mem-fraction-static", "0.7"]`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (existing test moved, no new tests required)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (n/a — CI re-registration)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (n/a)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).