### PR TITLE
[AMD] fix ci: strip [asctime] prefix in JSON-log parsing tests broken by #24521

### DIFF
--- a/test/registered/bench_fn/test_bench_serving_functionality.py
+++ b/test/registered/bench_fn/test_bench_serving_functionality.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tempfile
 import threading
 import time
@@ -24,6 +25,9 @@ register_amd_ci(est_time=300, suite="nightly-amd-1-gpu", nightly=True)
 
 MODEL = "Qwen/Qwen3-0.6B"
 NUM_CONVERSATIONS, NUM_TURNS = 4, 3
+
+# Strip the "[YYYY-MM-DD HH:MM:SS] " prefix added by _create_logger_with_handler.
+_LOG_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ")
 
 
 class TestBenchServingFunctionality(CustomTestCase):
@@ -74,6 +78,7 @@ class TestBenchServingFunctionality(CustomTestCase):
     def _verify_multi_turn_logs(self, content: str):
         reqs = []
         for line in content.splitlines():
+            line = _LOG_PREFIX_RE.sub("", line)
             if not line.startswith("{"):
                 continue
             obj = json.loads(line)

--- a/test/registered/utils/test_request_logger.py
+++ b/test/registered/utils/test_request_logger.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import re
 import tempfile
 import time
 import unittest
@@ -25,6 +26,9 @@ TEST_ROUTING_KEY = "test-routing-key-12345"
 TEST_CUSTOM_HEADER_NAME = "X-Test-Header"
 TEST_CUSTOM_HEADER_VALUE = "test-header-value-67890"
 TEST_MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+# Strip the "[YYYY-MM-DD HH:MM:SS] " prefix added by _create_logger_with_handler.
+_LOG_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ")
 
 
 class BaseTestRequestLogger:
@@ -190,6 +194,7 @@ class TestRequestLoggerJson(BaseTestRequestLogger, CustomTestCase):
         received_found = False
         finished_found = False
         for line in content.splitlines():
+            line = _LOG_PREFIX_RE.sub("", line)
             if not line.strip() or not line.startswith("{"):
                 continue
             try:
@@ -227,6 +232,7 @@ class TestRequestLoggerJson(BaseTestRequestLogger, CustomTestCase):
     def _verify_openai_logs(self, content: str, source_name: str):
         openai_received_found = False
         for line in content.splitlines():
+            line = _LOG_PREFIX_RE.sub("", line)
             if not line.strip() or not line.startswith("{"):
                 continue
             try:

--- a/test/registered/utils/test_scheduler_status_logger.py
+++ b/test/registered/utils/test_scheduler_status_logger.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import tempfile
 import time
@@ -19,6 +20,9 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=120, suite="nightly-1-gpu", nightly=True)
 register_amd_ci(est_time=120, suite="nightly-amd-1-gpu", nightly=True)
+
+# Strip the "[YYYY-MM-DD HH:MM:SS] " prefix added by _create_logger_with_handler.
+_LOG_PREFIX_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] ")
 
 
 class TestSchedulerStatusLogger(CustomTestCase):
@@ -64,6 +68,7 @@ class TestSchedulerStatusLogger(CustomTestCase):
 def _find_log_events(log_dir: str, event_name: str):
     for f in Path(log_dir).glob("*.log"):
         for line in f.read_text().splitlines():
+            line = _LOG_PREFIX_RE.sub("", line)
             if line.startswith("{"):
                 data = json.loads(line)
                 if data.get("event") == event_name:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

PR #24521 (commit `b859f7ff`, "Improve metrics, observability, and PD deploy tooling") changed `_create_logger_with_handler` in `python/sglang/srt/utils/log_utils.py` so every emitted line is now prefixed with `[YYYY-MM-DD HH:MM:SS] `:

```python
handler.setFormatter(
    logging.Formatter("[%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
)
```

That PR updated its own new `test/registered/utils/test_log_utils.py` with `_LOG_PREFIX_RE` to strip the prefix before parsing JSON, but **3 pre-existing tests** that scan the same log streams with `if line.startswith("{")` were not updated, so they discard every event under the new formatter and fail.

This is the issue tracked as **R69** (2-day persistent failure across `nightly-test-amd / nightly-test-amd-rocm720 / amd-aiter-scout` sub-jobs; same defect also hit the next CUDA nightly via `register_cuda_ci`).

### Failing tests (all same root cause, all on the formatter prefix)

