### PR TITLE
[diffusion] hardware: support sage attention backend on MUSA (attn backend, 21/N)

### DIFF
--- a/docs_new/docs/sglang-diffusion/attention_backends.mdx
+++ b/docs_new/docs/sglang-diffusion/attention_backends.mdx
@@ -16,7 +16,7 @@ When using the diffusers backend, `--attention-backend` is passed through to dif
 - **CUDA**: prefers FlashAttention (FA3/FA4) when supported; otherwise falls back to PyTorch SDPA.
 - **ROCm**: uses FlashAttention when available; otherwise falls back to PyTorch SDPA.
 - **Intel XPU**: uses XPU Flash Attention backend (fp16/bf16, head sizes 64/96/128/192/256); otherwise falls back to PyTorch SDPA.
-- **MUSA**: uses FlashAttention when available; otherwise falls back to PyTorch SDPA.
+- **MUSA**: uses FlashAttention when available; also supports Sage Attention when installed; otherwise falls back to PyTorch SDPA.
 - **MPS**: always uses PyTorch SDPA.
 - **NPU**: for ring attention uses FA otherwise uses PyTorch SDPA.
 
@@ -349,10 +349,10 @@ Some backends require additional configuration. You can pass these parameters vi
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Yes</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>No</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>No</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>No</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Yes</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>CUDA-only (optional dependency).</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Optional dependency on CUDA and MUSA. Falls back to FlashAttention if <code>sageattention</code> is not installed.</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`sage_attn_3`</td>

--- a/python/sglang/multimodal_gen/README.md
+++ b/python/sglang/multimodal_gen/README.md
@@ -25,7 +25,7 @@ SGLang Diffusion supports AMD Instinct GPUs through ROCm. On AMD platforms, we u
 
 ### Moore Threads/MUSA Support
 
