### PR TITLE
Optimize large int32 clamp_position

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_clamp_position.py
+++ b/python/sglang/jit_kernel/benchmark/bench_clamp_position.py
@@ -16,15 +16,19 @@ from sglang.test.ci.ci_register import register_cuda_ci
 register_cuda_ci(est_time=13, suite="stage-b-kernel-benchmark-1-gpu-large")
 
 SIZE_LIST = get_benchmark_range(
-    full_range=[2**n for n in range(4, 16)],
+    full_range=[2**n for n in range(4, 16)] + [2**20, 2**22, 2**24],
     ci_range=[256, 4096],
 )
+DTYPE_LIST = get_benchmark_range(
+    full_range=[torch.int32, torch.int64],
+    ci_range=[torch.int32],
+)
 
-configs = list(itertools.product(SIZE_LIST))
+configs = list(itertools.product(SIZE_LIST, DTYPE_LIST))
 
 
 def _torch_clamp_position(seq_lens):
-    return torch.clamp(seq_lens - 1, min=0).to(torch.int64)
+    return torch.clamp(seq_lens - 1, min=0).to(seq_lens.dtype)
 
 
 _compiled_clamp_position = torch.compile(
@@ -34,7 +38,7 @@ _compiled_clamp_position = torch.compile(
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["size"],
+        x_names=["size", "dtype"],
         x_vals=configs,
         line_arg="provider",
         line_vals=["jit", "torch_compile", "torch"],
@@ -45,9 +49,9 @@ _compiled_clamp_position = torch.compile(
         args={},
     )
 )
-def benchmark(size: int, provider: str):
+def benchmark(size: int, dtype: torch.dtype, provider: str):
     seq_lens = torch.randint(
-        0, 10000, (size,), dtype=torch.int64, device=DEFAULT_DEVICE
+        0, 10000, (size,), dtype=dtype, device=DEFAULT_DEVICE
     )
 
     if provider == "jit":

--- a/python/sglang/jit_kernel/csrc/elementwise/clamp_position.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/clamp_position.cuh
@@ -6,8 +6,10 @@
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace {
 
@@ -20,7 +22,31 @@ __global__ void clamp_position_kernel(T* __restrict__ dst, const T* __restrict__
   }
 }
 
+__global__ void clamp_position_int32_vec4_kernel(
+    int32_t* __restrict__ dst,
+    const int32_t* __restrict__ seq_lens,
+    size_t n) {
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t n_vec = n / 4;
+
+  if (idx < n_vec) {
+    int4 values = reinterpret_cast<const int4*>(seq_lens)[idx];
+    values.x = values.x <= 0 ? 0 : values.x - 1;
+    values.y = values.y <= 0 ? 0 : values.y - 1;
+    values.z = values.z <= 0 ? 0 : values.z - 1;
+    values.w = values.w <= 0 ? 0 : values.w - 1;
+    reinterpret_cast<int4*>(dst)[idx] = values;
+  }
+
+  const size_t tail_idx = n_vec * 4 + idx;
+  if (tail_idx < n) {
+    int32_t val = seq_lens[tail_idx] - 1;
+    dst[tail_idx] = val < 0 ? 0 : val;
+  }
+}
+
 constexpr size_t kBlockSize = 256;
+constexpr size_t kVecMinElements = 1 << 20;
 
 template <typename T>
 struct ClampPosition {
@@ -40,13 +66,31 @@ struct ClampPosition {
     const size_t num_elements = N.unwrap();
     if (num_elements == 0) return;
 
-    const size_t grid_size = div_ceil(num_elements, kBlockSize);
     const DLDevice device = device_.unwrap();
+    auto* dst_ptr = static_cast<T*>(dst.data_ptr());
+    const auto* seq_lens_ptr = static_cast<const T*>(seq_lens.data_ptr());
 
+    if constexpr (std::is_same_v<T, int32_t>) {
+      const bool is_vec_aligned =
+          (reinterpret_cast<uintptr_t>(dst_ptr) % alignof(int4) == 0) &&
+          (reinterpret_cast<uintptr_t>(seq_lens_ptr) % alignof(int4) == 0);
+      if (num_elements >= kVecMinElements && is_vec_aligned) {
+        const size_t vec_work_items = std::max(num_elements / 4, num_elements % 4);
+        const size_t grid_size = div_ceil(vec_work_items, kBlockSize);
+        LaunchKernel(grid_size, kBlockSize, device)(
+            clamp_position_int32_vec4_kernel,
+            static_cast<int32_t*>(dst.data_ptr()),
+            static_cast<const int32_t*>(seq_lens.data_ptr()),
+            num_elements);
+        return;
+      }
+    }
+
+    const size_t grid_size = div_ceil(num_elements, kBlockSize);
     LaunchKernel(grid_size, kBlockSize, device)(
         clamp_position_kernel<T>,
-        static_cast<T*>(dst.data_ptr()),
-        static_cast<const T*>(seq_lens.data_ptr()),
+        dst_ptr,
+        seq_lens_ptr,
         num_elements);
   }
 };

--- a/python/sglang/jit_kernel/tests/test_clamp_position.py
+++ b/python/sglang/jit_kernel/tests/test_clamp_position.py
@@ -42,5 +42,13 @@ class TestClampPosition:
         assert torch.equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_clamp_position_large_and_unaligned(dtype: torch.dtype) -> None:
+    seq_lens = torch.randint(0, 10000, (1048578,), dtype=dtype, device="cuda")[1:]
+    expected = _reference_clamp_position(seq_lens)
+    result = clamp_position_cuda(seq_lens)
+    assert torch.equal(result, expected)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Summary

- add a 16-byte aligned `int4` fast path for large `int32` `clamp_position` inputs
- keep the scalar path for small tensors, unaligned inputs, and `int64`
- extend clamp_position tests with a large unaligned input case
- extend the benchmark to include int32/int64 and large sizes

## Accuracy / Tests

H100 (`CUDA_VISIBLE_DEVICES=7`):

```bash
PYTHONPATH=/tmp/sglang_clamp_vec/python \
TVM_FFI_CACHE_DIR=/tmp/tvm_cache_clamp_vec_final \
python -m compileall -q \
  python/sglang/jit_kernel/clamp_position.py \
  python/sglang/jit_kernel/tests/test_clamp_position.py \
  python/sglang/jit_kernel/benchmark/bench_clamp_position.py

PYTHONPATH=/tmp/sglang_clamp_vec/python \
TVM_FFI_CACHE_DIR=/tmp/tvm_cache_clamp_vec_final \
pytest -q python/sglang/jit_kernel/tests/test_clamp_position.py -q
```

Result: 66 tests passed.

## Benchmark

H100, CUDA event median, `int32`, base -> this PR:

| elements | direct module | speedup | wrapper | speedup |
| ---: | ---: | ---: | ---: | ---: |
| 128 | 5.504 -> 5.616 us | -2.03% | 5.888 -> 5.664 us | +3.80% |
| 1024 | 5.632 -> 5.616 us | +0.28% | 5.408 -> 5.520 us | -2.07% |
| 4096 | 5.792 -> 5.536 us | +4.42% | 5.712 -> 5.776 us | -1.12% |
| 65536 | 5.856 -> 5.840 us | +0.27% | 6.304 -> 5.984 us | +5.08% |
| 1048576 | 9.328 -> 8.784 us | +5.83% | 9.248 -> 8.736 us | +5.54% |
| 4194304 | 20.944 -> 18.336 us | +12.45% | 20.688 -> 18.160 us | +12.22% |
| 16777216 | 64.416 -> 50.960 us | +20.89% | 64.160 -> 51.216 us | +20.17% |

`int64` remains on the existing scalar path; an attempted `longlong2` path was rejected because it did not reach the 5% threshold.

`python/sglang/jit_kernel/benchmark/bench_clamp_position.py --print-data` on this PR includes both `torch.int32` and `torch.int64`; selected large rows:

```text
        size        dtype  SGL JIT Kernel  torch.compile     PyTorch
24   1048576  torch.int32        4.588633      40.468756    8.846763
25   1048576  torch.int64        7.608286      12.409000   15.883880
26   4194304  torch.int32       15.082795     337.625673   44.111578
27   4194304  torch.int64       50.694144      50.329760   98.268796
28  16777216  torch.int32       99.722141    1358.471534  199.171657
29  16777216  torch.int64      204.397230     198.169285  389.288743
```

## Profiling

H100, `int32`, 4194304 elements, 220 profiled launches:

| kernel | median |
| --- | ---: |
| baseline `clamp_position_kernel<int>` | 13056.0 ns |
| PR `clamp_position_int32_vec4_kernel` | 8032.0 ns |

Median kernel speedup: 38.5%.