### PR TITLE
Annotate dead max_running_requests_under_SLO read sites

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -771,6 +771,7 @@ class Scheduler(
         if self.enable_metrics:
             self.metrics_collector.emit_constants(
                 max_total_num_tokens=self.max_total_num_tokens,
+                # TODO: max_running_requests_under_SLO has no setter — dead chain.
                 max_running_requests_under_SLO=getattr(
                     self, "max_running_requests_under_SLO", None
                 ),

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -792,6 +792,7 @@ class SchedulerMetricsMixin:
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.stats.utilization = -1
         else:
+            # TODO: max_running_requests_under_SLO has no setter — sglang:utilization stuck at 0 (regressed #22713).
             max_under_slo = getattr(self, "max_running_requests_under_SLO", None)
             if max_under_slo is not None and max_under_slo > 0:
                 self.stats.utilization = max(


### PR DESCRIPTION
observe this pre-existing issue when scanning getattr/hasattr, thus mark it via comments as a separate issue (looks like there are already community prs on it)