### PR TITLE
test with cuda token group quant enabled

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -97,6 +97,7 @@ MOE_BIT_WISE_EQUAL_MODE = False
 ATTN_BIT_WISE_EQUAL_MODE = False
 COMPRESSOR_BIT_WISE_EQUAL_MODE = False
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
+_ENABLE_QUANT_8BIT_V2 = envs.SGLANG_PER_TOKEN_GROUP_QUANT_8BIT_V2.get()
 
 
 if TYPE_CHECKING:
@@ -898,9 +899,6 @@ class MQALayer(nn.Module):
 
         if _FP8_WO_A_GEMM:
             import deep_gemm
-            from sglang.srt.layers.fast_fp8_quant import (
-                fast_per_token_group_quant_fp8_128,
-            )
 
             T, G, D = o.shape
             R = self.o_lora_rank
@@ -908,8 +906,8 @@ class MQALayer(nn.Module):
             # implementation runs at ~42% HBM peak on this shape; the triton 2D-tile
             # variant hits ~85% peak (180 µs → 70 µs at T=8192,G=4,D=4096), enough
             # to flip the FP8_WO path from net-loss to ~+27% vs the bf16 einsum.
-            o_fp8, o_s = fast_per_token_group_quant_fp8_128(
-                o.reshape(T * G, D).contiguous(),
+            o_fp8, o_s = sglang_per_token_group_quant_fp8(
+                o.reshape(T * G, D).contiguous(), group_size=128, enable_v2=_ENABLE_QUANT_8BIT_V2
             )
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(

--- a/test/srt/models/bench_fast_fp8_quant.py
+++ b/test/srt/models/bench_fast_fp8_quant.py
@@ -30,7 +30,7 @@ def main():
     x = (torch.randn(M, K, dtype=torch.bfloat16, device="cuda") * 0.1).contiguous()
 
     # Correctness
-    q_a, s_a = sglang_per_token_group_quant_fp8(x, group_size=128)
+    q_a, s_a = sglang_per_token_group_quant_fp8(x, group_size=128, enable_v2=True)
     q_b, s_b = fast_per_token_group_quant_fp8_128(x)
     # Compare in fp32: max abs diff between (q*s) reconstructions
     rec_a = q_a.float() * s_a.repeat_interleave(128, dim=-1)
@@ -40,7 +40,7 @@ def main():
     print(f"correctness: max|reconstruct(sgl) - reconstruct(fast)| = {err:.4e}")
     print(f"             max|x - reconstruct(fast)|                = {err_x:.4e}")
 
-    t_sgl = bench_graph(lambda: sglang_per_token_group_quant_fp8(x, group_size=128))
+    t_sgl = bench_graph(lambda: sglang_per_token_group_quant_fp8(x, group_size=128, enable_v2=True))
     t_fast = bench_graph(lambda: fast_per_token_group_quant_fp8_128(x))
 
     print(f"shape: M={M} K={K} group=128")

--- a/test/srt/models/bench_wo_decode.py
+++ b/test/srt/models/bench_wo_decode.py
@@ -57,7 +57,8 @@ def run(T, G):
 
     def fp8_path_sgl():
         o_fp8, o_s = sglang_per_token_group_quant_fp8(
-            o.reshape(T * G, D).contiguous(), group_size=128
+            o.reshape(T * G, D).contiguous(), group_size=128,
+            enable_v2=True
         )
         deep_gemm.fp8_einsum(
             "bhr,hdr->bhd",

--- a/test/srt/models/bench_wo_fp8.py
+++ b/test/srt/models/bench_wo_fp8.py
@@ -54,7 +54,7 @@ def main():
 
     def fp8_quant_sgl():
         return sglang_per_token_group_quant_fp8(
-            o.reshape(T * G, D).contiguous(), group_size=128
+            o.reshape(T * G, D).contiguous(), group_size=128, enable_v2=True
         )
 
     def fp8_quant_fast():

--- a/test/srt/models/test_fast_fp8_quant_thorough.py
+++ b/test/srt/models/test_fast_fp8_quant_thorough.py
@@ -80,10 +80,10 @@ def run_one(M: int, K: int, dtype=torch.bfloat16, seed=0, label=""):
     # the wrapper without changing it; instead just check fast's own outputs.)
 
     if M > 0:
-        q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP)
+        q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP, enable_v2=True)
     else:
         # sglang_per_token_group_quant_fp8 still allocates outputs even for M=0.
-        q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP)
+        q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP, enable_v2=True)
 
     # ---- 1. Shape + dtype check ----
     assert q_fast.shape == q_sgl.shape == (M, K), \

