### PR TITLE
fix: add explicit UTF-8 encoding when loading chat/completion templates

### DIFF
--- a/python/sglang/srt/managers/template_manager.py
+++ b/python/sglang/srt/managers/template_manager.py
@@ -264,7 +264,7 @@ class TemplateManager:
         self, tokenizer_manager: TokenizerManager, template_path: str
     ) -> None:
         """Load a Jinja template file."""
-        with open(template_path, "r") as f:
+        with open(template_path, "r", encoding="utf-8") as f:
             chat_template = "".join(f.readlines()).strip("\n")
         tokenizer_manager.tokenizer.chat_template = chat_template.replace("\\n", "\n")
         self._chat_template_name = None
@@ -282,7 +282,7 @@ class TemplateManager:
             ".json"
         ), "unrecognized format of chat template file"
 
-        with open(template_path, "r") as filep:
+        with open(template_path, "r", encoding="utf-8") as filep:
             template = json.load(filep)
             try:
                 sep_style = SeparatorStyle[template["sep_style"]]
@@ -311,7 +311,7 @@ class TemplateManager:
             ".json"
         ), "unrecognized format of completion template file"
 
-        with open(template_path, "r") as filep:
+        with open(template_path, "r", encoding="utf-8") as filep:
             template = json.load(filep)
             try:
                 fim_position = FimPosition[template["fim_position"]]


### PR DESCRIPTION
## Motivation

`TemplateManager` opens user-supplied chat/completion template files without specifying an encoding:

- `_load_jinja_template` — `python/sglang/srt/managers/template_manager.py:267`
- `_load_json_chat_template` — `python/sglang/srt/managers/template_manager.py:285`
- `_load_json_completion_template` — `python/sglang/srt/managers/template_manager.py:314`

On platforms whose default text encoding is not UTF-8 (notably Windows, where `locale.getpreferredencoding()` is typically `cp1252` or `gbk`), templates that contain non-ASCII characters fail to load with a `UnicodeDecodeError`. This is a common situation in practice — templates with Chinese/CJK system prompts, multilingual instructions, or special tokens with non-ASCII bytes are widely used.

## Modifications

Add `encoding="utf-8"` to the three `open()` calls in `template_manager.py`. This matches the convention already used elsewhere in the codebase, e.g.:

- `python/sglang/auto_benchmark_lib.py` — many `open(..., encoding="utf-8")` calls
- `python/sglang/srt/compilation/backend.py:85` — config cache
- `python/sglang/check_env.py:359` — version file
- `python/sglang/srt/speculative/cpp_ngram/external_corpus.py:26` — corpus reader

## Accuracy Tests

No behavior change for ASCII-only template files. For non-ASCII templates that previously failed on Windows, loading now succeeds.

## Benchmarking and Profiling

N/A — read-time encoding fix; no runtime hot-path impact.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging and squashing commits to maintain a clean commit history.