### PR TITLE
fix(constrained): fix outlines grammar support in speculative decoding

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -69,6 +69,14 @@ class BaseGrammarObject:
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
         raise NotImplementedError()
 
+    def is_vocab_mask_allowed_token(
+        self,
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        raise NotImplementedError()
+
     @staticmethod
     def move_vocab_mask(vocab_mask: torch.Tensor, device) -> torch.Tensor:
         raise NotImplementedError()
@@ -156,6 +164,26 @@ class BaseGrammarBackend:
     def init_strict_reasoning_grammar(self, reasoning: bool):
         """Create a grammar object for strict token filtering only. Returns None by default."""
         return None
+
+    @staticmethod
+    def allocate_vocab_mask(vocab_size: int, batch_size: int, device) -> torch.Tensor:
+        raise NotImplementedError()
+
+    @staticmethod
+    def is_vocab_mask_allowed_token(
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        raise NotImplementedError()
+
+    @staticmethod
+    def move_vocab_mask(vocab_mask: torch.Tensor, device) -> torch.Tensor:
+        raise NotImplementedError()
+
+    @staticmethod
+    def apply_vocab_mask(logits: torch.Tensor, vocab_mask: torch.Tensor) -> None:
+        raise NotImplementedError()
 
     def dispatch_fallback(self, key_type: str, key_string: str) -> BaseGrammarObject:
         """

--- a/python/sglang/srt/constrained/llguidance_backend.py
+++ b/python/sglang/srt/constrained/llguidance_backend.py
@@ -32,7 +32,10 @@ from sglang.srt.constrained.base_grammar_backend import (
     BaseGrammarObject,
     InvalidGrammarObject,
 )
-from sglang.srt.constrained.utils import is_legacy_structural_tag
+from sglang.srt.constrained.utils import (
+    is_legacy_structural_tag,
+    is_packed_bitmask_allowed_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +82,14 @@ class GuidanceGrammar(BaseGrammarObject):
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
         fill_next_token_bitmask(self.ll_matcher, vocab_mask, idx)
         self._check_err()
+
+    def is_vocab_mask_allowed_token(
+        self,
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        return is_packed_bitmask_allowed_token(vocab_mask, token_id, vocab_size)
 
     def allocate_vocab_mask(
         self, vocab_size: int, batch_size: int, device

--- a/python/sglang/srt/constrained/outlines_backend.py
+++ b/python/sglang/srt/constrained/outlines_backend.py
@@ -29,6 +29,7 @@ from sglang.srt.constrained.base_grammar_backend import (
     InvalidGrammarObject,
 )
 from sglang.srt.constrained.outlines_jump_forward import OutlinesJumpForwardMap
+from sglang.srt.constrained.utils import is_dense_bool_mask_allowed_token
 
 try:
     from outlines.fsm.json_schema import build_regex_from_schema
@@ -49,9 +50,22 @@ class OutlinesGrammar(BaseGrammarObject):
         self.guide = guide
         self.jump_forward_map = jump_forward_map
         self.state = 0
+        self._state_history: List[int] = []
 
     def accept_token(self, token: int):
+        self._state_history.append(self.state)
         self.state = self.guide.get_next_state(self.state, token)
+
+    def rollback(self, k: int):
+        if k <= 0:
+            return
+        if k > len(self._state_history):
+            raise ValueError(
+                f"Cannot rollback {k} tokens with only {len(self._state_history)}"
+                " accepted tokens in history."
+            )
+        self.state = self._state_history[-k]
+        del self._state_history[-k:]
 
     def allocate_vocab_mask(
         self, vocab_size: int, batch_size: int, device
@@ -69,6 +83,14 @@ class OutlinesGrammar(BaseGrammarObject):
         vocab_mask = vocab_mask[idx]
         vocab_mask.fill_(1)
         vocab_mask.scatter_(0, tokens, torch.zeros_like(tokens, dtype=torch.bool))
+
+    def is_vocab_mask_allowed_token(
+        self,
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        return is_dense_bool_mask_allowed_token(vocab_mask, token_id, vocab_size)
 
     @staticmethod
     def apply_vocab_mask(logits: torch.Tensor, vocab_mask: torch.Tensor):

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -57,6 +57,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
         enable_token_filter: bool = False,
         token_filter_fn=None,
         allocate_vocab_mask_fn=None,
+        is_vocab_mask_allowed_token_fn=None,
         move_vocab_mask_fn=None,
         apply_vocab_mask_fn=None,
     ):
@@ -68,6 +69,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
         self.enable_token_filter = enable_token_filter
         self.token_filter_fn = token_filter_fn
         self.allocate_vocab_mask_fn = allocate_vocab_mask_fn
+        self.is_vocab_mask_allowed_token_fn = is_vocab_mask_allowed_token_fn
         self.move_vocab_mask_fn = move_vocab_mask_fn
         self.apply_vocab_mask_fn = apply_vocab_mask_fn
         self._think_end_id_list = [think_end_id]
@@ -155,6 +157,22 @@ class ReasonerGrammarObject(BaseGrammarObject):
             return self.allocate_vocab_mask_fn(vocab_size, batch_size, device)
         return None
 
+    def is_vocab_mask_allowed_token(
+        self,
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        if self.grammar is not None:
+            return self.grammar.is_vocab_mask_allowed_token(
+                vocab_mask, token_id, vocab_size=vocab_size
+            )
+        if self.is_vocab_mask_allowed_token_fn is not None:
+            return self.is_vocab_mask_allowed_token_fn(
+                vocab_mask, token_id, vocab_size=vocab_size
+            )
+        raise NotImplementedError()
+
     def move_vocab_mask(self, vocab_mask, device):
         if self.grammar is not None:
             return self.grammar.move_vocab_mask(vocab_mask, device)
@@ -177,6 +195,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
             self.enable_token_filter,
             self.token_filter_fn,
             self.allocate_vocab_mask_fn,
+            self.is_vocab_mask_allowed_token_fn,
             self.move_vocab_mask_fn,
             self.apply_vocab_mask_fn,
         )
@@ -295,6 +314,9 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
             enable_token_filter=self.enable_token_filter,
             token_filter_fn=self._token_filter_fn,
             allocate_vocab_mask_fn=self.grammar_backend.allocate_vocab_mask,
+            is_vocab_mask_allowed_token_fn=(
+                self.grammar_backend.is_vocab_mask_allowed_token
+            ),
             move_vocab_mask_fn=self.grammar_backend.move_vocab_mask,
             apply_vocab_mask_fn=self.grammar_backend.apply_vocab_mask,
         )

--- a/python/sglang/srt/constrained/utils.py
+++ b/python/sglang/srt/constrained/utils.py
@@ -1,4 +1,6 @@
-from typing import Dict
+from typing import Dict, Optional
+
+import torch
 
 
 def is_legacy_structural_tag(obj: Dict) -> bool:
@@ -10,3 +12,30 @@ def is_legacy_structural_tag(obj: Dict) -> bool:
     else:
         assert obj.get("format", None) is not None
         return False
+
+
+def is_packed_bitmask_allowed_token(
+    vocab_mask: torch.Tensor,
+    token_id: int,
+    vocab_size: Optional[int] = None,
+) -> bool:
+    if vocab_size is not None and token_id >= vocab_size:
+        return False
+
+    packed_idx = token_id // 32
+    if packed_idx >= vocab_mask.shape[-1]:
+        return False
+    packed_value = int(vocab_mask[packed_idx].item())
+    return (packed_value & (1 << (token_id % 32))) != 0
+
+
+def is_dense_bool_mask_allowed_token(
+    vocab_mask: torch.Tensor,
+    token_id: int,
+    vocab_size: Optional[int] = None,
+) -> bool:
+    if vocab_size is not None and token_id >= vocab_size:
+        return False
+    if token_id >= vocab_mask.shape[-1]:
+        return False
+    return not bool(vocab_mask[token_id].item())

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -35,7 +35,10 @@ from sglang.srt.constrained.base_grammar_backend import (
     GrammarStats,
     InvalidGrammarObject,
 )
-from sglang.srt.constrained.utils import is_legacy_structural_tag
+from sglang.srt.constrained.utils import (
+    is_legacy_structural_tag,
+    is_packed_bitmask_allowed_token,
+)
 from sglang.srt.utils import is_hip
 
 _is_hip = is_hip()
@@ -104,6 +107,14 @@ class XGrammarGrammar(BaseGrammarObject):
 
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
         self.matcher.fill_next_token_bitmask(vocab_mask, idx)
+
+    def is_vocab_mask_allowed_token(
+        self,
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        return is_packed_bitmask_allowed_token(vocab_mask, token_id, vocab_size)
 
     @staticmethod
     def move_vocab_mask(vocab_mask: torch.Tensor, device) -> torch.Tensor:
@@ -229,6 +240,14 @@ class XGrammarGrammarBackend(BaseGrammarBackend):
     @staticmethod
     def allocate_vocab_mask(vocab_size: int, batch_size: int, device) -> torch.Tensor:
         return allocate_token_bitmask(batch_size, vocab_size)
+
+    @staticmethod
+    def is_vocab_mask_allowed_token(
+        vocab_mask: torch.Tensor,
+        token_id: int,
+        vocab_size: Optional[int] = None,
+    ) -> bool:
+        return is_packed_bitmask_allowed_token(vocab_mask, token_id, vocab_size)
 
     @staticmethod
     def move_vocab_mask(vocab_mask: torch.Tensor, device) -> torch.Tensor:

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -339,14 +339,12 @@ def traverse_tree(
             is_accepted = True
         else:
             parent_bitmask = allocate_token_bitmask[parent_pos]
-            curr_token_id = draft_tokens[curr]
-            if vocab_size and curr_token_id >= vocab_size:
-                is_accepted = False
-            else:
-                # 32 boolean bitmask values are packed into 32-bit integers
-                is_accepted = (
-                    parent_bitmask[curr_token_id // 32] & (1 << (curr_token_id % 32))
-                ) != 0
+            curr_token_id = int(draft_tokens[curr])
+            is_accepted = grammar.is_vocab_mask_allowed_token(
+                parent_bitmask,
+                curr_token_id,
+                vocab_size=vocab_size,
+            )
 
         if is_accepted:
             if curr != 0:

--- a/test/registered/unit/constrained/test_outlines_backend.py
+++ b/test/registered/unit/constrained/test_outlines_backend.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for sglang.srt.constrained.outlines_backend.
+
+Test Coverage:
+- OutlinesGrammar: rollback state history, dense bool vocab masks, copy
+  semantics, and logit mask application.
+
+Usage:
+    python -m pytest test_outlines_backend.py -v
+"""
+
+import unittest
+from dataclasses import dataclass
+
+import torch
+
+from sglang.srt.constrained.outlines_backend import OutlinesGrammar
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(2.0, "stage-a-test-cpu")
+
+
+@dataclass
+class _Instruction:
+    tokens: list[int]
+
+
+class _Guide:
+    def __init__(self):
+        # State machine:
+        #        10        11       12
+        #   0 --------> 1 -----> 3 ----->
+        #   |    20        21
+        #   | --------> 2 ----->
+        # Allowed next tokens:
+        #   state 0: 10, 20
+        #   state 1: 11
+        #   state 2: 21
+        #   state 3: 12
+        self.allowed_tokens = {
+            0: [10, 20],
+            1: [11],
+            2: [21],
+            3: [12],
+        }
+        self.transitions = {
+            (0, 10): 1,
+            (0, 20): 2,
+            (1, 11): 3,
+        }
+
+    def get_next_instruction(self, state):
+        return _Instruction(self.allowed_tokens.get(state, []))
+
+    def get_next_state(self, state, token):
+        return self.transitions.get((state, token), -1)
+
+
+class TestOutlinesGrammarRollback(unittest.TestCase):
+    def test_rollback_and_restore(self):
+        grammar = OutlinesGrammar(_Guide(), None)
+        mask = grammar.allocate_vocab_mask(vocab_size=32, batch_size=3, device="cpu")
+
+        grammar.fill_vocab_mask(mask, 0)
+        self.assertTrue(grammar.is_vocab_mask_allowed_token(mask[0], 10))
+        self.assertTrue(grammar.is_vocab_mask_allowed_token(mask[0], 20))
+        self.assertFalse(grammar.is_vocab_mask_allowed_token(mask[0], 11))
+
+        grammar.accept_token(10)
+        self.assertEqual(grammar.state, 1)
+        grammar.fill_vocab_mask(mask, 1)
+        self.assertTrue(grammar.is_vocab_mask_allowed_token(mask[1], 11))
+        self.assertFalse(grammar.is_vocab_mask_allowed_token(mask[1], 21))
+
+        grammar.rollback(1)
+        self.assertEqual(grammar.state, 0)
+
+        grammar.accept_token(20)
+        self.assertEqual(grammar.state, 2)
+        grammar.fill_vocab_mask(mask, 2)
+        self.assertTrue(grammar.is_vocab_mask_allowed_token(mask[2], 21))
+        self.assertFalse(grammar.is_vocab_mask_allowed_token(mask[2], 11))
+
+    def test_rollback_multiple_tokens_and_bounds(self):
+        grammar = OutlinesGrammar(_Guide(), None)
+        grammar.accept_token(10)
+        grammar.accept_token(11)
+        self.assertEqual(grammar.state, 3)
+
+        grammar.rollback(0)
+        self.assertEqual(grammar.state, 3)
+
+        grammar.rollback(1)
+        self.assertEqual(grammar.state, 1)
+
+        grammar.rollback(1)
+        self.assertEqual(grammar.state, 0)
+
+        with self.assertRaisesRegex(ValueError, "Cannot rollback 1 tokens"):
+            grammar.rollback(1)
+
+    def test_rollback_multiple_tokens_at_once(self):
+        grammar = OutlinesGrammar(_Guide(), None)
+        grammar.accept_token(10)
+        grammar.accept_token(11)
+
+        grammar.rollback(2)
+
+        self.assertEqual(grammar.state, 0)
+
+
+class TestOutlinesGrammarApis(unittest.TestCase):
+    def test_dense_bool_vocab_mask_and_apply_mask(self):
+        grammar = OutlinesGrammar(_Guide(), None)
+        mask = grammar.allocate_vocab_mask(vocab_size=32, batch_size=1, device="cpu")
+
+        self.assertEqual(mask.shape, (1, 32))
+        self.assertEqual(mask.dtype, torch.bool)
+        self.assertFalse(mask.any().item())
+        self.assertIs(grammar.move_vocab_mask(mask, "cpu"), mask)
+
+        grammar.fill_vocab_mask(mask, 0)
+        self.assertTrue(grammar.is_vocab_mask_allowed_token(mask[0], 10))
+        self.assertTrue(grammar.is_vocab_mask_allowed_token(mask[0], 20))
+        self.assertFalse(grammar.is_vocab_mask_allowed_token(mask[0], 11))
+        self.assertFalse(grammar.is_vocab_mask_allowed_token(mask[0], 32))
+        self.assertFalse(
+            grammar.is_vocab_mask_allowed_token(mask[0], 20, vocab_size=20)
+        )
+
+        logits = torch.zeros(1, 32)
+        grammar.apply_vocab_mask(logits, mask)
+        self.assertEqual(logits[0, 10].item(), 0.0)
+        self.assertEqual(logits[0, 20].item(), 0.0)
+        self.assertTrue(torch.isneginf(logits[0, 11]).item())
+
+    def test_copy_returns_fresh_grammar(self):
+        guide = _Guide()
+        grammar = OutlinesGrammar(guide, None)
+        grammar.accept_token(10)
+        self.assertEqual(grammar.state, 1)
+
+        copied = grammar.copy()
+
+        self.assertIs(copied.guide, guide)
+        self.assertEqual(copied.state, 0)
+        with self.assertRaisesRegex(ValueError, "Cannot rollback 1 tokens"):
+            copied.rollback(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/constrained/test_utils.py
+++ b/test/registered/unit/constrained/test_utils.py
@@ -11,7 +11,13 @@ Usage:
 
 import unittest
 
-from sglang.srt.constrained.utils import is_legacy_structural_tag
+import torch
+
+from sglang.srt.constrained.utils import (
+    is_dense_bool_mask_allowed_token,
+    is_legacy_structural_tag,
+    is_packed_bitmask_allowed_token,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(1.0, "base-a-test-cpu")
@@ -69,6 +75,28 @@ class TestIsLegacyStructuralTag(unittest.TestCase):
             "format": {"type": "json_schema"},
         }
         self.assertTrue(is_legacy_structural_tag(obj))
+
+
+class TestVocabMaskAllowedTokenUtils(unittest.TestCase):
+    def test_packed_bitmask_allowed_token(self):
+        vocab_mask = torch.zeros(2, dtype=torch.int32)
+        vocab_mask[0] = 1 << 7
+        vocab_mask[1] = 1 << 2
+
+        self.assertTrue(is_packed_bitmask_allowed_token(vocab_mask, 7, vocab_size=64))
+        self.assertFalse(is_packed_bitmask_allowed_token(vocab_mask, 8, vocab_size=64))
+        self.assertTrue(is_packed_bitmask_allowed_token(vocab_mask, 34, vocab_size=64))
+        self.assertFalse(is_packed_bitmask_allowed_token(vocab_mask, 34, vocab_size=34))
+        self.assertFalse(is_packed_bitmask_allowed_token(vocab_mask, 64, vocab_size=64))
+
+    def test_dense_bool_mask_allowed_token(self):
+        # Dense bool masks use False for allowed tokens and True for masked tokens.
+        vocab_mask = torch.tensor([True, False, True, False], dtype=torch.bool)
+
+        self.assertTrue(is_dense_bool_mask_allowed_token(vocab_mask, 1, vocab_size=4))
+        self.assertFalse(is_dense_bool_mask_allowed_token(vocab_mask, 0, vocab_size=4))
+        self.assertFalse(is_dense_bool_mask_allowed_token(vocab_mask, 4, vocab_size=4))
+        self.assertFalse(is_dense_bool_mask_allowed_token(vocab_mask, 3, vocab_size=3))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_spec_utils_traverse_tree.py
+++ b/test/registered/unit/spec/test_spec_utils_traverse_tree.py
@@ -11,10 +11,111 @@ from unittest.mock import MagicMock
 
 import torch
 
+from sglang.srt.constrained.utils import is_packed_bitmask_allowed_token
 from sglang.srt.speculative.spec_utils import traverse_tree
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class TestIsVocabMaskAllowedToken(unittest.TestCase):
+    def test_outlines_dense_bool_mask(self):
+        from sglang.srt.constrained.outlines_backend import OutlinesGrammar
+
+        # Outlines uses dense bool masks: False means allowed, True means masked.
+        vocab_mask = torch.tensor([True, False, True, False], dtype=torch.bool)
+
+        self.assertTrue(
+            OutlinesGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 1, vocab_size=4
+            )
+        )
+        self.assertFalse(
+            OutlinesGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 0, vocab_size=4
+            )
+        )
+        self.assertFalse(
+            OutlinesGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 4, vocab_size=4
+            )
+        )
+        self.assertFalse(
+            OutlinesGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 3, vocab_size=3
+            )
+        )
+
+    def test_xgrammar_packed_bitmask(self):
+        from sglang.srt.constrained.xgrammar_backend import XGrammarGrammar
+
+        vocab_mask = torch.zeros(2, dtype=torch.int32)
+        vocab_mask[0] = 1 << 3
+        vocab_mask[1] = 1 << 3
+
+        self.assertTrue(
+            XGrammarGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 3, vocab_size=64
+            )
+        )
+        self.assertFalse(
+            XGrammarGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 4, vocab_size=64
+            )
+        )
+        self.assertTrue(
+            XGrammarGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 35, vocab_size=64
+            )
+        )
+        self.assertFalse(
+            XGrammarGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 64, vocab_size=64
+            )
+        )
+
+    def test_llguidance_packed_bitmask(self):
+        from sglang.srt.constrained.llguidance_backend import GuidanceGrammar
+
+        vocab_mask = torch.zeros(2, dtype=torch.int32)
+        vocab_mask[0] = 1 << 7
+        vocab_mask[1] = 1 << 2
+
+        self.assertTrue(
+            GuidanceGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 7, vocab_size=64
+            )
+        )
+        self.assertFalse(
+            GuidanceGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 8, vocab_size=64
+            )
+        )
+        self.assertTrue(
+            GuidanceGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 34, vocab_size=64
+            )
+        )
+        self.assertFalse(
+            GuidanceGrammar.is_vocab_mask_allowed_token(
+                None, vocab_mask, 34, vocab_size=34
+            )
+        )
+
+    def test_reasoner_delegates_to_inner_grammar(self):
+        from sglang.srt.constrained.reasoner_grammar_backend import (
+            ReasonerGrammarObject,
+        )
+
+        inner = MagicMock()
+        inner.is_vocab_mask_allowed_token.return_value = False
+        obj = ReasonerGrammarObject(inner, think_end_id=99)
+        vocab_mask = torch.zeros(1, dtype=torch.int32)
+
+        self.assertFalse(obj.is_vocab_mask_allowed_token(vocab_mask, 0, vocab_size=1))
+        inner.is_vocab_mask_allowed_token.assert_called_once_with(
+            vocab_mask, 0, vocab_size=1
+        )
 
 
 class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):
