### PR TITLE
[Router] Fire-and-forget prefill for streaming requests to reduce TTFT

### DIFF
--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -582,12 +582,16 @@ impl PDRouter {
             let prefill_url = prefill.url().to_string();
             tokio::spawn(async move {
                 match prefill_request.send().await {
-                    Ok(resp) if !resp.status().is_success() => {
-                        warn!(
-                            "Prefill returned error (fire-and-forget) prefill_url={} status={}",
-                            prefill_url,
-                            resp.status()
-                        );
+                    Ok(resp) => {
+                        let status = resp.status();
+                        if !status.is_success() {
+                            warn!(
+                                "Prefill returned error (fire-and-forget) prefill_url={} status={}",
+                                prefill_url, status
+                            );
+                        }
+                        // Consume body to allow connection reuse in the pool
+                        let _ = resp.bytes().await;
                     }
                     Err(e) => {
                         warn!(
@@ -595,7 +599,6 @@ impl PDRouter {
                             prefill_url, e
                         );
                     }
-                    _ => {}
                 }
             });
             (None, decode_request.send().await)
@@ -627,26 +630,16 @@ impl PDRouter {
 
                 // Process prefill response (skipped when fire-and-forget)
                 let prefill_body = if let Some(prefill_result) = prefill_result {
-                    if context.return_logprob {
-                        match self
-                            .process_prefill_response(
-                                prefill_result,
-                                prefill.url(),
-                                context.return_logprob,
-                            )
-                            .await
-                        {
-                            Ok((_, body)) => body,
-                            Err(error_response) => return error_response,
-                        }
-                    } else {
-                        match self
-                            .process_prefill_response(prefill_result, prefill.url(), false)
-                            .await
-                        {
-                            Ok((_, body)) => body,
-                            Err(error_response) => return error_response,
-                        }
+                    match self
+                        .process_prefill_response(
+                            prefill_result,
+                            prefill.url(),
+                            context.return_logprob,
+                        )
+                        .await
+                    {
+                        Ok((_, body)) => body,
+                        Err(error_response) => return error_response,
                     }
                 } else {
                     None

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -568,16 +568,41 @@ impl PDRouter {
             false,
         );
 
-        // Send both requests concurrently and wait for both
-        // Note: Using borrowed references avoids heap allocation
+        // Send both requests concurrently
         events::RequestPDSentEvent {
             prefill_url: prefill.url(),
             decode_url: decode.url(),
         }
         .emit();
 
-        let (prefill_result, decode_result) =
-            tokio::join!(prefill_request.send(), decode_request.send());
+        // For streaming requests without logprob, fire-and-forget prefill to reduce TTFT.
+        // The prefill response body is not needed (only triggers KV cache transfer as side-effect).
+        // If prefill fails, decode will timeout waiting for KV cache and report the error.
+        let (prefill_result, decode_result) = if context.is_stream && !context.return_logprob {
+            let prefill_url = prefill.url().to_string();
+            tokio::spawn(async move {
+                match prefill_request.send().await {
+                    Ok(resp) if !resp.status().is_success() => {
+                        warn!(
+                            "Prefill returned error (fire-and-forget) prefill_url={} status={}",
+                            prefill_url,
+                            resp.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Prefill request failed (fire-and-forget) prefill_url={} error={}",
+                            prefill_url, e
+                        );
+                    }
+                    _ => {}
+                }
+            });
+            (None, decode_request.send().await)
+        } else {
+            let (p, d) = tokio::join!(prefill_request.send(), decode_request.send());
+            (Some(p), d)
+        };
 
         events::RequestReceivedEvent {}.emit();
 
@@ -600,28 +625,31 @@ impl PDRouter {
                         .await;
                 }
 
-                // Process prefill response
-                let prefill_body = if context.return_logprob {
-                    match self
-                        .process_prefill_response(
-                            prefill_result,
-                            prefill.url(),
-                            context.return_logprob,
-                        )
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
+                // Process prefill response (skipped when fire-and-forget)
+                let prefill_body = if let Some(prefill_result) = prefill_result {
+                    if context.return_logprob {
+                        match self
+                            .process_prefill_response(
+                                prefill_result,
+                                prefill.url(),
+                                context.return_logprob,
+                            )
+                            .await
+                        {
+                            Ok((_, body)) => body,
+                            Err(error_response) => return error_response,
+                        }
+                    } else {
+                        match self
+                            .process_prefill_response(prefill_result, prefill.url(), false)
+                            .await
+                        {
+                            Ok((_, body)) => body,
+                            Err(error_response) => return error_response,
+                        }
                     }
                 } else {
-                    // Even if we don't need logprobs, we should check prefill status
-                    match self
-                        .process_prefill_response(prefill_result, prefill.url(), false)
-                        .await
-                    {
-                        Ok((_, body)) => body,
-                        Err(error_response) => return error_response,
-                    }
+                    None
                 };
 
                 if context.is_stream {


### PR DESCRIPTION
## Motivation

Fixes #22853

In PD disaggregation mode, the router uses `tokio::join!` to wait for **both** prefill and decode HTTP responses before it starts proxying the decode stream to the client. However, for streaming requests without logprob (the common production case), the prefill response body is never used — it is consumed and discarded by `process_prefill_response`. The prefill HTTP request only serves as a trigger for KV cache computation and transfer (a side-effect).

The problem is that the prefill response can be delayed by up to one full forward pass duration (~270ms) because `stream_output` (which sends the HTTP response) can only execute between `run_batch` calls in prefill's single-threaded event loop. Since decode is typically ready much sooner (KV transfer ~6ms + first forward ~10ms), the router unnecessarily blocks the client from receiving the first token.

## Changes

For streaming requests where `return_logprob` is false:
- The prefill request is spawned as a background task (`tokio::spawn`) with error logging
- The router only awaits the decode response and immediately starts proxying the stream

For all other cases (non-streaming, streaming with logprob):
- Original `tokio::join!` behavior is preserved unchanged

## Results

From issue author's testing (rps=2, input_len=12000):

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| TTFT avg | 737ms | 557ms | **-24%** |
| TTFT median | 585ms | 387ms | **-34%** |
| TTFT p99 | 1927ms | 1454ms | **-25%** |

## Safety

- If prefill fails, decode will timeout waiting for KV cache → client receives error (not silent)
- Prefill errors are logged at `warn` level for observability
- Non-streaming and logprob paths are completely untouched
- No behavioral change for any path that uses the prefill response body

## Test plan

- [ ] Existing PD disaggregation CI tests pass
- [ ] Streaming without logprob: verify TTFT reduction
- [ ] Streaming with logprob: verify logprobs are correctly merged (original path)
- [ ] Non-streaming: verify behavior unchanged
- [ ] Prefill failure: verify decode timeout surfaces error to client