### PR TITLE
[codex] Optimize small RMSNorm half-kernel dispatch

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/rmsnorm.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/rmsnorm.cuh
@@ -85,17 +85,22 @@ __global__ __launch_bounds__(kDim / 16) void rmsnorm_cta_double(const RMSNormPar
   }
 
   sum_of_squares = warp::reduce_sum(sum_of_squares);
-  const auto warp_id = threadIdx.x / kWarpThreads;
-  smem[warp_id] = sum_of_squares;
-  __syncthreads();
-  if (warp_id == 0) {
-    const auto tx = threadIdx.x;
-    const auto local_sum = tx < kNumWarps ? smem[tx] : 0.0f;
-    sum_of_squares = warp::reduce_sum(local_sum);
-    smem[tx] = math::rsqrt(sum_of_squares / kDim + eps);
+  float norm_factor;
+  if constexpr (kNumWarps == 1) {
+    norm_factor = math::rsqrt(sum_of_squares / kDim + eps);
+  } else {
+    const auto warp_id = threadIdx.x / kWarpThreads;
+    smem[warp_id] = sum_of_squares;
+    __syncthreads();
+    if (warp_id == 0) {
+      const auto tx = threadIdx.x;
+      const auto local_sum = tx < kNumWarps ? smem[tx] : 0.0f;
+      sum_of_squares = warp::reduce_sum(local_sum);
+      smem[tx] = math::rsqrt(sum_of_squares / kDim + eps);
+    }
+    __syncthreads();
+    norm_factor = smem[warp_id];
   }
-  __syncthreads();
-  const float norm_factor = smem[warp_id];
 
   Storage output_first, output_second;
 #pragma unroll
@@ -147,17 +152,22 @@ __global__ __launch_bounds__(kDim / 16) void rmsnorm_cta_wide(const RMSNormParam
   }
 
   sum_of_squares = warp::reduce_sum(sum_of_squares);
-  const auto warp_id = threadIdx.x / kWarpThreads;
-  smem[warp_id] = sum_of_squares;
-  __syncthreads();
-  if (warp_id == 0) {
-    const auto tx = threadIdx.x;
-    const auto local_sum = tx < kNumWarps ? smem[tx] : 0.0f;
-    sum_of_squares = warp::reduce_sum(local_sum);
-    smem[tx] = math::rsqrt(sum_of_squares / kDim + eps);
+  float norm_factor;
+  if constexpr (kNumWarps == 1) {
+    norm_factor = math::rsqrt(sum_of_squares / kDim + eps);
+  } else {
+    const auto warp_id = threadIdx.x / kWarpThreads;
+    smem[warp_id] = sum_of_squares;
+    __syncthreads();
+    if (warp_id == 0) {
+      const auto tx = threadIdx.x;
+      const auto local_sum = tx < kNumWarps ? smem[tx] : 0.0f;
+      sum_of_squares = warp::reduce_sum(local_sum);
+      smem[tx] = math::rsqrt(sum_of_squares / kDim + eps);
+    }
+    __syncthreads();
+    norm_factor = smem[warp_id];
   }
-  __syncthreads();
-  const float norm_factor = smem[warp_id];
 
   Storage output_vec;
 #pragma unroll

--- a/python/sglang/jit_kernel/norm.py
+++ b/python/sglang/jit_kernel/norm.py
@@ -33,7 +33,7 @@ def _jit_qknorm_module(head_dim: int, dtype: torch.dtype) -> Module:
 
 _RMSNORM_WARP_SIZES = frozenset({64, 128, 256})
 _RMSNORM_MAX_HIDDEN_SIZE = 16384
-_RMSNORM_HALF_BLOCK_MIN_SIZE = 2048
+_RMSNORM_HALF_BLOCK_MIN_SIZE = 512
 
 
 def _is_supported_rmsnorm_hidden_size(d: int) -> bool:

--- a/python/sglang/jit_kernel/tests/test_rmsnorm.py
+++ b/python/sglang/jit_kernel/tests/test_rmsnorm.py
@@ -88,8 +88,8 @@ def test_rmsnorm_hidden_size_support(hidden_size: int) -> None:
         (64, "RMSNormWarpKernel"),
         (128, "RMSNormWarpKernel"),
         (256, "RMSNormWarpKernel"),
-        (512, "RMSNormKernel"),
-        (1536, "RMSNormKernel"),
+        (512, "RMSNormHalfKernel"),
+        (1536, "RMSNormHalfKernel"),
         (2048, "RMSNormHalfKernel"),
         (2304, "RMSNormKernel"),  # NOTE: not 512 aligned
         (8192, "RMSNormHalfKernel"),


### PR DESCRIPTION
## Summary

Dispatch 512-aligned JIT RMSNorm hidden sizes from `512` upward to the existing half-kernel path, and skip the CTA shared-memory reduction in the half kernels when the shape uses a single warp.

This targets the H100 CI benchmark case where `hidden_size=512` was slower than FlashInfer under the generic CTA RMSNorm path.

## Accuracy

H100, `CUDA_VISIBLE_DEVICES=1`, `PYTHONPATH=python`, `SGLANG_IS_IN_CI=1`:

```text
pytest -q python/sglang/jit_kernel/tests/test_rmsnorm.py -q
.................................................................        [100%]
```

The test compares SGLang JIT RMSNorm against `flashinfer.norm.rmsnorm` for FP16/BF16 with `atol=1e-2`, `rtol=1e-2`.

## Benchmark

H100, `CUDA_VISIBLE_DEVICES=1`, `PYTHONPATH=python`, `SGLANG_IS_IN_CI=1`:

```bash
python python/sglang/jit_kernel/benchmark/bench_norm.py
```

`rmsnorm` SGL JIT median latency:

| hidden_size | batch_size | baseline us | optimized us | change |
| ---: | ---: | ---: | ---: | ---: |
| 512 | 16 | 1.074065 | 0.860519 | +19.88% |
| 512 | 32 | 1.248929 | 1.040443 | +16.69% |
| 2048 | 16 | 1.204039 | 1.206014 | -0.16% |
| 2048 | 32 | 1.207179 | 1.208210 | -0.09% |
| 16384 | 16 | 1.991542 | 1.991699 | -0.01% |
| 16384 | 32 | 2.007984 | 2.010286 | -0.11% |

## Profiling

`ncu --set basic` was attempted, but the container blocks performance counters with `ERR_NVGPUCTRPERM`, so I used Nsight Systems kernel summaries.

H100, BF16, `hidden_size=512`, `batch_size=32`, 100 calls:

| Kernel | Avg ns | Median ns |
| --- | ---: | ---: |
| baseline `rmsnorm_cta<512, true, bf16>` | 1474.5 | 1472.0 |
| optimized `rmsnorm_cta_double<512, true, bf16>` | 1275.2 | 1280.0 |

The optimized kernel is 13.52% shorter by nsys kernel average, matching the benchmark direction.
