### PR TITLE
Fix DSv4 attention backend for EAGLE per-step draft

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -664,11 +664,20 @@ class DeepseekV4AttnBackend(
         max_seq_len = int(seq_lens_cpu.max().item())
 
         if forward_batch.forward_mode.is_decode_or_idle():
+            out_cache_loc = forward_batch.out_cache_loc
+            if self.speculative_num_steps > 0:
+                # Per-step EAGLE draft: slice the shared `out_cache_loc` to
+                # this step's portion and advance `seq_lens` by `step_id + 1`.
+                bs = req_pool_indices.shape[0]
+                step_id = self.speculative_step_id
+                out_cache_loc = out_cache_loc[bs * step_id : bs * (step_id + 1)]
+                seq_lens = seq_lens + (step_id + 1)
+                max_seq_len = max_seq_len + (step_id + 1)
             metadata = self.init_forward_metadata_decode(
                 max_seq_len=max_seq_len,
                 req_pool_indices=req_pool_indices,
                 seq_lens=seq_lens,
-                out_cache_loc=forward_batch.out_cache_loc,
+                out_cache_loc=out_cache_loc,
             )
         elif forward_batch.forward_mode.is_target_verify():
             metadata = self.init_forward_metadata_target_verify(
@@ -813,6 +822,14 @@ class DeepseekV4AttnBackend(
         if bucket == _GraphBucket.DECODE_OR_IDLE:
             assert out_cache_loc is not None
             assert len(out_cache_loc.shape) == 1, f"{out_cache_loc.shape=}"
+            if self.speculative_num_steps > 0:
+                # Per-step EAGLE draft: take this step's slice of the
+                # shared `out_cache_loc` and advance `seq_lens` by
+                # `step_id + 1`. The captured buffer's `chosen_max_seq_len`
+                # already accommodates the spec extension.
+                step_id = self.speculative_step_id
+                out_cache_loc = out_cache_loc[bs * step_id : bs * (step_id + 1)]
+                seq_lens = seq_lens + (step_id + 1)
             out_cache_loc_padded = torch.nn.functional.pad(
                 out_cache_loc,
                 pad=(0, bs - len(out_cache_loc)),


### PR DESCRIPTION
## Summary

The `DeepseekV4MultiStepDraftBackend` (added in #23882) constructs one `DeepseekV4AttnBackend` per spec step and forwards the same `ForwardBatch` to each step's `init_forward_metadata`. For `forward_mode == decode`, that method passed `forward_batch.out_cache_loc` straight through to `init_forward_metadata_decode`, which then asserted `out_cache_loc.shape[0] == req_pool_indices.shape[0] == seq_lens.shape[0]`.

But in EAGLE draft, `forward_batch.out_cache_loc` has shape `[bs * speculative_num_steps]` (the full spec-decode cache-loc tensor — every step writes one new slot per request), while `req_pool_indices` and `seq_lens` are still at the unrepeated `[bs]` shape. The assertion fires whenever a draft batch reaches this path with `bs >= 2`:

```
AssertionError: req_pool_indices.shape=torch.Size([2])
    seq_lens.shape=torch.Size([2])
    out_cache_loc.shape=torch.Size([6])
```

In larger configurations (TP=8 / EP=8 / DP=8 multi-node decode) the shapes can coincidentally line up so the assertion does not fire, but the metadata is still mis-aligned: GSM8K accuracy collapses from ~0.93 to ~0.42 and decoded outputs are visibly malformed (stray `Weapon:` / `Weaponry` / `Weaponized` prefixes).

Mirror the FA3 backend's draft-decode handling at `flashattention_backend.py` (`cache_seqlens_int32 = seqlens_in_batch + (self.speculative_step_id + 1)`): when the backend was constructed as a per-step draft step (`self.speculative_num_steps > 0`), slice `out_cache_loc` to this step's portion and advance `seq_lens` / `max_seq_len` by `step_id + 1` before calling `init_forward_metadata_decode`.

Closes #24747.

## Reproducer

`lmsysorg/sglang:nightly-dev-cu13-20260509-9ee83034` (built from main `9ee83034`):

```bash
python3 -m sglang.launch_server \
  --model-path /model \
  --tp 4 --port 30001 \
  --trust-remote-code \
  --tool-call-parser deepseekv4 \
  --kv-cache-dtype fp8_e4m3 \
  --mem-fraction-static 0.85 \
  --max-running-requests 16 \
  --context-length 8192 \
  --moe-runner-backend flashinfer_mxfp4 \
  --disable-flashinfer-autotune \
  --disable-cuda-graph \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4
```

Send any 5-shot gsm8k chat-completion request — server crashes with the assertion above. With this patch, server completes normally and returns the correct answer (verified on the same prompt that GB300 disagg-decode CI was getting wrong).

## Test plan

- [x] Standalone 5-shot gsm8k (Janet ducks, target=18) before patch: scheduler crash with the assertion above.
- [x] Standalone 5-shot gsm8k after patch: returns correct answer 18 with clean thinking content.
- [ ] Multi-node disagg-decode CI sweep (TP=8 EP=8 DP=8) for em_strict ≥ ~0.93 — running.
- [ ] Single-step / single-batch (bs=1) regression test — assertion was already happy at bs=1, behaviour should be unchanged. Worth a unit test for the no-spec path.

## Related

- Bug report: #24747
- DSv4 backend introduced in #23882 (cc @Ying1123)

Signed-off-by: Cheng Wan <wan4ch@gmail.com>