### PR TITLE
LFM2: pass has_initial_state to causal_conv1d_fn for prefill

### DIFF
--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -302,11 +302,13 @@ class Lfm2ShortConv(nn.Module):
                     ]
                 )
                 cache_indices = mamba_indices.to(torch.int32)
+                has_initial_state = forward_batch.extend_prefix_lens > 0
             else:
                 query_start_loc = torch.tensor(
                     [0, T], dtype=torch.int32, device=hidden_states.device
                 )
                 cache_indices = mamba_indices[:1].to(torch.int32)
+                has_initial_state = forward_batch.extend_prefix_lens[:1] > 0
 
             conv_out = causal_conv1d_fn(
                 Bx_t,
@@ -314,7 +316,7 @@ class Lfm2ShortConv(nn.Module):
                 self.conv_bias,
                 query_start_loc=query_start_loc,
                 cache_indices=cache_indices,
-                has_initial_state=None,
+                has_initial_state=has_initial_state,
                 conv_states=conv_state,
                 activation=None,
             ).transpose(0, 1)

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -360,10 +360,12 @@ class Lfm2MoeShortConv(nn.Module):
                 query_start_loc[:-1] = extend_start_loc
                 query_start_loc[-1] = T
                 cache_indices = mamba_indices.to(torch.int32)
+                has_initial_state = forward_batch.extend_prefix_lens > 0
             else:
                 # Single sequence: [0, T]
                 query_start_loc = hidden_states.new_tensor([0, T], dtype=torch.int32)
                 cache_indices = mamba_indices[:1].to(torch.int32)
+                has_initial_state = forward_batch.extend_prefix_lens[:1] > 0
 
             conv_out = causal_conv1d_fn(
                 Bx_t,
@@ -371,7 +373,7 @@ class Lfm2MoeShortConv(nn.Module):
                 self.conv_bias,
                 query_start_loc=query_start_loc,
                 cache_indices=cache_indices,
-                has_initial_state=None,
+                has_initial_state=has_initial_state,
                 conv_states=conv_state,
                 activation=None,
             ).transpose(0, 1)


### PR DESCRIPTION
## Motivation

Follow-up to #23975. After that PR fixed which conv-state row gets indexed, a second source of cross-request contamination remains: `Lfm2ShortConv.forward` and `Lfm2MoeShortConv.forward` call `causal_conv1d_fn` with `has_initial_state=None` for prefill. The kernel then treats whatever currently lives at `conv_state[cache_indices[i]]` as valid prior conv state.

When a Mamba slot is freed and immediately reallocated to a fresh request under high concurrency, the slot may still contain the previous request's last conv state. The new request reads stale state on its first conv layer, which can cascade into completely off-topic decode (e.g. unrelated paragraphs in response to the actual prompt).

This is the same pattern `Mamba2Mixer` handles correctly in `python/sglang/srt/layers/attention/mamba/mamba.py:531` and `gdn_backend.py:381` — explicitly compute `has_initial_state` from `forward_batch.extend_prefix_lens > 0` and pass it to the kernel.

## Fix

In `Lfm2ShortConv.forward` and `Lfm2MoeShortConv.forward` prefill paths, compute `has_initial_state = forward_batch.extend_prefix_lens > 0` (sliced for the single-sequence branch) and pass it to `causal_conv1d_fn`. `False` tells the kernel to treat the slot as zero regardless of physical contents; `True` preserves prior state for chunked-prefill continuations.

## Reproducing

At temperature=0, identical prompts must produce byte-identical output regardless of concurrency.

Server (single MI325X, ROCm 7.2; small mamba cache to amplify slot recycling):

```bash
sglang serve \
  --model-path LiquidAI/LFM2.5-1.2B-Instruct \
  --host 0.0.0.0 --port 30000 \
  --dtype float16 \
  --mem-fraction-static 0.88 \
  --max-mamba-cache-size 64 \
  --disable-radix-cache \
  --cuda-graph-max-bs 256
```

Client:

```bash
for i in 1 2 3; do
  echo "=== run $i ==="
  seq 2048 | xargs -P 32 -I {} \
    curl -s http://localhost:30000/generate \
      -H 'Content-Type: application/json' \
      -d '{"text":"<|startoftext|><|im_start|>user\nWrite a short haiku about AMD<|im_end|>\n<|im_start|>assistant\n","sampling_params":{"max_new_tokens":128,"temperature":0}}' \
    | jq -r '.text' | sort | uniq -c
done
```

### Before fix (`main` with PR #23975 already in)

Different runs produce different mixes of variants. Run 1 happens to be clean (no race fired), run 2 shows mild token-level drift (a few requests deviate by a single word/punctuation mark), run 3 shows full state contamination — clusters of requests producing completely off-topic meta-responses about the prompt:

```
=== run 1 ===
   2048 AMD's power in every frame—
   2048 Silicon dreams take flight,
   2048 Tech soars ever on.
=== run 2 ===
      1 AMD threads weave the future,
   2044 AMD's power in every frame—
      1 AMD's pulse in every frame,
      1 AMDays of code and light,
      1 AMD's vision shines bright.
      1 Chips dance in the light,
      1 Power in each core.
      2 Silicon bright,
   2046 Silicon dreams take flight,
      1 Tech shines ever bright.
      1 Tech shines evergreen.
   2044 Tech soars ever on.
=== run 3 ===
    128 
     54    - *Innovation grows.*
     54    - *Silicon dreams,*
     54    - *Tech's steady flow,*
     54 1. **If you're asking for a haiku about AMD (Advanced Micro Devices):**
     54 2. **If you're referring to a specific article, product, or concept related to AMD:
   1983 AMD's power in every frame—
      5 If you're looking for a **haiku**
   1984 Silicon dreams take flight,
   1984 Tech soars ever on.
     54 Your query asks about "the short haiku about AMD," but it seems you may be referring to a specific piece of writing or a request that isn't fully clear. Could you please clarify what you mean by "the short haiku about AMD"? Here are a few possibilities based on common interpretations:
       (... and several more variants)
```

The non-determinism is reproducible across independent runs but the variant distribution changes — characteristic of a recycle-time race. On harder prompts the corruption rate is much higher:

| Prompt | Corrupted / 16384 (P=2048) | Rate |
|---|---:|---:|
| AMD haiku | 0 | 0% (latent on this prompt at P=2048) |
| Five interesting facts about deep-sea fish | 7232 | **44%** |
| A transformer model attends to its input by | 15207 | **93%** |

### After fix

Same haiku reproducer, all 3 runs collapse to a single output:

```
=== run 1 ===
   2048 AMD's power in every frame—
   2048 Silicon dreams take flight,
   2048 Tech soars ever on.
=== run 2 ===
   2048 AMD's power in every frame—
   2048 Silicon dreams take flight,
   2048 Tech soars ever on.
=== run 3 ===
   2048 AMD's power in every frame—
   2048 Silicon dreams take flight,
   2048 Tech soars ever on.
```

The 3-prompt table above also goes to 0/49152 corruption at the harder configurations (16384 reqs × P=2048 × 3 prompts).

### Larger mamba cache

At production-realistic `--max-mamba-cache-size 15000` the bug fires only ~0.006% of the time — still reliably non-zero across enough requests, but easy to miss in a single short run. Smaller cache + concurrency ≥ cache size is the most sensitive configuration for catching this regression.
