### PR TITLE
Propagate enable_memory_saver through SWAKVPool

### DIFF
--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -42,6 +42,7 @@ class SWAKVPool(BaseSWAKVPool):
         enable_kvcache_transpose: bool,
         device: str,
         token_to_kv_pool_class: KVCache = MHATokenToKVPool,
+        enable_memory_saver: bool = False,
         **kwargs,
     ):
         self.size = size
@@ -59,7 +60,7 @@ class SWAKVPool(BaseSWAKVPool):
         self.layer_transfer_counter = None
 
         kwargs["page_size"] = page_size
-        kwargs["enable_memory_saver"] = False
+        kwargs["enable_memory_saver"] = enable_memory_saver
         kwargs["head_num"] = head_num
         kwargs["head_dim"] = head_dim
         kwargs["device"] = device

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -412,6 +412,7 @@ class ModelRunnerKVCacheMixin:
                     enable_kvcache_transpose=False,
                     device=self.device,
                     token_to_kv_pool_class=NPUMHATokenToKVPool,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
                     **kwargs,
                 )
             elif self.use_mla_backend:
@@ -534,6 +535,7 @@ class ModelRunnerKVCacheMixin:
                     full_attention_layer_ids=self.model_config.full_attention_layer_ids,
                     enable_kvcache_transpose=False,
                     device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
                     **kwargs,
                 )
             elif config := self.mambaish_config:

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -132,6 +133,41 @@ class TestSWA(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         pass
+
+    def test_swa_kv_pool_propagates_memory_saver(self):
+        class RecordingKVPool:
+            def __init__(self, *args, enable_memory_saver, **kwargs):
+                recorded_enable_memory_saver.append(enable_memory_saver)
+
+            def get_kv_size_bytes(self):
+                return 0, 0
+
+        for enable_memory_saver, expected in [
+            (False, [False, False]),
+            (True, [True, True]),
+        ]:
+            with self.subTest(enable_memory_saver=enable_memory_saver):
+                recorded_enable_memory_saver = []
+                with patch(
+                    "sglang.srt.mem_cache.swa_memory_pool.maybe_init_custom_mem_pool",
+                    return_value=(False, None, None),
+                ):
+                    SWAKVPool(
+                        size=8,
+                        size_swa=4,
+                        page_size=1,
+                        dtype=torch.bfloat16,
+                        head_num=1,
+                        head_dim=8,
+                        swa_attention_layer_ids=[1],
+                        full_attention_layer_ids=[0],
+                        enable_kvcache_transpose=False,
+                        device="cpu",
+                        token_to_kv_pool_class=RecordingKVPool,
+                        enable_memory_saver=enable_memory_saver,
+                    )
+
+                self.assertEqual(recorded_enable_memory_saver, expected)
 
     def test_swa_memory_pool(self):
         size = 16


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
`release_memory_occupation(tags=["kv_cache"])` relies on KV cache tensors being allocated under the `GPU_MEMORY_TYPE_KV_CACHE` memory saver region.

However, `SWAKVPool` currently overrides `enable_memory_saver` to `False` before constructing its inner KV pools.
This means hybrid SWA KV cache buffers are not registered with memory saver even when `server_args.enable_memory_saver=True`.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Add an `enable_memory_saver` argument to `SWAKVPool`.
- Forward `server_args.enable_memory_saver` from both hybrid SWA call sites.
- Propagate the flag to both inner KV pools.
- Add a unit test that verifies the flag is forwarded to both the SWA and full-attention inner pools.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
