### PR TITLE
fix(cuda_graph): zero out_cache_loc_swa on pad and use int32 (hybrid-SWA accuracy fix)

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -182,7 +182,7 @@ class DecodeInputBuffers(ForwardInputBuffers):
             seq_lens = torch.full((max_bs,), seq_len_fill_value, dtype=torch.int32)
             out_cache_loc = torch.zeros((max_num_token,), dtype=cache_loc_dtype)
             out_cache_loc_swa = (
-                torch.zeros((max_num_token,), dtype=torch.int64)
+                torch.zeros((max_num_token,), dtype=torch.int32)
                 if is_hybrid_swa
                 else None
             )
@@ -289,6 +289,12 @@ class DecodeInputBuffers(ForwardInputBuffers):
         if bs != raw_bs:
             self.seq_lens.fill_(seq_len_fill_value)
             self.out_cache_loc.zero_()
+            # Padded SWA indices left over from a previous replay would point
+            # into real SWA slots, so set_kv_buffer on padded tokens would
+            # corrupt active requests' KV. Zero the whole buffer so padded
+            # positions map to the sentinel slot (matches piecewise runner).
+            if self.out_cache_loc_swa is not None:
+                self.out_cache_loc_swa.zero_()
             if self.mamba_track_indices is not None:
                 self.mamba_track_indices.zero_()
             if self.mamba_track_mask is not None:

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -238,7 +238,7 @@ class PiecewiseCudaGraphRunner:
                 (self.max_num_tokens,), dtype=self._cache_loc_dtype()
             )
             out_cache_loc_swa = (
-                torch.zeros((self.max_num_tokens,), dtype=torch.int64)
+                torch.zeros((self.max_num_tokens,), dtype=torch.int32)
                 if model_runner.is_hybrid_swa
                 else None
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  PR #23552 added a pre-computed `out_cache_loc_swa` buffer in `DecodeInputBuffers` so the captured decode graph can hit
  `set_kv_buffer`'s fast path on hybrid-SWA models (Gemma, MiMoV2, DeepSeek V4, …). On the main `CudaGraphRunner`, the main correctness issue is that `out_cache_loc_swa` is not cleared on padding, which can silently corrupt the SWA KV cache when decode cuda graphs are enabled. While touching this path, this patch also fixes a related dtype mismatch.                                                                                                                                                                 

  The user-visible symptom we hit is a measurable accuracy regression on **MiMoV2.5 Pro** (which is registered as hybrid SWA via `MIMO_V2_MODEL_ARCHS` in `model_config.py`). With the same checkpoint and identical eval workload:                                                                                                                                                                              

  | Benchmark      | Before | After   | Δ      |                                                                                                                                                            
  | -------------- | ------ | ------- | ------ |                                                                                                                                                            
  | aime24_25      | 80.3   | 90.3    | +10.0  |                                                                                                                                                            
  | cmmlu          | 87.6   | 90.1    | +2.5   |                                                                                                                                                            
  | minerva_math   | 89.4   | 93.6    | +4.2   |                                                                                                                                                            
  | mmlu-pro       | 82.6   | 85.1    | +2.5   |                                                                                                                                                            
  | mmlu_redux     | 93.1   | 94.97   | +1.87  |                                                                                                                                                            
  | supergpqa      | 59.1   | 62.4    | +3.3   |                                                                                                                                                            

  The regression is reproducible only when decode cuda graphs are enabled **and** the served batch size is small enough to be padded to a `capture_bs` bucket — which is exactly the common decode steady-state. 

## Root cause                                                                                                                                                                                             

  ### 1. Stale padding indices corrupt the SWA KV cache                                                                                                                                                     

  In `populate_from_forward_batch` (the main `CudaGraphRunner`), when `bs != raw_bs` only `out_cache_loc` is zeroed before the per-tensor copy. `out_cache_loc_swa` is not — and the subsequent copy only writes the first `raw_num_token` entries:                                                                                                                                                                        

  ```python                                                                                                                                                                                                 
  if bs != raw_bs:                                          
      self.seq_lens.fill_(seq_len_fill_value)                                                                                                                                                               
      self.out_cache_loc.zero_()                                                                                                                                                                            
      # out_cache_loc_swa is NOT zeroed                                                                                                                                                                     
      ...                                                                                                                                                                                                   

  if (                                                                                                                                                                                                      
      self.out_cache_loc_swa is not None                                                                                                                                                                    
      and forward_batch.out_cache_loc_swa is not None       
  ):                                                                                                                                                                                                        
      dsts.append(self.out_cache_loc_swa[:raw_num_token])
      srcs.append(forward_batch.out_cache_loc_swa[:raw_num_token])                                                                                                                                          
  ```

  The captured graph, however, runs set_kv_buffer over the full buffers.out_cache_loc_swa[:num_tokens] slice. The padded region [raw_num_token : num_tokens] keeps real SWA indices from the previous replay, so padded tokens write their junk KV into live SWA slots belonging to previously active requests. The pre-#23552 fallback path  (translate_loc_from_full_to_swa(out_cache_loc) per layer) didn't have this problem because out_cache_loc is zeroed on pad, so padded positions translate to the SWA sentinel.                                                                                                                                                                  

  The piecewise runner already does the right thing — it zeroes the buffer on pad in piecewise_cuda_graph_runner.py:654-655. The fix brings the main runner in line with that.                                                                                                                                                                 

  ### 2. Dtype mismatch with translate_loc_from_full_to_swa                                                                                                                                                     

  out_cache_loc_swa was allocated as torch.int64, but both SWAKVPool.translate_loc_from_full_to_swa (swa_memory_pool.py:170) and the DSV4 equivalent (deepseek_v4_memory_pool.py:482) return torch.int32. The populate_from_forward_batch copy then implicitly  widens int32 → int64 and the captured graph hands an int64 index tensor to SWAKVPool.set_kv_buffer. This was flagged in the #23552 review and deferred; it's cheap to fix here alongside the correctness issue.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
