### PR TITLE
feat: option to disable Mamba cache offload

### DIFF
--- a/docs_new/docs/advanced_features/hicache_best_practices.mdx
+++ b/docs_new/docs/advanced_features/hicache_best_practices.mdx
@@ -17,6 +17,7 @@ SGLang HiCache extends the traditional RadixAttention with a three-tier hierarch
 --enable-hierarchical-cache           # Enable HiCache
 --hicache-ratio 2                     # Host memory ratio (2x GPU memory)
 --hicache-size 100                    # Host memory size in GBs, will override the above ratio
+--hicache-disable-mamba               # Optional: do not allocate a host Mamba state pool for hybrid Mamba models
 --hicache-io-backend kernel           # The I/O backend of moving data between CPU and GPU
 --hicache-write-policy write_through  # Cache write policy from GPU to CPU
 --hicache-storage-backend             # Optional storage backend (e.g., hf3fs, mooncake, etc.)

--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -1705,6 +1705,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--hicache-disable-mamba`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Disable hierarchical-cache offloading for Mamba states while keeping KV HiCache enabled.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag<br/> (set to enable).</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--hicache-write-policy`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The write policy of hierarchical cache.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`write_through`</td>

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -191,7 +191,8 @@ class HiMambaRadixCache(MambaRadixCache):
         self._flush_pending_storage_backups_before_reset()
         self.cache_controller.reset()
         self.full_kv_pool_host.clear()
-        self.mamba_pool_host.clear()
+        if self.mamba_pool_host is not None:
+            self.mamba_pool_host.clear()
         self.ongoing_write_through = {}
         self.ongoing_load_back = {}
         self.ongoing_prefetch = {}
@@ -203,7 +204,11 @@ class HiMambaRadixCache(MambaRadixCache):
         logger.info(
             "HiMambaRadixCache reset completed: host_kv_available=%s host_mamba_available=%s",
             self.full_kv_pool_host.available_size(),
-            self.mamba_pool_host.available_size(),
+            (
+                self.mamba_pool_host.available_size()
+                if self.mamba_pool_host is not None
+                else 0
+            ),
         )
         super().reset()
 
@@ -498,6 +503,7 @@ class HiMambaRadixCache(MambaRadixCache):
             or node == self.root_node
             or node.host_ref_counter > 0
             or node.host_mamba_ref_counter > 0
+            or (node.mamba_value is not None and node.mamba_lock_ref > 0)
             or len(node.children) > 0
         ):
             self.evictable_full_host_leaves.discard(node)
@@ -519,7 +525,9 @@ class HiMambaRadixCache(MambaRadixCache):
         node.mamba_value = None
         return mamba_num
 
-    def _evict_to_host(self, node: TreeNode) -> Tuple[int, int]:
+    def _evict_to_host(
+        self, node: TreeNode, *, evict_mamba: bool = True
+    ) -> Tuple[int, int]:
         # GPU -> CPU demotion: node stays in tree as evicted+backuped
         assert not node.evicted, f"already evicted, {node.id=}"
         assert node.backuped, f"not backuped, {node.id=}"
@@ -532,7 +540,7 @@ class HiMambaRadixCache(MambaRadixCache):
         if self.full_lru_list.in_list(node):
             self.full_lru_list.remove_node(node)
 
-        mamba_num = self._free_device_mamba(node)
+        mamba_num = self._free_device_mamba(node) if evict_mamba else 0
 
         node.value = None
         self._update_leaf_status(node)
@@ -558,7 +566,8 @@ class HiMambaRadixCache(MambaRadixCache):
         if node.mamba_host_value is not None:
             if self.mamba_host_lru_list.in_list(node):
                 self.mamba_host_lru_list.remove_node(node)
-            self.mamba_pool_host.free(node.mamba_host_value)
+            if self.mamba_pool_host is not None:
+                self.mamba_pool_host.free(node.mamba_host_value)
             node.mamba_host_value = None
 
         node.value = None
@@ -579,10 +588,13 @@ class HiMambaRadixCache(MambaRadixCache):
         )
 
     def _evict_host_leaf(self, node: TreeNode) -> int:
