### PR TITLE
[sglang-miles] Cherry-pick #24854: Call torch.cuda.empty_cache() for in-place pause mode to avoid OOM

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1220,7 +1220,12 @@ class PauseGenerationReqInput(BaseReq):
 
 @dataclass
 class ContinueGenerationReqInput(BaseReq):
-    pass
+    # Call torch.cuda.empty_cache() before un-pausing. Returns blocks
+    # cached by the PyTorch allocator (left over from transient allocs
+    # during post-weight-update processing) back to the driver before
+    # inference resumes, with no race against active streams. Set to
+    # False to skip the empty_cache call.
+    torch_empty_cache: bool = True
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3376,6 +3376,15 @@ class Scheduler(
             self.chunked_req = None
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):
+        if recv_req.torch_empty_cache:
+            before_mb = torch.cuda.memory_reserved() / (1024 * 1024)
+            torch.cuda.empty_cache()
+            after_mb = torch.cuda.memory_reserved() / (1024 * 1024)
+            logger.info(
+                f"[continue_generation] torch.cuda.empty_cache() called: "
+                f"reserved {before_mb:.1f} MB -> {after_mb:.1f} MB "
+                f"(freed {before_mb - after_mb:.1f} MB)"
+            )
         self._engine_paused = False
 
     def load_lora_adapter(


### PR DESCRIPTION
## Summary

Cherry-pick of https://github.com/sgl-project/sglang/pull/24854 (merge commit `cfd3fd0`) onto `sglang-miles`.

- Adds `torch_empty_cache: bool = True` to `ContinueGenerationReqInput`
- Scheduler calls `torch.cuda.empty_cache()` while still paused (no race with active streams) for the `in-place` pause mode
- Logs reserved-memory delta at INFO level for observability
- Callers can opt out with `torch_empty_cache=False`

Fixes OOM after repeated weight updates in RL training loops where `in-place` pause mode skips `flush_cache` (and thus never called `empty_cache()`).

**Conflict resolution:** None — clean cherry-pick (auto-merged).

## Test plan

- Verified with 1-node Qwen3-30B-A3B agg recipe, in-place pause + routing replay: log fires every resume, stable memory

Made with [Cursor](https://cursor.com)