### PR TITLE
Fix short standalone DeepSeek-VL2 image embeddings

### DIFF
--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -155,6 +155,30 @@ class DeepseekVL2MlpProjector(nn.Module):
         return x
 
 
+def _init_vision_module(
+    vision_config, quant_config: Optional[QuantizationConfig]
+) -> nn.Module:
+    # Module-level helper so the vision tower can be constructed standalone
+    # (outside an Engine). Useful for tests + workflows that pre-compute image
+    # features and feed them via the PRECOMPUTED_EMBEDDING input format.
+    # TODO: refactor vision model through timm wrapper from transformers
+    try:
+        import timm
+    except ImportError:
+        raise ImportError("Please install timm") from ImportError
+
+    model = timm.create_model(
+        "vit_so400m_patch14_siglip_384.webli",
+        pretrained=False,
+        num_classes=0,
+        dynamic_img_size=True,
+        dynamic_img_pad=True,
+    )
+
+    model = model.to(dtype=torch.get_default_dtype())
+    return model
+
+
 class DeepseekVL2ForCausalLM(nn.Module):
 
     def __init__(
@@ -166,7 +190,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
 
         # ----------- vision encoder ------------
         vision_config = config.vision_config
-        self.vision = self._init_vision_module(vision_config, quant_config)
+        self.vision = _init_vision_module(vision_config, quant_config)
 
         # ----------- vl projector ------------
         projector_config = config.projector_config
@@ -195,26 +219,6 @@ class DeepseekVL2ForCausalLM(nn.Module):
         else:
             # deepseek-vl2-tiny forbids mla
             self.language_model = DeepseekForCausalLM(language_config)
-
-    def _init_vision_module(
-        self, vision_config, quant_config: Optional[QuantizationConfig]
-    ) -> nn.Module:
-        # TODO: refactor vision model through timm wrapper from transformers
-        try:
-            import timm
-        except ImportError:
-            raise ImportError("Please install timm") from ImportError
-
-        model = timm.create_model(
-            "vit_so400m_patch14_siglip_384.webli",
-            pretrained=False,
-            num_classes=0,
-            dynamic_img_size=True,
-            dynamic_img_pad=True,
-        )
-
-        model = model.to(dtype=torch.get_default_dtype())
-        return model
 
     def forward(
         self,
@@ -257,22 +261,31 @@ class DeepseekVL2ForCausalLM(nn.Module):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
-    def get_image_feature(self, items: List[MultimodalDataItem]):
+    @staticmethod
+    def build_image_features(
+        items: List[MultimodalDataItem],
+        vision: nn.Module,
+        projector: nn.Module,
+        image_newline: torch.Tensor,
+        view_seperator: torch.Tensor,
+        global_view_pos: str = "head",
+    ) -> torch.Tensor:
+        """Build per-tile image features for the language model.
 
-        images_spatial_crop = torch.cat(
-            [item.images_spatial_crop for item in items], dim=0
-        )
-
-        assert images_spatial_crop.dim() == 3
-
+        Factored out of ``get_image_feature`` so callers that need to pre-compute
+        image embeddings outside the engine — e.g. RL workflows, KV-cache reuse,
+        and standalone tests — can produce the exact embeddings the engine
+        produces and feed them back via the ``PRECOMPUTED_EMBEDDING`` input
+        format.
+        """
         # TODO: can it be batched ?
         images_in_this_batch = []
         for item in items:
             assert item.feature.dim() == 4
-            image_feature = self.vision.forward_features(
-                item.feature.type(next(self.vision.parameters()).dtype)
+            image_feature = vision.forward_features(
+                item.feature.type(next(vision.parameters()).dtype)
             )
-            images_embeds = self.projector(image_feature)
+            images_embeds = projector(image_feature)
             _, hw, n_dim = images_embeds.shape
             h = w = int(hw**0.5)
             tile_index = 0
@@ -297,7 +310,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 global_features = global_features.view(h, w, n_dim)
 
                 # [D]     -> [h, 1, D]
-                new_lines_in_global = repeat(self.image_newline, "d -> h 1 d", h=h)
+                new_lines_in_global = repeat(image_newline, "d -> h 1 d", h=h)
 
                 # cat([h, w, D], [h, 1, D], dim=1) -> [h, w + 1, D]
                 global_features = torch.cat(
@@ -321,7 +334,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
 
                 # [D] -> [num_height_tiles * h, 1, D]
                 new_lines_in_local = repeat(
-                    self.image_newline,
+                    image_newline,
                     "d -> (th h) 1 d",
                     th=num_height_tiles,
                     h=h,
@@ -335,11 +348,11 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 local_features = local_features.view(-1, n_dim)
 
                 # merge global and local tiles
-                if self.global_view_pos == "head":
+                if global_view_pos == "head":
                     global_local_features = torch.cat(
                         [
                             global_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             local_features,
                         ]
                     )
@@ -347,7 +360,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                     global_local_features = torch.cat(
                         [
                             local_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             global_features,
                         ]
                     )
@@ -355,6 +368,23 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 images_in_this_batch.append(global_local_features)
 
         return torch.cat(images_in_this_batch, dim=0)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]):
+
+        images_spatial_crop = torch.cat(
+            [item.images_spatial_crop for item in items], dim=0
+        )
+
+        assert images_spatial_crop.dim() == 3
+
+        return self.build_image_features(
+            items,
+            self.vision,
+            self.projector,
+            self.image_newline,
+            self.view_seperator,
+            self.global_view_pos,
+        )
 
 
 EntryClass = DeepseekVL2ForCausalLM

--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -8,6 +8,7 @@ from torch import nn
 from sglang.srt.configs.deepseekvl2 import (
     DeepseekVL2Config,
     DeepseekVL2MlpProjectorConfig,
+    DeepseekVL2VisionEncoderConfig,
 )
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -206,8 +207,10 @@ class DeepseekVL2ForCausalLM(nn.Module):
             # deepseek-vl2-tiny forbids mla
             self.language_model = DeepseekForCausalLM(language_config)
 
+    @staticmethod
     def _init_vision_module(
-        self, vision_config, quant_config: Optional[QuantizationConfig]
+        vision_config: DeepseekVL2VisionEncoderConfig,
+        quant_config: Optional[QuantizationConfig],
     ) -> nn.Module:
         # TODO: refactor vision model through timm wrapper from transformers
         try:
@@ -267,22 +270,24 @@ class DeepseekVL2ForCausalLM(nn.Module):
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
-    def get_image_feature(self, items: List[MultimodalDataItem]):
-
-        images_spatial_crop = torch.cat(
-            [item.images_spatial_crop for item in items], dim=0
-        )
-
-        assert images_spatial_crop.dim() == 3
-
+    @staticmethod
+    def build_image_features(
+        items: List[MultimodalDataItem],
+        vision: nn.Module,
+        projector: nn.Module,
+        image_newline: torch.Tensor,
+        view_seperator: torch.Tensor,
+        global_view_pos: str,
+    ) -> torch.Tensor:
+        """Build the final image features expected by the language model."""
         # TODO: can it be batched ?
         images_in_this_batch = []
         for item in items:
             assert item.feature.dim() == 4
-            image_feature = self.vision.forward_features(
-                item.feature.type(next(self.vision.parameters()).dtype)
+            image_feature = vision.forward_features(
+                item.feature.type(next(vision.parameters()).dtype)
             )
-            images_embeds = self.projector(image_feature)
+            images_embeds = projector(image_feature)
             _, hw, n_dim = images_embeds.shape
             h = w = int(hw**0.5)
             tile_index = 0
@@ -307,7 +312,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 global_features = global_features.view(h, w, n_dim)
 
                 # [D]     -> [h, 1, D]
-                new_lines_in_global = repeat(self.image_newline, "d -> h 1 d", h=h)
+                new_lines_in_global = repeat(image_newline, "d -> h 1 d", h=h)
 
                 # cat([h, w, D], [h, 1, D], dim=1) -> [h, w + 1, D]
                 global_features = torch.cat(
@@ -331,7 +336,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
 
                 # [D] -> [num_height_tiles * h, 1, D]
                 new_lines_in_local = repeat(
-                    self.image_newline,
+                    image_newline,
                     "d -> (th h) 1 d",
                     th=num_height_tiles,
                     h=h,
@@ -345,11 +350,11 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 local_features = local_features.view(-1, n_dim)
 
                 # merge global and local tiles
-                if self.global_view_pos == "head":
+                if global_view_pos == "head":
                     global_local_features = torch.cat(
                         [
                             global_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             local_features,
                         ]
                     )
@@ -357,7 +362,7 @@ class DeepseekVL2ForCausalLM(nn.Module):
                     global_local_features = torch.cat(
                         [
                             local_features,
-                            self.view_seperator[None, :],
+                            view_seperator[None, :],
                             global_features,
                         ]
                     )
@@ -365,6 +370,23 @@ class DeepseekVL2ForCausalLM(nn.Module):
                 images_in_this_batch.append(global_local_features)
 
         return torch.cat(images_in_this_batch, dim=0)
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+
+        images_spatial_crop = torch.cat(
+            [item.images_spatial_crop for item in items], dim=0
+        )
+
+        assert images_spatial_crop.dim() == 3
+
+        return self.build_image_features(
+            items=items,
+            vision=self.vision,
+            projector=self.projector,
+            image_newline=self.image_newline,
+            view_seperator=self.view_seperator,
+            global_view_pos=self.global_view_pos,
+        )
 
 
 EntryClass = DeepseekVL2ForCausalLM

--- a/test/registered/unit/models/test_deepseek_vl2.py
+++ b/test/registered/unit/models/test_deepseek_vl2.py
@@ -1,0 +1,57 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from sglang.srt.models.deepseek_vl2 import DeepseekVL2ForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _VisionStub(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dtype_anchor = nn.Parameter(torch.zeros(()), requires_grad=False)
+
+    def forward_features(self, features: torch.Tensor) -> torch.Tensor:
+        return features.flatten(start_dim=2) + 1
+
+
+class _ProjectorStub(nn.Module):
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return features * 10
+
+
+class TestDeepseekVL2ImageFeatures(CustomTestCase):
+    def test_global_and_local_views_keep_layout_tokens_in_order(self) -> None:
+        item = SimpleNamespace(
+            feature=torch.arange(3, dtype=torch.float32).reshape(3, 1, 1, 1),
+            images_spatial_crop=torch.tensor([[[2, 1]]]),
+        )
+        expected_by_global_view_pos = {
+            "head": [10, -1, -2, 20, 30, -1],
+            "tail": [20, 30, -1, -2, 10, -1],
+        }
+
+        for global_view_pos, expected in expected_by_global_view_pos.items():
+            with self.subTest(global_view_pos=global_view_pos):
+                image_features = DeepseekVL2ForCausalLM.build_image_features(
+                    items=[item],
+                    vision=_VisionStub(),
+                    projector=_ProjectorStub(),
+                    image_newline=torch.tensor([-1.0]),
+                    view_seperator=torch.tensor([-2.0]),
+                    global_view_pos=global_view_pos,
+                )
+
+                torch.testing.assert_close(
+                    image_features,
+                    torch.tensor(expected, dtype=torch.float32).unsqueeze(1),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Standalone DeepSeek-VL2 preprocessing can run the vision tower and projector, but it cannot reproduce the final feature sequence consumed by the language model. Row newlines and the global/local separator are assembled inside the model instance, so precomputed embeddings can be 72 tokens short and fail with:

```text
Insufficient multimodal embedding length:
num_mm_tokens_in_input_ids=2424 vs num_mm_tokens_in_embedding=2352.
```

This exposes the existing assembly without requiring callers to construct the full causal language model.

## Changes

`build_image_features` takes the vision module, projector, layout tokens, and view order explicitly. `get_image_feature` delegates to it, so engine behavior stays on the same path while standalone callers can produce the complete sequence.

## Testing

The CPU regression uses deterministic global and local tiles, then checks both view orders:

```console
$ git show f57256443c5e1294f17750b9292d9ca3b457dd85:test/registered/unit/models/test_deepseek_vl2.py \
    >/tmp/test_deepseek_vl2.py
$ git switch --detach 9eee990ce15d7fd7c8901587e6baaf4cc0603af0
$ PYTHONPATH=python python /tmp/test_deepseek_vl2.py -f
AttributeError: type object 'DeepseekVL2ForCausalLM' has no attribute 'build_image_features'

$ git switch --detach f57256443c5e1294f17750b9292d9ca3b457dd85
$ PYTHONPATH=python python test/registered/unit/models/test_deepseek_vl2.py -f
Ran 1 test in 0.024s
OK
```

The final scalar layouts are:

```text
head: [10, -1, -2, 20, 30, -1]
tail: [20, 30, -1, -2, 10, -1]
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32814498105](https://github.com/sgl-project/sglang/actions/runs/32814498105)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32814497798](https://github.com/sgl-project/sglang/actions/runs/32814497798)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32814497966](https://github.com/sgl-project/sglang/actions/runs/32814497966)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->