### PR TITLE
feat(multimodal): support per-request min_pixels/max_pixels for Qwen-VL

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -429,6 +429,20 @@ class ChatCompletionMessageContentImageURL(BaseModel):
     min_pixels: Optional[int] = None
     max_pixels: Optional[int] = None
 
+    @model_validator(mode="after")
+    def validate_pixel_range(self) -> "ChatCompletionMessageContentImageURL":
+        if self.min_pixels is not None and self.min_pixels <= 0:
+            raise ValueError("min_pixels must be a positive integer")
+        if self.max_pixels is not None and self.max_pixels <= 0:
+            raise ValueError("max_pixels must be a positive integer")
+        if (
+            self.min_pixels is not None
+            and self.max_pixels is not None
+            and self.min_pixels >= self.max_pixels
+        ):
+            raise ValueError("min_pixels must be less than max_pixels")
+        return self
+
 
 class ChatCompletionMessageContentVideoURL(BaseModel):
     url: str

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -426,6 +426,8 @@ class ChatCompletionMessageContentImageURL(BaseModel):
     detail: Optional[Literal["auto", "low", "high"]] = "auto"
     max_dynamic_patch: Optional[int] = None
     min_dynamic_patch: Optional[int] = None
+    min_pixels: Optional[int] = None
+    max_pixels: Optional[int] = None
 
 
 class ChatCompletionMessageContentVideoURL(BaseModel):

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -522,17 +522,34 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         # Extract per-request min_pixels/max_pixels from image_data items (Qwen-VL specific).
         # When users pass min_pixels/max_pixels in the image_url content part, these override
-        # the server-level pixel range configured at startup.
+        # the server-level pixel range configured at startup. The HF processor applies a single
+        # min_pixels/max_pixels value across all images in the call, so we take the most
+        # conservative across all images: minimum max_pixels, maximum min_pixels.
         image_pixel_kwargs = {}
         if image_data:
-            for img in image_data:
-                if isinstance(img, ImageData):
-                    if img.min_pixels is not None:
-                        image_pixel_kwargs["min_pixels"] = img.min_pixels
-                    if img.max_pixels is not None:
-                        image_pixel_kwargs["max_pixels"] = img.max_pixels
-                    if image_pixel_kwargs:
-                        break
+            min_pixels_vals = [
+                img.min_pixels
+                for img in image_data
+                if isinstance(img, ImageData) and img.min_pixels is not None
+            ]
+            max_pixels_vals = [
+                img.max_pixels
+                for img in image_data
+                if isinstance(img, ImageData) and img.max_pixels is not None
+            ]
+            agg_min = max(min_pixels_vals) if min_pixels_vals else None
+            agg_max = min(max_pixels_vals) if max_pixels_vals else None
+            if agg_min is not None and agg_max is not None and agg_min >= agg_max:
+                logger.warning(
+                    f"Per-request pixel constraints are incoherent after aggregation "
+                    f"(min_pixels={agg_min} >= max_pixels={agg_max}); "
+                    f"ignoring per-request pixel range and using server defaults."
+                )
+            else:
+                if agg_min is not None:
+                    image_pixel_kwargs["min_pixels"] = agg_min
+                if agg_max is not None:
+                    image_pixel_kwargs["max_pixels"] = agg_max
 
         # NOTE: for qwen3-vl, video_meta need to be passed in, since do_sample_frames is already done in preprocess_video
         if self.hf_config.model_type in (

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -32,6 +32,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
+from sglang.srt.utils import ImageData
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 
@@ -519,6 +520,20 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         preprocess_time = time.perf_counter()
 
+        # Extract per-request min_pixels/max_pixels from image_data items (Qwen-VL specific).
+        # When users pass min_pixels/max_pixels in the image_url content part, these override
+        # the server-level pixel range configured at startup.
+        image_pixel_kwargs = {}
+        if image_data:
+            for img in image_data:
+                if isinstance(img, ImageData):
+                    if img.min_pixels is not None:
+                        image_pixel_kwargs["min_pixels"] = img.min_pixels
+                    if img.max_pixels is not None:
+                        image_pixel_kwargs["max_pixels"] = img.max_pixels
+                    if image_pixel_kwargs:
+                        break
+
         # NOTE: for qwen3-vl, video_meta need to be passed in, since do_sample_frames is already done in preprocess_video
         if self.hf_config.model_type in (
             "qwen3_vl",
@@ -531,10 +546,11 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 self.mm_tokens,
                 video_metadata=video_metadata,
                 do_sample_frames=False,
+                **image_pixel_kwargs,
             )
         else:
             mm_items, input_ids, ret = self.process_and_combine_mm_data(
-                base_output, self.mm_tokens
+                base_output, self.mm_tokens, **image_pixel_kwargs
             )
 
         audio_feature_lengths = None

--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -166,6 +166,8 @@ def process_content_for_template_format(
                             url=image_obj["url"],
                             detail=image_obj.get("detail", "auto"),
                             max_dynamic_patch=mdp,
+                            min_pixels=image_obj.get("min_pixels", None),
+                            max_pixels=image_obj.get("max_pixels", None),
                         )
                     )
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -763,6 +763,8 @@ class ImageData:
     url: str
     detail: Optional[Literal["auto", "low", "high"]] = "auto"
     max_dynamic_patch: Optional[int] = None
+    min_pixels: Optional[int] = None
+    max_pixels: Optional[int] = None
 
 
 image_extension_names = (".png", ".jpg", ".jpeg", ".webp", ".gif")

