### PR TITLE
[LoRA] Parallelize rank dimension in embedding_lora_a kernel for up to 1.36x speedup

### DIFF
--- a/benchmark/lora/bench_embedding_lora_a.py
+++ b/benchmark/lora/bench_embedding_lora_a.py
@@ -1,0 +1,112 @@
+"""Benchmark for embedding_lora_a kernel.
+
+Measures kernel latency across different batch sizes, sequence lengths, and
+LoRA ranks. Uses ``triton.testing.perf_report`` for consistent output that
+matches the style of jit_kernel benchmarks.
+
+Usage:
+    python benchmark/lora/bench_embedding_lora_a.py
+"""
+
+import itertools
+
+import torch
+import triton
+import triton.testing
+
+from sglang.srt.lora.triton_ops.embedding_lora_a import embedding_lora_a_fwd
+from sglang.srt.lora.utils import LoRABatchInfo
+
+# ==============================================================================
+# Constants
+# ==============================================================================
+DEVICE = "cuda"
+DTYPE = torch.float16
+VOCAB_SIZE = 32000
+NUM_LORAS = 4
+DEFAULT_QUANTILES = [0.5, 0.2, 0.8]
+
+# ==============================================================================
+# Parameter ranges
+# ==============================================================================
+BS_LIST = [1, 8, 32]
+SEQ_LEN_LIST = [1, 128, 512]
+RANK_LIST = [16, 64, 128, 256]
+CONFIGS = list(itertools.product(BS_LIST, SEQ_LEN_LIST, RANK_LIST))
+
+
+# ==============================================================================
+# Helpers
+# ==============================================================================
+def create_batch_info(
+    batch_size: int, seq_len: int, num_loras: int, rank: int
+) -> LoRABatchInfo:
+    """Build a LoRABatchInfo for the triton (non-chunked) backend."""
+    total_tokens = batch_size * seq_len
+    seg_lens = torch.full(
+        (batch_size,), seq_len, dtype=torch.int32, device=DEVICE
+    )
+    seg_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=DEVICE)
+    seg_indptr[1:] = torch.cumsum(seg_lens, dim=0)
+    return LoRABatchInfo(
+        use_cuda_graph=False,
+        bs=batch_size,
+        num_segments=batch_size,
+        seg_indptr=seg_indptr,
+        weight_indices=torch.randint(
+            0, num_loras, (batch_size,), dtype=torch.int32, device=DEVICE
+        ),
+        lora_ranks=torch.full(
+            (num_loras,), rank, dtype=torch.int32, device=DEVICE
+        ),
+        scalings=torch.ones(num_loras, dtype=torch.float32, device=DEVICE),
+        max_len=seq_len,
+        seg_lens=seg_lens,
+        permutation=torch.arange(
+            total_tokens, dtype=torch.int32, device=DEVICE
+        ),
+    )
+
+
+def run_benchmark(fn, scale=1.0):
+    """Execute benchmark via ``triton.testing.do_bench`` and return µs."""
+    ms, min_ms, max_ms = triton.testing.do_bench(
+        fn, quantiles=DEFAULT_QUANTILES
+    )
+    return 1000 * ms / scale, 1000 * max_ms / scale, 1000 * min_ms / scale
+
+
+# ==============================================================================
+# Benchmark — embedding_lora_a kernel
+# ==============================================================================
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "seq_len", "rank"],
+        x_vals=CONFIGS,
+        line_arg="provider",
+        line_vals=["triton"],
+        line_names=["embedding_lora_a (triton)"],
+        styles=[("blue", "-")],
+        ylabel="us",
+        plot_name="embedding-lora-a",
+        args={},
+    )
+)
+def benchmark(batch_size: int, seq_len: int, rank: int, provider: str):
+    total_tokens = batch_size * seq_len
+    input_ids = torch.randint(
+        0, VOCAB_SIZE, (total_tokens,), dtype=torch.int64, device=DEVICE
+    )
+    weights = torch.randn(
+        NUM_LORAS, rank, VOCAB_SIZE, dtype=DTYPE, device=DEVICE
+    )
+    batch_info = create_batch_info(batch_size, seq_len, NUM_LORAS, rank)
+
+    def fn():
+        embedding_lora_a_fwd(input_ids, weights, batch_info, VOCAB_SIZE)
+
+    return run_benchmark(fn)
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True) 

