### PR TITLE
[Utils] Make request dump robust to unpicklable server_args and large meta_info

### DIFF
--- a/python/sglang/srt/managers/configure_logging.py
+++ b/python/sglang/srt/managers/configure_logging.py
@@ -33,15 +33,30 @@ if __name__ == "__main__":
         "--dump-requests-folder", type=str, default="/tmp/sglang_request_dump"
     )
     parser.add_argument("--dump-requests-threshold", type=int, default=1000)
+    parser.add_argument(
+        "--dump-requests-exclude-meta-keys",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated meta_info keys to strip from each dumped request "
+            "(e.g. 'routed_experts,hidden_states'). Pass an empty string to "
+            "keep all keys. If not set, the server default is used."
+        ),
+    )
     args = parser.parse_args()
 
-    response = requests.post(
-        args.url + "/configure_logging",
-        json={
-            "log_requests": args.log_requests,
-            "log_requests_level": args.log_requests_level,  # Log full requests
-            "dump_requests_folder": args.dump_requests_folder,
-            "dump_requests_threshold": args.dump_requests_threshold,
-        },
-    )
+    payload = {
+        "log_requests": args.log_requests,
+        "log_requests_level": args.log_requests_level,  # Log full requests
+        "dump_requests_folder": args.dump_requests_folder,
+        "dump_requests_threshold": args.dump_requests_threshold,
+    }
+    if args.dump_requests_exclude_meta_keys is not None:
+        payload["dump_requests_exclude_meta_keys"] = [
+            k.strip()
+            for k in args.dump_requests_exclude_meta_keys.split(",")
+            if k.strip()
+        ]
+
+    response = requests.post(args.url + "/configure_logging", json=payload)
     assert response.status_code == 200

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1758,6 +1758,11 @@ class ConfigureLoggingReq(BaseReq):
     dump_requests_folder: Optional[str] = None
     dump_requests_threshold: Optional[int] = None
     crash_dump_folder: Optional[str] = None
+    # Keys to strip from `meta_info` of every dumped request. Useful for
+    # dropping heavy blobs that bloat the dump file (e.g. "routed_experts"
+    # captured by --enable-routing-replay, "hidden_states" captured by
+    # --return-hidden-states). Pass an empty list to keep everything.
+    dump_requests_exclude_meta_keys: Optional[List[str]] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1758,10 +1758,6 @@ class ConfigureLoggingReq(BaseReq):
     dump_requests_folder: Optional[str] = None
     dump_requests_threshold: Optional[int] = None
     crash_dump_folder: Optional[str] = None
-    # Keys to strip from `meta_info` of every dumped request. Useful for
-    # dropping heavy blobs that bloat the dump file (e.g. "routed_experts"
-    # captured by --enable-routing-replay, "hidden_states" captured by
-    # --return-hidden-states). Pass an empty list to keep everything.
     dump_requests_exclude_meta_keys: Optional[List[str]] = None
 
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -391,10 +391,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Dumping
         self.dump_requests_folder = ""  # By default do not dump
         self.dump_requests_threshold = 1000
-        # Drop heavy meta_info entries from the dump payload by default. Both
-        # `routed_experts` (base64'd MoE routing tensor, ~KB-MB per request)
-        # and `hidden_states` blow up the pkl file size and are not used by
-        # the replay tooling. Override via /configure_logging if needed.
         self.dump_requests_exclude_meta_keys: List[str] = [
             "routed_experts",
             "hidden_states",
@@ -2205,9 +2201,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):
-        # Strip heavy keys from `meta_info` (e.g. routed_experts, hidden_states)
-        # to keep the on-disk pkl small. Don't mutate the original dict — it
-        # may still be referenced by the response path or other observers.
         if self.dump_requests_exclude_meta_keys and isinstance(
             out_dict.get("meta_info"), dict
         ):
@@ -2272,11 +2265,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     pickle.dump(to_dump_with_server_args, f)
                 except Exception as e:
                     # When the server is launched with --trust-remote-code,
