### PR TITLE
[Diffusion] Fix SANA model execution error

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py
+++ b/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py
@@ -115,9 +115,18 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         model_output: torch.Tensor,
         timestep: int,
         sample: torch.Tensor,
-        **kwargs,
+        generator: torch.Generator | None = None,
+        variance_noise: torch.Tensor | None = None,
+        return_dict: bool = True,
     ):
-        return self._inner.step(model_output, timestep, sample, **kwargs)
+        return self._inner.step(
+            model_output,
+            timestep,
+            sample,
+            generator=generator,
+            variance_noise=variance_noise,
+            return_dict=return_dict,
+        )
 
     @property
     def sigmas(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

SANA model inference is broken with a `TypeError` :

```TypeError: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'```

**error log**:
<details>
<summary> Sana_600M_512px_diffusers error log</summary>


Downloading [model_index.json]:   0%|          | 0.00/401 [00:00<?, ?B/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.74kB/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.74kB/s]
[05-08 22:53:10] Enabling large component offloading for GPU with low device memory
[05-08 22:53:10] server_args: {"model_path": "Efficient-Large-Model/Sana_600M_512px_diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "quantization": null, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5603, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}

Downloading [model_index.json]:   0%|          | 0.00/401 [00:00<?, ?B/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.63kB/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.63kB/s]
[05-08 22:53:12] Local mode: True
[05-08 22:53:12] Starting server...
[05-08 22:53:18] Scheduler bind at endpoint: tcp://127.0.0.1:5603
[05-08 22:53:18] Initializing distributed environment with world_size=1, device=cuda:0, timeout=3600
[05-08 22:53:18] Setting distributed timeout to 3600 seconds
[05-08 22:53:20] No pipeline_class_name specified, using model_index.json

Downloading [model_index.json]:   0%|          | 0.00/401 [00:00<?, ?B/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.12kB/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.12kB/s]
[05-08 22:53:22] Using pipeline from model_index.json: SanaPipeline
[05-08 22:53:22] Loading pipeline modules...
[05-08 22:53:23] Checking for cached model in HF Hub cache for Efficient-Large-Model/Sana_600M_512px_diffusers...
2026-05-08 22:53:23,372 - modelscope - WARNING - We can not confirm the cached file is for revision: master
[05-08 22:53:23] Found complete model in cache at /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers
[05-08 22:53:23] Model path: /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers
[05-08 22:53:23] Diffusers version: 0.32.0.dev0
[05-08 22:53:23] Loading pipeline modules from config: {'_class_name': 'SanaPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'DPMSolverMultistepScheduler'], 'text_encoder': ['transformers', 'Gemma2Model'], 'tokenizer': ['transformers', 'GemmaTokenizerFast'], 'transformer': ['diffusers', 'SanaTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderDC']}
[05-08 22:53:23] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']

Loading required modules:   0%|          | 0/5 [00:00<?, ?it/s][05-08 22:53:23] Loading text_encoder from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/text_encoder. avail mem: 2.33 GB
[05-08 22:53:26] [RunAI Streamer] Overall time to stream 4.9 GiB of all files to cpu: 2.72s, 1.8 GiB/s
[05-08 22:53:35] Applied FSDP to 132 submodules in FSDPGemma2Model using explicit shard conditions
[05-08 22:53:35] Loaded text_encoder: FSDPGemma2Model (sgl-diffusion version). model size: 4.87 GB, consumed GPU mem: 0.85 GB, avail GPU mem: 1.48 GB

Loading required modules:  20%|██        | 1/5 [00:12<00:50, 12.60s/it][05-08 22:53:35] Loading tokenizer from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/tokenizer. avail mem: 1.48 GB
[05-08 22:53:37] Loaded tokenizer: GemmaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 1.48 GB

Loading required modules:  40%|████      | 2/5 [00:14<00:19,  6.36s/it][05-08 22:53:37] Loading vae from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/vae. avail mem: 1.48 GB
The config attributes {'stacked_params_mapping': [], 'vae_scale_factor': 32, 'temporal_compression_ratio': 4, 'spatial_compression_ratio': 32} were passed to AutoencoderDC, but are not expected and will be ignored. Please verify your config.json configuration file.
[05-08 22:53:39] Loaded vae: AutoencoderDC (sgl-diffusion version). model size: 1.16 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 1.48 GB

Loading required modules:  60%|██████    | 3/5 [00:16<00:08,  4.31s/it][05-08 22:53:39] Loading transformer from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer. avail mem: 1.48 GB
[05-08 22:53:39] Filtered 1 duplicate transformer precision variant file(s): ['/home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer/diffusion_pytorch_model.fp16.safetensors']
[05-08 22:53:39] Loading SanaTransformer2DModel from 1 safetensors file(s) , param_dtype: torch.bfloat16
[05-08 22:54:11] [RunAI Streamer] Overall time to stream 2.2 GiB of all files to cpu: 31.21s, 72.3 MiB/s
[05-08 22:54:12] Loaded model with 0.59B parameters
[05-08 22:54:12] Loaded transformer: SanaTransformer2DModel (sgl-diffusion version). model size: 1.1 GB, consumed GPU mem: 0.10 GB, avail GPU mem: 1.39 GB

Loading required modules:  80%|████████  | 4/5 [00:49<00:15, 15.50s/it][05-08 22:54:12] Loading scheduler from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/scheduler. avail mem: 1.39 GB
[05-08 22:54:12] Loaded scheduler: DPMSolverMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 1.39 GB

Loading required modules: 100%|██████████| 5/5 [00:49<00:00,  9.96s/it]
Loading required modules: 100%|██████████| 5/5 [00:49<00:00,  9.85s/it]
[05-08 22:54:12] Creating pipeline stages...
[05-08 22:54:12] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[05-08 22:54:12] Pipeline instantiated
[05-08 22:54:12] Worker 0: Initialized device, model, and distributed environment.
[05-08 22:54:12] Worker 0: Scheduler loop started.
[05-08 22:54:12] Processing 1 grouped request(s)
[05-08 22:54:12] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=173>
                        seed: 42
                 infer_steps: 20
      num_outputs_per_prompt: 1
              guidance_scale: 4.5
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260508-225412_1245ee62.png
        
[05-08 22:54:12] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-08 22:54:12] [InputValidationStage] started...
[05-08 22:54:12] [InputValidationStage] finished in 0.0029 seconds
[05-08 22:54:12] [TextEncodingStage] started...
[05-08 22:54:14] [TextEncodingStage] finished in 1.2500 seconds
[05-08 22:54:14] [TimestepPreparationStage] started...
[05-08 22:54:14] [TimestepPreparationStage] finished in 0.0098 seconds
[05-08 22:54:14] [LatentPreparationStage] started...
[05-08 22:54:14] [LatentPreparationStage] finished in 0.0068 seconds
[05-08 22:54:14] [DenoisingStage] started...

  0%|          | 0/20 [00:00<?, ?it/s]
  0%|          | 0/20 [00:00<?, ?it/s]
[91m[05-08 22:54:15] [DenoisingStage] Error during execution after 874.8007 ms: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 288, in __call__
    result = self.forward(batch, server_args)
  File "/home/thomas/miniconda3/envs/mylearn/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1266, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 937, in _run_denoising_step
    ctx.latents = ctx.scheduler.step(
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py", line 120, in step
    return self._inner.step(model_output, timestep, sample, **kwargs)
TypeError: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[91m[05-08 22:54:15] Error executing request 5f3391aa-4ade-4659-8b4b-93cb6546ee55: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 334, in _execute_forward_common
    result = forward_fn()
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 272, in <lambda>
    forward_fn=lambda: self.pipeline.forward(req, self.server_args),
  File "/home/thomas/miniconda3/envs/mylearn/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py", line 770, in forward
    return self.executor.execute_with_profiling(self.stages, batch, server_args)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py", line 84, in execute_with_profiling
    batch = self.execute(stages, batch, server_args)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 110, in execute
    return self._execute_stages(
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 98, in _execute_stages
    batch = stage(batch, server_args)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 288, in __call__
    result = self.forward(batch, server_args)
  File "/home/thomas/miniconda3/envs/mylearn/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1266, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 937, in _run_denoising_step
    ctx.latents = ctx.scheduler.step(
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py", line 120, in step
    return self._inner.step(model_output, timestep, sample, **kwargs)
TypeError: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[91m[05-08 22:54:15] Failed to generate output for prompt: Error executing request 5f3391aa-4ade-4659-8b4b-93cb6546ee55: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/utils/logging_utils.py", line 626, in log_generation_timer
    yield timer
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 5f3391aa-4ade-4659-8b4b-93cb6546ee55: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[91m[05-08 22:54:15] Generation failed: Error executing request 5f3391aa-4ade-4659-8b4b-93cb6546ee55: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/thomas/repos/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 5f3391aa-4ade-4659-8b4b-93cb6546ee55: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[93m[05-08 22:54:15] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-08 22:54:24] Worker 0: Shutdown complete.
[93m[05-08 22:54:25] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m


</details>


 ### Root cause analysis

  The denoising loop constructs `extra_step_kwargs` via `prepare_extra_func_kwargs`:

  ```python
  extra_step_kwargs = self.prepare_extra_func_kwargs(
      scheduler.step,
      {"generator": batch.generator, "eta": batch.eta, "batch": batch},
  )
  ```
  The purpose of prepare_extra_func_kwargs is to filter out kwargs that the target function doesn't accept, preventing
  TypeError. Before fbebfdec9, it always filtered:

Old logic — always filters:
  ```
  params = inspect.signature(target_func).parameters
  return {k: v for k, v in kwargs.items() if k in params}
  ```
  Since DPMSolverMultistepScheduler.step(self, model_output, timestep, sample, **kwargs) has params = {'self',
  'model_output', 'timestep', 'sample', 'kwargs'}, neither eta nor batch matched any param name, so both were correctly
  filtered out.

  After fbebfdec9, a shortcut was added: if the target function has **kwargs (VAR_KEYWORD), skip filtering and return
  all kwargs directly:

  New logic — shortcuts when **kwargs is detected
  ```
  accepts_var_kwargs, param_names = self._get_extra_func_kwarg_names(func)
  if accepts_var_kwargs:
      return kwargs  # ← all kwargs passed through unfiltered
  return {k: v for k, v in kwargs.items() if k in param_names}
  ```
For the DPMSolverMultistepScheduler.step() wrapper, **kwargs is used for forwarding — the underlying diffusers step() has an explicit signature (generator, variance_noise, return_dict) and does not accept eta or batch. The shortcut caused these unsupported kwargs to leak through, triggering the TypeError.

## Modifications

<!-- Detail the changes made in this pull request. -->

**File**: `python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py`

Replaced `**kwargs` in `DPMSolverMultistepScheduler.step()` with explicit parameter declarations that align with the diffusers native `DPMSolverMultistepScheduler.step()` signature.

Fix approach: 
Replace the wrapper's **kwargs with explicit parameter declarations matching the diffusers native signature. This way:
1. prepare_extra_func_kwargs detects accepts_var_kwargs=False and applies the whitelist filter.
2. eta and batch are filtered out before reaching scheduler.step().
3. The wrapper is consistent with all other schedulers in the repo (FlowMatchEulerDiscreteScheduler, UniPCMultistepScheduler, FlowUniPCMultistepScheduler, etc.), which all use explicit parameters.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

cmd: 
python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate --model-path=Efficient-Large-Model/Sana_600M_512px_diffusers --prompt="A curious raccoon" --num-gpus 1

res:
<img width="1024" height="1024" alt="A_curious_raccoon_20260508-232056_f9a361ea" src="https://github.com/user-attachments/assets/8b3730ce-eabf-4f50-8fc0-604cd1fad9d8" />

<details>
<summary> Sana_600M_512px_diffusers log</summary>

Downloading [model_index.json]:   0%|          | 0.00/401 [00:00<?, ?B/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.32kB/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.32kB/s]
[05-08 23:19:58] Enabling large component offloading for GPU with low device memory
[05-08 23:19:58] server_args: {"model_path": "Efficient-Large-Model/Sana_600M_512px_diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "quantization": null, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5649, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}

Downloading [model_index.json]:   0%|          | 0.00/401 [00:00<?, ?B/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.66kB/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.65kB/s]
[05-08 23:20:00] Local mode: True
[05-08 23:20:00] Starting server...
[05-08 23:20:06] Scheduler bind at endpoint: tcp://127.0.0.1:5649
[05-08 23:20:06] Initializing distributed environment with world_size=1, device=cuda:0, timeout=3600
[05-08 23:20:06] Setting distributed timeout to 3600 seconds
[05-08 23:20:08] No pipeline_class_name specified, using model_index.json

Downloading [model_index.json]:   0%|          | 0.00/401 [00:00<?, ?B/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.57kB/s]
Downloading [model_index.json]: 100%|██████████| 401/401 [00:00<00:00, 1.57kB/s]
[05-08 23:20:10] Using pipeline from model_index.json: SanaPipeline
[05-08 23:20:10] Loading pipeline modules...
[05-08 23:20:11] Checking for cached model in HF Hub cache for Efficient-Large-Model/Sana_600M_512px_diffusers...
2026-05-08 23:20:11,503 - modelscope - WARNING - We can not confirm the cached file is for revision: master
[05-08 23:20:11] Found complete model in cache at /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers
[05-08 23:20:11] Model path: /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers
[05-08 23:20:11] Diffusers version: 0.32.0.dev0
[05-08 23:20:11] Loading pipeline modules from config: {'_class_name': 'SanaPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'DPMSolverMultistepScheduler'], 'text_encoder': ['transformers', 'Gemma2Model'], 'tokenizer': ['transformers', 'GemmaTokenizerFast'], 'transformer': ['diffusers', 'SanaTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderDC']}
[05-08 23:20:11] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']

Loading required modules:   0%|          | 0/5 [00:00<?, ?it/s][05-08 23:20:11] Loading text_encoder from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/text_encoder. avail mem: 2.33 GB
[05-08 23:20:14] [RunAI Streamer] Overall time to stream 4.9 GiB of all files to cpu: 3.1s, 1.6 GiB/s
[05-08 23:20:24] Applied FSDP to 132 submodules in FSDPGemma2Model using explicit shard conditions
[05-08 23:20:24] Loaded text_encoder: FSDPGemma2Model (sgl-diffusion version). model size: 4.87 GB, consumed GPU mem: 1.03 GB, avail GPU mem: 1.30 GB

Loading required modules:  20%|██        | 1/5 [00:12<00:50, 12.74s/it][05-08 23:20:24] Loading tokenizer from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/tokenizer. avail mem: 1.24 GB
[05-08 23:20:26] Loaded tokenizer: GemmaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: -0.08 GB, avail GPU mem: 1.31 GB

Loading required modules:  40%|████      | 2/5 [00:15<00:19,  6.64s/it][05-08 23:20:26] Loading vae from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/vae. avail mem: 1.31 GB
The config attributes {'stacked_params_mapping': [], 'vae_scale_factor': 32, 'temporal_compression_ratio': 4, 'spatial_compression_ratio': 32} were passed to AutoencoderDC, but are not expected and will be ignored. Please verify your config.json configuration file.
[05-08 23:20:28] Loaded vae: AutoencoderDC (sgl-diffusion version). model size: 1.16 GB, consumed GPU mem: -0.03 GB, avail GPU mem: 1.34 GB

Loading required modules:  60%|██████    | 3/5 [00:16<00:08,  4.43s/it][05-08 23:20:28] Loading transformer from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer. avail mem: 1.34 GB
[05-08 23:20:28] Filtered 1 duplicate transformer precision variant file(s): ['/home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer/diffusion_pytorch_model.fp16.safetensors']
[05-08 23:20:28] Loading SanaTransformer2DModel from 1 safetensors file(s) , param_dtype: torch.bfloat16
[05-08 23:20:54] [RunAI Streamer] Overall time to stream 2.2 GiB of all files to cpu: 26.4s, 85.5 MiB/s
[05-08 23:20:56] Loaded model with 0.59B parameters
[05-08 23:20:56] Loaded transformer: SanaTransformer2DModel (sgl-diffusion version). model size: 1.1 GB, consumed GPU mem: 0.03 GB, avail GPU mem: 1.31 GB

Loading required modules:  80%|████████  | 4/5 [00:44<00:13, 13.64s/it][05-08 23:20:56] Loading scheduler from /home/thomas/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/scheduler. avail mem: 1.31 GB
[05-08 23:20:56] Loaded scheduler: DPMSolverMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 1.31 GB

Loading required modules: 100%|██████████| 5/5 [00:44<00:00,  8.94s/it]
[05-08 23:20:56] Creating pipeline stages...
[05-08 23:20:56] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[05-08 23:20:56] Pipeline instantiated
[05-08 23:20:56] Worker 0: Initialized device, model, and distributed environment.
[05-08 23:20:56] Worker 0: Scheduler loop started.
[05-08 23:20:56] Processing 1 grouped request(s)
[05-08 23:20:56] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=173>
                        seed: 42
                 infer_steps: 20
      num_outputs_per_prompt: 1
              guidance_scale: 4.5
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260508-232056_f9a361ea.png
        
[05-08 23:20:56] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-08 23:20:56] [InputValidationStage] started...
[05-08 23:20:56] [InputValidationStage] finished in 0.0008 seconds
[05-08 23:20:56] [TextEncodingStage] started...
[05-08 23:20:57] [TextEncodingStage] finished in 1.3780 seconds
[05-08 23:20:57] [TimestepPreparationStage] started...
[05-08 23:20:57] [TimestepPreparationStage] finished in 0.0038 seconds
[05-08 23:20:57] [LatentPreparationStage] started...
[05-08 23:20:57] [LatentPreparationStage] finished in 0.0054 seconds
[05-08 23:20:57] [DenoisingStage] started...

  0%|          | 0/20 [00:00<?, ?it/s]
  5%|▌         | 1/20 [00:00<00:18,  1.05it/s]
 10%|█         | 2/20 [00:01<00:09,  1.95it/s]
 15%|█▌        | 3/20 [00:01<00:06,  2.58it/s]
 20%|██        | 4/20 [00:01<00:05,  3.16it/s]
 25%|██▌       | 5/20 [00:01<00:04,  3.52it/s]
 30%|███       | 6/20 [00:02<00:03,  3.74it/s]
 35%|███▌      | 7/20 [00:02<00:03,  4.00it/s]
 40%|████      | 8/20 [00:02<00:02,  4.14it/s]
 45%|████▌     | 9/20 [00:02<00:02,  4.23it/s]
 50%|█████     | 10/20 [00:02<00:02,  4.28it/s]
 50%|█████     | 10/20 [00:02<00:02,  3.38it/s]
[05-08 23:21:00] [DenoisingStage] average time per step: 0.1479 seconds
[05-08 23:21:00] [DenoisingStage] finished in 2.9597 seconds
[05-08 23:21:00] [DecodingStage] started...
[05-08 23:21:22] [DecodingStage] finished in 21.5184 seconds
[05-08 23:21:22] Output saved to [1;36moutputs/A_curious_raccoon_20260508-232056_f9a361ea.png[0;0m
[05-08 23:21:23] Pixel data generated successfully in [92m26.73[0;0m seconds
[05-08 23:21:23] Memory usage - Max peak: 4106.00 MB, Avg peak: 4106.00 MB
[93m[05-08 23:21:23] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-08 23:21:28] Worker 0: Shutdown complete.

</details>

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
NA

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
