### PR TITLE
[RL] Call torch.cuda.empty_cache() for `in-place` pause mode to avoid OOM

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1378,11 +1378,11 @@ class PauseGenerationReqInput(BaseReq):
 
 @dataclass
 class ContinueGenerationReqInput(BaseReq):
-    # Call empty_device_cache() before un-pausing. Returns blocks
-    # cached by the device allocator (left over from transient allocs
+    # Call torch.cuda.empty_cache() before un-pausing. Returns blocks
+    # cached by the PyTorch allocator (left over from transient allocs
     # during post-weight-update processing) back to the driver before
     # inference resumes, with no race against active streams. Set to
-    # False to skip the call.
+    # False to skip the empty_cache call.
     torch_empty_cache: bool = True
 
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1378,11 +1378,11 @@ class PauseGenerationReqInput(BaseReq):
 
 @dataclass
 class ContinueGenerationReqInput(BaseReq):
-    # Call torch.cuda.empty_cache() before un-pausing. Returns blocks
-    # cached by the PyTorch allocator (left over from transient allocs
+    # Call empty_device_cache() before un-pausing. Returns blocks
+    # cached by the device allocator (left over from transient allocs
     # during post-weight-update processing) back to the driver before
     # inference resumes, with no race against active streams. Set to
-    # False to skip the empty_cache call.
+    # False to skip the call.
     torch_empty_cache: bool = True
 
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1378,7 +1378,12 @@ class PauseGenerationReqInput(BaseReq):
 
 @dataclass
 class ContinueGenerationReqInput(BaseReq):
-    pass
+    # Call torch.cuda.empty_cache() before un-pausing. Returns blocks
+    # cached by the PyTorch allocator (left over from transient allocs
+    # during post-weight-update processing) back to the driver before
+    # inference resumes, with no race against active streams. Set to
+    # False to skip the empty_cache call.
+    empty_cache: bool = True
 
 
 @dataclass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1383,7 +1383,7 @@ class ContinueGenerationReqInput(BaseReq):
     # during post-weight-update processing) back to the driver before
     # inference resumes, with no race against active streams. Set to
     # False to skip the empty_cache call.
-    empty_cache: bool = True
+    torch_empty_cache: bool = True
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3648,7 +3648,7 @@ class Scheduler(
             self.chunked_req = None
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):
-        if recv_req.empty_cache:
+        if recv_req.torch_empty_cache:
             before_mb = torch.cuda.memory_reserved() / (1024 * 1024)
             torch.cuda.empty_cache()
             after_mb = torch.cuda.memory_reserved() / (1024 * 1024)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3647,14 +3647,18 @@ class Scheduler(
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):
         if recv_req.torch_empty_cache:
