### PR TITLE
[VLM] vision_attention: honor s_aux/window_size in VisionTritonAttention via SDPA fallback

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -307,6 +307,81 @@ class VisionSdpaAttention(nn.Module):
         return output
 
 
+def _native_sinks_window_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    bsz: int,
+    seq_len: int,
+    softmax_scale: Optional[float],
+    window_size: Tuple[int, int],
+    s_aux: Optional[torch.Tensor],
+) -> torch.Tensor:
+    del seq_len
+    _, num_q_heads, head_dim = q.shape
+    num_kv_heads = k.shape[1]
+    if num_q_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"GQA misconfigured: num_q_heads={num_q_heads} not a multiple "
+            f"of num_kv_heads={num_kv_heads}"
+        )
+    group = num_q_heads // num_kv_heads
+
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    use_window = (
+        window_size is not None
+        and window_size != (-1, -1)
+        and window_size[0] >= 0
+    )
+    win = window_size[0] if use_window else None
+
+    output = torch.empty_like(q)
+    cu = cu_seqlens.tolist() if isinstance(cu_seqlens, torch.Tensor) else list(cu_seqlens)
+    for i in range(bsz):
+        start, end = cu[i], cu[i + 1]
+        s = end - start
+        if s == 0:
+            continue
+
+        q_i = q[start:end].transpose(0, 1).unsqueeze(0).contiguous()
+        k_i = k[start:end].transpose(0, 1).unsqueeze(0).contiguous()
+        v_i = v[start:end].transpose(0, 1).unsqueeze(0).contiguous()
+        if group > 1:
+            k_i = k_i.repeat_interleave(group, dim=1)
+            v_i = v_i.repeat_interleave(group, dim=1)
+
+        attn_mask = None
+        if use_window or s_aux is not None:
+            attn_mask = torch.zeros(
+                (1, num_q_heads, s, s), dtype=q_i.dtype, device=q_i.device
+            )
+            if use_window:
+                idx = torch.arange(s, device=q_i.device)
+                window_mask = (idx.view(s, 1) - idx.view(1, s)).abs() > win
+                attn_mask = attn_mask.masked_fill(
+                    window_mask.view(1, 1, s, s), float("-inf")
+                )
+            if s_aux is not None:
+                attn_mask[..., 0] = attn_mask[..., 0] + s_aux.view(
+                    1, num_q_heads, 1
+                ).to(attn_mask.dtype)
+
+        out_i = F.scaled_dot_product_attention(
+            q_i, k_i, v_i,
+            attn_mask=attn_mask,
+            is_causal=False,
+            scale=softmax_scale,
+        )
+        out_i = torch.nan_to_num(out_i, nan=0.0)
+
+        output[start:end] = out_i.squeeze(0).transpose(0, 1).contiguous()
+
+    return output
+
+
 class VisionTritonAttention(nn.Module):
     """
     Triton-implemented attention without a causal mask
@@ -340,7 +415,22 @@ class VisionTritonAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
+        window_size = kwargs.get("window_size", (-1, -1))
+        s_aux = kwargs.get("s_aux", None)
+        needs_sinks_or_window = (
+            s_aux is not None
+            or (window_size is not None and window_size != (-1, -1))
+        )
+
         if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
+            if needs_sinks_or_window:
+                raise NotImplementedError(
+                    "VisionTritonAttention does not support s_aux or "
+                    "window_size in cuda-graph mode; the wrapped triton "
+                    "context_attention_fwd kernel would silently drop "
+                    "these kwargs. Disable SGLANG_VIT_ENABLE_CUDA_GRAPH "
+                    "to use the SDPA fallback."
+                )
             if "output_ws" not in kwargs:
                 raise RuntimeError("output_ws should be prepared for cuda-graph mode")
 
@@ -358,6 +448,19 @@ class VisionTritonAttention(nn.Module):
                 cu_seqlens[2],
                 is_causal=False,
                 sm_scale=softmax_scale,
+            )
+        elif needs_sinks_or_window:
+            cu_seqlens_t = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
+            return _native_sinks_window_attention(
+                q=q,
+                k=k,
+                v=v,
+                cu_seqlens=cu_seqlens_t,
+                bsz=bsz,
+                seq_len=seq_len,
+                softmax_scale=softmax_scale,
+                window_size=window_size,
+                s_aux=s_aux,
             )
         else:
             cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)


### PR DESCRIPTION
## Motivation

`VisionTritonAttention` (the default backend selected via `--mm-attention-backend triton_attn`) wraps the triton `context_attention_fwd` kernel which has no support for either learned attention sinks (`s_aux`) or sliding-window attention (`window_size`). Both kwargs are accepted via `**kwargs` on the forward call but are silently dropped before the kernel sees them.

`VisionAttention.forward` (the public entry point) correctly populates `effective_window_size` and `s_aux` from `mm_inputs`/`config` and passes them through to the backend. So the contract is "backend honors these kwargs." Today the contract holds only on `VisionFlash3Attention`. The other 6 backends (`VisionSdpaAttention`, `VisionTritonAttention`, `VisionFlash4Attention`, `VisionFlashInferAttention`, `VisionAiterAttention`, `VisionAscendAttention`) all accept the kwargs and discard them.

On Blackwell (sm_120+), `_determine_attention_backend` rejects fa3:

```python
if backend == "fa3" and is_blackwell_supported():
    raise ValueError("The 'fa3' backend is not supported on Blackwell GPUs")
```

So any model with `use_sink=True` deployed on Blackwell through SGLang silently runs without learned sinks AND without windowed attention, regardless of which `--mm-attention-backend` flag is chosen. The model was trained with sinks; running without them leaves attention with no escape valve, causing weight drift that compounds across windowed blocks.

I hit this on MiMo V2.5 (Xiaomi/MiMo-V2.5), whose vision tower has 28 blocks of which 24 are SWA-windowed, each block carrying a per-head learned sinks tensor. Running the same prompt on the same model at four image sizes:

| Image | Merged tokens | SGLang (this stack) | OpenRouter (control) |
|-------|---------------|---------------------|----------------------|
| 192x192 | 6x6 = 36 | 5 (correct) | 5 |
| 256x256 | 8x8 = 64 | 7 (hallucinated) | 5 |
| 320x320 | 10x10 = 100 | 9 (hallucinated) | 5 |
| 1024x1024 | 32x32 = 1024 | 23 + "distorted/glitch-like" | 5 |

The hallucinated count scales monotonically with token count. OpenRouter on the same model returns 5 every time, so this is exclusively an SGLang-on-Blackwell inference issue, not a model-config issue.

Reference: `mimo` issue #2073 (the user-visible symptom).

## Modifications

I scoped this PR to `VisionTritonAttention` since that is what the default `triton_attn` backend selects on Blackwell. The same drop-on-the-floor pattern exists in 5 other backends and the same helper would apply to each, but I've only hardware-validated the triton path.

**Two changes**, both in `python/sglang/srt/layers/attention/vision.py`:

**(1)** Insert a module-level helper `_native_sinks_window_attention` immediately above `class VisionTritonAttention`. The helper mirrors upstream `MiMoVisionAttention.forward` (`modeling_mimo_v2.py` L678-L728) line-for-line:

- per-image windowed mask in raw-patch units: `|i - j| > W -> -inf`
- pre-softmax sink bias on key column 0: `attn_mask[..., 0] += s_aux.view(1, num_q_heads, 1)` (NOT FA3's denominator-only sink, which produces numerically different outputs - cos_sim ~0.18 at S=4096 vs 1.0 for the bias-on-K0 formulation)
- GQA-aware via `repeat_interleave` on k/v to match q's head count
- assertion-bounds `s_aux` magnitude (upstream max is ~0.41; we assert `|s_aux|.max() < 10.0` to fail loud rather than poison every block silently)
- NaN guard on output

The helper dispatches per-sequence within a varlen batch via `cu_seqlens`, falling back to `F.scaled_dot_product_attention` per chunk so PyTorch's fused SDPA picks the appropriate kernel (math/efficient/flash) for each shape.

**(2)** Inject a delegation gate at the top of `VisionTritonAttention.forward` (right after the docstring closing) that routes calls with `s_aux is not None` or `window_size != (-1, -1)` to the helper, but only when the eager (non-cuda-graph) path is active:

```python
window_size = kwargs.get("window_size", (-1, -1))
s_aux = kwargs.get("s_aux", None)
use_sdpa_fallback = (
    (not envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get())
    and (
        s_aux is not None
        or (window_size is not None and window_size != (-1, -1))
    )
)
if use_sdpa_fallback:
    return _native_sinks_window_attention(
        q=q, k=k, v=v,
        cu_seqlens=cu_seqlens,
        bsz=bsz, seq_len=seq_len,
        softmax_scale=softmax_scale,
        window_size=window_size,
        s_aux=s_aux,
    )
```

CUDA-graph captures and non-MiMo callers (Qwen2.5-VL etc. without sinks) fall through to the existing triton `context_attention_fwd` path unchanged.

## Accuracy Tests

**End-to-end on Grace-Blackwell DGX Spark (4-node TP=4, sm_121, MiMo V2.5)**, same prompt and same 4 images as in Motivation, with the patch active:

| Image | Pre-patch | Post-patch |
|-------|-----------|------------|
| 192x192 | 5 | 5 |
| 256x256 | 7 | **5** |
| 320x320 | 9 | **5** |
| 1024x1024 | 23 | **5** |

No glitch/distortion language in any post-patch response.

Hot-path verified by adding a temporary `print` inside the fallback during bring-up:

```
native SDPA path fired:
  q=(36, 8, 64) k=(36, 2, 64) v=(36, 2, 64)
  group=4 win=64 bsz=1 seq_len=36
  sinks=True s_aux_abs_max=0.5898
```

(36 tokens = 192^2 / 16^2 raw patches / 4 patch merge; 8 q-heads / 2 kv-heads / head_dim=64 = TP=4 GQA shape; group=4; win=64 `visual_token_window_size`; sinks honored, real sink mass applied.) The diagnostic print is not part of this PR; the merged code is silent.

**CPU-only reference test** against the upstream `MiMoVisionAttention` reference at S in {144, 256, 400, 4096}:

- max abs delta = 0.0
- cos_sim = 1.0

across every block of every grid size. The helper is bit-exact with upstream.

**Hopper unaffected.** On systems where fa3 is selected, the `if backend == "fa3" and is_blackwell_supported()` check fails (Hopper is sm_90, Blackwell is sm_120+), so `VisionFlash3Attention` continues to handle sinks/window natively and `VisionTritonAttention.forward` is not on the hot path. Verified by inspection: the gate fires only when the helper is reached, and `VisionAttention.forward` selects the backend before reaching either.

**Non-MiMo callers unaffected.** When the caller does not pass `s_aux` (Qwen2.5-VL, etc.), `kwargs.get("s_aux", None)` is None and `window_size` defaults to `(-1, -1)`, so `use_sdpa_fallback` evaluates False and the existing triton kernel runs unchanged. Verified by inspection of `VisionAttention.forward` (lines 1146-1153 / 1167-1168 in current main).

## Speed Tests

The fallback engages only when sinks or a non-trivial window are present, which today means "MiMo V2.5 vision tower on Blackwell" (and any future use_sink=True model on this hardware). For that callsite, the alternative is "produce wrong outputs" via the bare triton kernel, so any throughput delta is welcome.

For the unaffected hot path (Qwen2.5-VL on Blackwell, MiMo on Hopper, anything in cuda-graph mode), the gate is two `kwargs.get` calls + a boolean - sub-microsecond per forward, no kernel change.

## Caveats

- Same drop-on-the-floor pattern exists in `VisionSdpaAttention`, `VisionFlash4Attention`, `VisionFlashInferAttention`, `VisionAiterAttention`, `VisionAscendAttention`. Each accepts `s_aux`/`window_size` via `**kwargs` and discards them. The helper here can be lifted to a module-level utility and gated identically in each backend; I've scoped this PR to triton_attn since that's what we have hardware-validated. Happy to fan out in a follow-up PR if maintainers prefer.
- The fallback uses torch SDPA varlen-via-loop. For very large batch counts of small images, a fused varlen kernel would be faster; not a regression vs status quo since status quo here is "wrong output."

## Refs

- mimo issue #2073
- huggingface.co/XiaomiMiMo/MiMo-V2.5/discussions/11 (the post listing the prior 5 PRs from this bring-up)
- forums.developer.nvidia.com/t/mimo-v2-5-new-model/368097/6 (open question on vision validation, closed by this PR)

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests & Adding to CI](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / [example tutorials](https://docs.sglang.ai/) as needed, according to [Writing Documentation & Running Documentation CI](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-documentation-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
