### PR TITLE
feat: DFlash supports PD disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -182,3 +182,60 @@ class ScheduleBatchDisaggregationDecodeMixin:
                     spec_info.future_indices, spec_info
                 )
             self.spec_info = spec_info
+
+        elif self.spec_algorithm.is_dflash():
+            # Initialize DFLASH draft input for PD disaggregation.
+            # The draft KV cache is already transferred from the prefill side via
+            # RDMA, so no target_hidden materialization is needed on first decode.
+            bs = len(self.reqs)
+
+            if self.enable_overlap:
+                # Overlap (spec_v2) mode uses DFlashDraftInputV2.
+                from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+
+                cur_allocated_seq_lens_cpu = torch.tensor(
+                    [int(req.kv_allocated_len) for req in self.reqs],
+                    dtype=torch.int32,
+                )
+                spec_info = DFlashDraftInputV2(
+                    topk_p=torch.empty(
+                        (bs, 0), device=self.device, dtype=torch.float32
+                    ),
+                    topk_index=torch.empty(
+                        (bs, 0), device=self.device, dtype=torch.int64
+                    ),
+                    verified_id=self.output_ids.to(dtype=torch.int32),
+                    new_seq_lens=self.seq_lens.to(dtype=torch.int32),
+                    hidden_states=torch.empty(
+                        (bs, 0), device=self.device, dtype=torch.float16
+                    ),
+                    verify_done=None,
+                    cur_allocated_seq_lens_cpu=cur_allocated_seq_lens_cpu,
+                )
+                spec_info.future_indices = future_map.alloc_future_indices(
+                    len(self.seq_lens)
+                )
+                future_map.store_to_map_for_new_batch(
+                    spec_info.future_indices, spec_info
+                )
+                self.spec_info = spec_info
+            else:
+                # Non-overlap (spec_v1) mode uses DFlashDraftInput.
+                # Draft KV cache was transferred from prefill via RDMA, so
+                # target_hidden is empty and ctx_lens is zero (nothing to append).
+                from sglang.srt.speculative.dflash_info import DFlashDraftInput
+
+                draft_seq_lens = self.seq_lens.to(dtype=torch.int32)
+                draft_window = server_args.speculative_dflash_draft_window_size
+                if draft_window is not None:
+                    draft_seq_lens = torch.clamp(draft_seq_lens, max=int(draft_window))
+
+                spec_info = DFlashDraftInput(
+                    verified_id=self.output_ids.to(dtype=torch.int64),
+                    target_hidden=torch.empty(
+                        0, device=self.device, dtype=torch.float16
+                    ),
+                    ctx_lens=torch.zeros(bs, dtype=torch.int32, device=self.device),
+                    draft_seq_lens=draft_seq_lens,
+                )
+                self.spec_info = spec_info

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1074,6 +1074,14 @@ class Scheduler(
                 draft_runner = self.draft_worker.draft_worker.draft_runner
             draft_token_to_kv_pool = draft_runner.token_to_kv_pool
             model_config = draft_runner.model_config
+        elif self.spec_algorithm.is_dflash():
+            # DFlashWorker.model_runner is the target model's runner;
+            # the draft model's KV pool lives in draft_model_runner.
+            draft_token_to_kv_pool = (
+                self.draft_worker.draft_model_runner.token_to_kv_pool
+            )
+            # Actually we don't need draft model config for DFlash because DFlash use KV cache to transfer hidden states rather than metadata buffer.
+            model_config = self.draft_worker.draft_model_runner.model_config
         else:
             # todo: should we fix this when enabling mtp or it doesn't matter since we only enable mtp in decode node thus we don't transfer draft kvs between P and D?
             draft_token_to_kv_pool = self.draft_worker.model_runner.token_to_kv_pool


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Enable DFlash Speculative Decoding V2 to work with PD (Prefill-Decode) disaggregation. 

## Modifications

<!-- Detail the changes made in this pull request. -->
 1. `python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py`:
    - Added a new elif `self.spec_algorithm.is_dflash()` branch in the decode schedule batch mixin to handle DFlash draft input initialization on the decode side.
    - Supports both overlap (V2) and non-overlap (V1) modes:
        - Overlap mode: Creates `DFlashDraftInputV2` with empty topk_p/topk_index/hidden_states (since draft KV is already transferred via RDMA), allocates future indices for async speculation.
      - Non-overlap mode: Creates `DFlashDraftInput` with empty target_hidden and zero ctx_lens, respecting the speculative_dflash_draft_window_size setting.
  2. `python/sglang/srt/managers/scheduler.py`:
    - Added a new elif self.spec_algorithm.is_dflash() branch to correctly resolve the draft model's token_to_kv_pool and model_config from DFlashWorker.draft_model_runner, enabling proper KV cache transfer handling for PD disaggregation.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
