### PR TITLE
[Spec] Introduce `EagleDraftExtendInput`; eliminate hidden_states phase-shift

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3025,6 +3025,10 @@ class Scheduler(
                 batch_result = self.model_worker.forward_batch_generation(
                     worker_batch_or_batch, **kwargs
                 )
+                if batch_result.next_draft_input is not None:
+                    # V1 spec: relay this iter's draft-extend output as next
+                    # iter's draft spec_info (mirrors the V2 path above).
+                    batch.spec_info = batch_result.next_draft_input
                 future_indices_or_next_token_ids = batch_result.next_token_ids
                 self.update_cache_from_scheduler(batch, batch_result)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3018,14 +3018,15 @@ class Scheduler(
                 future_indices_or_next_token_ids = batch_result.next_token_ids
                 self.update_cache_from_scheduler(batch, batch_result)
 
-            # Unified relay: this iter's draft-extend output becomes next
-            # iter's draft spec_info. V1 + V2 share this install.
             if batch_result.next_draft_input is not None:
                 batch.spec_info = batch_result.next_draft_input
                 if batch.is_spec_v2:
-                    # V2 overlap extras: thread future_indices into spec_info
-                    # and override batch.seq_lens with the post-verify lengths.
+                    # FIXME(lsyin): tmp code for spec v2
+                    # We only keep future indices for next draft input
                     batch.spec_info.future_indices = future_indices
+
+                    # The future value, usually for next batch preparation
+                    # Current implementation strictly synchronizes the seq_lens
                     batch.seq_lens = batch_result.next_draft_input.new_seq_lens
 
             # NOTE: future_indices_or_next_token_ids is used in ScheduleBatch,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2974,6 +2974,7 @@ class Scheduler(
                 # TODO(lsyin): delete this branch after unifying the abstraction.
                 worker_batch_or_batch = batch
 
+            future_indices = None
             if self.enable_overlap:
                 model_worker_batch = worker_batch_or_batch
                 self.record_batch_in_overlap(model_worker_batch)
@@ -3002,17 +3003,6 @@ class Scheduler(
 
                 # FIXME(lsyin): move this assignment elsewhere
                 future_indices_or_next_token_ids = -future_indices.indices
-
-                if batch.is_spec_v2:
-                    # FIXME(lsyin): tmp code for spec v2
-                    # We only keep future indices for next draft input
-
-                    batch.spec_info = batch_result.next_draft_input
-                    batch.spec_info.future_indices = future_indices
-
-                    # The future value, usually for next batch preparation
-                    # Current implementation strictly synchronizes the seq_lens
-                    batch.seq_lens = batch_result.next_draft_input.new_seq_lens
             elif self.enable_pdmux and batch.forward_mode.is_split_prefill():
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)
                 future_indices_or_next_token_ids = batch_result.next_token_ids
@@ -3025,12 +3015,18 @@ class Scheduler(
                 batch_result = self.model_worker.forward_batch_generation(
                     worker_batch_or_batch, **kwargs
                 )
-                if batch_result.next_draft_input is not None:
-                    # V1 spec: relay this iter's draft-extend output as next
-                    # iter's draft spec_info (mirrors the V2 path above).
-                    batch.spec_info = batch_result.next_draft_input
                 future_indices_or_next_token_ids = batch_result.next_token_ids
                 self.update_cache_from_scheduler(batch, batch_result)
+
+            # Unified relay: this iter's draft-extend output becomes next
+            # iter's draft spec_info. V1 + V2 share this install.
+            if batch_result.next_draft_input is not None:
+                batch.spec_info = batch_result.next_draft_input
+                if batch.is_spec_v2:
+                    # V2 overlap extras: thread future_indices into spec_info
+                    # and override batch.seq_lens with the post-verify lengths.
+                    batch.spec_info.future_indices = future_indices
+                    batch.seq_lens = batch_result.next_draft_input.new_seq_lens
 
             # NOTE: future_indices_or_next_token_ids is used in ScheduleBatch,
             #       which can probably be replaced by future_indices later [TODO(lsyin)].

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -16,7 +16,10 @@ from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import GenerationBatchResult
-    from sglang.srt.speculative.eagle_info import EagleDraftInput
+    from sglang.srt.speculative.eagle_info import (
+        EagleDraftExtendInput,
+        EagleDraftInput,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +50,9 @@ class GenerationBatchResult:
 
     # relay path: forward stream -> next step forward
     next_draft_input: Optional[EagleDraftInput] = None
+    # V2 only: draft-extend spec_info produced by verify, installed by
+    # `_draft_extend_for_decode` before the draft-extend forward.
+    next_draft_extend_input: Optional[EagleDraftExtendInput] = None
 
     # Routed experts: pending async D2H for overlap scheduling
     routed_experts_output: Optional[TopkCaptureOutput] = None

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -16,10 +16,7 @@ from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import GenerationBatchResult
-    from sglang.srt.speculative.eagle_info import (
-        EagleDraftExtendInput,
-        EagleDraftInput,
-    )
+    from sglang.srt.speculative.eagle_info import EagleDraftInput
 
 
 logger = logging.getLogger(__name__)
@@ -50,9 +47,6 @@ class GenerationBatchResult:
 
     # relay path: forward stream -> next step forward
     next_draft_input: Optional[EagleDraftInput] = None
-    # V2 only: draft-extend spec_info produced by verify, installed by
-    # `_draft_extend_for_decode` before the draft-extend forward.
-    next_draft_extend_input: Optional[EagleDraftExtendInput] = None
 
     # Routed experts: pending async D2H for overlap scheduling
     routed_experts_output: Optional[TopkCaptureOutput] = None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -993,9 +993,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             spec_info = self.spec_info
             self.output_cache_loc_backup = self.out_cache_loc
             self.hidden_states_backup = spec_info.hidden_states
-            if spec_info.topk_p is not None:
+            # `topk_p` / `topk_index` only live on `EagleDraftInput` (draft phase).
+            # `EagleDraftExtendInput` (draft-extend phase) doesn't have these,
+            # so use `getattr` so the guard skips cleanly there.
+            if getattr(spec_info, "topk_p", None) is not None:
                 spec_info.topk_p = self._pad_tensor_to_size(spec_info.topk_p, bs)
-            if spec_info.topk_index is not None:
+            if getattr(spec_info, "topk_index", None) is not None:
                 spec_info.topk_index = self._pad_tensor_to_size(
                     spec_info.topk_index, bs
                 )

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -999,7 +999,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 spec_info.topk_index = self._pad_tensor_to_size(
                     spec_info.topk_index, bs
                 )
-            if spec_info.num_accepted_drafts is not None:
+            # `num_accepted_*` only live on `EagleDraftExtendInput` (draft-extend
+            # phase). `EagleDraftInput` (draft phase) doesn't have these fields,
+            # so use `getattr` to skip when spec_info is the latter.
+            if getattr(spec_info, "num_accepted_drafts", None) is not None:
                 spec_info.num_accepted_drafts = self._pad_tensor_to_size(
                     spec_info.num_accepted_drafts, bs
                 )

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -365,7 +365,6 @@ class EAGLEDraftExtendCudaGraphRunner:
             num_accepted_drafts=num_accepted_drafts,
             num_accepted_tokens=num_accepted_tokens,
         )
-        spec_info.positions = None
 
         self.deepep_adapter.capture(is_extend_in_batch=True)
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -26,7 +26,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
 )
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
-from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 from sglang.srt.speculative.spec_utils import fast_topk
 from sglang.srt.utils import (
     require_attn_tp_gather,
@@ -360,7 +360,7 @@ class EAGLEDraftExtendCudaGraphRunner:
         else:
             global_dp_buffer_len = None
 
-        spec_info = EagleDraftInput(
+        spec_info = EagleDraftExtendInput(
             hidden_states=hidden_states,
             num_accepted_drafts=num_accepted_drafts,
             num_accepted_tokens=num_accepted_tokens,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -668,10 +668,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     # shape: (b, topk)
     topk_p: torch.Tensor = None
     topk_index: torch.Tensor = None
-    # shape: (b, hidden_size) when consumed by `draft` forward (one hidden per req);
-    # shape: (total_accepted, hidden_size) when consumed by `draft_extend` forward
-    # (one hidden per accepted token). Workers maintain this invariant locally;
-    # there is no type-level guard. Don't add new readers without checking phase.
+    # shape: (b, hidden_size) - one hidden per req, consumed by `draft` forward.
     hidden_states: torch.Tensor = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -240,15 +240,14 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
-            next_draft_input = EagleDraftInput.create_idle_input(
+            extend_input = EagleDraftExtendInput.create_idle_input(
                 device=batch.device,
                 hidden_size=batch.model_config.spec_hidden_size,
                 dtype=batch.model_config.dtype,
-                topk=self.topk,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
             return EagleVerifyOutput.create_idle(
-                next_draft_input=next_draft_input,
+                extend_input=extend_input,
                 logits_output=logits_output,
                 device=batch.device,
                 spec_steps=self.spec_steps,
@@ -545,7 +544,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             batch.seq_lens.add_(num_accepted_drafts + 1)
             batch.seq_lens_cpu.add_(num_accepted_tokens_cpu)
 
-            next_draft_input = EagleDraftInput(
+            extend_input = EagleDraftExtendInput(
                 hidden_states=batch.spec_info.hidden_states[accept_index],
                 num_accepted_drafts=num_accepted_drafts,
                 num_accepted_tokens=num_accepted_drafts + 1,
@@ -553,7 +552,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             )
 
             return EagleVerifyOutput(
-                next_draft_input=next_draft_input,
+                extend_input=extend_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 unfinished_accept_tokens=accept_tokens,
@@ -620,7 +619,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 req_pool_indices_for_draft_extend = batch.req_pool_indices[
                     unfinished_index_device
                 ]
-                next_draft_input = EagleDraftInput(
+                extend_input = EagleDraftExtendInput(
                     hidden_states=batch.spec_info.hidden_states[
                         unfinished_accept_index
                     ],
@@ -643,16 +642,15 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     dtype=batch.req_pool_indices.dtype,
                     device=batch.req_pool_indices.device,
                 )
-                next_draft_input = EagleDraftInput.create_idle_input(
+                extend_input = EagleDraftExtendInput.create_idle_input(
                     device=batch.device,
                     hidden_size=batch.model_config.spec_hidden_size,
                     dtype=batch.model_config.dtype,
-                    topk=self.topk,
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
 
             return EagleVerifyOutput(
-                next_draft_input=next_draft_input,
+                extend_input=extend_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 unfinished_accept_tokens=unfinished_accept_tokens,
@@ -677,17 +675,10 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     hidden_states: torch.Tensor = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
-    # Inputs for extend
-    # shape: (b,)
-    # `num_accepted_drafts` and `num_accepted_tokens` are kept in sync:
-    # `num_accepted_tokens = num_accepted_drafts + 1` (per-req, one bonus per req).
-    # Storing both avoids repeated `+ 1` at every consumer (attn backends, kernels).
+    # Per-req bonus token (the "+1" target prediction at the end of each accept
+    # chain). Set by `EagleDraftExtendInput.prepare_extend_after_decode`'s kernel
+    # via the worker's post-extend assembly.
     bonus_tokens: torch.Tensor = None
-    num_accepted_drafts: torch.Tensor = None
-    num_accepted_tokens: torch.Tensor = None
-    # Read by attention backends during draft-extend forward; kept on the
-    # dataclass because the backends access it via `forward_batch.spec_info`.
-    num_accepted_tokens_cpu: List[int] = None
 
     # Inputs for the attention backends
     # shape: (b + 1,)
@@ -741,47 +732,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             topk_index=torch.empty((0, topk), device=device, dtype=torch.int64),
             capture_hidden_mode=capture_hidden_mode,
             new_seq_lens=torch.empty((0,), device=device, dtype=torch.int32),
-            num_accepted_drafts=torch.empty((0,), device=device, dtype=torch.int32),
-            num_accepted_tokens=torch.empty((0,), device=device, dtype=torch.int32),
-            num_accepted_tokens_cpu=[],
-        )
-
-    def prepare_extend_after_decode(
-        self,
-        batch: ScheduleBatch,
-        verify_output: "EagleVerifyOutput",
-        speculative_num_steps: int,
-    ):
-
-        if batch.forward_mode.is_idle():
-            return
-
-        # All transient verify->extend handoff state is read off `verify_output`,
-        # not from `self`. The kernel below populates `self.bonus_tokens`
-        # ([bs] per-req) for the next decode round; that is the only state on
-        # `self` that survives past this method.
-        batch.input_ids = verify_output.unfinished_accept_tokens
-        batch.extend_lens = batch.spec_info.num_accepted_tokens_cpu
-        batch.extend_num_tokens = sum(batch.extend_lens)
-        batch.seq_lens = verify_output.seq_lens_for_draft_extend
-        batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
-        batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
-        batch.return_logprob = False
-        batch.return_hidden_states = False
-
-        self.capture_hidden_mode = CaptureHiddenMode.LAST
-        self.positions = torch.empty_like(batch.input_ids, dtype=torch.long)
-        self.bonus_tokens = torch.empty_like(
-            self.num_accepted_tokens, dtype=torch.int32
-        )
-
-        create_extend_after_decode_spec_info[(len(batch.seq_lens),)](
-            batch.input_ids,
-            batch.seq_lens,
-            self.num_accepted_tokens,
-            self.positions,
-            self.bonus_tokens,
-            next_power_of_2(max(speculative_num_steps + 1, len(batch.seq_lens))),
         )
 
     def generate_attn_arg_prefill(
@@ -872,9 +822,105 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
 
 @dataclass
+class EagleDraftExtendInput(SpecInput):
+    """Inputs to the draft-extend forward (the per-accepted-token pass after verify).
+
+    Lives on `batch.spec_info` only during the draft-extend forward pass.
+    After draft-extend completes, the worker assembles a fresh `EagleDraftInput`
+    for next iter and replaces `batch.spec_info`.
+
+    All fields here have single shapes (no phase-shift across phases).
+    """
+
+    # shape: (total_accepted, hidden_size). Sliced from verify-time hidden_states
+    # by accept_index; consumed by the draft-extend forward.
+    hidden_states: torch.Tensor = None
+
+    # Per-req accept counts. `num_accepted_tokens = num_accepted_drafts + 1`
+    # (one bonus per req). Both retained for cuda-graph buffer indexing and
+    # the `create_extend_after_decode_spec_info` kernel.
+    num_accepted_drafts: torch.Tensor = None
+    num_accepted_tokens: torch.Tensor = None
+    # CPU view, read by attention backends during the extend forward.
+    num_accepted_tokens_cpu: List[int] = None
+
+    # Set by `prepare_extend_after_decode`:
+    #   - positions: kernel-written, shape `[total_accepted]`.
+    #   - bonus_tokens: kernel-written, shape `[bs]`. The worker reads this
+    #     post-extend to populate next iter's `EagleDraftInput.bonus_tokens`.
+    positions: Optional[torch.Tensor] = None
+    bonus_tokens: Optional[torch.Tensor] = None
+
+    # Forward-pass config (set during prepare_extend / construction).
+    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST
+    num_tokens_per_req: int = -1
+    num_tokens_for_logprob_per_req: int = 1
+
+    def __post_init__(self):
+        super().__init__(SpecInputType.EAGLE_DRAFT_EXTEND)
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
+
+    @classmethod
+    def create_idle_input(
+        cls,
+        device: torch.device,
+        hidden_size: int,
+        dtype: torch.dtype,
+        capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST,
+    ) -> "EagleDraftExtendInput":
+        return cls(
+            hidden_states=torch.empty((0, hidden_size), device=device, dtype=dtype),
+            num_accepted_drafts=torch.empty((0,), device=device, dtype=torch.int32),
+            num_accepted_tokens=torch.empty((0,), device=device, dtype=torch.int32),
+            num_accepted_tokens_cpu=[],
+            capture_hidden_mode=capture_hidden_mode,
+        )
+
+    def prepare_extend_after_decode(
+        self,
+        batch: ScheduleBatch,
+        verify_output: "EagleVerifyOutput",
+        speculative_num_steps: int,
+    ):
+        if batch.forward_mode.is_idle():
+            return
+
+        # All transient verify->extend handoff state is read off `verify_output`.
+        # The kernel below populates `self.positions` and `self.bonus_tokens`;
+        # the worker reads `self.bonus_tokens` to construct next iter's
+        # `EagleDraftInput`.
+        batch.input_ids = verify_output.unfinished_accept_tokens
+        batch.extend_lens = self.num_accepted_tokens_cpu
+        batch.extend_num_tokens = sum(batch.extend_lens)
+        batch.seq_lens = verify_output.seq_lens_for_draft_extend
+        batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
+        batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
+        batch.return_logprob = False
+        batch.return_hidden_states = False
+
+        self.capture_hidden_mode = CaptureHiddenMode.LAST
+        self.positions = torch.empty_like(batch.input_ids, dtype=torch.long)
+        self.bonus_tokens = torch.empty_like(
+            self.num_accepted_tokens, dtype=torch.int32
+        )
+
+        create_extend_after_decode_spec_info[(len(batch.seq_lens),)](
+            batch.input_ids,
+            batch.seq_lens,
+            self.num_accepted_tokens,
+            self.positions,
+            self.bonus_tokens,
+            next_power_of_2(max(speculative_num_steps + 1, len(batch.seq_lens))),
+        )
+
+
+@dataclass
 class EagleVerifyOutput:
-    # Next iter's persistent draft state, ready to be installed as `batch.spec_info`.
-    next_draft_input: EagleDraftInput
+    # Next iter's draft-extend input, ready to be installed as `batch.spec_info`
+    # for the draft-extend forward.
+    extend_input: EagleDraftExtendInput
     # Logit outputs from target worker.
     logits_output: LogitsProcessorOutput
     # All accepted tokens flat across all reqs incl. those that finished this
@@ -903,13 +949,13 @@ class EagleVerifyOutput:
     def create_idle(
         cls,
         *,
-        next_draft_input: EagleDraftInput,
+        extend_input: EagleDraftExtendInput,
         logits_output: LogitsProcessorOutput,
         device: torch.device,
         spec_steps: int,
     ) -> "EagleVerifyOutput":
         return cls(
-            next_draft_input=next_draft_input,
+            extend_input=extend_input,
             logits_output=logits_output,
             accept_tokens=torch.empty(0, dtype=torch.long, device=device),
             unfinished_accept_tokens=torch.empty(0, dtype=torch.long, device=device),

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -27,6 +27,7 @@ from sglang.srt.mem_cache.common import (
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.eagle_info_v2 import (
+    EagleDraftExtendInputV2Mixin,
     EagleDraftInputV2Mixin,
     EagleVerifyInputV2Mixin,
 )
@@ -667,10 +668,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     future_indices: Optional[FutureIndices] = None
     new_seq_lens: Optional[torch.Tensor] = None
     verify_done: Optional[torch.cuda.Event] = None
-    # V2 reuses `EagleDraftInput` across phases (V1 has a separate
-    # `EagleDraftExtendInput` for these). Set during V2's draft-extend.
-    num_accepted_drafts: Optional[torch.Tensor] = None
-    num_accepted_tokens: Optional[torch.Tensor] = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT)
@@ -768,7 +765,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
 
 @dataclass
-class EagleDraftExtendInput(SpecInput):
+class EagleDraftExtendInput(SpecInput, EagleDraftExtendInputV2Mixin):
     """Inputs to the draft-extend forward (the per-accepted-token pass after verify).
 
     Produced by `EagleVerifyInput.verify`, installed on `batch.spec_info` for

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -59,22 +59,36 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
+    """Inputs to the verify forward (target model verifies draft tokens).
+
+    All fields are common across V1 and V2 — the shape sits between the two
+    workers and TBO splitter.
+    """
+
+    # === common (V1 + V2) ===
+    # Tree structure consumed by the verify kernel.
     draft_token: torch.Tensor
     custom_mask: torch.Tensor
     positions: torch.Tensor
     retrieve_index: torch.Tensor
     retrieve_next_token: torch.Tensor
     retrieve_next_sibling: torch.Tensor
+    # Optional: filled by TBO `split_spec_info`; None outside TBO.
     retrieve_cum_len: torch.Tensor
+
+    # Per-step config.
     spec_steps: int
     topk: int
     draft_token_num: int
     capture_hidden_mode: CaptureHiddenMode
+
+    # Batch state (read by TBO splitter and cuda-graph runners).
     seq_lens_sum: int
     seq_lens_cpu: torch.Tensor
+
     grammar: BaseGrammarObject = None
 
-    # Shape info for padding
+    # Shape info for padding.
     num_tokens_per_req: int = -1  # -1 auto-fills from draft_token_num.
 
     def __post_init__(self):
@@ -645,29 +659,35 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
 
 @dataclass
 class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
+    """Inputs to the draft forward (proposes draft tokens for next verify)."""
+
+    # === common (V1 + V2) ===
+    # Per-req draft state, consumed by `draft` forward.
     # shape: (b, topk)
     topk_p: torch.Tensor = None
     topk_index: torch.Tensor = None
-    # shape: (b, hidden_size) - one hidden per req, consumed by `draft` forward.
+    # shape: (b, hidden_size) - one hidden per req.
     hidden_states: torch.Tensor = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
     # Per-req bonus token (the "+1" target prediction at end of each accept
-    # chain). Written by `EagleDraftExtendInput.prepare_extend_after_decode`;
-    # the worker copies it here for next iter's draft.
+    # chain). V1: written by `EagleDraftExtendInput.prepare_extend_after_decode`,
+    # then the worker copies it here. V2: set directly during verify.
     bonus_tokens: torch.Tensor = None
 
-    # shape: (b + 1,)
-    kv_indptr: torch.Tensor = None
-    kv_indices: torch.Tensor = None
-
+    # Shape info for padding.
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = -1
 
-    # V2 overlap worker only
+    # === V2 only (overlap scheduling) ===
     future_indices: Optional[FutureIndices] = None
     new_seq_lens: Optional[torch.Tensor] = None
     verify_done: Optional[torch.cuda.Event] = None
+
+    # === V1 only (filled by attention backends; V2 paths leave None) ===
+    # shape: (b + 1,) — populated by flashinfer/wave/aiter backends.
+    kv_indptr: torch.Tensor = None
+    kv_indices: torch.Tensor = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT)
@@ -768,44 +788,49 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 class EagleDraftExtendInput(SpecInput, EagleDraftExtendInputV2Mixin):
     """Inputs to the draft-extend forward (the per-accepted-token pass after verify).
 
-    Produced by `EagleVerifyInput.verify`, installed on `batch.spec_info` for
-    the draft-extend forward, then replaced with a fresh `EagleDraftInput` for
-    the next iter's draft.
+    Produced by `EagleVerifyInput.verify` (V1) or `EagleVerifyInput.sample` (V2),
+    installed on `batch.spec_info` for the draft-extend forward, then replaced
+    with a fresh `EagleDraftInput` for the next iter's draft.
     """
 
-    # shape: (total_accepted, hidden_size). Sliced from verify-time hidden_states
-    # by accept_index; consumed by the draft-extend forward.
+    # === common (V1 + V2) ===
+    # V1: shape (total_accepted, hidden_size), sliced from verify-time
+    #     hidden_states by accept_index.
+    # V2: shape (bs * draft_token_num, hidden_size), full target output (V2
+    #     selects accepted positions later via `select_index`).
     hidden_states: torch.Tensor = None
 
     # Per-req accept counts. `num_accepted_tokens = num_accepted_drafts + 1`.
-    # Both kept for cuda-graph buffer indexing and the
-    # `create_extend_after_decode_spec_info` kernel.
+    # V1: feeds `create_extend_after_decode_spec_info` kernel + cuda-graph
+    #     buffer indexing. V2: feeds attn backend + cuda-graph buffer indexing.
     num_accepted_drafts: torch.Tensor = None
     num_accepted_tokens: torch.Tensor = None
-    # CPU view, read by attention backends during the extend forward.
+
+    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST
+    num_tokens_per_req: int = -1
+    num_tokens_for_logprob_per_req: int = 1
+
+    # === V1 only (some synced via shared cuda-graph / attn backend infra) ===
+    # CPU view of `num_accepted_tokens`. V1 attn backends (flashattention,
+    # trtllm_mha) read it for `max_seq_len_q`; V2 paths leave None.
     num_accepted_tokens_cpu: List[int] = None
 
-    # Batch-state slices for the draft-extend forward. Set by verify (sliced to
-    # reqs continuing into next iter). `prepare_extend_after_decode` copies
-    # these onto `batch.{input_ids, seq_lens, seq_lens_cpu, req_pool_indices}`.
-    #   - input_ids:        accept tokens flat over surviving reqs
-    #   - seq_lens / _cpu:  per-req sequence length (post-accept)
-    #   - req_pool_indices: per-req kv-pool slot
+    # Batch-state slices for the draft-extend forward. V1 verify produces;
+    # `prepare_extend_after_decode` copies onto `batch.{input_ids, seq_lens,
+    # seq_lens_cpu, req_pool_indices}`. V2 manages batch fields directly via
+    # `prepare_for_extend_to_fill_draft_kvcache`, so leaves these None.
     input_ids: torch.Tensor = None
     seq_lens: torch.Tensor = None
     seq_lens_cpu: torch.Tensor = None
     req_pool_indices: torch.Tensor = None
 
-    # Set by `prepare_extend_after_decode`:
+    # Set by V1's `prepare_extend_after_decode` kernel; also written by the
+    # shared cuda-graph runner before replay (so V2 may see them populated).
     #   - positions: kernel-written, shape `[total_accepted]`.
-    #   - bonus_tokens: kernel-written, shape `[bs]`. The worker reads this
+    #   - bonus_tokens: kernel-written, shape `[bs]`. The V1 worker reads it
     #     post-extend to populate next iter's `EagleDraftInput.bonus_tokens`.
     positions: Optional[torch.Tensor] = None
     bonus_tokens: Optional[torch.Tensor] = None
-
-    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST
-    num_tokens_per_req: int = -1
-    num_tokens_for_logprob_per_req: int = 1
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT_EXTEND)

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -918,6 +918,10 @@ class EagleVerifyOutput:
     # Per-req accepted draft count (no bonus). V1 fills this for tracing /
     # adaptive controller; V2 leaves it None to avoid the CPU sync.
     num_accepted_drafts_per_req_cpu: Optional[List[int]] = None
+    # Whether the target verify forward ran a captured cuda graph. Set by
+    # the worker after `EagleVerifyInput.verify` returns; default kept so
+    # idle / direct constructions don't have to pass it.
+    can_run_cuda_graph: bool = False
 
     @classmethod
     def create_idle(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -667,6 +667,10 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     future_indices: Optional[FutureIndices] = None
     new_seq_lens: Optional[torch.Tensor] = None
     verify_done: Optional[torch.cuda.Event] = None
+    # V2 reuses `EagleDraftInput` across phases (V1 has a separate
+    # `EagleDraftExtendInput` for these). Set during V2's draft-extend.
+    num_accepted_drafts: Optional[torch.Tensor] = None
+    num_accepted_tokens: Optional[torch.Tensor] = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT)

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -240,14 +240,14 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
-            extend_input = EagleDraftExtendInput.create_idle_input(
+            draft_extend_input = EagleDraftExtendInput.create_idle_input(
                 device=batch.device,
                 hidden_size=batch.model_config.spec_hidden_size,
                 dtype=batch.model_config.dtype,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
             return EagleVerifyOutput.create_idle(
-                extend_input=extend_input,
+                draft_extend_input=draft_extend_input,
                 logits_output=logits_output,
                 device=batch.device,
                 spec_steps=self.spec_steps,
@@ -544,7 +544,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             batch.seq_lens.add_(num_accepted_drafts + 1)
             batch.seq_lens_cpu.add_(num_accepted_tokens_cpu)
 
-            extend_input = EagleDraftExtendInput(
+            draft_extend_input = EagleDraftExtendInput(
                 hidden_states=batch.spec_info.hidden_states[accept_index],
                 num_accepted_drafts=num_accepted_drafts,
                 num_accepted_tokens=num_accepted_drafts + 1,
@@ -552,7 +552,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             )
 
             return EagleVerifyOutput(
-                extend_input=extend_input,
+                draft_extend_input=draft_extend_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 unfinished_accept_tokens=accept_tokens,
@@ -619,7 +619,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 req_pool_indices_for_draft_extend = batch.req_pool_indices[
                     unfinished_index_device
                 ]
-                extend_input = EagleDraftExtendInput(
+                draft_extend_input = EagleDraftExtendInput(
                     hidden_states=batch.spec_info.hidden_states[
                         unfinished_accept_index
                     ],
@@ -642,7 +642,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     dtype=batch.req_pool_indices.dtype,
                     device=batch.req_pool_indices.device,
                 )
-                extend_input = EagleDraftExtendInput.create_idle_input(
+                draft_extend_input = EagleDraftExtendInput.create_idle_input(
                     device=batch.device,
                     hidden_size=batch.model_config.spec_hidden_size,
                     dtype=batch.model_config.dtype,
@@ -650,7 +650,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
 
             return EagleVerifyOutput(
-                extend_input=extend_input,
+                draft_extend_input=draft_extend_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
                 unfinished_accept_tokens=unfinished_accept_tokens,
@@ -920,7 +920,7 @@ class EagleDraftExtendInput(SpecInput):
 class EagleVerifyOutput:
     # Next iter's draft-extend input, ready to be installed as `batch.spec_info`
     # for the draft-extend forward.
-    extend_input: EagleDraftExtendInput
+    draft_extend_input: EagleDraftExtendInput
     # Logit outputs from target worker.
     logits_output: LogitsProcessorOutput
     # All accepted tokens flat across all reqs incl. those that finished this
@@ -949,13 +949,13 @@ class EagleVerifyOutput:
     def create_idle(
         cls,
         *,
-        extend_input: EagleDraftExtendInput,
+        draft_extend_input: EagleDraftExtendInput,
         logits_output: LogitsProcessorOutput,
         device: torch.device,
         spec_steps: int,
     ) -> "EagleVerifyOutput":
         return cls(
-            extend_input=extend_input,
+            draft_extend_input=draft_extend_input,
             logits_output=logits_output,
             accept_tokens=torch.empty(0, dtype=torch.long, device=device),
             unfinished_accept_tokens=torch.empty(0, dtype=torch.long, device=device),

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -731,38 +731,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             new_seq_lens=torch.empty((0,), device=device, dtype=torch.int32),
         )
 
-    def generate_attn_arg_prefill(
-        self,
-        req_pool_indices: torch.Tensor,
-        paged_kernel_lens: torch.Tensor,
-        paged_kernel_lens_sum: int,
-        req_to_token: torch.Tensor,
-    ):
-        device = req_pool_indices.device
-        bs = self.num_accepted_drafts.numel()
-        qo_indptr = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
-        qo_indptr[1:] = torch.cumsum(self.num_accepted_tokens, dim=0)
-        cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
-        cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
-
-        if paged_kernel_lens_sum is None:
-            paged_kernel_lens_sum = cum_kv_seq_len[-1]
-
-        kv_indices = torch.empty(
-            paged_kernel_lens_sum, dtype=torch.int32, device=device
-        )
-
-        create_flashinfer_kv_indices_triton[(bs,)](
-            req_to_token,
-            req_pool_indices,
-            paged_kernel_lens,
-            cum_kv_seq_len,
-            None,
-            kv_indices,
-            req_to_token.size(1),
-        )
-        return kv_indices, cum_kv_seq_len, qo_indptr, None
-
     def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
         if self.future_indices is not None:
             self.future_indices.indices = self.future_indices.indices[new_indices]
@@ -913,6 +881,38 @@ class EagleDraftExtendInput(SpecInput):
             self.bonus_tokens,
             next_power_of_2(max(speculative_num_steps + 1, len(batch.seq_lens))),
         )
+
+    def generate_attn_arg_prefill(
+        self,
+        req_pool_indices: torch.Tensor,
+        paged_kernel_lens: torch.Tensor,
+        paged_kernel_lens_sum: Optional[int],
+        req_to_token: torch.Tensor,
+    ):
+        device = req_pool_indices.device
+        bs = self.num_accepted_drafts.numel()
+        qo_indptr = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
+        qo_indptr[1:] = torch.cumsum(self.num_accepted_tokens, dim=0)
+        cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=device)
+        cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
+
+        if paged_kernel_lens_sum is None:
+            paged_kernel_lens_sum = cum_kv_seq_len[-1]
+
+        kv_indices = torch.empty(
+            paged_kernel_lens_sum, dtype=torch.int32, device=device
+        )
+
+        create_flashinfer_kv_indices_triton[(bs,)](
+            req_to_token,
+            req_pool_indices,
+            paged_kernel_lens,
+            cum_kv_seq_len,
+            None,
+            kv_indices,
+            req_to_token.size(1),
+        )
+        return kv_indices, cum_kv_seq_len, qo_indptr, None
 
 
 @dataclass

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -549,16 +549,16 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 num_accepted_drafts=num_accepted_drafts,
                 num_accepted_tokens=num_accepted_drafts + 1,
                 num_accepted_tokens_cpu=num_accepted_tokens_list,
+                input_ids=accept_tokens,
+                seq_lens=batch.seq_lens,
+                seq_lens_cpu=batch.seq_lens_cpu,
+                req_pool_indices=batch.req_pool_indices,
             )
 
             return EagleVerifyOutput(
                 draft_extend_input=draft_extend_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
-                unfinished_accept_tokens=accept_tokens,
-                seq_lens_for_draft_extend=batch.seq_lens,
-                seq_lens_for_draft_extend_cpu=batch.seq_lens_cpu,
-                req_pool_indices_for_draft_extend=batch.req_pool_indices,
                 num_accepted_drafts_per_req_cpu=num_accepted_drafts_list,
                 accepted_indices=accept_index,
             )
@@ -613,12 +613,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 unfinished_num_accepted_drafts = num_accepted_drafts[
                     unfinished_index_device
                 ]
-                unfinished_accept_tokens = predict[unfinished_accept_index]
-                seq_lens_for_draft_extend = batch.seq_lens[unfinished_index_device]
-                seq_lens_for_draft_extend_cpu = batch.seq_lens_cpu[unfinished_index]
-                req_pool_indices_for_draft_extend = batch.req_pool_indices[
-                    unfinished_index_device
-                ]
                 draft_extend_input = EagleDraftExtendInput(
                     hidden_states=batch.spec_info.hidden_states[
                         unfinished_accept_index
@@ -626,22 +620,12 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     num_accepted_tokens_cpu=draft_input_num_accepted_tokens_cpu,
                     num_accepted_drafts=unfinished_num_accepted_drafts,
                     num_accepted_tokens=unfinished_num_accepted_drafts + 1,
+                    input_ids=predict[unfinished_accept_index],
+                    seq_lens=batch.seq_lens[unfinished_index_device],
+                    seq_lens_cpu=batch.seq_lens_cpu[unfinished_index],
+                    req_pool_indices=batch.req_pool_indices[unfinished_index_device],
                 )
             else:
-                unfinished_accept_tokens = torch.empty(
-                    (0,), dtype=accept_tokens.dtype, device=accept_tokens.device
-                )
-                seq_lens_for_draft_extend = torch.empty(
-                    (0,), dtype=batch.seq_lens.dtype, device=batch.seq_lens.device
-                )
-                seq_lens_for_draft_extend_cpu = torch.empty(
-                    (0,), dtype=batch.seq_lens_cpu.dtype
-                )
-                req_pool_indices_for_draft_extend = torch.empty(
-                    (0,),
-                    dtype=batch.req_pool_indices.dtype,
-                    device=batch.req_pool_indices.device,
-                )
                 draft_extend_input = EagleDraftExtendInput.create_idle_input(
                     device=batch.device,
                     hidden_size=batch.model_config.spec_hidden_size,
@@ -653,10 +637,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 draft_extend_input=draft_extend_input,
                 logits_output=logits_output,
                 accept_tokens=accept_tokens,
-                unfinished_accept_tokens=unfinished_accept_tokens,
-                seq_lens_for_draft_extend=seq_lens_for_draft_extend,
-                seq_lens_for_draft_extend_cpu=seq_lens_for_draft_extend_cpu,
-                req_pool_indices_for_draft_extend=req_pool_indices_for_draft_extend,
                 num_accepted_drafts_per_req_cpu=num_accepted_drafts_list,
                 accepted_indices=accept_index,
             )
@@ -664,7 +644,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
 
 @dataclass
 class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
-    # The inputs for decode
     # shape: (b, topk)
     topk_p: torch.Tensor = None
     topk_index: torch.Tensor = None
@@ -672,21 +651,19 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     hidden_states: torch.Tensor = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
-    # Per-req bonus token (the "+1" target prediction at the end of each accept
-    # chain). Set by `EagleDraftExtendInput.prepare_extend_after_decode`'s kernel
-    # via the worker's post-extend assembly.
+    # Per-req bonus token (the "+1" target prediction at end of each accept
+    # chain). Written by `EagleDraftExtendInput.prepare_extend_after_decode`;
+    # the worker copies it here for next iter's draft.
     bonus_tokens: torch.Tensor = None
 
-    # Inputs for the attention backends
     # shape: (b + 1,)
     kv_indptr: torch.Tensor = None
     kv_indices: torch.Tensor = None
 
-    # Shape info for padding
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = -1
 
-    # Inputs for V2 overlap worker
+    # V2 overlap worker only
     future_indices: Optional[FutureIndices] = None
     new_seq_lens: Optional[torch.Tensor] = None
     verify_done: Optional[torch.cuda.Event] = None
@@ -790,24 +767,33 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 class EagleDraftExtendInput(SpecInput):
     """Inputs to the draft-extend forward (the per-accepted-token pass after verify).
 
-    Lives on `batch.spec_info` only during the draft-extend forward pass.
-    After draft-extend completes, the worker assembles a fresh `EagleDraftInput`
-    for next iter and replaces `batch.spec_info`.
-
-    All fields here have single shapes (no phase-shift across phases).
+    Produced by `EagleVerifyInput.verify`, installed on `batch.spec_info` for
+    the draft-extend forward, then replaced with a fresh `EagleDraftInput` for
+    the next iter's draft.
     """
 
     # shape: (total_accepted, hidden_size). Sliced from verify-time hidden_states
     # by accept_index; consumed by the draft-extend forward.
     hidden_states: torch.Tensor = None
 
-    # Per-req accept counts. `num_accepted_tokens = num_accepted_drafts + 1`
-    # (one bonus per req). Both retained for cuda-graph buffer indexing and
-    # the `create_extend_after_decode_spec_info` kernel.
+    # Per-req accept counts. `num_accepted_tokens = num_accepted_drafts + 1`.
+    # Both kept for cuda-graph buffer indexing and the
+    # `create_extend_after_decode_spec_info` kernel.
     num_accepted_drafts: torch.Tensor = None
     num_accepted_tokens: torch.Tensor = None
     # CPU view, read by attention backends during the extend forward.
     num_accepted_tokens_cpu: List[int] = None
+
+    # Batch-state slices for the draft-extend forward. Set by verify (sliced to
+    # reqs continuing into next iter). `prepare_extend_after_decode` copies
+    # these onto `batch.{input_ids, seq_lens, seq_lens_cpu, req_pool_indices}`.
+    #   - input_ids:        accept tokens flat over surviving reqs
+    #   - seq_lens / _cpu:  per-req sequence length (post-accept)
+    #   - req_pool_indices: per-req kv-pool slot
+    input_ids: torch.Tensor = None
+    seq_lens: torch.Tensor = None
+    seq_lens_cpu: torch.Tensor = None
+    req_pool_indices: torch.Tensor = None
 
     # Set by `prepare_extend_after_decode`:
     #   - positions: kernel-written, shape `[total_accepted]`.
@@ -816,7 +802,6 @@ class EagleDraftExtendInput(SpecInput):
     positions: Optional[torch.Tensor] = None
     bonus_tokens: Optional[torch.Tensor] = None
 
-    # Forward-pass config (set during prepare_extend / construction).
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = 1
@@ -840,13 +825,16 @@ class EagleDraftExtendInput(SpecInput):
             num_accepted_drafts=torch.empty((0,), device=device, dtype=torch.int32),
             num_accepted_tokens=torch.empty((0,), device=device, dtype=torch.int32),
             num_accepted_tokens_cpu=[],
+            input_ids=torch.empty((0,), device=device, dtype=torch.long),
+            seq_lens=torch.empty((0,), device=device, dtype=torch.int32),
+            seq_lens_cpu=torch.empty((0,), dtype=torch.int32),
+            req_pool_indices=torch.empty((0,), device=device, dtype=torch.int64),
             capture_hidden_mode=capture_hidden_mode,
         )
 
     def prepare_extend_after_decode(
         self,
         batch: ScheduleBatch,
-        verify_output: "EagleVerifyOutput",
         speculative_num_steps: int,
     ):
         # Caller must have installed `self` as `batch.spec_info` before calling.
@@ -854,16 +842,15 @@ class EagleDraftExtendInput(SpecInput):
         if batch.forward_mode.is_idle():
             return
 
-        # All transient verify->extend handoff state is read off `verify_output`.
         # The kernel below populates `self.positions` and `self.bonus_tokens`;
         # the worker reads `self.bonus_tokens` to construct next iter's
         # `EagleDraftInput`.
-        batch.input_ids = verify_output.unfinished_accept_tokens
+        batch.input_ids = self.input_ids
         batch.extend_lens = self.num_accepted_tokens_cpu
         batch.extend_num_tokens = sum(batch.extend_lens)
-        batch.seq_lens = verify_output.seq_lens_for_draft_extend
-        batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
-        batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
+        batch.seq_lens = self.seq_lens
+        batch.seq_lens_cpu = self.seq_lens_cpu
+        batch.req_pool_indices = self.req_pool_indices
         batch.return_logprob = False
         batch.return_hidden_states = False
 
@@ -917,28 +904,14 @@ class EagleDraftExtendInput(SpecInput):
 
 @dataclass
 class EagleVerifyOutput:
-    # Next iter's draft-extend input, ready to be installed as `batch.spec_info`
-    # for the draft-extend forward.
+    # Next iter's draft-extend input, installed as `batch.spec_info` for the
+    # draft-extend forward.
     draft_extend_input: EagleDraftExtendInput
     # Logit outputs from target worker.
     logits_output: LogitsProcessorOutput
     # All accepted tokens flat across all reqs incl. those that finished this
     # step. Includes the bonus token. Used for output processing.
     accept_tokens: torch.Tensor
-    # Below are transient handoff fields for the next iter's draft-extend pass.
-    # They are scoped to the verify -> prepare_extend_after_decode window only;
-    # `prepare_extend_after_decode` reads them off this object via method arg
-    # rather than smuggling them through `EagleDraftInput`.
-    #
-    # Subset of `accept_tokens` for reqs continuing into next iter's draft-extend
-    # forward (= `accept_tokens` when no req finished; flat over unfinished
-    # reqs only otherwise). Becomes `batch.input_ids` for that forward pass.
-    unfinished_accept_tokens: torch.Tensor
-    # `batch.seq_lens` / `batch.seq_lens_cpu` / `batch.req_pool_indices` to
-    # use for the next iter's draft-extend forward; sliced to surviving reqs.
-    seq_lens_for_draft_extend: torch.Tensor
-    seq_lens_for_draft_extend_cpu: torch.Tensor
-    req_pool_indices_for_draft_extend: torch.Tensor
     # Accepted token length per sequence in a batch in CPU (full set).
     num_accepted_drafts_per_req_cpu: List[int]
     # Accepted indices from logits_output.next_token_logits
@@ -957,12 +930,6 @@ class EagleVerifyOutput:
             draft_extend_input=draft_extend_input,
             logits_output=logits_output,
             accept_tokens=torch.empty(0, dtype=torch.long, device=device),
-            unfinished_accept_tokens=torch.empty(0, dtype=torch.long, device=device),
-            seq_lens_for_draft_extend=torch.empty(0, dtype=torch.int32, device=device),
-            seq_lens_for_draft_extend_cpu=torch.empty(0, dtype=torch.int32),
-            req_pool_indices_for_draft_extend=torch.empty(
-                0, dtype=torch.int64, device=device
-            ),
             num_accepted_drafts_per_req_cpu=[],
             accepted_indices=torch.full(
                 (0, spec_steps + 1), -1, dtype=torch.int32, device=device

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -884,6 +884,8 @@ class EagleDraftExtendInput(SpecInput):
         verify_output: "EagleVerifyOutput",
         speculative_num_steps: int,
     ):
+        # Caller must have installed `self` as `batch.spec_info` before calling.
+        assert batch.spec_info is self
         if batch.forward_mode.is_idle():
             return
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -913,10 +913,11 @@ class EagleVerifyOutput:
     # All accepted tokens flat across all reqs incl. those that finished this
     # step. Includes the bonus token. Used for output processing.
     accept_tokens: torch.Tensor
-    # Accepted token length per sequence in a batch in CPU (full set).
-    num_accepted_drafts_per_req_cpu: List[int]
     # Accepted indices from logits_output.next_token_logits
     accepted_indices: torch.Tensor
+    # Per-req accepted draft count (no bonus). V1 fills this for tracing /
+    # adaptive controller; V2 leaves it None to avoid the CPU sync.
+    num_accepted_drafts_per_req_cpu: Optional[List[int]] = None
 
     @classmethod
     def create_idle(

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -228,10 +228,11 @@ class EagleDraftExtendInputV2Mixin:
         draft_model_runner: Any,
         cuda_graph_runner: Any,
     ):
+        # Caller is responsible for `batch.spec_info = self` before calling.
+        assert batch.spec_info is self
         seq_lens_cpu_ = batch.seq_lens_cpu
         extend_num_tokens = len(batch.seq_lens) * num_draft_tokens
 
-        batch.spec_info = self
         batch.input_ids = predict
         batch.seq_lens = batch.seq_lens + num_draft_tokens
         batch.seq_lens_cpu = batch.seq_lens_cpu + num_draft_tokens
@@ -323,15 +324,18 @@ class EagleVerifyInputV2Mixin:
 
         return verify_forward_batch, can_run_cuda_graph
 
-    def sample(
+    def verify_v2(
         self: EagleVerifyInput,
         batch: ModelWorkerBatch,
         logits_output: LogitsProcessorOutput,
         vocab_mask: torch.Tensor = None,
     ) -> Tuple["EagleVerifyOutput", torch.Tensor]:
         """
-        Verify and find accepted tokens based on logits output and batch
-        (which contains spec decoding information).
+        V2 counterpart to `EagleVerifyInput.verify` (V1). Sample target tokens,
+        verify against drafts, and produce an `EagleVerifyOutput`.
+
+        Cannot be named `verify` because the V1 method is defined directly on
+        `EagleVerifyInput` and would shadow this mixin method via MRO.
 
         Returns `(verify_output, predict)` where `predict` is the full
         per-position sampled tokens (V2 caller uses it as `next_token_ids`).

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
         EagleDraftExtendInput,
         EagleDraftInput,
         EagleVerifyInput,
+        EagleVerifyOutput,
     )
 
 if is_cuda() or is_musa():
@@ -327,20 +328,36 @@ class EagleVerifyInputV2Mixin:
         batch: ModelWorkerBatch,
         logits_output: LogitsProcessorOutput,
         vocab_mask: torch.Tensor = None,
-    ):
+    ) -> Tuple["EagleVerifyOutput", torch.Tensor]:
         """
         Verify and find accepted tokens based on logits output and batch
         (which contains spec decoding information).
+
+        Returns `(verify_output, predict)` where `predict` is the full
+        per-position sampled tokens (V2 caller uses it as `next_token_ids`).
+        `verify_output.accept_tokens` is the V1-style flat accepted slice.
         """
+        from sglang.srt.speculative.eagle_info import (
+            EagleDraftExtendInput,
+            EagleVerifyOutput,
+        )
+
+        device = batch.input_ids.device
         if batch.forward_mode.is_idle():
-            predict = torch.empty(0, dtype=torch.int32, device=batch.input_ids.device)
-            num_accepted_drafts = torch.empty(
-                0, dtype=torch.int32, device=batch.input_ids.device
+            predict = torch.empty(0, dtype=torch.int32, device=device)
+            num_accepted_drafts = torch.empty(0, dtype=torch.int32, device=device)
+            accept_index = torch.empty(0, dtype=torch.int32, device=device)
+            verify_output = EagleVerifyOutput(
+                draft_extend_input=EagleDraftExtendInput(
+                    hidden_states=logits_output.hidden_states,
+                    num_accepted_drafts=num_accepted_drafts,
+                    num_accepted_tokens=num_accepted_drafts + 1,
+                ),
+                logits_output=logits_output,
+                accept_tokens=torch.empty(0, dtype=torch.int32, device=device),
+                accepted_indices=accept_index,
             )
-            accept_index = torch.empty(
-                0, dtype=torch.int32, device=batch.input_ids.device
-            )
-            return predict, num_accepted_drafts, accept_index
+            return verify_output, predict
 
         bs = len(batch.seq_lens)
         sampling_info = batch.sampling_info
@@ -473,10 +490,24 @@ class EagleVerifyInputV2Mixin:
                 spec_steps=self.spec_steps,
             )
 
-        # `num_accepted_drafts` stays drafts-only inside this function; the returned
-        # tensor includes the trailing/bonus token via out-of-place +1 so the
-        # name no longer flips semantics mid-function (naming doc C2).
-        return predict, num_accepted_drafts + 1, accept_index
+        # `num_accepted_drafts` is drafts-only here; bonus is added via out-of-place
+        # +1 when packaged into `EagleDraftExtendInput.num_accepted_tokens`, so the
+        # local name does not flip semantics mid-function (naming doc C2).
+        verify_output = EagleVerifyOutput(
+            draft_extend_input=EagleDraftExtendInput(
+                # V2 keeps `hidden_states` as the full target output (shape
+                # `[bs * draft_token_num, hidden]`); V1 instead stores the
+                # accept-sliced view. The downstream V2 cuda-graph runner
+                # expects the full layout.
+                hidden_states=logits_output.hidden_states,
+                num_accepted_drafts=num_accepted_drafts,
+                num_accepted_tokens=num_accepted_drafts + 1,
+            ),
+            logits_output=logits_output,
+            accept_tokens=predict[accept_index],
+            accepted_indices=accept_index,
+        )
+        return verify_output, predict
 
 
 @triton.jit

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -47,7 +47,11 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
         EAGLEDraftCudaGraphRunner,
     )
-    from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+    from sglang.srt.speculative.eagle_info import (
+        EagleDraftExtendInput,
+        EagleDraftInput,
+        EagleVerifyInput,
+    )
 
 if is_cuda() or is_musa():
     from sgl_kernel import (
@@ -212,8 +216,11 @@ class EagleDraftInputV2Mixin:
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         return forward_batch, can_cuda_graph
 
+
+@dataclass
+class EagleDraftExtendInputV2Mixin:
     def prepare_for_extend_to_fill_draft_kvcache(
-        self,
+        self: EagleDraftExtendInput,
         batch: ModelWorkerBatch,
         predict: torch.Tensor,
         num_draft_tokens: int,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -980,7 +980,6 @@ class EAGLEWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.draft_extend_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 
@@ -1110,8 +1109,10 @@ class EAGLEWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        assert isinstance(batch.spec_info, EagleDraftExtendInput)
-        draft_extend_input: EagleDraftExtendInput = batch.spec_info
+        # Install the draft-extend input as `batch.spec_info` for this method's
+        # forward pass. Replaced with a fresh `EagleDraftInput` post-extend.
+        draft_extend_input: EagleDraftExtendInput = verify_output.draft_extend_input
+        batch.spec_info = draft_extend_input
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -461,7 +461,7 @@ class EAGLEWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
-                self.forward_draft_extend(
+                next_draft_input = self.forward_draft_extend(
                     batch,
                     logits_output.hidden_states,
                     next_token_ids,
@@ -473,6 +473,7 @@ class EAGLEWorker(TpModelWorker):
                 next_token_ids=next_token_ids,
                 num_accepted_drafts=0,
                 can_run_cuda_graph=can_run_cuda_graph,
+                next_draft_input=next_draft_input,
             )
         else:
             set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
@@ -1084,37 +1085,47 @@ class EAGLEWorker(TpModelWorker):
         next_token_ids: torch.Tensor,
         seq_lens_cpu: Optional[torch.Tensor],
         mm_input_embeds: Optional[torch.Tensor] = None,
-    ):
-        """Run draft model extend. This API modifies the states of the batch.
+    ) -> EagleDraftInput:
+        """Run draft model extend. Returns next-iter `EagleDraftInput`;
+        scheduler installs it on `batch.spec_info` via `batch_result.next_draft_input`.
 
-        Args:
-            batch: The batch to run.
-            hidden_states: Hidden states from the target model forward
-            next_token_ids: Next token ids generated from the target forward.
+        We mutate `batch.spec_info` transiently so the forward kernel can read
+        the draft input via `batch.get_model_worker_batch`, then restore on
+        return.
         """
-        batch.spec_info = EagleDraftInput(
+        next_draft_input = EagleDraftInput(
             hidden_states=hidden_states,
             bonus_tokens=next_token_ids,
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
         )
+        return_hidden_states_backup = batch.return_hidden_states
+        spec_info_backup = batch.spec_info
+
+        batch.spec_info = next_draft_input
         batch.return_hidden_states = False
-        batch.spec_info.prepare_for_extend(batch)
-        batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
-        model_worker_batch = batch.get_model_worker_batch(
-            seq_lens_cpu_cache=seq_lens_cpu
-        )
-        forward_batch = ForwardBatch.init_new(
-            model_worker_batch, self.draft_model_runner
-        )
-        forward_batch.return_logprob = False
-        if mm_input_embeds is not None:
-            forward_batch.mm_input_embeds = mm_input_embeds
-        logits_output = self.draft_model_runner.forward(forward_batch).logits_output
-        maybe_detect_nan(logits_output.next_token_logits, "draft_extend_for_prefill")
-        assert isinstance(forward_batch.spec_info, EagleDraftInput)
-        assert forward_batch.spec_info is batch.spec_info
-        self.capture_for_decode(logits_output, forward_batch.spec_info)
+        next_draft_input.prepare_for_extend(batch)
+        next_draft_input.capture_hidden_mode = CaptureHiddenMode.LAST
+        try:
+            model_worker_batch = batch.get_model_worker_batch(
+                seq_lens_cpu_cache=seq_lens_cpu
+            )
+            forward_batch = ForwardBatch.init_new(
+                model_worker_batch, self.draft_model_runner
+            )
+            forward_batch.return_logprob = False
+            if mm_input_embeds is not None:
+                forward_batch.mm_input_embeds = mm_input_embeds
+            logits_output = self.draft_model_runner.forward(forward_batch).logits_output
+            maybe_detect_nan(
+                logits_output.next_token_logits, "draft_extend_for_prefill"
+            )
+            self.capture_for_decode(logits_output, next_draft_input)
+        finally:
+            batch.spec_info = spec_info_backup
+            batch.return_hidden_states = return_hidden_states_backup
+
+        return next_draft_input
 
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -540,6 +540,26 @@ class EAGLEWorker(TpModelWorker):
                         extend_batch
                     )
 
+                if next_draft_input is None:
+                    # Skipped the extend forward (no dp_attention + all reqs
+                    # finished). batch.spec_info is still the verify_input from
+                    # before verify; replace with an idle EagleDraftInput so
+                    # the scheduler's unified relay installs a mergeable
+                    # spec_info (EagleVerifyInput has no merge_batch).
+                    hidden_size = (
+                        self.model_config.hidden_size * 3
+                        if self.speculative_algorithm.is_eagle3()
+                        and self.eagle_use_aux_hidden_state
+                        else self.model_config.spec_hidden_size
+                    )
+                    next_draft_input = EagleDraftInput.create_idle_input(
+                        device=self.device,
+                        hidden_size=hidden_size,
+                        dtype=self.model_config.dtype,
+                        topk=self.topk,
+                        capture_hidden_mode=CaptureHiddenMode.LAST,
+                    )
+
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
             )

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -481,13 +481,15 @@ class EAGLEWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
-                spec_info = self.draft(batch)
+                verify_input = self.draft(batch)
 
             set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
             set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
 
+            # Install verify_input as `batch.spec_info` for the verify forward.
+            batch.spec_info = verify_input
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
-                self.verify(batch, spec_info)
+                self.verify(batch, verify_input)
             )
 
             if get_global_tracing_enabled():
@@ -509,6 +511,10 @@ class EAGLEWorker(TpModelWorker):
                     or verify_output.unfinished_accept_tokens.shape[0] > 0
                 ):
                     # decode is not finished
+                    # Install draft_extend_input as `batch.spec_info` for the
+                    # draft-extend forward (replaced post-extend with a fresh
+                    # EagleDraftInput by `forward_draft_extend_after_decode`).
+                    batch.spec_info = verify_output.draft_extend_input
                     self.forward_draft_extend_after_decode(batch, verify_output)
 
             set_time_batch(
@@ -894,6 +900,9 @@ class EAGLEWorker(TpModelWorker):
         pass
 
     def verify(self, batch: ScheduleBatch, spec_info: EagleVerifyInput):
+        # Caller (forward_batch_generation) is responsible for installing
+        # `spec_info` as `batch.spec_info` before calling.
+        assert batch.spec_info is spec_info
         seq_lens_pre_verify = batch.seq_lens.clone()
         spec_info.prepare_for_verify(batch, self.page_size)
         spec_info.num_tokens_per_req = self.speculative_num_steps + 1
@@ -903,7 +912,6 @@ class EAGLEWorker(TpModelWorker):
             if not batch.forward_mode.is_idle()
             else ForwardMode.IDLE
         )
-        batch.spec_info = spec_info
 
         model_worker_batch = batch.get_model_worker_batch(
             seq_lens_cpu_cache=spec_info.seq_lens_cpu
@@ -1109,11 +1117,11 @@ class EAGLEWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        # Install the draft-extend input as `batch.spec_info` for this method's
-        # forward pass. Replaced with a fresh `EagleDraftInput` post-extend.
+        # Caller (forward_batch_generation) is responsible for installing
+        # verify_output.draft_extend_input as batch.spec_info before calling.
         draft_extend_input = verify_output.draft_extend_input
         assert isinstance(draft_extend_input, EagleDraftExtendInput)
-        batch.spec_info = draft_extend_input
+        assert batch.spec_info is draft_extend_input
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -488,9 +488,7 @@ class EAGLEWorker(TpModelWorker):
 
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
-            logits_output, verify_output, can_run_cuda_graph = self.verify(
-                batch, verify_input
-            )
+            logits_output, verify_output, can_run_cuda_graph = self.verify(batch)
 
             if get_global_tracing_enabled():
                 for idx, req in enumerate(batch.reqs):
@@ -901,10 +899,8 @@ class EAGLEWorker(TpModelWorker):
         # allocator and kv cache pool are shared with target worker
         pass
 
-    def verify(self, batch: ScheduleBatch, spec_info: EagleVerifyInput):
-        # Caller (forward_batch_generation) is responsible for installing
-        # `spec_info` as `batch.spec_info` before calling.
-        assert batch.spec_info is spec_info
+    def verify(self, batch: ScheduleBatch):
+        spec_info: EagleVerifyInput = batch.spec_info
         seq_lens_pre_verify = batch.seq_lens.clone()
         spec_info.prepare_for_verify(batch, self.page_size)
         spec_info.num_tokens_per_req = self.speculative_num_steps + 1
@@ -1119,11 +1115,7 @@ class EAGLEWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> EagleDraftInput:
-        # Caller (forward_batch_generation) is responsible for installing
-        # verify_output.draft_extend_input as batch.spec_info before calling.
-        draft_extend_input = verify_output.draft_extend_input
-        assert isinstance(draft_extend_input, EagleDraftExtendInput)
-        assert batch.spec_info is draft_extend_input
+        draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -980,7 +980,7 @@ class EAGLEWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.extend_input
+        batch.spec_info = res.draft_extend_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 
@@ -1111,7 +1111,7 @@ class EAGLEWorker(TpModelWorker):
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
         assert isinstance(batch.spec_info, EagleDraftExtendInput)
-        extend_input: EagleDraftExtendInput = batch.spec_info
+        draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
@@ -1131,18 +1131,18 @@ class EAGLEWorker(TpModelWorker):
                 and self.eagle_use_aux_hidden_state
                 else self.model_config.spec_hidden_size
             )
-            extend_input = EagleDraftExtendInput.create_idle_input(
+            draft_extend_input = EagleDraftExtendInput.create_idle_input(
                 device=self.device,
                 hidden_size=hidden_size,
                 dtype=self.model_config.dtype,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
-            batch.spec_info = extend_input
+            batch.spec_info = draft_extend_input
 
-        # Phase 1: prepare extend (kernel writes extend_input.{positions, bonus_tokens})
-        extend_input.num_tokens_per_req = self.speculative_num_steps + 1
-        extend_input.num_tokens_for_logprob_per_req = 1
-        extend_input.prepare_extend_after_decode(
+        # Phase 1: prepare extend (kernel writes draft_extend_input.{positions, bonus_tokens})
+        draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
+        draft_extend_input.num_tokens_for_logprob_per_req = 1
+        draft_extend_input.prepare_extend_after_decode(
             batch,
             verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
@@ -1203,7 +1203,7 @@ class EAGLEWorker(TpModelWorker):
 
         # Phase 3: assemble next-iter EagleDraftInput from extend output
         next_draft_input = EagleDraftInput(
-            bonus_tokens=extend_input.bonus_tokens,
+            bonus_tokens=draft_extend_input.bonus_tokens,
             hidden_states=hidden_states,
             topk_p=topk_p,
             topk_index=topk_index,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -504,17 +504,16 @@ class EAGLEWorker(TpModelWorker):
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 # NOTE: We should use `check_forward_draft_extend_after_decode`
                 # when DP attention is enabled, but it is slow. Skip it for now.
+                draft_extend_input = verify_output.draft_extend_input
                 if (
                     self.server_args.enable_dp_attention
-                    or verify_output.unfinished_accept_tokens.shape[0] > 0
+                    or draft_extend_input.input_ids.shape[0] > 0
                 ):
                     # decode is not finished
                     # Install draft_extend_input for the extend forward, then
                     # install the assembled next-iter EagleDraftInput it returns.
-                    batch.spec_info = verify_output.draft_extend_input
-                    next_draft_input = self.forward_draft_extend_after_decode(
-                        batch, verify_output
-                    )
+                    batch.spec_info = draft_extend_input
+                    next_draft_input = self.forward_draft_extend_after_decode(batch)
                     batch.spec_info = next_draft_input
 
             set_time_batch(
@@ -537,7 +536,7 @@ class EAGLEWorker(TpModelWorker):
     def check_forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        local_need_forward = verify_output.unfinished_accept_tokens.shape[0] > 0
+        local_need_forward = verify_output.draft_extend_input.input_ids.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -1113,7 +1112,7 @@ class EAGLEWorker(TpModelWorker):
         self.capture_for_decode(logits_output, forward_batch.spec_info)
 
     def forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
+        self, batch: ScheduleBatch
     ) -> EagleDraftInput:
         draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
@@ -1125,7 +1124,7 @@ class EAGLEWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
+        if not input_is_idle and draft_extend_input.input_ids.numel() == 0:
             # All reqs finished this verify; swap to an idle ExtendInput.
             batch = batch.copy()
             batch.prepare_for_idle()
@@ -1148,7 +1147,6 @@ class EAGLEWorker(TpModelWorker):
         draft_extend_input.num_tokens_for_logprob_per_req = 1
         draft_extend_input.prepare_extend_after_decode(
             batch,
-            verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
         )
         batch.forward_mode = (
@@ -1193,9 +1191,7 @@ class EAGLEWorker(TpModelWorker):
             logits_output = self.draft_model_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
-            # Non-cuda-graph path: compute topk_p / topk_index inline (used to be
-            # `capture_for_decode` which mutated spec_info; we instead carry the
-            # values to next-iter `EagleDraftInput` assembly below).
+            # Non-cuda-graph path: compute topk_p / topk_index inline.
             probs = torch.softmax(logits_output.next_token_logits, dim=-1)
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
             hidden_states = logits_output.hidden_states

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1111,7 +1111,8 @@ class EAGLEWorker(TpModelWorker):
     ):
         # Install the draft-extend input as `batch.spec_info` for this method's
         # forward pass. Replaced with a fresh `EagleDraftInput` post-extend.
-        draft_extend_input: EagleDraftExtendInput = verify_output.draft_extend_input
+        draft_extend_input = verify_output.draft_extend_input
+        assert isinstance(draft_extend_input, EagleDraftExtendInput)
         batch.spec_info = draft_extend_input
 
         # Backup fields that will be modified in-place

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -511,11 +511,13 @@ class EAGLEWorker(TpModelWorker):
                     or verify_output.unfinished_accept_tokens.shape[0] > 0
                 ):
                     # decode is not finished
-                    # Install draft_extend_input as `batch.spec_info` for the
-                    # draft-extend forward (replaced post-extend with a fresh
-                    # EagleDraftInput by `forward_draft_extend_after_decode`).
+                    # Install draft_extend_input for the extend forward, then
+                    # install the assembled next-iter EagleDraftInput it returns.
                     batch.spec_info = verify_output.draft_extend_input
-                    self.forward_draft_extend_after_decode(batch, verify_output)
+                    next_draft_input = self.forward_draft_extend_after_decode(
+                        batch, verify_output
+                    )
+                    batch.spec_info = next_draft_input
 
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
@@ -1116,7 +1118,7 @@ class EAGLEWorker(TpModelWorker):
 
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
-    ):
+    ) -> EagleDraftInput:
         # Caller (forward_batch_generation) is responsible for installing
         # verify_output.draft_extend_input as batch.spec_info before calling.
         draft_extend_input = verify_output.draft_extend_input
@@ -1220,16 +1222,17 @@ class EAGLEWorker(TpModelWorker):
             capture_hidden_mode=CaptureHiddenMode.FULL,
         )
 
-        # Restore batch fields and install the new draft input.
-        # `seq_lens` etc. were modified by `prepare_extend_after_decode`.
+        # Restore batch fields. `seq_lens` etc. were modified by
+        # `prepare_extend_after_decode`. Caller installs `next_draft_input` as
+        # `batch.spec_info`.
         batch.forward_mode = (
             ForwardMode.DECODE if not input_is_idle else ForwardMode.IDLE
         )
         batch.seq_lens = seq_lens_backup
         batch.seq_lens_cpu = seq_lens_cpu_backup
         batch.req_pool_indices = req_pool_indices_backup
-        batch.spec_info = next_draft_input
         batch.return_logprob = return_logprob_backup
+        return next_draft_input
 
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -505,16 +505,17 @@ class EAGLEWorker(TpModelWorker):
                 # NOTE: We should use `check_forward_draft_extend_after_decode`
                 # when DP attention is enabled, but it is slow. Skip it for now.
                 draft_extend_input = verify_output.draft_extend_input
+                next_draft_input = None
                 if (
                     self.server_args.enable_dp_attention
                     or draft_extend_input.input_ids.shape[0] > 0
                 ):
-                    # decode is not finished
-                    # Install draft_extend_input for the extend forward, then
-                    # install the assembled next-iter EagleDraftInput it returns.
+                    # decode is not finished. Install draft_extend_input as
+                    # batch.spec_info for the extend forward; the assembled
+                    # next-iter EagleDraftInput is returned via batch_result
+                    # and installed by the scheduler before the next draft.
                     batch.spec_info = draft_extend_input
                     next_draft_input = self.forward_draft_extend_after_decode(batch)
-                    batch.spec_info = next_draft_input
 
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
@@ -531,6 +532,7 @@ class EAGLEWorker(TpModelWorker):
                 num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
                 num_accepted_drafts_per_req_cpu=verify_output.num_accepted_drafts_per_req_cpu,
                 can_run_cuda_graph=verify_output.can_run_cuda_graph,
+                next_draft_input=next_draft_input,
             )
 
     def check_forward_draft_extend_after_decode(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -488,8 +488,8 @@ class EAGLEWorker(TpModelWorker):
 
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
-            logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
-                self.verify(batch, verify_input)
+            logits_output, verify_output, can_run_cuda_graph = self.verify(
+                batch, verify_input
             )
 
             if get_global_tracing_enabled():
@@ -991,7 +991,7 @@ class EAGLEWorker(TpModelWorker):
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
 
-        return logits_output, res, model_worker_batch, can_run_cuda_graph
+        return logits_output, res, can_run_cuda_graph
 
     def _mamba_verify_update(
         self,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Tuple
 
 import torch
 
-from sglang.srt.distributed import get_tp_group
 from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner import (
     EAGLEDraftNpuGraphRunner,
 )
@@ -502,8 +501,6 @@ class EAGLEWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
-                # NOTE: We should use `check_forward_draft_extend_after_decode`
-                # when DP attention is enabled, but it is slow. Skip it for now.
                 draft_extend_input = verify_output.draft_extend_input
                 next_draft_input = None
                 if (
@@ -559,26 +556,6 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph=verify_output.can_run_cuda_graph,
                 next_draft_input=next_draft_input,
             )
-
-    def check_forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
-    ):
-        local_need_forward = verify_output.draft_extend_input.input_ids.shape[0] > 0
-        if not self.server_args.enable_dp_attention:
-            return local_need_forward
-
-        global_need_forward = torch.tensor(
-            [
-                (local_need_forward),
-            ],
-            dtype=torch.int64,
-        )
-        torch.distributed.all_reduce(
-            global_need_forward, group=get_tp_group().cpu_group
-        )
-        global_need_forward_cnt = global_need_forward[0].item()
-        need_forward = global_need_forward_cnt > 0
-        return need_forward
 
     def forward_target_extend(
         self, batch: ScheduleBatch

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -46,6 +46,7 @@ from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
 )
 from sglang.srt.speculative.eagle_info import (
+    EagleDraftExtendInput,
     EagleDraftInput,
     EagleVerifyInput,
     EagleVerifyOutput,
@@ -979,7 +980,7 @@ class EAGLEWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.next_draft_input
+        batch.spec_info = res.extend_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 
@@ -1109,18 +1110,19 @@ class EAGLEWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        assert isinstance(batch.spec_info, EagleDraftInput)
+        assert isinstance(batch.spec_info, EagleDraftExtendInput)
+        extend_input: EagleDraftExtendInput = batch.spec_info
+
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
         seq_lens_cpu_backup = batch.seq_lens_cpu.clone()
         req_pool_indices_backup = batch.req_pool_indices
-        num_accepted_drafts_backup = batch.spec_info.num_accepted_drafts.clone()
-        num_accepted_tokens_backup = batch.spec_info.num_accepted_tokens.clone()
         return_logprob_backup = batch.return_logprob
 
         input_is_idle = batch.forward_mode.is_idle()
 
         if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
+            # All reqs finished this verify; swap to an idle ExtendInput.
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (
@@ -1129,17 +1131,18 @@ class EAGLEWorker(TpModelWorker):
                 and self.eagle_use_aux_hidden_state
                 else self.model_config.spec_hidden_size
             )
-            batch.spec_info = EagleDraftInput.create_idle_input(
+            extend_input = EagleDraftExtendInput.create_idle_input(
                 device=self.device,
                 hidden_size=hidden_size,
                 dtype=self.model_config.dtype,
-                topk=self.topk,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
+            batch.spec_info = extend_input
 
-        batch.spec_info.num_tokens_per_req = self.speculative_num_steps + 1
-        batch.spec_info.num_tokens_for_logprob_per_req = 1
-        batch.spec_info.prepare_extend_after_decode(
+        # Phase 1: prepare extend (kernel writes extend_input.{positions, bonus_tokens})
+        extend_input.num_tokens_per_req = self.speculative_num_steps + 1
+        extend_input.num_tokens_for_logprob_per_req = 1
+        extend_input.prepare_extend_after_decode(
             batch,
             verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
@@ -1161,7 +1164,7 @@ class EAGLEWorker(TpModelWorker):
         else:
             forward_batch.seq_lens_sum = batch.seq_lens.sum().item()
 
-        # Run
+        # Phase 2: run draft-extend forward
         can_cuda_graph = (
             self.cuda_graph_runner_for_draft_extend
             and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
@@ -1170,11 +1173,10 @@ class EAGLEWorker(TpModelWorker):
             logits_output = self.cuda_graph_runner_for_draft_extend.replay(
                 forward_batch
             )
-            forward_batch.spec_info.topk_p, forward_batch.spec_info.topk_index = (
-                logits_output.topk_p,
-                logits_output.topk_index,
-            )
-            forward_batch.spec_info.hidden_states = logits_output.hidden_states
+            # cuda-graph replay populates logits_output.{topk_p, topk_index, hidden_states}.
+            topk_p = logits_output.topk_p
+            topk_index = logits_output.topk_index
+            hidden_states = logits_output.hidden_states
         else:
             forward_batch.can_run_dp_cuda_graph = False
             if not forward_batch.forward_mode.is_idle():
@@ -1187,23 +1189,36 @@ class EAGLEWorker(TpModelWorker):
             logits_output = self.draft_model_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
-            self.capture_for_decode(logits_output, forward_batch.spec_info)
+            # Non-cuda-graph path: compute topk_p / topk_index inline (used to be
+            # `capture_for_decode` which mutated spec_info; we instead carry the
+            # values to next-iter `EagleDraftInput` assembly below).
+            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            hidden_states = logits_output.hidden_states
 
         maybe_detect_nan(
             logits_output.next_token_logits,
             f"draft_extend_after_decode (cuda_graph={can_cuda_graph})",
         )
 
-        # Restore backup.
-        # This is because `seq_lens` can be modified in `prepare_extend_after_decode`
+        # Phase 3: assemble next-iter EagleDraftInput from extend output
+        next_draft_input = EagleDraftInput(
+            bonus_tokens=extend_input.bonus_tokens,
+            hidden_states=hidden_states,
+            topk_p=topk_p,
+            topk_index=topk_index,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+        )
+
+        # Restore batch fields and install the new draft input.
+        # `seq_lens` etc. were modified by `prepare_extend_after_decode`.
         batch.forward_mode = (
             ForwardMode.DECODE if not input_is_idle else ForwardMode.IDLE
         )
         batch.seq_lens = seq_lens_backup
         batch.seq_lens_cpu = seq_lens_cpu_backup
         batch.req_pool_indices = req_pool_indices_backup
-        batch.spec_info.num_accepted_drafts = num_accepted_drafts_backup
-        batch.spec_info.num_accepted_tokens = num_accepted_tokens_backup
+        batch.spec_info = next_draft_input
         batch.return_logprob = return_logprob_backup
 
     def capture_for_decode(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -514,8 +514,33 @@ class EAGLEWorker(TpModelWorker):
                     # batch.spec_info for the extend forward; the assembled
                     # next-iter EagleDraftInput is returned via batch_result
                     # and installed by the scheduler before the next draft.
-                    batch.spec_info = draft_extend_input
-                    next_draft_input = self.forward_draft_extend_after_decode(batch)
+                    extend_batch = batch
+                    if (
+                        not batch.forward_mode.is_idle()
+                        and draft_extend_input.input_ids.numel() == 0
+                    ):
+                        # All reqs finished this verify (only reachable when
+                        # dp_attention forces the forward). Run the extend on
+                        # an idle batch copy + idle ExtendInput so the original
+                        # batch is not mutated.
+                        extend_batch = batch.copy()
+                        extend_batch.prepare_for_idle()
+                        hidden_size = (
+                            self.model_config.hidden_size * 3
+                            if self.speculative_algorithm.is_eagle3()
+                            and self.eagle_use_aux_hidden_state
+                            else self.model_config.spec_hidden_size
+                        )
+                        draft_extend_input = EagleDraftExtendInput.create_idle_input(
+                            device=self.device,
+                            hidden_size=hidden_size,
+                            dtype=self.model_config.dtype,
+                            capture_hidden_mode=CaptureHiddenMode.LAST,
+                        )
+                    extend_batch.spec_info = draft_extend_input
+                    next_draft_input = self.forward_draft_extend_after_decode(
+                        extend_batch
+                    )
 
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
@@ -1117,6 +1142,9 @@ class EAGLEWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch
     ) -> EagleDraftInput:
+        # Caller installs the EagleDraftExtendInput on `batch.spec_info`
+        # (using either the verify-produced one or an idle one for the
+        # all-finished + dp_attention edge case).
         draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
         # Backup fields that will be modified in-place
@@ -1126,24 +1154,6 @@ class EAGLEWorker(TpModelWorker):
         return_logprob_backup = batch.return_logprob
 
         input_is_idle = batch.forward_mode.is_idle()
-
-        if not input_is_idle and draft_extend_input.input_ids.numel() == 0:
-            # All reqs finished this verify; swap to an idle ExtendInput.
-            batch = batch.copy()
-            batch.prepare_for_idle()
-            hidden_size = (
-                self.model_config.hidden_size * 3
-                if self.speculative_algorithm.is_eagle3()
-                and self.eagle_use_aux_hidden_state
-                else self.model_config.spec_hidden_size
-            )
-            draft_extend_input = EagleDraftExtendInput.create_idle_input(
-                device=self.device,
-                hidden_size=hidden_size,
-                dtype=self.model_config.dtype,
-                capture_hidden_mode=CaptureHiddenMode.LAST,
-            )
-            batch.spec_info = draft_extend_input
 
         # Phase 1: prepare extend (kernel writes draft_extend_input.{positions, bonus_tokens})
         draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -161,7 +161,7 @@ class EAGLEWorker(TpModelWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=0,  # spec workers don't support pipeline parallelism
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 attn_cp_rank=attn_cp_rank,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -543,20 +543,16 @@ class EAGLEWorker(TpModelWorker):
                 if next_draft_input is None:
                     # Skipped the extend forward (no dp_attention + all reqs
                     # finished). batch.spec_info is still the verify_input from
-                    # before verify; replace with an idle EagleDraftInput so
+                    # before verify; replace with an empty EagleDraftInput so
                     # the scheduler's unified relay installs a mergeable
                     # spec_info (EagleVerifyInput has no merge_batch).
-                    hidden_size = (
-                        self.model_config.hidden_size * 3
-                        if self.speculative_algorithm.is_eagle3()
-                        and self.eagle_use_aux_hidden_state
-                        else self.model_config.spec_hidden_size
-                    )
-                    next_draft_input = EagleDraftInput.create_idle_input(
-                        device=self.device,
-                        hidden_size=hidden_size,
-                        dtype=self.model_config.dtype,
-                        topk=self.topk,
+                    #
+                    # Leave hidden_states/bonus_tokens/topk_* as None so the
+                    # downstream `EagleDraftInput.merge_batch` short-circuits
+                    # at the `if spec_info.hidden_states is None: return` guard,
+                    # avoiding a hidden_states shape mismatch when running_batch
+                    # carries an EAGLE3 aux-hidden-state layout (3*hidden_size).
+                    next_draft_input = EagleDraftInput(
                         capture_hidden_mode=CaptureHiddenMode.LAST,
                     )
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -488,7 +488,7 @@ class EAGLEWorker(TpModelWorker):
 
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
-            logits_output, verify_output, can_run_cuda_graph = self.verify(batch)
+            verify_output = self.verify(batch)
 
             if get_global_tracing_enabled():
                 for idx, req in enumerate(batch.reqs):
@@ -526,11 +526,11 @@ class EAGLEWorker(TpModelWorker):
                 )
 
             return GenerationBatchResult(
-                logits_output=logits_output,
+                logits_output=verify_output.logits_output,
                 next_token_ids=verify_output.accept_tokens,
                 num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
                 num_accepted_drafts_per_req_cpu=verify_output.num_accepted_drafts_per_req_cpu,
-                can_run_cuda_graph=can_run_cuda_graph,
+                can_run_cuda_graph=verify_output.can_run_cuda_graph,
             )
 
     def check_forward_draft_extend_after_decode(
@@ -986,7 +986,8 @@ class EAGLEWorker(TpModelWorker):
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
 
-        return logits_output, res, can_run_cuda_graph
+        res.can_run_cuda_graph = can_run_cuda_graph
+        return res
 
     def _mamba_verify_update(
         self,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -156,7 +156,7 @@ class EagleDraftWorker(BaseDraftWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=0,  # spec workers don't support pipeline parallelism
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 attn_cp_rank=attn_cp_rank,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -590,6 +590,9 @@ class EagleDraftWorker(BaseDraftWorker):
             - 1
         )
 
+        # Install draft_extend_input as `batch.spec_info` for the extend forward.
+        batch.spec_info = draft_extend_input
+
         # Prepare for draft extend in a separate stream
         with self.plan_stream_ctx:
             forward_batch = draft_extend_input.prepare_for_extend_to_fill_draft_kvcache(
@@ -1027,7 +1030,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # Sample
         maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
-        verify_output, predict = verify_input.sample(batch, logits_output, vocab_mask)
+        verify_output, predict = verify_input.verify_v2(
+            batch, logits_output, vocab_mask
+        )
         accept_lens = verify_output.draft_extend_input.num_accepted_tokens
         new_seq_lens = batch.seq_lens + accept_lens
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -49,6 +49,7 @@ from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
     EagleDraftInput,
     EagleVerifyInput,
+    EagleVerifyOutput,
 )
 from sglang.srt.speculative.eagle_info_v2 import (
     assign_extend_cache_locs,
@@ -569,12 +570,15 @@ class EagleDraftWorker(BaseDraftWorker):
         return next_draft_input
 
     def _draft_extend_for_decode(
-        self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
+        self,
+        batch: ModelWorkerBatch,
+        batch_result: GenerationBatchResult,
+        verify_output: EagleVerifyOutput,
     ):
         # Batch 2: Draft extend. verify already built draft_extend_input with
         # hidden_states / num_accepted_*; we only need to set the per-req
         # padding info for this forward.
-        draft_extend_input = batch_result.next_draft_extend_input
+        draft_extend_input = verify_output.draft_extend_input
         draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
         draft_extend_input.num_tokens_for_logprob_per_req = (
             self.speculative_num_steps + 1
@@ -785,12 +789,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 self._draft_done_event = torch.get_device_module(self.device).Event()
                 self._draft_done_event.record()
             model_worker_batch.spec_info = verify_input
-            batch_output = self.verify(model_worker_batch)
+            batch_output, verify_output = self.verify(model_worker_batch)
             with self.draft_worker.draft_tp_context(
                 self.draft_worker.draft_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
                 self.draft_worker._draft_extend_for_decode(
-                    model_worker_batch, batch_output
+                    model_worker_batch, batch_output, verify_output
                 )
 
             return batch_output
@@ -1070,17 +1074,17 @@ class EAGLEWorkerV2(BaseSpecWorker):
             verify_done=verify_done,
         )
 
-        return GenerationBatchResult(
+        batch_result = GenerationBatchResult(
             logits_output=logits_output,
             next_token_ids=predict,
             can_run_cuda_graph=can_run_cuda_graph,
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             next_draft_input=next_draft_input,
-            next_draft_extend_input=verify_output.draft_extend_input,
             accept_lens=accept_lens,
             routed_experts_output=forward_batch_output.routed_experts_output,
             indexer_topk_output=forward_batch_output.indexer_topk_output,
         )
+        return batch_result, verify_output
 
     def _mamba_verify_update(
         self,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -571,15 +571,13 @@ class EagleDraftWorker(BaseDraftWorker):
     def _draft_extend_for_decode(
         self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
     ):
-        # Batch 2: Draft extend.
-        # `batch_result.accept_lens` already includes the bonus token, so use it
-        # directly for `num_accepted_tokens` and subtract 1 for `num_accepted_drafts`.
-        draft_extend_input = EagleDraftExtendInput(
-            hidden_states=batch_result.logits_output.hidden_states,
-            num_accepted_drafts=batch_result.accept_lens - 1,
-            num_accepted_tokens=batch_result.accept_lens,
-            num_tokens_per_req=self.speculative_num_steps + 1,
-            num_tokens_for_logprob_per_req=self.speculative_num_steps + 1,
+        # Batch 2: Draft extend. verify already built draft_extend_input with
+        # hidden_states / num_accepted_*; we only need to set the per-req
+        # padding info for this forward.
+        draft_extend_input = batch_result.next_draft_extend_input
+        draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
+        draft_extend_input.num_tokens_for_logprob_per_req = (
+            self.speculative_num_steps + 1
         )
         select_index = (
             torch.arange(len(batch.seq_lens), device=self.device)
@@ -1025,11 +1023,8 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # Sample
         maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
-        (
-            predict,
-            accept_lens,
-            accept_index,
-        ) = verify_input.sample(batch, logits_output, vocab_mask)
+        verify_output, predict = verify_input.sample(batch, logits_output, vocab_mask)
+        accept_lens = verify_output.draft_extend_input.num_accepted_tokens
         new_seq_lens = batch.seq_lens + accept_lens
 
         # Update mamba state for hybrid GDN models after verification
@@ -1038,17 +1033,20 @@ class EAGLEWorkerV2(BaseSpecWorker):
             or self.target_worker.model_runner.mamba2_config is not None
         ):
             self._mamba_verify_update(
-                batch, verify_input, accept_lens, accept_index, bs
+                batch,
+                verify_input,
+                accept_lens,
+                verify_output.accepted_indices,
+                bs,
             )
 
         verify_done = torch.get_device_module(self.device).Event()
         verify_done.record()
 
         if not batch.forward_mode.is_idle():
-            accept_tokens = predict[accept_index]
             bonus_tokens = torch.empty_like(accept_lens, dtype=torch.int32)
             fill_bonus_tokens[(bs,)](
-                accept_tokens,
+                verify_output.accept_tokens,
                 accept_lens,
                 bonus_tokens,
                 self.speculative_num_draft_tokens,
@@ -1058,7 +1056,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         if batch.return_logprob and not batch.forward_mode.is_idle():
             compute_spec_v2_logprobs(
-                batch, logits_output, predict, accept_index, self.speculative_num_steps
+                batch,
+                logits_output,
+                predict,
+                verify_output.accepted_indices,
+                self.speculative_num_steps,
             )
 
         # Construct the next draft input
@@ -1074,6 +1076,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             can_run_cuda_graph=can_run_cuda_graph,
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             next_draft_input=next_draft_input,
+            next_draft_extend_input=verify_output.draft_extend_input,
             accept_lens=accept_lens,
             routed_experts_output=forward_batch_output.routed_experts_output,
             indexer_topk_output=forward_batch_output.indexer_topk_output,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -45,7 +45,11 @@ from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
 from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
     EAGLEDraftExtendCudaGraphRunner,
 )
-from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+from sglang.srt.speculative.eagle_info import (
+    EagleDraftExtendInput,
+    EagleDraftInput,
+    EagleVerifyInput,
+)
 from sglang.srt.speculative.eagle_info_v2 import (
     assign_extend_cache_locs,
     fill_accepted_out_cache_loc,
@@ -534,17 +538,13 @@ class EagleDraftWorker(BaseDraftWorker):
                 )
                 pt += extend_len
 
-        # Construct spec_info
-        next_draft_input = EagleDraftInput(
+        # Install draft-extend spec_info for the extend forward.
+        extend_input = EagleDraftExtendInput(
             hidden_states=target_hidden_states,
-            bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
-            # draft mode is same with decode mode, only 1 token per req
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
         )
-
-        batch.spec_info = next_draft_input
+        batch.spec_info = extend_input
 
         # Run forward
         forward_batch = ForwardBatch.init_new(batch, self.draft_runner)
@@ -554,20 +554,30 @@ class EagleDraftWorker(BaseDraftWorker):
         logits_output = self.draft_runner.forward(forward_batch).logits_output
         maybe_detect_nan(logits_output.next_token_logits, "draft_extend_for_prefill")
 
-        # Update spec_info for the next draft step
+        # Assemble fresh next-iter draft spec_info from the extend output.
         probs = torch.softmax(logits_output.next_token_logits, dim=-1)
-        next_draft_input.topk_p, next_draft_input.topk_index = fast_topk(
-            probs, self.topk, dim=-1
+        topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+        next_draft_input = EagleDraftInput(
+            topk_p=topk_p,
+            topk_index=topk_index,
+            hidden_states=logits_output.hidden_states,
+            bonus_tokens=next_token_ids,
+            new_seq_lens=batch.seq_lens,
+            num_tokens_per_req=1,
+            num_tokens_for_logprob_per_req=1,
         )
-        next_draft_input.hidden_states = logits_output.hidden_states
         return next_draft_input
 
     def _draft_extend_for_decode(
         self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
     ):
-        # Batch 2: Draft extend
-        draft_input = EagleDraftInput(
+        # Batch 2: Draft extend.
+        # `batch_result.accept_lens` already includes the bonus token, so use it
+        # directly for `num_accepted_tokens` and subtract 1 for `num_accepted_drafts`.
+        draft_extend_input = EagleDraftExtendInput(
             hidden_states=batch_result.logits_output.hidden_states,
+            num_accepted_drafts=batch_result.accept_lens - 1,
+            num_accepted_tokens=batch_result.accept_lens,
             num_tokens_per_req=self.speculative_num_steps + 1,
             num_tokens_for_logprob_per_req=self.speculative_num_steps + 1,
         )
@@ -580,7 +590,7 @@ class EagleDraftWorker(BaseDraftWorker):
 
         # Prepare for draft extend in a separate stream
         with self.plan_stream_ctx:
-            forward_batch = draft_input.prepare_for_extend_to_fill_draft_kvcache(
+            forward_batch = draft_extend_input.prepare_for_extend_to_fill_draft_kvcache(
                 batch,
                 batch_result.next_token_ids,
                 self.speculative_num_draft_tokens,
@@ -592,12 +602,6 @@ class EagleDraftWorker(BaseDraftWorker):
             torch.get_device_module(self.device).current_stream().wait_stream(
                 self.plan_stream
             )
-
-        if forward_batch.spec_info.num_accepted_drafts is None:
-            # `batch_result.accept_lens` already includes the bonus token, so use it
-            # directly for `num_accepted_tokens` and subtract 1 for `num_accepted_drafts`.
-            forward_batch.spec_info.num_accepted_drafts = batch_result.accept_lens - 1
-            forward_batch.spec_info.num_accepted_tokens = batch_result.accept_lens
 
         # Run draft extend batch in the main compute stream
         can_cuda_graph = (

--- a/python/sglang/srt/speculative/frozen_kv_mtp_info.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_info.py
@@ -18,6 +18,7 @@ from typing import Dict
 
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.speculative.eagle_info import (
+    EagleDraftExtendInput,
     EagleDraftInput,
     EagleVerifyInput,
     EagleVerifyOutput,
@@ -54,6 +55,14 @@ class FrozenKVMTPDraftInput(EagleDraftInput):
 
 
 @dataclass
+class FrozenKVMTPDraftExtendInput(EagleDraftExtendInput):
+    """Draft-extend input for Frozen-KV MTP. Tag-only subclass."""
+
+    def __post_init__(self):
+        SpecInput.__init__(self, SpecInputType.FROZEN_KV_MTP_DRAFT_EXTEND)
+
+
+@dataclass
 class FrozenKVMTPVerifyInput(EagleVerifyInput):
     """Verify input for Frozen-KV MTP."""
 
@@ -62,21 +71,21 @@ class FrozenKVMTPVerifyInput(EagleVerifyInput):
 
     def verify(self, *args, **kwargs) -> EagleVerifyOutput:
         output = super().verify(*args, **kwargs)
-        output.next_draft_input = _to_frozen_kv_mtp_draft_input(output.next_draft_input)
+        output.extend_input = _to_frozen_kv_mtp_draft_extend_input(output.extend_input)
         return output
 
 
 FrozenKVMTPVerifyOutput = EagleVerifyOutput
 
 
-def _to_frozen_kv_mtp_draft_input(
-    draft_input: EagleDraftInput,
-) -> FrozenKVMTPDraftInput:
-    if isinstance(draft_input, FrozenKVMTPDraftInput):
-        return draft_input
-    return FrozenKVMTPDraftInput(
+def _to_frozen_kv_mtp_draft_extend_input(
+    extend_input: EagleDraftExtendInput,
+) -> FrozenKVMTPDraftExtendInput:
+    if isinstance(extend_input, FrozenKVMTPDraftExtendInput):
+        return extend_input
+    return FrozenKVMTPDraftExtendInput(
         **{
-            field.name: getattr(draft_input, field.name)
-            for field in fields(EagleDraftInput)
+            field.name: getattr(extend_input, field.name)
+            for field in fields(EagleDraftExtendInput)
         }
     )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_info.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_info.py
@@ -71,7 +71,9 @@ class FrozenKVMTPVerifyInput(EagleVerifyInput):
 
     def verify(self, *args, **kwargs) -> EagleVerifyOutput:
         output = super().verify(*args, **kwargs)
-        output.extend_input = _to_frozen_kv_mtp_draft_extend_input(output.extend_input)
+        output.draft_extend_input = _to_frozen_kv_mtp_draft_extend_input(
+            output.draft_extend_input
+        )
         return output
 
 
@@ -79,13 +81,13 @@ FrozenKVMTPVerifyOutput = EagleVerifyOutput
 
 
 def _to_frozen_kv_mtp_draft_extend_input(
-    extend_input: EagleDraftExtendInput,
+    draft_extend_input: EagleDraftExtendInput,
 ) -> FrozenKVMTPDraftExtendInput:
-    if isinstance(extend_input, FrozenKVMTPDraftExtendInput):
-        return extend_input
+    if isinstance(draft_extend_input, FrozenKVMTPDraftExtendInput):
+        return draft_extend_input
     return FrozenKVMTPDraftExtendInput(
         **{
-            field.name: getattr(extend_input, field.name)
+            field.name: getattr(draft_extend_input, field.name)
             for field in fields(EagleDraftExtendInput)
         }
     )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_utils.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_utils.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Tuple, Union
+from typing import Tuple
 
 import torch
 
@@ -135,11 +135,8 @@ def select_last_extend_hidden(
 
 
 def select_last_verified_seed(
-    draft_input: Union[FrozenKVMTPDraftInput, FrozenKVMTPDraftExtendInput],
+    draft_input: FrozenKVMTPDraftExtendInput,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    if draft_input.num_accepted_tokens is None:
-        return draft_input.bonus_tokens, draft_input.hidden_states
-
     counts = draft_input.num_accepted_tokens.to(torch.long)
     last_indices = torch.cumsum(counts, dim=0) - 1
     return (

--- a/python/sglang/srt/speculative/frozen_kv_mtp_utils.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_utils.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 
@@ -23,6 +23,7 @@ from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.speculative.frozen_kv_mtp_info import (
     FrozenKVMTPContext,
+    FrozenKVMTPDraftExtendInput,
     FrozenKVMTPDraftInput,
 )
 from sglang.srt.speculative.spec_utils import fast_topk
@@ -134,7 +135,7 @@ def select_last_extend_hidden(
 
 
 def select_last_verified_seed(
-    draft_input: FrozenKVMTPDraftInput,
+    draft_input: Union[FrozenKVMTPDraftInput, FrozenKVMTPDraftExtendInput],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if draft_input.num_accepted_tokens is None:
         return draft_input.bonus_tokens, draft_input.hidden_states

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -352,17 +352,21 @@ class FrozenKVMTPWorker(TpModelWorker):
         seq_lens_cpu: Optional[torch.Tensor] = None,
         mm_input_embeds: Optional[torch.Tensor] = None,
         draft_input: Optional[FrozenKVMTPDraftInput] = None,
-    ) -> None:
-        """Run the one-token assistant seed step against frozen target KV."""
+    ) -> FrozenKVMTPDraftInput:
+        """Run the one-token assistant seed step against frozen target KV.
+
+        Returns the next-iter `FrozenKVMTPDraftInput`. Caller installs it as
+        `batch.spec_info` (we only mutate `batch.spec_info` transiently for
+        the forward and restore it on return).
+        """
         if batch.forward_mode.is_idle() or last_token_ids.numel() == 0:
-            batch.spec_info = FrozenKVMTPDraftInput.create_idle_input(
+            return FrozenKVMTPDraftInput.create_idle_input(
                 device=batch.device,
                 hidden_size=self._recurrent_hidden_size,
                 dtype=self.model_config.dtype,
                 topk=self.topk,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
-            return
 
         if draft_input is None:
             draft_input = FrozenKVMTPDraftInput()
@@ -409,10 +413,9 @@ class FrozenKVMTPWorker(TpModelWorker):
             batch.input_ids = input_ids_backup
             batch.return_hidden_states = return_hidden_states_backup
             batch.return_logprob = return_logprob_backup
-            # Keep the seeded draft state; only restore the old object on error paths
-            # before the assignment above could have happened.
-            if batch.spec_info is not draft_input:
-                batch.spec_info = spec_info_backup
+            batch.spec_info = spec_info_backup
+
+        return draft_input
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
@@ -465,11 +468,12 @@ class FrozenKVMTPWorker(TpModelWorker):
                 self.server_args.enable_dp_attention
                 or draft_extend_input.input_ids.numel() > 0
             ):
-                # Install draft_extend_input as `batch.spec_info` for the seed
-                # step (`_run_assistant_seed_step` replaces it with a fresh
-                # `FrozenKVMTPDraftInput` for next iter).
+                # Install draft_extend_input as batch.spec_info for the seed
+                # step; the assembled next-iter FrozenKVMTPDraftInput is
+                # returned and installed by the executor here.
                 batch.spec_info = draft_extend_input
-                self.forward_draft_extend_after_decode(batch)
+                next_draft_input = self.forward_draft_extend_after_decode(batch)
+                batch.spec_info = next_draft_input
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
 
         return GenerationBatchResult(
@@ -502,7 +506,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         mm_input_embeds: Optional[torch.Tensor] = None,
     ) -> None:
         last_hidden = self._select_last_extend_hidden(batch, hidden_states)
-        self._run_assistant_seed_step(
+        batch.spec_info = self._run_assistant_seed_step(
             batch,
             next_token_ids,
             last_hidden,
@@ -510,26 +514,25 @@ class FrozenKVMTPWorker(TpModelWorker):
             mm_input_embeds=mm_input_embeds,
         )
 
-    def forward_draft_extend_after_decode(self, batch: ScheduleBatch) -> None:
+    def forward_draft_extend_after_decode(
+        self, batch: ScheduleBatch
+    ) -> FrozenKVMTPDraftInput:
+        """Run the post-verify seed step. Returns next-iter
+        `FrozenKVMTPDraftInput`; caller installs on `batch.spec_info`.
+        """
         draft_extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
-        input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and draft_extend_input.input_ids.numel() == 0:
-            # All reqs finished. Install an idle FrozenKVMTPDraftInput so the
-            # next-iter draft sees a valid spec_info.
-            batch = batch.copy()
-            batch.prepare_for_idle()
-            batch.spec_info = FrozenKVMTPDraftInput.create_idle_input(
+        # Idle / all-finished short-circuit: idle DraftExtendInput leaves
+        # `bonus_tokens=None`, so we can't run `_select_last_verified_seed`.
+        # Return an idle FrozenKVMTPDraftInput for the next iter's draft.
+        if batch.forward_mode.is_idle() or draft_extend_input.input_ids.numel() == 0:
+            return FrozenKVMTPDraftInput.create_idle_input(
                 device=self.device,
                 hidden_size=self._recurrent_hidden_size,
                 dtype=self.model_config.dtype,
                 topk=self.topk,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
-            return
-
-        if batch.forward_mode.is_idle():
-            return
 
         seq_lens_backup = batch.seq_lens.clone()
         seq_lens_cpu_backup = batch.seq_lens_cpu.clone()
@@ -545,9 +548,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             last_token_ids, last_hidden = self._select_last_verified_seed(
                 draft_extend_input
             )
-            # `_run_assistant_seed_step` constructs a fresh `FrozenKVMTPDraftInput`
-            # and installs it on `batch.spec_info` for next iter.
-            self._run_assistant_seed_step(
+            return self._run_assistant_seed_step(
                 batch,
                 last_token_ids,
                 last_hidden,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -450,9 +450,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         # Install verify_input as `batch.spec_info` for the verify forward.
         batch.spec_info = verify_input
-        logits_output, verify_output, can_run_cuda_graph = self.verify(
-            batch, verify_input
-        )
+        logits_output, verify_output, can_run_cuda_graph = self.verify(batch)
 
         if get_global_tracing_enabled():
             for idx, req in enumerate(batch.reqs):
@@ -515,13 +513,9 @@ class FrozenKVMTPWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> None:
-        # Caller (forward_batch_generation) is responsible for installing
-        # verify_output.draft_extend_input as batch.spec_info before calling.
-        # `_run_assistant_seed_step` will replace it with a fresh
+        # `_run_assistant_seed_step` will replace `batch.spec_info` with a fresh
         # `FrozenKVMTPDraftInput` for the next iter's draft.
-        draft_extend_input = verify_output.draft_extend_input
-        assert isinstance(draft_extend_input, FrozenKVMTPDraftExtendInput)
-        assert batch.spec_info is draft_extend_input
+        draft_extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
         input_is_idle = batch.forward_mode.is_idle()
 
         if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
@@ -708,10 +702,8 @@ class FrozenKVMTPWorker(TpModelWorker):
             score_list, token_list, parents_list, self.speculative_num_draft_tokens
         )
 
-    def verify(self, batch: ScheduleBatch, spec_info: FrozenKVMTPVerifyInput):
-        # Caller (forward_batch_generation) is responsible for installing
-        # `spec_info` as `batch.spec_info` before calling.
-        assert batch.spec_info is spec_info
+    def verify(self, batch: ScheduleBatch):
+        spec_info: FrozenKVMTPVerifyInput = batch.spec_info
         seq_lens_pre_verify = batch.seq_lens.clone()
         spec_info.prepare_for_verify(batch, self.page_size)
         spec_info.num_tokens_per_req = self.speculative_num_steps + 1

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -509,8 +509,12 @@ class FrozenKVMTPWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> None:
-        assert isinstance(batch.spec_info, FrozenKVMTPDraftExtendInput)
-        draft_extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
+        # Install the draft-extend input as `batch.spec_info` for the seed step.
+        # `_run_assistant_seed_step` will replace it with a fresh
+        # `FrozenKVMTPDraftInput` for the next iter's draft.
+        draft_extend_input = verify_output.draft_extend_input
+        assert isinstance(draft_extend_input, FrozenKVMTPDraftExtendInput)
+        batch.spec_info = draft_extend_input
         input_is_idle = batch.forward_mode.is_idle()
 
         if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
@@ -776,7 +780,6 @@ class FrozenKVMTPWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.draft_extend_input
 
         del seq_lens_pre_verify
         return logits_output, res, model_worker_batch, can_run_cuda_graph

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -336,7 +336,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         return select_last_extend_hidden(batch, hidden_states)
 
     def _select_last_verified_seed(
-        self, draft_input: FrozenKVMTPDraftInput
+        self, draft_input: FrozenKVMTPDraftExtendInput
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return select_last_verified_seed(draft_input)
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -510,7 +510,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> None:
         assert isinstance(batch.spec_info, FrozenKVMTPDraftExtendInput)
-        extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
+        draft_extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
         input_is_idle = batch.forward_mode.is_idle()
 
         if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
@@ -541,7 +541,9 @@ class FrozenKVMTPWorker(TpModelWorker):
             batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
             batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
 
-            last_token_ids, last_hidden = self._select_last_verified_seed(extend_input)
+            last_token_ids, last_hidden = self._select_last_verified_seed(
+                draft_extend_input
+            )
             # `_run_assistant_seed_step` constructs a fresh `FrozenKVMTPDraftInput`
             # and installs it on `batch.spec_info` for next iter.
             self._run_assistant_seed_step(
@@ -774,7 +776,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.extend_input
+        batch.spec_info = res.draft_extend_input
 
         del seq_lens_pre_verify
         return logits_output, res, model_worker_batch, can_run_cuda_graph

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -43,7 +43,6 @@ from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.speculative.eagle_info import EagleVerifyOutput
 from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     organize_draft_results,
@@ -461,15 +460,16 @@ class FrozenKVMTPWorker(TpModelWorker):
         with self.draft_tp_context(
             self.draft_model_runner.tp_group
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+            draft_extend_input = verify_output.draft_extend_input
             if (
                 self.server_args.enable_dp_attention
-                or verify_output.unfinished_accept_tokens.numel() > 0
+                or draft_extend_input.input_ids.numel() > 0
             ):
                 # Install draft_extend_input as `batch.spec_info` for the seed
                 # step (`_run_assistant_seed_step` replaces it with a fresh
                 # `FrozenKVMTPDraftInput` for next iter).
-                batch.spec_info = verify_output.draft_extend_input
-                self.forward_draft_extend_after_decode(batch, verify_output)
+                batch.spec_info = draft_extend_input
+                self.forward_draft_extend_after_decode(batch)
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
 
         return GenerationBatchResult(
@@ -510,15 +510,11 @@ class FrozenKVMTPWorker(TpModelWorker):
             mm_input_embeds=mm_input_embeds,
         )
 
-    def forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
-    ) -> None:
-        # `_run_assistant_seed_step` will replace `batch.spec_info` with a fresh
-        # `FrozenKVMTPDraftInput` for the next iter's draft.
+    def forward_draft_extend_after_decode(self, batch: ScheduleBatch) -> None:
         draft_extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
+        if not input_is_idle and draft_extend_input.input_ids.numel() == 0:
             # All reqs finished. Install an idle FrozenKVMTPDraftInput so the
             # next-iter draft sees a valid spec_info.
             batch = batch.copy()
@@ -541,10 +537,10 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         try:
             # Verify may leave finished requests in ScheduleBatch; seed only
-            # the unfinished requests carried by `verify_output`.
-            batch.seq_lens = verify_output.seq_lens_for_draft_extend
-            batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
-            batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
+            # the unfinished reqs carried by `draft_extend_input`.
+            batch.seq_lens = draft_extend_input.seq_lens
+            batch.seq_lens_cpu = draft_extend_input.seq_lens_cpu
+            batch.req_pool_indices = draft_extend_input.req_pool_indices
 
             last_token_ids, last_hidden = self._select_last_verified_seed(
                 draft_extend_input
@@ -555,7 +551,7 @@ class FrozenKVMTPWorker(TpModelWorker):
                 batch,
                 last_token_ids,
                 last_hidden,
-                seq_lens_cpu=verify_output.seq_lens_for_draft_extend_cpu,
+                seq_lens_cpu=draft_extend_input.seq_lens_cpu,
             )
         finally:
             batch.seq_lens = seq_lens_backup

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -428,7 +428,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.draft_model_runner.tp_group
             ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
-                self.forward_draft_extend(
+                next_draft_input = self.forward_draft_extend(
                     batch,
                     logits_output.hidden_states,
                     next_token_ids,
@@ -440,6 +440,7 @@ class FrozenKVMTPWorker(TpModelWorker):
                 next_token_ids=next_token_ids,
                 num_accepted_drafts=0,
                 can_run_cuda_graph=can_run_cuda_graph,
+                next_draft_input=next_draft_input,
             )
 
         set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
@@ -460,6 +461,7 @@ class FrozenKVMTPWorker(TpModelWorker):
                 req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
 
         set_time_batch(batch.reqs, "set_spec_draft_extend_start_time", trace_only=True)
+        next_draft_input = None
         with self.draft_tp_context(
             self.draft_model_runner.tp_group
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
@@ -470,10 +472,10 @@ class FrozenKVMTPWorker(TpModelWorker):
             ):
                 # Install draft_extend_input as batch.spec_info for the seed
                 # step; the assembled next-iter FrozenKVMTPDraftInput is
-                # returned and installed by the executor here.
+                # returned via batch_result and installed by the scheduler
+                # before the next draft.
                 batch.spec_info = draft_extend_input
                 next_draft_input = self.forward_draft_extend_after_decode(batch)
-                batch.spec_info = next_draft_input
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
 
         return GenerationBatchResult(
@@ -482,6 +484,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
             num_accepted_drafts_per_req_cpu=verify_output.num_accepted_drafts_per_req_cpu,
             can_run_cuda_graph=verify_output.can_run_cuda_graph,
+            next_draft_input=next_draft_input,
         )
 
     def forward_target_extend(
@@ -504,9 +507,12 @@ class FrozenKVMTPWorker(TpModelWorker):
         next_token_ids: torch.Tensor,
         seq_lens_cpu: Optional[torch.Tensor],
         mm_input_embeds: Optional[torch.Tensor] = None,
-    ) -> None:
+    ) -> FrozenKVMTPDraftInput:
+        """Run the prefill seed step. Returns next-iter `FrozenKVMTPDraftInput`;
+        scheduler installs it on `batch.spec_info` via `batch_result.next_draft_input`.
+        """
         last_hidden = self._select_last_extend_hidden(batch, hidden_states)
-        batch.spec_info = self._run_assistant_seed_step(
+        return self._run_assistant_seed_step(
             batch,
             next_token_ids,
             last_hidden,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -449,7 +449,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         # Install verify_input as `batch.spec_info` for the verify forward.
         batch.spec_info = verify_input
-        logits_output, verify_output, can_run_cuda_graph = self.verify(batch)
+        verify_output = self.verify(batch)
 
         if get_global_tracing_enabled():
             for idx, req in enumerate(batch.reqs):
@@ -473,11 +473,11 @@ class FrozenKVMTPWorker(TpModelWorker):
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
 
         return GenerationBatchResult(
-            logits_output=logits_output,
+            logits_output=verify_output.logits_output,
             next_token_ids=verify_output.accept_tokens,
             num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
             num_accepted_drafts_per_req_cpu=verify_output.num_accepted_drafts_per_req_cpu,
-            can_run_cuda_graph=can_run_cuda_graph,
+            can_run_cuda_graph=verify_output.can_run_cuda_graph,
         )
 
     def forward_target_extend(
@@ -779,4 +779,5 @@ class FrozenKVMTPWorker(TpModelWorker):
         )
 
         del seq_lens_pre_verify
-        return logits_output, res, can_run_cuda_graph
+        res.can_run_cuda_graph = can_run_cuda_graph
+        return res

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -450,7 +450,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         # Install verify_input as `batch.spec_info` for the verify forward.
         batch.spec_info = verify_input
-        logits_output, verify_output, _, can_run_cuda_graph = self.verify(
+        logits_output, verify_output, can_run_cuda_graph = self.verify(
             batch, verify_input
         )
 
@@ -791,4 +791,4 @@ class FrozenKVMTPWorker(TpModelWorker):
         )
 
         del seq_lens_pre_verify
-        return logits_output, res, model_worker_batch, can_run_cuda_graph
+        return logits_output, res, can_run_cuda_graph

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -50,6 +50,7 @@ from sglang.srt.speculative.eagle_utils import (
 )
 from sglang.srt.speculative.frozen_kv_mtp_info import (
     FrozenKVMTPContext,
+    FrozenKVMTPDraftExtendInput,
     FrozenKVMTPDraftInput,
     FrozenKVMTPVerifyInput,
     FrozenKVMTPVerifyOutput,
@@ -462,7 +463,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
             if (
                 self.server_args.enable_dp_attention
-                or batch.spec_info.bonus_tokens.numel()
+                or verify_output.unfinished_accept_tokens.numel() > 0
             ):
                 self.forward_draft_extend_after_decode(batch, verify_output)
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
@@ -508,9 +509,13 @@ class FrozenKVMTPWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> None:
-        assert isinstance(batch.spec_info, FrozenKVMTPDraftInput)
+        assert isinstance(batch.spec_info, FrozenKVMTPDraftExtendInput)
+        extend_input: FrozenKVMTPDraftExtendInput = batch.spec_info
         input_is_idle = batch.forward_mode.is_idle()
-        if not input_is_idle and batch.spec_info.bonus_tokens.numel() == 0:
+
+        if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
+            # All reqs finished. Install an idle FrozenKVMTPDraftInput so the
+            # next-iter draft sees a valid spec_info.
             batch = batch.copy()
             batch.prepare_for_idle()
             batch.spec_info = FrozenKVMTPDraftInput.create_idle_input(
@@ -520,11 +525,11 @@ class FrozenKVMTPWorker(TpModelWorker):
                 topk=self.topk,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
+            return
 
         if batch.forward_mode.is_idle():
             return
 
-        draft_input = batch.spec_info
         seq_lens_backup = batch.seq_lens.clone()
         seq_lens_cpu_backup = batch.seq_lens_cpu.clone()
         req_pool_indices_backup = batch.req_pool_indices
@@ -536,13 +541,14 @@ class FrozenKVMTPWorker(TpModelWorker):
             batch.seq_lens_cpu = verify_output.seq_lens_for_draft_extend_cpu
             batch.req_pool_indices = verify_output.req_pool_indices_for_draft_extend
 
-            last_token_ids, last_hidden = self._select_last_verified_seed(draft_input)
+            last_token_ids, last_hidden = self._select_last_verified_seed(extend_input)
+            # `_run_assistant_seed_step` constructs a fresh `FrozenKVMTPDraftInput`
+            # and installs it on `batch.spec_info` for next iter.
             self._run_assistant_seed_step(
                 batch,
                 last_token_ids,
                 last_hidden,
                 seq_lens_cpu=verify_output.seq_lens_for_draft_extend_cpu,
-                draft_input=draft_input,
             )
         finally:
             batch.seq_lens = seq_lens_backup
@@ -768,7 +774,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.next_draft_input
+        batch.spec_info = res.extend_input
 
         del seq_lens_pre_verify
         return logits_output, res, model_worker_batch, can_run_cuda_graph

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -444,12 +444,14 @@ class FrozenKVMTPWorker(TpModelWorker):
         with self.draft_tp_context(
             self.draft_model_runner.tp_group
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
-            spec_info = self.draft(batch)
+            verify_input = self.draft(batch)
         set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
         set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
 
+        # Install verify_input as `batch.spec_info` for the verify forward.
+        batch.spec_info = verify_input
         logits_output, verify_output, _, can_run_cuda_graph = self.verify(
-            batch, spec_info
+            batch, verify_input
         )
 
         if get_global_tracing_enabled():
@@ -465,6 +467,10 @@ class FrozenKVMTPWorker(TpModelWorker):
                 self.server_args.enable_dp_attention
                 or verify_output.unfinished_accept_tokens.numel() > 0
             ):
+                # Install draft_extend_input as `batch.spec_info` for the seed
+                # step (`_run_assistant_seed_step` replaces it with a fresh
+                # `FrozenKVMTPDraftInput` for next iter).
+                batch.spec_info = verify_output.draft_extend_input
                 self.forward_draft_extend_after_decode(batch, verify_output)
         set_time_batch(batch.reqs, "set_spec_draft_extend_end_time", trace_only=True)
 
@@ -509,12 +515,13 @@ class FrozenKVMTPWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> None:
-        # Install the draft-extend input as `batch.spec_info` for the seed step.
+        # Caller (forward_batch_generation) is responsible for installing
+        # verify_output.draft_extend_input as batch.spec_info before calling.
         # `_run_assistant_seed_step` will replace it with a fresh
         # `FrozenKVMTPDraftInput` for the next iter's draft.
         draft_extend_input = verify_output.draft_extend_input
         assert isinstance(draft_extend_input, FrozenKVMTPDraftExtendInput)
-        batch.spec_info = draft_extend_input
+        assert batch.spec_info is draft_extend_input
         input_is_idle = batch.forward_mode.is_idle()
 
         if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
@@ -702,6 +709,9 @@ class FrozenKVMTPWorker(TpModelWorker):
         )
 
     def verify(self, batch: ScheduleBatch, spec_info: FrozenKVMTPVerifyInput):
+        # Caller (forward_batch_generation) is responsible for installing
+        # `spec_info` as `batch.spec_info` before calling.
+        assert batch.spec_info is spec_info
         seq_lens_pre_verify = batch.seq_lens.clone()
         spec_info.prepare_for_verify(batch, self.page_size)
         spec_info.num_tokens_per_req = self.speculative_num_steps + 1
@@ -711,7 +721,6 @@ class FrozenKVMTPWorker(TpModelWorker):
             if not batch.forward_mode.is_idle()
             else ForwardMode.IDLE
         )
-        batch.spec_info = spec_info
 
         model_worker_batch = batch.get_model_worker_batch(
             seq_lens_cpu_cache=spec_info.seq_lens_cpu

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -41,7 +41,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
 )
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
-from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 from sglang.srt.speculative.multi_layer_eagle_utils import assign_new_state_triton
 from sglang.srt.speculative.spec_utils import fast_topk
 from sglang.srt.utils import (
@@ -349,7 +349,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
         else:
             global_dp_buffer_len = None
 
-        spec_info = EagleDraftInput(
+        spec_info = EagleDraftExtendInput(
             hidden_states=hidden_states,
             num_accepted_drafts=num_accepted_drafts,
             num_accepted_tokens=num_accepted_tokens,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -34,6 +34,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import (
+    EagleDraftExtendInput,
     EagleDraftInput,
     EagleVerifyInput,
     EagleVerifyOutput,
@@ -591,7 +592,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.next_draft_input
+        batch.spec_info = res.extend_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 
@@ -657,13 +658,13 @@ class MultiLayerEagleWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        assert isinstance(batch.spec_info, EagleDraftInput)
+        assert isinstance(batch.spec_info, EagleDraftExtendInput)
+        extend_input: EagleDraftExtendInput = batch.spec_info
+
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
         seq_lens_cpu_backup = batch.seq_lens_cpu.clone()
         req_pool_indices_backup = batch.req_pool_indices
-        num_accepted_drafts_backup = batch.spec_info.num_accepted_drafts
-        num_accepted_tokens_backup = batch.spec_info.num_accepted_tokens
         return_logprob_backup = batch.return_logprob
 
         input_is_idle = batch.forward_mode.is_idle()
@@ -676,17 +677,18 @@ class MultiLayerEagleWorker(TpModelWorker):
                 if self.speculative_algorithm.is_eagle3()
                 else self.model_config.hidden_size
             )
-            batch.spec_info = EagleDraftInput.create_idle_input(
+            extend_input = EagleDraftExtendInput.create_idle_input(
                 device=self.device,
                 hidden_size=hidden_size,
                 dtype=self.model_config.dtype,
-                topk=self.topk,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
+            batch.spec_info = extend_input
 
-        batch.spec_info.num_tokens_per_req = self.speculative_num_steps + 1
-        batch.spec_info.num_tokens_for_logprob_per_req = 1
-        batch.spec_info.prepare_extend_after_decode(
+        # Phase 1: prepare extend (kernel writes extend_input.{positions, bonus_tokens})
+        extend_input.num_tokens_per_req = self.speculative_num_steps + 1
+        extend_input.num_tokens_for_logprob_per_req = 1
+        extend_input.prepare_extend_after_decode(
             batch,
             verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
@@ -750,17 +752,22 @@ class MultiLayerEagleWorker(TpModelWorker):
                     )
                     pt += extend_len
 
-        forward_batch.spec_info.topk_p = torch.cat(topk_p_list, dim=1)
-        forward_batch.spec_info.topk_index = torch.cat(topk_index_list, dim=1)
+        # Phase 3: assemble next-iter EagleDraftInput from extend output
+        next_draft_input = EagleDraftInput(
+            bonus_tokens=extend_input.bonus_tokens,
+            hidden_states=logits_output.hidden_states,
+            topk_p=torch.cat(topk_p_list, dim=1),
+            topk_index=torch.cat(topk_index_list, dim=1),
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+        )
 
-        # Restore backup.
-        # This is because `seq_lens` can be modified in `prepare_extend_after_decode`
+        # Restore batch fields and install the new draft input.
+        # `seq_lens` etc. were modified by `prepare_extend_after_decode`.
         batch.forward_mode = (
             ForwardMode.DECODE if not input_is_idle else ForwardMode.IDLE
         )
         batch.seq_lens = seq_lens_backup
         batch.seq_lens_cpu = seq_lens_cpu_backup
         batch.req_pool_indices = req_pool_indices_backup
-        batch.spec_info.num_accepted_drafts = num_accepted_drafts_backup
-        batch.spec_info.num_accepted_tokens = num_accepted_tokens_backup
+        batch.spec_info = next_draft_input
         batch.return_logprob = return_logprob_backup

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 
-from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.utils import speculative_moe_backend_context
@@ -297,8 +296,6 @@ class MultiLayerEagleWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
             ), speculative_moe_backend_context():
-                # NOTE: We should use `check_forward_draft_extend_after_decode`
-                # when DP attention is enabled, but it is slow. Skip it for now.
                 draft_extend_input = verify_output.draft_extend_input
                 next_draft_input = None
                 if (
@@ -347,26 +344,6 @@ class MultiLayerEagleWorker(TpModelWorker):
                 can_run_cuda_graph=verify_output.can_run_cuda_graph,
                 next_draft_input=next_draft_input,
             )
-
-    def check_forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
-    ):
-        local_need_forward = verify_output.draft_extend_input.input_ids.shape[0] > 0
-        if not self.server_args.enable_dp_attention:
-            return local_need_forward
-
-        global_need_forward = torch.tensor(
-            [
-                (local_need_forward),
-            ],
-            dtype=torch.int64,
-        )
-        torch.distributed.all_reduce(
-            global_need_forward, group=get_tp_group().cpu_group
-        )
-        global_need_forward_cnt = global_need_forward[0].item()
-        need_forward = global_need_forward_cnt > 0
-        return need_forward
 
     def forward_target_extend(
         self, batch: ScheduleBatch

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -592,7 +592,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.extend_input
+        batch.spec_info = res.draft_extend_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 
@@ -659,7 +659,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
         assert isinstance(batch.spec_info, EagleDraftExtendInput)
-        extend_input: EagleDraftExtendInput = batch.spec_info
+        draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
@@ -677,18 +677,18 @@ class MultiLayerEagleWorker(TpModelWorker):
                 if self.speculative_algorithm.is_eagle3()
                 else self.model_config.hidden_size
             )
-            extend_input = EagleDraftExtendInput.create_idle_input(
+            draft_extend_input = EagleDraftExtendInput.create_idle_input(
                 device=self.device,
                 hidden_size=hidden_size,
                 dtype=self.model_config.dtype,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
-            batch.spec_info = extend_input
+            batch.spec_info = draft_extend_input
 
-        # Phase 1: prepare extend (kernel writes extend_input.{positions, bonus_tokens})
-        extend_input.num_tokens_per_req = self.speculative_num_steps + 1
-        extend_input.num_tokens_for_logprob_per_req = 1
-        extend_input.prepare_extend_after_decode(
+        # Phase 1: prepare extend (kernel writes draft_extend_input.{positions, bonus_tokens})
+        draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
+        draft_extend_input.num_tokens_for_logprob_per_req = 1
+        draft_extend_input.prepare_extend_after_decode(
             batch,
             verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
@@ -754,7 +754,7 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         # Phase 3: assemble next-iter EagleDraftInput from extend output
         next_draft_input = EagleDraftInput(
-            bonus_tokens=extend_input.bonus_tokens,
+            bonus_tokens=draft_extend_input.bonus_tokens,
             hidden_states=logits_output.hidden_states,
             topk_p=torch.cat(topk_p_list, dim=1),
             topk_index=torch.cat(topk_index_list, dim=1),

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -283,22 +283,24 @@ class MultiLayerEagleWorker(TpModelWorker):
                 # NOTE: We should use `check_forward_draft_extend_after_decode`
                 # when DP attention is enabled, but it is slow. Skip it for now.
                 draft_extend_input = verify_output.draft_extend_input
+                next_draft_input = None
                 if (
                     self.server_args.enable_dp_attention
                     or draft_extend_input.input_ids.shape[0] > 0
                 ):
-                    # decode is not finished
-                    # Install draft_extend_input for the extend forward, then
-                    # install the assembled next-iter EagleDraftInput it returns.
+                    # decode is not finished. Install draft_extend_input as
+                    # batch.spec_info for the extend forward; the assembled
+                    # next-iter EagleDraftInput is returned via batch_result
+                    # and installed by the scheduler before the next draft.
                     batch.spec_info = draft_extend_input
                     next_draft_input = self.forward_draft_extend_after_decode(batch)
-                    batch.spec_info = next_draft_input
 
             return GenerationBatchResult(
                 logits_output=verify_output.logits_output,
                 next_token_ids=verify_output.accept_tokens,
                 num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
                 can_run_cuda_graph=verify_output.can_run_cuda_graph,
+                next_draft_input=next_draft_input,
             )
 
     def check_forward_draft_extend_after_decode(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -275,7 +275,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                 verify_input = self.draft(batch)
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
-            logits_output, verify_output, can_run_cuda_graph = self.verify(batch)
+            verify_output = self.verify(batch)
 
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
@@ -295,10 +295,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                     batch.spec_info = next_draft_input
 
             return GenerationBatchResult(
-                logits_output=logits_output,
+                logits_output=verify_output.logits_output,
                 next_token_ids=verify_output.accept_tokens,
                 num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
-                can_run_cuda_graph=can_run_cuda_graph,
+                can_run_cuda_graph=verify_output.can_run_cuda_graph,
             )
 
     def check_forward_draft_extend_after_decode(
@@ -598,7 +598,8 @@ class MultiLayerEagleWorker(TpModelWorker):
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
 
-        return logits_output, res, can_run_cuda_graph
+        res.can_run_cuda_graph = can_run_cuda_graph
+        return res
 
     def forward_draft_extend(
         self,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -135,7 +135,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=0,  # spec workers don't support pipeline parallelism
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 attn_cp_rank=attn_cp_rank,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -592,7 +592,6 @@ class MultiLayerEagleWorker(TpModelWorker):
         batch.forward_mode = (
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
-        batch.spec_info = res.draft_extend_input
 
         return logits_output, res, model_worker_batch, can_run_cuda_graph
 
@@ -658,8 +657,10 @@ class MultiLayerEagleWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        assert isinstance(batch.spec_info, EagleDraftExtendInput)
-        draft_extend_input: EagleDraftExtendInput = batch.spec_info
+        # Install the draft-extend input as `batch.spec_info` for this method's
+        # forward pass. Replaced with a fresh `EagleDraftInput` post-extend.
+        draft_extend_input: EagleDraftExtendInput = verify_output.draft_extend_input
+        batch.spec_info = draft_extend_input
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -334,20 +334,11 @@ class MultiLayerEagleWorker(TpModelWorker):
                     )
 
                 if next_draft_input is None:
-                    # Skipped the extend forward (no dp_attention + all reqs
-                    # finished). batch.spec_info is still the verify_input;
-                    # install an idle EagleDraftInput so the scheduler's unified
-                    # relay installs a mergeable spec_info next iter.
-                    hidden_size = (
-                        self.model_config.hidden_size * 3
-                        if self.speculative_algorithm.is_eagle3()
-                        else self.model_config.hidden_size
-                    )
-                    next_draft_input = EagleDraftInput.create_idle_input(
-                        device=self.device,
-                        hidden_size=hidden_size,
-                        dtype=self.model_config.dtype,
-                        topk=self.topk,
+                    # Skipped the extend forward. Empty EagleDraftInput so
+                    # merge_batch can short-circuit on None hidden_states
+                    # (avoids shape mismatch with running_batch that carries
+                    # an EAGLE3 aux-hidden-state layout).
+                    next_draft_input = EagleDraftInput(
                         capture_hidden_mode=CaptureHiddenMode.LAST,
                     )
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -309,8 +309,31 @@ class MultiLayerEagleWorker(TpModelWorker):
                     # batch.spec_info for the extend forward; the assembled
                     # next-iter EagleDraftInput is returned via batch_result
                     # and installed by the scheduler before the next draft.
-                    batch.spec_info = draft_extend_input
-                    next_draft_input = self.forward_draft_extend_after_decode(batch)
+                    extend_batch = batch
+                    if (
+                        not batch.forward_mode.is_idle()
+                        and draft_extend_input.input_ids.numel() == 0
+                    ):
+                        # All reqs finished this verify (only reachable when
+                        # dp_attention forces the forward). Use an idle batch
+                        # copy + idle ExtendInput.
+                        extend_batch = batch.copy()
+                        extend_batch.prepare_for_idle()
+                        hidden_size = (
+                            self.model_config.hidden_size * 3
+                            if self.speculative_algorithm.is_eagle3()
+                            else self.model_config.hidden_size
+                        )
+                        draft_extend_input = EagleDraftExtendInput.create_idle_input(
+                            device=self.device,
+                            hidden_size=hidden_size,
+                            dtype=self.model_config.dtype,
+                            capture_hidden_mode=CaptureHiddenMode.LAST,
+                        )
+                    extend_batch.spec_info = draft_extend_input
+                    next_draft_input = self.forward_draft_extend_after_decode(
+                        extend_batch
+                    )
 
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
@@ -687,6 +710,9 @@ class MultiLayerEagleWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch
     ) -> EagleDraftInput:
+        # Caller installs the EagleDraftExtendInput on `batch.spec_info`
+        # (using either the verify-produced one or an idle one for the
+        # all-finished + dp_attention edge case).
         draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
         # Backup fields that will be modified in-place
@@ -696,22 +722,6 @@ class MultiLayerEagleWorker(TpModelWorker):
         return_logprob_backup = batch.return_logprob
 
         input_is_idle = batch.forward_mode.is_idle()
-
-        if not input_is_idle and draft_extend_input.input_ids.numel() == 0:
-            batch = batch.copy()
-            batch.prepare_for_idle()
-            hidden_size = (
-                self.model_config.hidden_size * 3
-                if self.speculative_algorithm.is_eagle3()
-                else self.model_config.hidden_size
-            )
-            draft_extend_input = EagleDraftExtendInput.create_idle_input(
-                device=self.device,
-                hidden_size=hidden_size,
-                dtype=self.model_config.dtype,
-                capture_hidden_mode=CaptureHiddenMode.LAST,
-            )
-            batch.spec_info = draft_extend_input
 
         # Phase 1: prepare extend (kernel writes draft_extend_input.{positions, bonus_tokens})
         draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -260,7 +260,7 @@ class MultiLayerEagleWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
             ), speculative_moe_backend_context():
-                self.forward_draft_extend(
+                next_draft_input = self.forward_draft_extend(
                     batch, logits_output.hidden_states, next_token_ids, seq_lens_cpu
                 )
             return GenerationBatchResult(
@@ -268,6 +268,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                 next_token_ids=next_token_ids,
                 num_accepted_drafts=0,
                 can_run_cuda_graph=can_run_cuda_graph,
+                next_draft_input=next_draft_input,
             )
         else:
             set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
@@ -631,58 +632,66 @@ class MultiLayerEagleWorker(TpModelWorker):
         hidden_states: torch.Tensor,
         next_token_ids: torch.Tensor,
         seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        """Run draft model extend. This API modifies the states of the batch.
+    ) -> EagleDraftInput:
+        """Run draft model extend. Returns next-iter `EagleDraftInput`;
+        scheduler installs it on `batch.spec_info` via `batch_result.next_draft_input`.
 
-        Args:
-            batch: The batch to run.
-            hidden_states: Hidden states from the target model forward
-            next_token_ids: Next token ids generated from the target forward.
+        We mutate `batch.spec_info` transiently so the forward kernel can read
+        the draft input via `batch.get_model_worker_batch`, then restore on
+        return.
         """
-        batch.spec_info = EagleDraftInput(
+        next_draft_input = EagleDraftInput(
             hidden_states=hidden_states,
             bonus_tokens=next_token_ids,
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
         )
-        batch.return_hidden_states = False
-        batch.spec_info.prepare_for_extend(batch)
-        batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
-        model_worker_batch = batch.get_model_worker_batch(
-            seq_lens_cpu_cache=seq_lens_cpu
-        )
-        forward_batch = ForwardBatch.init_new(
-            model_worker_batch, self.mtp_model_runner(0)
-        )
-        forward_batch.return_logprob = False
-        forward_batch.return_hidden_states_before_norm = True
-        topk_p_list = []
-        topk_index_list = []
-        for step in range(self.speculative_num_steps):
-            logits_output = (
-                self.mtp_model_runner(step).forward(forward_batch).logits_output
-            )
-            maybe_detect_nan(
-                logits_output.next_token_logits,
-                f"draft_extend_for_prefill step {step}",
-            )
-            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
-            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
-            topk_p_list.append(topk_p)
-            topk_index_list.append(topk_index)
-            pt = 0
-            if forward_batch.extend_seq_lens is not None:
-                for i, extend_len in enumerate(forward_batch.extend_seq_lens):
-                    input_ids = forward_batch.input_ids[pt : pt + extend_len]
-                    forward_batch.input_ids[pt : pt + extend_len] = torch.cat(
-                        (input_ids[1:], topk_index[i].reshape(1))
-                    )
-                    pt += extend_len
+        return_hidden_states_backup = batch.return_hidden_states
+        spec_info_backup = batch.spec_info
 
-        assert isinstance(forward_batch.spec_info, EagleDraftInput)
-        assert forward_batch.spec_info is batch.spec_info
-        forward_batch.spec_info.topk_p = torch.cat(topk_p_list, dim=1)
-        forward_batch.spec_info.topk_index = torch.cat(topk_index_list, dim=1)
+        batch.spec_info = next_draft_input
+        batch.return_hidden_states = False
+        next_draft_input.prepare_for_extend(batch)
+        next_draft_input.capture_hidden_mode = CaptureHiddenMode.LAST
+        try:
+            model_worker_batch = batch.get_model_worker_batch(
+                seq_lens_cpu_cache=seq_lens_cpu
+            )
+            forward_batch = ForwardBatch.init_new(
+                model_worker_batch, self.mtp_model_runner(0)
+            )
+            forward_batch.return_logprob = False
+            forward_batch.return_hidden_states_before_norm = True
+            topk_p_list = []
+            topk_index_list = []
+            for step in range(self.speculative_num_steps):
+                logits_output = (
+                    self.mtp_model_runner(step).forward(forward_batch).logits_output
+                )
+                maybe_detect_nan(
+                    logits_output.next_token_logits,
+                    f"draft_extend_for_prefill step {step}",
+                )
+                probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+                topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+                topk_p_list.append(topk_p)
+                topk_index_list.append(topk_index)
+                pt = 0
+                if forward_batch.extend_seq_lens is not None:
+                    for i, extend_len in enumerate(forward_batch.extend_seq_lens):
+                        input_ids = forward_batch.input_ids[pt : pt + extend_len]
+                        forward_batch.input_ids[pt : pt + extend_len] = torch.cat(
+                            (input_ids[1:], topk_index[i].reshape(1))
+                        )
+                        pt += extend_len
+
+            next_draft_input.topk_p = torch.cat(topk_p_list, dim=1)
+            next_draft_input.topk_index = torch.cat(topk_index_list, dim=1)
+        finally:
+            batch.spec_info = spec_info_backup
+            batch.return_hidden_states = return_hidden_states_backup
+
+        return next_draft_input
 
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -659,7 +659,8 @@ class MultiLayerEagleWorker(TpModelWorker):
     ):
         # Install the draft-extend input as `batch.spec_info` for this method's
         # forward pass. Replaced with a fresh `EagleDraftInput` post-extend.
-        draft_extend_input: EagleDraftExtendInput = verify_output.draft_extend_input
+        draft_extend_input = verify_output.draft_extend_input
+        assert isinstance(draft_extend_input, EagleDraftExtendInput)
         batch.spec_info = draft_extend_input
 
         # Backup fields that will be modified in-place

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -31,6 +31,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import (
@@ -269,13 +271,28 @@ class MultiLayerEagleWorker(TpModelWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
             )
         else:
+            set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
+
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
             ), speculative_moe_backend_context():
                 verify_input = self.draft(batch)
+
+            set_time_batch(batch.reqs, "set_spec_draft_end_time", trace_only=True)
+            set_time_batch(batch.reqs, "set_spec_verify_start_time", trace_only=True)
+
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
             verify_output = self.verify(batch)
+
+            if get_global_tracing_enabled():
+                for idx, req in enumerate(batch.reqs):
+                    accepted = verify_output.num_accepted_drafts_per_req_cpu[idx]
+                    req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
+
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_start_time", trace_only=True
+            )
 
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
@@ -295,10 +312,15 @@ class MultiLayerEagleWorker(TpModelWorker):
                     batch.spec_info = draft_extend_input
                     next_draft_input = self.forward_draft_extend_after_decode(batch)
 
+            set_time_batch(
+                batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
+            )
+
             return GenerationBatchResult(
                 logits_output=verify_output.logits_output,
                 next_token_ids=verify_output.accept_tokens,
                 num_accepted_drafts=sum(verify_output.num_accepted_drafts_per_req_cpu),
+                num_accepted_drafts_per_req_cpu=verify_output.num_accepted_drafts_per_req_cpu,
                 can_run_cuda_graph=verify_output.can_run_cuda_graph,
                 next_draft_input=next_draft_input,
             )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -282,17 +282,16 @@ class MultiLayerEagleWorker(TpModelWorker):
             ), speculative_moe_backend_context():
                 # NOTE: We should use `check_forward_draft_extend_after_decode`
                 # when DP attention is enabled, but it is slow. Skip it for now.
+                draft_extend_input = verify_output.draft_extend_input
                 if (
                     self.server_args.enable_dp_attention
-                    or verify_output.unfinished_accept_tokens.shape[0] > 0
+                    or draft_extend_input.input_ids.shape[0] > 0
                 ):
                     # decode is not finished
                     # Install draft_extend_input for the extend forward, then
                     # install the assembled next-iter EagleDraftInput it returns.
-                    batch.spec_info = verify_output.draft_extend_input
-                    next_draft_input = self.forward_draft_extend_after_decode(
-                        batch, verify_output
-                    )
+                    batch.spec_info = draft_extend_input
+                    next_draft_input = self.forward_draft_extend_after_decode(batch)
                     batch.spec_info = next_draft_input
 
             return GenerationBatchResult(
@@ -305,7 +304,7 @@ class MultiLayerEagleWorker(TpModelWorker):
     def check_forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        local_need_forward = verify_output.unfinished_accept_tokens.shape[0] > 0
+        local_need_forward = verify_output.draft_extend_input.input_ids.shape[0] > 0
         if not self.server_args.enable_dp_attention:
             return local_need_forward
 
@@ -661,7 +660,7 @@ class MultiLayerEagleWorker(TpModelWorker):
         forward_batch.spec_info.topk_index = torch.cat(topk_index_list, dim=1)
 
     def forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
+        self, batch: ScheduleBatch
     ) -> EagleDraftInput:
         draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
@@ -673,7 +672,7 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         input_is_idle = batch.forward_mode.is_idle()
 
-        if not input_is_idle and verify_output.unfinished_accept_tokens.numel() == 0:
+        if not input_is_idle and draft_extend_input.input_ids.numel() == 0:
             batch = batch.copy()
             batch.prepare_for_idle()
             hidden_size = (
@@ -694,7 +693,6 @@ class MultiLayerEagleWorker(TpModelWorker):
         draft_extend_input.num_tokens_for_logprob_per_req = 1
         draft_extend_input.prepare_extend_after_decode(
             batch,
-            verify_output=verify_output,
             speculative_num_steps=self.speculative_num_steps,
         )
         batch.forward_mode = (

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -333,6 +333,24 @@ class MultiLayerEagleWorker(TpModelWorker):
                         extend_batch
                     )
 
+                if next_draft_input is None:
+                    # Skipped the extend forward (no dp_attention + all reqs
+                    # finished). batch.spec_info is still the verify_input;
+                    # install an idle EagleDraftInput so the scheduler's unified
+                    # relay installs a mergeable spec_info next iter.
+                    hidden_size = (
+                        self.model_config.hidden_size * 3
+                        if self.speculative_algorithm.is_eagle3()
+                        else self.model_config.hidden_size
+                    )
+                    next_draft_input = EagleDraftInput.create_idle_input(
+                        device=self.device,
+                        hidden_size=hidden_size,
+                        dtype=self.model_config.dtype,
+                        topk=self.topk,
+                        capture_hidden_mode=CaptureHiddenMode.LAST,
+                    )
+
             set_time_batch(
                 batch.reqs, "set_spec_draft_extend_end_time", trace_only=True
             )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -275,9 +275,7 @@ class MultiLayerEagleWorker(TpModelWorker):
                 verify_input = self.draft(batch)
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
-            logits_output, verify_output, can_run_cuda_graph = self.verify(
-                batch, verify_input
-            )
+            logits_output, verify_output, can_run_cuda_graph = self.verify(batch)
 
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
@@ -482,10 +480,8 @@ class MultiLayerEagleWorker(TpModelWorker):
         # allocator and kv cache pool are shared with target worker
         pass
 
-    def verify(self, batch: ScheduleBatch, spec_info: EagleVerifyInput):
-        # Caller (forward_batch_generation) is responsible for installing
-        # `spec_info` as `batch.spec_info` before calling.
-        assert batch.spec_info is spec_info
+    def verify(self, batch: ScheduleBatch):
+        spec_info: EagleVerifyInput = batch.spec_info
         spec_info.prepare_for_verify(batch, self.page_size)
         batch.return_hidden_states = False
         batch.forward_mode = (
@@ -667,11 +663,7 @@ class MultiLayerEagleWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ) -> EagleDraftInput:
-        # Caller (forward_batch_generation) is responsible for installing
-        # verify_output.draft_extend_input as batch.spec_info before calling.
-        draft_extend_input = verify_output.draft_extend_input
-        assert isinstance(draft_extend_input, EagleDraftExtendInput)
-        assert batch.spec_info is draft_extend_input
+        draft_extend_input: EagleDraftExtendInput = batch.spec_info
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -272,9 +272,11 @@ class MultiLayerEagleWorker(TpModelWorker):
             with self.draft_tp_context(
                 self.mtp_model_runner(0).tp_group
             ), speculative_moe_backend_context():
-                spec_info = self.draft(batch)
+                verify_input = self.draft(batch)
+            # Install verify_input as `batch.spec_info` for the verify forward.
+            batch.spec_info = verify_input
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
-                self.verify(batch, spec_info)
+                self.verify(batch, verify_input)
             )
 
             with self.draft_tp_context(
@@ -287,6 +289,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                     or verify_output.unfinished_accept_tokens.shape[0] > 0
                 ):
                     # decode is not finished
+                    # Install draft_extend_input as `batch.spec_info` for the
+                    # draft-extend forward (replaced post-extend with a fresh
+                    # EagleDraftInput by `forward_draft_extend_after_decode`).
+                    batch.spec_info = verify_output.draft_extend_input
                     self.forward_draft_extend_after_decode(batch, verify_output)
 
             return GenerationBatchResult(
@@ -475,6 +481,9 @@ class MultiLayerEagleWorker(TpModelWorker):
         pass
 
     def verify(self, batch: ScheduleBatch, spec_info: EagleVerifyInput):
+        # Caller (forward_batch_generation) is responsible for installing
+        # `spec_info` as `batch.spec_info` before calling.
+        assert batch.spec_info is spec_info
         spec_info.prepare_for_verify(batch, self.page_size)
         batch.return_hidden_states = False
         batch.forward_mode = (
@@ -482,7 +491,6 @@ class MultiLayerEagleWorker(TpModelWorker):
             if not batch.forward_mode.is_idle()
             else ForwardMode.IDLE
         )
-        batch.spec_info = spec_info
 
         model_worker_batch = batch.get_model_worker_batch(
             seq_lens_cpu_cache=spec_info.seq_lens_cpu
@@ -657,11 +665,11 @@ class MultiLayerEagleWorker(TpModelWorker):
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
     ):
-        # Install the draft-extend input as `batch.spec_info` for this method's
-        # forward pass. Replaced with a fresh `EagleDraftInput` post-extend.
+        # Caller (forward_batch_generation) is responsible for installing
+        # verify_output.draft_extend_input as batch.spec_info before calling.
         draft_extend_input = verify_output.draft_extend_input
         assert isinstance(draft_extend_input, EagleDraftExtendInput)
-        batch.spec_info = draft_extend_input
+        assert batch.spec_info is draft_extend_input
 
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -289,11 +289,13 @@ class MultiLayerEagleWorker(TpModelWorker):
                     or verify_output.unfinished_accept_tokens.shape[0] > 0
                 ):
                     # decode is not finished
-                    # Install draft_extend_input as `batch.spec_info` for the
-                    # draft-extend forward (replaced post-extend with a fresh
-                    # EagleDraftInput by `forward_draft_extend_after_decode`).
+                    # Install draft_extend_input for the extend forward, then
+                    # install the assembled next-iter EagleDraftInput it returns.
                     batch.spec_info = verify_output.draft_extend_input
-                    self.forward_draft_extend_after_decode(batch, verify_output)
+                    next_draft_input = self.forward_draft_extend_after_decode(
+                        batch, verify_output
+                    )
+                    batch.spec_info = next_draft_input
 
             return GenerationBatchResult(
                 logits_output=logits_output,
@@ -664,7 +666,7 @@ class MultiLayerEagleWorker(TpModelWorker):
 
     def forward_draft_extend_after_decode(
         self, batch: ScheduleBatch, verify_output: EagleVerifyOutput
-    ):
+    ) -> EagleDraftInput:
         # Caller (forward_batch_generation) is responsible for installing
         # verify_output.draft_extend_input as batch.spec_info before calling.
         draft_extend_input = verify_output.draft_extend_input
@@ -771,13 +773,14 @@ class MultiLayerEagleWorker(TpModelWorker):
             capture_hidden_mode=CaptureHiddenMode.FULL,
         )
 
-        # Restore batch fields and install the new draft input.
-        # `seq_lens` etc. were modified by `prepare_extend_after_decode`.
+        # Restore batch fields. `seq_lens` etc. were modified by
+        # `prepare_extend_after_decode`. Caller installs `next_draft_input` as
+        # `batch.spec_info`.
         batch.forward_mode = (
             ForwardMode.DECODE if not input_is_idle else ForwardMode.IDLE
         )
         batch.seq_lens = seq_lens_backup
         batch.seq_lens_cpu = seq_lens_cpu_backup
         batch.req_pool_indices = req_pool_indices_backup
-        batch.spec_info = next_draft_input
         batch.return_logprob = return_logprob_backup
+        return next_draft_input

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -275,8 +275,8 @@ class MultiLayerEagleWorker(TpModelWorker):
                 verify_input = self.draft(batch)
             # Install verify_input as `batch.spec_info` for the verify forward.
             batch.spec_info = verify_input
-            logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
-                self.verify(batch, verify_input)
+            logits_output, verify_output, can_run_cuda_graph = self.verify(
+                batch, verify_input
             )
 
             with self.draft_tp_context(
@@ -603,7 +603,7 @@ class MultiLayerEagleWorker(TpModelWorker):
             ForwardMode.DECODE if not batch.forward_mode.is_idle() else ForwardMode.IDLE
         )
 
-        return logits_output, res, model_worker_batch, can_run_cuda_graph
+        return logits_output, res, can_run_cuda_graph
 
     def forward_draft_extend(
         self,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -128,7 +128,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=0,  # spec workers don't support pipeline parallelism
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 attn_cp_rank=attn_cp_rank,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -36,6 +36,7 @@ from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
     EagleDraftInput,
     EagleVerifyInput,
+    EagleVerifyOutput,
 )
 from sglang.srt.speculative.eagle_info_v2 import fill_bonus_tokens
 from sglang.srt.speculative.eagle_utils import TreeMaskMode, build_tree_kernel_efficient
@@ -457,12 +458,15 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         return next_draft_input
 
     def _draft_extend_for_decode(
-        self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
+        self,
+        batch: ModelWorkerBatch,
+        batch_result: GenerationBatchResult,
+        verify_output: EagleVerifyOutput,
     ):
         # Batch 2: Draft extend. verify already built draft_extend_input with
         # hidden_states / num_accepted_*; we only need to set the per-req
         # padding info for this forward.
-        draft_extend_input = batch_result.next_draft_extend_input
+        draft_extend_input = verify_output.draft_extend_input
         draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
         draft_extend_input.num_tokens_for_logprob_per_req = 1
 
@@ -701,8 +705,10 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                 self._draft_done_event = torch.get_device_module(self.device).Event()
                 self._draft_done_event.record()
             model_worker_batch.spec_info = verify_input
-            batch_output = self.verify(model_worker_batch)
-            self.draft_worker._draft_extend_for_decode(model_worker_batch, batch_output)
+            batch_output, verify_output = self.verify(model_worker_batch)
+            self.draft_worker._draft_extend_for_decode(
+                model_worker_batch, batch_output, verify_output
+            )
             return batch_output
 
     def verify(
@@ -795,17 +801,17 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             new_seq_lens=new_seq_lens,
             verify_done=verify_done,
         )
-        return GenerationBatchResult(
+        batch_result = GenerationBatchResult(
             logits_output=logits_output,
             next_token_ids=predict,
             can_run_cuda_graph=can_run_cuda_graph,
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             next_draft_input=next_draft_input,
-            next_draft_extend_input=verify_output.draft_extend_input,
             accept_lens=accept_lens,
             routed_experts_output=forward_batch_output.routed_experts_output,
             indexer_topk_output=forward_batch_output.indexer_topk_output,
         )
+        return batch_result, verify_output
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         for i in range(self.speculative_num_steps):

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -470,6 +470,9 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
         draft_extend_input.num_tokens_for_logprob_per_req = 1
 
+        # Install draft_extend_input as `batch.spec_info` for the extend forward.
+        batch.spec_info = draft_extend_input
+
         # Prepare for draft extend in a separate stream
         # Notice that here we use batch_result.next_token_ids as the input ids
         with self.plan_stream_ctx:
@@ -769,7 +772,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
 
         # Sample
         maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
-        verify_output, predict = verify_input.sample(batch, logits_output)
+        verify_output, predict = verify_input.verify_v2(batch, logits_output)
         accept_lens = verify_output.draft_extend_input.num_accepted_tokens
         new_seq_lens = batch.seq_lens + accept_lens
         verify_done = torch.get_device_module(self.device).Event()

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -459,12 +459,12 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
     def _draft_extend_for_decode(
         self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
     ):
-        # Batch 2: Draft extend
-        draft_extend_input = EagleDraftExtendInput(
-            hidden_states=batch_result.logits_output.hidden_states,
-            num_tokens_per_req=self.speculative_num_steps + 1,
-            num_tokens_for_logprob_per_req=1,
-        )
+        # Batch 2: Draft extend. verify already built draft_extend_input with
+        # hidden_states / num_accepted_*; we only need to set the per-req
+        # padding info for this forward.
+        draft_extend_input = batch_result.next_draft_extend_input
+        draft_extend_input.num_tokens_per_req = self.speculative_num_steps + 1
+        draft_extend_input.num_tokens_for_logprob_per_req = 1
 
         # Prepare for draft extend in a separate stream
         # Notice that here we use batch_result.next_token_ids as the input ids
@@ -763,20 +763,16 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
 
         # Sample
         maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
-        (
-            predict,
-            accept_lens,
-            accept_index,
-        ) = verify_input.sample(batch, logits_output)
+        verify_output, predict = verify_input.sample(batch, logits_output)
+        accept_lens = verify_output.draft_extend_input.num_accepted_tokens
         new_seq_lens = batch.seq_lens + accept_lens
         verify_done = torch.get_device_module(self.device).Event()
         verify_done.record()
 
         if not batch.forward_mode.is_idle():
-            accept_tokens = predict[accept_index]
             bonus_tokens = torch.empty_like(accept_lens, dtype=torch.int32)
             fill_bonus_tokens[(bs,)](
-                accept_tokens,
+                verify_output.accept_tokens,
                 accept_lens,
                 bonus_tokens,
                 self.speculative_num_draft_tokens,
@@ -786,7 +782,11 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
 
         if batch.return_logprob and not batch.forward_mode.is_idle():
             compute_spec_v2_logprobs(
-                batch, logits_output, predict, accept_index, self.speculative_num_steps
+                batch,
+                logits_output,
+                predict,
+                verify_output.accepted_indices,
+                self.speculative_num_steps,
             )
 
         # Construct the next draft input
@@ -801,6 +801,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             can_run_cuda_graph=can_run_cuda_graph,
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             next_draft_input=next_draft_input,
+            next_draft_extend_input=verify_output.draft_extend_input,
             accept_lens=accept_lens,
             routed_experts_output=forward_batch_output.routed_experts_output,
             indexer_topk_output=forward_batch_output.indexer_topk_output,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -32,7 +32,11 @@ from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, Forw
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
-from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+from sglang.srt.speculative.eagle_info import (
+    EagleDraftExtendInput,
+    EagleDraftInput,
+    EagleVerifyInput,
+)
 from sglang.srt.speculative.eagle_info_v2 import fill_bonus_tokens
 from sglang.srt.speculative.eagle_utils import TreeMaskMode, build_tree_kernel_efficient
 from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner import (
@@ -371,17 +375,13 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
             target_hidden_states: Hidden states from the target model forward
             next_token_ids: Next token ids generated from the target forward.
         """
-        # Construct spec_info
-        next_draft_input = EagleDraftInput(
+        # Install draft-extend spec_info for the extend forward.
+        extend_input = EagleDraftExtendInput(
             hidden_states=target_hidden_states,
-            bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
-            # draft mode is same with decode mode, only 1 token per req
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
         )
-
-        batch.spec_info = next_draft_input
+        batch.spec_info = extend_input
 
         # Run forward
         forward_batch = ForwardBatch.init_new(batch, self.draft_runner_list[0])
@@ -429,8 +429,19 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
                     forward_batch.extend_seq_lens,
                     topk_index,
                 )
-        next_draft_input.topk_p = torch.cat(topk_p_list, dim=1)
-        next_draft_input.topk_index = torch.cat(topk_index_list, dim=1)
+
+        # Assemble fresh next-iter draft spec_info from the extend output.
+        # `extend_input.hidden_states` is the chain-MTP-propagated value from
+        # the loop, or `target_hidden_states` if chain-MTP is disabled.
+        next_draft_input = EagleDraftInput(
+            topk_p=torch.cat(topk_p_list, dim=1),
+            topk_index=torch.cat(topk_index_list, dim=1),
+            hidden_states=extend_input.hidden_states,
+            bonus_tokens=next_token_ids,
+            new_seq_lens=batch.seq_lens,
+            num_tokens_per_req=1,
+            num_tokens_for_logprob_per_req=1,
+        )
 
         # Update req_to_hidden_states_pool for KV Cache reversion
         if forward_batch.extend_seq_lens is not None:
@@ -449,7 +460,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         self, batch: ModelWorkerBatch, batch_result: GenerationBatchResult
     ):
         # Batch 2: Draft extend
-        draft_input = EagleDraftInput(
+        draft_extend_input = EagleDraftExtendInput(
             hidden_states=batch_result.logits_output.hidden_states,
             num_tokens_per_req=self.speculative_num_steps + 1,
             num_tokens_for_logprob_per_req=1,
@@ -458,7 +469,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         # Prepare for draft extend in a separate stream
         # Notice that here we use batch_result.next_token_ids as the input ids
         with self.plan_stream_ctx:
-            forward_batch = draft_input.prepare_for_extend_to_fill_draft_kvcache(
+            forward_batch = draft_extend_input.prepare_for_extend_to_fill_draft_kvcache(
                 batch,
                 batch_result.next_token_ids,
                 self.speculative_num_draft_tokens,

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -195,8 +195,10 @@ class SpecInputType(IntEnum):
     # NOTE: introduce this to distinguish the SpecInput types of multiple algorithms when asserting in attention backends.
     # If all algorithms can share the same datastrucutre of draft_input and verify_input, consider simplify it
     EAGLE_DRAFT = auto()
+    EAGLE_DRAFT_EXTEND = auto()
     EAGLE_VERIFY = auto()
     FROZEN_KV_MTP_DRAFT = auto()
+    FROZEN_KV_MTP_DRAFT_EXTEND = auto()
     FROZEN_KV_MTP_VERIFY = auto()
     DFLASH_DRAFT = auto()
     DFLASH_VERIFY = auto()
@@ -212,7 +214,9 @@ class SpecInput(ABC):
         # or use another variable name like `draft_input` to substitute `spec_info`
         return self.spec_input_type in {
             SpecInputType.EAGLE_DRAFT,
+            SpecInputType.EAGLE_DRAFT_EXTEND,
             SpecInputType.FROZEN_KV_MTP_DRAFT,
+            SpecInputType.FROZEN_KV_MTP_DRAFT_EXTEND,
             SpecInputType.DFLASH_DRAFT,
         }
 

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -209,9 +209,11 @@ class SpecInput(ABC):
     def __init__(self, spec_input_type: SpecInputType):
         self.spec_input_type = spec_input_type
 
+    # Cross-algorithm phase guards. Used by attention backends and
+    # ForwardBatch padding logic to dispatch on phase without hardcoding the
+    # specific algo class (EAGLE / FROZEN_KV_MTP / DFLASH / NGRAM each have
+    # their own draft / verify SpecInput subclasses).
     def is_draft_input(self) -> bool:
-        # FIXME: remove this function which is only used for assertion
-        # or use another variable name like `draft_input` to substitute `spec_info`
         return self.spec_input_type in {
             SpecInputType.EAGLE_DRAFT,
             SpecInputType.EAGLE_DRAFT_EXTEND,

--- a/python/sglang/srt/speculative/standalone_worker.py
+++ b/python/sglang/srt/speculative/standalone_worker.py
@@ -83,7 +83,7 @@ class StandaloneWorker(EAGLEWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=0,  # spec workers don't support pipeline parallelism
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 attn_cp_rank=attn_cp_rank,

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -93,7 +93,7 @@ class StandaloneDraftWorker(EagleDraftWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=0,  # spec workers don't support pipeline parallelism
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 attn_cp_rank=attn_cp_rank,


### PR DESCRIPTION
Follow-up to #24735.

Splits the draft-extend forward's input contract into a dedicated `EagleDraftExtendInput` class. `EagleDraftInput` becomes pure cross-iter persistent state (no field shape phase-shift); `EagleDraftExtendInput` carries the verify-time slice (hidden_states [total_accepted, H], num_accepted_*) consumed by the draft-extend forward.

Worker `forward_draft_extend_after_decode` now runs in two explicit phases: install ExtendInput, run extend, then assemble a fresh `EagleDraftInput` for next iter.

attn backends are untouched (their reads are field-name based, and all required fields exist on EagleDraftExtendInput).