### PR TITLE
[AMD] Fix DeepSeek import cascade by supporting both pre- and post-#2958 aiter `fused_qk_rmsnorm` APIs

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -64,9 +64,39 @@ if _is_cuda:
 
 
 if _use_aiter:
-    from aiter.ops.fused_qk_norm_rope_cache_quant import (
-        fused_qk_rmsnorm as fused_qk_rmsnorm_bf16,
-    )
+    # aiter ROCm/aiter#2958 renamed the public `fused_qk_rmsnorm` in
+    # `aiter.ops.fused_qk_norm_rope_cache_quant` to a private `_fused_qk_rmsnorm`
+    # and introduced a unified entry point in `aiter.ops.fused_qk_rmsnorm_group_quant`
+    # with a different (in-place, kwarg-only, no-return) signature. Probe for the
+    # new symbol first so SGLang works with both pre- and post-#2958 aiter without
+    # requiring the docker pin to be bumped atomically.
+    try:
+        from aiter.ops.enum import QuantType as _AiterQuantType
+        from aiter.ops.fused_qk_rmsnorm_group_quant import (
+            fused_qk_rmsnorm as _aiter_fused_qk_rmsnorm_unified,
+        )
+
+        def fused_qk_rmsnorm_bf16(q, q_weight, q_eps, k, k_weight, k_eps):
+            q_out = torch.empty_like(q)
+            k_out = torch.empty_like(k)
+            _aiter_fused_qk_rmsnorm_unified(
+                q_out_quantized=q_out,
+                k_out=k_out,
+                q=q,
+                q_weight=q_weight,
+                q_epsilon=q_eps,
+                k=k,
+                k_weight=k_weight,
+                k_epsilon=k_eps,
+                quant_type=_AiterQuantType.No,
+            )
+            return q_out, k_out
+
+    except ImportError:
+        from aiter.ops.fused_qk_norm_rope_cache_quant import (
+            fused_qk_rmsnorm as fused_qk_rmsnorm_bf16,
+        )
+
     from aiter.ops.triton.batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant import (
         batched_gemm_a8w8_a_per_token_group_prequant_w_per_batched_tensor_quant,
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

[ROCm/aiter#2958](https://github.com/ROCm/aiter/pull/2958) renamed the public `fused_qk_rmsnorm` in `aiter.ops.fused_qk_norm_rope_cache_quant` to a private `_fused_qk_rmsnorm` and introduced a new unified entry point in `aiter.ops.fused_qk_rmsnorm_group_quant` with a different (in-place, kwarg-only, no-return) signature.

Because `forward_mla.py` imports this symbol at **module load time**, the rename causes an `ImportError` that cascades through 28 SGLang model modules (`deepseek_v2`, `deepseek_nextn`, `deepseek_v4`, `kimi_k25`, `glm4_moe`, `longcat_flash`, `mistral_large_3`, etc.). `ModelRegistry.register(strict=False)` then silently swallows those errors, so `DeepseekV3ForCausalLM` appears unsupported, SGLang falls back to the Transformers backend, and the `trust_remote_code` `modeling_deepseek.py` for `amd/DeepSeek-R1-MXFP4-Preview` eventually crashes with `KeyError: 'sglang'` because its `ATTENTION_CLASSES` does not contain that key. This brought down all 8 TP ranks in the MI35x DeepSeek-R1-MXFP4 perf job: [aiter run #25586397205](https://github.com/ROCm/aiter/actions/runs/25586397205/job/75115897406).

We cannot fix this purely on either side:
- **Only switching to the new aiter API** breaks SGLang's currently-pinned aiter (`a6bb4993`, pre-#2958), which doesn't have the new symbol — the same cascade reappears.
- **Only keeping the old API** keeps the aiter-side CI red.

The robust, decoupled fix is feature detection in SGLang so it works against both pre- and post-#2958 aiter without requiring an atomic docker pin bump.

## Modifications

`python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py`

- Probe for the new unified `aiter.ops.fused_qk_rmsnorm_group_quant.fused_qk_rmsnorm` symbol first.
  - If present (post-#2958 aiter): wrap it to preserve the legacy 6-positional-arg, tuple-returning interface used at the call site. Pre-allocates `q_out` / `k_out` via `torch.empty_like` (the new API is in-place and discards `_fused_qk_rmsnorm`'s tuple return, so callers must own the buffers) and passes `quant_type=QuantType.No`.
  - Otherwise (pre-#2958 aiter): fall back to the legacy direct import as before.
- The call site (`elif _use_aiter:` block, ~line 200) is unchanged — both code paths expose the same `fused_qk_rmsnorm_bf16(q, q_w, q_eps, k, k_w, k_eps) -> (q, k)` interface.

Performance impact:
- **Legacy aiter path**: identical kernel, identical positional-arg call. The wrapper isn't on this path.
- **New aiter path**: same underlying kernel (new `fused_qk_rmsnorm` with `QuantType.No` just dispatches to `_fused_qk_rmsnorm`, which is the renamed legacy function). Two extra `torch.empty_like` allocations per call relocate the output buffer ownership from inside aiter to the caller — total allocation traffic is unchanged, sub-microsecond on the caching allocator, well below noise on a per-layer-per-step basis.

## Accuracy Tests

This change is a no-op for the legacy aiter path (currently in production). On the new aiter path, the dispatched kernel is the same one the legacy function called, so numerical outputs are bit-identical.

Recommended verification before merge:

1. Module-import smoke test on ROCm: confirm `DeepseekV3ForCausalLM in ModelRegistry.get_supported_archs()` is `True`, and SGLang server logs do **not** contain `has no SGLang implementation, falling back to Transformers implementation`.
2. End-to-end: rerun `test/registered/amd/perf/mi35x/test_deepseek_r1_mxfp4_perf_mi35x.py::test_bench_one_batch` against this branch with both:
   - the currently-pinned aiter (`a6bb499375849eec45d68c5ccaebc8865fd422c0`)
   - aiter HEAD (post-#2958)
3. (Optional) Numerical cross-check of `fused_qk_rmsnorm_bf16` on a few representative shapes between old and new aiter to confirm bit-identity.

## Speed Tests and Profiling

No expected delta. The wrapper adds one Python frame and two `torch.empty_like` calls per layer per forward step on the new-aiter path; the underlying kernel is unchanged. On the pre-#2958 aiter path (current default) there is no wrapper at all on the hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aca80f8-e843-4367-afc2-4600e7124104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aca80f8-e843-4367-afc2-4600e7124104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

