### PR TITLE
[PD] Centralize per-room cleanup in common backend

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -183,12 +183,6 @@ class CommonKVManager(BaseKVManager):
         return self.request_status[bootstrap_room]
 
     def update_status(self, bootstrap_room: int, status: KVPoll):
-        if (
-            status == KVPoll.Failed
-            and self.disaggregation_mode == DisaggregationMode.PREFILL
-            and hasattr(self, "req_to_decode_prefix_len")
-        ):
-            self.req_to_decode_prefix_len.pop(bootstrap_room, None)
         if bootstrap_room not in self.request_status:
             self.request_status[bootstrap_room] = status
         else:
@@ -539,6 +533,13 @@ class CommonKVSender(BaseKVSender):
     def failure_exception(self):
         raise Exception("Fake KVReceiver Exception")
 
+    def clear(self) -> None:
+        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+        if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
+            self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
+        if hasattr(self.kv_mgr, "transfer_infos"):
+            self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+
     def abort(self):
         self.kv_mgr.record_failure(
             self.bootstrap_room,
@@ -733,6 +734,11 @@ class CommonKVReceiver(BaseKVReceiver):
 
     def failure_exception(self):
         raise Exception("Fake KVReceiver Exception")
+
+    def clear(self) -> None:
+        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+        self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
+        self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1736,10 +1736,6 @@ class MooncakeKVSender(CommonKVSender):
         else:
             return self.conclude_state
 
-    def clear(self) -> None:
-        if self.bootstrap_room in self.kv_mgr.request_status:
-            self.kv_mgr.request_status.pop(self.bootstrap_room)
-
     def failure_exception(self):
         # Explicitly set the status to failure since this request has failed in another rank
         if self.conclude_state is None:
@@ -1910,16 +1906,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
 
         else:
             return self.conclude_state
-
-    def clear(self) -> None:
-        if self.bootstrap_room in self.kv_mgr.request_status:
-            self.kv_mgr.request_status.pop(self.bootstrap_room)
-
-        if self.bootstrap_room in self.kv_mgr.required_prefill_response_num_table:
-            self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room)
-
-        if self.bootstrap_room in self.kv_mgr.prefill_response_tracker:
-            self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room)
 
     def failure_exception(self):
         # Explicitly set the status to failure since this request has failed in another rank

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -959,9 +959,6 @@ class MoriKVSender(CommonKVSender):
         self._notify_decode(KVPoll.Failed, failure_reason)
         self.conclude_state = KVPoll.Failed
 
-    def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-
     def failure_exception(self):
         if self.conclude_state is None:
             self._finalize_failure()
@@ -1087,9 +1084,7 @@ class MoriKVReceiver(CommonKVReceiver):
     def clear(self) -> None:
         if self.bootstrap_room is None:
             return
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
-        self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
+        super().clear()
         self.kv_mgr._cleanup_room_tracking(self.bootstrap_room)
 
     def failure_exception(self):

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1009,9 +1009,6 @@ class NixlKVManager(CommonKVManager):
                     aux_notif,
                 )
                 handles.append(aux_xfer_handle)
-        if is_last:
-            del self.transfer_infos[bootstrap_room]
-            self.req_to_decode_prefix_len.pop(bootstrap_room, None)
         return handles
 
     def update_transfer_status(self):
@@ -1185,7 +1182,6 @@ class NixlKVSender(CommonKVSender):
         self.chunk_id += 1
         if is_last:
             self.has_sent = True
-            del self.kv_mgr.request_status[self.bootstrap_room]
 
     def poll(self) -> KVPoll:
         if self._send_failed:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Per-room state cleanup for PD disaggregation is currently spread across each backend (`mooncake`, `mori`, `nixl`) and across multiple call sites (`failure_exception()`, transfer-thread last-chunk handling, the success path, and even an obscure side-effect inside `KVManager.update_status`).
The result is:
- Each backend's `clear()` re-implements a slightly different subset of pops, and it is easy to forget a field (e.g. `addr_to_rooms_tracker` is only cleaned up by mori's receiver today).
- `update_status(Failed)` carries a hidden side effect that pops `req_to_decode_prefix_len`, which makes it brittle to call from new sites.
- `nixl` deletes `request_status` / `transfer_infos` directly with `del` inside `send()`, which makes any future call to `clear()` racy (would raise `KeyError`).

## Modifications
Introduce a single, authoritative `clear()` on `CommonKVSender` and `CommonKVReceiver` that pops every per-room dict owned by the corresponding manager, and have every backend delegate to it.
- **`common/conn.py`**
  - New `CommonKVSender.clear()`: pops `request_status`, `req_to_decode_prefix_len`, `transfer_infos`.
  - New `CommonKVReceiver.clear()`: pops `request_status`, `required_prefill_response_num_table`, `prefill_response_tracker`。
  - Drop the `req_to_decode_prefix_len.pop` side effect from `update_status(Failed)` — it is now handled by the unified `clear()`.
- **`mooncake/conn.py`**
  - Remove `MooncakeKVSender.clear()` and `MooncakeKVReceiver.clear()`; they were strict subsets of the new base implementation. Ascend inherits from Mooncake and gets the fix automatically.
- **`mori/conn.py`**
  - Remove `MoriKVSender.clear()`; it was identical to the base now.
  - Simplify `MoriKVReceiver.clear()` to `super().clear()` plus mori's backend-specific `room_to_bootstrap_addr.pop(...)`.
- **`nixl/conn.py`**
  - Replace `del self.kv_mgr.request_status[room]` / `del self.transfer_infos[room]` with idempotent `pop(..., None)` so that nixl's eager cleanup in `send()` and the unified `clear()` can coexist without `KeyError`.
<!-- Describe the purpose and goals of this pull request. -->


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
