### PR TITLE
env: add SGLANG_RADIX_FORCE_MISS to force radix prefix-cache miss

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -254,10 +254,6 @@ class Envs:
     SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(False)
     SGLANG_SCHEDULER_MAX_RECV_PER_POLL = EnvInt(-1)
     SGLANG_EXPERIMENTAL_CPP_RADIX_TREE = EnvBool(False)
-    # Force radix `match_prefix` to always return an empty match while keeping
-    # the radix code path on (insertion / eviction still run). Use this to
-    # benchmark engine performance under the cache-enabled code path with a
-    # guaranteed 0% prefix-cache hit rate.
     SGLANG_RADIX_FORCE_MISS = EnvBool(False)
     SGLANG_DYNAMIC_CHUNKING_SMOOTH_FACTOR = EnvFloat(0.75)
     SGLANG_SCHEDULER_SKIP_ALL_GATHER = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -254,6 +254,11 @@ class Envs:
     SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(False)
     SGLANG_SCHEDULER_MAX_RECV_PER_POLL = EnvInt(-1)
     SGLANG_EXPERIMENTAL_CPP_RADIX_TREE = EnvBool(False)
+    # Force radix `match_prefix` to always return an empty match while keeping
+    # the radix code path on (insertion / eviction still run). Use this to
+    # benchmark engine performance under the cache-enabled code path with a
+    # guaranteed 0% prefix-cache hit rate.
+    SGLANG_RADIX_FORCE_MISS = EnvBool(False)
     SGLANG_DYNAMIC_CHUNKING_SMOOTH_FACTOR = EnvFloat(0.75)
     SGLANG_SCHEDULER_SKIP_ALL_GATHER = EnvBool(False)
     SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE = EnvBool(False)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1029,6 +1029,9 @@ class Req(ReqDllmMixin):
                     cow_mamba=cow_mamba,
                 )
             )
+            if envs.SGLANG_RADIX_FORCE_MISS.get():
+                from sglang.srt.managers.schedule_policy import _zero_match_result
+                match_result = _zero_match_result(tree_cache, match_result)
             (
                 self.prefix_indices,
                 self.last_node,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -61,7 +61,11 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchPrefixParams
+from sglang.srt.mem_cache.base_prefix_cache import (
+    BasePrefixCache,
+    MatchPrefixParams,
+    zero_match_result,
+)
 from sglang.srt.mem_cache.common import (
     alloc_for_decode,
     alloc_for_extend,
@@ -1030,9 +1034,7 @@ class Req(ReqDllmMixin):
                 )
             )
             if envs.SGLANG_RADIX_FORCE_MISS.get():
-                from sglang.srt.managers.schedule_policy import _zero_match_result
-
-                match_result = _zero_match_result(tree_cache, match_result)
+                match_result = zero_match_result(tree_cache, match_result)
             (
                 self.prefix_indices,
                 self.last_node,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1031,6 +1031,7 @@ class Req(ReqDllmMixin):
             )
             if envs.SGLANG_RADIX_FORCE_MISS.get():
                 from sglang.srt.managers.schedule_policy import _zero_match_result
+
                 match_result = _zero_match_result(tree_cache, match_result)
             (
                 self.prefix_indices,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from sglang.srt.environ import envs
 from sglang.srt.managers.prefill_delayer import PrefillDelayerSinglePassExecutor
 from sglang.srt.mem_cache.base_prefix_cache import DecLockRefParams
 from sglang.srt.utils import get_bool_env_var
@@ -98,6 +99,8 @@ def match_prefix_for_req(
             req=req if include_req else None,
         )
     )