| Test | File:func | Symptom |
|---|---|---|
| `TestBenchServingFunctionality.test_gsp_multi_turn` | `test/registered/bench_fn/test_bench_serving_functionality.py::_verify_multi_turn_logs` | `AssertionError: 0 not greater than or equal to 12` |
| `TestRequestLoggerJson.test_logging` / `test_openai_chat_logging` | `test/registered/utils/test_request_logger.py::_verify_logs` / `_verify_openai_logs` | `AssertionError: False is not true : request.received event not found in stdout` |
| `TestSchedulerStatusLogger.test_scheduler_status_dump` | `test/registered/utils/test_scheduler_status_logger.py::_find_log_events` | `AssertionError: 0 not greater than 0 : scheduler.status event not found` (`events=[]`) |

Smoking gun (from CI run 25534700106 stdout, log line 36 of the failing job): the server actually emitted the events — they were just hidden behind the new prefix:

```
[2026-05-08 03:28:37] {"timestamp": "...", "event": "request.received", "rid": "...", ...}
```

## Modifications

3 commits, each fixing one file with the same minimal pattern (strip the prefix once per line before the existing `startswith("{")` check, mirroring `_LOG_PREFIX_RE` from `test_log_utils.py:15` introduced in #24521):

| Commit | File | Function(s) |
|---|---|---|
| `30815bc` | `test/registered/bench_fn/test_bench_serving_functionality.py` | `_verify_multi_turn_logs` |
| `260686a` | `test/registered/utils/test_request_logger.py` | `TestRequestLoggerJson._verify_logs`, `_verify_openai_logs` |
| `78dcd82` | `test/registered/utils/test_scheduler_status_logger.py` | `_find_log_events` |

Production code is **not** touched — the formatter change in #24521 is intentional (the same PR added the prefix-aware regex in its new test); we adapt the consumer-side parsers. The diff is hardware-agnostic, so a single fix covers AMD + NV.

## Verification (CI on this branch)

Same suite (`--suite nightly-1-gpu` / `--suite nightly-amd-1-gpu`) verified on **3 platforms**, all green, **0 AssertionError** in any run:

| Platform | Workflow / Job | Run | Duration | Tests |
|---|---|---|---|---|
| **NVIDIA H100** | `nightly-test-nvidia / nightly-test-general-1-gpu-h100` | [25547402955 / 74986870471](https://github.com/sgl-project/sglang/actions/runs/25547402955/job/74986870471) | 24m13s ✓ | bench_serving 66s · request_logger 100s · scheduler_status 39s |
| **AMD MI30x (ROCm 7.0)** | `nightly-test-amd / nightly-test-1-gpu-unit` | [25538321996 / 74958702806](https://github.com/sgl-project/sglang/actions/runs/25538321996/job/74958702806) | 32m28s ✓ | bench_serving 64s · request_logger 135s · scheduler_status 66s |
| **AMD MI30x (ROCm 7.2)** | `nightly-test-amd-rocm720 / nightly-test-1-gpu-unit-rocm720` | [25541580666 / 74968459684](https://github.com/sgl-project/sglang/actions/runs/25541580666/job/74968459684) | 32m57s ✓ | bench_serving 65s · request_logger 134s · scheduler_status 84s |

For reference, the most recent pre-fix scheduled NV nightly [25530453303](https://github.com/sgl-project/sglang/actions/runs/25530453303/job/74935407079) (2026-05-08 00:55 UTC) reproduced exactly these three `AssertionError` messages in its `nightly-test-general-1-gpu-h100` job log — the same set this PR clears.

A previous run on the first commit only ([25534700106](https://github.com/sgl-project/sglang/actions/runs/25534700106)) confirmed the first commit cleared `test_gsp_multi_turn` while the other two failures still surfaced — that's what motivated extending the same fix pattern to the remaining two files in this PR.

## Accuracy Tests

N/A — test-only change.

## Speed Tests and Profiling

N/A — test-only change.

## Checklist

- [x] Surgical fix; no behavior change to production code.
- [x] Mirrors existing prefix-handling pattern from `test/registered/utils/test_log_utils.py:15` introduced in #24521.
- [x] Each logical change is a separate commit.
- [x] Verified green on NVIDIA H100, AMD MI30x ROCm 7.0, and AMD MI30x ROCm 7.2 — `nightly-test-1-gpu-unit*` jobs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dd47e01-ebf1-4191-95f3-f03eba912587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dd47e01-ebf1-4191-95f3-f03eba912587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

