### PR TITLE
ci: run H20 stage with CUDA 13

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1182,7 +1182,6 @@ jobs:
     timeout-minutes: 240
     env:
       SGLANG_CI_RDMA_ALL_DEVICES: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
-      CU_VERSION: cu129
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Start running the H20 CI stage with CUDA 13.

The H20 runner is already using CUDA 13.0, but `stage-c-test-8-gpu-h20` currently forces CUDA 12.9 dependencies via `CU_VERSION: cu129`. This causes DeepEP extension build failure during dependency installation.

Failure log: https://github.com/sgl-project/sglang/actions/runs/25635867709/job/75247521703#step:6:1

```text
copying deep_ep/__init__.py -> build/lib.linux-x86_64-cpython-312/deep_ep
running build_ext
Traceback (most recent call last):
  File "/root/.cache/deepep/setup.py", line 110, in <module>
    setuptools.setup(
  File "/usr/local/lib/python3.12/dist-packages/setuptools/__init__.py", line 103, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/core.py", line 184, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/core.py", line 200, in run_commands
    dist.run_commands()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 969, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/dist.py", line 968, in run_command
    super().run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/install.py", line 87, in run
    self.do_egg_install()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/install.py", line 139, in do_egg_install
    self.run_command('bdist_egg')
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/cmd.py", line 316, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/dist.py", line 968, in run_command
    super().run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/bdist_egg.py", line 167, in run
    cmd = self.call_command('install_lib', warn_dir=0)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/bdist_egg.py", line 153, in call_command
    self.run_command(cmdname)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/cmd.py", line 316, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/dist.py", line 968, in run_command
    super().run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/install_lib.py", line 11, in run
    self.build()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/command/install_lib.py", line 110, in build
    self.run_command('build_ext')
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/cmd.py", line 316, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/dist.py", line 968, in run_command
    super().run_command(command)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.12/dist-packages/setuptools/command/build_ext.py", line 91, in run
    _build_ext.run(self)
  File "/usr/local/lib/python3.12/dist-packages/setuptools/_distutils/command/build_ext.py", line 359, in run
    self.build_extensions()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/cpp_extension.py", line 716, in build_extensions
    _check_cuda_version(compiler_name, compiler_version)
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/cpp_extension.py", line 545, in _check_cuda_version
    raise RuntimeError(CUDA_MISMATCH_MESSAGE, cuda_str_version, torch.version.cuda)
RuntimeError: ('The detected CUDA version (%s) mismatches the version that was used to compilePyTorch (%s). Please make sure to use the same CUDA versions.', '13.0', '12.9')
```

## Modifications

Remove the `CU_VERSION: cu129` override from `stage-c-test-8-gpu-h20`, matching the H100 stage behavior. The CUDA version now falls back to the default in `scripts/ci/cuda/ci_install_dependency.sh`, which is `cu130`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`git diff --check`)
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Not applicable for workflow-only change.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable for workflow-only change.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable for workflow-only change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
