### PR TITLE
ci(amd): add sgl-kernel-unit-test-8-gpu-amd benchmark smoke (rocm700 + rocm720)

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -287,10 +287,8 @@ jobs:
       - name: Run test
         timeout-minutes: 45
         run: |
-          # V1 custom all-reduce correctness: SGLang vs NCCL/RCCL across
-          # WORLD_SIZES={2,4,6,8} x dtypes={fp16,bf16,fp32} x {eager,graph}.
-          docker exec -w /sglang-checkout/test/manual ci_sglang python3 -m pytest test_custom_allreduce.py
           # SGLang vs Aiter custom all-reduce performance smoke at TP=8.
+          # No perf assertion yet; informational kernel-crash signal only.
           docker exec -w /sglang-checkout/benchmark/kernels/all_reduce ci_sglang torchrun --standalone --nproc_per_node=8 benchmark_aiter.py
 
   # =============================================== primary ====================================================

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -35,6 +35,7 @@ on:
           - ''
           - sgl-kernel-unit-test-amd-rocm720
           - sgl-kernel-unit-test-2-gpu-amd-rocm720
+          - sgl-kernel-unit-test-8-gpu-amd-rocm720
           - stage-a-test-1-gpu-small-amd-rocm720
           - jit-kernel-unit-test-amd-rocm720
           - stage-b-test-1-gpu-small-amd-rocm720
@@ -249,6 +250,48 @@ jobs:
         run: |
           docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_amd_deterministic_custom_allreduce.py
           docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_amd_nccl_allreduce_determinism.py
+
+  sgl-kernel-unit-test-8-gpu-amd-rocm720:
+    needs: [check-changes]
+    if: |
+      always() &&
+      (
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',sgl-kernel-unit-test-8-gpu-amd-rocm720,')) ||
+        (
+          !(inputs.target_stage || inputs.target_stage_select) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [linux-mi325-8gpu-sglang]
+    runs-on: ${{matrix.runner}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh
+      - name: Run test
+        timeout-minutes: 45
+        run: |
+          # V1 custom all-reduce correctness: SGLang vs NCCL/RCCL across
+          # WORLD_SIZES={2,4,6,8} x dtypes={fp16,bf16,fp32} x {eager,graph}.
+          docker exec -w /sglang-checkout/test/manual ci_sglang python3 -m pytest test_custom_allreduce.py
+          # SGLang vs Aiter custom all-reduce performance smoke at TP=8.
+          docker exec -w /sglang-checkout/benchmark/kernels/all_reduce ci_sglang torchrun --standalone --nproc_per_node=8 benchmark_aiter.py
 
   # =============================================== primary ====================================================
 
@@ -1065,6 +1108,7 @@ jobs:
 
         sgl-kernel-unit-test-amd-rocm720,
         sgl-kernel-unit-test-2-gpu-amd-rocm720,
+        sgl-kernel-unit-test-8-gpu-amd-rocm720,
         multimodal-gen-test-1-gpu-amd-rocm720,
         multimodal-gen-test-2-gpu-amd-rocm720,
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -329,11 +329,8 @@ jobs:
               "$@"
             fi
           }
-          # V1 custom all-reduce correctness: SGLang vs NCCL/RCCL across
-          # WORLD_SIZES={2,4,6,8} x dtypes={fp16,bf16,fp32} x {eager,graph}.
-          run_step docker exec -w /sglang-checkout/test/manual ci_sglang python3 -m pytest test_custom_allreduce.py
-          # SGLang vs Aiter custom all-reduce performance smoke (no perf
-          # assertion yet; informational kernel-crash signal at TP=8).
+          # SGLang vs Aiter custom all-reduce performance smoke at TP=8.
+          # No perf assertion yet; informational kernel-crash signal only.
           run_step docker exec -w /sglang-checkout/benchmark/kernels/all_reduce ci_sglang torchrun --standalone --nproc_per_node=8 benchmark_aiter.py
           exit $failures
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -26,6 +26,7 @@ on:
           - ''
           - sgl-kernel-unit-test-amd
           - sgl-kernel-unit-test-2-gpu-amd
+          - sgl-kernel-unit-test-8-gpu-amd
           - stage-a-test-1-gpu-small-amd
           - jit-kernel-unit-test-amd
           - stage-b-test-1-gpu-small-amd
@@ -279,7 +280,61 @@ jobs:
           }
           run_pytest docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_amd_deterministic_custom_allreduce.py
           run_pytest docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_amd_nccl_allreduce_determinism.py
