### PR TITLE
Fix TRTLLM MHA routing for draft extend

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -848,10 +848,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        if forward_batch.forward_mode.is_target_verify():
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,


### PR DESCRIPTION
## Summary

This PR keeps `DRAFT_EXTEND_V2` on the TRTLLM MHA context kernel path instead of routing it through `trtllm_batch_decode_with_kv_cache`.

`TARGET_VERIFY` still uses the decode kernel. Draft extend uses extend-shaped metadata, so sending it to the decode kernel can trigger an illegal CUDA memory access on Qwen3.5 MTP/NEXTN runs.

## Validation

Both runs use the same recipe except for the mounted SGLang source tree:

- model: `Qwen/Qwen3.5-397B-A17B-FP8`
- container: `lmsysorg+sglang+dev-0509`
- attention backend: `trtllm_mha`
- speculative decoding: `NEXTN`, `speculative-num-draft-tokens=4`
- radix cache: enabled
- benchmark: GSM8K, `num_examples=1319`, `num_threads=32`, `num_shots=8`

Before this PR, upstream `main` at `12f42f2e7e7520bef573230cadbdf6c10241aa61` fails:

```text
job: 1726390
result: FAILED
error: CUDA error: an illegal memory access was encountered
```

With this PR at `20d5f7ec2d392e4ba0ca2f416cf03474b017d84a`, the same benchmark completes:

```text
job: 1726391
result: COMPLETED
gsm8k_score: 0.9786422578184591
gsm8k_latency: 1107.6183524439984
```