### PR TITLE
Fix awq offload

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -490,17 +490,25 @@ class CompressedTensorsConfig(QuantizationConfig):
         )
 
     def _is_wNa16_group_channel(
-        self, weight_quant: BaseModel, input_quant: BaseModel
+        self,
+        weight_quant: BaseModel,
+        input_quant: Optional[BaseModel],
+        allow_asymmetric: bool = False,
     ) -> bool:
         input_quant_none = input_quant is None
-        is_symmetric = weight_quant.symmetric
+        is_supported_symmetry = weight_quant.symmetric or allow_asymmetric
         is_channel_group = (
             weight_quant.strategy == QuantizationStrategy.CHANNEL.value
             or weight_quant.strategy == QuantizationStrategy.GROUP.value
         )
         is_static = not weight_quant.dynamic
 
-        return is_channel_group and input_quant_none and is_symmetric and is_static
+        return (
+            is_channel_group
+            and input_quant_none
+            and is_supported_symmetry
+            and is_static
+        )
 
     def _is_mxint4a16(self, weight_quant: BaseModel, input_quant: BaseModel) -> bool:
         input_quant_none = input_quant is None
@@ -543,7 +551,9 @@ class CompressedTensorsConfig(QuantizationConfig):
     ) -> CompressedTensorsLinearScheme:
 
         # Detect If Mixed Precision
-        if self._is_wNa16_group_channel(weight_quant, input_quant):
+        if self._is_wNa16_group_channel(
+            weight_quant, input_quant, allow_asymmetric=True
+        ):
             if (
                 self.quant_format == CompressionFormat.pack_quantized.value
                 and weight_quant.num_bits in WNA16_SUPPORTED_BITS
@@ -552,6 +562,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                     num_bits=weight_quant.num_bits,
                     strategy=weight_quant.strategy,
                     group_size=weight_quant.group_size,
+                    symmetric=weight_quant.symmetric,
                     actorder=weight_quant.actorder,
                 )
             else:

--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from abc import ABC
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Set
 
 import torch
 from torch.func import functional_call
@@ -45,6 +45,45 @@ class BaseOffloader(ABC):
 
 class NoopOffloader(BaseOffloader):
     pass
+
+
+def _duplicate_state_dict_aliases(module: torch.nn.Module) -> Set[str]:
+    duplicate_names = set()
+    seen_tensors = set()
+
+    for name, tensor in module.named_parameters(remove_duplicate=False):
+        tensor_id = id(tensor)
+        if tensor_id in seen_tensors:
+            duplicate_names.add(name)
+        else:
+            seen_tensors.add(tensor_id)
+
+    try:
+        named_buffers = module.named_buffers(remove_duplicate=False)
+    except TypeError:
+        named_buffers = module.named_buffers()
+
+    for name, tensor in named_buffers:
+        tensor_id = id(tensor)
+        if tensor_id in seen_tensors:
+            duplicate_names.add(name)
+        else:
+            seen_tensors.add(tensor_id)
+
+    return duplicate_names
+
+
+def _make_functional_call_state(
+    module: torch.nn.Module, device: torch.device
+) -> dict[str, torch.Tensor]:
+    duplicate_names = _duplicate_state_dict_aliases(module)
+    return {
+        # here we blindly call `to(device)`
+        # if the parameter is already on the device, it will be a no-op
+        k: v.to(device, non_blocking=True)
+        for k, v in module.state_dict().items()
+        if k not in duplicate_names
+    }
 
 
 # For simplicity use singleton, but can surely support multi instance
@@ -135,12 +174,7 @@ class OffloaderV1(BaseOffloader):
 
             def forward(*args, **kwargs):
                 module.forward = original_forward
-                device_state = {
-                    # here we blindly call `to(device)`
-                    # if the parameter is already on the device, it will be a no-op
-                    k: v.to(device, non_blocking=True)
-                    for k, v in module.state_dict().items()
-                }
+                device_state = _make_functional_call_state(module, device)
                 output = functional_call(module, device_state, args=args, kwargs=kwargs)
                 module.forward = forward
                 return output