@@ -24,6 +125,7 @@ class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):
         grammar.is_terminated.return_value = False
         accept_calls = []
         fill_calls = []
+        allowed_calls = []
 
         def record_accept(token):
             if isinstance(token, torch.Tensor):
@@ -35,10 +137,22 @@ class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):
                 raise TypeError(f"fill_vocab_mask got torch.Tensor idx: {idx!r}")
             fill_calls.append(idx)
 
+        def record_is_vocab_mask_allowed_token(vocab_mask, token_id, vocab_size=None):
+            if isinstance(token_id, torch.Tensor):
+                raise TypeError(
+                    "is_vocab_mask_allowed_token got torch.Tensor token_id: "
+                    f"{token_id!r}"
+                )
+            allowed_calls.append((token_id, vocab_size))
+            return is_packed_bitmask_allowed_token(vocab_mask, token_id, vocab_size)
+
         grammar.accept_token.side_effect = record_accept
         grammar.fill_vocab_mask.side_effect = record_fill
+        grammar.is_vocab_mask_allowed_token.side_effect = (
+            record_is_vocab_mask_allowed_token
+        )
         grammar.rollback.return_value = None
-        return grammar, accept_calls, fill_calls
+        return grammar, accept_calls, fill_calls, allowed_calls
 
     def test_branching_tree_passes_ints(self):
         # Binary tree exercises both child recursion and sibling recursion:
