### PR TITLE
fix(scheduler): undo kv_committed_len inflation for requests finishing under overlap scheduling

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -521,6 +521,14 @@ class SchedulerOutputProcessorMixin:
             req.time_stats.set_last_decode_finish_time()
             req.check_finished(new_accepted_len)
 
+            if req.finished() and (self.enable_overlap or self.enable_overlap_mlx):
+                # The overlap scheduler's prepare_for_decode() already ran for
+                # this request before we processed the batch that generated its
+                # EOS token, inflating kv_committed_len by 1.  Undo that so
+                # cache_finished_req inserts the correct prefix (seqlen - 1),
+                # not one position past it (the EOS KV itself).
+                req.kv_committed_len -= 1
+
             self._handle_finished_req(req, i, logits_output)
 
             if req.return_logprob:

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -596,8 +596,12 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     # strip_thinking_cache intentionally reports output tokens as overallocated
     # so they fall into the free path below (#22373).
     if spec_algo is None and not global_server_args.strip_thinking_cache:
+        # In overlap mode, prepare_for_decode() may have pre-incremented
+        # kv_committed_len for a request whose EOS was not yet detected,
+        # leaving exactly 1 extra allocated slot that must be freed here.
+        max_overalloc = 0 if global_server_args.disable_overlap_schedule else 1
         assert (
-            start_p == end_p
+            end_p - start_p <= max_overalloc
         ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv_allocated_len=}"
 
     if page_size > 1:

--- a/test/registered/radix_cache/test_overlap_kv_committed_len.py
+++ b/test/registered/radix_cache/test_overlap_kv_committed_len.py
@@ -1,0 +1,108 @@
+"""
+Test that kv_committed_len is not inflated by 1 when a request finishes
+during overlap-scheduled decoding (issue: overlap scheduler off-by-one).
+
+With overlap scheduling enabled (the default), prepare_for_decode() is called
+for every request in the running batch before the previous batch's EOS results
+are processed.  This means a request that generated EOS in batch N has its
+kv_committed_len incremented by 1 during batch N+1's setup, causing
+cache_finished_req to insert one extra token into the radix tree.
+
+The observable symptom is that a follow-up request whose input_ids extend the
+finished sequence by 1 token reports cached_tokens == seqlen instead of the
+correct seqlen - 1.
+"""
+
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=90, suite="stage-b-test-1-gpu-small")
+
+MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+
+# Fixed token sequences so the test is deterministic and model-independent.
+INPUT_IDS_A = [1, 2, 3, 4]
+MAX_NEW_TOKENS_A = 2  # A will finish with seqlen = len(INPUT_IDS_A) + MAX_NEW_TOKENS_A = 6
+
+
+def generate(base_url, input_ids, max_new_tokens):
+    resp = requests.post(
+        base_url + "/generate",
+        json={
+            "input_ids": input_ids,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": max_new_tokens,
+            },
+            "stream": False,
+            "return_logprob": False,
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+class TestOverlapKvCommittedLen(CustomTestCase):
+    """
+    Regression test for the overlap-scheduler kv_committed_len off-by-one.
+
+    Reference: https://github.com/sgl-project/sglang/issues/24590
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # Overlap scheduling is enabled by default; we also need cache reporting.
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--enable-cache-report"],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_cached_tokens_after_finish(self):
+        """
+        After request A finishes, a request B that extends A's output by one
+        token should report cached_tokens == seqlen_A - 1, not seqlen_A.
+        """
+        # Step 1: run request A and get its output token ids.
+        result_a = generate(self.base_url, INPUT_IDS_A, MAX_NEW_TOKENS_A)
+        output_ids_a = result_a["output_ids"]  # top-level field in /generate response
+        seqlen_a = len(INPUT_IDS_A) + len(output_ids_a)
+
+        # Step 2: build request B = A's full sequence + 1 extra token.
+        input_ids_b = INPUT_IDS_A + output_ids_a + [1]
+        result_b = generate(self.base_url, input_ids_b, max_new_tokens=1)
+        cached_tokens_b = result_b["meta_info"].get("cached_tokens", 0)
+
+        # Without the fix, cached_tokens_b == seqlen_a (off by one).
+        # With the fix, cached_tokens_b == seqlen_a - 1 (correct).
+        self.assertLessEqual(
+            cached_tokens_b,
+            seqlen_a - 1,
+            msg=(
+                f"cached_tokens={cached_tokens_b} should be at most seqlen_a-1="
+                f"{seqlen_a - 1}; got seqlen_a={seqlen_a}.  "
+                "This suggests the overlap scheduler kv_committed_len off-by-one is back."
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/radix_cache/test_overlap_kv_committed_len.py
+++ b/test/registered/radix_cache/test_overlap_kv_committed_len.py
@@ -33,7 +33,9 @@ MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 # Fixed token sequences so the test is deterministic and model-independent.
 INPUT_IDS_A = [1, 2, 3, 4]
-MAX_NEW_TOKENS_A = 2  # A will finish with seqlen = len(INPUT_IDS_A) + MAX_NEW_TOKENS_A = 6
+MAX_NEW_TOKENS_A = (
+    2  # A will finish with seqlen = len(INPUT_IDS_A) + MAX_NEW_TOKENS_A = 6
+)
 
 
 def generate(base_url, input_ids, max_new_tokens):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #24590

When overlap scheduling is enabled (the default), `prepare_for_decode()` is called for every request in the running batch **before** the previous batch's results are processed. A request R that generated EOS in batch N therefore has its `kv_committed_len` incremented by 1 during batch N+1's `prepare_for_decode()`, before we detect the EOS.

When batch N's results are later processed, `cache_finished_req` is called with this inflated `kv_committed_len`, inserting one extra token (the EOS position's KV) into the radix tree. The observable symptom: a follow-up request that extends R's output by one token reports `cached_tokens == seqlen` instead of the correct `seqlen - 1`, violating the invariant `kv_committed_len == seqlen - 1` at finish time.

## Modifications

**`python/sglang/srt/managers/scheduler_output_processor_mixin.py`**

After `check_finished()` detects EOS in `process_batch_result_decode`, if overlap scheduling is active, decrement `req.kv_committed_len` by 1 to undo the premature increment from `prepare_for_decode()`. The resulting `kv_committed_len < kv_allocated_len` difference is detected by `pop_overallocated_kv_cache()` in `release_kv_cache()`, which frees the extra-allocated slot correctly.

**`python/sglang/srt/mem_cache/common.py`**

Relax the no-overalloc assertion in `release_kv_cache` to allow exactly 1 over-allocated slot when overlap scheduling is enabled (since the extra EOS-position slot now lands in the "over-allocated" range to be freed rather than inserted into the radix tree).

**`test/registered/radix_cache/test_overlap_kv_committed_len.py`**

New regression test: sends a fixed-token request A to completion, then sends request B whose `input_ids` extend A's full output by 1 token, and asserts that `cached_tokens ≤ seqlen_A - 1`.

## Accuracy Tests

This change only affects radix-cache insertion bookkeeping for finished requests — it does not touch any model forward pass or sampling path. No accuracy regression is expected.

## Speed Tests and Profiling

No inference speed impact expected. The change is a single integer decrement on the CPU scheduling path, executed once per finished request.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.