+    if envs.SGLANG_RADIX_FORCE_MISS.get():
+        match_result = _zero_match_result(tree_cache, match_result)
     (
         req.prefix_indices,
         req.last_node,
@@ -114,6 +117,16 @@ def match_prefix_for_req(
     if match_result.cache_protected_len is not None:
         req.cache_protected_len = match_result.cache_protected_len
     return match_result
+
+
+def _zero_match_result(tree_cache, match_result):
+    root = getattr(tree_cache, "root_node", None)
+    return match_result._replace(
+        device_indices=match_result.device_indices[:0],
+        last_device_node=root if root is not None else match_result.last_device_node,
+        last_host_node=root if root is not None else match_result.last_host_node,
+        host_hit_length=0,
+    )
 
 
 class CacheAwarePolicy(Enum):

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -43,6 +43,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InitLoadBackParams,
     InsertParams,
     MatchPrefixParams,
+    zero_match_result,
 )
 from sglang.srt.mem_cache.hisparse_memory_pool import (
     DeepSeekV4HiSparseTokenToKVPoolAllocator,
@@ -100,7 +101,7 @@ def match_prefix_for_req(
         )
     )
     if envs.SGLANG_RADIX_FORCE_MISS.get():
-        match_result = _zero_match_result(tree_cache, match_result)
+        match_result = zero_match_result(tree_cache, match_result)
     (
         req.prefix_indices,
         req.last_node,
@@ -117,16 +118,6 @@ def match_prefix_for_req(
     if match_result.cache_protected_len is not None:
         req.cache_protected_len = match_result.cache_protected_len
     return match_result
-
-
-def _zero_match_result(tree_cache, match_result):
-    root = getattr(tree_cache, "root_node", None)
-    return match_result._replace(
-        device_indices=match_result.device_indices[:0],
-        last_device_node=root if root is not None else match_result.last_device_node,
-        last_host_node=root if root is not None else match_result.last_host_node,
-        host_hit_length=0,
-    )
 
 
 class CacheAwarePolicy(Enum):
@@ -262,6 +253,10 @@ class SchedulePolicy:
                         key=RadixKey(token_ids=prefix_ids, extra_key=extra_key)
                     )
                 )
+                if envs.SGLANG_RADIX_FORCE_MISS.get():
+                    match_result = zero_match_result(
+                        self.waiting_queue_radix_tree, match_result
+                    )
                 in_batch_matching_prefixes = match_result.device_indices
                 if (
                     len(in_batch_matching_prefixes)

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -151,6 +151,20 @@ class MatchResult(NamedTuple):
     cache_protected_len: Optional[int] = None
 
 
+def zero_match_result(tree_cache, match_result: "MatchResult") -> "MatchResult":
+    root = getattr(tree_cache, "root_node", None)
+    if root is None:
+        return match_result
+    return match_result._replace(
+        # [:0] keeps dtype and device of the original tensor (e.g. CUDA int64)
+        # without allocating a fresh empty tensor.
+        device_indices=match_result.device_indices[:0],
+        last_device_node=root,
+        last_host_node=root,
+        host_hit_length=0,
+    )
+
+
 class BasePrefixCache(ABC, PrefixCacheTrait):
     """Cache can be indexed by either rid or key."""
 

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -154,7 +154,11 @@ class MatchResult(NamedTuple):
 def zero_match_result(tree_cache, match_result: "MatchResult") -> "MatchResult":
     root = getattr(tree_cache, "root_node", None)
     if root is None:
-        return match_result
+        raise RuntimeError(
+            f"SGLANG_RADIX_FORCE_MISS is not supported by {type(tree_cache).__name__} "
+            "(no `root_node` attribute). Disable the flag or use a cache backend "
+            "that exposes a tree root."
+        )
     return match_result._replace(
         # [:0] keeps dtype and device of the original tensor (e.g. CUDA int64)
         # without allocating a fresh empty tensor.

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -46,7 +46,6 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
-from sglang.srt.environ import envs
 from sglang.srt.mem_cache.events import KVCacheEventMixin
 from sglang.srt.mem_cache.evict_policy import (
     EvictionStrategy,
@@ -397,7 +396,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         key = params.key
         key, _ = key.maybe_to_bigram_view(self.is_eagle)
 
-        if self.disable or len(key) == 0 or envs.SGLANG_RADIX_FORCE_MISS.get():
+        if self.disable or len(key) == 0:
             return self._empty_match_result
 
         key = key.page_aligned(self.page_size)

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -46,6 +46,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.events import KVCacheEventMixin
 from sglang.srt.mem_cache.evict_policy import (
     EvictionStrategy,
@@ -396,7 +397,7 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         key = params.key
         key, _ = key.maybe_to_bigram_view(self.is_eagle)
 
-        if self.disable or len(key) == 0:
+        if self.disable or len(key) == 0 or envs.SGLANG_RADIX_FORCE_MISS.get():
             return self._empty_match_result
 
         key = key.page_aligned(self.page_size)

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -57,8 +57,9 @@ class TestZeroMatchResult(unittest.TestCase):
         self.assertEqual(zeroed.device_indices.dtype, match.device_indices.dtype)
         self.assertEqual(zeroed.device_indices.device, match.device_indices.device)
 
-    def test_no_root_node_returns_unchanged(self):
-        # tree_cache without a root_node: helper must not fabricate inconsistent state.
+    def test_no_root_node_raises(self):
+        # tree_cache without a root_node: must raise loudly rather than silently
+        # leak cache hits past the gate.
         class _NoRoot:
             pass
 
@@ -68,8 +69,8 @@ class TestZeroMatchResult(unittest.TestCase):
             last_host_node="sentinel-host",
             host_hit_length=4,
         )
-        out = zero_match_result(_NoRoot(), original)
-        self.assertIs(out, original)
+        with self.assertRaisesRegex(RuntimeError, "SGLANG_RADIX_FORCE_MISS"):
+            zero_match_result(_NoRoot(), original)
 
 
 class TestMatchPrefixForReqForceMiss(unittest.TestCase):

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -44,7 +44,9 @@ class TestZeroMatchResult(unittest.TestCase):
     def test_zero_replaces_indices_and_nodes(self):
         tree = RadixCache.create_simulated()
         tree.insert(InsertParams(key=RadixKey(token_ids=[1, 2, 3, 4, 5])))
-        match = tree.match_prefix(MatchPrefixParams(key=RadixKey(token_ids=[1, 2, 3, 9])))
+        match = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(token_ids=[1, 2, 3, 9]))
+        )
         self.assertGreater(len(match.device_indices), 0)
         zeroed = zero_match_result(tree, match)
         self.assertEqual(int(zeroed.device_indices.numel()), 0)
@@ -73,7 +75,9 @@ class TestZeroMatchResult(unittest.TestCase):
 class TestMatchPrefixForReqForceMiss(unittest.TestCase):
     def test_force_miss_zeros_req_prefix(self):
         tree = RadixCache.create_simulated()
-        tree.insert(InsertParams(key=RadixKey(token_ids=[10, 11, 12, 13, 14, 15, 16, 17])))
+        tree.insert(
+            InsertParams(key=RadixKey(token_ids=[10, 11, 12, 13, 14, 15, 16, 17]))
+        )
 
         # Sanity: without the flag, the same lookup hits.
         baseline_req = _StubReq([10, 11, 12, 13, 99, 100])

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -5,11 +5,9 @@ plus an end-to-end check of `match_prefix_for_req` driving a populated
 RadixCache.
 """
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci
 
-# CPU-based unit test, runs quickly on any runner.
-register_cuda_ci(est_time=10, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=5, suite="stage-b-test-1-gpu-small-amd")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 import unittest
 import unittest.mock

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -1,0 +1,96 @@
+"""Unit tests for SGLANG_RADIX_FORCE_MISS.
+
+The flag is gated at the scheduler boundary, so we test the helper directly
+plus an end-to-end check of `match_prefix_for_req` driving a populated
+RadixCache.
+"""
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+# CPU-based unit test, runs quickly on any runner.
+register_cuda_ci(est_time=10, suite="stage-b-test-1-gpu-small")
+register_amd_ci(est_time=5, suite="stage-b-test-1-gpu-small-amd")
+
+import unittest
+import unittest.mock
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.schedule_policy import match_prefix_for_req
+from sglang.srt.mem_cache.base_prefix_cache import (
+    InsertParams,
+    MatchPrefixParams,
+    MatchResult,
+    zero_match_result,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+
+class _StubReq:
+    def __init__(self, token_ids):
+        self.origin_input_ids = list(token_ids)
+        self.output_ids = []
+        self.extra_key = None
+        self.prefix_indices = None
+        self.last_node = None
+        self.last_host_node = None
+        self.host_hit_length = None
+        self.mamba_branching_seqlen = None
+        self.cache_protected_len = None
+
+
+class TestZeroMatchResult(unittest.TestCase):
+    def test_zero_replaces_indices_and_nodes(self):
+        tree = RadixCache.create_simulated()
+        tree.insert(InsertParams(key=RadixKey(token_ids=[1, 2, 3, 4, 5])))
+        match = tree.match_prefix(MatchPrefixParams(key=RadixKey(token_ids=[1, 2, 3, 9])))
+        self.assertGreater(len(match.device_indices), 0)
+        zeroed = zero_match_result(tree, match)
+        self.assertEqual(int(zeroed.device_indices.numel()), 0)
+        self.assertIs(zeroed.last_device_node, tree.root_node)
+        self.assertIs(zeroed.last_host_node, tree.root_node)
+        self.assertEqual(zeroed.host_hit_length, 0)
+        # dtype/device preserved (slice-not-allocate).
+        self.assertEqual(zeroed.device_indices.dtype, match.device_indices.dtype)
+        self.assertEqual(zeroed.device_indices.device, match.device_indices.device)
+
+    def test_no_root_node_returns_unchanged(self):
+        # tree_cache without a root_node: helper must not fabricate inconsistent state.
+        class _NoRoot:
+            pass
+
+        original = MatchResult(
+            device_indices=torch.tensor([7, 8, 9], dtype=torch.int64),
+            last_device_node="sentinel-device",
+            last_host_node="sentinel-host",
+            host_hit_length=4,
+        )
+        out = zero_match_result(_NoRoot(), original)
+        self.assertIs(out, original)
+
+
+class TestMatchPrefixForReqForceMiss(unittest.TestCase):
+    def test_force_miss_zeros_req_prefix(self):
+        tree = RadixCache.create_simulated()
+        tree.insert(InsertParams(key=RadixKey(token_ids=[10, 11, 12, 13, 14, 15, 16, 17])))
+
+        # Sanity: without the flag, the same lookup hits.
+        baseline_req = _StubReq([10, 11, 12, 13, 99, 100])
+        with envs.SGLANG_RADIX_FORCE_MISS.override(False):
+            match_prefix_for_req(tree, baseline_req)
+        self.assertGreater(int(baseline_req.prefix_indices.numel()), 0)
+        self.assertIsNot(baseline_req.last_node, tree.root_node)
+
+        # With the flag, the same lookup is forced to miss.
+        forced_req = _StubReq([10, 11, 12, 13, 99, 100])
+        with envs.SGLANG_RADIX_FORCE_MISS.override(True):
+            match_prefix_for_req(tree, forced_req)
+        self.assertEqual(int(forced_req.prefix_indices.numel()), 0)
+        self.assertIs(forced_req.last_node, tree.root_node)
+        self.assertIs(forced_req.last_host_node, tree.root_node)
+        self.assertEqual(forced_req.host_hit_length, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add an environment variable to force a 0% prefix-cache hit rate while keeping the radix code path enabled, so engine performance can be benchmarked under the cache-enabled scheduling path without the confound of cache hits. Toggling `--disable-radix-cache` is not equivalent because it switches the scheduler to a different code path (`ChunkCache`), which masks what we actually want to measure.

## Modifications

- `python/sglang/srt/environ.py`: declare `SGLANG_RADIX_FORCE_MISS` (`EnvBool`, default `False`) alongside the other radix-related env vars.
- `python/sglang/srt/mem_cache/base_prefix_cache.py`: add `zero_match_result(tree_cache, match_result)` next to `MatchResult`. Returns a `MatchResult._replace(...)` with empty `device_indices` (sliced as `[:0]` to preserve dtype/device without allocating), the cache's `root_node` as `last_device_node`/`last_host_node`, and `host_hit_length=0`. **Raises** `RuntimeError` if the cache has no `root_node` (currently only `RadixCacheCpp`, behind `SGLANG_EXPERIMENTAL_CPP_RADIX_TREE`); a loud failure is preferable to silently leaking cache hits past the gate.
- `python/sglang/srt/managers/schedule_policy.py`: in `match_prefix_for_req`, route the result through `zero_match_result(tree_cache, match_result)` when the flag is set. The same gate is also applied to the **in-batch prefix-caching deprioritization** lookup on `self.waiting_queue_radix_tree` — without this, FORCE_MISS would still let the scheduler deprioritize same-prefix waiters even though no actual KV reuse can happen.
- `python/sglang/srt/managers/schedule_batch.py`: same gate in `Req.init_next_round_input` (the third external `match_prefix` call site).

The gate is intentionally **outside** `RadixCache.match_prefix` because the cache calls its own `match_prefix` internally (e.g. `cache_unfinished_req` inserts and then re-matches, asserting the just-inserted prefix is fully found). Gating inside the cache breaks that internal contract; gating at the scheduler boundary leaves the radix tree's lookup/insertion/eviction/lock-ref machinery running normally and only zeroes the result the scheduler consumes.

### Backend coverage

| Cache | `root_node`? | FORCE_MISS honored |
|---|---|---|
| `RadixCache`, `MambaRadixCache`, `UnifiedRadixCache`, `SWARadixCache`, `HiRadixCache`, `HiMambaRadixCache`, `LMCRadixCache` | ✓ | yes |
| `RadixCacheCpp` (experimental) | ✗ | raises `RuntimeError` |

### Tests

`test/registered/unit/mem_cache/test_radix_force_miss.py` — CPU-only unit tests:
1. `zero_match_result` zeros indices/nodes and preserves tensor dtype/device.
2. `zero_match_result` raises `RuntimeError` when the cache has no `root_node`.
3. `match_prefix_for_req` under `envs.SGLANG_RADIX_FORCE_MISS.override(True)` leaves `req.prefix_indices` empty and `req.last_node` pointing at the tree root, while the same call with the flag off still hits.

## Accuracy Tests

GSM8K with `Qwen/Qwen2.5-7B-Instruct`, greedy decoding (temperature=0), 100 questions, parallel=32, on a single GB300 inside the deepseek-v4-grace-blackwell-dev container:

| `SGLANG_RADIX_FORCE_MISS` | Accuracy | Invalid | Latency | Output throughput |
|---|---:|---:|---:|---:|
| off (default) | **0.880** | 0.000 | 12.84 s | 1246.79 tok/s |
| on            | **0.880** | 0.000 | 12.99 s | 1218.37 tok/s |

Identical accuracy and zero invalid responses → the flag preserves model correctness.

### Engine-log verification of `#cached-token`

Counted `Prefill batch ... #cached-token: N` lines from each run's scheduler log (latest run, post-loud-raise):

| | total prefill batches | with `#cached-token: 0` | max `#cached-token` |
|---|---:|---:|---:|
| off (default) | ~70 | 3 (warmup only) | ~14 K |
| on            | 69 | **69 (all)** | **0** |

## Speed Tests and Profiling

Not applicable — the flag's purpose is to enable controlled benchmarks; when it is off (default) the only added cost is one boolean env-var read per scheduler-side `match_prefix` call.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).