@@ -50,7 +164,7 @@ class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):
         # all bits set: every draft token passes the parent's bitmask check
         bitmask = torch.full((4, 4), -1, dtype=torch.int32)
 
-        grammar, accept_calls, fill_calls = self._record_grammar()
+        grammar, accept_calls, fill_calls, allowed_calls = self._record_grammar()
         traverse_tree(
             retrieve_next_token,
             retrieve_next_sibling,
@@ -61,8 +175,12 @@ class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):
 
         self.assertEqual(set(accept_calls), {11, 22, 33})
         self.assertEqual(set(fill_calls), {0, 1, 2, 3})
+        self.assertEqual(set(allowed_calls), {(11, None), (22, None), (33, None)})
         for token in accept_calls:
             self.assertIsInstance(token, int)
+        for token, vocab_size in allowed_calls:
+            self.assertIsInstance(token, int)
+            self.assertIsNone(vocab_size)
         for idx in fill_calls:
             self.assertIsInstance(idx, int)
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/sgl-project/sglang/issues/24413.

## Modifications

- Add a backend-neutral `is_vocab_mask_allowed_token(...)` interface for grammar objects/backends.
- Use that interface in speculative `traverse_tree()` instead of hard-coding packed-bitmask logic.
- Implement packed-mask membership for packed-bitmask backends and dense bool membership for outlines.
- Add `OutlinesGrammar.rollback()` with state history so speculative DFS can safely visit sibling branches.
- Delegate the new membership interface through `ReasonerGrammarObject`.
- Add focused unit tests for dense bool membership, packed bitmask membership, Outlines rollback, and speculative traversal.

