### PR TITLE
[Diffusion][NPU][GPU] Fix SANA model execution error

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/activation.py
+++ b/python/sglang/multimodal_gen/runtime/layers/activation.py
@@ -82,6 +82,15 @@ class GeluAndMul(CustomOp):
     def forward_cuda(self, *args, **kwargs) -> Any:
         return self.forward_native(*args, **kwargs)
 
+    def forward_npu(self, x: torch.Tensor) -> torch.Tensor:
+        y_npu, _ = torch_npu.npu_geglu(
+            x,
+            dim=-1,
+            approximate=1 if self.approximate == "tanh" else 0,
+            activate_left=True,
+        )
+        return y_npu
+
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
         d = x.shape[-1] // 2

--- a/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
@@ -178,8 +178,8 @@ class Gemma2Attention(nn.Module):
         key = k.transpose(1, 2)
         value = v.transpose(1, 2)
 
-        attn_mask = torch.zeros(
-            (seq_len, seq_len), device=hidden_states.device, dtype=torch.float32
+        attn_mask = torch.ones(
+            (seq_len, seq_len), device=hidden_states.device, dtype=torch.bool
         )
         causal = torch.triu(
             torch.ones(
@@ -187,22 +187,18 @@ class Gemma2Attention(nn.Module):
             ),
             diagonal=1,
         )
-        attn_mask = attn_mask.masked_fill(causal, float("-inf"))
+        attn_mask = attn_mask.masked_fill(causal, False)
         if self.is_sliding and self.sliding_window is not None:
             idx = torch.arange(seq_len, device=hidden_states.device)
             dist = idx[None, :] - idx[:, None]
             too_far = dist > self.sliding_window
-            attn_mask = attn_mask.masked_fill(too_far, float("-inf"))
+            attn_mask = attn_mask.masked_fill(too_far, False)
 
         if attention_mask is not None:
-            key_pad = ~attention_mask.to(torch.bool)
             attn_mask = attn_mask[None, None, :, :].expand(
                 batch_size, 1, seq_len, seq_len
             )
-            attn_mask = attn_mask.masked_fill(
-                key_pad[:, None, None, :].expand(batch_size, 1, seq_len, seq_len),
-                float("-inf"),
-            )
+            attn_mask = attn_mask & attention_mask.to(torch.bool)[:, None, None, :]
 
         attn_kwargs = {
             "attn_mask": attn_mask,

--- a/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py
@@ -178,16 +178,11 @@ class Gemma2Attention(nn.Module):
         key = k.transpose(1, 2)
         value = v.transpose(1, 2)
 
-        attn_mask = torch.ones(
-            (seq_len, seq_len), device=hidden_states.device, dtype=torch.bool
-        )
-        causal = torch.triu(
+        attn_mask = torch.tril(
             torch.ones(
                 (seq_len, seq_len), device=hidden_states.device, dtype=torch.bool
-            ),
-            diagonal=1,
+            )
         )
-        attn_mask = attn_mask.masked_fill(causal, False)
         if self.is_sliding and self.sliding_window is not None:
             idx = torch.arange(seq_len, device=hidden_states.device)
             dist = idx[None, :] - idx[:, None]

--- a/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py
+++ b/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py
@@ -115,9 +115,18 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
         model_output: torch.Tensor,
         timestep: int,
         sample: torch.Tensor,
-        **kwargs,
+        generator: torch.Generator | None = None,
+        variance_noise: torch.Tensor | None = None,
+        return_dict: bool = True,
     ):
-        return self._inner.step(model_output, timestep, sample, **kwargs)
+        return self._inner.step(
+            model_output,
+            timestep,
+            sample,
+            generator=generator,
+            variance_noise=variance_noise,
+            return_dict=return_dict,
+        )
 
     @property
     def sigmas(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

While resolving the issues in PR #23049, I encountered errors when running the Sana model. There are 2 errors on NPU and 1 error on GPU:

1. NPU Error: 
```RuntimeError: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.```

<details>
  <summary> Complete log of NPU error </summary>
  /root/log_requests/sglang/python/sglang/srt/layers/attention/fla/utils.py:223: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[05-07 11:28:14] Disabling some offloading (except dit, text_encoder) for image generation model
[05-07 11:28:14] server_args: {"model_path": "/root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5593, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "../wan_output/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "log_requests": false, "log_requests_level": 2, "log_requests_format": "text", "log_requests_target": null, "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[05-07 11:28:14] Diffusers version: 0.32.0.dev0
[05-07 11:28:14] Local mode: True
[05-07 11:28:14] Starting server...
/root/log_requests/sglang/python/sglang/srt/layers/attention/fla/utils.py:223: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[05-07 11:28:34] Scheduler bind at endpoint: tcp://127.0.0.1:5593
[05-07 11:28:35] get env LOCAL_RANK = 0
[05-07 11:28:35] get env WORLD_SIZE = 1
[05-07 11:28:35] get env RANK = 0
[05-07 11:28:35] Initializing distributed environment with world_size=1, device=npu:0, timeout=3600
[05-07 11:28:35] Setting distributed timeout to 3600 seconds
[05-07 11:28:36] No pipeline_class_name specified, using model_index.json
[05-07 11:28:36] Diffusers version: 0.32.0.dev0
[05-07 11:28:36] Using pipeline from model_index.json: SanaPipeline
[05-07 11:28:36] Loading pipeline modules...
[05-07 11:28:36] Model already exists locally and is complete
[05-07 11:28:36] Model path: /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers
[05-07 11:28:36] Diffusers version: 0.32.0.dev0
[05-07 11:28:36] Loading pipeline modules from config: {'_class_name': 'SanaPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'DPMSolverMultistepScheduler'], 'text_encoder': ['transformers', 'Gemma2Model'], 'tokenizer': ['transformers', 'GemmaTokenizerFast'], 'transformer': ['diffusers', 'SanaTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderDC']}
[05-07 11:28:36] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']

Loading required modules:   0%|          | 0/5 [00:00<?, ?it/s][05-07 11:28:36] Loading text_encoder from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/text_encoder. avail mem: 60.56 GB


Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  2.11it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  2.11it/s]

[05-07 11:28:39] Applied FSDP to 132 submodules in FSDPGemma2Model using explicit shard conditions
[05-07 11:28:40] Loaded text_encoder: FSDPGemma2Model (sgl-diffusion version). model size: 4.87 GB, consumed GPU mem: 0.06 GB, avail GPU mem: 60.50 GB

Loading required modules:  20%|██        | 1/5 [00:03<00:13,  3.39s/it][05-07 11:28:40] Loading tokenizer from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/tokenizer. avail mem: 60.50 GB
[05-07 11:28:43] Loaded tokenizer: GemmaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: -0.00 GB, avail GPU mem: 60.50 GB

Loading required modules:  40%|████      | 2/5 [00:07<00:11,  3.71s/it][05-07 11:28:43] Loading vae from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/vae. avail mem: 60.50 GB
The config attributes {'stacked_params_mapping': [], 'vae_scale_factor': 32, 'temporal_compression_ratio': 4, 'spatial_compression_ratio': 32} were passed to AutoencoderDC, but are not expected and will be ignored. Please verify your config.json configuration file.
[05-07 11:28:47] Loaded vae: AutoencoderDC (sgl-diffusion version). model size: 1.16 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules:  60%|██████    | 3/5 [00:10<00:07,  3.69s/it][05-07 11:28:47] Loading transformer from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer. avail mem: 60.50 GB
[05-07 11:28:47] Filtered 1 duplicate transformer precision variant file(s): ['/root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer/diffusion_pytorch_model.fp16.safetensors']
[05-07 11:28:47] Loading SanaTransformer2DModel from 1 safetensors file(s) , param_dtype: torch.bfloat16


Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 26.22it/s]

[05-07 11:28:49] Loaded model with 0.59B parameters
[05-07 11:28:49] Loaded transformer: SanaTransformer2DModel (sgl-diffusion version). model size: 1.1 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules:  80%|████████  | 4/5 [00:12<00:02,  2.97s/it][05-07 11:28:49] Loading scheduler from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/scheduler. avail mem: 60.50 GB
[05-07 11:28:49] Loaded scheduler: DPMSolverMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules: 100%|██████████| 5/5 [00:12<00:00,  2.57s/it]
[05-07 11:28:49] Creating pipeline stages...
[05-07 11:28:49] Using Torch SDPA backend.
[05-07 11:28:49] Pipeline instantiated
[05-07 11:28:49] Worker 0: Initialized device, model, and distributed environment.
[05-07 11:28:49] Worker 0: Scheduler loop started.
[05-07 11:28:49] Processing 1 grouped request(s)
[05-07 11:28:49] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=173>
                        seed: 42
                 infer_steps: 20
      num_outputs_per_prompt: 1
              guidance_scale: 4.5
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: ../wan_output/A_curious_raccoon_20260507-112849_dfe4c15c.png
        
[05-07 11:28:49] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-07 11:28:49] [InputValidationStage] started...
[05-07 11:28:49] [InputValidationStage] finished in 0.0006 seconds
[05-07 11:28:49] [TextEncodingStage] started...
[91m[05-07 11:28:50] [TextEncodingStage] Error during execution after 630.2616 ms: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported
Traceback (most recent call last):
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 288, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py", line 194, in forward
    ) = self.encode_text(
        ^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py", line 498, in encode_text
    outputs: BaseEncoderOutput = self._forward_text_encoder(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py", line 357, in _forward_text_encoder
    return text_encoder(**encoder_forward_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1882, in _call_impl
    return inner()
           ^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1830, in inner
    result = forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py", line 365, in forward
    hidden_states = layer(position_ids, hidden_states, attention_mask)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1882, in _call_impl
    return inner()
           ^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1830, in inner
    result = forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py", line 279, in forward
    hidden_states = self.self_attn(positions, hidden_states, attention_mask)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py", line 215, in forward
    attn_output = torch.nn.functional.scaled_dot_product_attention(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported[0;0m
[91m[05-07 11:28:50] Error executing request 725cd25d-bce9-4942-8257-723a2b0a2763: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported
Traceback (most recent call last):
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 330, in _execute_forward_common
    result = forward_fn()
             ^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 268, in <lambda>
    forward_fn=lambda: self.pipeline.forward(req, self.server_args),
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py", line 770, in forward
    return self.executor.execute_with_profiling(self.stages, batch, server_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py", line 84, in execute_with_profiling
    batch = self.execute(stages, batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 110, in execute
    return self._execute_stages(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 98, in _execute_stages
    batch = stage(batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 288, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py", line 194, in forward
    ) = self.encode_text(
        ^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py", line 498, in encode_text
    outputs: BaseEncoderOutput = self._forward_text_encoder(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py", line 357, in _forward_text_encoder
    return text_encoder(**encoder_forward_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1882, in _call_impl
    return inner()
           ^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1830, in inner
    result = forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py", line 365, in forward
    hidden_states = layer(position_ids, hidden_states, attention_mask)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1882, in _call_impl
    return inner()
           ^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1830, in inner
    result = forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py", line 279, in forward
    hidden_states = self.self_attn(positions, hidden_states, attention_mask)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/models/encoders/gemma2.py", line 215, in forward
    attn_output = torch.nn.functional.scaled_dot_product_attention(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported[0;0m
[91m[05-07 11:28:50] Failed to generate output for prompt: Error executing request 725cd25d-bce9-4942-8257-723a2b0a2763: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported
Traceback (most recent call last):
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/utils/logging_utils.py", line 626, in log_generation_timer
    yield timer
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 725cd25d-bce9-4942-8257-723a2b0a2763: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported[0;0m
[91m[05-07 11:28:50] Generation failed: Error executing request 725cd25d-bce9-4942-8257-723a2b0a2763: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported
Traceback (most recent call last):
  File "/root/log_requests/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 725cd25d-bce9-4942-8257-723a2b0a2763: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.
[ERROR] 2026-05-07-11:28:50 (PID:11146, Device:0, RankID:0) ERR01007 OPS feature not supported[0;0m
[93m[05-07 11:28:50] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-07 11:28:50] Worker 0: Shutdown complete.

</details>



2. NPU & GPU Error: 
``` TypeError: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta' ```
<details>
  <summary> Complete log of NPU & GPU error </summary>
  Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[05-09 15:54:42] Disabling some offloading (except dit, text_encoder) for image generation model
[05-09 15:54:42] server_args: {"model_path": "Efficient-Large-Model/Sana_600M_512px_diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "quantization": null, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5645, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "../wan_output/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[05-09 15:54:43] Local mode: True
[05-09 15:54:43] Starting server...
Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`
[05-09 15:54:52] Scheduler bind at endpoint: tcp://127.0.0.1:5645
[05-09 15:54:52] Initializing distributed environment with world_size=1, device=cuda:0, timeout=3600
[05-09 15:54:52] Setting distributed timeout to 3600 seconds
[05-09 15:54:53] No pipeline_class_name specified, using model_index.json
[05-09 15:54:53] Using pipeline from model_index.json: SanaPipeline
[05-09 15:54:53] Loading pipeline modules...
[05-09 15:54:54] Checking for cached model in HF Hub cache for Efficient-Large-Model/Sana_600M_512px_diffusers...
[05-09 15:54:54] Found complete model in cache at /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15
[05-09 15:54:54] Model path: /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15
[05-09 15:54:54] Diffusers version: 0.32.0.dev0
[05-09 15:54:54] Loading pipeline modules from config: {'_class_name': 'SanaPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'DPMSolverMultistepScheduler'], 'text_encoder': ['transformers', 'Gemma2Model'], 'tokenizer': ['transformers', 'GemmaTokenizerFast'], 'transformer': ['diffusers', 'SanaTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderDC']}
[05-09 15:54:54] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']

Loading required modules:   0%|          | 0/5 [00:00<?, ?it/s][05-09 15:54:54] Loading text_encoder from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/text_encoder. avail mem: 74.15 GB
[05-09 15:54:55] [RunAI Streamer] Overall time to stream 4.9 GiB of all files to cpu: 1.42s, 3.4 GiB/s
[05-09 15:55:02] Applied FSDP to 132 submodules in FSDPGemma2Model using explicit shard conditions
[05-09 15:55:02] Loaded text_encoder: FSDPGemma2Model (sgl-diffusion version). model size: 4.87 GB, consumed GPU mem: 0.04 GB, avail GPU mem: 74.12 GB

Loading required modules:  20%|██        | 1/5 [00:08<00:35,  8.81s/it][05-09 15:55:02] Loading tokenizer from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/tokenizer. avail mem: 74.12 GB
[05-09 15:55:06] Loaded tokenizer: GemmaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules:  40%|████      | 2/5 [00:12<00:17,  5.77s/it][05-09 15:55:06] Loading vae from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/vae. avail mem: 74.12 GB
The config attributes {'stacked_params_mapping': [], 'vae_scale_factor': 32, 'temporal_compression_ratio': 4, 'spatial_compression_ratio': 32} were passed to AutoencoderDC, but are not expected and will be ignored. Please verify your config.json configuration file.
[05-09 15:55:09] Loaded vae: AutoencoderDC (sgl-diffusion version). model size: 1.16 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules:  60%|██████    | 3/5 [00:15<00:09,  4.53s/it][05-09 15:55:09] Loading transformer from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/transformer. avail mem: 74.12 GB
[05-09 15:55:09] Filtered 1 duplicate transformer precision variant file(s): ['/home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/transformer/diffusion_pytorch_model.fp16.safetensors']
[05-09 15:55:09] Loading SanaTransformer2DModel from 1 safetensors file(s) , param_dtype: torch.bfloat16
[05-09 15:55:10] [RunAI Streamer] Overall time to stream 2.2 GiB of all files to cpu: 0.41s, 5.3 GiB/s
[05-09 15:55:10] Loaded model with 0.59B parameters
[05-09 15:55:10] Loaded transformer: SanaTransformer2DModel (sgl-diffusion version). model size: 1.1 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules:  80%|████████  | 4/5 [00:16<00:03,  3.27s/it][05-09 15:55:10] Loading scheduler from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/scheduler. avail mem: 74.12 GB
[05-09 15:55:10] Loaded scheduler: DPMSolverMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules: 100%|██████████| 5/5 [00:16<00:00,  3.37s/it]
[05-09 15:55:10] Creating pipeline stages...
[05-09 15:55:10] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[05-09 15:55:10] Pipeline instantiated
[05-09 15:55:10] Worker 0: Initialized device, model, and distributed environment.
[05-09 15:55:10] Worker 0: Scheduler loop started.
[05-09 15:55:10] Processing 1 grouped request(s)
[05-09 15:55:10] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=173>
                        seed: 42
                 infer_steps: 20
      num_outputs_per_prompt: 1
              guidance_scale: 4.5
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: ../wan_output/A_curious_raccoon_20260509-155510_7d8931bd.png
        
[05-09 15:55:10] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-09 15:55:10] [InputValidationStage] started...
[05-09 15:55:10] [InputValidationStage] finished in 0.0001 seconds
[05-09 15:55:10] [TextEncodingStage] started...
[05-09 15:55:11] [TextEncodingStage] finished in 0.9229 seconds
[05-09 15:55:11] [TimestepPreparationStage] started...
[05-09 15:55:11] [TimestepPreparationStage] finished in 0.0012 seconds
[05-09 15:55:11] [LatentPreparationStage] started...
[05-09 15:55:11] [LatentPreparationStage] finished in 0.0013 seconds
[05-09 15:55:11] [DenoisingStage] started...

  0%|          | 0/20 [00:00<?, ?it/s]
  0%|          | 0/20 [00:01<?, ?it/s]
[91m[05-09 15:55:13] [DenoisingStage] Error during execution after 1899.7921 ms: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 288, in __call__
    result = self.forward(batch, server_args)
  File "/home/workspace/.../env/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1266, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 937, in _run_denoising_step
    ctx.latents = ctx.scheduler.step(
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py", line 120, in step
    return self._inner.step(model_output, timestep, sample, **kwargs)
TypeError: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[91m[05-09 15:55:13] Error executing request 87a9a97f-409d-4ddc-96a5-08bbff153f83: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 334, in _execute_forward_common
    result = forward_fn()
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 272, in <lambda>
    forward_fn=lambda: self.pipeline.forward(req, self.server_args),
  File "/home/workspace/.../env/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py", line 770, in forward
    return self.executor.execute_with_profiling(self.stages, batch, server_args)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py", line 84, in execute_with_profiling
    batch = self.execute(stages, batch, server_args)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 110, in execute
    return self._execute_stages(
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 98, in _execute_stages
    batch = stage(batch, server_args)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 288, in __call__
    result = self.forward(batch, server_args)
  File "/home/workspace/.../env/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1266, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 937, in _run_denoising_step
    ctx.latents = ctx.scheduler.step(
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_dpm_solver_multistep.py", line 120, in step
    return self._inner.step(model_output, timestep, sample, **kwargs)
TypeError: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[91m[05-09 15:55:13] Failed to generate output for prompt: Error executing request 87a9a97f-409d-4ddc-96a5-08bbff153f83: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/utils/logging_utils.py", line 626, in log_generation_timer
    yield timer
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 87a9a97f-409d-4ddc-96a5-08bbff153f83: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[91m[05-09 15:55:13] Generation failed: Error executing request 87a9a97f-409d-4ddc-96a5-08bbff153f83: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'
Traceback (most recent call last):
  File "/home/workspace/.../sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request 87a9a97f-409d-4ddc-96a5-08bbff153f83: DPMSolverMultistepScheduler.step() got an unexpected keyword argument 'eta'[0;0m
[93m[05-09 15:55:13] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-09 15:55:19] Worker 0: Shutdown complete.

</details>

### Root cause analysis of error 2

  The denoising loop constructs `extra_step_kwargs` via `prepare_extra_func_kwargs`:

  ```python
  extra_step_kwargs = self.prepare_extra_func_kwargs(
      scheduler.step,
      {"generator": batch.generator, "eta": batch.eta, "batch": batch},
  )
  ```
  The purpose of prepare_extra_func_kwargs is to filter out kwargs that the target function doesn't accept, preventing
  TypeError. Before fbebfdec9, it always filtered:

Old logic — always filters:
  ```
  params = inspect.signature(target_func).parameters
  return {k: v for k, v in kwargs.items() if k in params}
  ```
  Since DPMSolverMultistepScheduler.step(self, model_output, timestep, sample, **kwargs) has params = {'self',
  'model_output', 'timestep', 'sample', 'kwargs'}, neither eta nor batch matched any param name, so both were correctly
  filtered out.

  After fbebfdec9, a shortcut was added: if the target function has **kwargs (VAR_KEYWORD), skip filtering and return
  all kwargs directly:

  New logic — shortcuts when **kwargs is detected
  ```
  accepts_var_kwargs, param_names = self._get_extra_func_kwarg_names(func)
  if accepts_var_kwargs:
      return kwargs  # ← all kwargs passed through unfiltered
  return {k: v for k, v in kwargs.items() if k in param_names}
  ```
For the DPMSolverMultistepScheduler.step() wrapper, **kwargs is used for forwarding — the underlying diffusers step() has an explicit signature (generator, variance_noise, return_dict) and does not accept eta or batch. The shortcut caused these unsupported kwargs to leak through, triggering the TypeError.

## Modifications

<!-- Detail the changes made in this pull request. -->

- scheduling_dpm_solver_multistep.py: 
Replace **kwargs in DPMSolverMultistepScheduler.step() with explicit keyword arguments (generator, variance_noise, return_dict) to match the inner scheduler's signature.
- gemma2.py: 
Refactor attention mask in Gemma2Attention from float("-inf") fill to boolean mask (True/False) according to Gemma3Attention, compatible with both NPU and GPU scaled_dot_product_attention.
- activation.py: 
Add forward_npu to GeluAndMul, using torch_npu.npu_geglu for NPU-accelerated GeGLU computation.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

cmd:
python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate --model-path=Efficient-Large-Model/Sana_600M_512px_diffusers --prompt="A curious raccoon" --num-gpus 1 --save-output

### NPU: success
Full log:
<details>
  <summary> Complete log of NPU </summary>
/root/sana/sglang/python/sglang/srt/layers/attention/fla/utils.py:223: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[05-09 07:42:17] Disabling some offloading (except dit, text_encoder) for image generation model
[05-09 07:42:17] server_args: {"model_path": "/root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "quantization": null, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5654, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[05-09 07:42:17] Diffusers version: 0.32.0.dev0
[05-09 07:42:17] Local mode: True
[05-09 07:42:17] Starting server...
/root/sana/sglang/python/sglang/srt/layers/attention/fla/utils.py:223: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[05-09 07:42:35] Scheduler bind at endpoint: tcp://127.0.0.1:5654
[05-09 07:42:36] get env LOCAL_RANK = 0
[05-09 07:42:36] get env WORLD_SIZE = 1
[05-09 07:42:36] get env RANK = 0
[05-09 07:42:36] Initializing distributed environment with world_size=1, device=npu:0, timeout=3600
[05-09 07:42:36] Setting distributed timeout to 3600 seconds
[05-09 07:42:37] No pipeline_class_name specified, using model_index.json
[05-09 07:42:37] Diffusers version: 0.32.0.dev0
[05-09 07:42:37] Using pipeline from model_index.json: SanaPipeline
[05-09 07:42:37] Loading pipeline modules...
[05-09 07:42:37] Model already exists locally and is complete
[05-09 07:42:37] Model path: /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers
[05-09 07:42:37] Diffusers version: 0.32.0.dev0
[05-09 07:42:37] Loading pipeline modules from config: {'_class_name': 'SanaPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'DPMSolverMultistepScheduler'], 'text_encoder': ['transformers', 'Gemma2Model'], 'tokenizer': ['transformers', 'GemmaTokenizerFast'], 'transformer': ['diffusers', 'SanaTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderDC']}
[05-09 07:42:37] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']

Loading required modules:   0%|          | 0/5 [00:00<?, ?it/s][05-09 07:42:37] Loading text_encoder from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/text_encoder. avail mem: 60.56 GB


Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  4.43it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  4.42it/s]

[05-09 07:42:40] Applied FSDP to 132 submodules in FSDPGemma2Model using explicit shard conditions
[05-09 07:42:40] Loaded text_encoder: FSDPGemma2Model (sgl-diffusion version). model size: 4.87 GB, consumed GPU mem: 0.06 GB, avail GPU mem: 60.50 GB

Loading required modules:  20%|██        | 1/5 [00:03<00:12,  3.18s/it][05-09 07:42:40] Loading tokenizer from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/tokenizer. avail mem: 60.50 GB
[05-09 07:42:44] Loaded tokenizer: GemmaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules:  40%|████      | 2/5 [00:06<00:10,  3.45s/it][05-09 07:42:44] Loading vae from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/vae. avail mem: 60.50 GB
The config attributes {'stacked_params_mapping': [], 'vae_scale_factor': 32, 'temporal_compression_ratio': 4, 'spatial_compression_ratio': 32} were passed to AutoencoderDC, but are not expected and will be ignored. Please verify your config.json configuration file.
[05-09 07:42:47] Loaded vae: AutoencoderDC (sgl-diffusion version). model size: 1.16 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules:  60%|██████    | 3/5 [00:09<00:06,  3.28s/it][05-09 07:42:47] Loading transformer from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer. avail mem: 60.50 GB
[05-09 07:42:47] Filtered 1 duplicate transformer precision variant file(s): ['/root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/transformer/diffusion_pytorch_model.fp16.safetensors']
[05-09 07:42:47] Loading SanaTransformer2DModel from 1 safetensors file(s) , param_dtype: torch.bfloat16


Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 25.45it/s]

[05-09 07:42:48] Loaded model with 0.59B parameters
[05-09 07:42:48] Loaded transformer: SanaTransformer2DModel (sgl-diffusion version). model size: 1.1 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules:  80%|████████  | 4/5 [00:11<00:02,  2.46s/it][05-09 07:42:48] Loading scheduler from /root/.cache/modelscope/hub/models/Efficient-Large-Model/Sana_600M_512px_diffusers/scheduler. avail mem: 60.50 GB
[05-09 07:42:48] Loaded scheduler: DPMSolverMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.50 GB

Loading required modules: 100%|██████████| 5/5 [00:11<00:00,  2.22s/it]
[05-09 07:42:48] Creating pipeline stages...
[05-09 07:42:48] Using Torch SDPA backend.
[05-09 07:42:48] Pipeline instantiated
[05-09 07:42:48] Worker 0: Initialized device, model, and distributed environment.
[05-09 07:42:48] Worker 0: Scheduler loop started.
[05-09 07:42:48] Processing 1 grouped request(s)
[05-09 07:42:48] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=173>
                        seed: 42
                 infer_steps: 20
      num_outputs_per_prompt: 1
              guidance_scale: 4.5
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260509-074248_380f4943.png
        
[05-09 07:42:48] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-09 07:42:48] [InputValidationStage] started...
[05-09 07:42:48] [InputValidationStage] finished in 0.0003 seconds
[05-09 07:42:48] [TextEncodingStage] started...
[05-09 07:42:49] [TextEncodingStage] finished in 1.2898 seconds
[05-09 07:42:49] [TimestepPreparationStage] started...
[05-09 07:42:49] [TimestepPreparationStage] finished in 0.0011 seconds
[05-09 07:42:49] [LatentPreparationStage] started...
[05-09 07:42:49] [LatentPreparationStage] finished in 0.0006 seconds
[05-09 07:42:49] [DenoisingStage] started...

  0%|          | 0/20 [00:00<?, ?it/s][05-09 07:42:51] get env ASCEND_OPP_PATH = /usr/local/Ascend/cann-8.5.0/opp
/root/sana/sglang/python/sglang/srt/layers/attention/fla/utils.py:223: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(
[05-09 07:43:10] get env HOME = /root
[05-09 07:43:10] get env TE_AUTO_RESTART_COUNTER = 0
[05-09 07:43:13] get env PYTHONPATH = /usr/local/Ascend/cann-8.5.0/python/site-packages:/usr/local/Ascend/cann-8.5.0/opp/built-in/op_impl/ai_core/tbe:/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:/usr/local/Ascend/ascend-toolkit/latest/opp/built-in/op_impl/ai_core/tbe:

  5%|▌         | 1/20 [00:26<08:14, 26.00s/it]
 10%|█         | 2/20 [00:26<03:15, 10.86s/it]
 15%|█▌        | 3/20 [00:26<01:42,  6.01s/it]
 20%|██        | 4/20 [00:26<00:59,  3.74s/it]
 25%|██▌       | 5/20 [00:27<00:37,  2.48s/it]
 30%|███       | 6/20 [00:27<00:24,  1.73s/it]
 35%|███▌      | 7/20 [00:27<00:16,  1.25s/it]
 40%|████      | 8/20 [00:27<00:11,  1.07it/s]
 45%|████▌     | 9/20 [00:28<00:07,  1.38it/s]
 50%|█████     | 10/20 [00:28<00:05,  1.72it/s]
 50%|█████     | 10/20 [00:28<00:28,  2.83s/it]
[05-09 07:43:18] [DenoisingStage] average time per step: 1.4162 seconds
[05-09 07:43:18] [DenoisingStage] finished in 28.3329 seconds
[05-09 07:43:18] [DecodingStage] started...
[05-09 07:43:19] [DecodingStage] finished in 0.8108 seconds
.[05-09 07:43:26] Output saved to [1;36moutputs/A_curious_raccoon_20260509-074248_380f4943.png[0;0m
[05-09 07:43:26] Pixel data generated successfully in [92m37.67[0;0m seconds
[05-09 07:43:26] Memory usage - Max peak: 3570.00 MB, Avg peak: 3570.00 MB
[93m[05-09 07:43:26] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-09 07:43:26] Worker 0: Shutdown complete.
[93m[05-09 07:43:36] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m
</details>

### GPU: success
<details>
  <summary> Complete log of GPU </summary>
  Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`
[05-09 15:56:33] Disabling some offloading (except dit, text_encoder) for image generation model
[05-09 15:56:33] server_args: {"model_path": "Efficient-Large-Model/Sana_600M_512px_diffusers", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": false, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": true, "quantization": null, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5636, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "../wan_output/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[93m[05-09 15:56:34] Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.[0;0m
[05-09 15:56:34] Local mode: True
[05-09 15:56:34] Starting server...
Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`
[05-09 15:56:43] Scheduler bind at endpoint: tcp://127.0.0.1:5636
[05-09 15:56:43] Initializing distributed environment with world_size=1, device=cuda:0, timeout=3600
[05-09 15:56:43] Setting distributed timeout to 3600 seconds
[05-09 15:56:44] No pipeline_class_name specified, using model_index.json
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
[93m[05-09 15:56:45] Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.[0;0m
[05-09 15:56:45] Using pipeline from model_index.json: SanaPipeline
[05-09 15:56:45] Loading pipeline modules...
[05-09 15:56:45] Checking for cached model in HF Hub cache for Efficient-Large-Model/Sana_600M_512px_diffusers...
[05-09 15:56:45] Found complete model in cache at /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15
[05-09 15:56:45] Model path: /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15
[05-09 15:56:45] Diffusers version: 0.32.0.dev0
[05-09 15:56:45] Loading pipeline modules from config: {'_class_name': 'SanaPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'DPMSolverMultistepScheduler'], 'text_encoder': ['transformers', 'Gemma2Model'], 'tokenizer': ['transformers', 'GemmaTokenizerFast'], 'transformer': ['diffusers', 'SanaTransformer2DModel'], 'vae': ['diffusers', 'AutoencoderDC']}
[05-09 15:56:45] Loading required components: ['text_encoder', 'tokenizer', 'vae', 'transformer', 'scheduler']

Loading required modules:   0%|          | 0/5 [00:00<?, ?it/s][05-09 15:56:45] Loading text_encoder from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/text_encoder. avail mem: 74.15 GB
[05-09 15:56:46] [RunAI Streamer] Overall time to stream 4.9 GiB of all files to cpu: 1.29s, 3.8 GiB/s
[05-09 15:56:54] Applied FSDP to 132 submodules in FSDPGemma2Model using explicit shard conditions
[05-09 15:56:54] Loaded text_encoder: FSDPGemma2Model (sgl-diffusion version). model size: 4.87 GB, consumed GPU mem: 0.04 GB, avail GPU mem: 74.12 GB

Loading required modules:  20%|██        | 1/5 [00:08<00:34,  8.66s/it][05-09 15:56:54] Loading tokenizer from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/tokenizer. avail mem: 74.12 GB
[05-09 15:56:55] Loaded tokenizer: GemmaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules:  40%|████      | 2/5 [00:10<00:14,  4.69s/it][05-09 15:56:55] Loading vae from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/vae. avail mem: 74.12 GB
The config attributes {'stacked_params_mapping': [], 'vae_scale_factor': 32, 'temporal_compression_ratio': 4, 'spatial_compression_ratio': 32} were passed to AutoencoderDC, but are not expected and will be ignored. Please verify your config.json configuration file.
[05-09 15:56:57] Loaded vae: AutoencoderDC (sgl-diffusion version). model size: 1.16 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules:  60%|██████    | 3/5 [00:12<00:06,  3.30s/it][05-09 15:56:57] Loading transformer from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/transformer. avail mem: 74.12 GB
[05-09 15:56:57] Filtered 1 duplicate transformer precision variant file(s): ['/home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/transformer/diffusion_pytorch_model.fp16.safetensors']
[05-09 15:56:57] Loading SanaTransformer2DModel from 1 safetensors file(s) , param_dtype: torch.bfloat16
[05-09 15:56:58] [RunAI Streamer] Overall time to stream 2.2 GiB of all files to cpu: 0.4s, 5.6 GiB/s
[05-09 15:56:58] Loaded model with 0.59B parameters
[05-09 15:56:58] Loaded transformer: SanaTransformer2DModel (sgl-diffusion version). model size: 1.1 GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules:  80%|████████  | 4/5 [00:13<00:02,  2.49s/it][05-09 15:56:58] Loading scheduler from /home/traindata/.../.cache/hub/models--Efficient-Large-Model--Sana_600M_512px_diffusers/snapshots/2defc07f5fb66d0c53ace051585e9a2cb83f8c15/scheduler. avail mem: 74.12 GB
[05-09 15:56:58] Loaded scheduler: DPMSolverMultistepScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 74.12 GB

Loading required modules: 100%|██████████| 5/5 [00:13<00:00,  2.69s/it]
[05-09 15:56:58] Creating pipeline stages...
[05-09 15:56:58] Using FlashAttention (FA3 for hopper, FA4 for blackwell) backend
[05-09 15:56:58] Pipeline instantiated
[05-09 15:56:58] Worker 0: Initialized device, model, and distributed environment.
[05-09 15:56:58] Worker 0: Scheduler loop started.
[05-09 15:56:58] Processing 1 grouped request(s)
[05-09 15:56:58] Sampling params:
                       width: 1024
                      height: 1024
                  num_frames: 1
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=173>
                        seed: 42
                 infer_steps: 20
      num_outputs_per_prompt: 1
              guidance_scale: 4.5
     embedded_guidance_scale: 6.0
                    n_tokens: None
                  flow_shift: None
                  image_path: None
                 save_output: True
            output_file_path: ../wan_output/A_curious_raccoon_20260509-155658_8a51c97a.png
        
[05-09 15:56:58] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-09 15:56:58] [InputValidationStage] started...
[05-09 15:56:58] [InputValidationStage] finished in 0.0001 seconds
[05-09 15:56:58] [TextEncodingStage] started...
[05-09 15:56:59] [TextEncodingStage] finished in 0.9088 seconds
[05-09 15:56:59] [TimestepPreparationStage] started...
[05-09 15:56:59] [TimestepPreparationStage] finished in 0.0013 seconds
[05-09 15:56:59] [LatentPreparationStage] started...
[05-09 15:56:59] [LatentPreparationStage] finished in 0.0020 seconds
[05-09 15:56:59] [DenoisingStage] started...

  0%|          | 0/20 [00:00<?, ?it/s]
  5%|▌         | 1/20 [00:01<00:37,  2.00s/it]
 10%|█         | 2/20 [00:02<00:17,  1.03it/s]
 15%|█▌        | 3/20 [00:02<00:11,  1.54it/s]
 20%|██        | 4/20 [00:02<00:07,  2.02it/s]
 25%|██▌       | 5/20 [00:03<00:06,  2.44it/s]
 30%|███       | 6/20 [00:03<00:05,  2.76it/s]
 35%|███▌      | 7/20 [00:03<00:04,  3.03it/s]
 40%|████      | 8/20 [00:03<00:03,  3.25it/s]
 45%|████▌     | 9/20 [00:04<00:03,  3.39it/s]
 50%|█████     | 10/20 [00:04<00:02,  3.51it/s]
 50%|█████     | 10/20 [00:04<00:04,  2.30it/s]
[05-09 15:57:04] [DenoisingStage] average time per step: 0.2179 seconds
[05-09 15:57:04] [DenoisingStage] finished in 4.3636 seconds
[05-09 15:57:04] [DecodingStage] started...
[05-09 15:57:08] [DecodingStage] finished in 3.9596 seconds
[05-09 15:57:08] Output saved to [1;36m../wan_output/A_curious_raccoon_20260509-155658_8a51c97a.png[0;0m
[05-09 15:57:08] Pixel data generated successfully in [92m10.02[0;0m seconds
[05-09 15:57:08] Memory usage - Max peak: 3948.00 MB, Avg peak: 3948.00 MB
[93m[05-09 15:57:08] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-09 15:57:14] Worker 0: Shutdown complete.

</details>

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