-            before_mb = torch.cuda.memory_reserved() / (1024 * 1024)
-            torch.cuda.empty_cache()
-            after_mb = torch.cuda.memory_reserved() / (1024 * 1024)
-            logger.info(
-                f"[continue_generation] torch.cuda.empty_cache() called: "
-                f"reserved {before_mb:.1f} MB -> {after_mb:.1f} MB "
-                f"(freed {before_mb - after_mb:.1f} MB)"
-            )
+            mem_reserved = getattr(self.device_module, "memory_reserved", None)
+            before_mb = mem_reserved() / (1024 * 1024) if mem_reserved else None
+            empty_device_cache(self.device_module)
+            if before_mb is not None:
+                after_mb = mem_reserved() / (1024 * 1024)
+                logger.info(
+                    "[continue_generation] empty_device_cache: "
+                    f"reserved {before_mb:.1f} MB -> {after_mb:.1f} MB "
+                    f"(freed {before_mb - after_mb:.1f} MB)"
+                )
+            else:
+                logger.info("[continue_generation] empty_device_cache called")
         self._engine_paused = False
 
     def load_lora_adapter(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3648,6 +3648,15 @@ class Scheduler(
             self.chunked_req = None
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):
+        if recv_req.empty_cache:
+            before_mb = torch.cuda.memory_reserved() / (1024 * 1024)
+            torch.cuda.empty_cache()
+            after_mb = torch.cuda.memory_reserved() / (1024 * 1024)
+            logger.info(
+                f"[continue_generation] torch.cuda.empty_cache() called: "
+                f"reserved {before_mb:.1f} MB -> {after_mb:.1f} MB "
+                f"(freed {before_mb - after_mb:.1f} MB)"
+            )
         self._engine_paused = False
 
     def load_lora_adapter(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3647,18 +3647,14 @@ class Scheduler(
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):
         if recv_req.torch_empty_cache:
-            mem_reserved = getattr(self.device_module, "memory_reserved", None)
-            before_mb = mem_reserved() / (1024 * 1024) if mem_reserved else None
-            empty_device_cache(self.device_module)
-            if before_mb is not None:
-                after_mb = mem_reserved() / (1024 * 1024)
-                logger.info(
-                    "[continue_generation] empty_device_cache: "
-                    f"reserved {before_mb:.1f} MB -> {after_mb:.1f} MB "
-                    f"(freed {before_mb - after_mb:.1f} MB)"
-                )
-            else:
-                logger.info("[continue_generation] empty_device_cache called")
+            before_mb = torch.cuda.memory_reserved() / (1024 * 1024)
+            torch.cuda.empty_cache()
+            after_mb = torch.cuda.memory_reserved() / (1024 * 1024)
+            logger.info(
+                f"[continue_generation] torch.cuda.empty_cache() called: "
+                f"reserved {before_mb:.1f} MB -> {after_mb:.1f} MB "
+                f"(freed {before_mb - after_mb:.1f} MB)"
+            )
         self._engine_paused = False
 
     def load_lora_adapter(


### PR DESCRIPTION
## Motivation

Post-weight-update processing (e.g. DeepSeek MLA w_kc/w_vc derivation, FP8 scale rebuild) creates transient CUDA allocations that fragment PyTorch's block cache. Without `empty_cache()`, reserved memory grows each iteration and eventually OOMs.

| Pause mode | `flush_cache` called? | `empty_cache` before this PR | `empty_cache` after this PR |
|---|---|---|---|
| `abort` | Yes | Yes (via `flush_cache`) | Yes (via `flush_cache` + resume) |
| `retract` | Yes | Yes (via `flush_cache`) | Yes (via `flush_cache` + resume) |
| **`in_place`** | **No** | **No** ← the gap | **Yes** (via resume) |

`abort` and `retract` are safer because they already call `empty_cache()` as part of `flush_cache`. The `in_place` path never calls `flush_cache` (to preserve KV cache), so `empty_cache()` was never triggered — this PR closes that gap.

With this change, `abort` and `retract` will call `empty_cache()` twice (once in `flush_cache`, once on resume), but the second call is benign — it's a no-op when there are no cached blocks.

## Changes

- Add `empty_cache: bool = True` to `ContinueGenerationReqInput`. The scheduler calls `torch.cuda.empty_cache()` while still paused (no race with active streams).
- Log reserved-memory delta at INFO level for observability.
- Callers can opt out with `empty_cache=False`.

## Before
<img width="810" height="502" alt="image" src="https://github.com/user-attachments/assets/836594d0-71fa-4533-a31b-e8c5084ef4c7" />

OOM after repeated weight updates:

<details>
<summary>Full traceback</summary>

```
      ret, can_run_graph = self.forward_extend(
                           ^^^^^^^^^^^^^^^^^^^^
    File "sglang/srt/model_executor/model_runner.py", line 2780, in forward_extend
      self.model.forward(
    File "torch/utils/_contextlib.py", line 120, in decorate_context
      return func(*args, **kwargs)
    File "sglang/srt/models/deepseek_v2.py", line 2298, in forward
      hidden_states = self.model(
    File "sglang/srt/models/deepseek_v2.py", line 2061, in forward
      hidden_states, residual, topk_indices = layer(
    File "sglang/srt/models/deepseek_v2.py", line 1750, in forward
      hidden_states = self.mlp(
    File "sglang/srt/models/deepseek_v2.py", line 574, in forward
      return self.forward_deepep(hidden_states, forward_batch)
    File "sglang/srt/models/deepseek_v2.py", line 782, in forward_deepep
      shared_output = self._forward_shared_experts(hidden_states)
    File "sglang/srt/models/deepseek_v2.py", line 979, in _forward_shared_experts
      return self.shared_experts(
    File "sglang/srt/models/deepseek_v2.py", line 258, in forward
      x, _ = self.down_proj(
    File "sglang/srt/layers/linear.py", line 1509, in forward
      output_parallel = self.quant_method.apply(self, input_parallel, bias=bias_)
    File "sglang/srt/layers/quantization/fp8.py", line 737, in apply
      return self.w8a8_block_fp8_linear(
    File "sglang/srt/layers/quantization/fp8_utils.py", line 678, in deepgemm_w8a8_block_fp8_linear_with_fallback
      output = w8a8_block_fp8_matmul_deepgemm(
    File "sglang/srt/layers/quantization/fp8_kernel.py", line 1107, in w8a8_block_fp8_matmul_deepgemm
      deep_gemm_fp8_fp8_bf16_nt(A, As, B, Bs, C)
    File "sglang/srt/layers/quantization/fp8_kernel.py", line 123, in deep_gemm_fp8_fp8_bf16_nt
      deep_gemm_wrapper.gemm_nt_f8f8bf16((A, As), (B, Bs), C)
    File "sglang/srt/layers/deep_gemm_wrapper/entrypoint.py", line 98, in gemm_nt_f8f8bf16
      deep_gemm.fp8_gemm_nt(
    File "deep_gemm/__init__.py", line 50, in _fn
      return func(*args, **kwargs)
  RuntimeError: CUDA driver error (/sgl-kernel/build/_deps/repo-deepgemm-src/csrc/apis/../jit_kernels/impls/../../jit/handle.hpp:84): 2
  (CUDA_ERROR_OUT_OF_MEMORY, out of memory)
```

</details>

## After
<img width="840" height="368" alt="image" src="https://github.com/user-attachments/assets/9abd429d-209f-477e-83fb-eed3aa3ea43a" />

Stable memory, no OOM.

## Test plan
- [x] 1-node Qwen3-30B-A3B agg recipe, in-place pause + routing replay: log fires every resume, ~2 MB reclaimed on first, ~0 MB thereafter.
- [x] ESS, loss, exit code unchanged.