### PR TITLE
[AMD] Register 8 CPU-bound unit tests for AMD 1-GPU PR CI

### DIFF
--- a/test/registered/unit/auto_benchmark/test_dataset_tools.py
+++ b/test/registered/unit/auto_benchmark/test_dataset_tools.py
@@ -13,9 +13,10 @@ from auto_benchmark import AutoBenchmarkTestCase
 
 from sglang.auto_benchmark_lib import infer_backend, prepare_dataset
 from sglang.benchmark.datasets.autobench import sample_autobench_requests
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=6, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=6, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestAutoBenchmarkDatasetTools(AutoBenchmarkTestCase):

--- a/test/registered/unit/auto_benchmark/test_run_candidate.py
+++ b/test/registered/unit/auto_benchmark/test_run_candidate.py
@@ -12,9 +12,10 @@ if str(PARENT_DIR) not in sys.path:
 from auto_benchmark import AutoBenchmarkTestCase
 
 from sglang.auto_benchmark_lib import SearchDeadlineExceeded, run_candidate
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=6, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=6, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestAutoBenchmarkRunCandidate(AutoBenchmarkTestCase):

--- a/test/registered/unit/auto_benchmark/test_search_tools.py
+++ b/test/registered/unit/auto_benchmark/test_search_tools.py
@@ -26,9 +26,10 @@ from sglang.auto_benchmark_lib import (
     rendered_launch_command,
     resolve_max_candidates,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=6, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=6, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestAutoBenchmarkSearchTools(AutoBenchmarkTestCase):

--- a/test/registered/unit/layers/test_conv_layer.py
+++ b/test/registered/unit/layers/test_conv_layer.py
@@ -1,6 +1,7 @@
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=7, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=7, suite="stage-b-test-1-gpu-small-amd")
 
 import unittest
 

--- a/test/registered/unit/lora/test_mem_pool_ep_unit.py
+++ b/test/registered/unit/lora/test_mem_pool_ep_unit.py
@@ -13,10 +13,11 @@ Usage:
     python -m pytest test/registered/unit/lora/test_mem_pool_ep_unit.py -v
 """
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 # CPU-only unit test; no CUDA/distributed dependencies.
 register_cuda_ci(est_time=9, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=9, suite="stage-b-test-1-gpu-small-amd")
 
 import types
 import unittest

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -20,9 +20,10 @@ Usage:
     python -m pytest test/registered/unit/mem_cache/test_decode_radix_lock_ref.py -v
 """
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
 
 import unittest
 from unittest.mock import MagicMock

--- a/test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_slru_accuracy.py
@@ -11,9 +11,10 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=8, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=8, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestSLRUAccuracy(unittest.TestCase):

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -2,10 +2,11 @@ import unittest
 from unittest.mock import patch
 
 from sglang.srt.models.llava import AutoModel, LlavaForConditionalGeneration
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=9, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=9, suite="stage-b-test-1-gpu-small-amd")
 
 
 class PixtralVisionConfig:


### PR DESCRIPTION
## Summary

Register 8 CPU-bound unit tests for AMD's `stage-b-test-1-gpu-small-amd` PR
suite. These tests are already running on NVIDIA per-commit CI; they only
use plain Python/CPU torch ops (no FlashInfer, no FA3, no ModelOpt/Marlin
quant, no EAGLE), so adding `register_amd_ci(...)` next to the existing
`register_cuda_ci(...)` is sufficient.

After this change, `stage-b-test-1-gpu-small-amd` grows
from 88 → 96 tests.

### Tests added

| File | est_time | Why it's safe on AMD |
|---|---|---|
| `unit/auto_benchmark/test_dataset_tools.py` | 6s | Pure Python, mocks only |
| `unit/auto_benchmark/test_run_candidate.py` | 6s | Pure Python, mocks only |
| `unit/auto_benchmark/test_search_tools.py` | 6s | Pure Python, mocks only |
| `unit/lora/test_mem_pool_ep_unit.py` | 9s | \"CPU-only unit test\" per docstring |
| `unit/layers/test_conv_layer.py` | 7s | \`torch.nn.Conv*d\` on CPU tensors |
| `unit/models/test_llava.py` | 9s | Mock-based, no GPU work |
| `unit/mem_cache/test_radix_cache_slru_accuracy.py` | 8s | \`device = \"cpu\"\` pools |
| `unit/mem_cache/test_decode_radix_lock_ref.py` | 10s | \`torch.device(\"cpu\")\` pools |

Total added est_time: ~61s, distributed across 14 partitions.

### Verification

Ran the AST-based collector locally against `test/registered/`:

```
AMD stage-b-test-1-gpu-small-amd: 88 -> 96 tests
sanity_check=True: OK (842 registries collected)
```

All 8 files now appear in `python3 test/run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd` output.

## Test plan

- [ ] AMD CI passes on the new files (auto-runs via `pr-test-amd.yml` →
      `stage-b-test-1-gpu-small-amd`, partitioned across 14 jobs)
- [ ] NVIDIA CI still green (no behavior change for `register_cuda_ci`)