--- a/python/sglang/srt/lora/triton_ops/embedding_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/embedding_lora_a.py
@@ -37,17 +37,26 @@ def _embedding_lora_a_kernel(
     """
     Embedding lookup for LoRA A weights with support for extra tokens.
 
-    Each program handles one token across a block of rank dimensions.
-    Grid: (cdiv(max_len, 1), bs) - one program per token in each batch
+    Each program handles one block of rank dimensions for one token.
+
+    Grid: (max_len, bs, cdiv(rank, BLOCK_RANK))
+    - axis 0: token index within the segment
+    - axis 1: batch (segment) index
+    - axis 2: rank block index (parallelizes the rank dimension)
     """
-    batch_id = tl.program_id(axis=1)
     token_idx = tl.program_id(axis=0)
+    batch_id = tl.program_id(axis=1)
+    rank_block_id = tl.program_id(axis=2)
 
     w_index = tl.load(weight_indices + batch_id)
     rank_val = tl.load(lora_ranks + w_index)
 
-    # If rank is 0, skip
-    if rank_val == 0:
+    # Compute rank offsets for this block
+    rank_offset = tl.arange(0, BLOCK_RANK) + rank_block_id * BLOCK_RANK
+    rank_mask = rank_offset < rank_val
+
+    # Early exit: no work for this rank block
+    if rank_block_id * BLOCK_RANK >= rank_val:
         return
 
     seg_start = tl.load(seg_indptr + batch_id)
@@ -60,46 +69,39 @@ def _embedding_lora_a_kernel(
     # Load the token ID
     token_id = tl.load(input_ids + seg_start + token_idx)
 
-    # Process in chunks of BLOCK_RANK dimensions
-    num_blocks = tl.cdiv(rank_val, BLOCK_RANK)
+    # Check if this is an extra token
+    is_extra_token = token_id >= vocab_size
 
-    for block_id in range(num_blocks):
-        rank_offset = tl.arange(0, BLOCK_RANK) + block_id * BLOCK_RANK
-        rank_mask = rank_offset < rank_val
-
-        # Check if this is an extra token
-        is_extra_token = token_id >= vocab_size
-
-        if HAS_EXTRA_EMBEDDINGS and is_extra_token:
-            # Use extra embeddings
-            extra_token_id = token_id - vocab_size
-            extra_emb_ptr = (
-                extra_embeddings
-                + w_index * extra_emb_stride_0
-                + extra_token_id * extra_emb_stride_1
-                + rank_offset * extra_emb_stride_2
-            )
-            emb_values = tl.load(extra_emb_ptr, mask=rank_mask, other=0.0)
-        else:
-            # Use regular LoRA A weights
-            # weights shape: (num_loras, rank, vocab_size)
-            # We need to load weights[w_index, rank_offset, token_id]
-            token_id_clamped = tl.minimum(token_id, vocab_size - 1)
-            weight_ptr = (
-                weights
-                + w_index * w_stride_0
-                + rank_offset * w_stride_1
-                + token_id_clamped * w_stride_2
-            )
-            emb_values = tl.load(weight_ptr, mask=rank_mask, other=0.0)
-
-        # Write to output
-        output_ptr = (
-            output
-            + (seg_start + token_idx) * output_stride_0
-            + rank_offset * output_stride_1
+    if HAS_EXTRA_EMBEDDINGS and is_extra_token:
+        # Use extra embeddings
+        extra_token_id = token_id - vocab_size
+        extra_emb_ptr = (
+            extra_embeddings
+            + w_index * extra_emb_stride_0
+            + extra_token_id * extra_emb_stride_1
+            + rank_offset * extra_emb_stride_2
         )
-        tl.store(output_ptr, emb_values, mask=rank_mask)
+        emb_values = tl.load(extra_emb_ptr, mask=rank_mask, other=0.0)
+    else:
+        # Use regular LoRA A weights
+        # weights shape: (num_loras, rank, vocab_size)
+        # We need to load weights[w_index, rank_offset, token_id]
+        token_id_clamped = tl.minimum(token_id, vocab_size - 1)
+        weight_ptr = (
+            weights
+            + w_index * w_stride_0
+            + rank_offset * w_stride_1
+            + token_id_clamped * w_stride_2
+        )
+        emb_values = tl.load(weight_ptr, mask=rank_mask, other=0.0)
+
+    # Write to output
+    output_ptr = (
+        output
+        + (seg_start + token_idx) * output_stride_0
+        + rank_offset * output_stride_1
+    )
+    tl.store(output_ptr, emb_values, mask=rank_mask)
 
 
 def embedding_lora_a_fwd(
@@ -130,13 +132,11 @@ def embedding_lora_a_fwd(
     S = input_ids.shape[0]
     num_loras = weights.shape[0]
     rank = weights.shape[1]
-    vocab_size_weights = weights.shape[2]
 
     # Block size for rank dimension
     BLOCK_RANK = 128
 
     has_extra_embeddings = extra_embeddings is not None
-
     if has_extra_embeddings:
         assert extra_embeddings.is_contiguous()
         extra_emb_stride = (
@@ -151,13 +151,17 @@ def embedding_lora_a_fwd(
         )
         extra_emb_stride = (1, 1, 1)
 
-    # Grid: one program per token in each batch segment
+    # Grid: parallelize across tokens, batches, AND rank blocks
+    num_rank_blocks = triton.cdiv(rank, BLOCK_RANK)
     grid = (
         batch_info.max_len,
         batch_info.bs,
+        num_rank_blocks,
     )
 
-    output = torch.zeros((S, rank), device=input_ids.device, dtype=weights.dtype)
+    output = torch.zeros(
+        (S, rank), device=input_ids.device, dtype=weights.dtype
+    )
 
     _embedding_lora_a_kernel[grid](
         input_ids,
@@ -181,6 +185,7 @@ def embedding_lora_a_fwd(
         batch_info.lora_ranks,
         BLOCK_RANK,
         has_extra_embeddings,
+        num_warps=4,
     )
 
     return output

--- a/python/sglang/srt/lora/triton_ops/embedding_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/embedding_lora_a.py
@@ -51,13 +51,13 @@ def _embedding_lora_a_kernel(
     w_index = tl.load(weight_indices + batch_id)
     rank_val = tl.load(lora_ranks + w_index)
 
-    # Compute rank offsets for this block
-    rank_offset = tl.arange(0, BLOCK_RANK) + rank_block_id * BLOCK_RANK
-    rank_mask = rank_offset < rank_val
-
     # Early exit: no work for this rank block
     if rank_block_id * BLOCK_RANK >= rank_val:
         return
+
+    # Compute rank offsets for this block
+    rank_offset = tl.arange(0, BLOCK_RANK) + rank_block_id * BLOCK_RANK
+    rank_mask = rank_offset < rank_val
 
     seg_start = tl.load(seg_indptr + batch_id)
     seg_len = tl.load(seg_lens + batch_id)

--- a/test/registered/lora/test_embedding_lora_a.py
+++ b/test/registered/lora/test_embedding_lora_a.py
@@ -1,0 +1,338 @@
+"""Correctness tests for the optimized embedding_lora_a kernel.
+
+Compares :func:`sglang.srt.lora.triton_ops.embedding_lora_a.embedding_lora_a_fwd`
+output against the reference implementation
+:func:`sglang.test.lora_utils.reference_embedding_lora_a_shrink` across
+various batch sizes, ranks, and edge cases.
+
+Style follows ``test/registered/lora/test_fused_moe_lora_kernel.py``.
+"""
+
+import random
+import sys
+from typing import List
+
+import pytest
+import torch
+
+from sglang.srt.lora.triton_ops.embedding_lora_a import embedding_lora_a_fwd
+from sglang.srt.lora.utils import LoRABatchInfo
+from sglang.srt.utils import set_random_seed
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.lora_utils import reference_embedding_lora_a_shrink
+
+
+register_cuda_ci(est_time=30, suite="stage-b-test-1-gpu-small")
+
+DEVICE = "cuda:0"
+SEED = 42
+VOCAB_SIZE = 32000
+DTYPE = torch.float16
+
+
+# ==============================================================================
+# HELPERS
+# ==============================================================================
+
+def create_batch_info(
+    seq_lengths: List[int],
+    lora_assignments: List[int],
+    lora_ranks: List[int],
+    device: str,
+) -> LoRABatchInfo:
+    """Build a LoRABatchInfo for the triton (non-chunked) backend.
+
+    For the triton backend every segment == one request, so num_segments == bs
+    and permutation is identity.
+    """
+    bs = len(seq_lengths)
+    total_tokens = sum(seq_lengths)
+    num_loras = len(lora_ranks)
+
+    seg_lens = torch.tensor(seq_lengths, dtype=torch.int32, device=device)
+    seg_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=device)
+    seg_indptr[1:] = torch.cumsum(seg_lens, dim=0)
+
+    return LoRABatchInfo(
+        use_cuda_graph=False,
+        bs=bs,
+        num_segments=bs,
+        seg_indptr=seg_indptr,
+        weight_indices=torch.tensor(
+            lora_assignments, dtype=torch.int32, device=device
+        ),
+        lora_ranks=torch.tensor(lora_ranks, dtype=torch.int32, device=device),
+        scalings=torch.ones(num_loras, dtype=torch.float32, device=device),
+        max_len=max(seq_lengths) if seq_lengths else 0,
+        seg_lens=seg_lens,
+        permutation=torch.arange(total_tokens, dtype=torch.int32, device=device),
+    )
+
+
+def create_embedding_weights(
+    lora_ranks: List[int],
+    max_rank: int,
+    vocab_size: int,
+    dtype: torch.dtype,
+    device: str,
+) -> torch.Tensor:
+    """Create LoRA A embedding weights of shape (num_loras, max_rank, vocab_size)."""
+    num_loras = len(lora_ranks)
+    weights = torch.zeros(
+        num_loras,
+        max_rank,
+        vocab_size,
+        dtype=dtype,
+        device=device,
+    )
+
+    for i, rank in enumerate(lora_ranks):
+        if rank > 0:
+            weights[i, :rank, :] = torch.randn(
+                rank, vocab_size, dtype=dtype, device=device
+            )
+
+    return weights
+
+
+def run_kernel_and_reference(
+    seq_lengths: List[int],
+    lora_assignments: List[int],
+    lora_ranks: List[int],
+    max_rank: int,
+    vocab_size: int = VOCAB_SIZE,
+    dtype: torch.dtype = DTYPE,
+    device: str = DEVICE,
+):
+    """Run the Triton kernel and the PyTorch reference, return both outputs."""
+    total_tokens = sum(seq_lengths)
+    input_ids = torch.randint(
+        0,
+        vocab_size,
+        (total_tokens,),
+        dtype=torch.int64,
+        device=device,
+    )
+    weights = create_embedding_weights(
+        lora_ranks, max_rank, vocab_size, dtype, device
+    )
+    batch_info = create_batch_info(seq_lengths, lora_assignments, lora_ranks, device)
+
+    # --- Triton kernel under test ---
+    kernel_output = embedding_lora_a_fwd(input_ids, weights, batch_info, vocab_size)
+
+    # --- PyTorch reference (same one used by test_chunked_sgmv_backend) ---
+    reference_output = reference_embedding_lora_a_shrink(
+        input_ids,
+        weights,
+        torch.tensor(lora_assignments, dtype=torch.int32, device="cpu"),
+        torch.tensor(seq_lengths, dtype=torch.int32, device="cpu"),
+        batch_info.lora_ranks.detach().cpu(),
+        vocab_size,
+    )
+
+    return kernel_output, reference_output
+
+
+# ==============================================================================
+# TESTS — basic operations
+# ==============================================================================
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 32])
+@pytest.mark.parametrize("max_rank", [8, 32])
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_basic_batch_sizes(batch_size, max_rank, device, seed):
+    """Test basic embedding LoRA A for various batch sizes."""
+    set_random_seed(seed)
+    seq_lengths = [random.randint(1, 128) for _ in range(batch_size)]
+    lora_ranks = [max_rank]
+    lora_assignments = [0] * batch_size
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths,
+        lora_assignments,
+        lora_ranks,
+        max_rank,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [1, 8, 32])
+@pytest.mark.parametrize("max_rank", [16, 64])
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_decode_mode(batch_size, max_rank, device, seed):
+    """Test with seq_len=1 (decode mode)."""
+    set_random_seed(seed)
+    seq_lengths = [1] * batch_size
+    lora_ranks = [max_rank]
+    lora_assignments = [0] * batch_size
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths,
+        lora_assignments,
+        lora_ranks,
+        max_rank,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+# ==============================================================================
+# TESTS — rank parallelization (the core optimization)
+# ==============================================================================
+
+@pytest.mark.parametrize("max_rank", [16, 64, 128])
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_rank_single_block(max_rank, device, seed):
+    """rank <= 128 (BLOCK_RANK) — single rank block, baseline behavior."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 64],
+        lora_assignments=[0, 1],
+        lora_ranks=[max_rank, max_rank],
+        max_rank=max_rank,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("max_rank", [256, 384, 512])
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_rank_multiple_blocks(max_rank, device, seed):
+    """rank > 128 — multiple rank blocks parallelized in grid dim 2."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 16],
+        lora_assignments=[0, 1],
+        lora_ranks=[max_rank, max_rank],
+        max_rank=max_rank,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("max_rank", [100, 200, 300])
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_rank_not_multiple_of_block(max_rank, device, seed):
+    """rank not divisible by BLOCK_RANK=128 — tests mask correctness."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 16],
+        lora_assignments=[0, 0],
+        lora_ranks=[max_rank],
+        max_rank=max_rank,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+# ==============================================================================
+# TESTS — mixed configurations
+# ==============================================================================
+
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_mixed_ranks_across_adapters(device, seed):
+    """Different adapters use different ranks."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 16, 64, 8],
+        lora_assignments=[0, 1, 2, 0],
+        lora_ranks=[64, 256, 128],
+        max_rank=256,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_uniform_adapter(device, seed):
+    """All sequences share the same adapter."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 64, 16, 48],
+        lora_assignments=[0, 0, 0, 0],
+        lora_ranks=[256],
+        max_rank=256,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+# ==============================================================================
+# TESTS — edge cases
+# ==============================================================================
+
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_rank_zero_skipped(device, seed):
+    """Adapter with rank=0 should produce zero output for its segment."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 16],
+        lora_assignments=[0, 1],
+        lora_ranks=[0, 128],
+        max_rank=128,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_all_rank_zero(device, seed):
+    """All adapters have rank=0 — output should be all zeros."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[32, 16],
+        lora_assignments=[0, 1],
+        lora_ranks=[0, 0],
+        max_rank=1,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("device", [DEVICE])
+@pytest.mark.parametrize("seed", [SEED])
+def test_unequal_segment_lengths(device, seed):
+    """Segments with very different lengths."""
+    set_random_seed(seed)
+
+    kernel_out, ref_out = run_kernel_and_reference(
+        seq_lengths=[1, 512, 3, 128],
+        lora_assignments=[0, 1, 0, 1],
+        lora_ranks=[128, 256],
+        max_rank=256,
+        device=device,
+    )
+
+    torch.testing.assert_close(kernel_out, ref_out, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))
+ 

--- a/test/registered/lora/test_embedding_lora_a.py
+++ b/test/registered/lora/test_embedding_lora_a.py
@@ -128,6 +128,7 @@ def run_kernel_and_reference(
         torch.tensor(lora_assignments, dtype=torch.int32, device="cpu"),
         torch.tensor(seq_lengths, dtype=torch.int32, device="cpu"),
         batch_info.lora_ranks.detach().cpu(),
+        batch_info.scalings.detach().cpu(),
         vocab_size,
     )
 


### PR DESCRIPTION


## Motivation

The `embedding_lora_a` Triton kernel processes the rank dimension in a **serial loop** inside each program:

```python
# Before: serial loop over rank blocks
for block_id in range(num_blocks):
    rank_offset = tl.arange(0, BLOCK_RANK) + block_id * BLOCK_RANK
    ...
```

When `rank > BLOCK_RANK (128)`, multiple iterations execute sequentially within a single GPU thread block, leaving GPU parallelism on the table. This is the same pattern that `chunked_sgmv_shrink.py` already parallelizes via its grid N‑dimension.

## Modifications

### Kernel optimization (`python/sglang/srt/lora/triton_ops/embedding_lora_a.py`)

- **Replaced the serial `for` loop** with a third grid dimension that parallelizes rank blocks across GPU thread blocks
- Grid changed from `(max_len, bs)` → `(max_len, bs, cdiv(rank, BLOCK_RANK))`
- Each program now handles exactly one rank block via `rank_block_id = tl.program_id(axis=2)`
- Added early‑exit guard: `if rank_block_id * BLOCK_RANK >= rank_val: return`
- **No interface change**: `embedding_lora_a_fwd()` signature is unchanged; callers (`triton_backend.py`) require zero modifications

### New correctness test (`test/registered/lora/test_embedding_lora_a.py`)

- pytest style following `test_fused_moe_lora_kernel.py`
- 28 test cases covering:
  - Basic batch sizes
  - Decode mode (seq_len=1)
  - Single / multiple rank blocks
  - Non‑aligned ranks (100/200/300)
  - Mixed ranks across adapters
  - Rank=0 edge cases
  - Unequal segment lengths
- Registered to `stage-b-test-1-gpu-small` CI suite

### New benchmark (`benchmark/lora/bench_embedding_lora_a.py`)

- `triton.testing.perf_report` style following `jit_kernel/benchmark/bench_activation.py`
- Sweeps batch_size × seq_len × rank combinations

## Accuracy Tests

**28/28 passed** ✅

```bash
$ python -m pytest test/registered/lora/test_embedding_lora_a.py -v
========================= 28 passed, 17 warnings in 7.61s =========================
```

## Speed Tests and Profiling

| batch_size | seq_len | rank | Before (µs) | After (µs) | Speedup |
|------------|---------|------|-------------|------------|---------|
| 8          | 512     | 256  | 122.90      | 100.70     | **1.22x** |
| 32         | 128     | 256  | 151.31      | 131.92     | **1.15x** |
| 32         | 512     | 256  | 295.10      | 216.90     | **1.36x** |

- **rank ≤ 128**: Performance unchanged (single rank block)
- **rank = 256 + large batch**: Up to **1.36x speedup**
- **No regression** at any configuration







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26808801748](https://github.com/sgl-project/sglang/actions/runs/26808801748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26808801541](https://github.com/sgl-project/sglang/actions/runs/26808801541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->