### PR TITLE
Fix:  KV-Event Block Hash Collisions Across cache_salt Namespaces

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -195,6 +195,10 @@ class RadixKey:
     def hash_page(self, start: int, end: int, prior_hash: Optional[str] = None) -> str:
         """SHA256 for logical units [start, end); bigram mode feeds overlapping (t_i, t_{i+1}) byte pairs."""
         hasher = hashlib.sha256()
+        if self.extra_key is not None:
+            encoded_extra_key = self.extra_key.encode("utf-8")
+            hasher.update(len(encoded_extra_key).to_bytes(4, byteorder="little"))
+            hasher.update(encoded_extra_key)
         if prior_hash:
             hasher.update(bytes.fromhex(prior_hash))
         t = self.token_ids

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -140,6 +140,19 @@ class TestRadixKey(unittest.TestCase):
         repr_str = repr(key)
         self.assertIn("...", repr_str)  # Should be truncated
 
+    def test_hash_page_includes_extra_key(self):
+        """Test that hash_page is namespaced by extra_key."""
+        tokens = [1, 2, 3, 4]
+
+        hash_none = RadixKey(tokens, None).hash_page(0, len(tokens))
+        hash_empty = RadixKey(tokens, "").hash_page(0, len(tokens))
+        hash_key1 = RadixKey(tokens, "key1").hash_page(0, len(tokens))
+        hash_key2 = RadixKey(tokens, "key2").hash_page(0, len(tokens))
+
+        self.assertNotEqual(hash_none, hash_empty)
+        self.assertNotEqual(hash_key1, hash_key2)
+        self.assertNotEqual(hash_none, hash_key1)
+
 
 class TestTreeNode(unittest.TestCase):
     """Test cases for TreeNode class."""
@@ -732,6 +745,36 @@ class TestRadixCache(unittest.TestCase):
             self.assertIsNotNone(node.hash_value)
             # Should have 1 page (split at page_size=2)
             self.assertEqual(len(node.hash_value), 1)
+
+    def test_block_hashes_are_isolated_by_extra_key(self):
+        """Test that KV event block hashes differ across extra_key namespaces."""
+        cache = RadixCache.create_simulated(
+            page_size=4,
+            enable_kv_cache_events=True,
+        )
+        tokens = [1, 2, 3, 4]
+
+        cache.insert(InsertParams(key=RadixKey(tokens, "key1"), value=None))
+        events_key1 = [
+            event for event in cache.take_events() if isinstance(event, BlockStored)
+        ]
+
+        match_other_namespace = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(tokens, "key2"))
+        )
+        self.assertEqual(match_other_namespace.prefix_len, 0)
+
+        cache.insert(InsertParams(key=RadixKey(tokens, "key2"), value=None))
+        events_key2 = [
+            event for event in cache.take_events() if isinstance(event, BlockStored)
+        ]
+
+        self.assertEqual(len(events_key1), 1)
+        self.assertEqual(len(events_key2), 1)
+        self.assertNotEqual(
+            events_key1[0].block_hashes[0],
+            events_key2[0].block_hashes[0],
+        )
 
     def test_memory_allocated(self):
         keys, values = [], []


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix KV-event block hashes to include RadixKey.extra_key namespace

fix issue https://github.com/sgl-project/sglang/issues/24568

Trigger scenario:
KV-cache event reporting is enabled, and an external consumer relies on BlockStored.block_hashes to identify cache blocks.  Two requests share the same token prefix, but use different cache_salt values, or more generally different extra_key values.  In-memory radix prefix caching already isolates these requests correctly by namespace, but KV events were still emitting the same block hash for both.

failure:
Token-identical prefixes under different extra_key / cache_salt namespaces produced identical BlockStored.block_hashes. BlockStored does not carry a separate namespace field, so downstream consumers had no way to disambiguate those blocks. As a result, external KV-event consumers could incorrectly treat logically distinct cache blocks as the same block.

Expected behavior
  - KV-event block identity should follow the same namespace semantics as the in-memory radix cache.
  - If extra_key differs, the emitted block hash must also differ, even when the token content is identical.
  - External consumers should be able to rely on block_hashes as a namespace-safe cache identifier.

## Modifications

The bug was in  radix_cache.py
Before the fix, the hash only included prior_hash and token bytes, but completely ignored self.extra_key.
This created a semantic mismatch: in-memory cache keys already treated extra_key as part of namespace identity, but event block hashes did not.

## Accuracy Tests


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
