### PR TITLE
[AMD] Retry logic for lmms-eval installation

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -128,7 +128,8 @@ if [[ -n "${SKIP_TT_DEPS}" ]]; then
   echo "Didn't build lmms_eval, human-eval, and others"
 else
   # For lmms_evals evaluating MMMU
-  docker exec -w / ci_sglang git clone --branch v0.4.1 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+  git_clone_with_retry https://github.com/EvolvingLMMs-Lab/lmms-eval.git lmms-eval "--branch v0.4.1"
+  docker cp lmms-eval ci_sglang:/
   install_with_retry docker exec -w /lmms-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
 
   git_clone_with_retry https://github.com/akao-amd/human-eval.git human-eval

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -128,8 +128,12 @@ if [[ -n "${SKIP_TT_DEPS}" ]]; then
   echo "Didn't build lmms_eval, human-eval, and others"
 else
   # For lmms_evals evaluating MMMU
+  # Clone on host (with retry), then copy into the container. The checkout is
+  # owned by the runner (non-root); mark it safe so setuptools_scm /
+  # vcs_versioning can run `git` introspection during pip install.
   git_clone_with_retry https://github.com/EvolvingLMMs-Lab/lmms-eval.git lmms-eval "--branch v0.4.1"
   docker cp lmms-eval ci_sglang:/
+  docker exec ci_sglang git config --global --add safe.directory /lmms-eval
   install_with_retry docker exec -w /lmms-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
 
   git_clone_with_retry https://github.com/akao-amd/human-eval.git human-eval


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

https://github.com/sgl-project/sglang/actions/runs/25503286022/job/74841874050

The AMD CI `Install dependencies` step occasionally fails during the `lmms-eval` clone with a transient TLS error:
```
fatal: unable to access 'https://github.com/EvolvingLMMs-Lab/lmms-eval.git/': gnutls_handshake() failed: Error in the pull function.
```
This is a transient network/TLS hiccup against `github.com` (more likely on larger repos like `lmms-eval` v0.4.1 because the clone takes longer). The problem is not the network glitch itself — those are unavoidable — but that the clone command in `scripts/ci/amd/amd_ci_install_dependency.sh` is a bare `git clone` with **no retry and no low-speed timeout**. With `set -euo pipefail`, a single transient failure aborts the entire install step and fails the job.
The script already defines `git_clone_with_retry`, and the immediately following `human-eval` clone uses it. `lmms-eval` was simply missed.

## Update: additional fix on top of host-side clone
The first iteration switched `lmms-eval` to clone on the host with retry. CI then surfaced a follow-up failure:
```
fatal: detected dubious ownership in repository at '/lmms-eval'
```
Root cause: Git ≥ 2.35.2's cross-user safety check. `docker cp` preserves the host runner's non-root UID/GID, so when `lmms-eval`'s build backend invokes `git` (via the `vcs_versioning` build dep) inside the container as root, ownership mismatch is rejected. The new commit adds:
```bash
docker exec ci_sglang git config --global --add safe.directory /lmms-eval
```
mirroring the same workaround already in place for /sglang-checkout (see scripts/ci/amd/amd_ci_start_container.sh). human-eval is not affected because its build backend does not invoke git, so it's intentionally left unchanged in this PR.

## Modifications
`scripts/ci/amd/amd_ci_install_dependency.sh`: replace the bare in-container clone with the same `git_clone_with_retry` + `docker cp` pattern already used for `human-eval` right below it.
Before:
```bash
docker exec -w / ci_sglang git clone --branch v0.4.1 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
install_with_retry docker exec -w /lmms-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
```
After:
```bash
git_clone_with_retry https://github.com/EvolvingLMMs-Lab/lmms-eval.git lmms-eval "--branch v0.4.1"
docker cp lmms-eval ci_sglang:/
install_with_retry docker exec -w /lmms-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
```
This adds:
- up to 3 retries on the clone
- `http.lowSpeedLimit=1000` + `http.lowSpeedTime=30` (fail fast on stalled transfers instead of waiting for the long default timeout, then retry)
- partial-clone cleanup before each retry
`--branch v0.4.1` is preserved via `git_clone_with_retry`'s third argument; `--depth 1` is added by the helper itself. The final `/lmms-eval` path inside `ci_sglang` is unchanged, so the subsequent `pip install -e .` line needs no modification. `lmms-eval` is already in `.gitignore`, so the host-side checkout does not pollute the working tree.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
