### PR TITLE
DSv4 on MI300: force uint8 store dtype for packed KV pool

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -72,6 +72,10 @@ class DeepSeekV4SingleKVPool(KVCache):
         self.quantize_block_size = 64
         self.rope_storage_dtype = torch.bfloat16
         self.k_with_scale_buffer_dtype = torch.int8
+        # Packed layout stores raw bytes per page. KVCache may set store_dtype from the
+        # logical KV dtype (e.g. fp8); buffer allocation must use uint8.
+        self.store_dtype = torch.uint8
+
         self._create_buffers()
 
     def _create_buffers(self):


### PR DESCRIPTION
## Motivation

DeepSeek-V4 uses a **packed KV cache layout** where each page stores **raw bytes**. When running DSv4 with **FP8 KV dtype** on ROCm/MI300, `KVCache` may set `store_dtype` based on the *logical* KV dtype (FP8), but `DeepSeekV4SingleKVPool.create_buffer()` asserts the backing storage dtype must be `torch.uint8`. This causes server startup to fail with:

- `AssertionError: assert self.store_dtype == torch.uint8`

This PR makes the DSv4 KV pool robust by ensuring the packed KV backing buffer is always allocated as **uint8**.

## Modifications

- In `python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py`:
  - Force `self.store_dtype = torch.uint8` in `DeepSeekV4SingleKVPool.__init__` before `_create_buffers()`.
  
  ### Reproduction / validation

- Hardware: AMD MI300-class (ROCm)
- Container image: `rocm/sgl-dev:rocm720-mi30x-06b3110-20260508-DSv4`
- Launch config: based on [PR #23608](https://github.com/sgl-project/sglang/pull/23608)

Environment + server args used:

```bash
export CUDA_VISIBLE_DEVICES=0,1,2,3

export SGLANG_OPT_USE_FUSED_COMPRESS=false
export SGLANG_OPT_USE_OLD_COMPRESSOR=true
export SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false
export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false
export SGLANG_OPT_USE_FUSED_HASH_TOPK=false

export SGLANG_HACK_FLASHMLA_BACKEND=torch
export SGLANG_OPT_DEEPGEMM_HC_PRENORM=false

export SGLANG_OPT_USE_TILELANG_MHC_PRE=false
export SGLANG_OPT_USE_TILELANG_MHC_POST=false

export SGLANG_ENABLE_THINKING=1
export SGLANG_USE_AITER=1
export SGLANG_USE_ROCM700A=1
export SGLANG_TOPK_TRANSFORM_512_TORCH=1
export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1

export SGLANG_DSV4_FP4_EXPERTS=false

export SGLANG_OPT_DPSK_V4_RADIX=0
export SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false
export SGLANG_OPT_USE_FUSED_STORE_CACHE=false

export SGLANG_FORCE_TRITON_MOE_FP8=1

python3 -m sglang.launch_server \
  --model-path sgl-project/DeepSeek-V4-Flash-FP8 \
  --trust-remote-code \
  --tp 4 \
  --dp 4 \
  --enable-dp-attention \
  --disable-radix-cache \
  --attention-backend compressed \
  --max-running-request 256 \
  --page-size 256 \
  --chunked-prefill-size 8192 \
  --port 30010 \
  --disable-shared-experts-fusion \
  --disable-cuda-graph \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4