-          run_pytest docker exec -w /sglang-checkout/benchmark/kernels/all_reduce ci_sglang torchrun --standalone --nproc_per_node=2 benchmark_aiter.py
+          exit $failures
+
+  sgl-kernel-unit-test-8-gpu-amd:
+    name: ${{ format('sgl-kernel-unit-test-8-gpu-amd (linux-{0}-8gpu-sglang)', inputs.runner_arch || (github.event_name == 'pull_request' && 'mi300' || 'mi325')) }}
+    needs: [check-changes, call-gate]
+    if: |
+      always() && !cancelled() &&
+      (
+        (contains(format(',{0},', inputs.target_stage || inputs.target_stage_select), ',sgl-kernel-unit-test-8-gpu-amd,')) ||
+        (
+          !(inputs.target_stage || inputs.target_stage_select) &&
+          (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
+    runs-on: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || (github.event_name == 'pull_request' && 'mi300' || 'mi325')) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Run test
+        timeout-minutes: 45
+        env:
+          CONTINUE_ON_ERROR: ${{ needs.check-changes.outputs.continue_on_error }}
+        run: |
+          # In continue-on-error mode (schedule/full runs), keep running all
+          # commands and aggregate the exit code. In PR mode, preserve fail-fast.
+          failures=0
+          run_step() {
+            if [[ "$CONTINUE_ON_ERROR" == "true" ]]; then
+              "$@" || failures=$((failures + 1))
+            else
+              "$@"
+            fi
+          }
+          # V1 custom all-reduce correctness: SGLang vs NCCL/RCCL across
+          # WORLD_SIZES={2,4,6,8} x dtypes={fp16,bf16,fp32} x {eager,graph}.
+          run_step docker exec -w /sglang-checkout/test/manual ci_sglang python3 -m pytest test_custom_allreduce.py
+          # SGLang vs Aiter custom all-reduce performance smoke (no perf
+          # assertion yet; informational kernel-crash signal at TP=8).
+          run_step docker exec -w /sglang-checkout/benchmark/kernels/all_reduce ci_sglang torchrun --standalone --nproc_per_node=8 benchmark_aiter.py
           exit $failures
 
   # =============================================== primary ====================================================
@@ -1148,6 +1203,7 @@ jobs:
 
         sgl-kernel-unit-test-amd,
         sgl-kernel-unit-test-2-gpu-amd,
+        sgl-kernel-unit-test-8-gpu-amd,
         multimodal-gen-test-1-gpu-amd,
         multimodal-gen-test-2-gpu-amd,
 

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -279,6 +279,7 @@ jobs:
           }
           run_pytest docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_amd_deterministic_custom_allreduce.py
           run_pytest docker exec -w /sglang-checkout/sgl-kernel/tests ci_sglang python3 -m pytest test_amd_nccl_allreduce_determinism.py
+          run_pytest docker exec -w /sglang-checkout/benchmark/kernels/all_reduce ci_sglang torchrun --standalone --nproc_per_node=2 benchmark_aiter.py
           exit $failures
 
   # =============================================== primary ====================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

AMD CI currently has no automated coverage for SGLang's V1 custom all-reduce path at TP=8. This PR adds a new dedicated 8-GPU sgl-kernel job, in **both** the ROCm 7.0 (default) and ROCm 7.2 workflows, that runs `benchmark/kernels/all_reduce/benchmark_aiter.py` at `--nproc_per_node=8` as a kernel-crash smoke. The benchmark exits 0 unless the SGLang or Aiter custom all-reduce kernel actually fails to launch / segfaults / disagrees on shape, so it is a minimum-viable regression signal for the AMD CAR path under both rocm700 and rocm720 toolchains.

### Why 8-GPU

The V1 custom AR ROCm path branches on `world_size`:

```python
if self.world_size == 2 or self.full_nvlink:
    ...  # special-case algorithm
```

`world_size = 2` uses a different code path from 4/6/8. TP=8 is also the dominant production shape for ROCm deployments, so it's the most valuable size to gate regressions on.

### Why a new job instead of folding into existing 8-GPU jobs

`stage-c-test-large-8-gpu-amd` runs via `run_suite.py` with auto-partitioning, which is awkward for a benchmark that uses `torchrun` directly. A dedicated `sgl-kernel-unit-test-8-gpu-amd` job, modeled on the existing `sgl-kernel-unit-test-2-gpu-amd`, lets us invoke `torchrun` directly inside the `ci_sglang` container without restructuring upstream tests.

### Scope intentionally narrow (smoke only, no correctness, no perf assertion)

The initial plan also included `test/manual/test_custom_allreduce.py` (Ray-based correctness vs NCCL/RCCL across `WORLD_SIZES = {2, 4, 6, 8}` x dtypes x eager/graph). The first CI trigger surfaced two pre-existing issues that are not appropriate to fix in this PR:

- `test/manual/test_custom_allreduce.py` passes the `unittest.TestCase` instance (`self`) as a positional argument to a Ray remote actor. On Python 3.10+ the TestCase carries thread-local `_outcome` state that cannot be pickled, so Ray fails with `TypeError: cannot pickle '_Local' object`. The test has lived under `test/manual/` and was never wired to CI before, so the bug has been latent for a while.
- The rocm720 `ci_sglang` container does not have `ray` installed at all (`ModuleNotFoundError: No module named 'ray'`).

Both require non-surgical changes (refactor the manual test to use module-level Ray actors with a `try/finally` around `ray.shutdown`, plus add `ray` to the rocm720 dependency installer) and will be handled in a follow-up PR. Performance-assertion hardening for the benchmark (per-size SGLang/Aiter interleaving, median, relative threshold) will likewise land separately.

## Modifications

`.github/workflows/pr-test-amd.yml` (ROCm 7.0):

- Add new job `sgl-kernel-unit-test-8-gpu-amd`:
  - `runs-on: linux-{mi300|mi325}-8gpu-sglang` (uses the same runner pool as `stage-c-test-large-8-gpu-amd`).
  - Gated on `main_package OR sgl_kernel` so it triggers on changes to the C++/HIP kernel under `sgl-kernel/`, the Python wrapper at `python/sglang/srt/distributed/device_communicators/custom_all_reduce.py`, or the test files themselves under `test/`.
  - 45 minute timeout. Honors `CONTINUE_ON_ERROR` like sibling sgl-kernel jobs (fail-fast on PRs, aggregate failures on schedule / `run_all_tests`).
  - Runs `torchrun --standalone --nproc_per_node=8 benchmark_aiter.py`.
- Register the new stage name in the `workflow_dispatch.target_stage_select` dropdown so it can be re-run individually via `/rerun-stage sgl-kernel-unit-test-8-gpu-amd`.
- Add the job to `pr-test-amd-finish.needs` so its failure surfaces in the aggregate finish job.

`.github/workflows/pr-test-amd-rocm720.yml` (ROCm 7.2):

- Mirror the same job as `sgl-kernel-unit-test-8-gpu-amd-rocm720` adapted to rocm720 conventions (no call-gate dependency, fixed `linux-mi325-8gpu-sglang` runner, `--rocm-version rocm720` flag on container start, no `run_pytest` continue-on-error wrapper).
- Register in dropdown and `pr-test-amd-rocm720-finish.needs`.

No changes to other AMD jobs, no path-filter changes, no kernel/source code changes.

## Trigger / Validation

Both workflows triggered via `workflow_dispatch` against this branch, targeting only the new stages:

- ROCm 7.0: https://github.com/sgl-project/sglang/actions/runs/25552119722
- ROCm 7.2: https://github.com/sgl-project/sglang/actions/runs/25552120755

(Earlier runs that exercised the dropped `test_custom_allreduce.py` are 25546952948 / 25546968825.)

## Accuracy Tests

N/A — CI plumbing only.

## Speed Tests and Profiling

N/A — CI plumbing only. The benchmark prints per-size avg latency (SGLang vs Aiter) on rank 0; trends can be inspected in job logs while we decide on a perf-assertion strategy in a follow-up.

## Follow-ups (not in this PR)

- Refactor `test/manual/test_custom_allreduce.py` to module-level Ray remote functions (drop the `self` argument), add `try/finally` around `ray.shutdown`, and wire it into the same 8-GPU job.
- Add `ray` to the rocm720 dependency installer so the refactored correctness test can run there too.
- Harden `benchmark_aiter.py` for PR-time perf assertion: per-size SGLang/Aiter interleaving + median + relative `<= 2x` threshold + warmup bump.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3605affd-d4a3-43b9-a499-cd92393312ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3605affd-d4a3-43b9-a499-cd92393312ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

