### PR TITLE
DSv4 on MI300: use fp8 fnuz output dtype on HIP in triton act_quant

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/triton_kernel.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_kernel.py
@@ -4,6 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+
 
 # Triton implementation
 @triton.jit
@@ -95,7 +97,7 @@ def act_quant(
         scale_fmt (Optional[str], optional): The format of the scale. Default is None.
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
-            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - The quantized tensor (`float8_e4m3fn` on CUDA, `float8_e4m3fnuz` on HIP MI300-class).
             - A tensor of scaling factors with dtype `torch.float32`.
     """
     assert x.is_contiguous(), "Input tensor must be contiguous"
@@ -108,8 +110,11 @@ def act_quant(
     x_flat = x.view(-1, N)
     M = x_flat.size(0)
 
-    # Allocate output tensors
-    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    # Allocate output tensors (match platform FP8; must align with index_buf_accessor SetKAndS)
+    _out_fp8 = (
+        torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+    )
+    y = torch.empty_like(x, dtype=_out_fp8)
     y_flat = y.view(-1, N)
     s = x.new_empty(*x.size()[:-1], N // block_size, dtype=torch.float32)
     s_flat = s.view(-1, N // block_size)


### PR DESCRIPTION
## Motivation
On ROCm/MI300 (`is_fp8_fnuz()` true), NSA Triton `act_quant` should produce `torch.float8_e4m3fnuz` to match downstream index buffer accessors. Previously it always allocated `torch.float8_e4m3fn`, which can trigger dtype assertions during DSv4 serving.

## Modifications
- In `python/sglang/srt/layers/attention/nsa/triton_kernel.py`, allocate `float8_e4m3fnuz` when `is_fp8_fnuz()` else `float8_e4m3fn`.

## Reproduction / validation
- Hardware: AMD MI300-class (ROCm)
- Container image: `rocm/sgl-dev:rocm720-mi30x-06b3110-20260508-DSv4`
- Launch config: based on [PR #23608](https://github.com/sgl-project/sglang/pull/23608)