### PR TITLE
[WIP] feat: Integrate Kubernetes Weight Propagation Interface (WPI) for SGLangInitial WPI Support

### DIFF
--- a/python/sglang/srt/checkpoint_engine/wpi_worker.py
+++ b/python/sglang/srt/checkpoint_engine/wpi_worker.py
@@ -1,0 +1,137 @@
+import logging
+import math
+from typing import Callable, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+def _import_wpi_client():
+    """Lazily import WPIClient."""
+    try:
+        from wpi_client.client import WPIClient
+        return WPIClient
+    except ImportError:
+        raise ImportError(
+            "WPI weight transfer requires the `wpi_client` package. "
+            "Please install it."
+        ) from None
+
+class SGLangWPIWorkerExtension:
+    """Worker extension for SGLang to support WPI weight updates."""
+
+    def __init__(self, model_runner):
+        self.model_runner = model_runner
+        self.client = None
+        self.vram_buffer = None
+        self.buffer_id = ""
+        self.buffer_size = 0
+        self.staged = False
+
+    def init_wpi(self, buffer_id: str, buffer_size: int, socket_dir: str, driver_port: int):
+        """Initialize WPI client and map memory."""
+        WPIClient = _import_wpi_client()
+        self.buffer_id = buffer_id
+        self.buffer_size = buffer_size
+
+        self.client = WPIClient(socket_dir=socket_dir, driver_port=driver_port)
+
+        # Assume TP rank/size maps to shard index/total shards
+        shard_index = self.model_runner.tp_rank
+        total_shards = self.model_runner.tp_size
+        if total_shards <= 1:
+            shard_index = -1
+            total_shards = 0
+
+        self.client.stage_weight(
+            buffer_id=self.buffer_id,
+            size_bytes=self.buffer_size,
+            claim_id=f"{self.buffer_id}-claim",
+            shard_index=shard_index,
+            total_shards=total_shards,
+        )
+        self.staged = True
+
+        # Receive FD and map memory
+        device_id = torch.cuda.current_device()
+        fd = self.client.receive_fd(
+            self.buffer_id,
+            gpu_id=device_id,
+            shard_index=shard_index,
+            total_shards=total_shards,
+        )
+        device_ptr = self.client.import_cuda_memory(fd, self.buffer_size, device_id=device_id)
+        self.vram_buffer = self.client.wrap_as_buffer(device_ptr, self.buffer_size)
+
+        # Connect to notify socket
+        self.client.connect_notify_socket(
+            self.buffer_id,
+            shard_index=shard_index,
+            total_shards=total_shards,
+        )
+        logger.info(f"WPI: Worker initialized for buffer {buffer_id}, shard {shard_index}/{total_shards}")
+
+    def update_weights_from_wpi(self, update_info: dict):
+        """Wait for READY and load weights from mapped memory."""
+        if self.client is None:
+            raise RuntimeError("WPI not initialized. Call init_wpi first.")
+
+        logger.info("WPI: Waiting for READY signal...")
+        self.client.wait_for_ready(timeout=300.0)
+
+        names = update_info["names"]
+        dtype_names = update_info["dtype_names"]
+        shapes = update_info["shapes"]
+        offsets = update_info["offsets"]
+
+        def weight_iterator():
+            for name, dtype_name, shape, offset in zip(names, dtype_names, shapes, offsets):
+                dtype = getattr(torch, dtype_name)
+                num_elements = math.prod(shape)
+                nbytes = num_elements * dtype.itemsize
+
+                weight = (
+                    self.vram_buffer[offset:offset + nbytes]
+                    .view(dtype=dtype)
+                    .view(shape)
+                )
+                yield name, weight
+
+        logger.info(f"WPI: Loading {len(names)} weights into model...")
+        self.model_runner.model.load_weights(weight_iterator())
+
+        # Post hook processing (quantization etc.)
+        self._post_hook()
+        logger.info("WPI: Weight update completed successfully")
+
+    def _post_hook(self):
+        """Perform post-processing after weight loading."""
+        try:
+            from sglang.srt.model_loader.loader import device_loading_context
+
+            # Process quantization methods after loading weights
+            for _, module in self.model_runner.model.named_modules():
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is not None:
+                    target_device = torch.device("cuda", torch.cuda.current_device())
+                    with device_loading_context(module, target_device):
+                        quant_method.process_weights_after_loading(module)
+            
+            # Call model-specific post-loading hook if available
+            if hasattr(self.model_runner.model, "post_load_weights"):
+                self.model_runner.model.post_load_weights()
+        except Exception as e:
+            logger.warning(f"WPI: Post-hook processing failed: {e}")
+
+    def shutdown(self):
+        """Clean up resources."""
+        if self.client is not None:
+            if self.staged:
+                try:
+                    self.client.unstage_weight(f"{self.buffer_id}-claim")
+                except Exception as e:
+                    logger.warning(f"WPI: Error during unstage: {e}")
+                self.staged = False
+            self.client.close()
+            self.client = None
+        self.vram_buffer = None

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -138,6 +138,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
+    UpdateWeightsFromWPIReqInput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightVersionReqInput,
     VertexGenerateReqInput,
