### PR TITLE
[HiCache] ci: lower est_time for test_hicache_spec_file_storage

### DIFF
--- a/test/registered/hicache/test_hicache_spec_file_storage.py
+++ b/test/registered/hicache/test_hicache_spec_file_storage.py
@@ -30,7 +30,7 @@ from sglang.test.test_utils import (
 )
 from sglang.utils import wait_for_http_ready
 
-register_cuda_ci(est_time=600, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=200, suite="stage-b-test-1-gpu-large")
 
 
 @unittest.skipIf(is_hip(), "HiCache + EAGLE3 file-storage loadback e2e is CUDA-only.")


### PR DESCRIPTION
## Summary
- `test/registered/hicache/test_hicache_spec_file_storage.py` registered `est_time=600s`, but the observed wall-time on `stage-b-test-1-gpu-large` runners is ~240s.
- `run_suite.py`'s LPT partitioner uses `est_time` to balance files across the 14 partitions of this stage. A 2.5× over-estimate causes the runner that picks this file to finish well before its siblings, while the other partitions get over-packed — net effect is a longer stage critical path.
- Lowered `est_time` to 200s so the partitioner has a realistic figure. No other behavior changes; `est_time` is consumed only by partition planning (no timeout/gating impact).

## Test plan
- [ ] CI green on `stage-b-test-1-gpu-large` for this PR.
- [ ] Eyeball the per-partition wall-times in the PR run vs. main to confirm the partition holding this test is no longer noticeably idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)