### PR TITLE
Convert forward_pass_device_timer to None-init

### DIFF
--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -159,6 +159,8 @@ class SchedulerMetricsMixin:
 
         self.fwd_occupancy = float("nan")
 
+        self.forward_pass_device_timer: Optional[DeviceTimer] = None
+
         if ENABLE_METRICS_DEVICE_TIMER:
             self._device_timer_window_batch_count = 0
             self._device_timer_window_gpu_time = 0.0
@@ -180,7 +182,7 @@ class SchedulerMetricsMixin:
         )
 
     def install_device_timer_on_runners(self: Scheduler):
-        if not hasattr(self, "forward_pass_device_timer"):
+        if self.forward_pass_device_timer is None:
             return
         timer = self.forward_pass_device_timer
         self.tp_worker.model_runner.device_timer = timer


### PR DESCRIPTION
The `forward_pass_device_timer` field was a "conditional-init" attribute — only assigned when the env var `SGLANG_ENABLE_METRICS_DEVICE_TIMER` is true:

```python
# init_metrics, scheduler_metrics_mixin.py
if ENABLE_METRICS_DEVICE_TIMER:
    ...
    self.forward_pass_device_timer = DeviceTimer(reporter=...)
```

The single non-self reader checked `hasattr` to skip when unset:

```python
def install_device_timer_on_runners(self: Scheduler):
    if not hasattr(self, "forward_pass_device_timer"):
        return
    timer = self.forward_pass_device_timer
    ...
```

This PR predeclares the field as `None` at the top of `init_metrics`, before the env-gated branch, and switches the reader to `is None`:

```python
# init_metrics, before the env branch:
self.forward_pass_device_timer: Optional[DeviceTimer] = None

if ENABLE_METRICS_DEVICE_TIMER:
    ...
    self.forward_pass_device_timer = DeviceTimer(reporter=...)

# reader:
def install_device_timer_on_runners(self: Scheduler):
    if self.forward_pass_device_timer is None:
        return
    timer = self.forward_pass_device_timer
    ...
```

## Why this is correct

- **Semantics identical**: `hasattr` was true iff the env was set; `is not None` is true iff the env was set. Same predicate, different mechanism.
- **Field always exists** after `init_metrics` regardless of env state — eliminates one source of "attribute may or may not exist" uncertainty.
- **Env-disabled path** (`SGLANG_ENABLE_METRICS_DEVICE_TIMER` unset): `init_metrics` sets `forward_pass_device_timer = None`; `install_device_timer_on_runners` early-returns; downstream `_report` calls at L952 are already gated by `if not ENABLE_METRICS_DEVICE_TIMER: return` (L950) so they won't dereference `None`.
- **Env-enabled path**: `init_metrics` overwrites `None` with a real `DeviceTimer`; `install_device_timer_on_runners` proceeds as before.

This is part of the broader preflight cleanup that tightens "field may not exist" patterns into "field is `None` until set" patterns.
