### PR TITLE
fix(vit-cuda-graph): add fa4 support for B200 GPUs

### DIFF
--- a/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
@@ -167,10 +167,14 @@ class ViTCudaGraphRunner:
 
                 if override_backend == "triton_attn":
                     cu_seq_len_ws = [cu_seqlens_now, cu_seqlens_kk_now, max_len]
-                elif override_backend == "fa3":
+                elif override_backend in ("fa3", "fa4"):
+                    # fa4 (FlashAttention-4) uses the same cu_seqlens format as fa3
                     cu_seq_len_ws = [cu_seqlens_now, max_len]
                 else:
-                    raise RuntimeError("Not supported ViT attention backend")
+                    raise RuntimeError(
+                        f"Not supported ViT attention backend: {override_backend}. "
+                        f"Supported backends are: triton_attn, fa3, fa4."
+                    )
 
                 if position_embeddings is not None:
                     if layer_num == 0:


### PR DESCRIPTION
## Bug Description

When using `--mm-attention-backend fa4` on B200 GPUs, the ViT CUDA Graph Runner crashes with:

```
RuntimeError: Not supported ViT attention backend
```

B200 GPUs use FlashAttention-4 (fa4) which was not recognized by the ViT CUDA Graph Runner.

## Root Cause

In `vit_cuda_graph_runner.py`, the attention backend check only supports `triton_attn` and `fa3`:

```python
if override_backend == "triton_attn":
    ...
elif override_backend == "fa3":
    ...
else:
    raise RuntimeError("Not supported ViT attention backend")
```

## Fix

Add `fa4` to the supported backends list, using the same `cu_seqlens` format as `fa3` since fa4 maintains backward compatibility with fa3's attention interface.

Also improved the error message to show the actual backend name and list all supported backends for easier debugging.

## Changes

- `python/sglang/srt/multimodal/vit_cuda_graph_runner.py`: Added fa4 support

## Related

Fixes #24834