-        # evict a host-resident leaf: free host KV + mamba, delete from tree, cascade
+        # Evict a host-resident leaf: free host KV + any remaining Mamba,
+        # delete from tree, cascade.
         assert node.evicted, f"not evicted, {node.id=}"
         assert node.backuped, f"not backuped, {node.id=}"
-        assert node.mamba_value is None, f"has device mamba, {node.id=}"
+        assert (
+            node.mamba_value is None or node.mamba_lock_ref == 0
+        ), f"device mamba in use, {node.id=} {node.mamba_lock_ref=}"
         assert (
             node.host_ref_counter == 0
         ), f"host kv in use, {node.id=} {node.host_ref_counter=}"
@@ -594,10 +606,13 @@ class HiMambaRadixCache(MambaRadixCache):
         full_num_evicted = self.cache_controller.evict_host(node.host_value)
         node.host_value = None
 
+        self._free_device_mamba(node)
+
         if node.mamba_host_value is not None:
             if self.mamba_host_lru_list.in_list(node):
                 self.mamba_host_lru_list.remove_node(node)
-            self.mamba_pool_host.free(node.mamba_host_value)
+            if self.mamba_pool_host is not None:
+                self.mamba_pool_host.free(node.mamba_host_value)
             node.mamba_host_value = None
 
         self._discard_from_leaf_sets(node)
@@ -670,21 +685,27 @@ class HiMambaRadixCache(MambaRadixCache):
 
         return node, full_num_evicted, mamba_num_evicted
 
-    def _evict_device_leaf(self, x: TreeNode) -> Tuple[int, int]:
+    def _evict_device_leaf(
+        self, x: TreeNode, *, evict_mamba: bool = True
+    ) -> Tuple[int, int]:
         """Evict a device leaf node, choosing the right strategy:
 
         - backuped: demote to host via _evict_to_host (node stays in tree)
         - not backuped + write_back: write_backup first, then demote
         - not backuped + write_through: _evict_regular (delete from tree)
+
+        evict_mamba controls whether host demotion also frees device Mamba.
+        Full-KV pressure keeps device Mamba resident when host Mamba HiCache
+        is disabled, because there is no host Mamba copy to restore from.
         """
         if not x.backuped:
             if self.cache_controller.write_policy == "write_back":
                 self.write_backup(x, write_back=True)
                 self.writing_check(write_back=True)
-                return self._evict_to_host(x)
+                return self._evict_to_host(x, evict_mamba=evict_mamba)
             else:
                 return self._evict_regular(x)
-        return self._evict_to_host(x)
+        return self._evict_to_host(x, evict_mamba=evict_mamba)
 
     def evict(self, params: EvictParams) -> EvictResult:
         if self.disable:
@@ -698,13 +719,16 @@ class HiMambaRadixCache(MambaRadixCache):
             leaves = list(self.evictable_full_device_leaves)
             eviction_heap = [(n.last_access_time, n) for n in leaves]
             heapq.heapify(eviction_heap)
+            evict_mamba_with_full = self.mamba_pool_host is not None
 
             while full_num_evicted < full_num_tokens and eviction_heap:
                 _, x = heapq.heappop(eviction_heap)
                 if x not in self.evictable_full_device_leaves:
                     continue
 
-                evicted_full, evicted_mamba = self._evict_device_leaf(x)
+                evicted_full, evicted_mamba = self._evict_device_leaf(
+                    x, evict_mamba=evict_mamba_with_full
+                )
                 full_num_evicted += evicted_full
                 mamba_num_evicted += evicted_mamba
 
