### PR TITLE
fix: NSA prefill context parallel crash (dsv4-rebase)

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -70,7 +70,9 @@ def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:
             f"got {server_args.nsa_prefill_cp_mode}"
         )
 
+    server_args.enable_dp_attention = True
     server_args.moe_dense_tp_size = 1
+    server_args.attn_cp_size = server_args.tp_size // server_args.dp_size
     assert (
         server_args.dp_size == 1
     ), "For round-robin split mode, dp attention is not supported."
@@ -80,5 +82,5 @@ def validate_deepseek_v4_cp(server_args: "ServerArgs") -> None:
     logger.warning(
         f"Enable Context Parallel for DeepSeekV4, "
         f"dp_size={server_args.dp_size}, moe_dense_tp_size={server_args.moe_dense_tp_size}, "
-        f"ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
+        f"attn_cp_size={server_args.attn_cp_size}, ep_size={server_args.ep_size}, tp_size={server_args.tp_size}"
     )

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -37,8 +37,10 @@ from sglang.srt.layers.attention.dsv4.metadata_kernel import (
 from sglang.srt.layers.attention.dsv4.quant_k_cache import (
     quant_to_nope_fp8_rope_bf16_pack_triton,
 )
-from sglang.srt.layers.attention.nsa.utils import is_nsa_prefill_cp_round_robin_split
-from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
+from sglang.srt.layers.dp_attention import (
+    get_attention_cp_rank,
+    get_attention_cp_size,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
@@ -197,8 +199,8 @@ class DSV4AttnMetadata:
     ]
 
     def apply_cp_reindex(self) -> None:
-        cp_rank = get_attention_tp_rank()
-        cp_size = get_attention_tp_size()
+        cp_rank = get_attention_cp_rank()
+        cp_size = get_attention_cp_size()
         idx = slice(cp_rank, None, cp_size)
         pre_global_len = self.seq_lens_casual.shape[0]
         assert pre_global_len % cp_size == 0, (
@@ -1138,8 +1140,6 @@ class DeepseekV4AttnBackend(
 
         if need_compress:
             core_attn_metadata.init_compression_metadata()
-            if is_prefill and is_nsa_prefill_cp_round_robin_split():
-                core_attn_metadata.apply_cp_reindex()
             core_attn_metadata.init_flashmla_related()
         else:
             core_attn_metadata.c4_sparse_topk_lengths = None

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -20,7 +20,7 @@ from sglang.srt.layers.attention.dsv4.quant_k_cache import (
 )
 from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 from sglang.srt.layers.attention.nsa.utils import nsa_use_prefill_cp
-from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.dp_attention import get_attention_cp_size
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
@@ -355,7 +355,7 @@ class Compressor(nn.Module):
         if nsa_use_prefill_cp(forward_batch):
             kv_score = cp_all_gather_rerange_output(
                 kv_score,
-                get_attention_tp_size(),
+                get_attention_cp_size(),
                 forward_batch,
                 torch.cuda.current_stream(),
             )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.attention.dsv4.indexer import C4Indexer
 from sglang.srt.layers.attention.nsa.utils import (
     can_nsa_cp_split,
     is_nsa_enable_prefill_cp,
+    is_nsa_prefill_cp_round_robin_split,
     nsa_use_prefill_cp,
 )
 from sglang.srt.layers.communicator import get_attn_tp_context
@@ -30,6 +31,8 @@ from sglang.srt.layers.dp_attention import (
     attn_tp_all_gather,
     dp_gather_partial,
     dp_scatter,
+    get_attention_cp_rank,
+    get_attention_cp_size,
     get_attention_dp_size,
     get_attention_tp_rank,
     get_attention_tp_size,
@@ -151,7 +154,7 @@ class MQALayer(nn.Module):
         self.tp_size = attn_tp_size = get_attention_tp_size()
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
-            self.cp_size = get_attention_tp_size()
+            self.cp_size = get_attention_cp_size()
             self.tp_rank = attn_tp_rank = 0
             self.tp_size = attn_tp_size = 1
         self.layer_id = layer_id
@@ -791,8 +794,8 @@ class DeepseekV4DecoderLayer(nn.Module):
                 "CP requires DeepEP (moe_a2a_backend == deepep). "
                 "Only DeepEP is tested with CP's per-rank token split."
             )
-            cp_rank = get_attention_tp_rank()
-            cp_size = get_attention_tp_size()
+            cp_rank = get_attention_cp_rank()
+            cp_size = get_attention_cp_size()
             input_ids = input_ids[cp_rank::cp_size].contiguous()
             input_ids_global = input_ids
         elif _use_tp_moe_gather:
@@ -872,7 +875,7 @@ class DeepseekV4Model(nn.Module):
 
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
-            self.cp_size = get_attention_tp_size()
+            self.cp_size = get_attention_cp_size()
 
     def hc_head(
         self,
@@ -982,8 +985,8 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
-            self.cp_rank = get_attention_tp_rank()
-            self.cp_size = get_attention_tp_size()
+            self.cp_rank = get_attention_cp_rank()
+            self.cp_size = get_attention_cp_size()
 
     @property
     def routed_experts_weights_of_layer(self):
@@ -1018,6 +1021,17 @@ class DeepseekV4ForCausalLM(nn.Module):
                     self.cp_size,
                     forward_batch.seq_lens_cpu.tolist(),
                 )
+                if is_nsa_prefill_cp_round_robin_split():
+                    metadata = forward_batch.attn_backend.forward_metadata
+                    core_meta = metadata.core_attn_metadata
+                    core_meta.apply_cp_reindex()
+                    core_meta.init_flashmla_related()
+                    if metadata.indexer_metadata is not None:
+                        metadata.indexer_metadata = (
+                            forward_batch.attn_backend.init_forward_metadata_indexer(
+                                core_meta
+                            )
+                        )
 
         with get_attn_tp_context().maybe_input_scattered(forward_batch):
             hidden_states = self.model.forward(


### PR DESCRIPTION
Fix `--enable-nsa-prefill-context-parallel` crash on `dsv4-rebase`.

`dsv4-rebase` introduced `_ATTN_CP` process group via `attn_cp_size`, but CP operations still used `get_attention_tp_*` (pointing to `_ATTN_TP` which shrinks to size 1 when CP is active). This caused shape mismatches in metadata, compressor allgather, and indexer.

Fix: use `get_attention_cp_rank/size` consistently, configure `attn_cp_size` in hook, and rebuild indexer metadata after CP reindex.

AIME25 on B300 8xGPU TP=8 CP=8 (DeepSeek-V4-Flash, 480 evals):
- max_tokens=default: 91.46%
- max_tokens=400k: 96.88%