### PR TITLE
Optimize HF RMSNorm vector CTA path

### DIFF
--- a/python/sglang/jit_kernel/csrc/elementwise/rmsnorm_hf.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/rmsnorm_hf.cuh
@@ -9,7 +9,7 @@
  *
  * Two launch configs:
  *   - Warp kernel: 32 threads/row for small hidden sizes (q/k norms).
- *   - CTA kernel:  512-thread scalar-strided with register cache (token norms).
+ *   - CTA kernel:  vectorized 16 dtype elems/thread (token norms).
  */
 
 #include <sgl_kernel/tensor.h>  // For TensorMatcher, SymbolicSize, SymbolicDevice
@@ -17,7 +17,9 @@
 
 #include <sgl_kernel/math.cuh>     // For device::math::rsqrt
 #include <sgl_kernel/runtime.cuh>  // For runtime::get_blocks_per_sm, get_sm_count
+#include <sgl_kernel/tile.cuh>     // For tile::Memory
 #include <sgl_kernel/utils.cuh>    // For LaunchKernel, SGL_DEVICE, type aliases, PDL, cast
+#include <sgl_kernel/vec.cuh>      // For AlignedVector, packed_t
 #include <sgl_kernel/warp.cuh>     // For warp::reduce_sum
 
 #include <tvm/ffi/container/tensor.h>
@@ -142,6 +144,139 @@ __global__ __launch_bounds__(512) void rmsnorm_hf_scalar_kernel(const RMSNormHFP
 }
 
 // ---------------------------------------------------------------------------
