### PR TITLE
Drop redundant defenses on metrics_collector and model_config

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -768,7 +768,7 @@ class Scheduler(
                 f"{'available_cpu_mem' if self.device == 'cpu' else 'available_gpu_mem'}={avail_mem:.2f} GB"
             )
 
-        if self.enable_metrics and hasattr(self, "metrics_collector"):
+        if self.enable_metrics:
             self.metrics_collector.emit_constants(
                 max_total_num_tokens=self.max_total_num_tokens,
                 max_running_requests_under_SLO=getattr(

--- a/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
@@ -676,7 +676,7 @@ class TokenizerManagerScoreMixin:
                     "It requires a model with a task-specific head "
                     "(e.g. SequenceClassification or RewardModel)."
                 )
-            model_config = getattr(self, "model_config", None)
+            model_config = self.model_config
             if model_config is not None:
                 archs = getattr(model_config.hf_config, "architectures", []) or []
                 if is_cross_encoding_pooler_model(archs):


### PR DESCRIPTION
Two more `getattr/hasattr` defenses surfaced in the audit pass that drove the rest of this chain. Both are unreachable; both can be dropped without restructuring `__init__`.

## Commit 1: `metrics_collector` (scheduler.py:771)

The reader was:

```python
if self.enable_metrics and hasattr(self, "metrics_collector"):
    self.metrics_collector.emit_constants(...)
```

`scheduler_metrics_mixin.py:128` is the only branch that assigns `self.metrics_collector`, and it's inside `if self.enable_metrics:`. `init_metrics` runs at `Scheduler.__init__:414`, well before this `emit_constants` call (which lives later in `__init__`).

So when `self.enable_metrics` is `True`, `metrics_collector` is guaranteed to exist. The `hasattr` is pure redundant defense.

```python
# After:
if self.enable_metrics:
    self.metrics_collector.emit_constants(...)
```

## Commit 2: `model_config` in score mixin (tokenizer_manager_score_mixin.py:679)

The reader was:

```python
model_config = getattr(self, "model_config", None)
if model_config is not None:
    archs = getattr(model_config.hf_config, "architectures", []) or []
    ...
```

`TokenizerManager.__init__` (tokenizer_manager.py:232) unconditionally calls `self.init_model_config()`, which unconditionally assigns `self.model_config = model_config_class.from_server_args(server_args)` at L271. The only `TokenizerManager` subclass — `TokenizerWorker` (multi_tokenizer_mixin.py:422) — calls `super().__init__()` as its first statement, so it inherits the same guarantee. Score-mixin readers run from request-handler async paths, well after `__init__`.

I audited `git grep` for `class.*TokenizerManager` and `TokenizerManager(` callsites to confirm there is no grpc / lazy / partial-init path that constructs an instance without going through `init_model_config`.

```python
# After:
model_config = self.model_config
if model_config is not None:
    archs = getattr(model_config.hf_config, "architectures", []) or []
    ...
```

The downstream `if model_config is not None:` guard is now formally unreachable too, but stays as-is — removing it is a separate control-flow simplification that does not belong in a getattr-cleanup PR. Same for the `getattr(model_config.hf_config, "architectures", [])` cross-object feature detection, which falls under preflight #6.

## Why this is correct

- Both readers are gated on conditions (`enable_metrics`, `is_generation` plus other request flags) that are stricter than mere field existence; the `hasattr/getattr` adds no semantic check.
- Both fields are assigned on every `__init__` path that reaches the corresponding reader.
- No subclass bypasses the host `__init__`.
