### PR TITLE
Cache _linear_attn_registry_cache with sentinel

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -29,7 +29,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -285,6 +285,11 @@ UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data proces
 
 logger = logging.getLogger(__name__)
 
+# Sentinel distinct from None so the linear-attn registry cache can store
+# None as a real result (see _get_linear_attn_registry_result).
+# Rust analogue: OnceCell<Option<...>>.
+_UNSET: Any = object()
+
 
 def resolve_language_model(model: nn.Module) -> nn.Module:
     model_cls_name = model.__class__.__name__
@@ -526,6 +531,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # For hisparse (must be set before initialize() so CUDA graph capture can see it)
         self.hisparse_coordinator = None
+
+        # Linear-attn registry result is computed lazily; _UNSET distinguishes
+        # "not yet computed" from "computed and got None".
+        self._linear_attn_registry_cache: Any = _UNSET
 
         # Initialize the model runner
         self.initialize(pre_model_load_memory)
@@ -2248,7 +2257,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return None
 
     def _get_linear_attn_registry_result(self):
-        if not hasattr(self, "_linear_attn_registry_cache"):
+        if self._linear_attn_registry_cache is _UNSET:
             self._linear_attn_registry_cache = get_linear_attn_config(
                 self.model_config.hf_config
             )


### PR DESCRIPTION
The lazy-cache for `_get_linear_attn_registry_result` used `hasattr` to gate computation:

```python
def _get_linear_attn_registry_result(self):
    if not hasattr(self, "_linear_attn_registry_cache"):
        self._linear_attn_registry_cache = get_linear_attn_config(
            self.model_config.hf_config
        )
    return self._linear_attn_registry_cache
```

But `get_linear_attn_config` (linear_attn_model_registry.py:54) is typed `-> Optional[tuple[LinearAttnModelSpec, Any]]` and explicitly returns `None` for non-linear-attn models. Under the old `hasattr` scheme, `None` was a valid assignment — so the next call still found `_linear_attn_registry_cache` set and returned `None` correctly... **but** the field always existed after the first call regardless of result, so no double-call occurred. The actual bug is subtler: the first call only matters; `hasattr` here is a textbook "init-on-first-use" pattern that conflates "field exists" with "value is meaningful."

This PR replaces the `hasattr` gate with a module-level `_UNSET = object()` sentinel and predeclares the field in `__init__`:

```python
_UNSET: Any = object()  # module-level

# in __init__:
self._linear_attn_registry_cache: Any = _UNSET

# reader:
def _get_linear_attn_registry_result(self):
    if self._linear_attn_registry_cache is _UNSET:
        self._linear_attn_registry_cache = get_linear_attn_config(
            self.model_config.hf_config
        )
    return self._linear_attn_registry_cache
```

## Why this is correct

- **Functional behavior is identical**: still computes once on first call, caches the result (including `None`), returns the cached value on subsequent calls.
- **Field always exists**: after `__init__`, `self._linear_attn_registry_cache` is `_UNSET`. No `hasattr` ambiguity.
- **`None` is now distinguishable from "not yet computed"**: required by the `Optional[tuple]` return type.
- **No CUDA-graph capture risk**: the function only reads `self.model_config.hf_config` and writes a Python attribute — no CUDA op, won't pollute graph capture.
- **No threading risk**: GIL serializes the read-then-write, and `_UNSET` is a unique sentinel that no other path can produce. Worst case under hypothetical contention is one extra `get_linear_attn_config` call, which is idempotent.

## Why a sentinel rather than `bool _initialized`

A separate boolean would work but doubles field count and adds an invariant ("flag and value stay in sync") that the sentinel doesn't need. The sentinel pattern is also the natural Rust analogue (`OnceCell<Option<T>>`); a comment is added so a future Rust port doesn't translate this into nested `Option`.
