### PR TITLE
Fix LoRA pool not appearing in /v1/loads response

### DIFF
--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -880,7 +880,7 @@ class SchedulerMetricsMixin:
 
         lora = None
         if include_all or "lora" in include:
-            if hasattr(self, "lora_scheduler") and self.lora_scheduler is not None:
+            if self.enable_lora:
                 lora = LoRAMetrics(
                     slots_used=self.stats.lora_pool_slots_used,
                     slots_total=self.stats.lora_pool_slots_total,


### PR DESCRIPTION
The `/v1/loads` endpoint gates LoRA-pool exposure on:

```python
lora = None
if include_all or "lora" in include:
    if hasattr(self, "lora_scheduler") and self.lora_scheduler is not None:
        lora = LoRAMetrics(
            slots_used=self.stats.lora_pool_slots_used,
            slots_total=self.stats.lora_pool_slots_total,
            utilization=self.stats.lora_pool_utilization,
        )
```

But `self.lora_scheduler` has no setter anywhere in the codebase:

```bash
$ git grep -n 'self\.lora_scheduler\s*=' python/ test/
# no matches
```

The gate is permanently `False`, and **all LoRA users have been seeing `lora=null` in `/v1/loads` since the endpoint was introduced**.

## Root cause (git blame)

`git log -G "lora_scheduler" -- python/` shows the field was introduced in #16976 ("[API] Add /v1/loads endpoint for load metrics", Simo Lin, Jan 2026), in the same commit that wrote the gate. Inside that same PR, the LoRA-pool stats collector (`update_lora_metrics_from_running_batch` in `scheduler_metrics_mixin.py`) already gates on:

```python
if not self.enable_lora:
    return
```

— exactly the predicate the author wanted at the `/v1/loads` callsite. They referenced a non-existent `self.lora_scheduler` field by mistake. Since the gate has always been `False`, no one noticed.

## Fix

Replace the broken gate with `self.enable_lora`, matching the same-PR sibling reader. `self.enable_lora` is set unconditionally in `Scheduler.__init__` from `server_args.enable_lora` (scheduler.py:380).

```python
lora = None
if include_all or "lora" in include:
    if self.enable_lora:
        lora = LoRAMetrics(...)
```

## Effect

- **`--enable-lora` ON**: `/v1/loads` now returns `LoRAMetrics(slots_used, slots_total, utilization)` populated from `self.stats.lora_pool_*`, the same fields the Prometheus `sglang:lora_pool_*` gauges already export. Internal consistency between the two observability surfaces is restored — Prometheus and `/v1/loads` will agree.
- **`--enable-lora` OFF**: behavior unchanged (`lora` stays `None`).

No new fields, no new gauges, no schema change — just a corrected gate.

## Why this is correct

- `self.enable_lora` is always set in `Scheduler.__init__` from server args; the field always exists. No hasattr needed.
- The `LoRAMetrics` payload is already populated correctly by `update_lora_metrics_from_running_batch` (which gates on the same `self.enable_lora`), so when LoRA is on, the data is real.
- When LoRA is off, the LoRA-pool stats fields stay at their dataclass defaults (`int = 0`, `float = 0.0`), so even an erroneous emission would just be zeros — but the gate prevents that anyway.

The user-visible improvement: LoRA users get their pool utilization in `/v1/loads`, matching what they already see in Prometheus.