@@ -743,7 +767,7 @@ class HiMambaRadixCache(MambaRadixCache):
         Host leaf node: same as Full host evict — _evict_host_leaf_node frees
                         host KV + mamba, deletes from tree, cascades.
         """
-        if self.disable or num_mamba_hosts <= 0:
+        if self.disable or num_mamba_hosts <= 0 or self.mamba_pool_host is None:
             return 0
 
         x = self.mamba_host_lru_list.get_lru_no_lock()
@@ -789,11 +813,19 @@ class HiMambaRadixCache(MambaRadixCache):
             assert x.mamba_value is not None, f"node has no mamba value, {x.id=}"
             assert x != self.root_node, f"root node is not evictable, {x.id=}"
             assert x.mamba_lock_ref == 0, f"node is in use, {x.id=}"
-            assert (
-                not x.evicted
-            ), f"evicted node should not be in mamba_lru_list, {x.id=}"
 
-            if len(x.children) > 0:
+            if x.evicted:
+                x_next = self.mamba_lru_list.get_prev_no_lock(x)
+                mamba_num_evicted += self._free_device_mamba(x)
+
+                if len(x.children) == 0:
+                    self._delete_tombstone_leaf(x)
+                    _, _, cascade_mamba = self._iteratively_delete_tombstone_leaf(x)
+                    mamba_num_evicted += cascade_mamba
+
+                if not self.mamba_lru_list.in_list(x_next):
+                    x_next = self.mamba_lru_list.get_lru_no_lock()
+            elif len(x.children) > 0:
                 # Internal: free device mamba only, KV stays on device (tombstone)
                 x_next = self.mamba_lru_list.get_prev_no_lock(x)
                 mamba_num_evicted += len(x.mamba_value)
@@ -807,7 +839,7 @@ class HiMambaRadixCache(MambaRadixCache):
                 ), f"evict device leaf: full_lock_ref mismatch with {x.id=} {x.full_lock_ref=} {x.mamba_lock_ref=}"
 
                 x_next = self.mamba_lru_list.get_prev_no_lock(x)
-                _, mamba_evicted = self._evict_device_leaf(x)
+                _, mamba_evicted = self._evict_device_leaf(x, evict_mamba=True)
                 mamba_num_evicted += mamba_evicted
 
                 if not self.mamba_lru_list.in_list(x_next):
@@ -819,13 +851,19 @@ class HiMambaRadixCache(MambaRadixCache):
 
     def _unevict_node(self, node: TreeNode, fresh_value: torch.Tensor):
         assert node.evicted, f"not evicted, {node.id=}"
-        assert node.mamba_value is None, f"evicted node has device mamba, {node.id=}"
         n = len(fresh_value)
 
         node.value = fresh_value.clone()
         self.full_lru_list.insert_mru(node)
         self.full_evictable_size_ += n
         self._record_store_event(node, medium=StorageMedium.GPU)
+
+        if node.mamba_value is not None:
+            if self.mamba_lru_list.in_list(node):
+                self.mamba_lru_list.reset_node_mru(node)
+            else:
+                self.mamba_lru_list.insert_mru(node)
+                self.mamba_evictable_size_ += len(node.mamba_value)
 
         self._update_leaf_status(node)
         if node.parent is not None:
@@ -1391,6 +1429,8 @@ class HiMambaRadixCache(MambaRadixCache):
 
     def prefetch_abort(self, pool_transfers: Optional[list[PoolTransfer]]) -> None:
         """Free any allocated mamba host slots on prefetch abort/revoke."""
+        if self.mamba_pool_host is None:
+            return
         for transfer in pool_transfers or []:
             if transfer.name == PoolName.MAMBA:
                 if transfer.host_indices is not None:
@@ -1759,10 +1799,11 @@ class HiMambaRadixCache(MambaRadixCache):
             self._release_host_node(last_host_node, release_mamba=False)
             return
 
-        # mamba is also being loaded, protect host mamba as well
-        last_host_node.protect_host_mamba()
-        if self.mamba_host_lru_list.in_list(last_host_node):
-            self.mamba_host_lru_list.remove_node(last_host_node)
+        # Mamba is also being loaded when its host pool is enabled.
+        if extra_pools:
+            last_host_node.protect_host_mamba()
+            if self.mamba_host_lru_list.in_list(last_host_node):
+                self.mamba_host_lru_list.remove_node(last_host_node)
 
         operation = self.cache_controller.prefetch(
             req_id,
@@ -1847,7 +1888,8 @@ class HiMambaRadixCache(MambaRadixCache):
         if mamba_host_indices is not None:
             inserted_new = matched_length < min_completed_tokens
             if not inserted_new or not mamba_loaded:
-                self.mamba_pool_host.free(mamba_host_indices)
+                if self.mamba_pool_host is not None:
+                    self.mamba_pool_host.free(mamba_host_indices)
 
         self._release_host_node(last_host_node)
         del self.ongoing_prefetch[req_id]
@@ -1998,6 +2040,8 @@ class HiMambaRadixCache(MambaRadixCache):
 
     def mamba_backup_transfers(self, node: TreeNode) -> Optional[list[PoolTransfer]]:
         # build D→H transfer descriptor for mamba state
+        if self.mamba_pool_host is None:
+            return None
         if node.mamba_value is None:
             return None
         return [
@@ -2021,6 +2065,8 @@ class HiMambaRadixCache(MambaRadixCache):
 
     def mamba_archive_transfers(self, node: TreeNode) -> Optional[list[PoolTransfer]]:
         # build H→Storage transfer descriptor for mamba state
+        if self.mamba_pool_host is None:
+            return None
         if node.mamba_host_value is None or not node.hash_value:
             return None
         return [
@@ -2038,6 +2084,8 @@ class HiMambaRadixCache(MambaRadixCache):
         last_hash: Optional[str],
     ) -> Optional[list[PoolTransfer]]:
         # allocate a mamba host slot and build Storage→H transfer descriptor
+        if self.mamba_pool_host is None:
+            return []
         if not token_ids:
             return None
         host_indices = self._alloc_with_evict(
@@ -2062,6 +2110,8 @@ class HiMambaRadixCache(MambaRadixCache):
         req,
     ) -> Optional[list[PoolTransfer]]:
         # build H→D transfer descriptors for mamba state
+        if self.mamba_pool_host is None:
+            return None
         backed_up_host_indices: list[torch.Tensor] = []
         for node in nodes_to_restore:
             if not node.mamba_backuped:

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -500,18 +500,12 @@ def build_hybrid_mamba_stack(
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping | mamba_layer_mapping)
     mamba_allocator = params.req_to_token_pool.mamba_allocator
+    enable_mamba_hicache = not server_args.hicache_disable_mamba
     kv_host_pool = build_kv_host_pool(
         kv_pool=kv_pool,
         page_size=page_size,
         server_args=server_args,
         use_mla=use_mla,
-    )
-    mamba_host_pool = MambaPoolHost(
-        mamba_pool,
-        server_args.hicache_ratio,
-        server_args.hicache_size,
-        allocator_type=server_args.hicache_storage_backend,
-        layout=server_args.hicache_mem_layout,
     )
     entries = [
         build_pool_entry(
@@ -522,18 +516,28 @@ def build_hybrid_mamba_stack(
             transfer_layer_num=transfer_layer_num,
             is_anchor=True,
         ),
-        build_pool_entry(
-            name=PoolName.MAMBA,
-            host_pool=mamba_host_pool,
-            device_pool=mamba_pool,
-            layer_mapping=mamba_layer_mapping,
-            transfer_layer_num=transfer_layer_num,
-            host_evict_fn=host_mamba_evict_fn,
-            device_evict_fn=device_mamba_evict_fn,
-            device_alloc_fn=mamba_allocator.alloc,
-            device_free_fn=mamba_allocator.free,
-        ),
     ]
+    if enable_mamba_hicache:
+        mamba_host_pool = MambaPoolHost(
+            mamba_pool,
+            server_args.hicache_ratio,
+            server_args.hicache_size,
+            allocator_type=server_args.hicache_storage_backend,
+            layout=server_args.hicache_mem_layout,
+        )
+        entries.append(
+            build_pool_entry(
+                name=PoolName.MAMBA,
+                host_pool=mamba_host_pool,
+                device_pool=mamba_pool,
+                layer_mapping=mamba_layer_mapping,
+                transfer_layer_num=transfer_layer_num,
+                host_evict_fn=host_mamba_evict_fn,
+                device_evict_fn=device_mamba_evict_fn,
+                device_alloc_fn=mamba_allocator.alloc,
+                device_free_fn=mamba_allocator.free,
+            )
+        )
     host_pool_group = HostPoolGroup(entries)
     cache_controller = HybridCacheController(
         params.token_to_kv_pool_allocator,
@@ -800,16 +804,21 @@ class _MambaStrategy(StackStrategy):
             storage_backend_extra_config=storage_backend_extra_config,
             enable_storage_metrics=enable_storage_metrics,
         )
+        mamba_pool_host = (
+            host_pool_group.get_pool(PoolName.MAMBA)
+            if not server_args.hicache_disable_mamba
+            else None
+        )
         return StackBuildResult(
             host_pool_group=host_pool_group,
             cache_controller=cache_controller,
             component_host_pools={
                 ComponentType.FULL: host_pool_group.get_pool(PoolName.KV),
-                ComponentType.MAMBA: host_pool_group.get_pool(PoolName.MAMBA),
+                ComponentType.MAMBA: mamba_pool_host,
             },
             register_req_to_token_counter=True,
             transfer_layer_num=len(full_layer_mapping | mamba_layer_mapping),
-            pools_desc="KV + MAMBA",
+            pools_desc="KV + MAMBA" if mamba_pool_host is not None else "KV",
         )
 
 
@@ -1221,7 +1230,11 @@ def attach_hybrid_pool_to_mamba_cache(
             enable_storage_metrics=enable_storage_metrics,
         )
         mamba_cache.full_kv_pool_host = host_pool_group.get_pool(PoolName.KV)
-        mamba_cache.mamba_pool_host = host_pool_group.get_pool(PoolName.MAMBA)
+        mamba_cache.mamba_pool_host = (
+            host_pool_group.get_pool(PoolName.MAMBA)
+            if not server_args.hicache_disable_mamba
+            else None
+        )
         mamba_cache.transfer_layer_num = len(full_layer_mapping | mamba_layer_mapping)
         mamba_cache.host_pool_group = host_pool_group
         mamba_cache.cache_controller = cache_controller
@@ -1230,8 +1243,9 @@ def attach_hybrid_pool_to_mamba_cache(
         )
         hybrid_kv.register_layer_transfer_counter(cache_controller.layer_done_counter)
         logger.info(
-            "Attached hybrid Mamba pool stack to HiMambaRadixCache: pools=KV + MAMBA, "
+            "Attached hybrid Mamba pool stack to HiMambaRadixCache: pools=%s, "
             "transfer_layer_num=%s",
+            "KV + MAMBA" if mamba_cache.mamba_pool_host is not None else "KV",
             mamba_cache.transfer_layer_num,
         )
     except Exception:

--- a/python/sglang/srt/mem_cache/unified_cache_components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/full_component.py
@@ -143,7 +143,11 @@ class FullComponent(TreeComponent):
             _, x = heapq.heappop(heap)
             if x not in self.cache.evictable_device_leaves:
                 continue
-            self.cache._evict_device_leaf(x, tracker)
+            self.cache._evict_device_leaf(
+                x,
+                tracker,
+                evict_mamba=self.cache._should_evict_mamba_with_full(),
+            )
             if x.parent is not None and x.parent in self.cache.evictable_device_leaves:
                 heapq.heappush(
                     heap,

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -385,6 +385,8 @@ class MambaComponent(TreeComponent):
         last_hash: Optional[str] = None,
     ) -> Optional[list[PoolTransfer]]:
         ct = self.component_type
+        if self._mamba_pool_host is None:
+            return None
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             cd = node.component_data[ct]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1200,6 +1200,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         trigger: TreeComponent,
         tracker: dict[ComponentType, int],
         target: EvictLayer = EvictLayer.DEVICE,
+        evict_mamba: bool = True,
     ):
         """Cascade eviction from trigger to lower-or-equal priority components."""
 
@@ -1212,6 +1213,8 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         trigger_priority = trigger.eviction_priority(is_leaf)
 
         for comp in self._components_tuple:
+            if not evict_mamba and comp.component_type == ComponentType.MAMBA:
+                continue
             if comp.eviction_priority(is_leaf) <= trigger_priority:
                 if comp is not trigger and comp.node_has_component_data(node, target):
                     cd = node.component_data[comp.component_type]
@@ -1389,8 +1392,19 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         else:
             self.evictable_host_leaves.discard(node)
 
+    def _should_evict_mamba_with_full(self) -> bool:
+        mamba_component = self.components.get(ComponentType.MAMBA)
+        return (
+            mamba_component is None
+            or getattr(mamba_component, "_mamba_pool_host", None) is not None
+        )
+
     def _evict_to_host(
-        self, node: UnifiedTreeNode, tracker: Optional[dict[ComponentType, int]] = None
+        self,
+        node: UnifiedTreeNode,
+        tracker: Optional[dict[ComponentType, int]] = None,
+        *,
+        evict_mamba: bool = True,
     ) -> None:
         """GPU→CPU demotion: release all device resources, node stays in tree."""
         assert not node.evicted and node.backuped
@@ -1398,7 +1412,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self._evict_component_and_detach_lru(
             node, trigger, target=EvictLayer.DEVICE, tracker=tracker
         )
-        self._cascade_evict(node, trigger, tracker)
+        self._cascade_evict(node, trigger, tracker, evict_mamba=evict_mamba)
         self._record_remove_event(node, medium=StorageMedium.GPU)
 
         # after device eviction, insert aux components into host LRU.
@@ -1408,7 +1422,11 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self._update_evictable_leaf_sets(node.parent)
 
     def _evict_device_leaf(
-        self, node: UnifiedTreeNode, tracker: dict[ComponentType, int]
+        self,
+        node: UnifiedTreeNode,
+        tracker: dict[ComponentType, int],
+        *,
+        evict_mamba: bool = True,
     ) -> None:
         """Evict a device leaf node, choosing the right strategy:
 
