### PR TITLE
[HiSparse & PD] support context input length > max_total_num_tokens

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -478,6 +478,8 @@ class DecodePreallocQueue:
 
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
         if len(req.origin_input_ids) > self.max_total_num_tokens:
+            if self.scheduler.enable_hisparse and len(req.origin_input_ids) <= self.scheduler.hisparse_max_req_len:
+                return False
             message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
             logger.error(message)
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1861,7 +1861,7 @@ class Scheduler(
         )
 
     def init_req_max_new_tokens(self, req):
-        if self.enable_hisparse:
+        if self.enable_hisparse and self.disaggregation_mode == DisaggregationMode.DECODE:
             max_req_len = self.hisparse_max_req_len
         else:
             max_req_len = self.max_req_len
@@ -2136,7 +2136,7 @@ class Scheduler(
 
         max_input_len = (
             self.hisparse_max_req_len - 5
-            if self.enable_hisparse
+            if self.enable_hisparse and self.disaggregation_mode == DisaggregationMode.DECODE
             else self.max_req_input_len
         )
         # Validate prompt length
@@ -2386,7 +2386,7 @@ class Scheduler(
 
         max_input_len = (
             self.hisparse_max_req_len - 5
-            if self.enable_hisparse
+            if self.enable_hisparse and self.disaggregation_mode == DisaggregationMode.DECODE
             else self.max_req_input_len
         )
         # Validate prompt length

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1853,14 +1853,25 @@ class Scheduler(
         if self.external_corpus_manager is not None:
             self.external_corpus_manager.check_pending_load()
 
+    @property
+    def hisparse_max_req_len(self):
+        return min(
+            self.model_config.context_len - 1,
+            self.hisparse_coordinator.mem_pool_host.size - 1,
+        )
+
     def init_req_max_new_tokens(self, req):
+        if self.enable_hisparse:
+            max_req_len = self.hisparse_max_req_len
+        else:
+            max_req_len = self.max_req_len
         req.sampling_params.max_new_tokens = min(
             (
                 req.sampling_params.max_new_tokens
                 if req.sampling_params.max_new_tokens is not None
                 else 1 << 30
             ),
-            self.max_req_len - len(req.origin_input_ids) - 1,
+            max_req_len - len(req.origin_input_ids) - 1,
         )
 
     def _process_and_broadcast_mm_inputs(
@@ -2123,12 +2134,13 @@ class Scheduler(
         # initialize before returning
         self.init_req_max_new_tokens(req)
 
-        # Validate prompt length
-        error_msg = validate_input_length(
-            req,
-            self.max_req_input_len,
-            self.server_args.allow_auto_truncate,
+        max_input_len = (
+            self.hisparse_max_req_len - 5
+            if self.enable_hisparse
+            else self.max_req_input_len
         )
+        # Validate prompt length
+        error_msg = validate_input_length(req, max_input_len, self.server_args.allow_auto_truncate)
         if error_msg:
             req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
@@ -2372,12 +2384,13 @@ class Scheduler(
                 self._add_request_to_queue(req)
                 return
 
-        # Validate prompts length
-        error_msg = validate_input_length(
-            req,
-            self.max_req_input_len,
-            self.server_args.allow_auto_truncate,
+        max_input_len = (
+            self.hisparse_max_req_len - 5
+            if self.enable_hisparse
+            else self.max_req_input_len
         )
+        # Validate prompt length
+        error_msg = validate_input_length(req, max_input_len, self.server_args.allow_auto_truncate)
         if error_msg:
             self._add_request_to_queue(req)
             return


### PR DESCRIPTION
## Motivation

HiSparse is designed to save GPU memory by keeping the bulk of KV on the host pool and only staging a small `device_buffer_size` (e.g. 4096) per request on the GPU. However, request admission today is still gated by `max_total_num_tokens` (the GPU KV capacity), which defeats the purpose of HiSparse in long-context, memory-constrained applications within PD-disaggregation scenarios.

Concretely, when `context_len > max_total_num_tokens`, the scheduler rejects a request even though:

1. `logical_attn_allocator` has enough headroom to hold the request's logical slots and the host pool has enough capacity to hold the full KV.
2. `hisparse_attn_allocator` has enough free space to reserve one `device_buffer_size` window for the request.

In other words, the admission check enforces "the GPU must be able to fit the entire request" — a constraint that does not actually apply under HiSparse, where each running request only needs `device_buffer_size` on the GPU at a time. As a result, HiSparse cannot reach its full potential on long-context workloads.

This PR fixes the admission bound so that HiSparse requests are gated by what HiSparse actually needs, not by the GPU full-context capacity.

## Modifications

- **`srt/managers/scheduler.py`**: introduce `Scheduler.hisparse_max_req_len` as a single source of truth for the HiSparse-mode upper bound on request length:
  ```python
  @property
  def hisparse_max_req_len(self):
      return min(
          self.model_config.context_len - 1,
          self.hisparse_coordinator.mem_pool_host.size - 1,
      )
  ```
  The same expression was previously duplicated in three places (`init_req_max_new_tokens` and two `max_input_len` computations). All three call sites now use the property.

- **`srt/disaggregation/decode.py`**: in `DecodePreallocQueue._check_if_req_exceed_kv_capacity`, if HiSparse, check `hisparse_max_req_len` instead of `max_total_num_tokens`.

## Accuracy Tests
Under PD-disaggregation decode side, with --hisparse-config '{"top_k": 2048, "device_buffer_size": 4096, "host_to_device_ratio": 12}' --context-length 1048576
```
[2026-05-09 04:41:36 DP0 TP0 EP0] logical_attn_allocator size: 2397696, hisparse_attn_allocator size: 199808
...
[2026-05-09 04:42:36 DP0 TP0 EP0] max_total_num_tokens=199808, chunked_prefill_size=1024, max_prefill_tokens=1048576, max_running_requests=64, context_len=1048576, available_gpu_mem=4.95 GB
...
[2026-05-09 04:44:08 DP1 TP1 EP1] Decode batch, #running-req: 1, #gpu token: 4160, gpu token usage: 0.02, #cpu token: 1024074, cpu token usage: 0.43, pre-allocated usage: 0.00, #prealloc-req: 0, #transfer-req: 0, #retracted-req: 0, cuda graph: True, gen throughput (token/s): 49.53, #queue-req: 0
```

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