--- a/test/registered/unit/layers/quantization/test_compressed_tensors.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors.py
@@ -1,0 +1,78 @@
+"""Unit tests for compressed-tensors quantization scheme selection."""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+def _make_asymmetric_int4_pack_quantized_config():
+    return {
+        "format": "pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "input_activations": None,
+                "output_activations": None,
+                "weights": {
+                    "actorder": None,
+                    "block_structure": None,
+                    "dynamic": False,
+                    "group_size": 32,
+                    "num_bits": 4,
+                    "observer": "mse",
+                    "observer_kwargs": {},
+                    "scale_dtype": None,
+                    "strategy": "group",
+                    "symmetric": False,
+                    "type": "int",
+                    "zp_dtype": "torch.int8",
+                },
+            }
+        },
+    }
+
+
+class TestCompressedTensorsWNA16SchemeSelection(CustomTestCase):
+    def _get_linear_scheme_dict(self):
+        from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+            CompressedTensorsConfig,
+        )
+
+        quant_config = CompressedTensorsConfig.from_config(
+            _make_asymmetric_int4_pack_quantized_config()
+        )
+        return quant_config, quant_config.target_scheme_map["Linear"]
+
+    def test_asymmetric_int4_pack_quantized_uses_wna16(self):
+        from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+            CompressedTensorsWNA16,
+        )
+
+        quant_config, scheme_dict = self._get_linear_scheme_dict()
+
+        scheme = quant_config._get_scheme_from_parts(
+            weight_quant=scheme_dict["weights"],
+            input_quant=scheme_dict["input_activations"],
+        )
+
+        self.assertIsInstance(scheme, CompressedTensorsWNA16)
+        self.assertFalse(scheme.symmetric)
+        self.assertEqual(scheme.group_size, 32)
+        self.assertEqual(scheme.pack_factor, 8)
+
+    def test_asymmetric_int4_wna16_is_not_enabled_by_default(self):
+        quant_config, scheme_dict = self._get_linear_scheme_dict()
+
+        self.assertFalse(
+            quant_config._is_wNa16_group_channel(
+                weight_quant=scheme_dict["weights"],
+                input_quant=scheme_dict["input_activations"],
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_offloader.py
+++ b/test/registered/unit/utils/test_offloader.py
@@ -1,0 +1,54 @@
+"""Unit tests for srt/utils/offloader.py -- no server, no model loading."""
+
+import unittest
+
+import torch
+from torch import nn
+from torch.func import functional_call
+
+from sglang.srt.utils.offloader import _make_functional_call_state
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class _ChildWithTiedParameter(nn.Module):
+    def __init__(self, shared_weight: nn.Parameter):
+        super().__init__()
+        self.A_log = shared_weight
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.A_log
+
+
+class _ModuleWithTiedParameter(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.A_log = nn.Parameter(torch.tensor(2.0))
+        self.attn = _ChildWithTiedParameter(self.A_log)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.attn(x) + self.A_log
+
+
+class TestOffloaderFunctionalCallState(CustomTestCase):
+    def test_tied_parameter_aliases_are_deduplicated(self):
+        module = _ModuleWithTiedParameter()
+        raw_state = {k: v.to("cpu") for k, v in module.state_dict().items()}
+
+        self.assertEqual(["A_log", "attn.A_log"], list(raw_state.keys()))
+        with self.assertRaisesRegex(ValueError, "multiple values.*tied"):
+            functional_call(module, raw_state, args=(torch.tensor(3.0),))
+
+        device_state = _make_functional_call_state(module, torch.device("cpu"))
+
+        self.assertEqual(["A_log"], list(device_state.keys()))
+        self.assertEqual(
+            torch.tensor(8.0),
+            functional_call(module, device_state, args=(torch.tensor(3.0),)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #24784.

This PR fixes two failures reported for Qwen3.6 AWQ models:

1. `cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit` can fail with `--cpu-offload-gb` because `OffloaderV1` passes tied parameter aliases from `state_dict()` into `torch.func.functional_call`.
2. The follow-up report for `cyankiwi/Qwen3.6-27B-AWQ-INT4` fails compressed-tensors scheme selection because the dense WNA16 matcher rejects asymmetric INT4 weight configs, even though the linear WNA16 scheme already supports zero-points.

## Modifications

- Deduplicate tied parameter and buffer aliases before passing module state into `functional_call` in `OffloaderV1`.
- Allow dense compressed-tensors WNA16 linear configs to match asymmetric INT4/INT8 weight-only quantization.
- Keep WNA16 MoE matching symmetric-only, since the MoE implementation still asserts symmetric quantization.
- Add CPU unit tests for asymmetric INT4 `pack-quantized` compressed-tensors scheme selection.
- Add a CPU unit test for tied parameter aliases in offloader functional-call state.

## Accuracy Tests

I did not run the full reported models locally.

Added targeted unit coverage and ran:

```bash
PYTHONPATH=python pytest -q test/registered/unit/layers/quantization/test_compressed_tensors.py test/registered/unit/utils/test_offloader.py
```

Result:

```text
3 passed
```

Also ran CI-style direct unittest execution:

```bash
PYTHONPATH=python python test/registered/unit/layers/quantization/test_compressed_tensors.py -f
PYTHONPATH=python python test/registered/unit/utils/test_offloader.py -f
```

Both passed.

## Speed Tests and Profiling

Not run. This PR does not add new kernels or change inference scheduling. The offloader change only removes duplicate tied aliases before `functional_call`, and the quantization change selects the existing WNA16 linear scheme for asymmetric configs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No docs update needed for this bugfix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Targeted unit tests are included; full model accuracy and speed benchmarks were not run.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