+// Vectorized CTA kernel: one block per row, each thread owns 16 dtype elements.
+//
+// This is the HF-semantics counterpart of the standard RMSNorm half path:
+// it reduces input traffic through vectorized 16B loads and avoids launching
+// 512 threads for medium hidden sizes such as 512/1024/2048.
+// ---------------------------------------------------------------------------
+template <typename Float2>
+SGL_DEVICE Float2
+apply_hf_weight(Float2 input_vec, Float2 weight_vec, float norm_factor) {
+  using namespace device;
+  const auto [ix, iy] = cast<fp32x2_t>(input_vec);
+  const auto [wx, wy] = cast<fp32x2_t>(weight_vec);
+  const auto x_norm = cast<Float2>(fp32x2_t{ix * norm_factor, iy * norm_factor});
+  const auto [nx, ny] = cast<fp32x2_t>(x_norm);
+  return cast<Float2>(fp32x2_t{nx * wx, ny * wy});
+}
+
+template <int64_t kDim, bool kUsePDL, typename Float>
+__global__ __launch_bounds__(kDim / 16) void
+rmsnorm_hf_vector_kernel(const RMSNormHFParams __grid_constant__ params) {
+  using namespace device;
+  using Float2 = packed_t<Float>;
+  using Storage = AlignedVector<Float2, 4>;
+
+  constexpr auto kNumThreads = kDim / 16;
+  constexpr auto kNumWarps = kNumThreads / kWarpThreads;
+
+  const auto& [input, weight_ptr, output, input_stride, output_stride, num_tokens, eps] = params;
+  const auto gmem = tile::Memory<Storage>::cta(kNumThreads);
+  __shared__ float smem[32];
+
+  PDLWaitPrimary<kUsePDL>();
+
+  const auto input_ptr = pointer::offset<Float>(input, blockIdx.x * input_stride);
+  const auto output_ptr = pointer::offset<Float>(output, blockIdx.x * output_stride);
+
+  const auto input_first = gmem.load(input_ptr, 0);
+  const auto input_second = gmem.load(input_ptr, 1);
+  const auto weight_first = gmem.load(weight_ptr, 0);
+  const auto weight_second = gmem.load(weight_ptr, 1);
+
+  float sum_of_squares = 0.0f;
+#pragma unroll
+  for (auto j = 0u; j < 4u; ++j) {
+    const auto [x, y] = cast<fp32x2_t>(input_first[j]);
+    sum_of_squares += x * x + y * y;
+  }
+#pragma unroll
+  for (auto j = 0u; j < 4u; ++j) {
+    const auto [x, y] = cast<fp32x2_t>(input_second[j]);
+    sum_of_squares += x * x + y * y;
+  }
+
+  sum_of_squares = warp::reduce_sum(sum_of_squares);
+  const auto warp_id = threadIdx.x / kWarpThreads;
+  smem[warp_id] = sum_of_squares;
+  __syncthreads();
+  if (warp_id == 0) {
+    const auto tx = threadIdx.x;
+    const auto local_sum = tx < kNumWarps ? smem[tx] : 0.0f;
+    sum_of_squares = warp::reduce_sum(local_sum);
+    smem[tx] = math::rsqrt(sum_of_squares / kDim + eps);
+  }
+  __syncthreads();
+  const float norm_factor = smem[warp_id];
+
+  Storage output_first, output_second;
+#pragma unroll
+  for (auto j = 0u; j < 4u; ++j) {
+    output_first[j] = apply_hf_weight(input_first[j], weight_first[j], norm_factor);
+    output_second[j] = apply_hf_weight(input_second[j], weight_second[j], norm_factor);
+  }
+
+  gmem.store(output_ptr, output_first, 0);
+  gmem.store(output_ptr, output_second, 1);
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+template <int64_t kDim, bool kUsePDL, typename Float>
+__global__ __launch_bounds__(kDim / 16) void rmsnorm_hf_wide_vector_kernel(
+    const RMSNormHFParams __grid_constant__ params) {
+  using namespace device;
+  using Float2 = packed_t<Float>;
+  using Storage = AlignedVector<Float2, 8>;
+
+  constexpr auto kNumThreads = kDim / 16;
+  constexpr auto kNumWarps = kNumThreads / kWarpThreads;
+
+  const auto& [input, weight_ptr, output, input_stride, output_stride, num_tokens, eps] = params;
+  const auto gmem = tile::Memory<Storage>::cta(kNumThreads);
+  __shared__ float smem[32];
+
+  PDLWaitPrimary<kUsePDL>();
+
+  const auto input_ptr = pointer::offset<Float>(input, blockIdx.x * input_stride);
+  const auto output_ptr = pointer::offset<Float>(output, blockIdx.x * output_stride);
+
+  const auto input_vec = gmem.load(input_ptr);
+  const auto weight_vec = gmem.load(weight_ptr);
+
+  float sum_of_squares = 0.0f;
+#pragma unroll
+  for (auto j = 0u; j < 8u; ++j) {
+    const auto [x, y] = cast<fp32x2_t>(input_vec[j]);
+    sum_of_squares += x * x + y * y;
+  }
+
+  sum_of_squares = warp::reduce_sum(sum_of_squares);
+  const auto warp_id = threadIdx.x / kWarpThreads;
+  smem[warp_id] = sum_of_squares;
+  __syncthreads();
+  if (warp_id == 0) {
+    const auto tx = threadIdx.x;
+    const auto local_sum = tx < kNumWarps ? smem[tx] : 0.0f;
+    sum_of_squares = warp::reduce_sum(local_sum);
+    smem[tx] = math::rsqrt(sum_of_squares / kDim + eps);
+  }
+  __syncthreads();
+  const float norm_factor = smem[warp_id];
+
+  Storage output_vec;
+#pragma unroll
+  for (auto j = 0u; j < 8u; ++j) {
+    output_vec[j] = apply_hf_weight(input_vec[j], weight_vec[j], norm_factor);
+  }
+
+  gmem.store(output_ptr, output_vec);
+
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+// ---------------------------------------------------------------------------
 // Warp launcher: occupancy-sized grid, 32 threads/block, one warp per row.
 // Targets small hidden sizes (q/k RMSNorms). kDim must be a multiple of 32
 // in [32, 512).
@@ -202,6 +337,68 @@ struct HFRMSNormKernel {
   static_assert(kDim >= 512 && kDim % 512 == 0, "rmsnorm_hf: kDim must be a multiple of 512");
   static constexpr auto kernel = rmsnorm_hf_scalar_kernel<kDim, kUsePDL, DType>;
   static constexpr uint32_t kBlockSize = 512;
+
+  static void
+  run(const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView weight,
+      const tvm::ffi::TensorView output,
+      float eps) {
+    using namespace host;
+    auto N = SymbolicSize{"num_tokens"};
+    auto D = SymbolicSize{"hidden_size"};
+    auto SI = SymbolicSize{"input_stride"};
+    auto SO = SymbolicSize{"output_stride"};
+    auto device_ = SymbolicDevice{};
+    D.set_value(kDim);
+    device_.set_options<kDLCUDA>();
+
+    TensorMatcher({N, D})  // input
+        .with_strides({SI, 1})
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(input);
+    TensorMatcher({D})  // weight
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(weight);
+    TensorMatcher({N, D})  // output
+        .with_strides({SO, 1})
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(output);
+
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    RuntimeCheck(num_tokens > 0, "rmsnorm_hf: num_tokens must be > 0");
+
+    const auto params = RMSNormHFParams{
+        .input = input.data_ptr(),
+        .weight = weight.data_ptr(),
+        .output = output.data_ptr(),
+        .input_stride = SI.unwrap(),
+        .output_stride = SO.unwrap(),
+        .num_tokens = num_tokens,
+        .eps = eps,
+    };
+
+    LaunchKernel(num_tokens, kBlockSize, device_.unwrap())  //
+        .enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Vectorized CTA launcher: validates tensors, launches one block per row.
+// ---------------------------------------------------------------------------
+template <int64_t kDim, bool kUsePDL, typename DType>
+struct HFRMSNormHalfKernel {
+  static_assert(sizeof(DType) == 2, "rmsnorm_hf: DType must be fp16_t or bf16_t");
+  static_assert(
+      kDim >= 512 && kDim % 512 == 0, "rmsnorm_hf_half: kDim must be a multiple of 512");
+#if SGL_ARCH_BLACKWELL_OR_GREATER
+  static constexpr auto kernel = rmsnorm_hf_wide_vector_kernel<kDim, kUsePDL, DType>;
+#else
+  static constexpr auto kernel = rmsnorm_hf_vector_kernel<kDim, kUsePDL, DType>;
+#endif
+  static constexpr auto kBlockSize = static_cast<uint32_t>(kDim / 16);
 
   static void
   run(const tvm::ffi::TensorView input,

--- a/python/sglang/jit_kernel/rmsnorm_hf.py
+++ b/python/sglang/jit_kernel/rmsnorm_hf.py
@@ -25,7 +25,7 @@ def is_supported_rmsnorm_hf_hidden_size(hidden_size: int) -> bool:
 
     Two launch configs cover the practical range:
       - Warp kernel: ``[32, 512)`` in multiples of 32 (q/k RMSNorm head dims).
-      - CTA kernel: ``>= 512`` in multiples of 512 (token RMSNorms).
+      - Vectorized CTA kernel: ``>= 512`` in multiples of 512 (token RMSNorms).
     """
     if _WARP_SIZE <= hidden_size < _CTA_BLOCK_SIZE and hidden_size % _WARP_SIZE == 0:
         return True
@@ -33,17 +33,30 @@ def is_supported_rmsnorm_hf_hidden_size(hidden_size: int) -> bool:
 
 
 @cache_once
-def _jit_rmsnorm_hf_module(hidden_size: int, dtype: torch.dtype) -> Module:
+def _jit_rmsnorm_hf_module(
+    hidden_size: int, dtype: torch.dtype, use_vector_cta: bool
+) -> Module:
     args = make_cpp_args(hidden_size, is_arch_support_pdl(), dtype)
-    kernel_cls = (
-        "HFRMSNormWarpKernel" if hidden_size < _CTA_BLOCK_SIZE else "HFRMSNormKernel"
-    )
+    if hidden_size < _CTA_BLOCK_SIZE:
+        kernel_cls = "HFRMSNormWarpKernel"
+    elif use_vector_cta:
+        kernel_cls = "HFRMSNormHalfKernel"
+    else:
+        kernel_cls = "HFRMSNormKernel"
     return load_jit(
         "rmsnorm_hf",
         *args,
         cuda_files=["elementwise/rmsnorm_hf.cuh"],
         cuda_wrappers=[("rmsnorm_hf", f"{kernel_cls}<{args}>::run")],
     )
+
+
+def _should_use_vector_cta(hidden_size: int, num_tokens: int) -> bool:
+    if hidden_size >= 8192:
+        return True
+    if hidden_size >= 4096 and num_tokens >= 512:
+        return True
+    return num_tokens >= 2048
 
 
 def rmsnorm_hf(
@@ -74,6 +87,7 @@ def rmsnorm_hf(
         out = torch.empty_like(input)
     if input.numel() == 0:
         return out
-    module = _jit_rmsnorm_hf_module(hidden_size, input.dtype)
+    use_vector_cta = _should_use_vector_cta(hidden_size, input.size(0))
+    module = _jit_rmsnorm_hf_module(hidden_size, input.dtype, use_vector_cta)
     module.rmsnorm_hf(input, weight, out, eps)
     return out

--- a/python/sglang/jit_kernel/tests/test_rmsnorm_hf.py
+++ b/python/sglang/jit_kernel/tests/test_rmsnorm_hf.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from sglang.jit_kernel.rmsnorm_hf import (
+    _should_use_vector_cta,
     is_supported_rmsnorm_hf_hidden_size,
     rmsnorm_hf,
 )
@@ -130,6 +131,25 @@ def test_rmsnorm_hf_empty_input() -> None:
 )
 def test_is_supported_hidden_size(hidden_size: int, expected: bool) -> None:
     assert is_supported_rmsnorm_hf_hidden_size(hidden_size) is expected
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "num_tokens", "expected"),
+    [
+        (512, 512, False),
+        (512, 2048, True),
+        (3072, 512, False),
+        (3072, 2048, True),
+        (4096, 128, False),
+        (4096, 512, True),
+        (8192, 1, True),
+        (16384, 1, True),
+    ],
+)
+def test_should_use_vector_cta(
+    hidden_size: int, num_tokens: int, expected: bool
+) -> None:
+    assert _should_use_vector_cta(hidden_size, num_tokens) is expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a vectorized half/bf16 CTA kernel for HF-semantics RMSNorm while preserving the cast-before-weight-mul behavior
- route only shapes with measured H100 wins to the vectorized path; keep the existing warp/scalar paths for smaller medium-token cases
- add a route-threshold regression test

## Accuracy / tests

H100 (`h100_sglang`, `sglang_bbuf`, `origin/main` base `50ed01674`):

```bash
python -m compileall -q python/sglang/jit_kernel/rmsnorm_hf.py python/sglang/jit_kernel/tests/test_rmsnorm_hf.py
CUDA_VISIBLE_DEVICES=2 PYTHONPATH=/tmp/sglang_rmsnorm_hf_half_h100/python \
  TVM_FFI_CACHE_DIR=/tmp/tvm_cache_rmsnorm_hf_half_tests2 \
  pytest -q python/sglang/jit_kernel/tests/test_rmsnorm_hf.py -q
```

Result: full `test_rmsnorm_hf.py` passed. Benchmarks also compared each optimized output against the HF reference expression; max abs diff stayed within the existing test tolerance (`<= 0.03125` for the listed bf16 large shapes, `<= 0.0078125` for listed fp16 large shapes).

## H100 benchmark

Method: same H100 GPU, 40 warmup iterations, 5 timed repeats, median latency. 300 timed iterations for shapes <= 2M elements, 120 otherwise.

| dtype | tokens | hidden | baseline us | optimized us | speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| fp16 | 2048 | 512 | 4.788907 | 3.797440 | 20.70% |
| fp16 | 2048 | 1024 | 5.340267 | 4.098400 | 23.25% |
| fp16 | 2048 | 2048 | 6.516000 | 4.430933 | 32.00% |
| fp16 | 2048 | 4096 | 10.505334 | 7.793067 | 25.82% |
| fp16 | 512 | 8192 | 5.809867 | 4.525600 | 22.10% |
| fp16 | 1 | 16384 | 6.933653 | 3.641280 | 47.48% |
| fp16 | 128 | 16384 | 7.780000 | 3.705600 | 52.37% |
| bf16 | 2048 | 512 | 4.806614 | 3.819093 | 20.55% |
| bf16 | 2048 | 1024 | 5.389867 | 4.082400 | 24.26% |
| bf16 | 2048 | 2048 | 6.624533 | 4.369333 | 34.04% |
| bf16 | 2048 | 4096 | 10.704000 | 7.788267 | 27.24% |
| bf16 | 512 | 8192 | 5.804000 | 4.660267 | 19.71% |
| bf16 | 1 | 16384 | 6.960853 | 3.466240 | 50.20% |
| bf16 | 128 | 16384 | 7.817333 | 3.700800 | 52.66% |

## Profiling

`nsys stats --report cuda_gpu_kern_sum` for bf16 `(tokens=2048, hidden=4096)`:

| variant | kernel | avg ns | median ns |
| --- | --- | ---: | ---: |
| baseline | `rmsnorm_hf_scalar_kernel<4096, true, __nv_bfloat16>` | 10904.5 | 10880.0 |
| optimized | `rmsnorm_hf_vector_kernel<4096, true, __nv_bfloat16>` | 8169.0 | 8160.0 |

Profiler speedup: 25.09%.