@@ -1218,6 +1219,21 @@ async def update_weights_from_ipc(obj: UpdateWeightsFromIPCReqInput, request: Re
     if success:
         if _global_state.tokenizer_manager.initial_weights_loaded is False:
             _global_state.tokenizer_manager.initial_weights_loaded = True
+        return ORJSONResponse(content)
+    else:
+        return ORJSONResponse(content, status_code=HTTPStatus.BAD_REQUEST)
+
+
+@app.post("/update_weights_from_wpi")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def update_weights_from_wpi(obj: UpdateWeightsFromWPIReqInput, request: Request):
+    """Update the weights from WPI."""
+    success, message = await _global_state.tokenizer_manager.update_weights_from_wpi(
+        obj, request
+    )
+
+    content = {"success": success, "message": message}
+    if success:
         return ORJSONResponse(content)
     else:
         return ORJSONResponse(content, status_code=HTTPStatus.BAD_REQUEST)

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1520,6 +1520,25 @@ class UpdateWeightsFromIPCReqOutput(BaseReq):
 
 
 @dataclass
+class UpdateWeightsFromWPIReqInput(BaseReq):
+    update_info: Dict[str, Any]
+    buffer_id: Optional[str] = "slime-weights"
+    buffer_size: Optional[int] = 20 * 1024**3
+    socket_dir: Optional[str] = "/run/wpi/sockets"
+    driver_port: Optional[int] = 50051
+    flush_cache: bool = True
+    torch_empty_cache: bool = False
+    prepare_only: bool = False
+    weight_version: Optional[str] = None
+
+
+@dataclass
+class UpdateWeightsFromWPIReqOutput(BaseReq):
+    success: bool
+    message: str
+
+
+@dataclass
 class InitWeightsSendGroupForRemoteInstanceReqOutput(BaseReq):
     success: bool
     message: str

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -145,6 +145,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
+    UpdateWeightsFromWPIReqInput,
 )
 from sglang.srt.managers.mm_utils import (
     has_shm_features,
@@ -1441,6 +1442,7 @@ class Scheduler(
                 ),
                 (UpdateWeightsFromTensorReqInput, self.update_weights_from_tensor),
                 (UpdateWeightsFromIPCReqInput, self.update_weights_from_ipc),
+                (UpdateWeightsFromWPIReqInput, self.update_weights_from_wpi),
                 (GetWeightsByNameReqInput, self.get_weights_by_name),
                 (ReleaseMemoryOccupationReqInput, self.release_memory_occupation),
                 (ResumeMemoryOccupationReqInput, self.resume_memory_occupation),

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -31,6 +31,8 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqOutput,
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromIPCReqOutput,
+    UpdateWeightsFromWPIReqInput,
+    UpdateWeightsFromWPIReqOutput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
@@ -128,6 +130,24 @@ class SchedulerUpdateWeightsMixin:
             logger.error(message)
         torch.distributed.barrier(group=self.tp_cpu_group)
         return UpdateWeightsFromIPCReqOutput(success, message)
+
+    def update_weights_from_wpi(
+        self: Scheduler, recv_req: UpdateWeightsFromWPIReqInput
+    ):
+        """Update the online model parameter from WPI."""
+        success, message = self.tp_worker.update_weights_from_wpi(recv_req)
+        tp_success = success
+        if success and self.draft_worker is not None:
+            success, message = self.draft_worker.update_weights_from_wpi(recv_req)
+        if tp_success and recv_req.flush_cache:
+            flush_cache_success = self.flush_cache(
+                empty_cache=recv_req.torch_empty_cache
+            )
+            assert flush_cache_success, "Cache flush failed after updating weights"
+        if not success:
+            logger.error(message)
+        torch.distributed.barrier(group=self.tp_cpu_group)
+        return UpdateWeightsFromWPIReqOutput(success, message)
 
     def get_weights_by_name(self: Scheduler, recv_req: GetWeightsByNameReqInput):
         parameter = self.tp_worker.get_weights_by_name(recv_req)

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -76,6 +76,8 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqOutput,
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromIPCReqOutput,
+    UpdateWeightsFromWPIReqInput,
+    UpdateWeightsFromWPIReqOutput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
@@ -102,6 +104,7 @@ _COMMUNICATOR_SPECS = [
     ("send_weights_to_remote_instance", SendWeightsToRemoteInstanceReqOutput),
     ("update_weights_from_tensor", UpdateWeightsFromTensorReqOutput),
     ("update_weights_from_ipc", UpdateWeightsFromIPCReqOutput),
+    ("update_weights_from_wpi", UpdateWeightsFromWPIReqOutput),
     ("get_weights_by_name", GetWeightsByNameReqOutput),
     ("release_memory_occupation", ReleaseMemoryOccupationReqOutput),
     ("resume_memory_occupation", ResumeMemoryOccupationReqOutput),
@@ -522,6 +525,40 @@ class TokenizerControlMixin:
                     success, message = result.success, result.message
         except Exception as e:
             error_msg = f"IPC weight update failed: {str(e)}"
+            logger.error(error_msg)
+            success, message = False, error_msg
+
+        if success and obj.weight_version is not None:
+            self._update_weight_version_if_provided(obj.weight_version)
+            message += f" Weight version updated to {obj.weight_version}."
+
+        return success, message
+
+    async def update_weights_from_wpi(
+        self: TokenizerManager,
+        obj: UpdateWeightsFromWPIReqInput,
+        request: Optional[fastapi.Request] = None,
+    ) -> Tuple[bool, str]:
+        """Update weights via WPI."""
+        self.auto_create_handle_loop()
+        try:
+            assert (
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for update weights from WPI"
+            logger.info("Starting WPI weight update")
+
+            async with self.is_pause_cond:
+                is_paused = self.is_pause
+                if is_paused:
+                    result = (await self.update_weights_from_wpi_communicator(obj))[0]
+                    success, message = result.success, result.message
+
+            if not is_paused:
+                async with self.model_update_lock.writer_lock:
+                    result = (await self.update_weights_from_wpi_communicator(obj))[0]
+                    success, message = result.success, result.message
+        except Exception as e:
+            error_msg = f"WPI weight update failed: {str(e)}"
             logger.error(error_msg)
             success, message = False, error_msg
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -35,6 +35,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
+    UpdateWeightsFromWPIReqInput,
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch, ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
@@ -169,6 +170,11 @@ class BaseTpWorker(ABC):
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):
         """Update weights from IPC for checkpoint-engine integration."""
         success, message = self.model_runner.update_weights_from_ipc(recv_req)
+        return success, message
+
+    def update_weights_from_wpi(self, recv_req: UpdateWeightsFromWPIReqInput):
+        """Update weights from WPI."""
+        success, message = self.model_runner.update_weights_from_wpi(recv_req)
         return success, message
 
     def get_weights_by_name(self, recv_req: GetWeightsByNameReqInput):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3518,6 +3518,31 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger.error(f"IPC weight update failed: {e}")
             return False, str(e)
 
+    def update_weights_from_wpi(self, recv_req):
+        """Update weights from WPI."""
+        try:
+            from sglang.srt.checkpoint_engine.wpi_worker import (
+                SGLangWPIWorkerExtension,
+            )
+
+            if not hasattr(self, "_wpi_worker"):
+                self._wpi_worker = SGLangWPIWorkerExtension(self)
+                buffer_id = getattr(recv_req, "buffer_id", "slime-weights")
+                buffer_size = getattr(recv_req, "buffer_size", 20 * 1024**3)
+                socket_dir = getattr(recv_req, "socket_dir", "/run/wpi/sockets")
+                driver_port = getattr(recv_req, "driver_port", 50051)
+                
+                self._wpi_worker.init_wpi(buffer_id, buffer_size, socket_dir, driver_port)
+                
+            if getattr(recv_req, "prepare_only", False):
+                return True, "WPI prepared successfully"
+                
+            self._wpi_worker.update_weights_from_wpi(recv_req.update_info)
+            return True, "WPI weight update completed successfully"
+        except Exception as e:
+            logger.error(f"WPI weight update failed: {e}")
+            return False, str(e)
+
     def prealloc_symmetric_memory_pool(self):
         # PyTorch mempools never de-fragment memory in OOM scenarios, so we need to pre-allocate a large chunk of memory to limit fragmentation.
         if (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The purpose of this pull request is to integrate the Kubernetes Weight Propagation Interface (WPI) into SGLang to enable high-performance, asynchronous cross-host weight streaming. 

This effort is part of a broader initiative to integrate WPI across various frameworks to enable efficient weight synchronization. This implementation brings SGLang on par with similar efforts in other frameworks, such as the work done in llmd (see [llm-d-incubation/weight-propagation-interface](https://github.com/llm-d-incubation/weight-propagation-interface)).

## Modifications

API Enhancements: Added support for updating weights via WPI in SGLang, including adding/updating APIs like update_weights_from_wpi to support WPI-based weight synchronization.

## Accuracy Tests

This pull request changes the method of weight transfer and loading but does not modify the model forward code or operator kernels.

Verification: We verified that weights were successfully received and loaded on the target side without errors from an RL job in Slime using SGLang

## Speed Tests and Profiling

We conducted extensive speed tests for cross-host weight transfer over the RDMA network with Qwen 3.5 35B model in an RL job in Slime:

* Buffer Size: ~6 GB
* Transfer Time: Consistently around 0.5 seconds.
* Bandwidth: Achieved a sustained average of ~15.97 GB/s, with occasional peaks up to 17.34 GB/s.
* Durability: Verified with a continuous loop job running for 12 hours, maintaining this high bandwidth without degradation or errors.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