-SGLang Diffusion supports Moore Threads GPUs (MTGPU) through the MUSA software stack. On MUSA platforms, we use the Torch SDPA backend for attention. See the [installation guide](https://github.com/sgl-project/sglang/tree/main/docs/diffusion/installation.md) for setup instructions.
+SGLang Diffusion supports Moore Threads GPUs (MTGPU) through the MUSA software stack. On MUSA platforms, we use FlashAttention (FA3) when available; also supports Sage Attention when installed; otherwise falls back to the Torch SDPA backend. See the [installation guide](https://github.com/sgl-project/sglang/tree/main/docs/diffusion/installation.md) for setup instructions.
 
 ### Apple MPS Support
 

--- a/python/sglang/multimodal_gen/runtime/platforms/musa.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/musa.py
@@ -174,7 +174,7 @@ class MusaPlatformBase(Platform):
             except ImportError as e:
                 logger.info(e)
                 logger.info(
-                    "Sage Attention backend is not installed (To install it, run `pip install sageattention==2.2.0 --no-build-isolation`). Falling back to Flash Attention."
+                    "Sage Attention backend is not installed (To install it, run `pip install sageattention>=0.1.0`). Falling back to Flash Attention."
                 )
                 target_backend = AttentionBackendEnum.FA
         elif selected_backend in [

--- a/python/sglang/multimodal_gen/runtime/platforms/musa.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/musa.py
@@ -160,6 +160,23 @@ class MusaPlatformBase(Platform):
         if selected_backend == AttentionBackendEnum.TORCH_SDPA:
             logger.info("Using Torch SDPA backend")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
+        elif selected_backend == AttentionBackendEnum.SAGE_ATTN:
+            try:
+                from sageattention import sageattn  # noqa: F401
+
+                from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn import (  # noqa: F401
+                    SageAttentionBackend,
+                )
+
+                logger.info("Using Sage Attention backend")
+
+                return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn.SageAttentionBackend"
+            except ImportError as e:
+                logger.info(e)
+                logger.info(
+                    "Sage Attention backend is not installed (To install it, run `pip install sageattention==2.2.0 --no-build-isolation`). Falling back to Flash Attention."
+                )
+                target_backend = AttentionBackendEnum.FA
         elif selected_backend in [
             AttentionBackendEnum.FA,
         ]:
@@ -208,7 +225,7 @@ class MusaPlatformBase(Platform):
             logger.info("Using Torch SDPA backend")
             return "sglang.multimodal_gen.runtime.layers.attention.backends.sdpa.SDPABackend"
 
-        logger.info("Using FlashAttention (FA3) backend on MUSA")
+        logger.info("Using FlashAttention (FA3) backend")
         return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
 
     @classmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Add Sage Attention backend support to `MUSA` platform.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. Update `musa.py` to add Sage Attention selection.
2. Update docs

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Key evidence:

```bash
[05-09 11:26:38] Using Sage Attention backend
[05-09 11:26:38] Using sage_attn backend for transformer
```

Full log:

```bash
root@worker3218:/ws# sglang generate --model-path /home/dist/FLUX.1-dev     --prompt "A logo With Bold Large text: SGL Diffusion"     --save-output --attention-backend sage_attn
WARNING:py.warnings:/ws/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-05-09 11:26:07 | warnings | 140678467908736 | WARNING : /ws/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

INFO:sglang.multimodal_gen.runtime.utils.hf_diffusers_utils:Diffusers version: 0.30.0.dev0
2026-05-09 11:26:09 | hf_diffusers_utils | 140678467908736 | INFO : Diffusers version: 0.30.0.dev0
[05-09 11:26:09] Disabling some offloading (except dit, text_encoder) for image generation model
[05-09 11:26:09] server_args: {"model_path": "/home/dist/FLUX.1-dev", "model_id": null, "backend": "auto", "attention_backend": "sage_attn", "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "quantization": null, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5611, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[05-09 11:26:09] Diffusers version: 0.30.0.dev0
[05-09 11:26:09] Local mode: True
[05-09 11:26:09] Starting server...
WARNING:py.warnings:/ws/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

2026-05-09 11:26:17 | warnings | 140094605653120 | WARNING : /ws/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")

[05-09 11:26:19] Scheduler bind at endpoint: tcp://127.0.0.1:5611
[05-09 11:26:19] Initializing distributed environment with world_size=1, device=musa:0, timeout=3600
[05-09 11:26:19] Setting distributed timeout to 3600 seconds
[05-09 11:26:19] No pipeline_class_name specified, using model_index.json
[05-09 11:26:19] Diffusers version: 0.30.0.dev0
[05-09 11:26:19] Using pipeline from model_index.json: FluxPipeline
[05-09 11:26:19] Loading pipeline modules...
[05-09 11:26:19] Model already exists locally and is complete
[05-09 11:26:19] Model path: /home/dist/FLUX.1-dev
[05-09 11:26:19] Diffusers version: 0.30.0.dev0
[05-09 11:26:19] Loading pipeline modules from config: {'_class_name': 'FluxPipeline', '_diffusers_version': '0.30.0.dev0', 'scheduler': ['diffusers', 'FlowMatchEulerDiscreteScheduler'], 'text_encoder': ['transformers', 'CLIPTextModel'], 'text_encoder_2': ['transformers', 'T5EncoderModel'], 'tokenizer': ['transformers', 'CLIPTokenizer'], 'tokenizer_2': ['transformers', 'T5TokenizerFast'], 'transformer': ['diffusers', 'FluxTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderKL']}
[05-09 11:26:19] Loading required components: ['text_encoder', 'text_encoder_2', 'tokenizer', 'tokenizer_2', 'vae', 'transformer', 'scheduler']
Loading required modules:   0%|                                                                                                        | 0/7 [00:00<?, ?it/s][05-09 11:26:19] Loading text_encoder from /home/dist/FLUX.1-dev/text_encoder. avail mem: 79.30 GB
[05-09 11:26:20] Using FlashAttention (FA3) backend
[05-09 11:26:20] Using fa backend for text_encoder
[05-09 11:26:20] [RunAI Streamer] Overall time to stream 234.7 MiB of all files to cpu: 0.06s, 4.1 GiB/s
[05-09 11:26:24] Applied FSDP to 13 submodules in FSDPCLIPTextModel using explicit shard conditions
[05-09 11:26:24] Loaded text_encoder: FSDPCLIPTextModel (sgl-diffusion version). model size: 0.23 GB, consumed GPU mem: 0.25 GB, avail GPU mem: 79.05 GB
Loading required modules:  14%|█████████████▋                                                                                  | 1/7 [00:05<00:30,  5.13s/it][05-09 11:26:24] Loading text_encoder_2 from /home/dist/FLUX.1-dev/text_encoder_2. avail mem: 79.05 GB
[05-09 11:26:26] [RunAI Streamer] Overall time to stream 8.9 GiB of all files to cpu: 1.95s, 4.6 GiB/s
[05-09 11:26:38] Applied FSDP to 26 submodules in FSDPT5EncoderModel using explicit shard conditions
[05-09 11:26:38] Loaded text_encoder_2: FSDPT5EncoderModel (sgl-diffusion version). model size: 8.87 GB, consumed GPU mem: 0.03 GB, avail GPU mem: 79.03 GB
Loading required modules:  29%|███████████████████████████▍                                                                    | 2/7 [00:18<00:50, 10.10s/it][05-09 11:26:38] Loading tokenizer from /home/dist/FLUX.1-dev/tokenizer. avail mem: 79.03 GB
[05-09 11:26:38] Loaded tokenizer: CLIPTokenizerFast (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 79.03 GB
Loading required modules:  43%|█████████████████████████████████████████▏                                                      | 3/7 [00:18<00:22,  5.53s/it][05-09 11:26:38] Loading tokenizer_2 from /home/dist/FLUX.1-dev/tokenizer_2. avail mem: 79.03 GB
You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
[05-09 11:26:38] Loaded tokenizer_2: T5TokenizerFast (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 79.03 GB
Loading required modules:  57%|██████████████████████████████████████████████████████▊                                         | 4/7 [00:19<00:10,  3.44s/it][05-09 11:26:38] Loading vae from /home/dist/FLUX.1-dev/vae. avail mem: 79.03 GB
[05-09 11:26:38] Loaded vae: AutoencoderKL (sgl-diffusion version). model size: 0.31 GB, consumed GPU mem: 0.35 GB, avail GPU mem: 78.68 GB
Loading required modules:  71%|████████████████████████████████████████████████████████████████████▌                           | 5/7 [00:19<00:04,  2.28s/it][05-09 11:26:38] Loading transformer from /home/dist/FLUX.1-dev/transformer. avail mem: 78.68 GB
[05-09 11:26:38] Loading FluxTransformer2DModel from 3 safetensors file(s) , param_dtype: torch.bfloat16
[05-09 11:26:38] Using Sage Attention backend
[05-09 11:26:38] Using sage_attn backend for transformer
[05-09 11:26:42] [RunAI Streamer] Overall time to stream 22.2 GiB of all files to cpu: 3.24s, 6.8 GiB/s
[05-09 11:26:52] Loaded model with 11.90B parameters
[05-09 11:26:52] Loaded transformer: FluxTransformer2DModel (sgl-diffusion version). model size: 22.17 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.68 GB
Loading required modules:  86%|██████████████████████████████████████████████████████████████████████████████████▎             | 6/7 [00:33<00:06,  6.25s/it][05-09 11:26:52] Loading scheduler from /home/dist/FLUX.1-dev/scheduler. avail mem: 78.68 GB
[05-09 11:26:52] Loaded scheduler: FlowMatchEulerDiscreteScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 78.68 GB
Loading required modules: 100%|████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:33<00:00,  4.75s/it]
[05-09 11:26:52] Creating pipeline stages...
[05-09 11:26:52] Using Sage Attention backend
[05-09 11:26:52] Pipeline instantiated
[05-09 11:26:52] Worker 0: Initialized device, model, and distributed environment.
[05-09 11:26:52] Worker 0: Scheduler loop started.
[05-09 11:26:52] Processing 1 grouped request(s)
[05-09 11:26:52] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=42>
                  neg_prompt: None
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 3.5
     embedded_guidance_scale: 3.5
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_logo_With_Bold_Large_text_SGL_Diffusion_20260509-112652_e04df28b.png
        
[05-09 11:26:52] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-09 11:26:52] [InputValidationStage] started...
[05-09 11:26:52] [InputValidationStage] finished in 0.0001 seconds
[05-09 11:26:52] [TextEncodingStage] started...
[05-09 11:27:07] [TextEncodingStage] finished in 14.0563 seconds
[05-09 11:27:13] [TimestepPreparationStage] started...
[05-09 11:27:13] [TimestepPreparationStage] finished in 0.0022 seconds
[05-09 11:27:13] [LatentPreparationStage] started...
[05-09 11:27:13] [LatentPreparationStage] finished in 0.0057 seconds
[05-09 11:27:13] [DenoisingStage] started...
  0%|                                                                                                                                 | 0/50 [00:00<?, ?it/s][05-09 11:27:18] FlashInfer not available, using Triton fallback for RoPE
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:25<00:00,  1.93it/s]
[05-09 11:27:39] [DenoisingStage] average time per step: 0.5188 seconds
[05-09 11:27:39] [DenoisingStage] finished in 25.9497 seconds
[05-09 11:27:39] [DecodingStage] started...
[05-09 11:27:39] [DecodingStage] finished in 0.0463 seconds
[05-09 11:27:39] Output saved to outputs/A_logo_With_Bold_Large_text_SGL_Diffusion_20260509-112652_e04df28b.png
[05-09 11:27:39] Pixel data generated successfully in 46.80 seconds
[05-09 11:27:39] Memory usage - Max peak: 29740.00 MB, Avg peak: 29740.00 MB
[05-09 11:27:39] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.
[05-09 11:27:40] Worker 0: Shutdown complete.
root@worker3218:/ws# 
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