## Accuracy Tests

Manual JSON-schema accuracy matrix on `Qwen/Qwen3-8B` using the OpenAI chat API, `NousResearch/json-mode-eval`, `num_jsons=50`, `parallel=8`, `max_tokens=2048`, and `temperature=0`.

Environment:

```text
GPU: NVIDIA H100 80GB HBM3
CUDA driver: 580.126.09
CUDA_HOME: /usr/local/cuda
NVCC: 12.4.131
Python: 3.11.10
PyTorch: 2.11.0+cu130
sglang-kernel: 0.4.2.post1
outlines: 0.1.11
xgrammar: 0.2.0
transformers: 5.6.0
```

Server parameters:

```text
python -m sglang.launch_server \
  --model-path Qwen/Qwen3-8B \
  --host 127.0.0.1 \
  --port 30000 \
  --reasoning-parser qwen3 \
  --dtype bfloat16 \
  --mem-fraction-static 0.7 \
  --cuda-graph-max-bs 8 \
  --grammar-backend <xgrammar|outlines>
```

Speculative parameters:

```text
--speculative-algorithm EAGLE3
--speculative-draft-model-path thoughtworks/Qwen3-8B-Eagle3
--speculative-num-steps 4
--speculative-eagle-topk 1
--speculative-num-draft-tokens 5
```

