### PR TITLE
fix UnifiedRadixCache MTP child_key index out of range

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -287,6 +287,16 @@ class UnifiedRadixCache(BasePrefixCache):
             self.cache_controller.reset()
             self.cache_controller.mem_pool_host.clear()
 
+        self._empty_match_result = MatchResult(
+            device_indices=torch.empty(
+                (0,),
+                dtype=torch.int64,
+                device=self.device,
+            ),
+            last_device_node=self.root_node,
+            last_host_node=self.root_node,
+        )
+
     def init_hicache(self, server_args: ServerArgs, params: CacheInitParams) -> None:
         """Initialize HiCache infrastructure."""
         from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
@@ -340,16 +350,10 @@ class UnifiedRadixCache(BasePrefixCache):
         key = params.key
         key, _ = key.maybe_to_bigram_view(self.is_eagle)
         if self.disable or len(key) == 0:
-            return MatchResult(
-                device_indices=torch.empty(
-                    (0,),
-                    dtype=torch.int64,
-                    device=self.device,
-                ),
-                last_device_node=self.root_node,
-                last_host_node=self.root_node,
-            )
+            return self._empty_match_result
         key = key.page_aligned(self.page_size)
+        if len(key) == 0:
+            return self._empty_match_result
 
         value, last_node, best_value_len = self._match_prefix_helper(key)
         return self._match_post_processor(params, value, last_node, best_value_len)
@@ -703,7 +707,7 @@ class UnifiedRadixCache(BasePrefixCache):
         if best_value_len > 0:
             device_indices = torch.cat(value[:best_value_len])
         else:
-            device_indices = torch.empty((0,), dtype=torch.int64, device=self.device)
+            device_indices = self._empty_match_result.device_indices
         result = MatchResult(
             device_indices=device_indices,
             last_device_node=last_device_node,
@@ -1397,7 +1401,7 @@ class UnifiedRadixCache(BasePrefixCache):
                 last_node = last_node.parent
 
         return (
-            torch.empty((0,), dtype=torch.int64, device=self.device),
+            self._empty_match_result.device_indices,
             last_node,
         )
 


### PR DESCRIPTION
## Motivation

The following error occurs when launching DeepSeek V4 with HiCache + MTP:
```
DP1 TP1 EP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 3972, in run_scheduler_process
    scheduler.run_event_loop()
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 1523, in run_event_loop
    dispatch_event_loop(self)
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 3842, in dispatch_event_loop
    scheduler.event_loop_overlap()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 1572, in event_loop_overlap
    batch = self.get_next_batch_to_run()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 2518, in get_next_batch_to_run
    new_batch = self.get_new_batch_prefill()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 2572, in get_new_batch_prefill
    ret = self._get_new_batch_prefill_raw(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/scheduler.py", line 2702, in _get_new_batch_prefill_raw
    req.init_next_round_input(self.tree_cache)
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/managers/schedule_batch.py", line 1029, in init_next_round_input
    match_result = tree_cache.match_prefix(
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/unified_radix_cache.py", line 352, in match_prefix
    value, last_node, best_value_len = self._match_prefix_helper(key)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/unified_radix_cache.py", line 631, in _match_prefix_helper
    child_key = key.child_key(self.page_size)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/radix_cache.py", line 185, in child_key
    plain = tuple((t[j], t[j + 1]) for j in range(page_size))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/luchangli/dsv4_hicache/sglang/python/sglang/srt/mem_cache/radix_cache.py", line 185, in <genexpr>
    plain = tuple((t[j], t[j + 1]) for j in range(page_size))
                   ~^^^
IndexError: list index out of range
```
The error occurs when key is empty, this PR fix this.



## Accuracy Tests

None

## Speed Tests and Profiling

None

## Checklist

- [Y] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
