### PR TITLE
Fix PD bootstrap failure handling

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -608,6 +608,8 @@ class CommonKVReceiver(BaseKVReceiver):
 
         self.prefill_dp_rank = prefill_dp_rank
         self._setup_bootstrap_infos()
+        if self.conclude_state == KVPoll.Failed:
+            return
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.WaitingForInput)
 
     def _setup_bootstrap_infos(self):
@@ -650,6 +652,7 @@ class CommonKVReceiver(BaseKVReceiver):
                             self.kv_mgr.update_status(
                                 self.bootstrap_room, KVPoll.Failed
                             )
+                            self.bootstrap_infos = None
                             return
 
                 self.bootstrap_infos = bootstrap_infos

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -562,6 +562,18 @@ class DataParallelController:
 
     def maybe_external_dp_rank_routing(self, req: Req):
         if req.routed_dp_rank is not None:
+            # In PD-prefill mode the cross-engine contract is `bootstrap_room`:
+            # the decode-side KV receiver locates the prefill DP rank via
+            # `bootstrap_room % prefill_dp_size`. Honoring an externally-set
+            # `routed_dp_rank` here breaks that contract whenever the two
+            # diverge (e.g., dynamo's KV router picks a rank for load-balance
+            # reasons that has no relation to `bootstrap_room`). Fall through
+            # to follow_bootstrap_room dispatch to keep prefill ↔ decode aligned.
+            if (
+                self.server_args.disaggregation_mode == "prefill"
+                and req.bootstrap_room is not None
+            ):
+                return False
             logger.debug(f"Direct routing to DP rank {req.routed_dp_rank}")
             self.workers[req.routed_dp_rank].send_pyobj(req)
             return True

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -562,18 +562,6 @@ class DataParallelController:
 
     def maybe_external_dp_rank_routing(self, req: Req):
         if req.routed_dp_rank is not None:
-            # In PD-prefill mode the cross-engine contract is `bootstrap_room`:
-            # the decode-side KV receiver locates the prefill DP rank via
-            # `bootstrap_room % prefill_dp_size`. Honoring an externally-set
-            # `routed_dp_rank` here breaks that contract whenever the two
-            # diverge (e.g., dynamo's KV router picks a rank for load-balance
-            # reasons that has no relation to `bootstrap_room`). Fall through
-            # to follow_bootstrap_room dispatch to keep prefill ↔ decode aligned.
-            if (
-                self.server_args.disaggregation_mode == "prefill"
-                and req.bootstrap_room is not None
-            ):
-                return False
             logger.debug(f"Direct routing to DP rank {req.routed_dp_rank}")
             self.workers[req.routed_dp_rank].send_pyobj(req)
             return True


### PR DESCRIPTION
## Summary
- Set `self.bootstrap_infos = None` on bootstrap info fetch failure so downstream code hits the None-check instead of `AttributeError`
- Skip `update_status(WaitingForInput)` when `_setup_bootstrap_infos` already marked the request as `Failed`

Ported from sgl-project/sglang@48135b23711550960019fc9f5adcc48818923c68

## Test plan
- [ ] PD disaggregation with bootstrap failure (e.g. prefill server down)