### PR TITLE
Replace running_batch and running_mbs hasattr defaults

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1037,6 +1037,10 @@ class Scheduler(
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching
         self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
+        # PP-mode running micro-batches; populated by init_pp_loop_state when PP
+        # is enabled. Default to [] so non-PP code can read self.running_mbs
+        # uniformly without hasattr guards.
+        self.running_mbs: List[ScheduleBatch] = []
         # The current forward batch
         self.cur_batch: Optional[ScheduleBatch] = None
         # The last forward batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1037,10 +1037,8 @@ class Scheduler(
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching
         self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
-        # PP-mode running micro-batches; populated by init_pp_loop_state when PP
-        # is enabled. Default to [] so non-PP code can read self.running_mbs
-        # uniformly without hasattr guards.
-        self.running_mbs: List[ScheduleBatch] = []
+        if self.server_args.pp_size > 1:
+            self.running_mbs: List[ScheduleBatch] = []
         # The current forward batch
         self.cur_batch: Optional[ScheduleBatch] = None
         # The last forward batch

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -763,14 +763,14 @@ class SchedulerMetricsMixin:
             active_lora_ids = set()
 
             # For PP mode, check all running micro batches
-            if hasattr(self, "running_mbs") and self.running_mbs:
+            if self.running_mbs:
                 for batch in self.running_mbs:
                     if batch and hasattr(batch, "reqs"):
                         for req in batch.reqs:
                             if hasattr(req, "lora_id") and req.lora_id is not None:
                                 active_lora_ids.add(req.lora_id)
             # For normal mode, check running_batch
-            elif hasattr(self, "running_batch") and self.running_batch:
+            elif self.running_batch:
                 if hasattr(self.running_batch, "reqs"):
                     for req in self.running_batch.reqs:
                         if hasattr(req, "lora_id") and req.lora_id is not None:

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -763,7 +763,7 @@ class SchedulerMetricsMixin:
             active_lora_ids = set()
 
             # For PP mode, check all running micro batches
-            if self.running_mbs:
+            if self.server_args.pp_size > 1:
                 for batch in self.running_mbs:
                     if batch and hasattr(batch, "reqs"):
                         for req in batch.reqs:


### PR DESCRIPTION
Two `hasattr(self, X) and X` defenses in the LoRA-stats reader (`scheduler_metrics_mixin.py:764, 771`) — one for `running_batch`, one for `running_mbs` — are no longer needed. Two commits in this PR address them; kept separate so the PP-conditional design choice (commit 2) is reviewable on its own. Will squash before merge if reviewers prefer.

## Commit 1: `running_batch` becomes unconditional; `running_mbs` gets a `[]` default

`Scheduler.init_running_status()` (scheduler.py:1039) unconditionally sets:

```python
self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
```

for every scheduler instance. The metrics-mixin reader is in `log_lora_pool_stats`, which runs from `event_loop_*` after init completes, so `running_batch` is always populated when read.

`running_mbs` was only created inside `init_pp_loop_state` (PP-mode only). Commit 1 also initialized it to `[]` unconditionally in `init_running_status` to make existence an invariant.

```python
# Before:
if hasattr(self, "running_mbs") and self.running_mbs:
    ...
elif hasattr(self, "running_batch") and self.running_batch:
    ...

# After commit 1:
if self.running_mbs:
    ...
elif self.running_batch:
    ...
```

## Commit 2: keep `running_mbs` strictly PP-only

The unconditional `[]` default has two downsides: every non-PP `Scheduler` carries a permanently-empty list it never uses, and the reader's PP-mode detection becomes implicit (`if self.running_mbs:` ⇔ "we're in PP mode and the loop has been entered").

Commit 2 reverts to PP-conditional init and switches the reader to explicit mode detection:

```python
# init_running_status:
self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
if self.server_args.pp_size > 1:
    self.running_mbs: List[ScheduleBatch] = []

# reader:
if self.server_args.pp_size > 1:
    for batch in self.running_mbs:
        ...
elif self.running_batch:
    ...
```

This matches how the rest of the code distinguishes PP vs non-PP (`self.server_args.pp_size > 1` is the canonical check elsewhere in the scheduler) and keeps the field's existence semantically tied to its purpose.

## Why this is correct

- `init_running_status` is called during `Scheduler.__init__` at scheduler.py:446, well before any metrics reader fires (those are in `log_stats` / `generate_loads_response`, both invoked from the running event loop).
- `init_pp_loop_state` (scheduler_pp_mixin.py:530) overrides `running_mbs` with the actual length-`pp_size` list each PP iteration; the `[]` default is only seen on the very first read in non-PP mode (where the new branch never reaches the `running_mbs` reader anyway).
- Truthiness semantics for `ScheduleBatch` are unchanged: `ScheduleBatch` has no `__bool__` / `__len__`, so the original `hasattr(...) and self.running_batch` was effectively just a `hasattr` check. The new `elif self.running_batch:` is `True` iff the batch instance exists, which it always does after `init_running_status`.
