### PR TITLE
Optimize large timestep embedding trig

### DIFF
--- a/python/sglang/jit_kernel/csrc/diffusion/timestep_embedding.cuh
+++ b/python/sglang/jit_kernel/csrc/diffusion/timestep_embedding.cuh
@@ -69,6 +69,54 @@ __global__ void timestep_embedding_kernel(
   }
 }
 
+template <bool kFlipSinToCos, typename TIn>
+__global__ void timestep_embedding_sincos_kernel(
+    const TIn* __restrict__ t_ptr,
+    float* __restrict__ output_ptr,
+    int dim,
+    float neg_log_max_period,
+    float scale,
+    int batch_size) {
+  int row_idx = static_cast<int>(blockIdx.x * blockDim.y + threadIdx.y);
+  if (row_idx >= batch_size) {
+    return;
+  }
+
+  float t_val = device::cast<float>(t_ptr[row_idx]);
+  float* output_batch_base_ptr = output_ptr + row_idx * dim;
+
+  int half_dim = dim / 2;
+  int thread_offset = static_cast<int>(threadIdx.x);
+  while (thread_offset * 4 < half_dim) {
+    float4* top_half;
+    float4* bottom_half;
+    if constexpr (!kFlipSinToCos) {
+      bottom_half = reinterpret_cast<float4*>(output_batch_base_ptr + thread_offset * 4);
+      top_half = reinterpret_cast<float4*>(output_batch_base_ptr + half_dim + thread_offset * 4);
+    } else {
+      top_half = reinterpret_cast<float4*>(output_batch_base_ptr + thread_offset * 4);
+      bottom_half = reinterpret_cast<float4*>(output_batch_base_ptr + half_dim + thread_offset * 4);
+    }
+
+    float4 vals;
+    vals.x = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 0));
+    vals.y = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 1));
+    vals.z = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 2));
+    vals.w = scale * t_val * device::math::exp(neg_log_max_period * __int2float_rn(thread_offset * 4 + 3));
+
+    float4 sin_vals;
+    float4 cos_vals;
+    sincosf(vals.x, &sin_vals.x, &cos_vals.x);
+    sincosf(vals.y, &sin_vals.y, &cos_vals.y);
+    sincosf(vals.z, &sin_vals.z, &cos_vals.z);
+    sincosf(vals.w, &sin_vals.w, &cos_vals.w);
+    *top_half = cos_vals;
+    *bottom_half = sin_vals;
+
+    thread_offset += static_cast<int>(blockDim.x);
+  }
+}
+
 template <typename TIn>
 inline void launch_timestep_embedding(
     const tvm::ffi::TensorView t,
@@ -97,9 +145,31 @@ inline void launch_timestep_embedding(
 
   const DLDevice device = output.device();
 
-  if (flip_sin_to_cos) {
+  // sincosf is profitable for large batches where trig work dominates launch
+  // overhead. Keep smaller and very wide cases on the original sinf/cosf path.
+  const bool use_sincos = batch_size >= 16384 && dim <= 1024;
+
+  if (flip_sin_to_cos && use_sincos) {
+    LaunchKernel(grid, block, device)(
+        timestep_embedding_sincos_kernel<true, TIn>,
+        static_cast<const TIn*>(t.data_ptr()),
+        static_cast<float*>(output.data_ptr()),
+        dim,
+        neg_log_max_period,
+        scale,
+        batch_size);
+  } else if (flip_sin_to_cos) {
     LaunchKernel(grid, block, device)(
         timestep_embedding_kernel<true, TIn>,
+        static_cast<const TIn*>(t.data_ptr()),
+        static_cast<float*>(output.data_ptr()),
+        dim,
+        neg_log_max_period,
+        scale,
+        batch_size);
+  } else if (use_sincos) {
+    LaunchKernel(grid, block, device)(
+        timestep_embedding_sincos_kernel<false, TIn>,
         static_cast<const TIn*>(t.data_ptr()),
         static_cast<float*>(output.data_ptr()),
         dim,


### PR DESCRIPTION
## Summary

- add a `sincosf` timestep embedding kernel variant
- route only large batches with medium dimensions (`batch_size >= 16384 && dim <= 1024`) to the new variant
- keep smaller and very wide shapes on the original `sinf`/`cosf` kernel path

## Accuracy / tests

H100 (`h100_sglang`, `sglang_bbuf`, `origin/main` base `50ed01674`):

```bash
CUDA_VISIBLE_DEVICES=7 PYTHONPATH=/tmp/sglang_timestep_sincos/python \
  TVM_FFI_CACHE_DIR=/tmp/tvm_cache_timestep_final_tests \
  pytest -q python/sglang/jit_kernel/tests/test_timestep_embedding.py -q
```

Result: full `test_timestep_embedding.py` passed, with the default perf test skipped as expected.

The selected benchmark shapes also compare against `get_timestep_embedding_reference`; max abs diff was `0` for the rows below.

## H100 benchmark

Method: same H100 GPU, random timesteps in `[0, 1000)`, 20 warmup iterations, 7 timed repeats, median latency.

| dtype | batch | dim | baseline us | optimized us | speedup | max diff |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| fp16 | 16384 | 512 | 12.465984 | 11.796864 | 5.37% | 0 |
| bf16 | 16384 | 512 | 12.513408 | 11.637632 | 7.00% | 0 |
| fp32 | 16384 | 512 | 12.556032 | 11.759552 | 6.34% | 0 |

Guardrail checks on non-`sincosf` shapes:

| dtype | batch | dim | baseline us | optimized us |
| --- | ---: | ---: | ---: | ---: |
| fp16 | 512 | 512 | 4.987136 | 4.942336 |
| bf16 | 8192 | 512 | 7.046400 | 7.078080 |
| fp16 | 16384 | 8192 | 173.510399 | 172.437763 |

## Profiling

`nsys stats --report cuda_gpu_kern_sum` for bf16 `(batch=16384, dim=512)`:

| variant | kernel | avg ns | median ns |
| --- | --- | ---: | ---: |
| baseline | `timestep_embedding_kernel<true, __nv_bfloat16>` | 11433.7 | 11424.0 |
| optimized | `timestep_embedding_sincos_kernel<true, __nv_bfloat16>` | 10391.4 | 10368.0 |

Profiler speedup: 9.12%.