### PR TITLE
docs: clarify how /tag-and-rerun-ci kicks off CI on the current commit

### DIFF
--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -110,9 +110,9 @@ Users with permission are listed in the [CI_PERMISSIONS.json](https://github.com
 
 For CI to run on a pull request, it must have the "run-ci" label. Authorized users can add the label or rerun failed tests by commenting on the PR with one of these commands:
 
-- `/tag-run-ci-label`: Adds the "run-ci" label. Every future commit will trigger CI.
-- `/rerun-failed-ci`: Reruns the failed or flaky tests from the most recent commit.
-- `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`.
+- `/tag-run-ci-label`: Adds the "run-ci" label. By itself, this only causes **future** commits to trigger CI; existing skipped workflow runs on the current commit are not retried.
+- `/rerun-failed-ci`: Reruns workflows from the latest commit that finished as **failed, flaky, or skipped**.
+- `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`. This is the standard way to kick off CI on the current commit when the PR did not have the `run-ci` label when it was pushed — adding the label alone does nothing for the current commit, but the rerun then picks up the now-skipped workflow runs and re-dispatches them with the label in place.
 - `/rerun-stage <stage-name>`: Reruns a specific test stage without waiting for its dependencies. This is useful when you want to quickly validate a fix for a specific test failure instead of waiting ~30 minutes for preceding stages to complete.
 
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).

--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -115,6 +115,8 @@ For CI to run on a pull request, it must have the "run-ci" label. Authorized use
 - `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`. This is the standard way to kick off CI on the current commit when the PR did not have the `run-ci` label when it was pushed — adding the label alone does nothing for the current commit, but the rerun then picks up the now-skipped workflow runs and re-dispatches them with the label in place.
 - `/rerun-stage <stage-name>`: Reruns a specific test stage without waiting for its dependencies. This is useful when you want to quickly validate a fix for a specific test failure instead of waiting ~30 minutes for preceding stages to complete.
 
+> **Tip:** Just opened a fresh PR and want CI to run on the latest commit? Comment `/tag-and-rerun-ci`. `/tag-run-ci-label` alone won't run anything until you push another commit.
+
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).
 
 To avoid spamming a PR with too many `/rerun-failed-ci` comments, you can also trigger the command by editing an existing comment and adding any suffix (e.g., `/rerun-failed-ci try again`).

--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -110,12 +110,10 @@ Users with permission are listed in the [CI_PERMISSIONS.json](https://github.com
 
 For CI to run on a pull request, it must have the "run-ci" label. Authorized users can add the label or rerun failed tests by commenting on the PR with one of these commands:
 
-- `/tag-run-ci-label`: Adds the "run-ci" label. By itself, this only causes **future** commits to trigger CI; existing skipped workflow runs on the current commit are not retried.
-- `/rerun-failed-ci`: Reruns workflows from the latest commit that finished as **failed, flaky, or skipped**.
-- `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`. This is the standard way to kick off CI on the current commit when the PR did not have the `run-ci` label when it was pushed — adding the label alone does nothing for the current commit, but the rerun then picks up the now-skipped workflow runs and re-dispatches them with the label in place.
-- `/rerun-stage <stage-name>`: Reruns a specific test stage without waiting for its dependencies. This is useful when you want to quickly validate a fix for a specific test failure instead of waiting ~30 minutes for preceding stages to complete.
-
-> **Tip:** Just opened a fresh PR and want CI to run on the latest commit? Comment `/tag-and-rerun-ci`. `/tag-run-ci-label` alone won't run anything until you push another commit.
+- `/tag-run-ci-label`: Adds the "run-ci" label. Only **future** commits trigger CI; the current commit is unaffected.
+- `/rerun-failed-ci`: Reruns workflows from the latest commit with conclusion **failed, flaky, or skipped**.
+- `/tag-and-rerun-ci`: Runs both. Use this on a fresh PR to kick off CI on the current commit — `/tag-run-ci-label` alone won't.
+- `/rerun-stage <stage-name>`: Reruns a single test stage without waiting for its dependencies. Useful for quickly validating a specific test fix instead of waiting ~30 minutes for preceding stages.
 
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).
 

