### PR TITLE
[MoE] Decouple Mega MoE from DeepEP backend

### DIFF
--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -429,7 +429,6 @@ export const DeepSeekV4Deployment = () => {
           "SGLANG_OPT_USE_JIT_NORM=1",
           "SGLANG_OPT_USE_JIT_INDEXER_METADATA=1",
           "SGLANG_OPT_USE_TOPK_V2=1",
-          "SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1",
         );
       }
     } else if (recipe === "balanced") {
@@ -445,14 +444,6 @@ export const DeepSeekV4Deployment = () => {
           "SGLANG_OPT_USE_JIT_NORM=1",
           "SGLANG_OPT_USE_JIT_INDEXER_METADATA=1",
           "SGLANG_OPT_USE_TOPK_V2=1",
-          "SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1",
-          "SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1",
-          "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=0",
-          "SGLANG_OPT_USE_FAST_MASK_EP=1",
-          "SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1",
-          "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=4096",
-          "SGLANG_OPT_FIX_NEXTN_MEGA_MOE=1",
-          "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=0",
         );
       } else {
         recipeEnv.push(isBig
@@ -475,15 +466,9 @@ export const DeepSeekV4Deployment = () => {
           "SGLANG_OPT_USE_JIT_NORM=1",
           "SGLANG_OPT_USE_JIT_INDEXER_METADATA=1",
           "SGLANG_OPT_USE_TOPK_V2=1",
-          "SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1",
-          "SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1",
-          "SGLANG_OPT_USE_FAST_MASK_EP=1",
-          "SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1",
-          "SGLANG_OPT_FIX_NEXTN_MEGA_MOE=1",
           "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=0",
           "NVSHMEM_DISABLE_IB=1",
           "SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1",
-          "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1",
           "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320",
         );
       } else {
@@ -610,7 +595,11 @@ export const DeepSeekV4Deployment = () => {
       flags.push(`  --dp ${tp}`);
       flags.push("  --enable-dp-attention");
       if (multinode) flags.push(...multiNodeFlags(nnodes));
-      flags.push("  --moe-a2a-backend deepep");
+      if (isBig && hardware === "b200") {
+        flags.push("  --moe-a2a-backend megamoe");
+      } else {
+        flags.push("  --moe-a2a-backend deepep");
+      }
       if (hardware === "h200" && isBig) {
         flags.push("  --mem-fraction-static 0.88");
       } else if (isBig && hardware === "gb300") {
@@ -993,12 +982,9 @@ python3 -m sglang_router.launch_router \\
         </p>
         <pre style={{ margin: "8px 0 0 0", padding: "8px 12px", background: isDark ? "#111827" : "#f5f5f5", borderRadius: "4px", fontSize: "12px", lineHeight: "1.5", overflowX: "auto" }}>{
 `# Add this flag to the sglang serve command:
---moe-a2a-backend deepep
+--moe-a2a-backend megamoe
 
 # And set these env vars:
-SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1
-SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1
-SGLANG_OPT_FIX_NEXTN_MEGA_MOE=1
 SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320
 SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=0`
         }</pre>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -598,6 +598,7 @@ class Envs:
     SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW = EnvBool(False)
 
     # DeepGemm Mega MoE
+    SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE = EnvBool(False)
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK = EnvInt(1024)
 
     # When set, the mega-MoE x slot is packed E2M1 (FP4) instead of FP8 E4M3.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -598,7 +598,6 @@ class Envs:
     SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW = EnvBool(False)
 
     # DeepGemm Mega MoE
-    SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE = EnvBool(False)
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK = EnvInt(1024)
 
     # When set, the mega-MoE x slot is packed E2M1 (FP4) instead of FP8 E4M3.

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -82,7 +82,7 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
     a2a_backend = get_moe_a2a_backend()
-    if a2a_backend.is_none():
+    if a2a_backend.is_none() or a2a_backend.is_megamoe():
         return StandardDispatcher(moe_runner_config)
     elif (
         a2a_backend.is_deepep()

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -25,6 +25,7 @@ from sglang.jit_kernel.deepseek_v4 import mega_moe_pre_dispatch
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.dp_attention import get_dp_global_num_tokens
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 
 if TYPE_CHECKING:
@@ -94,7 +95,7 @@ def _get_mega_moe_symm_buffer(
 
 
 def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bool:
-    if not envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get():
+    if not get_moe_a2a_backend().is_megamoe():
         return False
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
         return False

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -131,7 +131,6 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         if envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
             assert envs.SGLANG_OPT_SWIGLU_CLAMP_FUSION.get()
             assert envs.SGLANG_OPT_USE_JIT_EP_ACTIVATION.get()
-            assert envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
             self.use_swizzle = True
 
     def run(

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -29,6 +29,7 @@ class MoeA2ABackend(Enum):
     MORI = "mori"
     ASCEND_FUSEEP = "ascend_fuseep"
     FLASHINFER = "flashinfer"
+    MEGAMOE = "megamoe"
     CUSTOMIZED = "customized"
 
     @classmethod
@@ -60,6 +61,9 @@ class MoeA2ABackend(Enum):
 
     def is_mori(self):
         return self == MoeA2ABackend.MORI
+
+    def is_megamoe(self):
+        return self == MoeA2ABackend.MEGAMOE
 
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1193,7 +1193,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w13_weight.data = layer.w13_weight.data.view(torch.int8)
                 layer.w2_weight.data = layer.w2_weight.data.view(torch.int8)
 
-                if envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get():
+                if get_moe_a2a_backend().is_megamoe():
                     from sglang.srt.layers.moe.mega_moe import (
                         build_mega_moe_experts_weights,
                     )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3194,8 +3194,6 @@ class ServerArgs:
 
         if self.moe_a2a_backend == "megamoe":
             self.ep_size = self.tp_size
-            if not envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.is_set():
-                envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.set(True)
             if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():
                 envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
             logger.info(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3184,10 +3184,6 @@ class ServerArgs:
             )
             self.moe_a2a_backend = "deepep"
 
-        # Mega MoE uses deep_gemm for its own all-to-all communication and
-        # does not depend on DeepEP.  When the user has not explicitly chosen
-        # an a2a backend, auto-configure EP so that megamoe can run without
-        # requiring the deep_ep library or the DeepEP dispatcher.
         if (
             envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
             and self.moe_a2a_backend == "none"
@@ -3281,10 +3277,6 @@ class ServerArgs:
                     self.chunked_prefill_size
                 ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) must be larger or equal to chunked_prefill_size"
 
-        # When Mega MoE is enabled together with EP, both the Mega MoE path
-        # (decode) and the normal/DeepEP path (prefill fallback) share the
-        # same MoE weights at runtime. Auto-enable FIX_MEGA_MOE_MEMORY so
-        # they share one copy instead of duplicating.
         if (
             envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
             and self.ep_size > 1

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -209,6 +209,7 @@ MOE_A2A_BACKEND_CHOICES = [
     "mori",
     "ascend_fuseep",
     "flashinfer",
+    "megamoe",
 ]
 
 FP8_GEMM_RUNNER_BACKEND_CHOICES = [
@@ -609,7 +610,14 @@ class ServerArgs:
     # Expert parallelism
     ep_size: int = 1
     moe_a2a_backend: Literal[
-        "none", "deepep", "mooncake", "nixl", "mori", "ascend_fuseep", "flashinfer"
+        "none",
+        "deepep",
+        "mooncake",
+        "nixl",
+        "mori",
+        "ascend_fuseep",
+        "flashinfer",
+        "megamoe",
     ] = "none"
     moe_runner_backend: str = "auto"
     record_nolora_graph: bool = True
@@ -3184,12 +3192,12 @@ class ServerArgs:
             )
             self.moe_a2a_backend = "deepep"
 
-        if (
-            envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
-            and self.moe_a2a_backend == "none"
-            and self.ep_size == 1
-        ):
+        if self.moe_a2a_backend == "megamoe":
             self.ep_size = self.tp_size
+            if not envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.is_set():
+                envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.set(True)
+            if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():
+                envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
             logger.info(
                 f"Mega MoE is enabled. The expert parallel size is adjusted "
                 f"to be the same as the tensor parallel size[{self.tp_size}]."
@@ -3276,17 +3284,6 @@ class ServerArgs:
                 assert (
                     self.chunked_prefill_size
                 ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) must be larger or equal to chunked_prefill_size"
-
-        if (
-            envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
-            and self.ep_size > 1
-            and not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set()
-        ):
-            envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
-            logger.info(
-                "Mega MoE with EP enabled: auto-setting "
-                "SGLANG_OPT_FIX_MEGA_MOE_MEMORY=True to share weights."
-            )
 
     def _handle_eplb_and_dispatch(self):
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3184,6 +3184,21 @@ class ServerArgs:
             )
             self.moe_a2a_backend = "deepep"
 
+        # Mega MoE uses deep_gemm for its own all-to-all communication and
+        # does not depend on DeepEP.  When the user has not explicitly chosen
+        # an a2a backend, auto-configure EP so that megamoe can run without
+        # requiring the deep_ep library or the DeepEP dispatcher.
+        if (
+            envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
+            and self.moe_a2a_backend == "none"
+            and self.ep_size == 1
+        ):
+            self.ep_size = self.tp_size
+            logger.info(
+                f"Mega MoE is enabled. The expert parallel size is adjusted "
+                f"to be the same as the tensor parallel size[{self.tp_size}]."
+            )
+
         if self.moe_a2a_backend == "deepep":
             if self.deepep_mode == "normal":
                 logger.warning("Cuda graph is disabled because deepep_mode=`normal`")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3192,6 +3192,16 @@ class ServerArgs:
             )
             self.moe_a2a_backend = "deepep"
 
+        if (
+            envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
+            and self.moe_a2a_backend != "megamoe"
+        ):
+            self.moe_a2a_backend = "megamoe"
+            logger.info(
+                "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE is set, "
+                "auto-configuring --moe-a2a-backend megamoe."
+            )
+
         if self.moe_a2a_backend == "megamoe":
             self.ep_size = self.tp_size
             if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3281,6 +3281,21 @@ class ServerArgs:
                     self.chunked_prefill_size
                 ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) must be larger or equal to chunked_prefill_size"
 
+        # When Mega MoE is enabled together with EP, both the Mega MoE path
+        # (decode) and the normal/DeepEP path (prefill fallback) share the
+        # same MoE weights at runtime. Auto-enable FIX_MEGA_MOE_MEMORY so
+        # they share one copy instead of duplicating.
+        if (
+            envs.SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE.get()
+            and self.ep_size > 1
+            and not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set()
+        ):
+            envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
+            logger.info(
+                "Mega MoE with EP enabled: auto-setting "
+                "SGLANG_OPT_FIX_MEGA_MOE_MEMORY=True to share weights."
+            )
+
     def _handle_eplb_and_dispatch(self):
         if self.enable_eplb and (self.expert_distribution_recorder_mode is None):
             self.expert_distribution_recorder_mode = "stat"

--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_megamoe_b200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_megamoe_b200.py
@@ -28,18 +28,12 @@ SERVER_LAUNCH_TIMEOUT = 3600
 
 
 _W4A8_MEGAMOE_ENV = {
-    "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE": "1",
-    "SGLANG_OPT_FIX_MEGA_MOE_MEMORY": "1",
-    "SGLANG_OPT_FIX_NEXTN_MEGA_MOE": "1",
     "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK": "4096",
     "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "0",
 }
 
 
 _W4A4_MEGAMOE_ENV = {
-    "SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE": "1",
-    "SGLANG_OPT_FIX_MEGA_MOE_MEMORY": "1",
-    "SGLANG_OPT_FIX_NEXTN_MEGA_MOE": "1",
     "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK": "4096",
     "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "0",
     "SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS": "1",
@@ -81,7 +75,7 @@ class TestDSV4FlashFP4B200W4A8MegaMoE(ServerSanityMixin, CustomTestCase):
                 "4",
                 "--enable-dp-attention",
                 "--moe-a2a-backend",
-                "deepep",
+                "megamoe",
                 "--speculative-algorithm",
                 "EAGLE",
                 "--speculative-num-steps",
@@ -122,7 +116,7 @@ class TestDSV4FlashFP4B200W4A4MegaMoE(ServerSanityMixin, CustomTestCase):
                 "4",
                 "--enable-dp-attention",
                 "--moe-a2a-backend",
-                "deepep",
+                "megamoe",
                 "--speculative-algorithm",
                 "EAGLE",
                 "--speculative-num-steps",


### PR DESCRIPTION
## Summary
- Auto-configure EP (`ep_size = tp_size`) when `SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1` is set, so users no longer need `--moe-a2a-backend=deepep` or the `deep_ep` library to use Mega MoE.
- Mega MoE uses `deep_gemm.fp8_fp4_mega_moe()` for its own all-to-all communication and never touches the DeepEP dispatcher, so the dependency was unnecessary.