### PR TITLE
ci: add nightly-test-general-1-gpu-5090 job

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -80,6 +80,33 @@ jobs:
       - uses: ./.github/actions/upload-cuda-coredumps
         if: failure()
 
+  # General tests - 1 GPU 5090 (SM12.0)
+  nightly-test-general-1-gpu-5090:
+    if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-1-gpu-5090')
+    runs-on: 1-gpu-5090
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/check-maintenance
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/cuda/ci_install_dependency.sh
+
+      - name: Run test
+        timeout-minutes: 60
+        env:
+          RUNAI_STREAMER_MEMORY_LIMIT: 0
+        run: |
+          cd test
+          python3 run_suite.py --hw cuda --suite nightly-1-gpu-5090 --nightly --continue-on-error
+
+      - uses: ./.github/actions/upload-cuda-coredumps
+        if: failure()
+
   # JIT kernel full unit tests (expanded parameter ranges via SGLANG_JIT_KERNEL_RUN_FULL_TESTS)
   nightly-test-kernel-1-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-kernel-1-gpu-h100')
@@ -771,6 +798,7 @@ jobs:
     if: github.repository == 'sgl-project/sglang' && always()
     needs:
       - nightly-test-general-1-gpu-h100
+      - nightly-test-general-1-gpu-5090
       - nightly-test-general-4-gpu-h100
       - nightly-test-general-8-gpu-h200
       - nightly-test-general-8-gpu-h20


### PR DESCRIPTION
## Summary

Add a 1-GPU SM12.0/5090 nightly target to \`nightly-test-nvidia.yml\` so tests registered with \`suite=\"nightly-1-gpu-5090\"\` actually have a runner.

Patterned after the existing \`nightly-test-general-1-gpu-h100\` job — same install / timeout / coredump flow, only the runner label (\`runs-on: 1-gpu-5090\`) and the suite name differ.

Also adds the new job to the \`check-all-jobs\` needs list so it gates the same end-of-pipeline status check.

## Why

Companion to #24725 (PR2 — tag-gated nightly migration). PR2 registers \`nightly-1-gpu-5090\` in \`run_suite.py:NIGHTLY_SUITES[CUDA]\` and routes \`stage-a-test-1-gpu-small\` / \`stage-b-test-1-gpu-small\` to it via \`PER_COMMIT_TO_NIGHTLY\`, then moves 13 SM12.0 tests to that suite. Without this workflow job the suite has no executor.

## Test plan

- [ ] Merge order: this PR → then PR2 (#24725). If PR2 lands first, those 13 tests are silently skipped (no runner) until this lands; if this lands first, the new job runs an empty suite until PR2 registers tests there.
- [ ] On next scheduled nightly trigger, verify the new \`nightly-test-general-1-gpu-5090\` job appears in the run and exercises the SM12.0-only tests once both PRs are merged.