-                    # server_args sometimes fails to pickle because the
-                    # lazily-attached ModelConfig holds an hf_config whose
-                    # class lives under the dynamic transformers_modules.*
-                    # namespace. Retry without server_args so the request
-                    # data still gets persisted.
+                    # server_args sometimes fails to pickle. Retry without
+                    # server_args so the request data still gets persisted.
                     logger.error(
                         f"Failed to pickle dump with server_args: {e!r}; "
                         "retrying without server_args"

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -391,6 +391,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Dumping
         self.dump_requests_folder = ""  # By default do not dump
         self.dump_requests_threshold = 1000
+        # Drop heavy meta_info entries from the dump payload by default. Both
+        # `routed_experts` (base64'd MoE routing tensor, ~KB-MB per request)
+        # and `hidden_states` blow up the pkl file size and are not used by
+        # the replay tooling. Override via /configure_logging if needed.
+        self.dump_requests_exclude_meta_keys: List[str] = [
+            "routed_experts",
+            "hidden_states",
+        ]
         self.dump_request_list: List[Tuple] = []
         self.crash_dump_request_list: deque[Tuple] = deque()
         self.crash_dump_performed = False  # Flag to ensure dump is only called once
@@ -1577,6 +1585,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             self.dump_requests_folder = obj.dump_requests_folder
         if obj.dump_requests_threshold is not None:
             self.dump_requests_threshold = obj.dump_requests_threshold
+        if obj.dump_requests_exclude_meta_keys is not None:
+            self.dump_requests_exclude_meta_keys = list(
+                obj.dump_requests_exclude_meta_keys
+            )
         if obj.crash_dump_folder is not None:
             self.crash_dump_folder = obj.crash_dump_folder
         logging.info(f"Config logging: {obj=}")
@@ -2193,6 +2205,19 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):
+        # Strip heavy keys from `meta_info` (e.g. routed_experts, hidden_states)
+        # to keep the on-disk pkl small. Don't mutate the original dict — it
+        # may still be referenced by the response path or other observers.
+        if self.dump_requests_exclude_meta_keys and isinstance(
+            out_dict.get("meta_info"), dict
+        ):
+            exclude = self.dump_requests_exclude_meta_keys
+            if any(k in out_dict["meta_info"] for k in exclude):
+                filtered_meta = {
+                    k: v for k, v in out_dict["meta_info"].items() if k not in exclude
+                }
+                out_dict = {**out_dict, "meta_info": filtered_meta}
+
         self.dump_request_list.append(
             (
                 state.obj,
@@ -2243,7 +2268,23 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         def background_task():
             os.makedirs(os.path.dirname(filename), exist_ok=True)
             with open(filename, "wb") as f:
-                pickle.dump(to_dump_with_server_args, f)
+                try:
+                    pickle.dump(to_dump_with_server_args, f)
+                except Exception as e:
+                    # When the server is launched with --trust-remote-code,
+                    # server_args sometimes fails to pickle because the
+                    # lazily-attached ModelConfig holds an hf_config whose
+                    # class lives under the dynamic transformers_modules.*
+                    # namespace. Retry without server_args so the request
+                    # data still gets persisted.
+                    logger.error(
+                        f"Failed to pickle dump with server_args: {e!r}; "
+                        "retrying without server_args"
+                    )
+                    f.seek(0)
+                    f.truncate()
+                    to_dump_with_server_args["server_args"] = None
+                    pickle.dump(to_dump_with_server_args, f)
 
         asyncio.create_task(asyncio.to_thread(background_task))
 
@@ -2306,7 +2347,20 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "launch_command": " ".join(sys.argv),
         }
         with open(filename, "wb") as f:
-            pickle.dump(data_to_dump_with_server_args, f)
+            try:
+                pickle.dump(data_to_dump_with_server_args, f)
+            except Exception as e:
+                # When the server is launched with --trust-remote-code,
+                # server_args sometimes fails to pickle. Retry without
+                # server_args so the request data still gets persisted.
+                logger.error(
+                    f"Failed to pickle dump with server_args: {e!r}; "
+                    "retrying without server_args"
+                )
+                f.seek(0)
+                f.truncate()
+                data_to_dump_with_server_args["server_args"] = None
+                pickle.dump(data_to_dump_with_server_args, f)
         logger.error(
             f"Dumped {len(self.crash_dump_request_list)} finished and {len(unfinished_requests)} unfinished requests before crash to {filename}"
         )


### PR DESCRIPTION
## Motivation

Two issues with `/configure_logging` request dumps surfaced under `--trust-remote-code` + MoE models:

1. **Pickle fails silently** — `ServerArgs.get_model_config()` lazily attaches a `ModelConfig` whose `hf_config` lives under the dynamic `transformers_modules.*` namespace and isn't safely picklable. Both `_dump_data_to_file` and `dump_requests_before_crash` then leave an empty/corrupt `.pkl` and the request data is lost.
2. **Dumps balloon** — with `--enable-routing-replay` each finished request stashes a base64'd `routed_experts` tensor in `meta_info`; same for `hidden_states` under `--return-hidden-states`. Neither is used by the replay tooling.

## Modifications

- **Pickle safety**: wrap the dump in try/except in both `_dump_data_to_file` and `dump_requests_before_crash`; on failure, retry with `server_args=None` so request data is still persisted.
- **`meta_info` key filtering**: new `dump_requests_exclude_meta_keys` field on `TokenizerManager` and `ConfigureLoggingReq`, defaulting to `["routed_experts", "hidden_states"]`. Strips those keys from `meta_info` via a shallow copy in `dump_requests` (does not mutate the original `out_dict`).
- **CLI**: `python -m sglang.srt.managers.configure_logging --dump-requests-exclude-meta-keys 'a,b,c'` (empty string keeps all). Pass `[]` to `/configure_logging` to restore previous behavior.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Update documentation / docstrings as needed.
- [x] For reviewers: if you intend to acknowledge my contribution, please do so by including `Co-authored-by: bingyuhsu <byronhsu1230@gmail.com>` in the commit message after the PR is merged.
