### PR TITLE
fix: support more EAGLE-3 models

### DIFF
--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -50,9 +50,15 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
     ) -> None:
         super().__init__(config, layer_id, quant_config, prefix)
 
+        # EAGLE3's first layer concatenates input embeddings with hidden states, but
+        # inner layers don't need input embeddings, so only the first layer needs to
+        # adjust the qkv projection dimensions.
+        hidden_size = 2 * self.hidden_size if layer_id == 0 else self.hidden_size
+        self.layer_id = layer_id
+
         # override qkv
         self.self_attn.qkv_proj = QKVParallelLinear(
-            2 * self.hidden_size,
+            hidden_size,
             self.self_attn.head_dim,
             self.self_attn.total_num_heads,
             self.self_attn.total_num_kv_heads,
@@ -81,11 +87,16 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         residual: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
 
-        residual = hidden_states
-        embeds = self.input_layernorm(embeds)
-        hidden_states = self.hidden_norm(hidden_states)
+        if self.layer_id == 0:
+            # Layer 0 receives target-model hidden states; no carried residual to fuse.
+            residual = hidden_states
+            hidden_states = self.hidden_norm(hidden_states)
+            embeds = self.input_layernorm(embeds)
+            hidden_states = torch.cat([embeds, hidden_states], dim=-1)
+        else:
+            # Fuse the previous layer's MLP residual add into hidden_norm.
+            hidden_states, residual = self.hidden_norm(hidden_states, residual)
 
-        hidden_states = torch.cat([embeds, hidden_states], dim=-1)
         # Self Attention
         hidden_states = self.self_attn(
             positions=positions,
@@ -135,15 +146,43 @@ class LlamaModel(nn.Module):
         else:
             self.hidden_size_in = config.hidden_size
 
+        # EAGLE-3 uses 3 auxiliary hidden states (low, mid, high) by default.
+        num_aux_hidden_states = 3
+        eagle_config = getattr(config, "eagle_config", None)
+        if eagle_config:
+            ids = eagle_config.get("eagle_aux_hidden_state_layer_ids", None)
+            if ids:
+                num_aux_hidden_states = len(ids)
+
+        self.num_aux_hidden_states = getattr(
+            config, "num_aux_hidden_states", num_aux_hidden_states
+        )
+
         self.fc = torch.nn.Linear(
-            self.hidden_size_in * 3,
+            self.hidden_size_in * self.num_aux_hidden_states,
             config.hidden_size,
             bias=getattr(config, "bias", False),
         )
 
-        self.midlayer = LlamaDecoderLayer(config, 0, quant_config, prefix)
+        if getattr(config, "fc_norm", False):
+            self.fc_norm = nn.ModuleList(
+                [
+                    RMSNorm(self.hidden_size_in, eps=config.rms_norm_eps)
+                    for _ in range(self.num_aux_hidden_states)
+                ]
+            )
+        else:
+            self.fc_norm = None
+
+        self.layers = nn.ModuleList(
+            [
+                LlamaDecoderLayer(config, i, quant_config, prefix)
+                for i in range(config.num_hidden_layers)
+            ]
+        )
 
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm_output = getattr(config, "norm_output", False)
 
     def forward(
         self,
@@ -174,6 +213,12 @@ class LlamaModel(nn.Module):
 
         hidden_states = forward_batch.spec_info.hidden_states
         if hidden_states.shape[-1] != embeds.shape[-1]:
+            if self.fc_norm is not None:
+                chunks = hidden_states.chunk(self.num_aux_hidden_states, dim=-1)
+                hidden_states = torch.cat(
+                    [norm(chunk) for norm, chunk in zip(self.fc_norm, chunks)],
+                    dim=-1,
+                )
             hidden_states = self.fc(hidden_states)
 
         # idle batch
@@ -181,20 +226,24 @@ class LlamaModel(nn.Module):
             return hidden_states, [hidden_states]
 
         residual = None
-        hidden_states, residual = self.midlayer(
-            positions,
-            embeds,
-            hidden_states,
-            forward_batch,
-            residual,
-        )
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions,
+                embeds,
+                hidden_states,
+                forward_batch,
+                residual,
+            )
 
         hidden_states_to_logits, hidden_states_to_aux = self.norm(
             hidden_states, residual
         )
 
-        # For draft decode, we capture the hidden state before norm
-        return hidden_states_to_logits, [hidden_states_to_aux]
+        # For draft decode, we capture the hidden state before norm, but some models might prefer normed hidden states
+        draft_decode = (
+            [hidden_states] if not self.norm_output else [hidden_states_to_logits]
+        )
+        return hidden_states_to_logits, draft_decode
 
 
 class LlamaForCausalLMEagle3(LlamaForCausalLM):
@@ -208,9 +257,6 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
         self.config = config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
-
-        if self.config.num_hidden_layers != 1:
-            raise ValueError("EAGLE3 currently only supports 1 layer")
 
         self.model = LlamaModel(
             config, quant_config=quant_config, prefix=add_prefix("model", prefix)
@@ -253,6 +299,9 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
         ]
 
         for name, loaded_weight in weights:
+            if "midlayer" in name:
+                name = name.replace("midlayer", "layers.0")
+
             if "d2t" in name:
                 # d2t stores diffs between draft id and target id
                 self.hot_token_id = loaded_weight + torch.arange(loaded_weight.shape[0])

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -139,11 +139,13 @@ class EAGLEDraftExtendCudaGraphRunner:
                 hf_config = self.model_runner.model_config.hf_config
                 eagle_config = getattr(hf_config, "eagle_config", None) or {}
                 # EAGLE-3 uses 3 aux hidden states by default
-                num_aux = len(
-                    eagle_config.get(
-                        "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                num_aux = getattr(hf_config, "num_aux_hidden_states", None)
+                if num_aux is None:
+                    num_aux = len(
+                        eagle_config.get(
+                            "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                        )
                     )
-                )
                 target_hidden = (
                     hf_config.target_hidden_size
                     if hasattr(hf_config, "target_hidden_size")

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -136,19 +136,21 @@ class EAGLEDraftExtendCudaGraphRunner:
                 self.eagle_worker.speculative_algorithm.is_eagle3()
                 and self.eagle_worker.eagle_use_aux_hidden_state
             ):
+                hf_config = self.model_runner.model_config.hf_config
+                eagle_config = getattr(hf_config, "eagle_config", None) or {}
+                # EAGLE-3 uses 3 aux hidden states by default
+                num_aux = len(
+                    eagle_config.get(
+                        "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                    )
+                )
+                target_hidden = (
+                    hf_config.target_hidden_size
+                    if hasattr(hf_config, "target_hidden_size")
+                    else self.model_runner.model_config.hidden_size
+                )
                 hidden_states = torch.zeros(
-                    (
-                        self.max_num_token,
-                        (
-                            self.model_runner.model_config.hf_config.target_hidden_size
-                            * 3
-                            if hasattr(
-                                self.model_runner.model_config.hf_config,
-                                "target_hidden_size",
-                            )
-                            else self.model_runner.model_config.hidden_size * 3
-                        ),
-                    ),
+                    (self.max_num_token, target_hidden * num_aux),
                     dtype=self.model_runner.dtype,
                 )
             else:

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1120,12 +1120,21 @@ class EAGLEWorker(TpModelWorker):
                 eagle_config = (
                     getattr(self.model_config.hf_config, "eagle_config", None) or {}
                 )
-                num_aux = len(
-                    eagle_config.get(
-                        "eagle_aux_hidden_state_layer_ids", [None, None, None]
-                    )
+                num_aux = getattr(
+                    self.model_config.hf_config, "num_aux_hidden_states", None
                 )
-                hidden_size = self.model_config.hidden_size * num_aux
+                if num_aux is None:
+                    num_aux = len(
+                        eagle_config.get(
+                            "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                        )
+                    )
+                target_hidden = getattr(
+                    self.model_config.hf_config,
+                    "target_hidden_size",
+                    self.model_config.hidden_size,
+                )
+                hidden_size = target_hidden * num_aux
             else:
                 hidden_size = self.model_config.spec_hidden_size
             batch.spec_info = EagleDraftInput.create_idle_input(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1113,12 +1113,21 @@ class EAGLEWorker(TpModelWorker):
         if not input_is_idle and batch.spec_info.verified_id.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
-            hidden_size = (
-                self.model_config.hidden_size * 3
-                if self.speculative_algorithm.is_eagle3()
+            if (
+                self.speculative_algorithm.is_eagle3()
                 and self.eagle_use_aux_hidden_state
-                else self.model_config.spec_hidden_size
-            )
+            ):
+                eagle_config = (
+                    getattr(self.model_config.hf_config, "eagle_config", None) or {}
+                )
+                num_aux = len(
+                    eagle_config.get(
+                        "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                    )
+                )
+                hidden_size = self.model_config.hidden_size * num_aux
+            else:
+                hidden_size = self.model_config.spec_hidden_size
             batch.spec_info = EagleDraftInput.create_idle_input(
                 device=self.device,
                 hidden_size=hidden_size,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -671,12 +671,21 @@ class MultiLayerEagleWorker(TpModelWorker):
                 eagle_config = (
                     getattr(self.model_config.hf_config, "eagle_config", None) or {}
                 )
-                num_aux = len(
-                    eagle_config.get(
-                        "eagle_aux_hidden_state_layer_ids", [None, None, None]
-                    )
+                num_aux = getattr(
+                    self.model_config.hf_config, "num_aux_hidden_states", None
                 )
-                hidden_size = self.model_config.hidden_size * num_aux
+                if num_aux is None:
+                    num_aux = len(
+                        eagle_config.get(
+                            "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                        )
+                    )
+                target_hidden = getattr(
+                    self.model_config.hf_config,
+                    "target_hidden_size",
+                    self.model_config.hidden_size,
+                )
+                hidden_size = target_hidden * num_aux
             else:
                 hidden_size = self.model_config.hidden_size
             batch.spec_info = EagleDraftInput.create_idle_input(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -667,11 +667,18 @@ class MultiLayerEagleWorker(TpModelWorker):
         if not input_is_idle and batch.spec_info.verified_id.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
-            hidden_size = (
-                self.model_config.hidden_size * 3
-                if self.speculative_algorithm.is_eagle3()
-                else self.model_config.hidden_size
-            )
+            if self.speculative_algorithm.is_eagle3():
+                eagle_config = (
+                    getattr(self.model_config.hf_config, "eagle_config", None) or {}
+                )
+                num_aux = len(
+                    eagle_config.get(
+                        "eagle_aux_hidden_state_layer_ids", [None, None, None]
+                    )
+                )
+                hidden_size = self.model_config.hidden_size * num_aux
+            else:
+                hidden_size = self.model_config.hidden_size
             batch.spec_info = EagleDraftInput.create_idle_input(
                 device=self.device,
                 hidden_size=hidden_size,


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

We will have a paper-release soon and we would like our models to have day-0 support with the paper/model release. 

We will release checkpoints for gpt-oss-20b and gpt-oss-120b.

## Modifications

1) Multi-layer EAGLE-3: backwards compatible as we rename midlayer -> layers.0, this gives flexibility for users to run more models including vLLM supported ones.

2) Alternate norm positioning: this is about our upcoming paper release and new models.

3) Support EAGLE-3 backbones that take other than 3 aux hidden states: current models only use 3 hidden states but our models benefit from more hidden states.

## Accuracy Tests, Speed Tests and Profiling

Hardware GH200, VRAM 96 GB, vCPU: 64, RAM: 432 GiB hosted on lambda.ai

### MT-Bench Results (temperature=0.7, batch_size=1, depth=5, topk=1, max_tokens=6)

| Metric | Current (`zhuyksir/EAGLE3-gpt-oss-20b-bf16`) | New (ours) | Δ |
|---|---:|---:|---:|
| **Latency (s)** | 624.09 | **384.67** | −38.4% |
| **Throughput (tok/s)** | 224.53 | **365.15** | +62.6% |
| **Accept Length** | 1.547 | **2.646** | +71.1% |

### Per-Category Breakdown

| Category | Throughput (Old → New) | Δ | Accept Length (Old → New) | Δ |
|---|---:|---:|---:|---:|
| Writing | 163.58 → 292.93 | +79.1% | 1.483 → 2.534 | +70.9% |
| Roleplay | 258.29 → 390.37 | +51.1% | 1.504 → 2.502 | +66.4% |
| Reasoning | 173.00 → 281.20 | +62.5% | 1.557 → 2.593 | +66.5% |
| Math | 109.97 → 172.41 | +56.8% | 1.912 → **3.714** | **+94.2%** |
| Coding | 298.31 → 509.22 | +70.7% | 1.668 → 3.015 | +80.8% |
| Extraction | 134.42 → 263.02 | **+95.7%** | 1.570 → 2.999 | +91.0% |
| STEM | 321.15 → 494.25 | +53.9% | 1.486 → 2.468 | +66.1% |
| Humanities | 337.52 → 517.79 | +53.4% | 1.468 → 2.345 | +59.7% |


### vs. D-Flash

depth=5 seems to be the sweet-spot for GPT-oss for both models.

| Metric | d-flash | Ours | Δ |
|---|---:|---:|---:|
| **Latency (s)** | 501.69 | **384.67** | −23.3% |
| **Throughput (tok/s)** | 287.67 | **365.15** | +26.9% |
| **Accept Length** | 2.622 | **2.646** | +0.9% |

Accept length is essentially tied, but ours is meaningfully faster, ~27% higher throughput at the same draft quality.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
