### PR TITLE
[SMG] Remove deprecated endpoint aliases (/get_model_info, /get_server_info, /get_loads)

### DIFF
--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -598,18 +598,12 @@ pub fn build_app(
         .route("/engine_metrics", get(engine_metrics))
         .route("/v1/models", get(v1_models))
         .route("/model_info", get(get_model_info))
-        // TODO: Remove `/get_model_info` alias after one release-cycle deprecation window.
-        .route("/get_model_info", get(get_model_info))
-        .route("/server_info", get(get_server_info))
-        // TODO: Remove `/get_server_info` alias after one release-cycle deprecation window.
-        .route("/get_server_info", get(get_server_info));
+        .route("/server_info", get(get_server_info));
 
     // Build admin routes with control plane auth if configured, otherwise use simple API key auth
     let admin_routes = Router::new()
         .route("/flush_cache", post(flush_cache))
         .route("/v1/loads", get(get_loads))
-        // TODO: Remove `/get_loads` alias after one release-cycle deprecation window.
-        .route("/get_loads", get(get_loads))
         .route("/parse/function_call", post(parse_function_call))
         .route("/parse/reasoning", post(parse_reasoning))
         .route("/wasm", post(add_wasm_module))

--- a/sgl-model-gateway/tests/api/api_endpoints_test.rs
+++ b/sgl-model-gateway/tests/api/api_endpoints_test.rs
@@ -352,7 +352,7 @@ mod model_info_tests {
 
         let req = Request::builder()
             .method("GET")
-            .uri("/get_model_info")
+            .uri("/model_info")
             .body(Body::empty())
             .unwrap();
 
@@ -461,7 +461,7 @@ mod model_info_tests {
 
         let req = Request::builder()
             .method("GET")
-            .uri("/get_model_info")
+            .uri("/model_info")
             .body(Body::empty())
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
@@ -519,7 +519,7 @@ mod model_info_tests {
         for _ in 0..5 {
             let req = Request::builder()
                 .method("GET")
-                .uri("/get_model_info")
+                .uri("/model_info")
                 .body(Body::empty())
                 .unwrap();
 
@@ -554,7 +554,7 @@ mod model_info_tests {
 
         let req = Request::builder()
             .method("GET")
-            .uri("/get_model_info")
+            .uri("/model_info")
             .body(Body::empty())
             .unwrap();
 
@@ -1245,7 +1245,7 @@ mod cache_tests {
 
         let req = Request::builder()
             .method("GET")
-            .uri("/get_loads")
+            .uri("/v1/loads")
             .body(Body::empty())
             .unwrap();
 


### PR DESCRIPTION
### Motivation

The `/get_model_info`, `/get_server_info`, and `/get_loads` endpoint aliases were previously deprecated in favor of canonical paths (`/model_info`, `/server_info`, `/v1/loads`). The deprecation window has passed, and all internal references in the sglang project have already been migrated to canonical paths (verified in commit d74d9bda4). Keeping the aliases adds unnecessary API surface and maintenance burden.

### Modifications

- `sgl-model-gateway/src/server.rs`: Remove route registrations for `/get_model_info`, `/get_server_info`, `/get_loads` and their associated TODO comments.
- `sgl-model-gateway/tests/api/api_endpoints_test.rs`: Update 5 test assertions to use canonical paths (`/model_info`, `/v1/loads`) instead of deprecated aliases.

### Accuracy Tests

N/A — no model execution logic changed. Test coverage updated to reflect canonical paths.

### Speed Tests and Profiling

N/A — this is a routing table cleanup with no performance impact.

### Checklist

- [x] Format code with pre-commit (Rust code follows `rustfmt` conventions)
- [x] Unit tests pass — test URIs updated to canonical paths
- [x] Documentation update not needed — deprecated endpoints are internal implementation details
- [x] Follow SGLang code style guidance
