### PR TITLE
[Fix] Disable FlashInfer allreduce fusion under deterministic inference

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -883,6 +883,12 @@ class ServerArgs:
         # Handle memory-related, chunked prefill, and CUDA graph batch size configurations.
         self._handle_gpu_memory_settings(gpu_mem)
 
+        # enforce_disable_flashinfer_allreduce_fusion must be set before
+        # _handle_model_specific_adjustments, which auto-enables the fusion
+        # for several SM90/SM100 MoE arches.
+        if self.enable_deterministic_inference:
+            self.enforce_disable_flashinfer_allreduce_fusion = True
+
         # Apply model-specific adjustments.
         self._handle_model_specific_adjustments()
 
@@ -4022,10 +4028,9 @@ class ServerArgs:
 
             if self.enable_flashinfer_allreduce_fusion:
                 logger.warning(
-                    "Disable enable_flashinfer_allreduce_fusion because deterministic inference is enabled."
+                    "Disable --enable-flashinfer-allreduce-fusion because deterministic inference is enabled."
                 )
                 self.enable_flashinfer_allreduce_fusion = False
-            self.enforce_disable_flashinfer_allreduce_fusion = True
 
             # Check sampling backend
             self.sampling_backend = "pytorch"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4020,6 +4020,13 @@ class ServerArgs:
                 )
                 self.enable_aiter_allreduce_fusion = False
 
+            if self.enable_flashinfer_allreduce_fusion:
+                logger.warning(
+                    "Disable enable_flashinfer_allreduce_fusion because deterministic inference is enabled."
+                )
+                self.enable_flashinfer_allreduce_fusion = False
+            self.enforce_disable_flashinfer_allreduce_fusion = True
+
             # Check sampling backend
             self.sampling_backend = "pytorch"
             logger.warning(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

PR #22664 (commit `c6a45fab64`) added `Qwen3NextForCausalLM` to the model-arch list in `ServerArgs._handle_model_specific_adjustments` that auto-enables `enable_flashinfer_allreduce_fusion` on SM90/SM100 with `tp_size > 1`. The fused FlashInfer/TRTLLM allreduce kernel chooses different reduction shapes/orderings depending on batch size, which breaks bit-exact determinism.

This violates the `--enable-deterministic-inference` contract, and has been failing the `nightly-test-general-4-gpu-h100 :: TestFlashInferDeterministic.test_prefix_with_logprobs` CI lane every dispatched run from 2026-04-19 through today (e.g. [run 24971499389](https://github.com/sgl-project/sglang/actions/runs/24971499389/job/73115280649), [run 25469734855](https://github.com/sgl-project/sglang/actions/runs/25469734855)). The same auto-enable list also covers `DeepseekV3`, `GptOss`, `Glm4Moe`, `Qwen3MoE`, `KimiK2.5`, `Qwen3.5 MoE/non-MoE`, so any other deterministic-inference test on those arches with TP>1 on H100/H200/B200 is silently affected as well.

`_handle_deterministic_inference` currently force-disables only the **aiter** allredxruce fusion path; the FlashInfer counterpart is missing.

## Modifications

`python/sglang/srt/server_args.py`:

1. In `_handle_deterministic_inference`, mirror the existing `enable_aiter_allreduce_fusion` handling — when `enable_deterministic_inference` is set, warn and clear `enable_flashinfer_allreduce_fusion`.
2. In `__post_init__`, set `enforce_disable_flashinfer_allreduce_fusion = True` **before** `_handle_model_specific_adjustments` runs, so the existing enforce check at the end of that handler (already present, line ~2378) is the single source of truth that drives the override. This addresses the concern that setting the enforce flag inside `_handle_deterministic_inference` would be redundant given `_handle_model_specific_adjustments` runs earlier in `__post_init__`.

No change to default (non-deterministic) behavior; `enable_flashinfer_allreduce_fusion` is still auto-enabled for the listed MoE arches when deterministic inference is **not** requested.

## Accuracy Tests

Local repro on 8× H100 80GB (driver 580.126.20), `--tp 4`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, command identical to CI:

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 SGLANG_IS_IN_CI=true \
python test/registered/core/test_qwen3_next_deterministic.py \
  TestFlashInferDeterministic.test_prefix_with_logprobs -v
```

| Commit | `enable_flashinfer_allreduce_fusion` | Result |
|---|---|---|
| `4839cecbb0` (parent of #22664) | `False` | PASS — `Ran 1 test in 118.4s / OK / ✓✓✓ Logprobs are identical across all batch sizes! ✓✓✓` |
| `c6a45fab64` (#22664, introducing) | `True` | FAIL — `Ran 1 test in 102.6s / FAILED (errors=1) / ✗✗✗ Some logprobs differ across batch sizes! ✗✗✗`, 244 per-sample mismatches |
| HEAD (`5b589ed2e7`) | `True` | FAIL (same signature) |
| HEAD + this PR | `False` (forced via enforce flag) | PASS — `Ran 1 test in 94.6s / OK / ✓✓✓ Logprobs are identical across all batch sizes! ✓✓✓` |

Failing-vs-passing diffs reproduce the exact CI numerical fingerprint, e.g. `Logprob mismatch at position 0: -2.3552... vs -2.3723... (diff 0.017068...)`, the same value seen in the failing nightly logs.

## Speed Tests and Profiling

Not applicable — change only fires when the user opts into `--enable-deterministic-inference`, where deterministic correctness already supersedes peak performance. No effect on the default (non-deterministic) path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.