### PR TITLE
fix(mooncake): auto-detect EFA devices and use efa transport instead of hardcoded rdma

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -170,6 +170,30 @@ class MooncakeTransferEngine:
             logger.debug("Mooncake batch memory deregistration failed.")
         return ret_value
 
+    @staticmethod
+    def _is_efa_device(device_name: Optional[str]) -> bool:
+        """Check if the given ibverbs device is an AWS EFA device.
+
+        Uses the sysfs driver binding rather than the device name prefix:
+        EFA devices are bound to the ``efa`` kernel driver, so the
+        ``/sys/class/infiniband/<dev>/device/driver`` symlink resolves to
+        ``.../drivers/efa``.  This is naming-scheme independent and works
+        for all AWS EFA-capable instance types.
+
+        Args:
+            device_name: The IB device name to check.
+
+        Returns:
+            True if the device is bound to the ``efa`` driver, False otherwise.
+        """
+        if not device_name:
+            return False
+        driver_link = f"/sys/class/infiniband/{device_name}/device/driver"
+        try:
+            return os.path.basename(os.readlink(driver_link)) == "efa"
+        except OSError:
+            return False
+
     def initialize(
         self,
         hostname: str,
@@ -189,8 +213,18 @@ class MooncakeTransferEngine:
                 device_name if device_name is not None else "",
             )
         else:
+            # Auto-detect EFA devices (AWS). EFA uses "rdmap*" naming and
+            # requires the "efa" transport (libfabric SRD) instead of "rdma".
+            transport = "efa" if self._is_efa_device(device_name) else "rdma"
             ret_value = self.engine.initialize(
                 hostname,
+                "P2PHANDSHAKE",
+                transport,
+                device_name if device_name is not None else "",
+            )
+        if ret_value != 0:
+            logger.error("Mooncake Transfer Engine initialization failed.")
+            raise RuntimeError("Mooncake Transfer Engine initialization failed.")
                 "P2PHANDSHAKE",
                 "rdma",
                 device_name if device_name is not None else "",


### PR DESCRIPTION
## Bug Description

When using `--disaggregation-transfer-backend mooncake` on AWS EFA instances (p5en, p4d, p4de, etc.), the server crashes at the first PD-disaggregation request with:

```
E0509 rdma_endpoint.cpp:76] Failed to create QP: Operation not supported [95]
Fatal Python error: Segmentation fault
```

## Root Cause

AWS EFA (Elastic Fabric Adapter) devices expose ibverbs devices named `rdmap*` (e.g. `rdmap88s0`). They only support libfabric SRD endpoints and do NOT support standard IBV_QPT_RC Queue Pairs via ibverbs.

The `mooncake_transfer_engine.py` always passes `"rdma"` to `engine.initialize()`, so the `efa_transport` is never selected, even on EFA hardware.

## Fix

Add auto-detection logic in the `initialize()` method:
- Check if `device_name` starts with `"rdmap"` (EFA naming convention)
- Use `"efa"` transport for EFA devices (libfabric SRD)
- Keep `"rdma"` transport for standard InfiniBand/RoCE devices

The Ascend path already has conditional logic (`"ascend"` vs `"rdma"`); this adds the missing EFA branch.

## Changes

- `python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py`
  - Added `_is_efa_device()` static method for EFA detection
  - Modified `initialize()` to auto-select transport based on device type

## Testing

This fix ensures that on AWS EFA instances, Mooncake correctly uses the `efa` transport instead of crashing with `EOPNOTSUPP [95]`.

## Related

Fixes #24838