### PR TITLE
[diffusion]: Fix diffusers executor crash when component residency manager is absent

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -20,6 +20,10 @@ from PIL import Image
 
 from sglang.multimodal_gen.configs.pipeline_configs.base import PipelineConfig
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
+from sglang.multimodal_gen.runtime.managers.component_manager import (
+    ComponentResidencyStrategy,
+    get_global_component_residency_manager,
+)
 from sglang.multimodal_gen.runtime.models.vision_utils import (
     load_image as load_vision_image,
 )
@@ -371,6 +375,8 @@ class DiffusersPipeline(ComposedPipelineBase):
         self._stage_name_mapping: dict[str, PipelineStage] = {}
         self.modules: dict[str, Any] = {}
         self.memory_usages: dict[str, float] = {}
+        self.component_residency_strategies: dict[str, ComponentResidencyStrategy] = {}
+        self.component_residency_manager = None
         self.post_init_called = False
         self.executor = executor or SyncExecutor(server_args=server_args)
         self._cache_dit_enabled = False
@@ -726,7 +732,13 @@ class DiffusersPipeline(ComposedPipelineBase):
         """Execute the pipeline on the given batch."""
         if not self.post_init_called:
             self.post_init()
-        return self.executor.execute(self.stages, batch, server_args)
+
+        self.component_residency_manager = get_global_component_residency_manager(
+            self, server_args
+        )
+        self.executor.component_residency_manager = self.component_residency_manager
+
+        return self.executor.execute_with_profiling(self.stages, batch, server_args)
 
     @classmethod
     def from_pretrained(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -53,8 +53,6 @@ class PipelineExecutor(ABC):
         batch: Req,
         server_args: ServerArgs,
     ) -> None:
-        if self.component_residency_manager is None:
-            return
         self.component_residency_manager.begin_request(stages, batch, server_args)
 
     def before_stage(
@@ -65,20 +63,14 @@ class PipelineExecutor(ABC):
         server_args: ServerArgs,
     ) -> None:
         stage.set_component_residency_manager(self.component_residency_manager)
-        if self.component_residency_manager is None:
-            return
         self.component_residency_manager.before_stage(
             stage, stage_index, batch, server_args
         )
 
     def after_stage(self, stage_index: int) -> None:
-        if self.component_residency_manager is None:
-            return
         self.component_residency_manager.after_stage(stage_index)
 
     def finish_component_residency_request(self) -> None:
-        if self.component_residency_manager is None:
-            return
         self.component_residency_manager.finish_request()
 
     def execute_with_profiling(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py
@@ -53,6 +53,8 @@ class PipelineExecutor(ABC):
         batch: Req,
         server_args: ServerArgs,
     ) -> None:
+        if self.component_residency_manager is None:
+            return
         self.component_residency_manager.begin_request(stages, batch, server_args)
 
     def before_stage(
@@ -63,14 +65,20 @@ class PipelineExecutor(ABC):
         server_args: ServerArgs,
     ) -> None:
         stage.set_component_residency_manager(self.component_residency_manager)
+        if self.component_residency_manager is None:
+            return
         self.component_residency_manager.before_stage(
             stage, stage_index, batch, server_args
         )
 
     def after_stage(self, stage_index: int) -> None:
+        if self.component_residency_manager is None:
+            return
         self.component_residency_manager.after_stage(stage_index)
 
     def finish_component_residency_request(self) -> None:
+        if self.component_residency_manager is None:
+            return
         self.component_residency_manager.finish_request()
 
     def execute_with_profiling(


### PR DESCRIPTION
## Summary

Fix a `--backend diffusers` runtime crash introduced by the component residency manager refactor in #23771.

`DiffusersPipeline` uses the common `SyncExecutor`, but it was not binding a component residency manager before executing stages the way composed/native pipelines do. After the refactor, the shared executor calls residency hooks such as `component_residency_manager.begin_request(...)`. For diffusers pipelines, that manager was `None`, so generation failed before the diffusers pipeline ran.

This change initializes the diffusers pipeline residency state and binds the global component residency manager to the executor before forwarding the request

## Motivation

Forced diffusers backend models can load successfully but fail on the first generation request:

```text
AttributeError: 'NoneType' object has no attribute 'begin_request'
```

## Testing

1x rtx5090 32GB
black-forest-labs/FLUX.2-klein-4B

Baseline command:

```bash
sglang generate \
  --model-path black-forest-labs/FLUX.2-klein-4B \
  --backend diffusers \
  --trust-remote-code \
  --prompt "A compact engineering test image of a red cube on a gray table, studio lighting" \
  --height 512 \
  --width 512 \
  --num-inference-steps 1 \
  --guidance-scale 1.0 \
```

the pipeline loads:

```text
Loaded diffusers pipeline: Flux2KleinPipeline
```

but the generation request fails before the diffusers stage runs:

```text
Error executing request ...: 'NoneType' object has no attribute 'begin_request'
AttributeError: 'NoneType' object has no attribute 'begin_request'
```

After fix command:

```text
sglang generate \
  --model-path black-forest-labs/FLUX.2-klein-4B \
  --backend diffusers \
  --trust-remote-code \
  --prompt "A compact engineering test image of a red cube on a gray table, studio lighting" \
  --height 512 \
  --width 512 \
  --num-inference-steps 1 \
  --guidance-scale 1.0 \
```

the pipeline loads:

```text
Loaded diffusers pipeline: Flux2KleinPipeline
```

And the generation request succeeds:

```text
Loaded diffusers pipeline: Flux2KleinPipeline
[DiffusersExecutionStage] finished
Output saved to outputs/flux2_klein_diffusers.png
Pixel data generated successfully
```