### PR TITLE
[CI] pin NeMo-Skills install to known-good SHA in accuracy_test_runner

### DIFF
--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -199,8 +199,11 @@ def _get_nemo_venv() -> Tuple[str, dict]:
             text=True,
         )
 
-    # Install nemo_skills
-    print("Installing nemo_skills...")
+    # Install nemo_skills.
+    # Pinned: NeMo-Skills main after PR #1433 pins litellm==1.83.14 (httpx==0.28.1),
+    # which is unsatisfiable against nemo-run's transitive leptonai dep.
+    nemo_skills_ref = "589294c"
+    print(f"Installing nemo_skills (pinned to {nemo_skills_ref})...")
     pip_result = subprocess.run(
         [
             "uv",
@@ -208,7 +211,7 @@ def _get_nemo_venv() -> Tuple[str, dict]:
             "install",
             "--python",
             f"{_nemo_venv_dir}/venv/bin/python",
-            "git+https://github.com/NVIDIA/NeMo-Skills.git",
+            f"git+https://github.com/NVIDIA/NeMo-Skills.git@{nemo_skills_ref}",
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

The GB300 nightly CI started failing for shards that run mmmu-pro evals (Qwen3.5 / Kimi-K2.5) with this resolver error during NeMo-Skills install:

```
litellm==1.83.14 depends on httpx==0.28.1 ... and litellm==1.83.14 and all
versions of nemo-run are incompatible. And because nemo-skills==0.7.0
depends on litellm[caching]==1.83.14 and nemo-run, ... your requirements
are unsatisfiable.
```

Root cause: NVIDIA/NeMo-Skills#1433 (commit `9c7ced8`, 2026-05-06 23:40 UTC) pinned `litellm==1.83.14`, which transitively requires `httpx==0.28.1` — unsatisfiable against `nemo-run`'s `leptonai==0.27.x` dep. `python/sglang/test/accuracy_test_runner.py::_get_nemo_venv` installs from `git+https://github.com/NVIDIA/NeMo-Skills.git` with no version pin, so the next nightly broke. Subsequent variants in the same shard then hit `ModuleNotFoundError: No module named 'nemo_skills'` because the venv was left without the package.

This pins to commit `589294c` ("Fix trtllm-server multinode launch", 2026-05-04) — the last clean commit before NeMo-Skills#1433.

## Test plan

- [x] `uv pip install git+https://github.com/NVIDIA/NeMo-Skills.git@589294c` resolves cleanly in a fresh venv (verified locally on aarch64 / Python 3.12)
- [x] `python -m nemo_skills.dataset.prepare --help` runs from the resulting venv (this is the module that crashed `ModuleNotFoundError` in the broken pods because the install itself had failed)
- [x] `pre-commit run --files python/sglang/test/accuracy_test_runner.py` — all hooks pass
- [ ] Re-run GB300 nightly FP8 round; previously failing shards 0 (Qwen3.5) and 2 (Kimi-K2.5) should reach `mmmu-pro_score=` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)