### PR TITLE
Optimize get_load with piggybacked snapshots

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -51,6 +51,7 @@ else:
 class BaseReq(ABC):
     rid: Optional[Union[str, List[str]]] = field(default=None, kw_only=True)
     http_worker_ipc: Optional[str] = field(default=None, kw_only=True)
+    load: Optional["GetLoadsReqOutput"] = field(default=None, kw_only=True)
 
     def regenerate_rid(self):
         """Generate a new request ID and return it."""
@@ -74,6 +75,7 @@ class BaseReq(ABC):
 class BaseBatchReq(ABC):
     rids: Optional[List[str]] = field(default=None, kw_only=True)
     http_worker_ipcs: Optional[List[str]] = field(default=None, kw_only=True)
+    load: Optional["GetLoadsReqOutput"] = field(default=None, kw_only=True)
 
     def regenerate_rids(self):
         """Generate new request IDs and return them."""
@@ -1125,8 +1127,6 @@ class BatchTokenIDOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: List[List[int]] = None
 
-    # Load for DP balance
-    load: GetLoadsReqOutput = None
     # Customized info
     customized_info: Optional[Dict[str, List[Any]]] = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
@@ -1189,9 +1189,6 @@ class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
 
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: List[List[int]] = None
-
-    # Load for DP balance
-    load: GetLoadsReqOutput = None
 
     # Customized info
     customized_info: Optional[Dict[str, List[Any]]] = None

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -288,6 +288,7 @@ def _handle_output_by_index(output, i):
         )
     else:
         new_output = output
+    new_output.load = output.load
     return new_output
 
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3832,11 +3832,7 @@ class SenderWrapper:
             # handle communicator reqs for multi-http worker case
             output.http_worker_ipc = recv_obj.http_worker_ipc
 
