### PR TITLE
fix(mimo_v2): auto-disable multimodal when vision/audio configs are absent

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -226,6 +226,16 @@ class ModelConfig:
                 logger.info(
                     f"Multimodal is disabled for {self.hf_config.model_type}. To enable it, set --enable-multimodal."
                 )
+            elif self.hf_config.architectures[0] in MIMO_V2_MULTIMODAL_ARCHS and not (
+                hasattr(self.hf_config, "vision_config")
+                and hasattr(self.hf_config, "audio_config")
+            ):
+                enable_multimodal = False
+                logger.info(
+                    "Multimodal is disabled for this MiMoV2 checkpoint: "
+                    "vision_config/audio_config not found in the model config "
+                    "(likely a text-only MiMoV2 variant)."
+                )
             else:
                 enable_multimodal = True
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  The `MiMoV2ForCausalLM` architecture is shared by both text-only and VL (vision-language + audio) MiMoV2 variants. Today `MIMO_V2_MULTIMODAL_ARCHS` unconditionally routes every `MiMoV2ForCausalLM` through the multimodal                                                                                                                                   
  processor path, so launching a **text-only** MiMoV2 checkpoint crashes during server startup:                                                                                                                                                                                    

```
    File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 638, in lifespan                                                                                                                      
      async with self.lifespan_context(app) as maybe_state:                                                                                                                                                         
    File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__                                                                                                                                               
      return await anext(self.gen)                                                                                                                                                                                  
             ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                  
    File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 216, in merged_lifespan                                                                                                                 
      async with original_context(app) as maybe_original_state:                                                                                                                                                     
    File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__                                                                                                                                               
      return await anext(self.gen)                                                                                                                                                                                  
             ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                  
    File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/http_server.py", line 298, in lifespan                                                                                                                
      server_args = await init_multi_tokenizer()                                                                                                                                                                    
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                    
    File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/http_server.py", line 264, in init_multi_tokenizer                                                                                                    
      tokenizer_manager = TokenizerWorker(server_args, port_args)                                                                                                                                                   
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                   
    File "/sgl-workspace/sglang/python/sglang/srt/managers/multi_tokenizer_mixin.py", line 392, in __init__                                                                                                         
      super().__init__(server_args, port_args)                                                                                                                                                                      
    File "/sgl-workspace/sglang/python/sglang/srt/managers/tokenizer_manager.py", line 235, in __init__                                                                                                             
      self.init_tokenizer_and_processor()                                                                                                                                                                           
    File "/sgl-workspace/sglang/python/sglang/srt/managers/tokenizer_manager.py", line 303, in init_tokenizer_and_processor                                                                                         
      self.mm_processor = get_mm_processor(                                                                                                                                                                         
                          ^^^^^^^^^^^^^^^^^                                                                                                                                                                         
    File "/sgl-workspace/sglang/python/sglang/srt/managers/multimodal_processor.py", line 67, in get_mm_processor                                                                                                   
      return processor_cls(                                                                                                                                                                                         
             ^^^^^^^^^^^^^^                                                                                                                                                                                         
    File "/sgl-workspace/sglang/python/sglang/srt/multimodal/processors/mimo_v2.py", line 1431, in __init__                                                                                                         
      self.vision_config = Qwen2_5_VLVisionConfig.from_dict(hf_config.vision_config)                                                                                                                                
                                                            ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                 
    File "/usr/local/lib/python3.12/dist-packages/transformers/configuration_utils.py", line 425, in __getattribute__                                                                                               
      return super().__getattribute__(key)                                                                                                                                                                          
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                          
  AttributeError: 'MiMoV2Config' object has no attribute 'vision_config'
```                                                                                                              


  The root cause is that the config-level multimodal gate and the model-level multimodal gate disagree: `models/mimo_v2.py` treats a checkpoint as multimodal only when both `vision_config` **and**                                                                                                                                           
  `audio_config` are present (see `_is_multimodal` at `models/mimo_v2.py:1038-1040`), but `ModelConfig` has no corresponding check and sends the text-only variant down the multimodal path anyway.    This PR aligns the two gates so the config layer refuses to build a multimodal processor for checkpoints the model itself would treat as text-only.

## Modifications

  In `ModelConfig.__init__`, when auto-deciding `enable_multimodal`, add an extra branch that disables multimodal for MiMoV2 architectures whose HF config is missing either `vision_config` or `audio_config`. The check mirrors the model-side `_is_multimodal` logic in `python/sglang/srt/models/mimo_v2.py` (which requires both configs), so the config-level gate and the model-level gate stay in lockstep.                                                                                                                                          
  - Text-only MiMoV2 checkpoints now boot out of the box.                                                                                                                                                   
  - VL MiMoV2 (both vision_config and audio_config present) keeps the                                                                                                                                       
    existing multimodal path unchanged. 

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
