### PR TITLE
[Bugfix][HiCache]: Use GroupCoordinator.all_gather_object for creating custom group

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2057,9 +2057,7 @@ def create_custom_parallel_group(
     rank = torch.distributed.get_rank()
 
     local_config = sorted(list(set(group_ranks)))
-    gathered_configs = [None for _ in range(world_size)]
-
-    torch.distributed.all_gather_object(gathered_configs, local_config)
+    gathered_configs = get_world_group().all_gather_object(local_config)
 
     unique_groups = []
     seen_signatures = set()


### PR DESCRIPTION
## Motivation
`create_custom_parallel_group()` currently discovers per-rank group configurations with `torch.distributed.all_gather_object()` on the default process group. We encountered a failure during **HiCache storage attachment**, where `_create_prefetch_sync_groups()` called `create_custom_parallel_group(..., backend="gloo")` and failed with `CUDA error: invalid argument`.

The payload being gathered is only small Python metadata, such as rank lists for the custom groups. However, in CUDA serving, the default process group is usually NCCL, so `all_gather_object(group=None)` may route this metadata exchange through the CUDA/NCCL path. This is unnecessary for control-plane metadata and can make the operation sensitive to communicator or rank timing state, especially during startup after TP setup and CUDA graph capture.

Related PRs: 
- [#15805](https://github.com/sgl-project/sglang/pull/15805) 
- [#20460](https://github.com/sgl-project/sglang/pull/20460) 

## Modifications
Use the existing world GroupCoordinator's CPU group for the metadata discovery step, avoiding an unnecessary NCCL collective before creating the requested custom group.

## Accuracy Tests

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.