### PR TITLE
Fix V2 trace filename collisions when DP/PP/EP enabled

### DIFF
--- a/python/sglang/srt/utils/profile_utils.py
+++ b/python/sglang/srt/utils/profile_utils.py
@@ -293,12 +293,12 @@ class _ProfilerTorch(_ProfilerConcreteBase):
             filename_parts = [self.profile_id, f"TP-{self.ps.tp_rank}"]
 
             # Only add other ranks if parallelism is enabled (size > 1)
-            if getattr(self, "dp_size", 1) > 1:
-                filename_parts.append(f"DP-{getattr(self, 'dp_rank', 0)}")
-            if getattr(self, "pp_size", 1) > 1:
-                filename_parts.append(f"PP-{getattr(self, 'pp_rank', 0)}")
-            if getattr(self, "moe_ep_size", 1) > 1:
-                filename_parts.append(f"EP-{getattr(self, 'moe_ep_rank', 0)}")
+            if self.ps.dp_size > 1:
+                filename_parts.append(f"DP-{self.ps.dp_rank}")
+            if self.ps.pp_size > 1:
+                filename_parts.append(f"PP-{self.ps.pp_rank}")
+            if self.ps.moe_ep_size > 1:
+                filename_parts.append(f"EP-{self.ps.moe_ep_rank}")
 
             filename = (
                 (self.output_prefix + "-" if self.output_prefix else "")


### PR DESCRIPTION
Restores intent that was lost to a copy-paste bug: when DP/PP/EP parallelism is enabled, V2 trace filenames now include `-DP-{rank}` / `-PP-{rank}` / `-EP-{rank}` so multi-rank traces don't collide. Previously the V2 profiler never forwarded these fields, so the gating `getattr(self, "dp_size", 1) > 1` always returned the default and the suffixes were never appended.

## Mechanical Move

Transform script: https://github.com/fzyzcjy/public_scratchpad/blob/master/refactor_202605a/tom_refactor_17.py

### One-click verification

```bash
python3 <(curl -sL https://raw.githubusercontent.com/fzyzcjy/public_scratchpad/master/refactor_202605a/tom_refactor_17.py)
```