### PR TITLE
Optimize large int32 future token resolution

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py
@@ -16,11 +16,15 @@ from sglang.test.ci.ci_register import register_cuda_ci
 register_cuda_ci(est_time=10, suite="stage-b-kernel-benchmark-1-gpu-large")
 
 SIZE_LIST = get_benchmark_range(
-    full_range=[2**n for n in range(4, 16)],  # 16 … 32K elements
+    full_range=[2**n for n in range(4, 16)] + [2**20, 2**22, 2**24],
     ci_range=[256, 4096],
 )
+DTYPE_LIST = get_benchmark_range(
+    full_range=[torch.int32, torch.int64],
+    ci_range=[torch.int32],
+)
 
-configs = list(itertools.product(SIZE_LIST))
+configs = list(itertools.product(SIZE_LIST, DTYPE_LIST))
 
 
 def _torch_resolve(input_ids, future_map):
@@ -38,7 +42,7 @@ _compiled_resolve = torch.compile(
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["size"],
+        x_names=["size", "dtype"],
         x_vals=configs,
         line_arg="provider",
         line_vals=["jit", "torch_compile", "torch"],
@@ -49,13 +53,13 @@ _compiled_resolve = torch.compile(
         args={},
     )
 )
-def benchmark(size: int, provider: str):
+def benchmark(size: int, dtype: torch.dtype, provider: str):
     map_size = 8192
     future_map = torch.randint(
-        0, 50000, (map_size,), dtype=torch.int64, device=DEFAULT_DEVICE
+        0, 50000, (map_size,), dtype=dtype, device=DEFAULT_DEVICE
     )
     input_ids = torch.randint(
-        -map_size + 1, 50000, (size,), dtype=torch.int64, device=DEFAULT_DEVICE
+        -map_size + 1, 50000, (size,), dtype=dtype, device=DEFAULT_DEVICE
     )
 
     if provider == "jit":

--- a/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/resolve_future_token_ids.cuh
@@ -6,8 +6,10 @@
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 namespace {
 
@@ -24,7 +26,54 @@ __global__ void resolve_future_token_ids_kernel(T* __restrict__ input_ids, const
   }
 }
 
+__global__ void resolve_future_token_ids_int32_vec4_kernel(
+    int32_t* __restrict__ input_ids,
+    const int32_t* __restrict__ future_map,
+    size_t n) {
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t n_vec = n / 4;
+
+  if (idx < n_vec) {
+    int4 values = reinterpret_cast<const int4*>(input_ids)[idx];
+    bool changed = false;
+    if (values.x < 0) {
+      int32_t key = -values.x;
+      values.x = future_map[key < 0 ? 0 : key];
+      changed = true;
+    }
+    if (values.y < 0) {
+      int32_t key = -values.y;
+      values.y = future_map[key < 0 ? 0 : key];
+      changed = true;
+    }
+    if (values.z < 0) {
+      int32_t key = -values.z;
+      values.z = future_map[key < 0 ? 0 : key];
+      changed = true;
+    }
+    if (values.w < 0) {
+      int32_t key = -values.w;
+      values.w = future_map[key < 0 ? 0 : key];
+      changed = true;
+    }
+    if (changed) {
+      reinterpret_cast<int4*>(input_ids)[idx] = values;
+    }
+  }
+
+  const size_t tail_idx = n_vec * 4 + idx;
+  if (tail_idx < n) {
+    int32_t val = input_ids[tail_idx];
+    if (val < 0) {
+      int32_t key = -val;
+      if (key < 0) key = 0;
+      input_ids[tail_idx] = future_map[key];
+    }
+  }
+}
+
 constexpr size_t kBlockSize = 256;
+constexpr size_t kVecMinElements = 1 << 20;
 
 template <typename T>
 struct ResolveFutureTokenIds {
@@ -43,13 +92,31 @@ struct ResolveFutureTokenIds {
     const size_t num_tokens = N.unwrap();
     if (num_tokens == 0) return;
 
-    const size_t grid_size = div_ceil(num_tokens, kBlockSize);
     const DLDevice device = device_.unwrap();
+    auto* input_ids_ptr = static_cast<T*>(input_ids.data_ptr());
+    const auto* future_map_ptr = static_cast<const T*>(future_map.data_ptr());
 
+    if constexpr (std::is_same_v<T, int32_t>) {
+      const bool is_vec_aligned =
+          (reinterpret_cast<uintptr_t>(input_ids_ptr) % alignof(int4) == 0) &&
+          (reinterpret_cast<uintptr_t>(future_map_ptr) % alignof(int4) == 0);
+      if (num_tokens >= kVecMinElements && is_vec_aligned) {
+        const size_t vec_work_items = std::max(num_tokens / 4, num_tokens % 4);
+        const size_t grid_size = div_ceil(vec_work_items, kBlockSize);
+        LaunchKernel(grid_size, kBlockSize, device)(
+            resolve_future_token_ids_int32_vec4_kernel,
+            static_cast<int32_t*>(input_ids.data_ptr()),
+            static_cast<const int32_t*>(future_map.data_ptr()),
+            num_tokens);
+        return;
+      }
+    }
+
+    const size_t grid_size = div_ceil(num_tokens, kBlockSize);
     LaunchKernel(grid_size, kBlockSize, device)(
         resolve_future_token_ids_kernel<T>,
-        static_cast<T*>(input_ids.data_ptr()),
-        static_cast<const T*>(future_map.data_ptr()),
+        input_ids_ptr,
+        future_map_ptr,
         num_tokens);
   }
 };

