### PR TITLE
feat(trace): support SGLANG_TRACE_LEVEL env var for startup trace level

### DIFF
--- a/docs/references/production_request_trace.md
+++ b/docs/references/production_request_trace.md
@@ -52,9 +52,14 @@ This section explains how to configure the request tracing and export the trace 
     0: disable tracing
     1: Trace important slices
     2: Trace all slices except nested ones
-    3: Trace all slices
+    3: Trace all slices (default)
     ```
-    The trace level can be dynamically set via HTTP API, for example:
+    **At startup** — set `SGLANG_TRACE_LEVEL` before launching the server:
+    ```bash
+    SGLANG_TRACE_LEVEL=2 python -m sglang.launch_server --enable-trace --otlp-traces-endpoint 0.0.0.0:4317 <other options>
+    ```
+
+    **At runtime** — dynamically adjust via HTTP API without restarting:
     ```bash
     curl http://0.0.0.0:30000/set_trace_level?level=2
     ```

--- a/python/sglang/srt/observability/trace.py
+++ b/python/sglang/srt/observability/trace.py
@@ -32,7 +32,7 @@ opentelemetry_initialized = False
 _trace_context_propagator = None
 tracer: Optional[trace.Tracer] = None
 
-global_trace_level = 3
+global_trace_level = get_int_env_var("SGLANG_TRACE_LEVEL", 3)
 
 TRACE_HEADERS = ["traceparent", "tracestate"]
 

--- a/test/registered/unit/observability/test_trace.py
+++ b/test/registered/unit/observability/test_trace.py
@@ -56,6 +56,15 @@ class TestTraceFunctions(unittest.TestCase):
         self.assertEqual(mod.global_trace_level, 5)
         mod.global_trace_level = orig
 
+    def test_global_trace_level_env_var(self):
+        import importlib
+
+        with patch.dict(os.environ, {"SGLANG_TRACE_LEVEL": "2"}):
+            importlib.reload(mod)
+            self.assertEqual(mod.global_trace_level, 2)
+        importlib.reload(mod)  # restore default (SGLANG_TRACE_LEVEL unset → 3)
+        self.assertEqual(mod.global_trace_level, 3)
+
     def test_get_global_tracing_enabled(self):
         self.assertEqual(get_global_tracing_enabled(), mod.opentelemetry_initialized)
 


### PR DESCRIPTION
## Motivation

`global_trace_level` defaults to 3, which includes high-volume scheduler spans (`decode_loop`, `chunked_prefill`) emitted every iteration. There is currently no way to set a lower level at startup — operators must either call the `/set_trace_level` HTTP endpoint after launch or accept the default verbosity.

## Modifications

- `python/sglang/srt/observability/trace.py`: initialize `global_trace_level` from `SGLANG_TRACE_LEVEL` env var (default `3`) using the existing `get_int_env_var` helper
- `test/registered/unit/observability/test_trace.py`: add unit test verifying the env var is read at module init
- `docs/references/production_request_trace.md`: document the startup env var option alongside the existing runtime HTTP endpoint

## Accuracy Tests

No model output changes — this only affects which spans are emitted.

## Speed Tests and Profiling

Lower trace levels reduce span generation overhead. No benchmark required for this change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)