### PR TITLE
[diffusion] fix FA3 varlen out argument handling

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -148,7 +148,7 @@ jobs:
               - ".github/workflows/pr-test-multimodal-gen.yml"
               - "python/pyproject.toml"
               - "python/sglang/multimodal_gen/**/!(*.md|*.ipynb)"
-              - "python/sglang/jit_kernel/diffusion/**"
+              - "python/sglang/jit_kernel/**"
               - "python/sglang/jit_kernel/tests/diffusion/**"
               - "python/sglang/jit_kernel/benchmark/diffusion/**"
               - "python/sglang/cli/**"

--- a/python/sglang/jit_kernel/flash_attention_v3.py
+++ b/python/sglang/jit_kernel/flash_attention_v3.py
@@ -16,15 +16,15 @@ SGL_FA3_KERNEL_REVISION = "v1"
 DEFAULT_FA3_KERNEL_LOCKFILE = "kernels.lock"
 
 
-def _call_fa3_kernel(kernel, *args, out=None):
+def _call_fa3_kernel(kernel, *args, out=None, **kwargs):
     if out is None:
-        return kernel(*args)
+        return kernel(*args, **kwargs)
     try:
-        return kernel(*args, out=out)
+        return kernel(*args, **kwargs, out=out)
     except TypeError as exc:
         if "unexpected keyword argument 'out'" not in str(exc):
             raise
-        return kernel(*args)
+        return kernel(*args, **kwargs)
 
 
 @cache_once
@@ -212,7 +212,8 @@ def flash_attn_varlen_func(
             "flash_attn at sgl-kernel is only supported on sm90 and above"
         )
 
-    return _load_fa3_kernels()["flash_attn_varlen_func"](
+    return _call_fa3_kernel(
+        _load_fa3_kernels()["flash_attn_varlen_func"],
         q=q,
         k=k,
         v=v,


### PR DESCRIPTION
## Summary

Fix FA3 varlen attention calls so wrappers do not pass `out=None` into kernels that do not expose an `out` keyword.

## Root Cause

`flash_attn_with_kvcache` already routes through `_call_fa3_kernel`, which omits `out` when it is `None` and retries without `out` for kernels that reject it. `flash_attn_varlen_func` bypassed that helper and always forwarded `out=out`, so kernels without an `out` parameter failed with:

```text
flash_attn_varlen_func() got an unexpected keyword argument 'out'
```

## Changes

- Extend `_call_fa3_kernel` to support keyword arguments.
- Route FA3 varlen attention through the same helper used by kvcache attention.

## Validation

- Remote H100, default FA3 backend, `--enable-torch-compile`, Flux.1-dev 1024x1024 1-step image request returned HTTP 200.
- No local tests were run.