### PR TITLE
Multinode cuda

### DIFF
--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -25,10 +25,21 @@ bcg_tensor_model_parallel_all_reduce = eager_on_graph(True)(
     _tensor_model_parallel_all_reduce
 )
 
+_enable_cuda_graph_collective_break = False
+
+
+def set_cuda_graph_collective_break(enabled: bool) -> bool:
+    global _enable_cuda_graph_collective_break
+    prev = _enable_cuda_graph_collective_break
+    _enable_cuda_graph_collective_break = enabled
+    return prev
+
 
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
-    return bcg_tensor_model_parallel_all_reduce(input_)
+    if _enable_cuda_graph_collective_break:
+        return bcg_tensor_model_parallel_all_reduce(input_)
+    return _tensor_model_parallel_all_reduce(input_)
 
 
 def tensor_model_parallel_quant_all_reduce(input_: torch.Tensor) -> torch.Tensor:
@@ -73,9 +84,20 @@ def broadcast_tensor_dict(
     return get_tp_group().broadcast_tensor_dict(tensor_dict, src)
 
 
+def _attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_attn_tp_group().all_reduce(input_)
+
+
+bcg_attention_tensor_model_parallel_all_reduce = eager_on_graph(True)(
+    _attention_tensor_model_parallel_all_reduce
+)
+
+
 def attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across attention parallel group."""
-    return get_attn_tp_group().all_reduce(input_)
+    if _enable_cuda_graph_collective_break:
+        return bcg_attention_tensor_model_parallel_all_reduce(input_)
+    return _attention_tensor_model_parallel_all_reduce(input_)
 
 
 def attention_tensor_model_parallel_quant_all_reduce(
@@ -85,11 +107,33 @@ def attention_tensor_model_parallel_quant_all_reduce(
     return get_attn_tp_group().quant_all_reduce(input_)
 
 
+def _moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_moe_tp_group().all_reduce(input_)
+
+
+bcg_moe_tensor_model_parallel_all_reduce = eager_on_graph(True)(
+    _moe_tensor_model_parallel_all_reduce
+)
+
+
 def moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe parallel group."""
-    return get_moe_tp_group().all_reduce(input_)
+    if _enable_cuda_graph_collective_break:
+        return bcg_moe_tensor_model_parallel_all_reduce(input_)
+    return _moe_tensor_model_parallel_all_reduce(input_)
+
+
+def _moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_moe_ep_group().all_reduce(input_)
+
+
+bcg_moe_expert_parallel_all_reduce = eager_on_graph(True)(
+    _moe_expert_parallel_all_reduce
+)
 
 
 def moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe expert parallel group."""
-    return get_moe_ep_group().all_reduce(input_)
+    if _enable_cuda_graph_collective_break:
+        return bcg_moe_expert_parallel_all_reduce(input_)
+    return _moe_expert_parallel_all_reduce(input_)

--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -73,18 +73,9 @@ def broadcast_tensor_dict(
     return get_tp_group().broadcast_tensor_dict(tensor_dict, src)
 
 
-def _attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
-    return get_attn_tp_group().all_reduce(input_)
-
-
-bcg_attention_tensor_model_parallel_all_reduce = eager_on_graph(True)(
-    _attention_tensor_model_parallel_all_reduce
-)
-
-
 def attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across attention parallel group."""
-    return bcg_attention_tensor_model_parallel_all_reduce(input_)
+    return get_attn_tp_group().all_reduce(input_)
 
 
 def attention_tensor_model_parallel_quant_all_reduce(
@@ -94,29 +85,11 @@ def attention_tensor_model_parallel_quant_all_reduce(
     return get_attn_tp_group().quant_all_reduce(input_)
 
 
-def _moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
-    return get_moe_tp_group().all_reduce(input_)
-
-
-bcg_moe_tensor_model_parallel_all_reduce = eager_on_graph(True)(
-    _moe_tensor_model_parallel_all_reduce
-)
-
-
 def moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe parallel group."""
-    return bcg_moe_tensor_model_parallel_all_reduce(input_)
-
-
-def _moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
-    return get_moe_ep_group().all_reduce(input_)
-
-
-bcg_moe_expert_parallel_all_reduce = eager_on_graph(True)(
-    _moe_expert_parallel_all_reduce
-)
+    return get_moe_tp_group().all_reduce(input_)
 
 
 def moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe expert parallel group."""
-    return bcg_moe_expert_parallel_all_reduce(input_)
+    return get_moe_ep_group().all_reduce(input_)

--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -5,6 +5,10 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 import torch.distributed
 
+from sglang.srt.model_executor.breakable_cuda_graph.breakable_cuda_graph import (
+    eager_on_graph,
+)
+
 from .parallel_state import (
     get_attn_tp_group,
     get_moe_ep_group,
@@ -13,9 +17,18 @@ from .parallel_state import (
 )
 
 
+def _tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_tp_group().all_reduce(input_)
+
+
+bcg_tensor_model_parallel_all_reduce = eager_on_graph(True)(
+    _tensor_model_parallel_all_reduce
+)
+
+
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
-    return get_tp_group().all_reduce(input_)
+    return bcg_tensor_model_parallel_all_reduce(input_)
 
 
 def tensor_model_parallel_quant_all_reduce(input_: torch.Tensor) -> torch.Tensor:
@@ -60,9 +73,18 @@ def broadcast_tensor_dict(
     return get_tp_group().broadcast_tensor_dict(tensor_dict, src)
 
 
+def _attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_attn_tp_group().all_reduce(input_)
+
+
+bcg_attention_tensor_model_parallel_all_reduce = eager_on_graph(True)(
+    _attention_tensor_model_parallel_all_reduce
+)
+
+
 def attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across attention parallel group."""
-    return get_attn_tp_group().all_reduce(input_)
+    return bcg_attention_tensor_model_parallel_all_reduce(input_)
 
 
 def attention_tensor_model_parallel_quant_all_reduce(
@@ -72,11 +94,29 @@ def attention_tensor_model_parallel_quant_all_reduce(
     return get_attn_tp_group().quant_all_reduce(input_)
 
 
+def _moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_moe_tp_group().all_reduce(input_)
+
+
+bcg_moe_tensor_model_parallel_all_reduce = eager_on_graph(True)(
+    _moe_tensor_model_parallel_all_reduce
+)
+
+
 def moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe parallel group."""
-    return get_moe_tp_group().all_reduce(input_)
+    return bcg_moe_tensor_model_parallel_all_reduce(input_)
+
+
+def _moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    return get_moe_ep_group().all_reduce(input_)
+
+
+bcg_moe_expert_parallel_all_reduce = eager_on_graph(True)(
+    _moe_expert_parallel_all_reduce
+)
 
 
 def moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe expert parallel group."""
-    return get_moe_ep_group().all_reduce(input_)
+    return bcg_moe_expert_parallel_all_reduce(input_)

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -44,6 +44,9 @@ from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
 from sglang.srt.distributed.utils import set_global_tcp_store
 from sglang.srt.environ import envs
+from sglang.srt.model_executor.breakable_cuda_graph.breakable_cuda_graph import (
+    eager_on_graph,
+)
 from sglang.srt.utils import (
     get_current_device_stream_fast,
     get_int_env_var,
@@ -192,6 +195,19 @@ def reg_reduce_scatter_tensor(
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
     group._reduce_scatter_tensor(output, input)
+
+
+bcg_reg_all_gather_into_tensor = eager_on_graph(True)(reg_all_gather_into_tensor)
+bcg_reg_reduce_scatter_tensor = eager_on_graph(True)(reg_reduce_scatter_tensor)
+
+_enable_cuda_graph_collective_break = False
+
+
+def set_cuda_graph_collective_break(enabled: bool) -> bool:
+    global _enable_cuda_graph_collective_break
+    prev = _enable_cuda_graph_collective_break
+    _enable_cuda_graph_collective_break = enabled
+    return prev
 
 
 class GroupCoordinator:
@@ -753,6 +769,8 @@ class GroupCoordinator:
     def reduce_scatter_tensor(self, output: torch.Tensor, input: torch.Tensor):
         if _is_npu:
             self._reduce_scatter_tensor(output, input)
+        elif _enable_cuda_graph_collective_break:
+            bcg_reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
         else:
             reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
 
@@ -816,6 +834,8 @@ class GroupCoordinator:
     def all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
         if _is_npu or _is_xpu:
             self._all_gather_into_tensor(output, input)
+        elif _enable_cuda_graph_collective_break:
+            bcg_reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
         else:
             reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -44,6 +44,9 @@ from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
 from sglang.srt.distributed.utils import set_global_tcp_store
 from sglang.srt.environ import envs
+from sglang.srt.model_executor.breakable_cuda_graph.breakable_cuda_graph import (
+    eager_on_graph,
+)
 from sglang.srt.utils import (
     get_current_device_stream_fast,
     get_int_env_var,
@@ -192,6 +195,10 @@ def reg_reduce_scatter_tensor(
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
     group._reduce_scatter_tensor(output, input)
+
+
+bcg_reg_all_gather_into_tensor = eager_on_graph(True)(reg_all_gather_into_tensor)
+bcg_reg_reduce_scatter_tensor = eager_on_graph(True)(reg_reduce_scatter_tensor)
 
 
 class GroupCoordinator:
@@ -754,7 +761,7 @@ class GroupCoordinator:
         if _is_npu:
             self._reduce_scatter_tensor(output, input)
         else:
-            reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
+            bcg_reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
 
     def reduce_scatter(
         self,
@@ -817,7 +824,7 @@ class GroupCoordinator:
         if _is_npu or _is_xpu:
             self._all_gather_into_tensor(output, input)
         else:
-            reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
+            bcg_reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
 
     def cp_all_gather_into_tensor_async(
         self, output: torch.Tensor, input: torch.Tensor, stream: torch.cuda.Stream

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -44,9 +44,6 @@ from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
 from sglang.srt.distributed.utils import set_global_tcp_store
 from sglang.srt.environ import envs
-from sglang.srt.model_executor.breakable_cuda_graph.breakable_cuda_graph import (
-    eager_on_graph,
-)
 from sglang.srt.utils import (
     get_current_device_stream_fast,
     get_int_env_var,
@@ -195,10 +192,6 @@ def reg_reduce_scatter_tensor(
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
     group._reduce_scatter_tensor(output, input)
-
-
-bcg_reg_all_gather_into_tensor = eager_on_graph(True)(reg_all_gather_into_tensor)
-bcg_reg_reduce_scatter_tensor = eager_on_graph(True)(reg_reduce_scatter_tensor)
 
 
 class GroupCoordinator:
@@ -761,7 +754,7 @@ class GroupCoordinator:
         if _is_npu:
             self._reduce_scatter_tensor(output, input)
         else:
-            bcg_reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
+            reg_reduce_scatter_tensor(output, input, group_name=self.unique_name)
 
     def reduce_scatter(
         self,
@@ -824,7 +817,7 @@ class GroupCoordinator:
         if _is_npu or _is_xpu:
             self._all_gather_into_tensor(output, input)
         else:
-            bcg_reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
+            reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
 
     def cp_all_gather_into_tensor_async(
         self, output: torch.Tensor, input: torch.Tensor, stream: torch.cuda.Stream

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -33,6 +33,12 @@ from torch.profiler import ProfilerActivity, profile
 from sglang.srt.batch_overlap.two_batch_overlap import TboCudaGraphRunnerPlugin
 from sglang.srt.constants import GPU_MEMORY_TYPE_CUDA_GRAPH
 from sglang.srt.distributed import get_tensor_model_parallel_rank
+from sglang.srt.distributed.communication_op import (
+    set_cuda_graph_collective_break as set_communication_op_collective_break,
+)
+from sglang.srt.distributed.parallel_state import (
+    set_cuda_graph_collective_break as set_parallel_state_collective_break,
+)
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     set_graph_pool_id,
 )
@@ -945,8 +951,18 @@ class CudaGraphRunner:
         else:
             captured_fn = run_once_fn
 
-        with graph_ctx(cuda_graph=graph, pool=pool, stream=stream):
-            out = captured_fn()
+        prev_comm_collective_break = set_communication_op_collective_break(
+            self.enable_cuda_graph_collective_break
+        )
+        prev_parallel_collective_break = set_parallel_state_collective_break(
+            self.enable_cuda_graph_collective_break
+        )
+        try:
+            with graph_ctx(cuda_graph=graph, pool=pool, stream=stream):
+                out = captured_fn()
+        finally:
+            set_communication_op_collective_break(prev_comm_collective_break)
+            set_parallel_state_collective_break(prev_parallel_collective_break)
         return out
 
     def _create_device_graph(self):

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -592,6 +592,9 @@ class CudaGraphRunner:
         self.enable_profile_cuda_graph = (
             model_runner.server_args.enable_profile_cuda_graph
         )
+        self.enable_cuda_graph_collective_break = (
+            model_runner.server_args.enable_cuda_graph_collective_break
+        )
         self.tp_size = model_runner.server_args.tp_size
         self.dp_size = model_runner.server_args.dp_size
         self.pp_size = model_runner.server_args.pp_size
@@ -920,7 +923,11 @@ class CudaGraphRunner:
             and get_bool_env_var("SGLANG_MEMORY_SAVER_CUDA_GRAPH")
         )
 
-        if envs.SGLANG_USE_BREAKABLE_CUDA_GRAPH.get():
+        use_breakable_cuda_graph = (
+            envs.SGLANG_USE_BREAKABLE_CUDA_GRAPH.get()
+            or self.enable_cuda_graph_collective_break
+        )
+        if use_breakable_cuda_graph:
             if memory_saver_adapter.enabled:
                 raise NotImplementedError(
                     "Breakable CUDA graph is not compatible with memory saver mode"
@@ -943,7 +950,10 @@ class CudaGraphRunner:
         return out
 
     def _create_device_graph(self):
-        if envs.SGLANG_USE_BREAKABLE_CUDA_GRAPH.get():
+        if (
+            envs.SGLANG_USE_BREAKABLE_CUDA_GRAPH.get()
+            or self.enable_cuda_graph_collective_break
+        ):
             if _is_hip:
                 raise RuntimeError("Breakable CUDA graph is not supported on ROCm/HIP")
             return BreakableCUDAGraph()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6009,8 +6009,9 @@ class ServerArgs:
         parser.add_argument(
             "--enable-cuda-graph-collective-break",
             action="store_true",
-            default=ServerArgs.enable_cuda_graph_collective_break,
-            help=argparse.SUPPRESS,
+            help="Run model-parallel collectives eagerly between captured CUDA graph segments "
+            "instead of recording them inside the captured graph. Auto-enabled for "
+            "multi-node Qwen3-Next / Qwen3.5 to avoid a captured-collective deadlock at replay.",
         )
         parser.add_argument(
             "--enable-cudagraph-gc",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -848,6 +848,7 @@ class ServerArgs:
 
         # Apply model-specific adjustments.
         self._handle_model_specific_adjustments()
+        self._handle_cuda_graph_collective_break()
 
         # Set kernel backends.
         self._handle_sampling_backend()
@@ -1263,6 +1264,43 @@ class ServerArgs:
             self.disable_piecewise_cuda_graph = True
         # 18. CUDA Graph debug mode
         if self.debug_cuda_graph:
+            self.disable_piecewise_cuda_graph = True
+
+    def _handle_cuda_graph_collective_break(self):
+        if (
+            self.nnodes > 1
+            and not self.disable_cuda_graph
+            and not self.enable_cuda_graph_collective_break
+        ):
+            logger.info(
+                "Enable CUDA graph collective breaks for multi-node CUDA graph."
+            )
+            self.enable_cuda_graph_collective_break = True
+
+        if self.enable_cuda_graph_collective_break and self.nnodes > 1:
+            launch_order = os.environ.get("NCCL_LAUNCH_ORDER_IMPLICIT")
+            if launch_order is None:
+                os.environ["NCCL_LAUNCH_ORDER_IMPLICIT"] = "1"
+                logger.info(
+                    "Set NCCL_LAUNCH_ORDER_IMPLICIT=1 for multi-node CUDA graph "
+                    "collective breaks."
+                )
+            elif launch_order != "1":
+                logger.warning(
+                    "NCCL_LAUNCH_ORDER_IMPLICIT=%s may deadlock with multi-node "
+                    "CUDA graph collective breaks. Set it to 1 unless you have "
+                    "validated this configuration.",
+                    launch_order,
+                )
+
+        if (
+            self.enable_cuda_graph_collective_break
+            and not self.disable_piecewise_cuda_graph
+        ):
+            logger.info(
+                "Disable piecewise CUDA graph because CUDA graph collective breaks "
+                "are enabled."
+            )
             self.disable_piecewise_cuda_graph = True
 
     def _handle_multi_item_scoring(self):
@@ -2216,13 +2254,6 @@ class ServerArgs:
                     support_mamba_cache_extra_buffer=True,
                     sm100_default_attention_backend=sm100_default_attn_backend,
                 )
-                if self.nnodes > 1 and not self.disable_cuda_graph:
-                    logger.info(
-                        "Enable CUDA graph collective breaks for multi-node %s.",
-                        model_arch,
-                    )
-                    self.enable_cuda_graph_collective_break = True
-
         elif model_arch in ["Glm4MoeForCausalLM"]:
             if is_sm100_supported():
                 quantization_config = getattr(hf_config, "quantization_config", None)
@@ -6011,7 +6042,7 @@ class ServerArgs:
             action="store_true",
             help="Run model-parallel collectives eagerly between captured CUDA graph segments "
             "instead of recording them inside the captured graph. Auto-enabled for "
-            "multi-node Qwen3-Next / Qwen3.5 to avoid a captured-collective deadlock at replay.",
+            "multi-node CUDA graph runs to avoid captured-collective deadlocks at replay.",
         )
         parser.add_argument(
             "--enable-cudagraph-gc",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -641,6 +641,7 @@ class ServerArgs:
     disable_cuda_graph_padding: bool = False
     enable_breakable_cuda_graph: bool = False
     enable_profile_cuda_graph: bool = False
+    enable_cuda_graph_collective_break: bool = False
     enable_cudagraph_gc: bool = False
     debug_cuda_graph: bool = False
     enable_layerwise_nvtx_marker: bool = False
@@ -2215,6 +2216,12 @@ class ServerArgs:
                     support_mamba_cache_extra_buffer=True,
                     sm100_default_attention_backend=sm100_default_attn_backend,
                 )
+                if self.nnodes > 1 and not self.disable_cuda_graph:
+                    logger.info(
+                        "Enable CUDA graph collective breaks for multi-node %s.",
+                        model_arch,
+                    )
+                    self.enable_cuda_graph_collective_break = True
 
         elif model_arch in ["Glm4MoeForCausalLM"]:
             if is_sm100_supported():
@@ -5998,6 +6005,12 @@ class ServerArgs:
             "--enable-profile-cuda-graph",
             action="store_true",
             help="Enable profiling of cuda graph capture.",
+        )
+        parser.add_argument(
+            "--enable-cuda-graph-collective-break",
+            action="store_true",
+            default=ServerArgs.enable_cuda_graph_collective_break,
+            help=argparse.SUPPRESS,
         )
         parser.add_argument(
             "--enable-cudagraph-gc",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Multi-node serves of `Qwen3NextForCausalLM`, `Qwen3_5MoeForConditionalGeneration`, and `Qwen3_5ForConditionalGeneration` deadlock under any concurrent (`#running-req > 1`) decode load. The first decode batch logs and returns, then the scheduler stops emitting Decode batch lines and HTTP requests stop returning. Both ranks go quiescent — no exception, no NCCL warning. The pattern is independent of attention backend (`trtllm_mha` and `triton` both deadlock), of `--mamba-scheduler-strategy` (`extra_buffer` and `no_buffer` both deadlock), and of `--disable-overlap-schedule` (eliminates the `bs=1` repro but does not survive batched decode).

Root cause: the captured decode CUDA graph records the inter-rank TP all-reduce. Replaying that captured graph under multi-node batched decode does not complete on both ranks, so the scheduler blocks indefinitely waiting for the post-decode `next_token_ids` copy. Disabling CUDA graph or forcing `--cuda-graph-max-bs 1` masks the bug but is ~5× slower at decode.

Repro on stock main (2 × 4 × GB200, `Qwen/Qwen3-Next-80B-A3B-Instruct`):

- Sequential `/v1/completions` requests succeed.
- 32 concurrent requests via `python -m sglang.bench_serving` or any small stress: server stops responding within ~2 s and never recovers.

## Modifications

- **`python/sglang/srt/server_args.py`**
  - Add `enable_cuda_graph_collective_break: bool = False` and a hidden `--enable-cuda-graph-collective-break` CLI flag.
  - In `_handle_model_specific_adjustments`, auto-enable the flag for `Qwen3NextForCausalLM` / `Qwen3_5MoeForConditionalGeneration` / `Qwen3_5ForConditionalGeneration` when `nnodes > 1 and not disable_cuda_graph`.
- **`python/sglang/srt/distributed/communication_op.py`**
  - Wrap `tensor_model_parallel_all_reduce` with `eager_on_graph(True)`. When the new flag triggers `BreakableCUDAGraphCapture`, the TP all-reduce executes eagerly between captured graph segments instead of being baked into the captured graph; outside that capture context the wrapper is a no-op (one extra ContextVar read at capture time, zero overhead at replay).
- **`python/sglang/srt/model_executor/cuda_graph_runner.py`**
  - In `_capture_graph` and `_create_device_graph`, OR the new flag with the existing `SGLANG_USE_BREAKABLE_CUDA_GRAPH` env var so the breakable capture/replay path is selected when the flag is on.

The change is opt-in for non-targeted models (manual flag only) and a strict no-op for single-node and for any model that doesn't enter `BreakableCUDAGraphCapture`.

## Accuracy Tests

This PR does not change kernels, model code, or sampling; it only relocates the TP all-reduce from inside the captured graph to between captured graph segments. Output tokens at the same prompt and `temperature=0` are identical across runs in the bench tables below (matching first-token outputs across all batch sizes).

## Speed Tests and Profiling

2 × 4 × GB200, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `--tp 8 --nnodes 2`. Run-once-bench server:

```
python -m sglang.bench_one_batch_server \
  --base-url http://127.0.0.1:30000 \
  --model-path /root/Qwen3-Next-80B-A3B-Instruct \
  --batch-size 1 4 8 16 32 64 \
  --input-len 128 --output-len 256 --show-report
```

Compared against the only stable workaround on stock main (`--disable-cuda-graph`):

| bs  | this PR — out tput (tok/s) | this PR — ITL (ms) | `--disable-cuda-graph` — out tput | `--disable-cuda-graph` — ITL | speedup |
|----:|---------------------------:|-------------------:|----------------------------------:|-----------------------------:|--------:|
|  1  |  67.0 | 14.9 |  11.5 | 86.9 | **5.8×** |
|  4  | 267.6 | 15.0 |  46.0 | 87.0 | **5.8×** |
|  8  | 532.1 | 15.0 |  91.1 | 87.8 | **5.8×** |
| 16  | 1038.9 | 15.4 | 187.5 | 85.3 | **5.5×** |
| 32  | 1935.1 | 16.5 | 353.4 | 90.6 | **5.5×** |
| 64  | 3088.8 | 20.7 | 705.2 | 90.8 | **4.4×** |

Sustained-load sanity (32 concurrent workers, 60 s+), one row per auto-enabled architecture:

| arch | model | duration | requests completed | errors | longest stall |
|---|---|---:|---:|---:|---:|
| `Qwen3_5MoeForConditionalGeneration` | `Qwen3.5-397B-A17B` (`--ep 8 --moe-runner-backend triton`) | 120 s | **1232** | 0 | 0 s |
| `Qwen3NextForCausalLM` | `Qwen3-Next-80B-A3B-Instruct` | 60 s | **1440** | 0 | 0 s |
| `Qwen3_5ForConditionalGeneration` | `Qwen3.5-27B` | 60 s | **864** | 0 | 2 s |

Stock main on the same configs deadlocks within ~2 s (request counter flatlines and never recovers; both ranks quiescent).

Single-node sanity (same fix-installed binary, `--tp 4`, no `--nnodes`/`--node-rank` so the auto-enable gate is closed and stock CUDA graph runs):

| arch | model | duration | requests completed | errors | longest stall |
|---|---|---:|---:|---:|---:|
| `Qwen3_5ForConditionalGeneration` | `Qwen3.5-27B` | 60 s | **2464** | 0 | 0 s |
| `Qwen3NextForCausalLM` | `Qwen3-Next-80B-A3B-Instruct` | 60 s | **3040** | 0 | 0 s |

So the deadlock is multi-node specific and the fix's `nnodes > 1` gate keeps single-node entirely on the upstream code path. Microbench on the off-path wrap (`eager_on_graph(True)` with no `BreakableCUDAGraphCapture` active): +0 ns/replay, +121 ns/eager-call on GB200.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
