### PR TITLE
fix MTP child_key index out of range

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -628,7 +628,7 @@ class UnifiedRadixCache(BasePrefixCache):
         self, key: RadixKey
     ) -> tuple[list[torch.Tensor], UnifiedTreeNode, int]:
         node = self.root_node
-        child_key = key.child_key(self.page_size)
+        child_key = key.child_key(self.page_size) if len(key) else None
         value: list[torch.Tensor] = []
         best_value_len = 0
         best_node = node


### PR DESCRIPTION
## Motivation

The following error occurs when launching DeepSeek V4 with HiCache + MTP:
```
DP1 TP1 EP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 3972, in run_scheduler_process
    scheduler.run_event_loop()
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 1523, in run_event_loop
    dispatch_event_loop(self)
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 3842, in dispatch_event_loop
    scheduler.event_loop_overlap()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 1572, in event_loop_overlap
    batch = self.get_next_batch_to_run()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 2518, in get_next_batch_to_run
    new_batch = self.get_new_batch_prefill()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 2572, in get_new_batch_prefill
    ret = self._get_new_batch_prefill_raw(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 2702, in _get_new_batch_prefill_raw
    req.init_next_round_input(self.tree_cache)
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/schedule_batch.py", line 1029, in init_next_round_input
    match_result = tree_cache.match_prefix(
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/unified_radix_cache.py", line 352, in match_prefix
    value, last_node, best_value_len = self._match_prefix_helper(key)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/unified_radix_cache.py", line 631, in _match_prefix_helper
    child_key = key.child_key(self.page_size)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/radix_cache.py", line 185, in child_key
    plain = tuple((t[j], t[j + 1]) for j in range(page_size))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/radix_cache.py", line 185, in <genexpr>
    plain = tuple((t[j], t[j + 1]) for j in range(page_size))
                   ~^^^
IndexError: list index out of range
```
The error occurs when key is empty, this PR fix this.

## Modifications

```
child_key = key.child_key(self.page_size) if len(key) else None
```

## Accuracy Tests

None

## Speed Tests and Profiling

None

## Checklist

- [Y] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
