### PR TITLE
[LoRA][MoE] Fix EP correctness: NVFP4 cutlass_moe_params sizing + Triton OOB pointer clamp

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1760,6 +1760,15 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         else:
             w13_input_scale = layer.w13_input_scale.max(dim=-1).values.to(torch.float32)
             w2_input_scale = layer.w2_input_scale
+            # w13/w2_input_scale are loaded globally (_sglang_require_global_experts);
+            # slice to this rank's local experts so shapes line up with
+            # w13_weight_scale_2 / w2_weight_scale_2 which are already per-local-expert.
+            if layer.moe_ep_size > 1:
+                assert layer.moe_ep_size * layer.num_local_experts == layer.num_experts
+                lo = layer.moe_ep_rank * layer.num_local_experts
+                hi = lo + layer.num_local_experts
+                w13_input_scale = w13_input_scale[lo:hi]
+                w2_input_scale = w2_input_scale[lo:hi]
 
         # Create shared parameters
         copy_or_rebind_param(
@@ -1947,7 +1956,10 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
             # Both flashinfer cutlass and regular cutlass use same processing for w2
 
-            # Set up CUTLASS MoE parameters (reuse to keep CUDA graph stable)
+            # Set up CUTLASS MoE parameters (reuse to keep CUDA graph stable).
+            # Size by `num_local_experts`: the FP4 grouped GEMM iterates
+            # `expert_offsets.size(0)` experts and indexes the (per-rank
+            # local-sized) `w13_weight` / `w2_weight` by `expert_id`.
             device = layer.w13_weight.device
             inter_size = layer.w2_weight.shape[2] * 2
             hidden_size = layer.w13_weight.shape[2] * 2
@@ -1955,7 +1967,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             if (
                 existing_params is None
                 or existing_params.cutlass_moe_type != CutlassMoEType.BlockscaledFP4
-                or existing_params.num_experts != layer.num_experts
+                or existing_params.num_experts != layer.num_local_experts
                 or existing_params.intermediate_size_per_partition != inter_size
                 or existing_params.hidden_size != hidden_size
                 or existing_params.device != device
@@ -1963,7 +1975,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 layer.cutlass_moe_params = CutlassMoEParams(
                     CutlassMoEType.BlockscaledFP4,
                     device,
-                    num_experts=layer.num_experts,  # global num experts
+                    num_experts=layer.num_local_experts,
                     intermediate_size_per_partition=inter_size,  # n
                     hidden_size=hidden_size,
                 )  # k

--- a/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
@@ -13,6 +13,7 @@ def _gate_up_lora_b_kernel(
     weights,
     output,
     # Parameters of size
+    S,  # total number of rows in x/output (used for OOB clamping)
     K,  # K = R
     output_dim,
     # Strides
@@ -96,43 +97,43 @@ def _gate_up_lora_b_kernel(
     s_physical = _resolve_token_positions(
         sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
     )
-    x_ptrs = (
-        x
-        + (gate_up_id * K) * x_stride_1
-        + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
-    )
-    w_ptrs = (weights + w_index * w_stride_0 + n_start * w_stride_1) + (
-        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
-    )
+    # See sgemm_lora_a for why we clamp masked-lane indices.
+    row_mask = s_offset < seg_len
+    safe_row = tl.minimum(s_physical, S - 1)
+    safe_n = tl.minimum(n_offset, output_dim - 1)
 
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
+        cur_k = k * BLOCK_K + k_offset
+        k_mask = cur_k < K
+        safe_k = tl.minimum(cur_k, K - 1)
         x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            x
+            + safe_row[:, None] * x_stride_0
+            + (gate_up_id * K + safe_k[None, :]) * x_stride_1,
+            mask=row_mask[:, None] & k_mask[None, :],
             other=0.0,
         )
         w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K)
-            & (n_offset[None, :] < output_dim),
+            weights
+            + w_index * w_stride_0
+            + (n_start + safe_n[None, :]) * w_stride_1
+            + safe_k[:, None] * w_stride_2,
+            mask=k_mask[:, None] & (n_offset[None, :] < output_dim),
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
-
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
 
     # Store result to output matrix
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
     output_ptr = (
         output
-        + n_start * output_stride_1
-        + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
+        + safe_row[:, None] * output_stride_0
+        + (n_start + safe_n[None, :]) * output_stride_1
     )
-    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < output_dim)
+    output_mask = row_mask[:, None] & (n_offset[None, :] < output_dim)
     partial_sum += tl.load(output_ptr, mask=output_mask)
     tl.store(output_ptr, partial_sum, mask=output_mask)
 
@@ -180,6 +181,7 @@ def gate_up_lora_b_fwd(
         x,
         gate_up_lora_b,
         output,
+        s,
         r,
         output_dim,
         x.stride(0),

--- a/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
@@ -13,6 +13,7 @@ def _qkv_lora_b_kernel(
     weights,
     output,
     # Parameters of size
+    S,  # total number of rows in x/output (used for OOB clamping)
     K,  # K = R
     max_qkv_out_dim,  # max(output_q_dim, output_kv_dim)
     # Strides
@@ -98,42 +99,43 @@ def _qkv_lora_b_kernel(
     s_physical = _resolve_token_positions(
         sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
     )
-    x_ptrs = (
-        x
-        + (qkv_id * K) * x_stride_1
-        + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
-    )
-    w_ptrs = (weights + w_index * w_stride_0 + n_start * w_stride_1) + (
-        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
-    )
+    # See sgemm_lora_a for why we clamp masked-lane indices.
+    row_mask = s_offset < seg_len
+    safe_row = tl.minimum(s_physical, S - 1)
+    safe_n = tl.minimum(n_offset, n_size - 1)
 
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
+        cur_k = k * BLOCK_K + k_offset
+        k_mask = cur_k < K
+        safe_k = tl.minimum(cur_k, K - 1)
         x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            x
+            + safe_row[:, None] * x_stride_0
+            + (qkv_id * K + safe_k[None, :]) * x_stride_1,
+            mask=row_mask[:, None] & k_mask[None, :],
             other=0.0,
         )
         w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & (n_offset[None, :] < n_size),
+            weights
+            + w_index * w_stride_0
+            + (n_start + safe_n[None, :]) * w_stride_1
+            + safe_k[:, None] * w_stride_2,
+            mask=k_mask[:, None] & (n_offset[None, :] < n_size),
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
-
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
 
     # Store result to output matrix
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
     output_ptr = (
         output
-        + n_start * output_stride_1
-        + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
+        + safe_row[:, None] * output_stride_0
+        + (n_start + safe_n[None, :]) * output_stride_1
     )
-    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < n_size)
+    output_mask = row_mask[:, None] & (n_offset[None, :] < n_size)
     partial_sum += tl.load(output_ptr, mask=output_mask)
     tl.store(output_ptr, partial_sum, mask=output_mask)
 
@@ -191,6 +193,7 @@ def qkv_lora_b_fwd(
         x,
         qkv_lora_b,
         output,
+        s,
         r,
         max_qkv_out_dim,
         x.stride(0),

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -13,6 +13,7 @@ def _sgemm_lora_a_kernel(
     weights,
     output,
     # Matrix dimensions
+    S,  # total number of rows in x/output (used for OOB clamping)
     N,  # stack_num * r
     K,  # input_dim
     stack_num,
@@ -87,34 +88,44 @@ def _sgemm_lora_a_kernel(
     s_physical = _resolve_token_positions(
         sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
     )
-    x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
-    w_ptrs = (weights + w_index * w_stride_0) + (
-        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
-    )
+    # Clamp masked-out lane indices into the valid range so that pointer
+    # arithmetic itself stays in-bounds. Without this, when a tile straddles
+    # the segment boundary or `n_offset` exceeds the rank-truncated `N`,
+    # certain Triton/cublas builds materialise the full pointer expression
+    # before applying the load mask, tripping CUDA "illegal memory access"
+    # under wider LoRA target sets (e.g. `q_b_proj`, `kv_b_proj`,
+    # `fused_qkv_a_proj_with_mqa`) where rank-truncated `N` does not align
+    # with `BLOCK_N`.
+    row_mask = s_offset < seg_len
+    safe_row = tl.minimum(s_physical, S - 1)
+    safe_n = tl.minimum(n_offset, N - 1)
 
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
+        cur_k = k * BLOCK_K + k_offset
+        k_mask = cur_k < K
+        safe_k = tl.minimum(cur_k, K - 1)
         x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            x + safe_row[:, None] * x_stride_0 + safe_k[None, :] * x_stride_1,
+            mask=row_mask[:, None] & k_mask[None, :],
             other=0.0,
         )
         w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & (n_offset[None, :] < N),
+            weights
+            + w_index * w_stride_0
+            + safe_k[:, None] * w_stride_2
+            + safe_n[None, :] * w_stride_1,
+            mask=k_mask[:, None] & (n_offset[None, :] < N),
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
 
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
-
     # Store result to output matrix
     partial_sum = partial_sum.to(x.dtype.element_ty)
-    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
-    output_ptr = output + (
-        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    output_mask = row_mask[:, None] & (n_offset[None, :] < N)
+    output_ptr = (
+        output + safe_row[:, None] * output_stride_0 + safe_n[None, :] * output_stride_1
     )
     tl.store(output_ptr, partial_sum, mask=output_mask)
 
@@ -159,6 +170,7 @@ def sgemm_lora_a_fwd(
         x,
         weights,
         output,
+        S,
         R,
         K,
         stack_num,

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
@@ -13,6 +13,7 @@ def _sgemm_lora_b_kernel(
     weights,
     output,
     # Matrix dimensions
+    S,  # total number of rows in x/output (used for OOB clamping)
     N,  # output_dim
     K,  # r
     # Strides
@@ -89,37 +90,40 @@ def _sgemm_lora_b_kernel(
     s_physical = _resolve_token_positions(
         sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
     )
-    x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
-    w_ptrs = (weights + w_index * w_stride_0) + (
-        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
-    )
+    # See sgemm_lora_a for why we clamp masked-lane indices.
+    row_mask = s_offset < seg_len
+    safe_row = tl.minimum(s_physical, S - 1)
+    safe_n = tl.minimum(n_offset, N - 1)
 
     # Iterate to compute the block in output matrix
     n_mask = n_offset[None, :] < N
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
+        cur_k = k * BLOCK_K + k_offset
+        k_mask = cur_k < K
+        safe_k = tl.minimum(cur_k, K - 1)
         x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            x + safe_row[:, None] * x_stride_0 + safe_k[None, :] * x_stride_1,
+            mask=row_mask[:, None] & k_mask[None, :],
             other=0.0,
         )
         w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & n_mask,
+            weights
+            + w_index * w_stride_0
+            + safe_k[:, None] * w_stride_2
+            + safe_n[None, :] * w_stride_1,
+            mask=k_mask[:, None] & n_mask,
             other=0.0,
         )
         partial_sum += tl.dot(x_tile, w_tile)
 
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
-
     # Store result to output matrix
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
-    output_ptr = output + (
-        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    output_ptr = (
+        output + safe_row[:, None] * output_stride_0 + safe_n[None, :] * output_stride_1
     )
-    output_mask = (s_offset[:, None] < seg_len) & n_mask
+    output_mask = row_mask[:, None] & n_mask
     partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
     tl.store(output_ptr, partial_sum, mask=output_mask)
 
@@ -165,6 +169,7 @@ def sgemm_lora_b_fwd(
         x,
         weights,
         output,
+        S,
         N,
         R,
         x.stride(0),


### PR DESCRIPTION
## Motivation

Two unrelated EP-correctness issues in the LoRA / NVFP4 stack, both reliably hit on multi-rank EP deployments and both root-causes for the same class of failure (CUDA "illegal memory access" or null TMA descriptor on the first forward).

### Bug 1 — `ModelOptNvFp4FusedMoEMethod.cutlass_moe_params` sized by global `num_experts`

The FlashInfer-CUTLASS NVFP4 path constructs `CutlassMoEParams` with `num_experts=layer.num_experts` (the global expert count). Under EP, the per-rank `w13_weight` / `w2_weight` tensors are sized by `num_local_experts`, but the FP4 grouped-GEMM kernel iterates `expert_offsets.size(0)` and indexes the weight tensors by `expert_id`. With `num_experts=384`, `ep_size=8`, `num_local_experts=48`, the kernel walks past the loaded weight tensors and produces a null TMA descriptor → first forward crashes with `CUDA error: an illegal memory access was encountered`.

When `ep_size=1`, `num_local_experts == num_experts`, so the change is a no-op for non-EP runs.

### Bug 2 — Existing LoRA Triton kernels build OOB pointers in masked lanes

The four kernels `sgemm_lora_a`, `sgemm_lora_b`, `qkv_lora_b`, `gate_up_lora_b` compute their `x_ptrs` / `w_ptrs` via raw arithmetic over `s_offset`, `n_offset`, `k_offset`, then mask the load:

```python
x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
...
x_tile = tl.load(x_ptrs, mask=(s_offset[:, None] < seg_len) & ...)
```

When a tile straddles the segment boundary (`s_offset >= seg_len`) or `n_offset` exceeds the rank-truncated `N`, `x_ptrs` / `w_ptrs` are computed with out-of-bounds offsets even though the load mask ultimately drops the values. On some Triton / cuBLAS / driver combos the pointer expression is materialised before the mask is applied, tripping CUDA "illegal memory access". In practice this surfaces with wider LoRA target sets (e.g. `q_b_proj`, `kv_b_proj`, `fused_qkv_a_proj_with_mqa` for MLA models) where the rank-truncated `N` does not align with `BLOCK_N`.

## Modifications

### `python/sglang/srt/layers/quantization/modelopt_quant.py`

In `ModelOptNvFp4FusedMoEMethod.process_weights_after_loading`, size `cutlass_moe_params` by `layer.num_local_experts` (per-rank) instead of `layer.num_experts` (global). Two-line fix:

```diff
-                or existing_params.num_experts != layer.num_experts
+                or existing_params.num_experts != layer.num_local_experts
...
-                    num_experts=layer.num_experts,  # global num experts
+                    num_experts=layer.num_local_experts,
```

### `python/sglang/srt/lora/triton_ops/{sgemm_lora_a,sgemm_lora_b,qkv_lora_b,gate_up_lora_b}.py`

Same pattern in all four kernels:

1. Pass total row count `S` as a kernel arg (used as the row-axis clamp).
2. Replace pointer-walk-then-mask with: clamp masked-out lane indices into the valid range first, then load with the mask. The mask still controls correctness; the clamp only ensures the *unmasked* pointer expression itself is in-bounds.

```python
# Before:
x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
...
x_tile = tl.load(x_ptrs, mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K), other=0.0)

# After:
row_mask = s_offset < seg_len
safe_row = tl.minimum(s_physical, S - 1)
safe_n   = tl.minimum(n_offset, N - 1)
...
cur_k  = k * BLOCK_K + k_offset
k_mask = cur_k < K
safe_k = tl.minimum(cur_k, K - 1)
x_tile = tl.load(
    x + safe_row[:, None] * x_stride_0 + safe_k[None, :] * x_stride_1,
    mask=row_mask[:, None] & k_mask[None, :], other=0.0,
)
```

Per-iteration K advancement also moves from `x_ptrs += BLOCK_K * x_stride_1` to recomputing `cur_k = k * BLOCK_K + k_offset` inside the loop, so the load expression is built fresh from clamped indices each step.

The patch is **semantically a no-op** — the load mask already prevented the OOB *value* from contributing; the clamp only prevents the OOB *pointer* from being computed.

## Accuracy Tests

### Triton kernels — bit-identical to `main`

12 case combinations (3 shapes × 4 kernels), exercised on a single B200 (per pod). For each shape we ran the kernel on `main`, saved the output, applied the patch, re-ran, and compared:

```
sgemm_lora_a (32, 32):    max_abs_diff=0  rel=0  OK
sgemm_lora_a (23, 24):    max_abs_diff=0  rel=0  OK
sgemm_lora_a (31, 32):    max_abs_diff=0  rel=0  OK     (K=513 straddles 2 BLOCK_K iters)
sgemm_lora_b (32, 256):   max_abs_diff=0  rel=0  OK
sgemm_lora_b (31, 257):   max_abs_diff=0  rel=0  OK     (N=257 straddles BLOCK_N=256)
sgemm_lora_b (27, 513):   max_abs_diff=0  rel=0  OK
qkv_lora_b   (32, 128):   max_abs_diff=0  rel=0  OK
qkv_lora_b   (31, 131):   max_abs_diff=0  rel=0  OK     (n_q=65, n_kv=33 straddle BLOCK_OUT=64)
qkv_lora_b   (27, 259):   max_abs_diff=0  rel=0  OK
gate_up_lora_b (32, 128): max_abs_diff=0  rel=0  OK
gate_up_lora_b (31, 514): max_abs_diff=0  rel=0  OK     (output_dim=257 straddles BLOCK_OUT=64)
gate_up_lora_b (27, 1026):max_abs_diff=0  rel=0  OK
ALL OK
```

Same 12 cases reproduced on a second host with the same byte-for-byte equivalence. The clamp does not change results on any covered shape.

### `modelopt_quant.py` — logical / structural check

Constructed `CutlassMoEParams` with both `(num_experts=384, num_local_experts=384)` (the no-EP case) and `(num_experts=384, num_local_experts=48)` (`ep_size=8`):

| ep_size | params.num_experts | tensor sizes (e.g. `expert_offsets`, `problem_sizes1/2`, `a_ptrs`, …) |
|---:|---:|---|
| 1 | 384 | sized 384 — unchanged from pre-patch (`num_local_experts == num_experts`) |
| 8 | 48  | sized 48 — matches per-rank `w13_weight` / `w2_weight` |
| 16| 24  | sized 24 — matches per-rank `w13_weight` / `w2_weight` |

The `ep_size=1` row demonstrates this is a no-op for non-EP deploys (the common case).

End-to-end EP launch was previously validated by the original author at TP=16 / EP=16 on Kimi-K2.5-NVFP4 with the `flashinfer_cutlass` MoE backend; on `main` (without this patch) the same launch crashes at the first forward with the null-TMA-descriptor failure described above.

## Speed Tests and Profiling

No expected impact:

- The clamp adds two `tl.minimum` operations per kernel invocation — trivially cheap relative to the GEMM body. Per-iteration `cur_k = k * BLOCK_K + k_offset` replaces an in-place `x_ptrs += BLOCK_K * x_stride_1` and is no more expensive.
- The `cutlass_moe_params` change is at weight-load time only; no hot-path cost.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).