--- a/python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py
+++ b/python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py
@@ -65,5 +65,17 @@ class TestResolveFutureTokenIds:
         assert torch.equal(input_ids, expected)
 
 
+def test_resolve_future_token_ids_large_unaligned_int32() -> None:
+    map_size = 8192
+    future_map = torch.randint(0, 50000, (map_size,), dtype=torch.int32, device="cuda")
+    input_ids = torch.randint(
+        -map_size + 1, 50000, (1048578,), dtype=torch.int32, device="cuda"
+    )[1:]
+
+    expected = _reference_resolve(input_ids, future_map)
+    resolve_future_token_ids_cuda(input_ids, future_map)
+    assert torch.equal(input_ids, expected)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Summary

- add a 16-byte aligned `int4` fast path for large `int32` `resolve_future_token_ids` inputs
- skip the vector store when no lane changes, preserving the scalar no-store behavior for all-nonnegative vectors
- keep the existing scalar path for small tensors, unaligned inputs, and `int64`
- extend tests with a large unaligned int32 case and extend the benchmark to cover int32/int64 large sizes

## Accuracy / Tests

H100 (`CUDA_VISIBLE_DEVICES=7`):

```bash
PYTHONPATH=/tmp/sglang_resolve_vec/python \
TVM_FFI_CACHE_DIR=/tmp/tvm_cache_resolve_vec_final \
python -m compileall -q \
  python/sglang/jit_kernel/resolve_future_token_ids.py \
  python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py \
  python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py

PYTHONPATH=/tmp/sglang_resolve_vec/python \
TVM_FFI_CACHE_DIR=/tmp/tvm_cache_resolve_vec_final \
pytest -q python/sglang/jit_kernel/tests/test_resolve_future_token_ids.py -q
```

Result: 65 tests passed.

## Benchmark

H100, CUDA event median, `int32`, base -> this PR:

All nonnegative:

| elements | base | this PR | speedup |
| ---: | ---: | ---: | ---: |
| 1048576 | 8.928 us | 8.256 us | +7.53% |
| 4194304 | 15.616 us | 8.928 us | +42.83% |
| 16777216 | 45.312 us | 26.480 us | +41.56% |

All negative, stable map:

| elements | base | this PR | speedup |
| ---: | ---: | ---: | ---: |
| 4194304 | 16.448 us | 13.232 us | +19.55% |
| 16777216 | 64.016 us | 51.760 us | +19.15% |

Mixed 50/50, stable map:

| elements | base | this PR | speedup |
| ---: | ---: | ---: | ---: |
| 1048576 | 8.848 us | 8.608 us | +2.71% |
| 4194304 | 16.128 us | 12.768 us | +20.83% |
| 16777216 | 63.776 us | 51.296 us | +19.57% |

`python/sglang/jit_kernel/benchmark/bench_resolve_future_token_ids.py --print-data` on this PR includes both `torch.int32` and `torch.int64`; selected large rows:

```text
        size        dtype  SGL JIT Kernel  torch.compile     PyTorch
24   1048576  torch.int32        5.585857      42.927401   27.455397
25   1048576  torch.int64        7.733681       8.257869   33.409532
26   4194304  torch.int32       15.252847     167.834934   98.770154
27   4194304  torch.int64       43.911256      45.896950  163.219958
28  16777216  torch.int32       86.934081     677.721385  443.317569
29  16777216  torch.int64      169.027478     180.668592  653.977617
```

## Profiling

H100, mixed 50/50 `int32`, 4194304 elements, 220 profiled launches:

| kernel | avg | median |
| --- | ---: | ---: |
| baseline `resolve_future_token_ids_kernel<int>` | 11770.5 ns | 11759.5 ns |
| PR `resolve_future_token_ids_int32_vec4_kernel` | 8268.2 ns | 8256.0 ns |

Median kernel speedup: 29.8%.