### PR TITLE
[OpenAI] Add --enable-thinking/--disable-thinking server flags

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -366,6 +366,12 @@ class OpenAIServingChat(OpenAIServingBase):
         return None
 
     def _server_thinking_toggle_key(self) -> Optional[str]:
+        # template_manager.reasoning_config is set when --reasoning-parser=auto
+        # picks the parser at template-load time; prefer it over the
+        # parser-level fallback.
+        config = getattr(self.template_manager, "reasoning_config", None)
+        if config is not None:
+            return getattr(config, "toggle_param", None)
         if self._reasoning_detector is None:
             return None
         mode = getattr(self._reasoning_detector, "reasoning_default", None)
@@ -377,6 +383,8 @@ class OpenAIServingChat(OpenAIServingBase):
 
     def _apply_server_thinking_default(self, request: ChatCompletionRequest) -> None:
         if self.enable_thinking is None:
+            return
+        if request.reasoning_effort == "none":
             return
         key = self._server_thinking_toggle_key()
         if key is None:

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -194,6 +194,7 @@ class OpenAIServingChat(OpenAIServingBase):
         self.template_manager = template_manager
         self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+        self.enable_thinking = self.tokenizer_manager.server_args.enable_thinking
         self._reasoning_detector = None
         if self.reasoning_parser:
             try:
@@ -364,6 +365,28 @@ class OpenAIServingChat(OpenAIServingBase):
 
         return None
 
+    def _server_thinking_toggle_key(self) -> Optional[str]:
+        if self._reasoning_detector is None:
+            return None
+        mode = getattr(self._reasoning_detector, "reasoning_default", None)
+        if mode in ("enable_thinking", "explicit_enable_thinking"):
+            return "enable_thinking"
+        if mode in ("thinking", "explicit_thinking"):
+            return "thinking"
+        return None
+
+    def _apply_server_thinking_default(self, request: ChatCompletionRequest) -> None:
+        if self.enable_thinking is None:
+            return
+        key = self._server_thinking_toggle_key()
+        if key is None:
+            return
+        ctk = request.chat_template_kwargs
+        if ctk is None:
+            ctk = {}
+            request.chat_template_kwargs = ctk
+        ctk.setdefault(key, self.enable_thinking)
+
     def _convert_to_internal_request(
         self,
         request: ChatCompletionRequest,
@@ -381,6 +404,8 @@ class OpenAIServingChat(OpenAIServingBase):
 
         if reasoning_effort is not None:
             request.reasoning_effort = reasoning_effort
+
+        self._apply_server_thinking_default(request)
 
         """Convert OpenAI chat completion request to internal format"""
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -500,6 +500,7 @@ class ServerArgs:
     file_storage_path: str = "sglang_storage"
     enable_cache_report: bool = False
     reasoning_parser: Optional[str] = None
+    enable_thinking: Optional[bool] = None
     strip_thinking_cache: bool = False
     enable_strict_thinking: bool = False
     tool_call_parser: Optional[str] = None
@@ -4260,6 +4261,12 @@ class ServerArgs:
                     self.preferred_sampling_params
                 )
 
+        if self.enable_thinking is not None and self.reasoning_parser is None:
+            logger.warning(
+                "--enable-thinking/--disable-thinking has no effect without "
+                "--reasoning-parser."
+            )
+
     def _handle_debug_utils(self):
         if is_in_ci() and self.soft_watchdog_timeout is None:
             logger.info("Set soft_watchdog_timeout since in CI")
@@ -5187,6 +5194,24 @@ class ServerArgs:
             help=f"Specify the parser for reasoning models. "
             f"Use 'auto' to detect from chat template. "
             f"Options include: {reasoning_parser_choices}.",
+        )
+        thinking_default_group = parser.add_mutually_exclusive_group()
+        thinking_default_group.add_argument(
+            "--enable-thinking",
+            action="store_true",
+            default=None,
+            dest="enable_thinking",
+            help="Enable the chat-template thinking toggle by default for "
+            "reasoning models (Qwen3, GLM-4.5, DeepSeek-V3, etc.). "
+            "Per-request chat_template_kwargs takes precedence. Requires "
+            "--reasoning-parser.",
+        )
+        thinking_default_group.add_argument(
+            "--disable-thinking",
+            action="store_false",
+            dest="enable_thinking",
+            help="Disable the chat-template thinking toggle by default. "
+            "See --enable-thinking.",
         )
         parser.add_argument(
             "--strip-thinking-cache",

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1489,6 +1489,31 @@ class ServingChatTestCase(unittest.TestCase):
         chat._apply_server_thinking_default(req)
         self.assertEqual(req.chat_template_kwargs, {"enable_thinking": True})
 
+    def test_thinking_default_skipped_when_reasoning_effort_none(self):
+        # reasoning_effort="none" is an explicit opt-out; server default
+        # must not flip the toggle back on.
+        chat = self._make_chat_with_thinking_default("qwen3", True)
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            reasoning_effort="none",
+        )
+        chat._apply_server_thinking_default(req)
+        self.assertFalse(req.chat_template_kwargs.get("enable_thinking"))
+
+    def test_thinking_default_uses_template_manager_for_auto_parser(self):
+        # --reasoning-parser=auto leaves _reasoning_detector unset; toggle
+        # key must come from TemplateManager.reasoning_config instead.
+        self.template_manager.reasoning_config = ReasoningToggleConfig(
+            toggle_param="enable_thinking", default_enabled=True
+        )
+        chat = self._make_chat_with_thinking_default(None, False)
+        req = ChatCompletionRequest(
+            model="x", messages=[{"role": "user", "content": "Hi?"}]
+        )
+        chat._apply_server_thinking_default(req)
+        self.assertEqual(req.chat_template_kwargs, {"enable_thinking": False})
+
     def test_thinking_default_noop_cases(self):
         # Each early-return guard in _apply_server_thinking_default:
         # flag unset, no reasoning parser, parser without binary toggle.

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -44,6 +44,7 @@ class _MockTokenizerManager:
             enable_cache_report=False,
             tool_call_parser="hermes",
             reasoning_parser=None,