-        if (
-            not self.scheduler.server_args.disable_load_piggyback
-            and output.load is None
-            and not isinstance(output, GetLoadsReqOutput)
-        ):
+        if output.load is None and not isinstance(output, GetLoadsReqOutput):
             output.load = self.scheduler.get_loads(GetLoadsReqInput(include=["all"]))
 
         self.socket.send_pyobj(output)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -111,6 +111,7 @@ from sglang.srt.managers.io_struct import (
     GetInternalStateReq,
     GetInternalStateReqOutput,
     GetLoadsReqInput,
+    GetLoadsReqOutput,
     GetWeightsByNameReqInput,
     HealthCheckOutput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
@@ -542,8 +543,8 @@ class Scheduler(
                     context, zmq.PUSH, port_args.detokenizer_ipc_name, False
                 )
 
-            self.send_to_tokenizer = SenderWrapper(send_to_tokenizer)
-            self.send_to_detokenizer = SenderWrapper(send_to_detokenizer)
+            self.send_to_tokenizer = SenderWrapper(send_to_tokenizer, self)
+            self.send_to_detokenizer = SenderWrapper(send_to_detokenizer, self)
 
             if self.server_args.sleep_on_idle:
                 self.idle_sleeper = IdleSleeper(
@@ -555,8 +556,8 @@ class Scheduler(
         else:
             self.recv_from_tokenizer = None
             self.recv_from_rpc = None
-            self.send_to_tokenizer = SenderWrapper(None)
-            self.send_to_detokenizer = SenderWrapper(None)
+            self.send_to_tokenizer = SenderWrapper(None, self)
+            self.send_to_detokenizer = SenderWrapper(None, self)
 
         if self.current_scheduler_metrics_enabled:
             self.send_metrics_from_scheduler = get_zmq_socket(
@@ -3811,8 +3812,9 @@ def is_work_request(recv_req):
 
 
 class SenderWrapper:
-    def __init__(self, socket: zmq.Socket):
+    def __init__(self, socket: zmq.Socket, scheduler: Scheduler):
         self.socket = socket
+        self.scheduler = scheduler
 
     def send_output(
         self,
@@ -3829,6 +3831,13 @@ class SenderWrapper:
         ):
             # handle communicator reqs for multi-http worker case
             output.http_worker_ipc = recv_obj.http_worker_ipc
+
+        if (
+            not self.scheduler.server_args.disable_load_piggyback
+            and output.load is None
+            and not isinstance(output, GetLoadsReqOutput)
+        ):
+            output.load = self.scheduler.get_loads(GetLoadsReqInput(include=["all"]))
 
         self.socket.send_pyobj(output)
 

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -12,7 +12,6 @@ from sglang.srt.managers.io_struct import (
     AbortReq,
     BatchEmbeddingOutput,
     BatchTokenIDOutput,
-    GetLoadsReqInput,
 )
 from sglang.srt.managers.schedule_batch import (
     BaseFinishReason,
@@ -999,7 +998,6 @@ class SchedulerOutputProcessorMixin:
         spec_acceptance_histogram = []
         retraction_counts = []
         output_hidden_states = None
-        load = self.get_loads(GetLoadsReqInput(include=["core"]))
         routed_experts = None
         indexer_topk = None
         customized_info = {}
@@ -1250,7 +1248,6 @@ class SchedulerOutputProcessorMixin:
                     placeholder_tokens_idx=None,
                     placeholder_tokens_val=None,
                     retraction_counts=retraction_counts,
-                    load=load,
                     dp_ranks=dp_ranks,
                 )
             )

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import time
 import uuid
@@ -79,6 +80,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
+from sglang.srt.observability.req_time_stats import real_time
 from sglang.srt.server_args import LoRARef, ServerArgs
 from sglang.srt.utils import get_bool_env_var
 from sglang.utils import TypeBasedDispatcher
@@ -87,6 +89,7 @@ if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
 
 logger = logging.getLogger(__name__)
+LOADS_CACHE_MAX_AGE_S = 5.0
 
 # Declarative spec: (attr_name_prefix, response_type[, mode])
 # Each entry creates self.{prefix}_communicator and registers
@@ -817,17 +820,36 @@ class TokenizerControlMixin:
             List of GetLoadsReqOutput, one per scheduler (filtered by dp_rank if specified)
         """
         self.auto_create_handle_loop()
-        # Always request all sections from scheduler — watching mode shares
-        # results across concurrent callers, so we fetch full data and filter here.
-        req = GetLoadsReqInput(include=["all"], dp_rank=None)
-        results = await self.get_loads_communicator(req)
+        if dp_rank is not None and (dp_rank < 0 or dp_rank >= self.server_args.dp_size):
+            return []
+
+        now = real_time()
+        if self.server_args.disable_load_piggyback:
+            refresh_loads = True
+        elif dp_rank is not None:
+            item = self.loads_cache.get(dp_rank)
+            refresh_loads = item is None or now - item[0] > LOADS_CACHE_MAX_AGE_S
+        elif len(self.loads_cache) == self.server_args.dp_size:
+            oldest_load_update = min(item[0] for item in self.loads_cache.values())
+            refresh_loads = now > oldest_load_update + LOADS_CACHE_MAX_AGE_S
+        else:
+            refresh_loads = True
+
+        if refresh_loads:
+            req = GetLoadsReqInput(include=["all"], dp_rank=None)
+            refreshed = await self.get_loads_communicator(req)
+            now = real_time()
+            self.loads_cache = {r.dp_rank: (now, r) for r in refreshed}
 
         # Filter by dp_rank if specified
         if dp_rank is not None:
-            results = [r for r in results if r.dp_rank == dp_rank]
+            results = [self.loads_cache[dp_rank][1]]
+        else:
+            results = [self.loads_cache[i][1] for i in sorted(self.loads_cache)]
 
         # Filter optional sections client-side (scheduler always returns all)
         if include and "all" not in include:
+            results = copy.deepcopy(results)
             include_set = set(include)
             _section_attrs = {
                 "memory": "memory",

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -60,6 +60,7 @@ from sglang.srt.managers.io_struct import (
     EmbeddingReqInput,
     FreezeGCReq,
     GenerateReqInput,
+    GetLoadsReqOutput,
     HealthCheckOutput,
     LoadLoRAAdapterReqInput,
     OpenSessionReqOutput,
@@ -370,6 +371,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.server_status = ServerStatus.Starting
         self.gracefully_exit = False
         self.last_receive_tstamp = real_time()
+        self.loads_cache = {}
 
         # Session
         self.session_futures = {}  # session_id -> asyncio event
@@ -1630,6 +1632,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         while True:
             with self.soft_watchdog.disable():
                 recv_obj = await self.recv_from_detokenizer.recv_pyobj()
+            self.last_receive_tstamp = real_time()
+            load = (
+                recv_obj if isinstance(recv_obj, GetLoadsReqOutput) else recv_obj.load
+            )
+            if load is not None:
+                self.loads_cache[load.dp_rank] = (self.last_receive_tstamp, load)
             if isinstance(
                 recv_obj,
                 (BatchStrOutput, BatchEmbeddingOutput, BatchTokenIDOutput),
@@ -1637,7 +1645,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 await self._handle_batch_output(recv_obj)
             else:
                 self._result_dispatcher(recv_obj)
-            self.last_receive_tstamp = real_time()
             self.soft_watchdog.feed()
 
     async def _handle_batch_output(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -394,6 +394,7 @@ class ServerArgs:
     pp_async_batch_depth: int = 0
     stream_interval: int = 1
     batch_notify_size: int = 16
+    disable_load_piggyback: bool = False
     stream_response_default_include_usage: bool = False
     incremental_streaming_output: bool = False
     enable_streaming_session: bool = False
@@ -4684,6 +4685,11 @@ class ServerArgs:
             default=ServerArgs.batch_notify_size,
             help="Number of streaming notifications to batch before yielding to the event loop. "
             "Reduces asyncio wakeup overhead under high concurrency.",
+        )
+        parser.add_argument(
+            "--disable-load-piggyback",
+            action="store_true",
+            help="Disable piggybacking /v1/loads snapshots on scheduler responses.",
         )
         parser.add_argument(
             "--incremental-streaming-output",


### PR DESCRIPTION
## Summary
- Piggyback scheduler load snapshots on scheduler outputs.
- Cache per-DP-rank load snapshots in TokenizerManager and serve /v1/loads from cache when fresh.
- Fall back to the existing RPC on missing/stale cache or when --disable-load-piggyback is set.

## Test Plan
- uv run --no-sync black python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/multi_tokenizer_mixin.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/scheduler_output_processor_mixin.py python/sglang/srt/managers/tokenizer_control_mixin.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/server_args.py
- git diff --check
- uv run --no-sync python -m py_compile python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/multi_tokenizer_mixin.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/scheduler_output_processor_mixin.py python/sglang/srt/managers/tokenizer_control_mixin.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/server_args.py
- uv run --no-sync pre-commit run --files python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/multi_tokenizer_mixin.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/scheduler_output_processor_mixin.py python/sglang/srt/managers/tokenizer_control_mixin.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/server_args.py

## Original commits
- `af686683`
- `7e1571a6`
- `8718756e`