--- a/test/registered/unit/parser/test_jinja_template_utils.py
+++ b/test/registered/unit/parser/test_jinja_template_utils.py
@@ -487,5 +487,93 @@ class TestTemplateContentFormatDetection(CustomTestCase):
         self.assertEqual(result, "openai")
 
 
+class TestQwenVLPixelRangeExtraction(CustomTestCase):
+    """Test that min_pixels/max_pixels are extracted from image_url into ImageData."""
+
+    def test_image_url_with_min_max_pixels(self):
+        """min_pixels and max_pixels in image_url should be stored in ImageData."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "http://example.com/image.jpg",
+                        "min_pixels": 100352,
+                        "max_pixels": 1003520,
+                    },
+                },
+                {"type": "text", "text": "Describe this image."},
+            ],
+        }
+
+        image_data = []
+        video_data = []
+        audio_data = []
+        modalities = []
+
+        process_content_for_template_format(
+            msg_dict, "openai", image_data, video_data, audio_data, modalities
+        )
+
+        self.assertEqual(len(image_data), 1)
+        self.assertEqual(image_data[0].url, "http://example.com/image.jpg")
+        self.assertEqual(image_data[0].min_pixels, 100352)
+        self.assertEqual(image_data[0].max_pixels, 1003520)
+
+    def test_image_url_without_pixel_params_defaults_to_none(self):
+        """When min_pixels/max_pixels are absent, ImageData fields should be None."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "http://example.com/image.jpg"},
+                },
+            ],
+        }
+
+        image_data = []
+        video_data = []
+        audio_data = []
+        modalities = []
+
+        process_content_for_template_format(
+            msg_dict, "openai", image_data, video_data, audio_data, modalities
+        )
+
+        self.assertEqual(len(image_data), 1)
+        self.assertIsNone(image_data[0].min_pixels)
+        self.assertIsNone(image_data[0].max_pixels)
+
+    def test_image_url_partial_pixel_params(self):
+        """Only max_pixels specified; min_pixels should remain None."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "http://example.com/image.jpg",
+                        "max_pixels": 512 * 512,
+                    },
+                },
+            ],
+        }
+
+        image_data = []
+        video_data = []
+        audio_data = []
+        modalities = []
+
+        process_content_for_template_format(
+            msg_dict, "openai", image_data, video_data, audio_data, modalities
+        )
+
+        self.assertEqual(len(image_data), 1)
+        self.assertIsNone(image_data[0].min_pixels)
+        self.assertEqual(image_data[0].max_pixels, 512 * 512)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- `protocol.py`: Added `min_pixels` and `max_pixels` optional fields to `ChatCompletionMessageContentImageURL`, with a `model_validator` that rejects non-positive values and min ≥ max at the API boundary.
- `utils/common.py`: Added `min_pixels` / `max_pixels` fields to the `ImageData` dataclass.
- `parser/jinja_template_utils.py`: Extracted `min_pixels` / `max_pixels` from the image URL content dict into `ImageData` during request parsing.
- `multimodal/processors/qwen_vl.py`: Aggregated per-image pixel constraints (most conservative range: `max(min_pixels)`, `min(max_pixels)`) and passed them as kwargs to the HF processor; incoherent aggregates are logged and discarded, falling back to server defaults.
- `test/registered/unit/parser/test_jinja_template_utils.py`: Three unit tests covering full params, absent params, and partial (max only).

## Why

Closes #5964. The remaining unchecked item from that issue is **Pixel Value Range Parameters (min_pixel/max_pixel) for Qwen-VL**.

Currently `Qwen2VLImageProcessor` uses server-level `MIN_PIXELS` / `MAX_PIXELS` for all requests. RL workflows and evaluation harnesses often need per-request control over image resolution to trade off quality vs. compute. The HF `Qwen2VLProcessor.__call__` already accepts `min_pixels` / `max_pixels` kwargs via `_merge_kwargs()` — this PR threads them from the API surface through to that call site.

## How to verify

```bash
# Start a Qwen2-VL server
python -m sglang.launch_server --model-path Qwen/Qwen2-VL-7B-Instruct --port 30000

# Send a request with per-request pixel constraints
curl -s http://localhost:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen2-VL-7B-Instruct",
    "messages": [{
      "role": "user",
      "content": [{
        "type": "image_url",
        "image_url": {
          "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/320px-Cat03.jpg",
          "min_pixels": 100352,
          "max_pixels": 501760
        }
      }, {"type": "text", "text": "Describe this image."}]
    }]
  }'

# Verify invalid values are rejected at the API layer
curl -s http://localhost:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "...", "messages": [{"role":"user","content":[{"type":"image_url","image_url":{"url":"...","min_pixels":0}}]}]}' \
  | jq .error   # should return validation error

# Run unit tests
python -m pytest test/registered/unit/parser/test_jinja_template_utils.py::TestQwenVLPixelRangeExtraction -v
```

## Impact scope

- Affects only `QwenVLImageProcessor` (Qwen2-VL and Qwen3-VL model types). Other VLM processors are unchanged.
- Requests without `min_pixels` / `max_pixels` are unaffected — the kwargs dict is empty and the call path is identical to before.
- Server startup args `min_pixels` / `max_pixels` remain authoritative when per-request values are absent.

> AI assistance was used in drafting this contribution; all changes have been reviewed and verified locally.