### PR TITLE
[hicache] Fix typing in hicache_storage.py

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import logging
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional, Set
+from typing import TYPE_CHECKING, Any, List, Optional, Set
 
 import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
+
+if TYPE_CHECKING:
+    from sglang.srt.observability.metrics_collector import StorageMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +37,7 @@ class HiCacheStorageConfig:
 
 @dataclass
 class HiCacheStorageExtraInfo:
-    prefix_keys: Optional[List[str]] = (None,)
+    prefix_keys: Optional[List[str]] = None
     extra_info: Optional[dict] = None
 
 
@@ -114,10 +119,14 @@ class HiCacheStorage(ABC):
     """
 
     # todo, the page size of storage backend does not have to be the same as the same as host memory pool
-    def register_mem_pool_host(self, mem_pool_host: HostKVCache):
+    def register_mem_pool_host(self, mem_pool_host: HostKVCache) -> None:
         self.mem_pool_host = mem_pool_host
 
-    def register_mem_host_pool_v2(self, host_pool: HostKVCache, host_pool_name):
+    def register_mem_host_pool_v2(
+        self,
+        host_pool: HostKVCache,
+        host_pool_name: PoolName,
+    ) -> None:
         if not hasattr(self, "registered_pools"):
             self.registered_pools = {}
         self.registered_pools[host_pool_name] = host_pool
@@ -187,7 +196,7 @@ class HiCacheStorage(ABC):
         Retrieve values for multiple keys.
         Returns a list of booleans indicating success for each key.
         """
-        pass
+        raise NotImplementedError()
 
     def batch_set_v1(
         self,
@@ -199,14 +208,14 @@ class HiCacheStorage(ABC):
         Store multiple key-value pairs.
         Returns a list of booleans indicating success for each key.
         """
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def get(
         self,
         key: str,
-        target_location: Optional[Any] = None,
-        target_sizes: Optional[Any] = None,
+        target_location: Optional[torch.Tensor | int] = None,
+        target_sizes: Optional[int] = None,
     ) -> torch.Tensor | None:
         """
         Retrieve the value associated with the given key.
@@ -219,8 +228,8 @@ class HiCacheStorage(ABC):
     def batch_get(
         self,
         keys: List[str],
-        target_locations: Optional[Any] = None,
-        target_sizes: Optional[Any] = None,
+        target_locations: Optional[List[torch.Tensor] | List[int]] = None,
+        target_sizes: Optional[List[int]] = None,
     ) -> List[torch.Tensor | None] | int:
         """
         Retrieve values for multiple keys.
@@ -232,7 +241,7 @@ class HiCacheStorage(ABC):
     def set(
         self,
         key: str,
-        value: Optional[Any] = None,
+        value: torch.Tensor,
         target_location: Optional[Any] = None,
         target_sizes: Optional[Any] = None,
     ) -> bool:
@@ -247,7 +256,7 @@ class HiCacheStorage(ABC):
     def batch_set(
         self,
         keys: List[str],
-        values: Optional[Any] = None,
+        values: List[torch.Tensor],
         target_locations: Optional[Any] = None,
         target_sizes: Optional[Any] = None,
     ) -> bool:
@@ -282,7 +291,7 @@ class HiCacheStorage(ABC):
     def clear(self) -> None:
         pass
 
-    def get_stats(self):
+    def get_stats(self) -> Optional[StorageMetrics]:
         return None
 
 
@@ -330,9 +339,10 @@ class HiCacheFile(HiCacheStorage):
     def get(
         self,
         key: str,
-        target_location: torch.Tensor,
-        target_sizes: Optional[Any] = None,
+        target_location: Optional[torch.Tensor | int] = None,
+        target_sizes: Optional[int] = None,
     ) -> torch.Tensor | None:
+        assert isinstance(target_location, torch.Tensor)
         key = self._get_suffixed_key(key)
         tensor_path = os.path.join(self.file_path, f"{key}.bin")
         try:
@@ -349,8 +359,8 @@ class HiCacheFile(HiCacheStorage):
     def batch_get(
         self,
         keys: List[str],
-        target_locations: List[torch.Tensor],
-        target_sizes: Optional[Any] = None,
+        target_locations: Optional[List[torch.Tensor] | List[int]] = None,
+        target_sizes: Optional[List[int]] = None,
     ) -> List[torch.Tensor | None]:
         return [
             self.get(key, target_location)
@@ -362,7 +372,7 @@ class HiCacheFile(HiCacheStorage):
     def set(
         self,
         key: str,
-        value: Optional[Any] = None,
+        value: torch.Tensor,
         target_location: Optional[Any] = None,
         target_sizes: Optional[Any] = None,
     ) -> bool:
@@ -382,7 +392,7 @@ class HiCacheFile(HiCacheStorage):
     def batch_set(
         self,
         keys: List[str],
-        values: Optional[Any] = None,
+        values: List[torch.Tensor],
         target_locations: Optional[Any] = None,
         target_sizes: Optional[Any] = None,
     ) -> bool:
@@ -523,14 +533,13 @@ class HiCacheFile(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         return self._batch_io_v2(transfers, self._write_page)
 
-    def clear(self) -> bool:
+    def clear(self) -> None:
         try:
             for filename in os.listdir(self.file_path):
                 file_path = os.path.join(self.file_path, filename)
                 if os.path.isfile(file_path):
                     os.remove(file_path)
             logger.info("Cleared all entries in HiCacheFile storage.")
-            return True
         except Exception as e:
             logger.error(f"Failed to clear HiCacheFile storage: {e}")
-            return False
+        return


### PR DESCRIPTION
## Motivation

There are tons of type linting issues in this project, which makes AI generate redundant code (e.g. none-checks) and difficulties in human reading as well.  My another PR in progress depends on `hicache_storage.py`.  Let me fix this file first.

## Modifications

This patch fixes typing issues in hicache_storage.py.  Besides just adding type typing annotation, there are 3 real code changes, which are reported by mypy.

1. Make `HiCacheStorageExtraInfo::prefix_keys` initialized to None, instead of `(None,)`.  I think this was a typo.

2. `HiCacheStorage::{batch_exists_v2, batch_set_v2}` should raise an exception when called accidentially.  The call-site code does not handle `None` returned by these functions.

3. `HiCacheFile::clear` should return `None` rather than bool.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
