### PR TITLE
Tune medium GroupNorm SiLU chunks on H100

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/group_norm_silu.py
+++ b/python/sglang/jit_kernel/diffusion/triton/group_norm_silu.py
@@ -9,9 +9,10 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 _SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
 _LARGE_GROUP_THRESHOLD = 1 << 18
+_MEDIUM_GROUP_THRESHOLD = 1 << 20
 _BLOCK_SIZE = 4096
-_BLOCKS_PER_PROGRAM = 2
-_CHUNK_SIZE = _BLOCK_SIZE * _BLOCKS_PER_PROGRAM
+_MEDIUM_BLOCKS_PER_PROGRAM = 1
+_LARGE_BLOCKS_PER_PROGRAM = 2
 
 
 @triton.jit
@@ -298,7 +299,13 @@ def _launch_chunked(
     channels_per_group = channels // num_groups
     group_size = channels_per_group * spatial_size
     rows = batch_size * num_groups
-    chunks_per_row = triton.cdiv(group_size, _CHUNK_SIZE)
+    blocks_per_program = (
+        _MEDIUM_BLOCKS_PER_PROGRAM
+        if group_size <= _MEDIUM_GROUP_THRESHOLD
+        else _LARGE_BLOCKS_PER_PROGRAM
+    )
+    chunk_size = _BLOCK_SIZE * blocks_per_program
+    chunks_per_row = triton.cdiv(group_size, chunk_size)
 
     x_flat = x_contiguous.reshape(-1)
     y = torch.empty_like(x_contiguous)
@@ -320,7 +327,7 @@ def _launch_chunked(
         group_size,
         chunks_per_row,
         BLOCK_SIZE=_BLOCK_SIZE,
-        BLOCKS_PER_PROGRAM=_BLOCKS_PER_PROGRAM,
+        BLOCKS_PER_PROGRAM=blocks_per_program,
         num_warps=8,
         num_stages=3,
     )
@@ -338,7 +345,7 @@ def _launch_chunked(
         num_stages=2,
     )
 
-    if spatial_size % _CHUNK_SIZE == 0 and chunks_per_row >= 64:
+    if spatial_size % chunk_size == 0 and chunks_per_row >= 64:
         _group_norm_apply_scalar_affine_kernel[(rows, chunks_per_row)](
             x_flat,
             weight,
@@ -352,7 +359,7 @@ def _launch_chunked(
             group_size,
             chunks_per_row,
             BLOCK_SIZE=_BLOCK_SIZE,
-            BLOCKS_PER_PROGRAM=_BLOCKS_PER_PROGRAM,
+            BLOCKS_PER_PROGRAM=blocks_per_program,
             num_warps=4,
             num_stages=3,
         )
@@ -370,7 +377,7 @@ def _launch_chunked(
             group_size,
             chunks_per_row,
             BLOCK_SIZE=_BLOCK_SIZE,
-            BLOCKS_PER_PROGRAM=_BLOCKS_PER_PROGRAM,
+            BLOCKS_PER_PROGRAM=blocks_per_program,
             num_warps=8,
             num_stages=3,
         )

--- a/python/sglang/jit_kernel/tests/diffusion/test_group_norm_silu.py
+++ b/python/sglang/jit_kernel/tests/diffusion/test_group_norm_silu.py
@@ -20,6 +20,7 @@ TEST_CASES = [
     pytest.param((4, 128), 32, id="token_2d"),
 ]
 LARGE_TILE_CASE = ((1, 128, 20, 256, 256), 32)
+MEDIUM_TILE_CASE = ((1, 128, 1, 256, 256), 32)
 
 
 def _tol(dtype: torch.dtype) -> tuple[float, float]:
@@ -83,6 +84,20 @@ def test_apply_group_norm_silu(
     expected = activation(norm(hidden_states))
 
     atol, rtol = _tol(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+@torch.no_grad()
+def test_triton_group_norm_silu_medium_tile_bf16() -> None:
+    shape, num_groups = MEDIUM_TILE_CASE
+    x = torch.randn(shape, device=DEVICE, dtype=torch.bfloat16)
+    weight = torch.randn(shape[1], device=DEVICE, dtype=torch.bfloat16)
+    bias = torch.randn(shape[1], device=DEVICE, dtype=torch.bfloat16)
+
+    actual = triton_group_norm_silu(x, weight, bias, num_groups=num_groups)
+    expected = _reference(x, weight, bias, num_groups)
+
+    atol, rtol = _tol(torch.bfloat16)
     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 


### PR DESCRIPTION
## Summary

Tune the diffusion Triton `GroupNorm+SiLU` chunked path so medium large-group shapes use one block per program while very large shapes keep the existing two-block chunk size.

This increases chunk-level parallelism for the H100 threshold shape without regressing the Hunyuan Video large case.

## Accuracy

H100 (`h100_sglang`, `sglang_bbuf`, `CUDA_VISIBLE_DEVICES=4`):

```bash
python -m compileall -q python/sglang/jit_kernel/diffusion/triton python/sglang/jit_kernel/tests/diffusion
pytest -q python/sglang/jit_kernel/tests/diffusion/test_group_norm_silu.py -q
```

Result:

```text
15 passed
```

Added `test_triton_group_norm_silu_medium_tile_bf16` to cover the new medium large-group path.

## Benchmark

H100 baseline from `origin/main` (`/tmp/sglang_rmsnorm_512_base_h100`, `CUDA_VISIBLE_DEVICES=6`):

```bash
PYTHONPATH=python python python/sglang/jit_kernel/benchmark/diffusion/bench_group_norm_silu.py \
  --cases threshold_3d,hunyuan_video_large --dtypes bf16,fp16 --rounds 3 --warmup 20 --rep 80
```

Optimized branch (`/tmp/sglang_groupnorm_silu_h100_final`, `CUDA_VISIBLE_DEVICES=5`) with the same command.

| case | dtype | baseline fused us | optimized fused us | change |
|---|---:|---:|---:|---:|
| threshold_3d | bf16 | 29.54 | 26.72 | +9.55% |
| threshold_3d | fp16 | 30.30 | 27.97 | +7.69% |
| hunyuan_video_large | bf16 | 351.49 | 351.76 | -0.08% |
| hunyuan_video_large | fp16 | 352.05 | 351.62 | +0.12% |