Request shape: `/v1/chat/completions` with `response_format.type = "json_schema"`, `separate_reasoning = true`, and `chat_template_kwargs.enable_thinking = true/false`.

Results:

| Grammar backend | Thinking | Spec | Valid / Total | Accuracy | Failed indexes | Latency (s) | Avg spec accept length |
| --- | --- | --- | ---: | ---: | --- | ---: | ---: |
| xgrammar | off | off | 49 / 50 | 98% | `[1]` | 15.127 | - |
| xgrammar | off | on | 49 / 50 | 98% | `[1]` | 8.498 | 3.782 |
| xgrammar | on | off | 47 / 50 | 94% | `[1, 15, 36]` | 26.136 | - |
| xgrammar | on | on | 47 / 50 | 94% | `[1, 15, 36]` | 18.058 | 2.453 |
| outlines | off | off | 49 / 50 | 98% | `[15]` | 105.723 | - |
| outlines | off | on | 49 / 50 | 98% | `[15]` | 111.509 | 3.321 |
| outlines | on | off | 49 / 50 | 98% | `[36]` | 124.048 | - |
| outlines | on | on | 49 / 50 | 98% | `[36]` | 122.241 | 2.422 |

The important regression signal is that speculative decoding does not introduce new failures for either xgrammar or outlines. For outlines, the spec and non-spec failure sets match in both thinking modes, while `avg_spec_accept_length > 1` confirms the speculative path was exercised.