--- a/test/srt/models/test_fast_fp8_quant_unit.py
+++ b/test/srt/models/test_fast_fp8_quant_unit.py
@@ -184,7 +184,7 @@ def t5_varying_shapes():
             return
         # Compare to sgl on small subset of values
         if M > 0:
-            q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP)
+            q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP, enable_v2=True)
             rec_a = q_a.float() * s_a.repeat_interleave(GROUP, dim=-1)
             rec_sgl = q_sgl.float() * s_sgl.repeat_interleave(GROUP, dim=-1)
             x_err_a = (rec_a - x.float()).abs().max().item()
@@ -230,7 +230,7 @@ def t6_edge_values():
     x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda") * 0.01
     x[:, 0] = 100.0
     q, s = fast_per_token_group_quant_fp8_128(x)
-    q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP)
+    q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP, enable_v2=True)
     rec_a = q.float() * s.repeat_interleave(GROUP, dim=-1)
     rec_sgl = q_sgl.float() * s_sgl.repeat_interleave(GROUP, dim=-1)
     e_a = (rec_a - x.float()).abs().max().item()
@@ -251,7 +251,7 @@ def t7_vs_sgl_dequant():
         torch.manual_seed(M)
         x = torch.randn(M, K, dtype=torch.bfloat16, device="cuda").contiguous() * 0.1
         q_a, s_a = fast_per_token_group_quant_fp8_128(x)
-        q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP)
+        q_sgl, s_sgl = sglang_per_token_group_quant_fp8(x, group_size=GROUP, enable_v2=True)
         rec_a = q_a.float() * s_a.repeat_interleave(GROUP, dim=-1)
         rec_sgl = q_sgl.float() * s_sgl.repeat_interleave(GROUP, dim=-1)
         ea = (rec_a - x.float()).abs().max().item()

--- a/test/srt/models/test_fp8_quant_padding.py
+++ b/test/srt/models/test_fp8_quant_padding.py
@@ -92,7 +92,7 @@ def t_compare_padding_with_sgl():
     M, K = 8192, 4096
     x = torch.empty(M, K, dtype=torch.bfloat16, device="cuda")
     qf, sf = fast_per_token_group_quant_fp8_128(x)
-    qs, ss = sglang_per_token_group_quant_fp8(x, group_size=GROUP)
+    qs, ss = sglang_per_token_group_quant_fp8(x, group_size=GROUP, enable_v2=True)
     qf_safe = safe_for_fp8(qf)
     qs_safe = safe_for_fp8(qs)
     report("uninit-vs-sgl: my-q-no-NaN", qf_safe)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The cuda `sgl_per_token_group_quant_8bit_v2` is faster than the triton `fast_per_token_group_quant_fp8_128`

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Unit tests
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
```
root@sglang-dsv4-chunan:/workspace/sglang# python test/srt/models/bench_fast_fp8_quant.py
correctness: max|reconstruct(sgl)  - reconstruct(fast)| = 3.1250e-02
             max|reconstruct(fast) - reconstruct(cute)| = 5.9605e-08
             max|x - reconstruct(fast)|                 = 1.7299e-02
             max|x - reconstruct(cute)|                 = 1.7299e-02
shape: M=32768 K=4096 group=128
  sgl_kernel:    61.51 us
  fast tri:      71.69 us  (-16.5% vs sgl)
  cutedsl:      112.72 us  (-83.3% vs sgl)
root@sglang-dsv4-chunan:/workspace/sglang# python test/srt/models/bench_wo_fp8.py
python test/srt/models/bench_wo_decode.pyshapes: T=8192 G=4 K=D=4096 N=R=1024  (per-group GEMM)
  bf16 einsum:                243.99 us
  fp8 quant (sgl_kernel):      63.72 us
  fp8 quant (fast triton):     71.69 us  (-12.5% vs sgl)
  fp8 GEMM only:              103.65 us
  fp8 full path (fast):       175.34 us
  delta(bf16 - fp8 fast):     +68.65 us  (+28.1%)

per-forward at T=8192, 60 layers: ~4.12 ms saved
root@sglang-dsv4-chunan:/workspace/sglang# python test/srt/models/bench_wo_decode.py
    T   G     bf16   fp8+sgl   fp8+fast   fast vs bf16
  128  16    40.96     30.77      30.92        +24.5%
  256  16    49.31     47.15      47.23         +4.2%
  400  16    59.31     55.37      57.07         +3.8%
  512  16    69.86     63.53      67.62         +3.2%
  768  16   106.15     84.10      86.22        +18.8%
 1024  16   129.83    106.39     111.72        +13.9%
```
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
