### PR TITLE
[Spec] Edge case fixes: retract idle ExtendInput; getattr-guard phase-specific spec_info fields

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -993,9 +993,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             spec_info = self.spec_info
             self.output_cache_loc_backup = self.out_cache_loc
             self.hidden_states_backup = spec_info.hidden_states
-            if spec_info.topk_p is not None:
+            # `topk_p` / `topk_index` only live on `EagleDraftInput` (draft phase).
+            # `EagleDraftExtendInput` (draft-extend phase) doesn't have these,
+            # so use `getattr` so the guard skips cleanly there.
+            if getattr(spec_info, "topk_p", None) is not None:
                 spec_info.topk_p = self._pad_tensor_to_size(spec_info.topk_p, bs)
-            if spec_info.topk_index is not None:
+            if getattr(spec_info, "topk_index", None) is not None:
                 spec_info.topk_index = self._pad_tensor_to_size(
                     spec_info.topk_index, bs
                 )


### PR DESCRIPTION
## Summary

Stacks on #24862. Fixes edge cases exposed by the schema split (PR 1 + PR 2):

1. **Retract / all-finished idle**: when V1 verify finishes and all reqs are done (no dp_attention forcing the forward), \`forward_batch_generation\` skips the draft-extend forward. Previously \`batch.spec_info\` would stay as \`EagleVerifyInput\`, which has no \`merge_batch\` and crashes the next iter's scheduler merge. Fix: install an empty \`EagleDraftInput\` so \`merge_batch\` short-circuits cleanly.

2. **forward_batch_info getattr-guards**: post-schema-split, \`EagleDraftInput\` no longer has \`num_accepted_drafts\` and \`EagleDraftExtendInput\` no longer has \`topk_p / topk_index\`. \`_pad_inputs_to_size\` accessed them unconditionally and crashed. Fix: \`getattr(spec_info, "<name>", None)\`.

These fixes were caught by retraction stress tests and the dsv4/deepep CUDA-graph paths.

## Test plan

- [ ] retraction tests (\`TestStreamingSessionEagleRetractLargePage\`) — covered by stage-b
- [ ] V2 deepep / dsv4 stage-c tests