Failure notes:

- xgrammar index `1` in non-thinking mode is a length/formatting artifact with extra generated text after a valid JSON object.
- xgrammar thinking indexes `1` and `15` return `{}` and fail required fields in both spec and non-spec.
- outlines index `15` in non-thinking mode is a backend/schema behavior difference that appears in both spec and non-spec.
- outlines index `36` in thinking mode is a length failure with empty final content in both spec and non-spec.

**These failures are not introduced by this change because each failure set is unchanged between spec and non-spec for the same backend and thinking mode.**

## Speed Tests and Profiling

Speculative speedup from the same 50-example matrix:

| Grammar backend | Thinking | Non-spec latency (s) | Spec latency (s) | Speedup |
| --- | --- | ---: | ---: | ---: |
| xgrammar | off | 15.127 | 8.498 | 1.78x |
| xgrammar | on | 26.136 | 18.058 | 1.45x |
| outlines | off | 105.723 | 111.509 | 0.95x |
| outlines | on | 124.048 | 122.241 | 1.01x |

The limited speculative gain for outlines may be related to the performance characteristics of the outlines backend itself, because it uses dense bool vocab masks and `masked_fill_` rather than the packed int32 bitmasks used by xgrammar. This does not affect the correctness of this fix: speculative decoding preserves the same pass/fail behavior as non-spec decoding, and `avg_spec_accept_length > 1` confirms that the speculative path is exercised. 

**Performance can be revisited later by upgrading the outlines version or optimizing the outlines mask path.**

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27146951607](https://github.com/sgl-project/sglang/actions/runs/27146951607)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27146951499](https://github.com/sgl-project/sglang/actions/runs/27146951499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->