### PR TITLE
Replace mixin getattr defaults with direct access

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -75,7 +75,7 @@ class SchedulerOutputProcessorMixin:
                 "host": req.cached_tokens_host,
             }
             # Only include storage fields if L3 storage is enabled
-            if getattr(self, "enable_hicache_storage", False):
+            if self.enable_hicache_storage:
                 details["storage"] = req.cached_tokens_storage
                 details["storage_backend"] = self._get_storage_backend_type()
             return details

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -717,7 +717,7 @@ class SchedulerPPMixin:
         ):
             return None
 
-        max_chunk_size = getattr(self, "max_prefill_tokens", None)
+        max_chunk_size = self.max_prefill_tokens
         predicted_size = self.length_predictor.predict_next_chunk_size(
             history_len=history_len,
             base_chunk_size=self.chunked_prefill_size,

--- a/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
@@ -261,7 +261,7 @@ class TokenizerManagerScoreMixin:
         has_phs = False
         prompt_tokens = 0
 
-        is_generation = getattr(self, "is_generation", True)
+        is_generation = self.is_generation
         if is_generation:
             for result in results:
                 # For single-item scoring, logprobs are in output_token_ids_logprobs
@@ -563,7 +563,7 @@ class TokenizerManagerScoreMixin:
                     return_pooled_hidden_states=True and the model supports it;
                     None otherwise.
         """
-        is_generation = getattr(self, "is_generation", True)
+        is_generation = self.is_generation
 
         if is_generation and label_token_ids is None:
             raise ValueError(


### PR DESCRIPTION
3 mixin attributes that were guarded by `getattr(self, X, default)` are unconditionally set by the host class; the defaults were unreachable defense. This PR drops them so future field renames surface as `AttributeError` instead of silently using the default.

## `enable_hicache_storage` (scheduler_output_processor_mixin.py:78)

Host: `Scheduler.__init__` sets `self.enable_hicache_storage = server_args.hicache_storage_backend is not None` at scheduler.py:394, very early in `__init__`. Two later branches at L3317/L3368 may overwrite it. The mixin reader runs from `_get_cached_tokens_details`, called during request processing, well after `__init__` completes.

- Before: `if getattr(self, "enable_hicache_storage", False):`
- After:&nbsp; `if self.enable_hicache_storage:`

## `max_prefill_tokens` (scheduler_pp_mixin.py:720)

Host: assigned via `self.tp_worker.get_worker_info()` unpacking in `Scheduler.init_model_worker()` (scheduler.py:716). The pp-mixin reader is in `predict_next_chunk_size`, called only from the schedule loop — strictly after `__init__` and `init_model_worker()`.

- Before: `max_chunk_size = getattr(self, "max_prefill_tokens", None)`
- After:&nbsp; `max_chunk_size = self.max_prefill_tokens`

## `is_generation` × 2 (tokenizer_manager_score_mixin.py:264, 566)

Host: `TokenizerManager.__init__` sets `self.is_generation = self.model_config.is_generation` at tokenizer_manager.py:269, right after `init_model_config()`. The only `TokenizerManager` subclass `TokenizerWorker` (multi_tokenizer_mixin.py:422) calls `super().__init__()` as its first statement, so the assignment runs there too. The score-mixin readers are in `score_request`, invoked async after init.

- Before: `is_generation = getattr(self, "is_generation", True)`
- After:&nbsp; `is_generation = self.is_generation`

## Why this is safe

- All three host fields have no conditional-init branch — they're set on every code path through `__init__`.
- All three readers run after `__init__` completes (request-handling / scheduler-loop paths).
- The fallback values (`False`, `None`, `True`) had no documented semantics; they were defensive scaffolding.
