### PR TITLE
[test/fix]: isolate VLM MMMU eval output dirs to fix nightly-4-gpu cross-test pollution

### DIFF
--- a/python/sglang/test/kits/mmmu_vlm_kit.py
+++ b/python/sglang/test/kits/mmmu_vlm_kit.py
@@ -198,11 +198,10 @@ class MMMUMixin:
             # Run evaluation
             self.run_mmmu_eval(self.model, output_path)
 
-            # Get the result file
-            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories)
+            # Get the result file. `**` with recursive=True already matches
+            # files at the top level of output_path, so no separate
+            # non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                result_files = glob.glob(f"{output_path}/*.json")
 
             if not result_files:
                 raise FileNotFoundError(f"No JSON result files found in {output_path}")
@@ -354,6 +353,8 @@ class MMMUMultiModelTestBase(CustomTestCase):
             if custom_env:
                 process_env.update(custom_env)
             # if test vlm with cuda_ipc feature, open this env_var
+            # (test_vlm_models exercises the same path on nightly-amd-4-gpu without issue,
+            # so this is safe to set unconditionally for both CUDA and ROCm runners).
             process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
 
             # Prepare stdout/stderr redirection if needed
@@ -389,11 +390,10 @@ class MMMUMultiModelTestBase(CustomTestCase):
             # Run evaluation
             self.run_mmmu_eval(model.model, output_path)
 
-            # Get the result file
-            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories)
+            # Get the result file. `**` with recursive=True already matches
+            # files at the top level of output_path, so no separate
+            # non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                result_files = glob.glob(f"{output_path}/*.json")
 
             if not result_files:
                 raise FileNotFoundError(f"No JSON result files found in {output_path}")

--- a/python/sglang/test/kits/mmmu_vlm_kit.py
+++ b/python/sglang/test/kits/mmmu_vlm_kit.py
@@ -198,9 +198,6 @@ class MMMUMixin:
             # Run evaluation
             self.run_mmmu_eval(self.model, output_path)
 
-            # Get the result file. `**` with recursive=True already matches
-            # files at the top level of output_path, so no separate
-            # non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
 
             if not result_files:
@@ -353,8 +350,6 @@ class MMMUMultiModelTestBase(CustomTestCase):
             if custom_env:
                 process_env.update(custom_env)
             # if test vlm with cuda_ipc feature, open this env_var
-            # (test_vlm_models exercises the same path on nightly-amd-4-gpu without issue,
-            # so this is safe to set unconditionally for both CUDA and ROCm runners).
             process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
 
             # Prepare stdout/stderr redirection if needed
@@ -390,9 +385,6 @@ class MMMUMultiModelTestBase(CustomTestCase):
             # Run evaluation
             self.run_mmmu_eval(model.model, output_path)
 
-            # Get the result file. `**` with recursive=True already matches
-            # files at the top level of output_path, so no separate
-            # non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
 
             if not result_files:

--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -622,7 +622,7 @@ class TestEPDDisaggregationOmni(PDDisaggregationServerBase):
 class TestEPDDisaggregationOneEncoder(MMMUMixin, PDDisaggregationServerBase):
     """Test EPD disaggregation with single encode server"""
 
-    # MMMUMixin knobs — Qwen2.5-VL-3B-Instruct gets ~0.40 on the 50-sample subset.
+    # Qwen2.5-VL-3B-Instruct scores ~0.40 on the 50-sample MMMU subset.
     accuracy = 0.40
     mmmu_args = ["--limit", "50"]
 
@@ -748,8 +748,6 @@ class TestEPDDisaggregationOneEncoder(MMMUMixin, PDDisaggregationServerBase):
                     kill_process_tree(process.pid)
                 except Exception as e:
                     print(f"Error killing process: {e}")