--- a/docs/platforms/ascend/ascend_contribution_guide.md
+++ b/docs/platforms/ascend/ascend_contribution_guide.md
@@ -90,12 +90,10 @@ Users with permission are listed in the [CI_PERMISSIONS.json](https://github.com
 
 For CI to run on a pull request, it must have the "run-ci" label. Authorized users can add the label or rerun failed tests by commenting on the PR with one of these commands:
 
-- `/tag-run-ci-label`: Adds the "run-ci" label. By itself, this only causes **future** commits to trigger CI; existing skipped workflow runs on the current commit are not retried.
-- `/rerun-failed-ci`: Reruns workflows from the latest commit that finished as **failed, flaky, or skipped**.
-- `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`. This is the standard way to kick off CI on the current commit when the PR did not have the `run-ci` label when it was pushed — adding the label alone does nothing for the current commit, but the rerun then picks up the now-skipped workflow runs and re-dispatches them with the label in place.
-- `/rerun-stage <stage-name>`: Reruns a specific test stage without waiting for its dependencies. This is useful when you want to quickly validate a fix for a specific test failure instead of waiting ~30 minutes for preceding stages to complete.
-
-> **Tip:** Just opened a fresh PR and want CI to run on the latest commit? Comment `/tag-and-rerun-ci`. `/tag-run-ci-label` alone won't run anything until you push another commit.
+- `/tag-run-ci-label`: Adds the "run-ci" label. Only **future** commits trigger CI; the current commit is unaffected.
+- `/rerun-failed-ci`: Reruns workflows from the latest commit with conclusion **failed, flaky, or skipped**.
+- `/tag-and-rerun-ci`: Runs both. Use this on a fresh PR to kick off CI on the current commit — `/tag-run-ci-label` alone won't.
+- `/rerun-stage <stage-name>`: Reruns a single test stage without waiting for its dependencies. Useful for quickly validating a specific test fix instead of waiting ~30 minutes for preceding stages.
 
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).
 

--- a/docs/platforms/ascend/ascend_contribution_guide.md
+++ b/docs/platforms/ascend/ascend_contribution_guide.md
@@ -90,9 +90,9 @@ Users with permission are listed in the [CI_PERMISSIONS.json](https://github.com
 
 For CI to run on a pull request, it must have the "run-ci" label. Authorized users can add the label or rerun failed tests by commenting on the PR with one of these commands:
 
-- `/tag-run-ci-label`: Adds the "run-ci" label. Every future commit will trigger CI.
-- `/rerun-failed-ci`: Reruns the failed or flaky tests from the most recent commit.
-- `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`.
+- `/tag-run-ci-label`: Adds the "run-ci" label. By itself, this only causes **future** commits to trigger CI; existing skipped workflow runs on the current commit are not retried.
+- `/rerun-failed-ci`: Reruns workflows from the latest commit that finished as **failed, flaky, or skipped**.
+- `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`. This is the standard way to kick off CI on the current commit when the PR did not have the `run-ci` label when it was pushed — adding the label alone does nothing for the current commit, but the rerun then picks up the now-skipped workflow runs and re-dispatches them with the label in place.
 - `/rerun-stage <stage-name>`: Reruns a specific test stage without waiting for its dependencies. This is useful when you want to quickly validate a fix for a specific test failure instead of waiting ~30 minutes for preceding stages to complete.
 
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).

--- a/docs/platforms/ascend/ascend_contribution_guide.md
+++ b/docs/platforms/ascend/ascend_contribution_guide.md
@@ -95,6 +95,8 @@ For CI to run on a pull request, it must have the "run-ci" label. Authorized use
 - `/tag-and-rerun-ci`: A single command that performs both `/tag-run-ci-label` and `/rerun-failed-ci`. This is the standard way to kick off CI on the current commit when the PR did not have the `run-ci` label when it was pushed — adding the label alone does nothing for the current commit, but the rerun then picks up the now-skipped workflow runs and re-dispatches them with the label in place.
 - `/rerun-stage <stage-name>`: Reruns a specific test stage without waiting for its dependencies. This is useful when you want to quickly validate a fix for a specific test failure instead of waiting ~30 minutes for preceding stages to complete.
 
+> **Tip:** Just opened a fresh PR and want CI to run on the latest commit? Comment `/tag-and-rerun-ci`. `/tag-run-ci-label` alone won't run anything until you push another commit.
+
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).
 
 To avoid spamming a PR with too many `/rerun-failed-ci` comments, you can also trigger the command by editing an existing comment and adding any suffix (e.g., `/rerun-failed-ci try again`).


### PR DESCRIPTION
## Motivation

The contribution guide makes `/tag-and-rerun-ci` look like just "label-add + rerun failed tests", which leaves people unsure why it actually triggers CI on the current commit of a freshly-pushed unlabeled PR.

In practice, [`handle_rerun_failed_ci`](https://github.com/sgl-project/sglang/blob/main/scripts/ci/utils/slash_command_handler.py) reruns workflows with conclusion `failure` **or `skipped`**. Test jobs on an unlabeled PR finish as `skipped`, so `/rerun-failed-ci` re-dispatches them — and once the label is added by `/tag-run-ci-label`, the gate passes and the tests actually run.

## Modifications

Tightens the four bullet descriptions in `docs/developer_guide/contribution_guide.md` and `docs/platforms/ascend/ascend_contribution_guide.md`:

- `/tag-run-ci-label`: only **future** commits trigger CI.
- `/rerun-failed-ci`: reruns workflows with conclusion **failed, flaky, or skipped**.
- `/tag-and-rerun-ci`: use this on a fresh PR to kick off CI on the current commit.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Update documentation / docstrings as needed.
- [x] For reviewers: if you intend to acknowledge my contribution, please do so by including `Co-authored-by: bingyuhsu <byronhsu1230@gmail.com>` in the commit message after the PR is merged.
