### PR TITLE
Initialize forward_ct and cur_batch before watchdog start, then drop getattr defenses

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -349,6 +349,9 @@ class Scheduler(
         dp_rank: Optional[int],
     ):
         self.is_initializing = True
+        # init_soft_watchdog starts a daemon thread that reads these on its first tick.
+        self.forward_ct: int = 0
+        self.cur_batch: Optional[ScheduleBatch] = None
         self.init_soft_watchdog(server_args)
 
         # Parse args

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -594,9 +594,9 @@ def create_scheduler_watchdog(
 
     return WatchdogRaw(
         debug_name="Scheduler",
-        get_counter=lambda: getattr(scheduler, "forward_ct", 0),
+        get_counter=lambda: scheduler.forward_ct,
         is_active=lambda: scheduler.is_initializing
-        or getattr(scheduler, "cur_batch", None) is not None,
+        or scheduler.cur_batch is not None,
         watchdog_timeout=watchdog_timeout,
         soft=soft,
         dump_info=dump_info,

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -595,8 +595,7 @@ def create_scheduler_watchdog(
     return WatchdogRaw(
         debug_name="Scheduler",
         get_counter=lambda: scheduler.forward_ct,
-        is_active=lambda: scheduler.is_initializing
-        or scheduler.cur_batch is not None,
+        is_active=lambda: scheduler.is_initializing or scheduler.cur_batch is not None,
         watchdog_timeout=watchdog_timeout,
         soft=soft,
         dump_info=dump_info,


### PR DESCRIPTION
## Summary

Two-step fix to make Scheduler watchdog initialization safe to read directly:

1. **Move `self.forward_ct = 0` and `self.cur_batch = None` to the start of `Scheduler.__init__`**, before `init_soft_watchdog` runs.
2. **Replace `getattr(scheduler, "forward_ct", 0)` and `getattr(scheduler, "cur_batch", None) is not None` in `create_scheduler_watchdog` with direct attribute access.**

## Why

`init_soft_watchdog` is called early in `Scheduler.__init__` and constructs a `WatchdogRaw`, which immediately starts a daemon thread. The thread enters `_watchdog_once` and on its very first tick calls `is_active()` (short-circuits on `is_initializing=True`) and then unconditionally calls `get_counter()`.

Previously `forward_ct` and `cur_batch` were only set later inside `init_running_status`, leaving a race window between watchdog construction and field initialization. The original `getattr(...)` fallbacks (`0` / `None`) silently masked this race; if reached, an `AttributeError` would have crashed the watchdog daemon thread (caught by the outer `except Exception` in `_watchdog_thread`), leaving the scheduler running but the watchdog dead.

Initializing both fields before any watchdog can run closes the race; direct attribute access then becomes safe and lets type checkers verify the contract.

This supersedes #24814 (closed; GitHub refused to reopen after force-push).

## Test plan

- [x] Pre-commit hooks pass.
- [x] AST parse OK.
- [ ] CI green on PR.