### PR TITLE
[codex] Route legacy RoPE API to fused path

### DIFF
--- a/python/sglang/jit_kernel/rope.py
+++ b/python/sglang/jit_kernel/rope.py
@@ -52,6 +52,10 @@ def rotary_embedding_with_key(
     cos_sin_cache: torch.Tensor,
     is_neox: bool = True,
 ) -> None:
+    if _try_fused_rope_for_legacy_api(
+        positions, query, key, head_size, cos_sin_cache, is_neox
+    ):
+        return
     module = _jit_rotary_embedding_module()
     module.rotary_embedding(positions, query, key, head_size, cos_sin_cache, is_neox)
 
@@ -69,6 +73,36 @@ def rotary_embedding_without_key(
 ) -> None:
     module = _jit_rotary_embedding_module()
     module.rotary_embedding(positions, query, None, head_size, cos_sin_cache, is_neox)
+
+
+def _try_fused_rope_for_legacy_api(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> bool:
+    if (
+        query.dim() != 2
+        or key.dim() != 2
+        or positions.dim() != 1
+        or cos_sin_cache.dim() != 2
+        or cos_sin_cache.dtype != torch.float32
+        or cos_sin_cache.size(1) != head_size
+        or query.size(0) != positions.numel()
+        or key.size(0) != positions.numel()
+        or query.size(1) % head_size != 0
+        or key.size(1) % head_size != 0
+        or not query.is_contiguous()
+        or not key.is_contiguous()
+    ):
+        return False
+
+    q = query.view(query.size(0), query.size(1) // head_size, head_size)
+    k = key.view(key.size(0), key.size(1) // head_size, head_size)
+    apply_rope_inplace(q, k, cos_sin_cache, positions, is_neox=is_neox)
+    return True
 
 
 def rotary_embedding(

--- a/python/sglang/jit_kernel/tests/test_rope.py
+++ b/python/sglang/jit_kernel/tests/test_rope.py
@@ -162,6 +162,37 @@ def test_rope_position_dtypes(dtype: torch.dtype) -> None:
     triton.testing.assert_close(k_fi, k_jit, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
+def test_legacy_rotary_embedding_with_key_float_cache_fast_path(
+    is_neox: bool,
+) -> None:
+    from sglang.jit_kernel.rope import apply_rope_inplace, rotary_embedding_with_key
+
+    batch_size, num_qo_heads, num_kv_heads, rope_dim = 16, 16, 2, 128
+    q = torch.randn(batch_size, num_qo_heads, rope_dim, device=DEVICE, dtype=DTYPE)
+    k = torch.randn(batch_size, num_kv_heads, rope_dim, device=DEVICE, dtype=DTYPE)
+    positions = torch.randint(0, MAX_SEQ_LEN, (batch_size,), device=DEVICE)
+    cos_sin_cache = create_cos_sin_cache(rope_dim)
+
+    q_legacy = q.clone().view(batch_size, -1)
+    k_legacy = k.clone().view(batch_size, -1)
+    q_fused = q.clone()
+    k_fused = k.clone()
+
+    rotary_embedding_with_key(
+        positions=positions,
+        query=q_legacy,
+        key=k_legacy,
+        head_size=rope_dim,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=is_neox,
+    )
+    apply_rope_inplace(q_fused, k_fused, cos_sin_cache, positions, is_neox=is_neox)
+
+    triton.testing.assert_close(q_legacy.view_as(q_fused), q_fused, atol=1e-2, rtol=1e-2)
+    triton.testing.assert_close(k_legacy.view_as(k_fused), k_fused, atol=1e-2, rtol=1e-2)
+
+
 @pytest.mark.parametrize("batch_size", BS_LIST)
 @pytest.mark.parametrize("is_neox", IS_NEOX_LIST)
 @pytest.mark.parametrize("rope_dim", PARTIAL_ROPE_DIM_LIST)


### PR DESCRIPTION
## Summary

Route the legacy `rotary_embedding_with_key` API to the existing fused RoPE kernel when the call is semantically equivalent:

- `query` and `key` are flattened 2D contiguous tensors
- `positions` is 1D
- `cos_sin_cache` is float32
- `cos_sin_cache.size(1) == head_size`, so this is full-RoPE rather than partial RoPE

All other legacy cases keep using the existing `RotaryEmbeddingKernel` path.

## Accuracy

H100, `CUDA_VISIBLE_DEVICES=4`, `PYTHONPATH=python`, `SGLANG_IS_IN_CI=1`:

```text
pytest -q python/sglang/jit_kernel/tests/test_rope.py -q
........................................................................ [31%]
....................................................................ssss [63%]
ssss.................................................................... [94%]
............                                                             [100%]
```

The new test compares the legacy flattened API fast path against `apply_rope_inplace` for both NeoX and interleaved RoPE.

## Benchmark

H100, `CUDA_VISIBLE_DEVICES=5`, `PYTHONPATH=python`, `SGLANG_IS_IN_CI=1`:

```bash
python python/sglang/jit_kernel/benchmark/bench_rope.py
```

RoPE-only CI shape, `num_q_k_heads=16,2`, `is_neox=True`, `batch_size=16`:

| Path | baseline us | optimized us | change |
| --- | ---: | ---: | ---: |
| SGL JIT PosEnc legacy API | 2.157193 | 1.142789 | +47.02% |
| SGL JIT Fused RoPE | 1.147890 | 1.135472 | +1.08% |

## Profiling

`ncu` is blocked in this container by `ERR_NVGPUCTRPERM`, so I used Nsight Systems kernel summaries.

Flattened legacy API, BF16, 100 calls:

| Kernel | Avg ns | Median ns |
| --- | ---: | ---: |
| baseline `rotary_embedding_kernel<bf16, true>` | 2016.6 | 2016.0 |
| optimized `fused_rope_kernel<true, 128, true, bf16, int64, ...>` | 1349.8 | 1344.0 |

The fast path reduces GPU kernel average time by 33.07% for the profiled shape.
