### PR TITLE
[Spec] Move `accept_tokens` off `EagleDraftInput`; pass via method arg

### DIFF
--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -213,7 +213,6 @@ class DFlashVerifyInput(SpecInput):
                 last_loc,
                 len(batch.input_ids),
             )
-            self.last_loc = last_loc
 
         bs = batch.batch_size()
         assign_req_to_token_pool_func(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -240,7 +240,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
-            draft_input = EagleDraftInput.create_idle_input(
+            next_draft_input = EagleDraftInput.create_idle_input(
                 device=batch.device,
                 hidden_size=batch.model_config.spec_hidden_size,
                 dtype=batch.model_config.dtype,
@@ -248,7 +248,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
             return EagleVerifyOutput.create_idle(
-                next_draft_input=draft_input,
+                next_draft_input=next_draft_input,
                 logits_output=logits_output,
                 device=batch.device,
                 spec_steps=self.spec_steps,
@@ -545,7 +545,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             batch.seq_lens.add_(num_accepted_drafts + 1)
             batch.seq_lens_cpu.add_(num_accepted_tokens_cpu)
 
-            draft_input = EagleDraftInput(
+            next_draft_input = EagleDraftInput(
                 hidden_states=batch.spec_info.hidden_states[accept_index],
                 num_accepted_drafts=num_accepted_drafts,
                 num_accepted_tokens=num_accepted_drafts + 1,
@@ -553,7 +553,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             )
 
             return EagleVerifyOutput(
-                next_draft_input=draft_input,
+                next_draft_input=next_draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 next_extend_input_ids=accept_tokens,
@@ -620,7 +620,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 req_pool_indices_for_draft_extend = batch.req_pool_indices[
                     unfinished_index_device
                 ]
-                draft_input = EagleDraftInput(
+                next_draft_input = EagleDraftInput(
                     hidden_states=batch.spec_info.hidden_states[
                         unfinished_accept_index
                     ],
@@ -643,7 +643,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     dtype=batch.req_pool_indices.dtype,
                     device=batch.req_pool_indices.device,
                 )
-                draft_input = EagleDraftInput.create_idle_input(
+                next_draft_input = EagleDraftInput.create_idle_input(
                     device=batch.device,
                     hidden_size=batch.model_config.spec_hidden_size,
                     dtype=batch.model_config.dtype,
@@ -652,7 +652,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
 
             return EagleVerifyOutput(
-                next_draft_input=draft_input,
+                next_draft_input=next_draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 next_extend_input_ids=next_extend_input_ids,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -140,7 +140,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 last_loc,
                 len(batch.input_ids),
             )
-            self.last_loc = last_loc
 
         bs = batch.batch_size()
         assign_req_to_token_pool_func(
@@ -686,7 +685,10 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     # shape: (b, topk)
     topk_p: torch.Tensor = None
     topk_index: torch.Tensor = None
-    # shape: (b, hidden_size)
+    # shape: (b, hidden_size) when consumed by `draft` forward (one hidden per req);
+    # shape: (total_accepted, hidden_size) when consumed by `draft_extend` forward
+    # (one hidden per accepted token). Workers maintain this invariant locally;
+    # there is no type-level guard. Don't add new readers without checking phase.
     hidden_states: torch.Tensor = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -251,6 +251,9 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 ),
                 logits_output=logits_output,
                 accept_tokens=torch.empty(0, dtype=torch.long, device=batch.device),
+                next_extend_input_ids=torch.empty(
+                    0, dtype=torch.long, device=batch.device
+                ),
                 num_accepted_drafts_per_req_cpu=[],
                 accepted_indices=torch.full(
                     (0, self.spec_steps + 1),
@@ -553,7 +556,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
 
             draft_input = EagleDraftInput(
                 hidden_states=batch.spec_info.hidden_states[accept_index],
-                accept_tokens=accept_tokens,
                 num_accepted_drafts=num_accepted_drafts,
                 num_accepted_tokens=num_accepted_drafts + 1,
                 num_accepted_drafts_cpu=num_accepted_drafts_list,
@@ -567,6 +569,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 draft_input=draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
+                next_extend_input_ids=accept_tokens,
                 num_accepted_drafts_per_req_cpu=draft_input.num_accepted_drafts_cpu,
                 accepted_indices=accept_index,
             )
@@ -621,11 +624,11 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 unfinished_num_accepted_drafts = num_accepted_drafts[
                     unfinished_index_device
                 ]
+                next_extend_input_ids = predict[unfinished_accept_index]
                 draft_input = EagleDraftInput(
                     hidden_states=batch.spec_info.hidden_states[
                         unfinished_accept_index
                     ],
-                    accept_tokens=predict[unfinished_accept_index],
                     num_accepted_drafts_cpu=draft_input_num_accepted_drafts_cpu,
                     num_accepted_tokens_cpu=draft_input_num_accepted_tokens_cpu,
                     num_accepted_drafts=unfinished_num_accepted_drafts,
@@ -637,6 +640,9 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     ],
                 )
             else:
+                next_extend_input_ids = torch.empty(
+                    (0,), dtype=accept_tokens.dtype, device=accept_tokens.device
+                )
                 draft_input = EagleDraftInput.create_idle_input(
                     device=batch.device,
                     hidden_size=batch.model_config.spec_hidden_size,
@@ -649,6 +655,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 draft_input=draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
+                next_extend_input_ids=next_extend_input_ids,
                 num_accepted_drafts_per_req_cpu=num_accepted_drafts_list,
                 accepted_indices=accept_index,
             )
@@ -670,13 +677,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     # `num_accepted_tokens = num_accepted_drafts + 1` (per-req, one bonus per req).
     # Storing both avoids repeated `+ 1` at every consumer (attn backends, kernels).
     bonus_tokens: torch.Tensor = None
-    # Flat accepted-token tensor for draft-extend, shape `[sum_accepted]`.
-    # Set right after verify and consumed by `prepare_extend_after_decode` as
-    # the extend batch's `input_ids`. Dead after that method returns.
-    # TODO: drop this field and pass `accept_tokens` directly to
-    # `prepare_extend_after_decode` as a method arg. Its lifetime is bounded
-    # by verify -> prepare_extend, no need to live on the dataclass.
-    accept_tokens: torch.Tensor = None
     num_accepted_drafts: torch.Tensor = None
     num_accepted_tokens: torch.Tensor = None
     num_accepted_drafts_cpu: List[int] = None
@@ -735,7 +735,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     ):
         return cls(
             bonus_tokens=torch.empty((0,), device=device, dtype=torch.int32),
-            accept_tokens=torch.empty((0,), device=device, dtype=torch.int32),
             hidden_states=torch.empty((0, hidden_size), device=device, dtype=dtype),
             topk_p=torch.empty((0, topk), device=device, dtype=torch.float32),
             topk_index=torch.empty((0, topk), device=device, dtype=torch.int64),
@@ -750,17 +749,18 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     def prepare_extend_after_decode(
         self,
         batch: ScheduleBatch,
+        extend_input_ids: torch.Tensor,
         speculative_num_steps: int,
     ):
 
         if batch.forward_mode.is_idle():
             return
 
-        # `self.accept_tokens` is the flat accepted-token tensor set by
-        # `EagleVerifyInput.verify`; use it as the extend batch's `input_ids`.
-        # The kernel below populates `self.bonus_tokens` ([bs] per-req) for
-        # the next decode round.
-        batch.input_ids = self.accept_tokens
+        # `extend_input_ids` is the flat accepted-token tensor for reqs that
+        # continue into the next iter (= `EagleVerifyOutput.next_extend_input_ids`).
+        # It becomes the extend batch's `input_ids`. The kernel below populates
+        # `self.bonus_tokens` ([bs] per-req) for the next decode round.
+        batch.input_ids = extend_input_ids
         batch.extend_lens = batch.spec_info.num_accepted_tokens_cpu
         batch.extend_num_tokens = sum(batch.extend_lens)
         batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
@@ -877,8 +877,13 @@ class EagleVerifyOutput:
     draft_input: EagleDraftInput
     # Logit outputs from target worker
     logits_output: LogitsProcessorOutput
-    # Accepted token ids including the bonus token (flat, [sum_accepted])
+    # All accepted tokens flat across all reqs incl. those that finished this
+    # step. Includes the bonus token. Used for output processing.
     accept_tokens: torch.Tensor
+    # Subset of `accept_tokens` for reqs continuing into next iter's draft-extend
+    # forward (= `accept_tokens` when no req finished; flat over unfinished
+    # reqs only otherwise). Becomes `batch.input_ids` for that forward pass.
+    next_extend_input_ids: torch.Tensor
     # Accepted token length per sequence in a batch in CPU.
     num_accepted_drafts_per_req_cpu: List[int]
     # Accepted indices from logits_output.next_token_logits

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -240,14 +240,15 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
+            draft_input = EagleDraftInput.create_idle_input(
+                device=batch.device,
+                hidden_size=batch.model_config.spec_hidden_size,
+                dtype=batch.model_config.dtype,
+                topk=self.topk,
+                capture_hidden_mode=CaptureHiddenMode.LAST,
+            )
             return EagleVerifyOutput.create_idle(
-                draft_input=EagleDraftInput.create_idle_input(
-                    device=batch.device,
-                    hidden_size=batch.model_config.spec_hidden_size,
-                    dtype=batch.model_config.dtype,
-                    topk=self.topk,
-                    capture_hidden_mode=CaptureHiddenMode.LAST,
-                ),
+                draft_input=draft_input,
                 logits_output=logits_output,
                 device=batch.device,
                 spec_steps=self.spec_steps,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -240,7 +240,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
-            return EagleVerifyOutput(
+            return EagleVerifyOutput.create_idle(
                 draft_input=EagleDraftInput.create_idle_input(
                     device=batch.device,
                     hidden_size=batch.model_config.spec_hidden_size,
@@ -249,24 +249,8 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 ),
                 logits_output=logits_output,
-                accept_tokens=torch.empty(0, dtype=torch.long, device=batch.device),
-                next_extend_input_ids=torch.empty(
-                    0, dtype=torch.long, device=batch.device
-                ),
-                seq_lens_for_draft_extend=torch.empty(
-                    0, dtype=torch.int32, device=batch.device
-                ),
-                seq_lens_for_draft_extend_cpu=torch.empty(0, dtype=torch.int32),
-                req_pool_indices_for_draft_extend=torch.empty(
-                    0, dtype=torch.int64, device=batch.device
-                ),
-                num_accepted_drafts_per_req_cpu=[],
-                accepted_indices=torch.full(
-                    (0, self.spec_steps + 1),
-                    -1,
-                    dtype=torch.int32,
-                    device=batch.device,
-                ),
+                device=batch.device,
+                spec_steps=self.spec_steps,
             )
 
         bs = self.retrieve_index.shape[0]
@@ -913,3 +897,28 @@ class EagleVerifyOutput:
     num_accepted_drafts_per_req_cpu: List[int]
     # Accepted indices from logits_output.next_token_logits
     accepted_indices: torch.Tensor
+
+    @classmethod
+    def create_idle(
+        cls,
+        *,
+        draft_input: EagleDraftInput,
+        logits_output: LogitsProcessorOutput,
+        device: torch.device,
+        spec_steps: int,
+    ) -> "EagleVerifyOutput":
+        return cls(
+            draft_input=draft_input,
+            logits_output=logits_output,
+            accept_tokens=torch.empty(0, dtype=torch.long, device=device),
+            next_extend_input_ids=torch.empty(0, dtype=torch.long, device=device),
+            seq_lens_for_draft_extend=torch.empty(0, dtype=torch.int32, device=device),
+            seq_lens_for_draft_extend_cpu=torch.empty(0, dtype=torch.int32),
+            req_pool_indices_for_draft_extend=torch.empty(
+                0, dtype=torch.int64, device=device
+            ),
+            num_accepted_drafts_per_req_cpu=[],
+            accepted_indices=torch.full(
+                (0, spec_steps + 1), -1, dtype=torch.int32, device=device
+            ),
+        )

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -248,7 +248,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
             return EagleVerifyOutput.create_idle(
-                draft_input=draft_input,
+                next_draft_input=draft_input,
                 logits_output=logits_output,
                 device=batch.device,
                 spec_steps=self.spec_steps,
@@ -553,7 +553,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             )
 
             return EagleVerifyOutput(
-                draft_input=draft_input,
+                next_draft_input=draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 next_extend_input_ids=accept_tokens,
@@ -652,7 +652,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
 
             return EagleVerifyOutput(
-                draft_input=draft_input,
+                next_draft_input=draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 next_extend_input_ids=next_extend_input_ids,
@@ -873,8 +873,8 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
 @dataclass
 class EagleVerifyOutput:
-    # Draft input batch (next iter's persistent draft state).
-    draft_input: EagleDraftInput
+    # Next iter's persistent draft state, ready to be installed as `batch.spec_info`.
+    next_draft_input: EagleDraftInput
     # Logit outputs from target worker.
     logits_output: LogitsProcessorOutput
     # All accepted tokens flat across all reqs incl. those that finished this
@@ -903,13 +903,13 @@ class EagleVerifyOutput:
     def create_idle(
         cls,
         *,
-        draft_input: EagleDraftInput,
+        next_draft_input: EagleDraftInput,
         logits_output: LogitsProcessorOutput,
         device: torch.device,
         spec_steps: int,
     ) -> "EagleVerifyOutput":
         return cls(
-            draft_input=draft_input,
+            next_draft_input=next_draft_input,
             logits_output=logits_output,
             accept_tokens=torch.empty(0, dtype=torch.long, device=device),
             next_extend_input_ids=torch.empty(0, dtype=torch.long, device=device),

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -556,7 +556,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 next_draft_input=next_draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
-                next_extend_input_ids=accept_tokens,
+                unfinished_accept_tokens=accept_tokens,
                 seq_lens_for_draft_extend=batch.seq_lens,
                 seq_lens_for_draft_extend_cpu=batch.seq_lens_cpu,
                 req_pool_indices_for_draft_extend=batch.req_pool_indices,
@@ -614,7 +614,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 unfinished_num_accepted_drafts = num_accepted_drafts[
                     unfinished_index_device
                 ]
-                next_extend_input_ids = predict[unfinished_accept_index]
+                unfinished_accept_tokens = predict[unfinished_accept_index]
                 seq_lens_for_draft_extend = batch.seq_lens[unfinished_index_device]
                 seq_lens_for_draft_extend_cpu = batch.seq_lens_cpu[unfinished_index]
                 req_pool_indices_for_draft_extend = batch.req_pool_indices[
@@ -629,7 +629,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     num_accepted_tokens=unfinished_num_accepted_drafts + 1,
                 )
             else:
-                next_extend_input_ids = torch.empty(
+                unfinished_accept_tokens = torch.empty(
                     (0,), dtype=accept_tokens.dtype, device=accept_tokens.device
                 )
                 seq_lens_for_draft_extend = torch.empty(
@@ -655,7 +655,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 next_draft_input=next_draft_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
-                next_extend_input_ids=next_extend_input_ids,
+                unfinished_accept_tokens=unfinished_accept_tokens,
                 seq_lens_for_draft_extend=seq_lens_for_draft_extend,
                 seq_lens_for_draft_extend_cpu=seq_lens_for_draft_extend_cpu,
                 req_pool_indices_for_draft_extend=req_pool_indices_for_draft_extend,
@@ -760,7 +760,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
         # not from `self`. The kernel below populates `self.bonus_tokens`
         # ([bs] per-req) for the next decode round; that is the only state on
         # `self` that survives past this method.
-        batch.input_ids = verify_output.next_extend_input_ids
+        batch.input_ids = verify_output.unfinished_accept_tokens
         batch.extend_lens = batch.spec_info.num_accepted_tokens_cpu
         batch.extend_num_tokens = sum(batch.extend_lens)
         batch.seq_lens = verify_output.seq_lens_for_draft_extend
@@ -888,7 +888,7 @@ class EagleVerifyOutput:
     # Subset of `accept_tokens` for reqs continuing into next iter's draft-extend
     # forward (= `accept_tokens` when no req finished; flat over unfinished
     # reqs only otherwise). Becomes `batch.input_ids` for that forward pass.
-    next_extend_input_ids: torch.Tensor
+    unfinished_accept_tokens: torch.Tensor
     # `batch.seq_lens` / `batch.seq_lens_cpu` / `batch.req_pool_indices` to
     # use for the next iter's draft-extend forward; sliced to surviving reqs.
     seq_lens_for_draft_extend: torch.Tensor
@@ -912,7 +912,7 @@ class EagleVerifyOutput:
             next_draft_input=next_draft_input,
             logits_output=logits_output,
             accept_tokens=torch.empty(0, dtype=torch.long, device=device),
-            next_extend_input_ids=torch.empty(0, dtype=torch.long, device=device),
+            unfinished_accept_tokens=torch.empty(0, dtype=torch.long, device=device),
             seq_lens_for_draft_extend=torch.empty(0, dtype=torch.int32, device=device),
             seq_lens_for_draft_extend_cpu=torch.empty(0, dtype=torch.int32),
             req_pool_indices_for_draft_extend=torch.empty(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -254,6 +254,13 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 next_extend_input_ids=torch.empty(
                     0, dtype=torch.long, device=batch.device
                 ),
+                seq_lens_for_draft_extend=torch.empty(
+                    0, dtype=torch.int32, device=batch.device
+                ),
+                seq_lens_for_draft_extend_cpu=torch.empty(0, dtype=torch.int32),
+                req_pool_indices_for_draft_extend=torch.empty(
+                    0, dtype=torch.int64, device=batch.device
+                ),
                 num_accepted_drafts_per_req_cpu=[],
                 accepted_indices=torch.full(
                     (0, self.spec_steps + 1),
@@ -558,11 +565,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 hidden_states=batch.spec_info.hidden_states[accept_index],
                 num_accepted_drafts=num_accepted_drafts,
                 num_accepted_tokens=num_accepted_drafts + 1,
-                num_accepted_drafts_cpu=num_accepted_drafts_list,
                 num_accepted_tokens_cpu=num_accepted_tokens_list,
-                seq_lens_for_draft_extend=batch.seq_lens,
-                seq_lens_for_draft_extend_cpu=batch.seq_lens_cpu,
-                req_pool_indices_for_draft_extend=batch.req_pool_indices,
             )
 
             return EagleVerifyOutput(
@@ -570,7 +573,10 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 next_extend_input_ids=accept_tokens,
-                num_accepted_drafts_per_req_cpu=draft_input.num_accepted_drafts_cpu,
+                seq_lens_for_draft_extend=batch.seq_lens,
+                seq_lens_for_draft_extend_cpu=batch.seq_lens_cpu,
+                req_pool_indices_for_draft_extend=batch.req_pool_indices,
+                num_accepted_drafts_per_req_cpu=num_accepted_drafts_list,
                 accepted_indices=accept_index,
             )
         else:
@@ -625,23 +631,33 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     unfinished_index_device
                 ]
                 next_extend_input_ids = predict[unfinished_accept_index]
+                seq_lens_for_draft_extend = batch.seq_lens[unfinished_index_device]
+                seq_lens_for_draft_extend_cpu = batch.seq_lens_cpu[unfinished_index]
+                req_pool_indices_for_draft_extend = batch.req_pool_indices[
+                    unfinished_index_device
+                ]
                 draft_input = EagleDraftInput(
                     hidden_states=batch.spec_info.hidden_states[
                         unfinished_accept_index
                     ],
-                    num_accepted_drafts_cpu=draft_input_num_accepted_drafts_cpu,
                     num_accepted_tokens_cpu=draft_input_num_accepted_tokens_cpu,
                     num_accepted_drafts=unfinished_num_accepted_drafts,
                     num_accepted_tokens=unfinished_num_accepted_drafts + 1,
-                    seq_lens_for_draft_extend=batch.seq_lens[unfinished_index_device],
-                    seq_lens_for_draft_extend_cpu=batch.seq_lens_cpu[unfinished_index],
-                    req_pool_indices_for_draft_extend=batch.req_pool_indices[
-                        unfinished_index_device
-                    ],
                 )
             else:
                 next_extend_input_ids = torch.empty(
                     (0,), dtype=accept_tokens.dtype, device=accept_tokens.device
+                )
+                seq_lens_for_draft_extend = torch.empty(
+                    (0,), dtype=batch.seq_lens.dtype, device=batch.seq_lens.device
+                )
+                seq_lens_for_draft_extend_cpu = torch.empty(
+                    (0,), dtype=batch.seq_lens_cpu.dtype
+                )
+                req_pool_indices_for_draft_extend = torch.empty(
+                    (0,),
+                    dtype=batch.req_pool_indices.dtype,
+                    device=batch.req_pool_indices.device,
                 )
                 draft_input = EagleDraftInput.create_idle_input(
                     device=batch.device,
@@ -656,6 +672,9 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 next_extend_input_ids=next_extend_input_ids,
+                seq_lens_for_draft_extend=seq_lens_for_draft_extend,
+                seq_lens_for_draft_extend_cpu=seq_lens_for_draft_extend_cpu,
+                req_pool_indices_for_draft_extend=req_pool_indices_for_draft_extend,
                 num_accepted_drafts_per_req_cpu=num_accepted_drafts_list,
                 accepted_indices=accept_index,
             )
@@ -679,7 +698,8 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     bonus_tokens: torch.Tensor = None
     num_accepted_drafts: torch.Tensor = None
     num_accepted_tokens: torch.Tensor = None
-    num_accepted_drafts_cpu: List[int] = None
+    # Read by attention backends during draft-extend forward; kept on the
+    # dataclass because the backends access it via `forward_batch.spec_info`.
     num_accepted_tokens_cpu: List[int] = None
 
     # Inputs for the attention backends
@@ -690,12 +710,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     # Shape info for padding
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = -1
-
-    # Inputs for draft extend
-    # shape: (b,)
-    seq_lens_for_draft_extend: torch.Tensor = None
-    seq_lens_for_draft_extend_cpu: torch.Tensor = None
-    req_pool_indices_for_draft_extend: torch.Tensor = None
 
     # Inputs for V2 overlap worker
     future_indices: Optional[FutureIndices] = None
@@ -742,30 +756,29 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             new_seq_lens=torch.empty((0,), device=device, dtype=torch.int32),
             num_accepted_drafts=torch.empty((0,), device=device, dtype=torch.int32),
             num_accepted_tokens=torch.empty((0,), device=device, dtype=torch.int32),
-            num_accepted_drafts_cpu=[],
             num_accepted_tokens_cpu=[],
         )
 
     def prepare_extend_after_decode(
         self,
         batch: ScheduleBatch,
-        extend_input_ids: torch.Tensor,
+        verify_output: "EagleVerifyOutput",
         speculative_num_steps: int,
     ):
 
         if batch.forward_mode.is_idle():
             return
 
-        # `extend_input_ids` is the flat accepted-token tensor for reqs that
-        # continue into the next iter (= `EagleVerifyOutput.next_extend_input_ids`).
-        # It becomes the extend batch's `input_ids`. The kernel below populates
-        # `self.bonus_tokens` ([bs] per-req) for the next decode round.
-        batch.input_ids = extend_input_ids
+        # All transient verify->extend handoff state is read off `verify_output`,
+        # not from `self`. The kernel below populates `self.bonus_tokens`
+        # ([bs] per-req) for the next decode round; that is the only state on
+        # `self` that survives past this method.
+        batch.input_ids = verify_output.next_extend_input_ids
         batch.extend_lens = batch.spec_info.num_accepted_tokens_cpu
         batch.extend_num_tokens = sum(batch.extend_lens)
-        batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
-        batch.seq_lens_cpu = batch.spec_info.seq_lens_for_draft_extend_cpu
-        batch.req_pool_indices = batch.spec_info.req_pool_indices_for_draft_extend
+        batch.seq_lens = verify_output.seq_lens_for_draft_extend
+        batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
+        batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
         batch.return_logprob = False
         batch.return_hidden_states = False
 
@@ -873,18 +886,28 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
 @dataclass
 class EagleVerifyOutput:
-    # Draft input batch
+    # Draft input batch (next iter's persistent draft state).
     draft_input: EagleDraftInput
-    # Logit outputs from target worker
+    # Logit outputs from target worker.
     logits_output: LogitsProcessorOutput
     # All accepted tokens flat across all reqs incl. those that finished this
     # step. Includes the bonus token. Used for output processing.
     accept_tokens: torch.Tensor
+    # Below are transient handoff fields for the next iter's draft-extend pass.
+    # They are scoped to the verify -> prepare_extend_after_decode window only;
+    # `prepare_extend_after_decode` reads them off this object via method arg
+    # rather than smuggling them through `EagleDraftInput`.
+    #
     # Subset of `accept_tokens` for reqs continuing into next iter's draft-extend
     # forward (= `accept_tokens` when no req finished; flat over unfinished
     # reqs only otherwise). Becomes `batch.input_ids` for that forward pass.
     next_extend_input_ids: torch.Tensor
-    # Accepted token length per sequence in a batch in CPU.
+    # `batch.seq_lens` / `batch.seq_lens_cpu` / `batch.req_pool_indices` to
+    # use for the next iter's draft-extend forward; sliced to surviving reqs.
+    seq_lens_for_draft_extend: torch.Tensor
+    seq_lens_for_draft_extend_cpu: torch.Tensor
+    req_pool_indices_for_draft_extend: torch.Tensor
+    # Accepted token length per sequence in a batch in CPU (full set).
     num_accepted_drafts_per_req_cpu: List[int]
     # Accepted indices from logits_output.next_token_logits
     accepted_indices: torch.Tensor

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -979,7 +979,7 @@ class EAGLEWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.draft_input
+        batch.spec_info = res.next_draft_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -508,9 +508,7 @@ class EAGLEWorker(TpModelWorker):
                     or verify_output.next_extend_input_ids.shape[0] > 0
                 ):
                     # decode is not finished
-                    self.forward_draft_extend_after_decode(
-                        batch, verify_output.next_extend_input_ids
-                    )
+                    self.forward_draft_extend_after_decode(batch, verify_output)
 
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
@@ -530,9 +528,9 @@ class EAGLEWorker(TpModelWorker):
             )
 
     def check_forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        local_need_forward = extend_input_ids.shape[0] > 0
+        local_need_forward = verify_output.next_extend_input_ids.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -1109,7 +1107,7 @@ class EAGLEWorker(TpModelWorker):
         self.capture_for_decode(logits_output, forward_batch.spec_info)
 
     def forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
         assert isinstance(batch.spec_info, EagleDraftInput)
         # Backup fields that will be modified in-place
@@ -1122,7 +1120,7 @@ class EAGLEWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and extend_input_ids.numel() == 0:
+        if not input_is_idle and verify_output.next_extend_input_ids.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (
@@ -1143,7 +1141,7 @@ class EAGLEWorker(TpModelWorker):
         batch.spec_info.num_tokens_for_logprob_per_req = 1
         batch.spec_info.prepare_extend_after_decode(
             batch,
-            extend_input_ids=extend_input_ids,
+            verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
         )
         batch.forward_mode = (

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -505,10 +505,12 @@ class EAGLEWorker(TpModelWorker):
                 # when DP attention is enabled, but it is slow. Skip it for now.
                 if (
                     self.server_args.enable_dp_attention
-                    or batch.spec_info.accept_tokens.shape[0] > 0
+                    or verify_output.next_extend_input_ids.shape[0] > 0
                 ):
                     # decode is not finished
-                    self.forward_draft_extend_after_decode(batch)
+                    self.forward_draft_extend_after_decode(
+                        batch, verify_output.next_extend_input_ids
+                    )
 
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
@@ -527,8 +529,10 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
 
-    def check_forward_draft_extend_after_decode(self, batch: ScheduleBatch):
-        local_need_forward = batch.spec_info.accept_tokens.shape[0] > 0
+    def check_forward_draft_extend_after_decode(
+        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+    ):
+        local_need_forward = extend_input_ids.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -1104,7 +1108,9 @@ class EAGLEWorker(TpModelWorker):
         assert forward_batch.spec_info is batch.spec_info
         self.capture_for_decode(logits_output, forward_batch.spec_info)
 
-    def forward_draft_extend_after_decode(self, batch: ScheduleBatch):
+    def forward_draft_extend_after_decode(
+        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+    ):
         assert isinstance(batch.spec_info, EagleDraftInput)
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
@@ -1116,7 +1122,7 @@ class EAGLEWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and batch.spec_info.accept_tokens.numel() == 0:
+        if not input_is_idle and extend_input_ids.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (
@@ -1137,7 +1143,8 @@ class EAGLEWorker(TpModelWorker):
         batch.spec_info.num_tokens_for_logprob_per_req = 1
         batch.spec_info.prepare_extend_after_decode(
             batch,
-            self.speculative_num_steps,
+            extend_input_ids=extend_input_ids,
+            speculative_num_steps=self.speculative_num_steps,
         )
         batch.forward_mode = (
             ForwardMode.DRAFT_EXTEND

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -505,7 +505,7 @@ class EAGLEWorker(TpModelWorker):
                 # when DP attention is enabled, but it is slow. Skip it for now.
                 if (
                     self.server_args.enable_dp_attention
-                    or verify_output.next_extend_input_ids.shape[0] > 0
+                    or verify_output.unfinished_accept_tokens.shape[0] > 0
                 ):
                     # decode is not finished
                     self.forward_draft_extend_after_decode(batch, verify_output)
@@ -530,7 +530,7 @@ class EAGLEWorker(TpModelWorker):
     def check_forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        local_need_forward = verify_output.next_extend_input_ids.shape[0] > 0
+        local_need_forward = verify_output.unfinished_accept_tokens.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -1120,7 +1120,7 @@ class EAGLEWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and verify_output.next_extend_input_ids.numel() == 0:
+        if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (

--- a/python/sglang/srt/speculative/frozen_kv_mtp_info.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_info.py
@@ -62,7 +62,7 @@ class FrozenKVMTPVerifyInput(EagleVerifyInput):
 
     def verify(self, *args, **kwargs) -> EagleVerifyOutput:
         output = super().verify(*args, **kwargs)
-        output.draft_input = _to_frozen_kv_mtp_draft_input(output.draft_input)
+        output.next_draft_input = _to_frozen_kv_mtp_draft_input(output.next_draft_input)
         return output
 
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -43,6 +43,7 @@ from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.eagle_info import EagleVerifyOutput
 from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     organize_draft_results,
@@ -463,7 +464,7 @@ class FrozenKVMTPWorker(TpModelWorker):
                 self.server_args.enable_dp_attention
                 or batch.spec_info.bonus_tokens.numel()
             ):
-                self.forward_draft_extend_after_decode(batch)
+                self.forward_draft_extend_after_decode(batch, verify_output)
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
 
         return GenerationBatchResult(
@@ -504,7 +505,9 @@ class FrozenKVMTPWorker(TpModelWorker):
             mm_input_embeds=mm_input_embeds,
         )
 
-    def forward_draft_extend_after_decode(self, batch: ScheduleBatch) -> None:
+    def forward_draft_extend_after_decode(
+        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
+    ) -> None:
         assert isinstance(batch.spec_info, FrozenKVMTPDraftInput)
         input_is_idle = batch.forward_mode.is_idle()
         if not input_is_idle and batch.spec_info.bonus_tokens.numel() == 0:
@@ -527,19 +530,18 @@ class FrozenKVMTPWorker(TpModelWorker):
         req_pool_indices_backup = batch.req_pool_indices
 
         try:
-            if draft_input.seq_lens_for_draft_extend is not None:
-                # Verify may leave finished requests in ScheduleBatch; seed only
-                # the unfinished requests carried by draft_input.
-                batch.seq_lens = draft_input.seq_lens_for_draft_extend
-                batch.seq_lens_cpu = draft_input.seq_lens_for_draft_extend_cpu
-                batch.req_pool_indices = draft_input.req_pool_indices_for_draft_extend
+            # Verify may leave finished requests in ScheduleBatch; seed only
+            # the unfinished requests carried by `verify_output`.
+            batch.seq_lens = verify_output.seq_lens_for_draft_extend
+            batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
+            batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
 
             last_token_ids, last_hidden = self._select_last_verified_seed(draft_input)
             self._run_assistant_seed_step(
                 batch,
                 last_token_ids,
                 last_hidden,
-                seq_lens_cpu=draft_input.seq_lens_for_draft_extend_cpu,
+                seq_lens_cpu=verify_output.seq_lens_for_draft_extend_cpu,
                 draft_input=draft_input,
             )
         finally:

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -768,7 +768,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.draft_input
+        batch.spec_info = res.next_draft_input
 
         del seq_lens_pre_verify
         return logits_output, res, model_worker_batch, can_run_cuda_graph

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -286,9 +286,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                     or verify_output.next_extend_input_ids.shape[0] > 0
                 ):
                     # decode is not finished
-                    self.forward_draft_extend_after_decode(
-                        batch, verify_output.next_extend_input_ids
-                    )
+                    self.forward_draft_extend_after_decode(batch, verify_output)
 
             return GenerationBatchResult(
                 logits_output=logits_output,
@@ -298,9 +296,9 @@ class MultiLayerEagleWorker(TpModelWorker):
             )
 
     def check_forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        local_need_forward = extend_input_ids.shape[0] > 0
+        local_need_forward = verify_output.next_extend_input_ids.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -657,7 +655,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         forward_batch.spec_info.topk_index = torch.cat(topk_index_list, dim=1)
 
     def forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
         assert isinstance(batch.spec_info, EagleDraftInput)
         # Backup fields that will be modified in-place
@@ -670,7 +668,7 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and extend_input_ids.numel() == 0:
+        if not input_is_idle and verify_output.next_extend_input_ids.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (
@@ -690,7 +688,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.spec_info.num_tokens_for_logprob_per_req = 1
         batch.spec_info.prepare_extend_after_decode(
             batch,
-            extend_input_ids=extend_input_ids,
+            verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
         )
         batch.forward_mode = (

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -591,7 +591,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.draft_input
+        batch.spec_info = res.next_draft_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -283,10 +283,12 @@ class MultiLayerEagleWorker(TpModelWorker):
                 # when DP attention is enabled, but it is slow. Skip it for now.
                 if (
                     self.server_args.enable_dp_attention
-                    or batch.spec_info.accept_tokens.shape[0] > 0
+                    or verify_output.next_extend_input_ids.shape[0] > 0
                 ):
                     # decode is not finished
-                    self.forward_draft_extend_after_decode(batch)
+                    self.forward_draft_extend_after_decode(
+                        batch, verify_output.next_extend_input_ids
+                    )
 
             return GenerationBatchResult(
                 logits_output=logits_output,
@@ -295,8 +297,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
 
-    def check_forward_draft_extend_after_decode(self, batch: ScheduleBatch):
-        local_need_forward = batch.spec_info.accept_tokens.shape[0] > 0
+    def check_forward_draft_extend_after_decode(
+        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+    ):
+        local_need_forward = extend_input_ids.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -652,7 +656,9 @@ class MultiLayerEagleWorker(TpModelWorker):
         forward_batch.spec_info.topk_p = torch.cat(topk_p_list, dim=1)
         forward_batch.spec_info.topk_index = torch.cat(topk_index_list, dim=1)
 
-    def forward_draft_extend_after_decode(self, batch: ScheduleBatch):
+    def forward_draft_extend_after_decode(
+        self, batch: ScheduleBatch, extend_input_ids: torch.Tensor
+    ):
         assert isinstance(batch.spec_info, EagleDraftInput)
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
@@ -664,7 +670,7 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and batch.spec_info.accept_tokens.numel() == 0:
+        if not input_is_idle and extend_input_ids.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (
@@ -684,7 +690,8 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.spec_info.num_tokens_for_logprob_per_req = 1
         batch.spec_info.prepare_extend_after_decode(
             batch,
-            self.speculative_num_steps,
+            extend_input_ids=extend_input_ids,
+            speculative_num_steps=self.speculative_num_steps,
         )
         batch.forward_mode = (
             ForwardMode.DRAFT_EXTEND

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -283,7 +283,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                 # when DP attention is enabled, but it is slow. Skip it for now.
                 if (
                     self.server_args.enable_dp_attention
-                    or verify_output.next_extend_input_ids.shape[0] > 0
+                    or verify_output.unfinished_accept_tokens.shape[0] > 0
                 ):
                     # decode is not finished
                     self.forward_draft_extend_after_decode(batch, verify_output)
@@ -298,7 +298,7 @@ class MultiLayerEagleWorker(TpModelWorker):
     def check_forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        local_need_forward = verify_output.next_extend_input_ids.shape[0] > 0
+        local_need_forward = verify_output.unfinished_accept_tokens.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -668,7 +668,7 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and verify_output.next_extend_input_ids.numel() == 0:
+        if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -106,7 +106,6 @@ class NgramVerifyInput(SpecInput):
                 last_loc,
                 len(batch.input_ids),
             )
-            self.last_loc = last_loc
 
         bs = batch.batch_size()
         assign_req_to_token_pool[(bs,)](


### PR DESCRIPTION
Follow-up to #24724. Removes the `accept_tokens` field from `EagleDraftInput` and plumbs it as a method arg through `forward_draft_extend_after_decode` -> `prepare_extend_after_decode`. Adds `next_extend_input_ids` to `EagleVerifyOutput` (semantically distinct from `accept_tokens`: subset for unfinished reqs vs full set for output processing).