@@ -1426,7 +1444,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             ):
                 self.write_backup(node, write_back=True)
                 self.writing_check(write_back=True)
-                self._evict_to_host(node, tracker)
+                self._evict_to_host(node, tracker, evict_mamba=evict_mamba)
                 return
             else:
                 # Write-through: node has no backup, delete entirely.
@@ -1441,7 +1459,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 self._update_evictable_leaf_sets(parent)
                 self._iteratively_delete_tombstone_leaf(node, tracker)
                 return
-        self._evict_to_host(node, tracker)
+        self._evict_to_host(node, tracker, evict_mamba=evict_mamba)
 
     def _evict_host_leaf(
         self, node: UnifiedTreeNode, tracker: dict[ComponentType, int]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -695,6 +695,7 @@ class ServerArgs:
     hicache_storage_backend: Optional[str] = None
     hicache_storage_prefetch_policy: str = "timeout"
     hicache_storage_backend_extra_config: Optional[str] = None
+    hicache_disable_mamba: bool = False
 
     # Hierarchical sparse attention
     enable_hisparse: bool = False
@@ -3751,6 +3752,10 @@ class ServerArgs:
             self.enable_hierarchical_cache
             or self.disaggregation_decode_enable_offload_kvcache
         ):
+            if self.hicache_disable_mamba:
+                logger.warning(
+                    "--hicache-disable-mamba has no effect unless hierarchical cache is enabled."
+                )
             return
 
         # Step 1: Initial layout-io compatibility normalization.
@@ -6279,6 +6284,11 @@ class ServerArgs:
             choices=["direct", "kernel", "kernel_ascend"],
             default=ServerArgs.hicache_io_backend,
             help="The IO backend for KV cache transfer between CPU and GPU",
+        )
+        parser.add_argument(
+            "--hicache-disable-mamba",
+            action="store_true",
+            help="Disable hierarchical-cache offloading for Mamba states while keeping KV HiCache enabled.",
         )
         parser.add_argument(
             "--hicache-mem-layout",


### PR DESCRIPTION
Mamba cache offloading (#20457) doubles the size of the HiCache, by allocating the same size pool for Mamba on host as full KV. But users with efficient session-aware caching may not need offload at all, so this half of the host memory is wasted.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27175103104](https://github.com/sgl-project/sglang/actions/runs/27175103104)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27175103046](https://github.com/sgl-project/sglang/actions/runs/27175103046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->