### PR TITLE
Delete dead hasattr guard for hisparse_coordinator

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -569,9 +569,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self._model_update_group = {}
         self._weights_send_group = {}
 
-        if not hasattr(self, "hisparse_coordinator"):
-            self.hisparse_coordinator = None
-
     def _build_model_config(
         self, server_args, model_path=None, model_revision=None, is_draft_model=False
     ):


### PR DESCRIPTION
`ModelRunner.__init__` already sets `self.hisparse_coordinator = None` unconditionally early on (model_runner.py:528, just before `self.initialize()`):

```python
# For hisparse (must be set before initialize() so CUDA graph capture can see it)
self.hisparse_coordinator = None
```

Later in the same `__init__`, near the tail (former L572-574), there was a defensive guard:

```python
if not hasattr(self, "hisparse_coordinator"):
    self.hisparse_coordinator = None
```

`hasattr` always returns `True` here — L528 has unconditionally set it. The guarded fallback is dead code.

## Why this is safe

- `git grep -n "self\.hisparse_coordinator\s*=" python/sglang/` shows the L528 assignment plus other read/write sites that all follow it in the call graph (model_runner.py:772 sets the real coordinator; tp_worker.py:414 registers an external one; cuda_graph_runner.py:1100 reads it via `if self.hisparse_coordinator is not None`).
- The only `ModelRunner` subclass in-tree (`MlxModelRunnerStub`) calls `super().__init__`, so it inherits the L528 assignment. No subclass bypasses `ModelRunner.__init__`.
- `git grep` finds no `del self.hisparse_coordinator` anywhere.
- The L528 comment explicitly notes "must be set before `initialize()` so CUDA graph capture can see it" — the field's existence is part of the contract, not optional.

Pure dead-code deletion, no behavior change.