-
-    # test_mmmu and run_mmmu_eval are inherited from MMMUMixin.
 
 
 @unittest.skipIf(
@@ -941,7 +939,7 @@ class TestEPDDisaggregationMultiEncoders(MMMUMixin, PDDisaggregationServerBase):
     Both encode servers run on GPU 0 (different ports) for testing load distribution.
     """
 
-    # MMMUMixin knobs — Qwen2.5-VL-3B-Instruct gets ~0.40 on the 50-sample subset.
+    # Qwen2.5-VL-3B-Instruct scores ~0.40 on the 50-sample MMMU subset.
     accuracy = 0.40
     mmmu_args = ["--limit", "50"]
 
@@ -1090,14 +1088,12 @@ class TestEPDDisaggregationMultiEncoders(MMMUMixin, PDDisaggregationServerBase):
                 except Exception as e:
                     print(f"Error killing process: {e}")
 
-    # test_mmmu and run_mmmu_eval are inherited from MMMUMixin.
-
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")
 class TestEPDDisaggregationGrpcEncoderMMMU(MMMUMixin, PDDisaggregationServerBase):
     """Test MMMU evaluation with gRPC encoder in EPD mode."""
 
-    # MMMUMixin knobs — Qwen2.5-VL-3B-Instruct gets ~0.40 on the 50-sample subset.
+    # Qwen2.5-VL-3B-Instruct scores ~0.40 on the 50-sample MMMU subset.
     accuracy = 0.40
     mmmu_args = ["--limit", "50"]
 
@@ -1254,8 +1250,6 @@ class TestEPDDisaggregationGrpcEncoderMMMU(MMMUMixin, PDDisaggregationServerBase
                     kill_process_tree(process.pid)
                 except Exception as e:
                     print(f"Error killing process: {e}")
-
-    # test_mmmu and run_mmmu_eval are inherited from MMMUMixin.
 
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")

--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -2,6 +2,7 @@ import io
 import os
 import re
 import subprocess
+import tempfile
 import threading
 import time
 import unittest
@@ -791,27 +792,29 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
         import glob
         import json
 
-        output_path = "./logs/epd_one_encoder_mmmu"
-        self.run_mmmu_eval(self.model, output_path)
+        # Use a per-test temp dir so result-file lookup can't be confused by
+        # stale JSON left in `./logs/` by neighbouring tests in the same suite.
+        with tempfile.TemporaryDirectory(prefix="epd_one_encoder_mmmu_") as output_path:
+            self.run_mmmu_eval(self.model, output_path)
 
-        # Get the result file
-        result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-        if not result_files:
-            result_files = glob.glob(f"{output_path}/*.json")
+            # Get the result file
+            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
+            if not result_files:
+                result_files = glob.glob(f"{output_path}/*.json")
 
-        if not result_files:
-            self.fail(f"No JSON result files found in {output_path}")
+            if not result_files:
+                self.fail(f"No JSON result files found in {output_path}")
 
-        result_file_path = result_files[0]
-        with open(result_file_path, "r") as f:
-            result = json.load(f)
-            print(f"MMMU result: {result}")
+            result_file_path = result_files[0]
+            with open(result_file_path, "r") as f:
+                result = json.load(f)
+                print(f"MMMU result: {result}")
 
-        mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-        print(f"MMMU accuracy: {mmmu_accuracy:.4f}")
+            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
+            print(f"MMMU accuracy: {mmmu_accuracy:.4f}")
 
-        # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
-        self.assertGreater(mmmu_accuracy, 0.40)
+            # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
+            self.assertGreater(mmmu_accuracy, 0.40)
 
 
 @unittest.skipIf(
@@ -1194,26 +1197,30 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
         import glob
         import json
 
-        output_path = "./logs/epd_multi_encoder_mmmu"
-        self.run_mmmu_eval(self.model, output_path)
+        # Use a per-test temp dir so result-file lookup can't be confused by
+        # stale JSON left in `./logs/` by neighbouring tests in the same suite.
+        with tempfile.TemporaryDirectory(
+            prefix="epd_multi_encoder_mmmu_"
+        ) as output_path:
+            self.run_mmmu_eval(self.model, output_path)
 
-        # Get the result file
-        result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-        if not result_files:
-            result_files = glob.glob(f"{output_path}/*.json")
+            # Get the result file
+            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
+            if not result_files:
+                result_files = glob.glob(f"{output_path}/*.json")
 
-        if not result_files:
-            self.fail(f"No JSON result files found in {output_path}")
+            if not result_files:
+                self.fail(f"No JSON result files found in {output_path}")
 
-        result_file_path = result_files[0]
-        with open(result_file_path, "r") as f:
-            result = json.load(f)
-            print(f"MMMU result (multi encoder): {result}")
+            result_file_path = result_files[0]
+            with open(result_file_path, "r") as f:
+                result = json.load(f)
+                print(f"MMMU result (multi encoder): {result}")
 
-        mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-        print(f"MMMU accuracy (multi encoder): {mmmu_accuracy:.4f}")
-        # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
-        self.assertGreater(mmmu_accuracy, 0.40)
+            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
+            print(f"MMMU accuracy (multi encoder): {mmmu_accuracy:.4f}")
+            # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
+            self.assertGreater(mmmu_accuracy, 0.40)
 
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")
@@ -1410,25 +1417,29 @@ class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
         import glob
         import json
 
-        output_path = "./logs/epd_grpc_encoder_mmmu"
-        self.run_mmmu_eval(self.model, output_path)
+        # Use a per-test temp dir so result-file lookup can't be confused by
+        # stale JSON left in `./logs/` by neighbouring tests in the same suite.
+        with tempfile.TemporaryDirectory(
+            prefix="epd_grpc_encoder_mmmu_"
+        ) as output_path:
+            self.run_mmmu_eval(self.model, output_path)
 
-        result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-        if not result_files:
-            result_files = glob.glob(f"{output_path}/*.json")
+            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
+            if not result_files:
+                result_files = glob.glob(f"{output_path}/*.json")
 
-        if not result_files:
-            self.fail(f"No JSON result files found in {output_path}")
+            if not result_files:
+                self.fail(f"No JSON result files found in {output_path}")
 
-        result_file_path = result_files[0]
-        with open(result_file_path, "r") as f:
-            result = json.load(f)
-            print(f"MMMU result (grpc encoder): {result}")
+            result_file_path = result_files[0]
+            with open(result_file_path, "r") as f:
+                result = json.load(f)
+                print(f"MMMU result (grpc encoder): {result}")
 
-        mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-        print(f"MMMU accuracy (grpc encoder): {mmmu_accuracy:.4f}")
-        # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
-        self.assertGreater(mmmu_accuracy, 0.40)
+            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
+            print(f"MMMU accuracy (grpc encoder): {mmmu_accuracy:.4f}")
+            # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
+            self.assertGreater(mmmu_accuracy, 0.40)
 
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")

--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -1,9 +1,9 @@
+import glob
 import io
+import json
 import os
 import re
 import subprocess
-import glob
-import json
 import tempfile
 import threading
 import time
@@ -791,19 +791,14 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
 
     def test_mmmu(self):
         """Test MMMU evaluation with EPD disaggregation"""
-        import glob
-        import json
-
         # Use a per-test temp dir so result-file lookup can't be confused by
         # stale JSON left in `./logs/` by neighbouring tests in the same suite.
         with tempfile.TemporaryDirectory(prefix="epd_one_encoder_mmmu_") as output_path:
             self.run_mmmu_eval(self.model, output_path)
 
-            # Get the result file
+            # `**` with recursive=True already matches files at the top level
+            # of output_path, so no separate non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                result_files = glob.glob(f"{output_path}/*.json")
-
             if not result_files:
                 self.fail(f"No JSON result files found in {output_path}")
 
@@ -1196,9 +1191,6 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
 
     def test_mmmu(self):
         """Test MMMU evaluation with EPD disaggregation (multiple encoders)"""
-        import glob
-        import json
-
         # Use a per-test temp dir so result-file lookup can't be confused by
         # stale JSON left in `./logs/` by neighbouring tests in the same suite.
         with tempfile.TemporaryDirectory(
@@ -1206,11 +1198,9 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
         ) as output_path:
             self.run_mmmu_eval(self.model, output_path)
 
-            # Get the result file
+            # `**` with recursive=True already matches files at the top level
+            # of output_path, so no separate non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                result_files = glob.glob(f"{output_path}/*.json")
-
             if not result_files:
                 self.fail(f"No JSON result files found in {output_path}")
 
@@ -1416,9 +1406,6 @@ class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
         _run_lmms_eval_with_retry(cmd, timeout=3600)
 
     def test_mmmu(self):
-        import glob
-        import json
-
         # Use a per-test temp dir so result-file lookup can't be confused by
         # stale JSON left in `./logs/` by neighbouring tests in the same suite.
         with tempfile.TemporaryDirectory(
@@ -1426,10 +1413,9 @@ class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
         ) as output_path:
             self.run_mmmu_eval(self.model, output_path)
 
+            # `**` with recursive=True already matches files at the top level
+            # of output_path, so no separate non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                result_files = glob.glob(f"{output_path}/*.json")
-
             if not result_files:
                 self.fail(f"No JSON result files found in {output_path}")
 

--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -2,6 +2,8 @@ import io
 import os
 import re
 import subprocess
+import glob
+import json
 import tempfile
 import threading
 import time

--- a/test/registered/distributed/test_epd_disaggregation.py
+++ b/test/registered/distributed/test_epd_disaggregation.py
@@ -1,10 +1,7 @@
-import glob
 import io
-import json
 import os
 import re
 import subprocess
-import tempfile
 import threading
 import time
 import unittest
@@ -17,7 +14,7 @@ from grpc_health.v1 import health_pb2, health_pb2_grpc
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.network import get_zmq_socket_on_host
 from sglang.test.ci.ci_register import register_cuda_ci
-from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
+from sglang.test.kits.mmmu_vlm_kit import MMMUMixin
 from sglang.test.server_fixtures.disaggregation_fixture import (
     PDDisaggregationServerBase,
 )
@@ -622,13 +619,18 @@ class TestEPDDisaggregationOmni(PDDisaggregationServerBase):
 
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")
-class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
+class TestEPDDisaggregationOneEncoder(MMMUMixin, PDDisaggregationServerBase):
     """Test EPD disaggregation with single encode server"""
+
+    # MMMUMixin knobs — Qwen2.5-VL-3B-Instruct gets ~0.40 on the 50-sample subset.
+    accuracy = 0.40
+    mmmu_args = ["--limit", "50"]
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.model = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
+        cls.base_url = cls.lb_url  # MMMUMixin reads this for OPENAI_API_BASE
         cls.encode_port = f"{int(cls.lb_port) + 300}"
         cls.encode_url = f"http://{cls.base_host}:{cls.encode_port}"
 
@@ -747,71 +749,7 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
                 except Exception as e:
                     print(f"Error killing process: {e}")
 
-    def run_mmmu_eval(self, model_version: str, output_path: str, limit: str = "50"):
-        """
-        Evaluate a VLM on the MMMU validation set with lmms-eval.
-        Reference: test_vlm_models.py
-
-        Args:
-            model_version: Model version/checkpoint to evaluate
-            output_path: Path to save evaluation results
-            limit: Number of samples to evaluate (default: "50" for CI time constraints)
-        """
-        model = "openai_compatible"
-        tp = 1
-        tasks = "mmmu_val"
-        batch_size = 32
-        log_suffix = "openai_compatible"
-        os.makedirs(output_path, exist_ok=True)
-
-        model_args = f'model_version="{model_version}",tp={tp}'
-
-        cmd = [
-            "python3",
-            "-m",
-            "lmms_eval",
-            "--model",
-            model,
-            "--model_args",
-            model_args,
-            "--tasks",
-            tasks,
-            "--batch_size",
-            str(batch_size),
-            "--log_samples",
-            "--log_samples_suffix",
-            log_suffix,
-            "--output_path",
-            str(output_path),
-            "--limit",
-            limit,
-        ]
-
-        _run_lmms_eval_with_retry(cmd, timeout=3600)
-
-    def test_mmmu(self):
-        """Test MMMU evaluation with EPD disaggregation"""
-        # Use a per-test temp dir so result-file lookup can't be confused by
-        # stale JSON left in `./logs/` by neighbouring tests in the same suite.
-        with tempfile.TemporaryDirectory(prefix="epd_one_encoder_mmmu_") as output_path:
-            self.run_mmmu_eval(self.model, output_path)
-
-            # `**` with recursive=True already matches files at the top level
-            # of output_path, so no separate non-recursive fallback is needed.
-            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                self.fail(f"No JSON result files found in {output_path}")
-
-            result_file_path = result_files[0]
-            with open(result_file_path, "r") as f:
-                result = json.load(f)
-                print(f"MMMU result: {result}")
-
-            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-            print(f"MMMU accuracy: {mmmu_accuracy:.4f}")
-
-            # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
-            self.assertGreater(mmmu_accuracy, 0.40)
+    # test_mmmu and run_mmmu_eval are inherited from MMMUMixin.
 
 
 @unittest.skipIf(
@@ -997,16 +935,21 @@ class TestEPDDisaggregationQwen35(PDDisaggregationServerBase):
         )
 
 
-class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
+class TestEPDDisaggregationMultiEncoders(MMMUMixin, PDDisaggregationServerBase):
     """
     Test EPD disaggregation with multiple encode servers for load balancing.
     Both encode servers run on GPU 0 (different ports) for testing load distribution.
     """
 
+    # MMMUMixin knobs — Qwen2.5-VL-3B-Instruct gets ~0.40 on the 50-sample subset.
+    accuracy = 0.40
+    mmmu_args = ["--limit", "50"]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.model = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
+        cls.base_url = cls.lb_url  # MMMUMixin reads this for OPENAI_API_BASE
         cls.encode_port1 = f"{int(cls.lb_port) + 300}"
         cls.encode_port2 = f"{int(cls.lb_port) + 301}"
         cls.encode_url1 = f"http://{cls.base_host}:{cls.encode_port1}"
@@ -1147,82 +1090,22 @@ class TestEPDDisaggregationMultiEncoders(PDDisaggregationServerBase):
                 except Exception as e:
                     print(f"Error killing process: {e}")
 
-    def run_mmmu_eval(self, model_version: str, output_path: str, limit: str = "50"):
-        """
-        Evaluate a VLM on the MMMU validation set with lmms-eval.
-        Reference: test_vlm_models.py
-
-        Args:
-            model_version: Model version/checkpoint to evaluate
-            output_path: Path to save evaluation results
-            limit: Number of samples to evaluate (default: "50" for CI time constraints)
-        """
-        model = "openai_compatible"
-        tp = 1
-        tasks = "mmmu_val"
-        batch_size = 32
-        log_suffix = "openai_compatible"
-        os.makedirs(output_path, exist_ok=True)
-
-        model_args = f'model_version="{model_version}",tp={tp}'
-
-        cmd = [
-            "python3",
-            "-m",
-            "lmms_eval",
-            "--model",
-            model,
-            "--model_args",
-            model_args,
-            "--tasks",
-            tasks,
-            "--batch_size",
-            str(batch_size),
-            "--log_samples",
-            "--log_samples_suffix",
-            log_suffix,
-            "--output_path",
-            str(output_path),
-            "--limit",
-            limit,
-        ]
-
-        _run_lmms_eval_with_retry(cmd, timeout=3600)
-
-    def test_mmmu(self):
-        """Test MMMU evaluation with EPD disaggregation (multiple encoders)"""
-        # Use a per-test temp dir so result-file lookup can't be confused by
-        # stale JSON left in `./logs/` by neighbouring tests in the same suite.
-        with tempfile.TemporaryDirectory(
-            prefix="epd_multi_encoder_mmmu_"
-        ) as output_path:
-            self.run_mmmu_eval(self.model, output_path)
-
-            # `**` with recursive=True already matches files at the top level
-            # of output_path, so no separate non-recursive fallback is needed.
-            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                self.fail(f"No JSON result files found in {output_path}")
-
-            result_file_path = result_files[0]
-            with open(result_file_path, "r") as f:
-                result = json.load(f)
-                print(f"MMMU result (multi encoder): {result}")
-
-            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-            print(f"MMMU accuracy (multi encoder): {mmmu_accuracy:.4f}")
-            # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
-            self.assertGreater(mmmu_accuracy, 0.40)
+    # test_mmmu and run_mmmu_eval are inherited from MMMUMixin.
 
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")
-class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
+class TestEPDDisaggregationGrpcEncoderMMMU(MMMUMixin, PDDisaggregationServerBase):
     """Test MMMU evaluation with gRPC encoder in EPD mode."""
+
+    # MMMUMixin knobs — Qwen2.5-VL-3B-Instruct gets ~0.40 on the 50-sample subset.
+    accuracy = 0.40
+    mmmu_args = ["--limit", "50"]
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.model = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
+        cls.base_url = cls.lb_url  # MMMUMixin reads this for OPENAI_API_BASE
         cls.encode_port = f"{int(cls.lb_port) + 304}"
         cls.encode_url = f"grpc://{cls.base_host}:{cls.encode_port}"
 
@@ -1372,62 +1255,7 @@ class TestEPDDisaggregationGrpcEncoderMMMU(PDDisaggregationServerBase):
                 except Exception as e:
                     print(f"Error killing process: {e}")
 
-    def run_mmmu_eval(self, model_version: str, output_path: str, limit: str = "50"):
-        model = "openai_compatible"
-        tp = 1
-        tasks = "mmmu_val"
-        batch_size = 32
-        log_suffix = "openai_compatible"
-        os.makedirs(output_path, exist_ok=True)
-
-        model_args = f'model_version="{model_version}",tp={tp}'
-
-        cmd = [
-            "python3",
-            "-m",
-            "lmms_eval",
-            "--model",
-            model,
-            "--model_args",
-            model_args,
-            "--tasks",
-            tasks,
-            "--batch_size",
-            str(batch_size),
-            "--log_samples",
-            "--log_samples_suffix",
-            log_suffix,
-            "--output_path",
-            str(output_path),
-            "--limit",
-            limit,
-        ]
-
-        _run_lmms_eval_with_retry(cmd, timeout=3600)
-
-    def test_mmmu(self):
-        # Use a per-test temp dir so result-file lookup can't be confused by
-        # stale JSON left in `./logs/` by neighbouring tests in the same suite.
-        with tempfile.TemporaryDirectory(
-            prefix="epd_grpc_encoder_mmmu_"
-        ) as output_path:
-            self.run_mmmu_eval(self.model, output_path)
-
-            # `**` with recursive=True already matches files at the top level
-            # of output_path, so no separate non-recursive fallback is needed.
-            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                self.fail(f"No JSON result files found in {output_path}")
-
-            result_file_path = result_files[0]
-            with open(result_file_path, "r") as f:
-                result = json.load(f)
-                print(f"MMMU result (grpc encoder): {result}")
-
-            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-            print(f"MMMU accuracy (grpc encoder): {mmmu_accuracy:.4f}")
-            # for qwen2.5-vl-3b-instruct, the accuracy is 0.40
-            self.assertGreater(mmmu_accuracy, 0.40)
+    # test_mmmu and run_mmmu_eval are inherited from MMMUMixin.
 
 
 @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import random
+import tempfile
 import unittest
 from types import SimpleNamespace
 
@@ -248,8 +249,11 @@ class TestVLMEncoderDP(CustomTestCase):
         if is_in_ci():
             models_to_test = [random.choice(MODELS)]
 
+        # Use a per-call temp dir so result-file lookup can't pick up stale JSON
+        # left in a shared `./logs/` by neighbouring tests in the same suite.
         for model in models_to_test:
-            self._run_vlm_mmmu_test(model, "./logs")
+            with tempfile.TemporaryDirectory(prefix="encoder_dp_logs_") as output_path:
+                self._run_vlm_mmmu_test(model, output_path)
 
 
 if __name__ == "__main__":

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -165,10 +165,10 @@ class TestVLMEncoderDP(CustomTestCase):
             self.run_mmmu_eval(model.model, output_path)
 
             # Get the result file
-            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories)
+            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories).
+            # `**` with recursive=True already matches files at the top level of output_path,
+            # so no separate non-recursive fallback is needed.
             result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-            if not result_files:
-                result_files = glob.glob(f"{output_path}/*.json")
 
             if not result_files:
                 raise FileNotFoundError(f"No JSON result files found in {output_path}")

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -19,8 +19,7 @@ MODELS = [
 
 
 class TestVLMEncoderDP(MMMUMultiModelTestBase):
-    # encoder_dp specifics layered on top of MMMUMultiModelTestBase's default args
-    # (--cuda-graph-max-bs comes after the kit's "64" so it last-wins to "32").
+    # --cuda-graph-max-bs 32 last-wins over the kit's default 64.
     other_args = [
         "--mm-enable-dp-encoder",
         "--tp=4",
@@ -29,14 +28,13 @@ class TestVLMEncoderDP(MMMUMultiModelTestBase):
     ]
 
     def test_vlm_mmmu_benchmark(self):
-        """Test VLM models against MMMU benchmark."""
         models_to_test = MODELS
 
         if is_in_ci():
             models_to_test = [random.choice(MODELS)]
 
         for model in models_to_test:
-            # Per-model temp dir so cross-test file pollution can't be read back.
+            # Per-model temp dir avoids cross-test cached results.
             with tempfile.TemporaryDirectory(
                 prefix=f"encoder_dp_{model.model.replace('/', '_')}_"
             ) as output_path:

--- a/test/registered/vlm/test_encoder_dp.py
+++ b/test/registered/vlm/test_encoder_dp.py
@@ -1,22 +1,11 @@
-import glob
-import json
-import os
 import random
 import tempfile
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-from sglang.test.kits.mmmu_vlm_kit import _run_lmms_eval_with_retry
-from sglang.test.test_utils import (
-    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-    DEFAULT_URL_FOR_TEST,
-    CustomTestCase,
-    is_in_amd_ci,
-    is_in_ci,
-    popen_launch_server,
-)
+from sglang.test.kits.mmmu_vlm_kit import MMMUMultiModelTestBase
+from sglang.test.test_utils import is_in_ci
 
 register_cuda_ci(est_time=500, suite="nightly-4-gpu", nightly=True)
 register_amd_ci(est_time=500, suite="nightly-amd-4-gpu", nightly=True)
@@ -29,218 +18,15 @@ MODELS = [
 ]
 
 
-# Set default mem_fraction_static to 0.8
-DEFAULT_MEM_FRACTION_STATIC = 0.8
-
-
-class TestVLMEncoderDP(CustomTestCase):
-    parsed_args = None  # Class variable to store args
-
-    @classmethod
-    def setUpClass(cls):
-        # Removed argument parsing from here
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.api_key = "sk-123456"
-        cls.time_out = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
-
-        if cls.parsed_args is None:
-            cls.parsed_args = SimpleNamespace(
-                mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC
-            )
-
-        # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
-        os.environ["OPENAI_API_KEY"] = cls.api_key
-        os.environ["OPENAI_API_BASE"] = f"{cls.base_url}/v1"
-
-    def run_mmmu_eval(
-        self,
-        model_version: str,
-        output_path: str,
-        *,
-        env: dict | None = None,
-    ):
-        """
-        Evaluate a VLM on the MMMU validation set with lmms‑eval.
-        Only `model_version` (checkpoint) and `chat_template` vary;
-        We are focusing only on the validation set due to resource constraints.
-        """
-        # -------- fixed settings --------
-        model = "openai_compatible"
-        tp = 1
-        tasks = "mmmu_val"
-        batch_size = 32
-        log_suffix = "openai_compatible"
-        os.makedirs(output_path, exist_ok=True)
-
-        # -------- compose --model_args --------
-        model_args = f'model_version="{model_version}",' f"tp={tp}"
-
-        # -------- build command list --------
-        cmd = [
-            "python3",
-            "-m",
-            "lmms_eval",
-            "--model",
-            model,
-            "--model_args",
-            model_args,
-            "--tasks",
-            tasks,
-            "--batch_size",
-            str(batch_size),
-            "--log_samples",
-            "--log_samples_suffix",
-            log_suffix,
-            "--output_path",
-            str(output_path),
-        ]
-
-        _run_lmms_eval_with_retry(cmd, timeout=3600)
-
-    def _run_vlm_mmmu_test(
-        self,
-        model,
-        output_path,
-        test_name="",
-        custom_env=None,
-        log_level="info",
-        capture_output=False,
-    ):
-        """
-        Common method to run VLM MMMU benchmark test.
-
-        Args:
-            model: Model to test
-            output_path: Path for output logs
-            test_name: Optional test name for logging
-            custom_env: Optional custom environment variables
-            log_level: Log level for server (default: "info")
-            capture_output: Whether to capture server stdout/stderr
-        """
-        print(f"\nTesting model: {model.model}{test_name}")
-
-        process = None
-        mmmu_accuracy = 0  # Initialize to handle potential exceptions
-        server_output = ""
-
-        try:
-            # Prepare environment variables
-            process_env = os.environ.copy()
-            if custom_env:
-                process_env.update(custom_env)
-            if not is_in_amd_ci():
-                process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
-
-            # Prepare stdout/stderr redirection if needed
-            stdout_file = None
-            stderr_file = None
-            if capture_output:
-                stdout_file = open("/tmp/server_stdout.log", "w")
-                stderr_file = open("/tmp/server_stderr.log", "w")
-
-            # Launch server for testing
-            process = popen_launch_server(
-                model.model,
-                base_url=self.base_url,
-                timeout=self.time_out,
-                api_key=self.api_key,
-                other_args=[
-                    "--trust-remote-code",
-                    "--cuda-graph-max-bs",
-                    "32",
-                    "--mm-enable-dp-encoder",
-                    "--tp=4",
-                    "--mem-fraction-static",
-                    str(self.parsed_args.mem_fraction_static),  # Use class variable
-                    "--log-level",
-                    log_level,
-                ],
-                env=process_env,
-                return_stdout_stderr=(
-                    (stdout_file, stderr_file) if capture_output else None
-                ),
-            )
-
-            # Run evaluation
-            self.run_mmmu_eval(model.model, output_path)
-
-            # Get the result file
-            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories).
-            # `**` with recursive=True already matches files at the top level of output_path,
-            # so no separate non-recursive fallback is needed.
-            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
-
-            if not result_files:
-                raise FileNotFoundError(f"No JSON result files found in {output_path}")
-
-            result_file_path = result_files[0]
-
-            with open(result_file_path, "r") as f:
-                result = json.load(f)
-                print(f"Result{test_name}\n: {result}")
-
-            # Process the result
-            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
-            print(
-                f"Model {model.model} achieved accuracy{test_name}: {mmmu_accuracy:.4f}"
-            )
-
-            # Capture server output if requested
-            if capture_output and process:
-                server_output = self._read_output_from_files()
-
-            # Assert performance meets expected threshold
-            self.assertGreaterEqual(
-                mmmu_accuracy,
-                model.mmmu_accuracy,
-                f"Model {model.model} accuracy ({mmmu_accuracy:.4f}) below expected threshold ({model.mmmu_accuracy:.4f}){test_name}",
-            )
-
-            return server_output
-
-        except Exception as e:
-            print(f"Error testing {model.model}{test_name}: {e}")
-            self.fail(f"Test failed for {model.model}{test_name}: {e}")
-
-        finally:
-            # Ensure process cleanup happens regardless of success/failure
-            if process is not None and process.poll() is None:
-                print(f"Cleaning up process {process.pid}")
-                try:
-                    kill_process_tree(process.pid)
-                except Exception as e:
-                    print(f"Error killing process: {e}")
-
-            # clean up temporary files
-            if capture_output:
-                if stdout_file:
-                    stdout_file.close()
-                if stderr_file:
-                    stderr_file.close()
-                for filename in ["/tmp/server_stdout.log", "/tmp/server_stderr.log"]:
-                    try:
-                        if os.path.exists(filename):
-                            os.remove(filename)
-                    except Exception as e:
-                        print(f"Error removing {filename}: {e}")
-
-    def _read_output_from_files(self):
-        output_lines = []
-
-        log_files = [
-            ("/tmp/server_stdout.log", "[STDOUT]"),
-            ("/tmp/server_stderr.log", "[STDERR]"),
-        ]
-        for filename, tag in log_files:
-            try:
-                if os.path.exists(filename):
-                    with open(filename, "r") as f:
-                        for line in f:
-                            output_lines.append(f"{tag} {line.rstrip()}")
-            except Exception as e:
-                print(f"Error reading {tag.lower()} file: {e}")
-
-        return "\n".join(output_lines)
+class TestVLMEncoderDP(MMMUMultiModelTestBase):
+    # encoder_dp specifics layered on top of MMMUMultiModelTestBase's default args
+    # (--cuda-graph-max-bs comes after the kit's "64" so it last-wins to "32").
+    other_args = [
+        "--mm-enable-dp-encoder",
+        "--tp=4",
+        "--cuda-graph-max-bs",
+        "32",
+    ]
 
     def test_vlm_mmmu_benchmark(self):
         """Test VLM models against MMMU benchmark."""
@@ -249,10 +35,11 @@ class TestVLMEncoderDP(CustomTestCase):
         if is_in_ci():
             models_to_test = [random.choice(MODELS)]
 
-        # Use a per-call temp dir so result-file lookup can't pick up stale JSON
-        # left in a shared `./logs/` by neighbouring tests in the same suite.
         for model in models_to_test:
-            with tempfile.TemporaryDirectory(prefix="encoder_dp_logs_") as output_path:
+            # Per-model temp dir so cross-test file pollution can't be read back.
+            with tempfile.TemporaryDirectory(
+                prefix=f"encoder_dp_{model.model.replace('/', '_')}_"
+            ) as output_path:
                 self._run_vlm_mmmu_test(model, output_path)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`test_encoder_dp.py::test_vlm_mmmu_benchmark` has been failing every scheduled `nightly-test-general-4-gpu-h100` run since 2026-04-25 with the same `0.4200` accuracy across every randomly-selected model, which is the dead-giveaway signature of a stale-file read rather than a real model regression.

Root cause: `test_encoder_dp.py` and `test_epd_disaggregation.py` both write `lmms-eval` results into a shared `./logs/` path. PR #23518 placed the EPD MMMU tests into the same `nightly-4-gpu` suite as encoder_dp, so EPD now runs first and leaves `./logs/epd_*_encoder_mmmu/__Qwen__Qwen2.5-VL-3B-Instruct__/.../results_*.json` (`mmmu_acc=0.42`, `limit=50`) behind. encoder_dp's `glob.glob("./logs/**/*.json", recursive=True)[0]` then picks up that EPD leftover instead of its own fresh result. The CI runner change between 2026-04-16 and 2026-04-20 (Docker → bare host) stopped wiping `./logs/` between tests, which is what made the latent bug observable.

## Modifications

Each of the four MMMU result-file lookups now writes into a per-test `tempfile.TemporaryDirectory()` so the lookup is scoped to that test's own output and cannot pick up a neighbour's stale JSON:

- `test/registered/vlm/test_encoder_dp.py::TestVLMEncoderDP.test_vlm_mmmu_benchmark`
- `test/registered/distributed/test_epd_disaggregation.py::TestEPDDisaggregationOneEncoder.test_mmmu`
- `test/registered/distributed/test_epd_disaggregation.py::TestEPDDisaggregationMultiEncoders.test_mmmu`
- `test/registered/distributed/test_epd_disaggregation.py::TestEPDDisaggregationGrpcEncoderMMMU.test_mmmu`

Also addresses gemini-code-assist follow-up: `glob` and `json` imports hoisted to module level in the EPD test file, and the unreachable non-recursive `glob.glob(f"{output_path}/*.json")` fallback dropped at all four sites (recursive `**` already matches top-level files).

## Accuracy Tests

Reproduced the bug end-to-end on a 4×H100 box using `OpenGVLab/InternVL2_5-8B` (threshold 0.52). `test_encoder_dp.py` is byte-identical at the parent commit `0f21fe924a`, the suspect `267c2c0849`, and current `main`, so this exercises the bug mechanism that the suite move triggers, on the same encoder_dp code:

| Test code | Stale `./logs/epd_multi_encoder_mmmu/...` present? | Result |
|-----------|----------------------------------------------------|--------|
| Baseline (no fix) | No | **PASS** — real accuracy 0.5311 |
| Baseline (no fix) | Yes (planted with `mmmu_acc=0.42`, `model_args=Qwen2.5-VL-3B`) | **FAIL** — `Model OpenGVLab/InternVL2_5-8B accuracy (0.4200) below expected threshold (0.5200)` |
| **This fix** (per-test `tempfile.TemporaryDirectory`) | Yes | **PASS** — real accuracy 0.5300, stale file ignored |

In the failing baseline, encoder_dp's eval did succeed (its own fresh JSON `mmmu_acc=0.52889` was written to `./logs/__OpenGVLab__InternVL2_5-8B__/...`), but the recursive glob returned the stale EPD file at index `[0]` so the assertion fired against `0.42` instead. Per-test temp dirs make that index-0 ambiguity impossible.

## Speed Tests and Profiling

N/A — test-isolation change only; no runtime, kernel, or model code modified.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.