### PR TITLE
Remove unnecessary bf16 assert in rotate_activation

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -104,7 +104,7 @@ class CompressorBackendMixin:
             freqs_cis_cache,
             plan,
         )
-        return rotate_activation(kv_compressed.bfloat16()) if rotate else kv_compressed
+        return rotate_activation(kv_compressed) if rotate else kv_compressed
 
     def forward_core_compressor(
         self,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -148,7 +148,6 @@ class BaseIndexerMetadata(ABC):
 
 
 def rotate_activation(x: torch.Tensor) -> torch.Tensor:
-    assert x.dtype == torch.bfloat16
     # from sgl_kernel import hadamard_transform
     if _is_hip:
         from fast_hadamard_transform import hadamard_transform


### PR DESCRIPTION
## Summary
- Remove the unnecessary `.bfloat16()` cast in `compressor.py` before calling `rotate_activation`, allowing other dtypes (e.g., fp8) to pass through
- Remove the `assert x.dtype == torch.bfloat16` guard in `rotate_activation` in `nsa_indexer.py`, since the function works correctly with other dtypes

## Test plan
- Existing DSv4 tests should continue to pass
- Verified that `rotate_activation` / hadamard transform does not require bf16 input