### PR TITLE
fix(server_args): reject SBO+enforce-shared-experts-fusion; guard deepseek_v2 runtime path

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2353,14 +2353,17 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             return
 
         # DeepEP + enforce: the only path that enables fusion under DeepEP.
+        # SBO/TBO must still be excluded even in this path — their overlap
+        # kernel execution is incompatible with fused shared experts.
         if is_deepep_class_backend() and server_args.enforce_shared_experts_fusion:
-            log_info_on_rank0(
-                logger,
-                "DeepEP shared expert fusion: fusing shared expert into MoE kernel "
-                "at home EP rank local slot (--enforce-shared-experts-fusion).",
-            )
-            self.num_fused_shared_experts = self.config.n_shared_experts
-            return
+            if not (is_sbo_enabled() or is_tbo_enabled()):
+                log_info_on_rank0(
+                    logger,
+                    "DeepEP shared expert fusion: fusing shared expert into MoE kernel "
+                    "at home EP rank local slot (--enforce-shared-experts-fusion).",
+                )
+                self.num_fused_shared_experts = self.config.n_shared_experts
+                return
 
         # Check all conditions that disable fusion.
         disable_reason = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7046,7 +7046,7 @@ class ServerArgs:
                 "--export-metrics-to-file-dir is required when --export-metrics-to-file is enabled"
             )
 
-        # Check two batch overlap
+        # Check two/single batch overlap
         if self.enable_two_batch_overlap and self.moe_a2a_backend == "none":
             raise ValueError(
                 "When enabling two batch overlap, moe_a2a_backend cannot be 'none'."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7052,9 +7052,12 @@ class ServerArgs:
                 "When enabling two batch overlap, moe_a2a_backend cannot be 'none'."
             )
 
-        if self.enable_two_batch_overlap and self.enforce_shared_experts_fusion:
+        if (
+            self.enable_two_batch_overlap or self.enable_single_batch_overlap
+        ) and self.enforce_shared_experts_fusion:
             raise ValueError(
-                "--enable-two-batch-overlap and --enforce-shared-experts-fusion cannot be used together."
+                "--enable-two-batch-overlap/--enable-single-batch-overlap and "
+                "--enforce-shared-experts-fusion cannot be used together."
             )
 
         # Check communications compression

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -85,6 +85,32 @@ class TestLoadBalanceMethod(unittest.TestCase):
         self.assertIn("('nixl', 'mooncake')", str(context.exception))
         self.assertIn("'fake'", str(context.exception))
 
+    def test_two_batch_overlap_rejects_enforced_shared_experts_fusion(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_two_batch_overlap=True,
+            enforce_shared_experts_fusion=True,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            server_args.check_server_args()
+
+        self.assertIn("--enable-two-batch-overlap", str(context.exception))
+        self.assertIn("--enforce-shared-experts-fusion", str(context.exception))
+
+    def test_single_batch_overlap_rejects_enforced_shared_experts_fusion(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_single_batch_overlap=True,
+            enforce_shared_experts_fusion=True,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            server_args.check_server_args()
+
+        self.assertIn("--enable-single-batch-overlap", str(context.exception))
+        self.assertIn("--enforce-shared-experts-fusion", str(context.exception))
+
 
 class TestPortArgs(unittest.TestCase):
     @patch("sglang.srt.server_args.get_free_port")


### PR DESCRIPTION
## What changed

- `python/sglang/srt/server_args.py`: Extended the existing TBO check (added by #24720) to also cover `--enable-single-batch-overlap`. Both TBO and SBO are incompatible with `--enforce-shared-experts-fusion`. Updated the section comment from \"Check two batch overlap\" to \"Check two/single batch overlap\".
- `python/sglang/srt/models/deepseek_v2.py`: The DeepEP+enforce early-return in `determine_num_fused_shared_experts` previously bypassed the `is_sbo_enabled() or is_tbo_enabled()` guard below it. Added an explicit check so the early-return only fires when neither SBO nor TBO is active, correctly falling through to the `disable_reason` path otherwise.
- `test/registered/unit/server_args/test_server_args.py`: Added unit tests for both TBO+enforce and SBO+enforce rejection — the TBO case was missing since #24720, and SBO is a gap not covered elsewhere.

## Why

When `--enable-two-batch-overlap` (or `--enable-single-batch-overlap`) and `--enforce-shared-experts-fusion` are both set under DeepEP, the server hangs. The overlap kernels and fused shared-expert kernels use incompatible execution paths.

`check_server_args` only rejected TBO (not SBO). More critically, `determine_num_fused_shared_experts` had an early-return for any `DeepEP + enforce` configuration that ran before the `is_sbo_enabled() or is_tbo_enabled()` check, so the SBO+TBO guard was silently skipped and fusion was incorrectly enabled.

## How to verify

```bash
python -m pytest test/registered/unit/server_args/test_server_args.py \
  -k "batch_overlap_rejects" -v
```

Expected: both `test_two_batch_overlap_rejects_enforced_shared_experts_fusion` and `test_single_batch_overlap_rejects_enforced_shared_experts_fusion` pass.

## Impact scope

- `server_args.py`: validation only — no change to inference path
- `deepseek_v2.py`: `determine_num_fused_shared_experts` init-time only; no effect on forward pass; normal (non-SBO/TBO, non-DeepEP+enforce) paths are unchanged
- Fixes #24690

Note: PR #24763 makes the same `server_args.py` change. This PR additionally guards the runtime path in `deepseek_v2.py` and adds the missing TBO unit test. Happy to coordinate or close in favour of whichever approach the maintainers prefer.