+            enable_thinking=None,
             stream_response_default_include_usage=False,
         )
         # Mock hf_config for _resolve_chat_encoding_spec check
@@ -1439,6 +1440,71 @@ class ServingChatTestCase(unittest.TestCase):
             conv_mock.return_value = conv_ins
             result = self.chat._apply_conversation_template(req, is_multimodal=False)
         self.assertEqual(result.prompt, "BASE_PROMPT")
+
+    # ------------- server-level --enable-thinking / --disable-thinking -------------
+    def _make_chat_with_thinking_default(
+        self, parser: Optional[str], enable_thinking: Optional[bool]
+    ):
+        """Rebuild OpenAIServingChat with the given parser + server-level
+        --enable-thinking default, then stub `reasoning_default` on the
+        detector so we don't depend on real ReasoningParser construction."""
+        self.tm.server_args.reasoning_parser = parser
+        self.tm.server_args.enable_thinking = enable_thinking
+        self.chat = OpenAIServingChat(self.tm, self.template_manager)
+        if self.chat._reasoning_detector is not None:
+            # `_server_thinking_toggle_key` reads `reasoning_default` only.
+            self.chat._reasoning_detector = Mock(
+                reasoning_default={
+                    "qwen3": "enable_thinking",
+                    "deepseek-v3": "explicit_thinking",
+                    "deepseek-r1": "always",
+                    "mistral": "mistral",
+                }.get(parser, "always")
+            )
+        return self.chat
+
+    def test_thinking_default_sets_toggle_per_parser(self):
+        # (parser, flag) -> expected chat_template_kwargs after apply.
+        cases = [
+            ("qwen3", True, {"enable_thinking": True}),
+            ("qwen3", False, {"enable_thinking": False}),
+            ("deepseek-v3", True, {"thinking": True}),
+        ]
+        for parser, flag, expected in cases:
+            with self.subTest(parser=parser, flag=flag):
+                chat = self._make_chat_with_thinking_default(parser, flag)
+                req = ChatCompletionRequest(
+                    model="x", messages=[{"role": "user", "content": "Hi?"}]
+                )
+                chat._apply_server_thinking_default(req)
+                self.assertEqual(req.chat_template_kwargs, expected)
+
+    def test_thinking_default_per_request_override_wins(self):
+        chat = self._make_chat_with_thinking_default("qwen3", False)
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        chat._apply_server_thinking_default(req)
+        self.assertEqual(req.chat_template_kwargs, {"enable_thinking": True})
+
+    def test_thinking_default_noop_cases(self):
+        # Each early-return guard in _apply_server_thinking_default:
+        # flag unset, no reasoning parser, parser without binary toggle.
+        cases = [
+            ("flag_unset", "qwen3", None),
+            ("no_parser", None, True),
+            ("non_toggleable_parser", "deepseek-r1", True),
+        ]
+        for label, parser, flag in cases:
+            with self.subTest(case=label):
+                chat = self._make_chat_with_thinking_default(parser, flag)
+                req = ChatCompletionRequest(
+                    model="x", messages=[{"role": "user", "content": "Hi?"}]
+                )
+                chat._apply_server_thinking_default(req)
+                self.assertIsNone(req.chat_template_kwargs)
 
 
 class TestProcessToolCallsWithRequiredToolChoice(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Closes #5948. Operators serving reasoning models (Qwen3, GLM-4.5, DeepSeek-V3, etc.) currently have no server-side switch to default the chat-template thinking toggle on or off — every client must send `chat_template_kwargs={"enable_thinking": false}` (or its parser-specific equivalent) on every request.

## Modifications

- `python/sglang/srt/server_args.py`: add `enable_thinking: Optional[bool]` and a mutually-exclusive `--enable-thinking` / `--disable-thinking` CLI group. Warn when set without `--reasoning-parser`.
- `python/sglang/srt/entrypoints/openai/serving_chat.py`: derive the toggle key (`enable_thinking` for Qwen3/GLM-4.5/etc., `thinking` for DeepSeek-V3/Kimi-K2) from `_reasoning_detector.reasoning_default` so the flag picks up new parsers automatically. Inject via `setdefault` in `_convert_to_internal_request` before chat-template rendering, so per-request `chat_template_kwargs`, `reasoning.enabled`, and `reasoning_effort` keep precedence.
- `test/registered/unit/entrypoints/openai/test_serving_chat.py`: 3 new tests (6 subtests) covering qwen3/deepseek-v3 key mapping, per-request precedence, and the early-return guards.

### Precedence (highest first)

1. Per-request `chat_template_kwargs[<toggle_key>]`
2. Per-request `reasoning_effort="none"`
3. Per-request `reasoning.enabled=true`
4. **New: server `--enable-thinking` / `--disable-thinking`**
5. Chat-template default

`setdefault` enforces 1–3 > 4.

## Accuracy Tests

N/A — no model-output behavior change. Only mutates pre-render `chat_template_kwargs` defaults.

## Speed Tests and Profiling

N/A — single dict `setdefault` per chat-completion request.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).