### PR TITLE
fix: Prevent Qwen3.5  startup crash on unmapped expert weights

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1873,6 +1873,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
                             )
                         elif self.enable_shared_expert_fusion:
                             # shared experts should be loaded to experts.w13_weight and experts.w2_weight
+                            if name_mapped not in params_dict:
+                                continue
                             param = params_dict[name_mapped]
                             weight_loader = getattr(
                                 param, "weight_loader", default_weight_loader

--- a/test/registered/unit/models/test_qwen3_5_load_weights_source.py
+++ b/test/registered/unit/models/test_qwen3_5_load_weights_source.py
@@ -1,0 +1,38 @@
+import pathlib
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
+
+
+class TestQwen35LoadWeightsSource(unittest.TestCase):
+    def test_shared_expert_fusion_skips_missing_mapped_params(self):
+        source_path = (
+            pathlib.Path(__file__).resolve().parents[4]
+            / "python"
+            / "sglang"
+            / "srt"
+            / "models"
+            / "qwen3_5.py"
+        )
+        lines = source_path.read_text().splitlines()
+
+        branch_line = next(
+            i
+            for i, line in enumerate(lines)
+            if "elif self.enable_shared_expert_fusion:" in line
+        )
+        first_param_access = next(
+            i
+            for i in range(branch_line + 1, len(lines))
+            if "param = params_dict[name_mapped]" in lines[i]
+        )
+        guard_block = "\n".join(lines[branch_line:first_param_access])
+
+        self.assertIn("if name_mapped not in params_dict:", guard_block)
+        self.assertIn("continue", guard_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Trigger scenario: 
  When loading an NVFP4-quantized Qwen3.5 checkpoint with enable_shared_expert_fusion enabled, checkpoint auxiliary weights such as  down_proj.input_scale are transformed by expert_params_mapping into parameter names like experts.w2_input_scale. These mapped names are not registered in the model's  params_dict, causing KeyError at startup and preventing the server from serving.

 Root cause: 
  The shared expert fusion branch in qwen3_5 directly accessed params_dict[name_mapped] without checking whether name_mapped exists. This is the only  expert-loading path in the file that lacked the guard — the non-expert path,  the non-fused expert path via load_fused_expert_weights , and the  MTP loading path all already had existence checks.

This fix brings Qwen3.5's shared expert fusion path into alignment with that convention obeyed by other models. All use the same guard pattern: if name_mapped not in params_dict: continue.
  
refer PR: https://github.com/sgl-project/sglang/pull/24434

