### PR TITLE
[diffusion] optimize: optimize frame returns path

### DIFF
--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for transferring large numpy arrays between local scheduler processes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_MIN_FILE_REF_BYTES = 1 << 20
+
+
+@dataclass
+class NumpyArrayFileRef:
+    path: str
+
+    def materialize(self) -> np.ndarray:
+        try:
+            return np.load(self.path, allow_pickle=False)
+        finally:
+            try:
+                os.unlink(self.path)
+            except FileNotFoundError:
+                pass
+
+
+def is_local_endpoint(endpoint: str) -> bool:
+    return endpoint.startswith(
+        ("tcp://127.0.0.1:", "tcp://localhost:", "ipc://", "inproc://")
+    )
+
+
+def spill_large_arrays_to_file_refs(value: Any) -> Any:
+    if isinstance(value, np.ndarray) and value.nbytes >= _MIN_FILE_REF_BYTES:
+        return _spill_array(value)
+    if isinstance(value, list):
+        return [spill_large_arrays_to_file_refs(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(spill_large_arrays_to_file_refs(item) for item in value)
+    return value
+
+
+def materialize_file_refs(value: Any) -> Any:
+    if isinstance(value, NumpyArrayFileRef):
+        return value.materialize()
+    if isinstance(value, list):
+        return [materialize_file_refs(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(materialize_file_refs(item) for item in value)
+    return value
+
+
+def _spill_array(array: np.ndarray) -> NumpyArrayFileRef:
+    if not array.flags.c_contiguous:
+        array = np.ascontiguousarray(array)
+
+    directory = _array_ipc_dir()
+    fd, path = tempfile.mkstemp(
+        prefix="sgldiffusion-array-",
+        suffix=".npy",
+        dir=directory,
+    )
+    with os.fdopen(fd, "wb") as f:
+        np.save(f, array, allow_pickle=False)
+    return NumpyArrayFileRef(path=path)
+
+
+def _array_ipc_dir() -> str | None:
+    shm_path = Path("/dev/shm")
+    if shm_path.is_dir() and os.access(shm_path, os.W_OK):
+        return str(shm_path)
+    return None

--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Helpers for transferring large numpy arrays between local scheduler processes."""
+"""Helpers for transferring large numpy arrays between local scheduler processes.
+
+Offline diffusion requests can return multi-frame numpy arrays that are much larger
+than the rest of the response metadata.  When the scheduler and client share a local
+filesystem, passing a small file reference keeps the ZMQ pickle payload small while
+preserving the same in-memory value after the client materializes the reference.
+"""
 
 from __future__ import annotations
 
@@ -19,6 +25,9 @@ class NumpyArrayFileRef:
     path: str
 
     def materialize(self) -> np.ndarray:
+        # A file ref has a single owner: the first client that materializes it.
+        # Removing the file here keeps repeated offline generations from leaking
+        # large frame arrays under /dev/shm or the system temp directory.
         try:
             return np.load(self.path, allow_pickle=False)
         finally:
@@ -29,12 +38,16 @@ class NumpyArrayFileRef:
 
 
 def is_local_endpoint(endpoint: str) -> bool:
+    # File refs are only safe when both processes can see the same filesystem.
+    # For non-loopback TCP endpoints we keep the old inline-pickle behavior.
     return endpoint.startswith(
         ("tcp://127.0.0.1:", "tcp://localhost:", "ipc://", "inproc://")
     )
 
 
 def spill_large_arrays_to_file_refs(value: Any) -> Any:
+    # Preserve small arrays inline: writing tiny payloads to disk is slower and
+    # makes ordinary control responses harder to inspect.
     if isinstance(value, np.ndarray) and value.nbytes >= _MIN_FILE_REF_BYTES:
         return _spill_array(value)
     if isinstance(value, list):
@@ -73,4 +86,5 @@ def _array_ipc_dir() -> str | None:
     shm_path = Path("/dev/shm")
     if shm_path.is_dir() and os.access(shm_path, os.W_OK):
         return str(shm_path)
+    # Returning None lets tempfile use the platform default temp directory.
     return None

--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -64,8 +64,15 @@ def _spill_array(array: np.ndarray) -> NumpyArrayFileRef:
         suffix=".npy",
         dir=directory,
     )
-    with os.fdopen(fd, "wb") as f:
-        np.save(f, array, allow_pickle=False)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            np.save(f, array, allow_pickle=False)
+    except Exception:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        raise
     return NumpyArrayFileRef(path=path)
 
 

--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import numpy as np
 
-_MIN_FILE_REF_BYTES = 1 << 20
+_MIN_FILE_REF_BYTES = 32 << 20
 
 
 @dataclass
@@ -35,12 +35,21 @@ def is_local_endpoint(endpoint: str) -> bool:
 
 
 def spill_large_arrays_to_file_refs(value: Any) -> Any:
+    directory = _array_ipc_dir()
+    if directory is None:
+        return value
+    return _spill_large_arrays_to_file_refs(value, directory)
+
+
+def _spill_large_arrays_to_file_refs(value: Any, directory: str) -> Any:
     if isinstance(value, np.ndarray) and value.nbytes >= _MIN_FILE_REF_BYTES:
-        return _spill_array(value)
+        return _spill_array(value, directory)
     if isinstance(value, list):
-        return [spill_large_arrays_to_file_refs(item) for item in value]
+        return [_spill_large_arrays_to_file_refs(item, directory) for item in value]
     if isinstance(value, tuple):
-        return tuple(spill_large_arrays_to_file_refs(item) for item in value)
+        return tuple(
+            _spill_large_arrays_to_file_refs(item, directory) for item in value
+        )
     return value
 
 
@@ -54,11 +63,10 @@ def materialize_file_refs(value: Any) -> Any:
     return value
 
 
-def _spill_array(array: np.ndarray) -> NumpyArrayFileRef:
+def _spill_array(array: np.ndarray, directory: str) -> NumpyArrayFileRef:
     if not array.flags.c_contiguous:
         array = np.ascontiguousarray(array)
 
-    directory = _array_ipc_dir()
     fd, path = tempfile.mkstemp(
         prefix="sgldiffusion-array-",
         suffix=".npy",

--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -19,7 +19,6 @@ class NumpyArrayFileRef:
     path: str
 
     def materialize(self) -> np.ndarray:
-        # File refs are single-use; unlink after np.load to avoid temp-file leaks.
         try:
             return np.load(self.path, allow_pickle=False)
         finally:
@@ -30,7 +29,6 @@ class NumpyArrayFileRef:
 
 
 def is_local_endpoint(endpoint: str) -> bool:
-    # File refs require a shared local filesystem between scheduler and client.
     return endpoint.startswith(
         ("tcp://127.0.0.1:", "tcp://localhost:", "ipc://", "inproc://")
     )

--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Helpers for transferring large numpy arrays between local scheduler processes.
-
-Offline diffusion requests can return multi-frame numpy arrays that are much larger
-than the rest of the response metadata.  When the scheduler and client share a local
-filesystem, passing a small file reference keeps the ZMQ pickle payload small while
-preserving the same in-memory value after the client materializes the reference.
-"""
+"""Helpers for transferring large numpy arrays between local scheduler processes."""
 
 from __future__ import annotations
 
@@ -25,9 +19,7 @@ class NumpyArrayFileRef:
     path: str
 
     def materialize(self) -> np.ndarray:
-        # A file ref has a single owner: the first client that materializes it.
-        # Removing the file here keeps repeated offline generations from leaking
-        # large frame arrays under /dev/shm or the system temp directory.
+        # File refs are single-use; unlink after np.load to avoid temp-file leaks.
         try:
             return np.load(self.path, allow_pickle=False)
         finally:
@@ -38,16 +30,13 @@ class NumpyArrayFileRef:
 
 
 def is_local_endpoint(endpoint: str) -> bool:
-    # File refs are only safe when both processes can see the same filesystem.
-    # For non-loopback TCP endpoints we keep the old inline-pickle behavior.
+    # File refs require a shared local filesystem between scheduler and client.
     return endpoint.startswith(
         ("tcp://127.0.0.1:", "tcp://localhost:", "ipc://", "inproc://")
     )
 
 
 def spill_large_arrays_to_file_refs(value: Any) -> Any:
-    # Preserve small arrays inline: writing tiny payloads to disk is slower and
-    # makes ordinary control responses harder to inspect.
     if isinstance(value, np.ndarray) and value.nbytes >= _MIN_FILE_REF_BYTES:
         return _spill_array(value)
     if isinstance(value, list):
@@ -86,5 +75,4 @@ def _array_ipc_dir() -> str | None:
     shm_path = Path("/dev/shm")
     if shm_path.is_dir() and os.access(shm_path, os.W_OK):
         return str(shm_path)
-    # Returning None lets tempfile use the platform default temp directory.
     return None

--- a/python/sglang/multimodal_gen/runtime/ipc_array.py
+++ b/python/sglang/multimodal_gen/runtime/ipc_array.py
@@ -43,6 +43,7 @@ def spill_large_arrays_to_file_refs(value: Any) -> Any:
 
 def _spill_large_arrays_to_file_refs(value: Any, directory: str) -> Any:
     if isinstance(value, np.ndarray) and value.nbytes >= _MIN_FILE_REF_BYTES:
+        # only spill if the array size is above the threshold. if not, it's not worth it
         return _spill_array(value, directory)
     if isinstance(value, list):
         return [_spill_large_arrays_to_file_refs(item, directory) for item in value]

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -411,11 +411,7 @@ class GPUWorker:
     def _materialize_frame_outputs_for_return(
         self, output_batch: OutputBatch, req: Req
     ) -> None:
-        if (
-            self.rank != 0
-            or output_batch.output is None
-            or not req.return_frames
-        ):
+        if self.rank != 0 or output_batch.output is None or not req.return_frames:
             return
 
         if (

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -370,6 +370,9 @@ class GPUWorker:
                 if torch.cuda.is_initialized():
                     torch.cuda.empty_cache()
             else:
+                # For offline return_frames requests, doing the tensor->uint8 frame
+                # conversion here keeps the expensive D2H copy inside the worker
+                # process/metrics and avoids sending GPU tensors through scheduler ZMQ.
                 self._materialize_frame_outputs_for_return(output_batch, req)
 
             if torch.cuda.is_initialized() and output_batch.output is None:
@@ -410,6 +413,9 @@ class GPUWorker:
     def _materialize_frame_outputs_for_return(
         self, output_batch: OutputBatch, req: Req
     ) -> None:
+        # Keep file-saving and non-frame-return requests on the existing path.
+        # This optimization targets the API shape that wants decoded frames back
+        # in Python, not the CLI/server path that only needs output files.
         if (
             self.rank != 0
             or output_batch.output is None
@@ -448,6 +454,8 @@ class GPUWorker:
             and not req.enable_frame_interpolation
             and not req.enable_upscaling
         ):
+            # Match post_process_sample's direct tensor conversion:
+            # decoded tensors are C/F/H/W, returned frames are F/H/W/C uint8.
             if output.dim() == 3:
                 output = output.unsqueeze(1)
             output = (output * 255).clamp(0, 255).to(torch.uint8)
@@ -459,8 +467,11 @@ class GPUWorker:
             and output.ndim == 4
             and output.shape[-1] in (1, 3, 4)
         ):
+            # Some pipeline configs already postprocess to HWC uint8 frames.
             return output
 
+        # Interpolation/upscaling and less common output formats still need the
+        # general post-processing path to preserve behavior.
         frames = post_process_sample(
             output,
             req.data_type,

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -10,6 +10,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Union
 
+import numpy as np
 import torch
 from setproctitle import setproctitle
 
@@ -31,7 +32,10 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_ulysses_parallel_rank,
     get_ulysses_parallel_world_size,
 )
-from sglang.multimodal_gen.runtime.entrypoints.utils import save_outputs
+from sglang.multimodal_gen.runtime.entrypoints.utils import (
+    post_process_sample,
+    save_outputs,
+)
 from sglang.multimodal_gen.runtime.loader.weight_utils import compute_weights_checksum
 from sglang.multimodal_gen.runtime.loader.weights_updater import (
     WeightsUpdater,
@@ -365,6 +369,8 @@ class GPUWorker:
 
                 if torch.cuda.is_initialized():
                     torch.cuda.empty_cache()
+            else:
+                self._materialize_frame_outputs_for_return(output_batch, req)
 
             if torch.cuda.is_initialized() and output_batch.output is None:
                 torch.cuda.empty_cache()
@@ -400,6 +406,77 @@ class GPUWorker:
             if torch.cuda.is_initialized():
                 torch.cuda.empty_cache()
         return output_batch
+
+    def _materialize_frame_outputs_for_return(
+        self, output_batch: OutputBatch, req: Req
+    ) -> None:
+        if (
+            self.rank != 0
+            or output_batch.output is None
+            or req.save_output
+            or not req.return_frames
+        ):
+            return
+
+        if (
+            os.environ.get("SGLANG_DIFFUSION_SYNC_STAGE_PROFILING", "0") == "1"
+            and torch.cuda.is_initialized()
+        ):
+            torch.cuda.synchronize()
+        start_time = time.perf_counter()
+        output_batch.output = [
+            self._materialize_frame_output(output, output_batch, req)
+            for output in output_batch.output
+        ]
+        if output_batch.metrics is not None:
+            if (
+                os.environ.get("SGLANG_DIFFUSION_SYNC_STAGE_PROFILING", "0") == "1"
+                and torch.cuda.is_initialized()
+            ):
+                torch.cuda.synchronize()
+            output_batch.metrics.record_stage(
+                "GPUWorker.frame_materialize_for_return",
+                time.perf_counter() - start_time,
+            )
+
+    @staticmethod
+    def _materialize_frame_output(
+        output: Any, output_batch: OutputBatch, req: Req
+    ) -> np.ndarray:
+        if (
+            isinstance(output, torch.Tensor)
+            and not req.enable_frame_interpolation
+            and not req.enable_upscaling
+        ):
+            if output.dim() == 3:
+                output = output.unsqueeze(1)
+            output = (output * 255).clamp(0, 255).to(torch.uint8)
+            return output.permute(1, 2, 3, 0).cpu().numpy()
+
+        if (
+            isinstance(output, np.ndarray)
+            and output.dtype == np.uint8
+            and output.ndim == 4
+            and output.shape[-1] in (1, 3, 4)
+        ):
+            return output
+
+        frames = post_process_sample(
+            output,
+            req.data_type,
+            req.fps,
+            save_output=False,
+            audio_sample_rate=output_batch.audio_sample_rate,
+            output_compression=req.output_compression,
+            enable_frame_interpolation=req.enable_frame_interpolation,
+            frame_interpolation_exp=req.frame_interpolation_exp,
+            frame_interpolation_scale=req.frame_interpolation_scale,
+            frame_interpolation_model_path=req.frame_interpolation_model_path,
+            enable_upscaling=req.enable_upscaling,
+            upscaling_model_path=req.upscaling_model_path,
+            upscaling_scale=req.upscaling_scale,
+        )
+        return np.asarray(frames)
 
     def _record_output_peak_memory(self, output_batch: OutputBatch) -> None:
         if self.rank != 0 or current_platform.is_cpu():
@@ -492,6 +569,7 @@ class GPUWorker:
         first_req = reqs[0]
         shared_output_fields = (
             "save_output",
+            "return_frames",
             "return_file_paths_only",
             "data_type",
             "fps",

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -369,9 +369,9 @@ class GPUWorker:
 
                 if torch.cuda.is_initialized():
                     torch.cuda.empty_cache()
-            else:
-                # Keep return_frames payloads off the scheduler's tensor ZMQ path.
-                self._materialize_frame_outputs_for_return(output_batch, req)
+
+            # Keep return_frames payloads off the scheduler's tensor ZMQ path.
+            self._materialize_frame_outputs_for_return(output_batch, req)
 
             if torch.cuda.is_initialized() and output_batch.output is None:
                 torch.cuda.empty_cache()
@@ -414,7 +414,6 @@ class GPUWorker:
         if (
             self.rank != 0
             or output_batch.output is None
-            or req.save_output
             or not req.return_frames
         ):
             return

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -371,8 +371,7 @@ class GPUWorker:
                     torch.cuda.empty_cache()
             else:
                 # For offline return_frames requests, doing the tensor->uint8 frame
-                # conversion here keeps the expensive D2H copy inside the worker
-                # process/metrics and avoids sending GPU tensors through scheduler ZMQ.
+                # conversion here avoids sending GPU tensors through scheduler ZMQ.
                 self._materialize_frame_outputs_for_return(output_batch, req)
 
             if torch.cuda.is_initialized() and output_batch.output is None:
@@ -413,9 +412,6 @@ class GPUWorker:
     def _materialize_frame_outputs_for_return(
         self, output_batch: OutputBatch, req: Req
     ) -> None:
-        # Keep file-saving and non-frame-return requests on the existing path.
-        # This optimization targets the API shape that wants decoded frames back
-        # in Python, not the CLI/server path that only needs output files.
         if (
             self.rank != 0
             or output_batch.output is None
@@ -454,8 +450,7 @@ class GPUWorker:
             and not req.enable_frame_interpolation
             and not req.enable_upscaling
         ):
-            # Match post_process_sample's direct tensor conversion:
-            # decoded tensors are C/F/H/W, returned frames are F/H/W/C uint8.
+            # Match post_process_sample: C/F/H/W float tensor -> F/H/W/C uint8.
             if output.dim() == 3:
                 output = output.unsqueeze(1)
             output = (output * 255).clamp(0, 255).to(torch.uint8)
@@ -467,11 +462,8 @@ class GPUWorker:
             and output.ndim == 4
             and output.shape[-1] in (1, 3, 4)
         ):
-            # Some pipeline configs already postprocess to HWC uint8 frames.
             return output
 
-        # Interpolation/upscaling and less common output formats still need the
-        # general post-processing path to preserve behavior.
         frames = post_process_sample(
             output,
             req.data_type,

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -370,8 +370,7 @@ class GPUWorker:
                 if torch.cuda.is_initialized():
                     torch.cuda.empty_cache()
             else:
-                # For offline return_frames requests, doing the tensor->uint8 frame
-                # conversion here avoids sending GPU tensors through scheduler ZMQ.
+                # Keep return_frames payloads off the scheduler's tensor ZMQ path.
                 self._materialize_frame_outputs_for_return(output_batch, req)
 
             if torch.cuda.is_initialized() and output_batch.output is None:
@@ -450,7 +449,6 @@ class GPUWorker:
             and not req.enable_frame_interpolation
             and not req.enable_upscaling
         ):
-            # Match post_process_sample: C/F/H/W float tensor -> F/H/W/C uint8.
             if output.dim() == 3:
                 output = output.unsqueeze(1)
             output = (output * 255).clamp(0, 255).to(torch.uint8)

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,7 +613,8 @@ class Scheduler(SchedulerDisaggMixin):
         replies to client, only on rank 0
         """
         if not is_warmup and self.receiver is not None and identity is not None:
-            # if the server is local, use temp file to spill the frame array instead of leaving it in OutputBatch to be pickled later
+            # if the server is local, use temp file to spill the frame array instead of
+            # leaving it in OutputBatch to be pickled later
             if is_local_endpoint(self.server_args.scheduler_endpoint):
                 with self._record_return_stage(
                     output_batch, "Scheduler.return_result.spill_arrays"

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,7 +613,7 @@ class Scheduler(SchedulerDisaggMixin):
         replies to client, only on rank 0
         """
         if not is_warmup and self.receiver is not None and identity is not None:
-            # if the server is local, use temp file to spill the frame array
+            # if the server is local, use temp file to spill the frame array instead of leaving it in OutputBatch to be picked later
             if is_local_endpoint(self.server_args.scheduler_endpoint):
                 with self._record_return_stage(
                     output_batch, "Scheduler.return_result.spill_arrays"

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,7 +613,6 @@ class Scheduler(SchedulerDisaggMixin):
         """
         if not is_warmup and self.receiver is not None and identity is not None:
             if is_local_endpoint(self.server_args.scheduler_endpoint):
-                # Same-host clients can receive large frame arrays as file refs.
                 start_time = time.perf_counter()
                 output_batch.output = spill_large_arrays_to_file_refs(
                     output_batch.output

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,6 +613,7 @@ class Scheduler(SchedulerDisaggMixin):
         replies to client, only on rank 0
         """
         if not is_warmup and self.receiver is not None and identity is not None:
+            # if the server is local, use temp file to spill the frame array
             if is_local_endpoint(self.server_args.scheduler_endpoint):
                 with self._record_return_stage(
                     output_batch, "Scheduler.return_result.spill_arrays"
@@ -635,6 +636,7 @@ class Scheduler(SchedulerDisaggMixin):
     def _record_return_stage(
         self, output_batch: OutputBatch, stage_name: str
     ) -> Iterator[None]:
+        """helper function to record a stage metric"""
         start_time = time.perf_counter()
         yield
         if output_batch.metrics is not None:

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,6 +613,9 @@ class Scheduler(SchedulerDisaggMixin):
         """
         if not is_warmup and self.receiver is not None and identity is not None:
             if is_local_endpoint(self.server_args.scheduler_endpoint):
+                # Offline scheduler/client traffic is usually same-host.  For large
+                # returned frame arrays, replace inline numpy payloads with local
+                # file refs before pickle so ZMQ only carries response metadata.
                 start_time = time.perf_counter()
                 output_batch.output = spill_large_arrays_to_file_refs(
                     output_batch.output
@@ -623,6 +626,8 @@ class Scheduler(SchedulerDisaggMixin):
                         time.perf_counter() - start_time,
                     )
 
+            # Keep pickle/send timing visible in request metrics; these used to be
+            # hidden client-side overhead when returning decoded video frames.
             start_time = time.perf_counter()
             payload = pickle.dumps(output_batch)
             if output_batch.metrics is not None:

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -35,6 +35,10 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
     ShutdownReq,
     UnmergeLoraWeightsReq,
 )
+from sglang.multimodal_gen.runtime.ipc_array import (
+    is_local_endpoint,
+    spill_large_arrays_to_file_refs,
+)
 from sglang.multimodal_gen.runtime.managers.cpu_worker import CPUWorker
 from sglang.multimodal_gen.runtime.managers.dynamic_batch_admission import (
     BatchAdmissionController,
@@ -608,7 +612,32 @@ class Scheduler(SchedulerDisaggMixin):
         replies to client, only on rank 0
         """
         if not is_warmup and self.receiver is not None and identity is not None:
-            self.receiver.send_multipart([identity, b"", pickle.dumps(output_batch)])
+            if is_local_endpoint(self.server_args.scheduler_endpoint):
+                start_time = time.perf_counter()
+                output_batch.output = spill_large_arrays_to_file_refs(
+                    output_batch.output
+                )
+                if output_batch.metrics is not None:
+                    output_batch.metrics.record_stage(
+                        "Scheduler.return_result.spill_arrays",
+                        time.perf_counter() - start_time,
+                    )
+
+            start_time = time.perf_counter()
+            payload = pickle.dumps(output_batch)
+            if output_batch.metrics is not None:
+                output_batch.metrics.record_stage(
+                    "Scheduler.return_result.pickle",
+                    time.perf_counter() - start_time,
+                )
+
+            start_time = time.perf_counter()
+            self.receiver.send_multipart([identity, b"", payload])
+            if output_batch.metrics is not None:
+                output_batch.metrics.record_stage(
+                    "Scheduler.return_result.send",
+                    time.perf_counter() - start_time,
+                )
 
     def _try_merge_generation_reqs(self, reqs: List[Req]) -> Req | None:
         """Create a batched generation request from compatible requests.

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,9 +613,7 @@ class Scheduler(SchedulerDisaggMixin):
         """
         if not is_warmup and self.receiver is not None and identity is not None:
             if is_local_endpoint(self.server_args.scheduler_endpoint):
-                # Offline scheduler/client traffic is usually same-host.  For large
-                # returned frame arrays, replace inline numpy payloads with local
-                # file refs before pickle so ZMQ only carries response metadata.
+                # Same-host clients can receive large frame arrays as file refs.
                 start_time = time.perf_counter()
                 output_batch.output = spill_large_arrays_to_file_refs(
                     output_batch.output
@@ -626,8 +624,6 @@ class Scheduler(SchedulerDisaggMixin):
                         time.perf_counter() - start_time,
                     )
 
-            # Keep pickle/send timing visible in request metrics; these used to be
-            # hidden client-side overhead when returning decoded video frames.
             start_time = time.perf_counter()
             payload = pickle.dumps(output_batch)
             if output_batch.metrics is not None:

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -613,7 +613,7 @@ class Scheduler(SchedulerDisaggMixin):
         replies to client, only on rank 0
         """
         if not is_warmup and self.receiver is not None and identity is not None:
-            # if the server is local, use temp file to spill the frame array instead of leaving it in OutputBatch to be picked later
+            # if the server is local, use temp file to spill the frame array instead of leaving it in OutputBatch to be pickled later
             if is_local_endpoint(self.server_args.scheduler_endpoint):
                 with self._record_return_stage(
                     output_batch, "Scheduler.return_result.spill_arrays"

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -8,9 +8,10 @@ import pickle
 import tempfile
 import time
 from collections import deque
+from contextlib import contextmanager
 from copy import deepcopy
 from enum import Enum
-from typing import Any, List
+from typing import Any, Iterator, List
 
 import zmq
 
@@ -613,31 +614,31 @@ class Scheduler(SchedulerDisaggMixin):
         """
         if not is_warmup and self.receiver is not None and identity is not None:
             if is_local_endpoint(self.server_args.scheduler_endpoint):
-                start_time = time.perf_counter()
-                output_batch.output = spill_large_arrays_to_file_refs(
-                    output_batch.output
-                )
-                if output_batch.metrics is not None:
-                    output_batch.metrics.record_stage(
-                        "Scheduler.return_result.spill_arrays",
-                        time.perf_counter() - start_time,
+                with self._record_return_stage(
+                    output_batch, "Scheduler.return_result.spill_arrays"
+                ):
+                    output_batch.output = spill_large_arrays_to_file_refs(
+                        output_batch.output
                     )
 
-            start_time = time.perf_counter()
-            payload = pickle.dumps(output_batch)
-            if output_batch.metrics is not None:
-                output_batch.metrics.record_stage(
-                    "Scheduler.return_result.pickle",
-                    time.perf_counter() - start_time,
-                )
+            with self._record_return_stage(
+                output_batch, "Scheduler.return_result.pickle"
+            ):
+                payload = pickle.dumps(output_batch)
 
-            start_time = time.perf_counter()
-            self.receiver.send_multipart([identity, b"", payload])
-            if output_batch.metrics is not None:
-                output_batch.metrics.record_stage(
-                    "Scheduler.return_result.send",
-                    time.perf_counter() - start_time,
-                )
+            with self._record_return_stage(output_batch, "Scheduler.return_result.send"):
+                self.receiver.send_multipart([identity, b"", payload])
+
+    @contextmanager
+    def _record_return_stage(
+        self, output_batch: OutputBatch, stage_name: str
+    ) -> Iterator[None]:
+        start_time = time.perf_counter()
+        yield
+        if output_batch.metrics is not None:
+            output_batch.metrics.record_stage(
+                stage_name, time.perf_counter() - start_time
+            )
 
     def _try_merge_generation_reqs(self, reqs: List[Req]) -> Req | None:
         """Create a batched generation request from compatible requests.

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -626,7 +626,9 @@ class Scheduler(SchedulerDisaggMixin):
             ):
                 payload = pickle.dumps(output_batch)
 
-            with self._record_return_stage(output_batch, "Scheduler.return_result.send"):
+            with self._record_return_stage(
+                output_batch, "Scheduler.return_result.send"
+            ):
                 self.receiver.send_multipart([identity, b"", payload])
 
     @contextmanager

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -383,7 +383,7 @@ class OutputBatch:
     Final output (after pipeline completion)
     """
 
-    output: torch.Tensor | None = None
+    output: Any | None = None
     audio: torch.Tensor | None = None
     audio_sample_rate: int | None = None
     trajectory_timesteps: torch.Tensor | None = None

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -1,9 +1,12 @@
 import pickle
+import time
 from typing import Any
 
 import zmq
 import zmq.asyncio
 
+from sglang.multimodal_gen.runtime.ipc_array import materialize_file_refs
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -80,6 +83,7 @@ class SchedulerClient:
         try:
             self.scheduler_socket.send_pyobj(batch)
             output_batch = self.scheduler_socket.recv_pyobj()
+            _materialize_output_batch_file_refs(output_batch)
             return output_batch
         except zmq.error.Again:
             logger.error("Timeout waiting for response from scheduler.")
@@ -162,7 +166,9 @@ class AsyncSchedulerClient:
         try:
             await socket.send(pickle.dumps(batch))
             payload = await socket.recv()
-            return pickle.loads(payload)
+            output_batch = pickle.loads(payload)
+            _materialize_output_batch_file_refs(output_batch)
+            return output_batch
         except zmq.error.Again:
             logger.error("Timeout waiting for response from scheduler.")
             raise TimeoutError("Scheduler did not respond in time.")
@@ -203,3 +209,16 @@ class AsyncSchedulerClient:
 # Singleton instances for easy access
 async_scheduler_client = AsyncSchedulerClient()
 sync_scheduler_client = SchedulerClient()
+
+
+def _materialize_output_batch_file_refs(output_batch: Any) -> None:
+    if not isinstance(output_batch, OutputBatch):
+        return
+
+    start_time = time.perf_counter()
+    output_batch.output = materialize_file_refs(output_batch.output)
+    if output_batch.metrics is not None:
+        output_batch.metrics.record_stage(
+            "SchedulerClient.materialize_file_refs",
+            time.perf_counter() - start_time,
+        )

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -215,7 +215,6 @@ def _materialize_output_batch_file_refs(output_batch: Any) -> None:
     if not isinstance(output_batch, OutputBatch):
         return
 
-    # Materialize at the first client boundary; file refs unlink themselves.
     start_time = time.perf_counter()
     output_batch.output = materialize_file_refs(output_batch.output)
     if output_batch.metrics is not None:

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -215,9 +215,7 @@ def _materialize_output_batch_file_refs(output_batch: Any) -> None:
     if not isinstance(output_batch, OutputBatch):
         return
 
-    # Materialization happens at the first scheduler client boundary.  The file
-    # ref unlinks itself after np.load, so downstream code receives ordinary
-    # numpy arrays and does not need to understand the transport detail.
+    # Materialize at the first client boundary; file refs unlink themselves.
     start_time = time.perf_counter()
     output_batch.output = materialize_file_refs(output_batch.output)
     if output_batch.metrics is not None:

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -215,6 +215,9 @@ def _materialize_output_batch_file_refs(output_batch: Any) -> None:
     if not isinstance(output_batch, OutputBatch):
         return
 
+    # Materialization happens at the first scheduler client boundary.  The file
+    # ref unlinks itself after np.load, so downstream code receives ordinary
+    # numpy arrays and does not need to understand the transport detail.
     start_time = time.perf_counter()
     output_batch.output = materialize_file_refs(output_batch.output)
     if output_batch.metrics is not None:

--- a/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
+++ b/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import numpy as np
+
+from sglang.multimodal_gen.runtime.ipc_array import (
+    NumpyArrayFileRef,
+    is_local_endpoint,
+    materialize_file_refs,
+    spill_large_arrays_to_file_refs,
+)
+
+
+def test_spill_large_arrays_round_trips_and_removes_file():
+    array = np.arange(1024 * 1024, dtype=np.uint8).reshape(1024, 1024)
+
+    spilled = spill_large_arrays_to_file_refs([array])
+
+    assert isinstance(spilled[0], NumpyArrayFileRef)
+    spilled_path = Path(spilled[0].path)
+    assert spilled_path.exists()
+
+    materialized = materialize_file_refs(spilled)
+
+    assert np.array_equal(materialized[0], array)
+    assert not spilled_path.exists()
+
+
+def test_small_arrays_are_kept_inline():
+    array = np.arange(16, dtype=np.uint8)
+
+    spilled = spill_large_arrays_to_file_refs((array,))
+
+    assert spilled[0] is array
+
+
+def test_local_endpoint_detection():
+    assert is_local_endpoint("tcp://127.0.0.1:30000")
+    assert is_local_endpoint("tcp://localhost:30000")
+    assert is_local_endpoint("ipc:///tmp/sgl.sock")
+    assert is_local_endpoint("inproc://scheduler")
+    assert not is_local_endpoint("tcp://10.0.0.2:30000")

--- a/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
+++ b/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import tempfile
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from sglang.multimodal_gen.runtime.ipc_array import (
     NumpyArrayFileRef,
@@ -33,6 +35,30 @@ def test_small_arrays_are_kept_inline():
     spilled = spill_large_arrays_to_file_refs((array,))
 
     assert spilled[0] is array
+
+
+def test_spill_removes_temp_file_when_save_fails(monkeypatch):
+    array = np.arange(1024 * 1024, dtype=np.uint8).reshape(1024, 1024)
+    created_paths = []
+
+    def fail_save(*args, **kwargs):
+        raise OSError("simulated write failure")
+
+    original_mkstemp = tempfile.mkstemp
+
+    def tracked_mkstemp(*args, **kwargs):
+        fd, path = original_mkstemp(*args, **kwargs)
+        created_paths.append(Path(path))
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(np, "save", fail_save)
+
+    with pytest.raises(OSError, match="simulated write failure"):
+        spill_large_arrays_to_file_refs(array)
+
+    assert created_paths
+    assert not created_paths[0].exists()
 
 
 def test_local_endpoint_detection():

--- a/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
+++ b/python/sglang/multimodal_gen/test/unit/test_ipc_array.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from sglang.multimodal_gen.runtime import ipc_array
 from sglang.multimodal_gen.runtime.ipc_array import (
     NumpyArrayFileRef,
     is_local_endpoint,
@@ -14,8 +15,9 @@ from sglang.multimodal_gen.runtime.ipc_array import (
 )
 
 
-def test_spill_large_arrays_round_trips_and_removes_file():
-    array = np.arange(1024 * 1024, dtype=np.uint8).reshape(1024, 1024)
+def test_spill_large_arrays_round_trips_and_removes_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(ipc_array, "_array_ipc_dir", lambda: str(tmp_path))
+    array = np.arange(ipc_array._MIN_FILE_REF_BYTES, dtype=np.uint8)
 
     spilled = spill_large_arrays_to_file_refs([array])
 
@@ -37,8 +39,18 @@ def test_small_arrays_are_kept_inline():
     assert spilled[0] is array
 
 
-def test_spill_removes_temp_file_when_save_fails(monkeypatch):
-    array = np.arange(1024 * 1024, dtype=np.uint8).reshape(1024, 1024)
+def test_large_arrays_are_kept_inline_without_shm(monkeypatch):
+    monkeypatch.setattr(ipc_array, "_array_ipc_dir", lambda: None)
+    array = np.arange(ipc_array._MIN_FILE_REF_BYTES, dtype=np.uint8)
+
+    spilled = spill_large_arrays_to_file_refs(array)
+
+    assert spilled is array
+
+
+def test_spill_removes_temp_file_when_save_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(ipc_array, "_array_ipc_dir", lambda: str(tmp_path))
+    array = np.arange(ipc_array._MIN_FILE_REF_BYTES, dtype=np.uint8)
     created_paths = []
 
     def fail_save(*args, **kwargs):


### PR DESCRIPTION
## Summary
- materialize diffusion `return_frames` outputs to uint8 numpy frames inside the rank-0 GPU worker before returning them to the offline client
- spill large local numpy frame arrays to temporary file refs before scheduler/client ZMQ pickling, then materialize and unlink them on the client side
- widen `OutputBatch.output` typing and add CPU-only coverage for the array IPC helper

## Why
Wan2.2 TI2V profiling showed a large gap between worker execution time and offline `generate()` wall time. The dominant overhead was returning generated frame tensors through pickle/ZMQ rather than the model forward path.

## Validation
- Prior remote H200/no-cache Wan2.2 TI2V benchmark with this return path: README literal size `576x768` SGLD `2.059s` vs vLLM-Omni `2.505s`; Wan official auto-size `800x1088` SGLD `3.761s` vs vLLM-Omni `5.100s`. The earlier unoptimized SGLD profile showed `outer ~4.421s`, worker `~3.093s`, with about `1.305s` in the scheduler/client return path.