### PR TITLE
[sglang-miles] Cherry-pick #24767: Make request dump robust to unpicklable server_args and large meta_info

### DIFF
--- a/python/sglang/srt/managers/configure_logging.py
+++ b/python/sglang/srt/managers/configure_logging.py
@@ -33,15 +33,30 @@ if __name__ == "__main__":
         "--dump-requests-folder", type=str, default="/tmp/sglang_request_dump"
     )
     parser.add_argument("--dump-requests-threshold", type=int, default=1000)
+    parser.add_argument(
+        "--dump-requests-exclude-meta-keys",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated meta_info keys to strip from each dumped request "
+            "(e.g. 'routed_experts,hidden_states'). Pass an empty string to "
+            "keep all keys. If not set, the server default is used."
+        ),
+    )
     args = parser.parse_args()
 
-    response = requests.post(
-        args.url + "/configure_logging",
-        json={
-            "log_requests": args.log_requests,
-            "log_requests_level": args.log_requests_level,  # Log full requests
-            "dump_requests_folder": args.dump_requests_folder,
-            "dump_requests_threshold": args.dump_requests_threshold,
-        },
-    )
+    payload = {
+        "log_requests": args.log_requests,
+        "log_requests_level": args.log_requests_level,  # Log full requests
+        "dump_requests_folder": args.dump_requests_folder,
+        "dump_requests_threshold": args.dump_requests_threshold,
+    }
+    if args.dump_requests_exclude_meta_keys is not None:
+        payload["dump_requests_exclude_meta_keys"] = [
+            k.strip()
+            for k in args.dump_requests_exclude_meta_keys.split(",")
+            if k.strip()
+        ]
+
+    response = requests.post(args.url + "/configure_logging", json=payload)
     assert response.status_code == 200

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1610,6 +1610,7 @@ class ConfigureLoggingReq(BaseReq):
     dump_requests_folder: Optional[str] = None
     dump_requests_threshold: Optional[int] = None
     crash_dump_folder: Optional[str] = None
+    dump_requests_exclude_meta_keys: Optional[List[str]] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -357,6 +357,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
         # Dumping
         self.dump_requests_folder = ""  # By default do not dump
         self.dump_requests_threshold = 1000
+        self.dump_requests_exclude_meta_keys: List[str] = [
+            "routed_experts",
+            "hidden_states",
+        ]
         self.dump_request_list: List[Tuple] = []
         self.crash_dump_request_list: deque[Tuple] = deque()
         self.crash_dump_performed = False  # Flag to ensure dump is only called once
@@ -1482,6 +1486,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
             self.dump_requests_folder = obj.dump_requests_folder
         if obj.dump_requests_threshold is not None:
             self.dump_requests_threshold = obj.dump_requests_threshold
+        if obj.dump_requests_exclude_meta_keys is not None:
+            self.dump_requests_exclude_meta_keys = list(
+                obj.dump_requests_exclude_meta_keys
+            )
         if obj.crash_dump_folder is not None:
             self.crash_dump_folder = obj.crash_dump_folder
         logging.info(f"Config logging: {obj=}")
@@ -2028,6 +2036,16 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):
+        if self.dump_requests_exclude_meta_keys and isinstance(
+            out_dict.get("meta_info"), dict
+        ):
+            exclude = self.dump_requests_exclude_meta_keys
+            if any(k in out_dict["meta_info"] for k in exclude):
+                filtered_meta = {
+                    k: v for k, v in out_dict["meta_info"].items() if k not in exclude
+                }
+                out_dict = {**out_dict, "meta_info": filtered_meta}
+
         self.dump_request_list.append(
             (
                 state.obj,
@@ -2078,7 +2096,20 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
         def background_task():
             os.makedirs(os.path.dirname(filename), exist_ok=True)
             with open(filename, "wb") as f:
-                pickle.dump(to_dump_with_server_args, f)
+                try:
+                    pickle.dump(to_dump_with_server_args, f)
+                except Exception as e:
+                    # When the server is launched with --trust-remote-code,
+                    # server_args sometimes fails to pickle. Retry without
+                    # server_args so the request data still gets persisted.
+                    logger.error(
+                        f"Failed to pickle dump with server_args: {e!r}; "
+                        "retrying without server_args"
+                    )
+                    f.seek(0)
+                    f.truncate()
+                    to_dump_with_server_args["server_args"] = None
+                    pickle.dump(to_dump_with_server_args, f)
 
         asyncio.create_task(asyncio.to_thread(background_task))
 
@@ -2137,7 +2168,20 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerScoreMixin):
             "launch_command": " ".join(sys.argv),
         }
         with open(filename, "wb") as f:
-            pickle.dump(data_to_dump_with_server_args, f)
+            try:
+                pickle.dump(data_to_dump_with_server_args, f)
+            except Exception as e:
+                # When the server is launched with --trust-remote-code,
+                # server_args sometimes fails to pickle. Retry without
+                # server_args so the request data still gets persisted.
+                logger.error(
+                    f"Failed to pickle dump with server_args: {e!r}; "
+                    "retrying without server_args"
+                )
+                f.seek(0)
+                f.truncate()
+                data_to_dump_with_server_args["server_args"] = None
+                pickle.dump(data_to_dump_with_server_args, f)
         logger.error(
             f"Dumped {len(self.crash_dump_request_list)} finished and {len(unfinished_requests)} unfinished requests before crash to {filename}"
         )


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/sgl-project/sglang/pull/24767 (merge commit `1e6c6d1`) onto `sglang-miles`.

- Wraps pickle dump in try/except; on failure retries with `server_args=None` so request data is still persisted
- Adds configurable `dump_requests_exclude_meta_keys` to strip bulky keys (`routed_experts`, `hidden_states`) from meta_info in dumps
- Surfaces the option in the configure_logging CLI as `--dump-requests-exclude-meta-keys`

**Conflict resolution:** None — clean cherry-pick (auto-merged).

## Test plan

- Existing request dump tests should pass
- Manual verification with `--trust-remote-code` models that previously caused pickle failures

Made with [Cursor](https://cursor.com)