### PR TITLE
Fix #24637: Enable spec decoding v2 for flashmla attention backend

### DIFF
--- a/test/registered/mla/test_flashmla.py
+++ b/test/registered/mla/test_flashmla.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 import requests
 import torch
 
-from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
@@ -98,13 +97,12 @@ class TestFlashMLAMTP(CustomTestCase):
                 ]
             )
         # Use longer timeout for DeepGEMM JIT compilation which can take 10-20 minutes
-        with envs.SGLANG_ENABLE_SPEC_V2.override(False):
-            cls.process = popen_launch_server(
-                cls.model,
-                cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 2,
-                other_args=other_args,
-            )
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 2,
+            other_args=other_args,
+        )
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Motivation

Issue #24637 requests enabling spec decoding v2 for the flashmla attention backend. Currently, `test_flashmla.py` explicitly overrides `SGLANG_ENABLE_SPEC_V2` to `False`, forcing a fallback to spec v1 for the FlashMLA + EAGLE MTP test path.

## Modifications

- Removed the `envs.SGLANG_ENABLE_SPEC_V2.override(False)` context manager in `TestFlashMLAMTP.setUpClass()`.
- Removed the now-unused `envs` import.

This allows the FlashMLA + EAGLE speculative decoding test to run with spec v2 by default, which is the current standard behavior.

## Checklist

- [x] Format your code according to the existing conventions.
- [x] Describe your changes in the pull request.

Fixes #24637