### PR TITLE
[Gateway] gRPC: strip tokenizer EOS ids in StopDecoder

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -196,3 +196,20 @@ codegen-units = 1
 [profile.dev-opt]
 inherits = "dev"
 opt-level = 1
+
+# Use the upstream smg `crates/tokenizer/` from a pinned sha instead of the
+# crates.io 1.3.2 release. The published 1.3.2 is missing several Kimi-K2 /
+# Kimi-K2.5 fixes that landed upstream after the version was bumped, notably:
+#   * smg PR #1044 — `encode_with_special_tokens` so Kimi-K2.5 chat templates
+#     don't BPE-split `<|media_pad|>` etc.
+#   * smg PR #1122 — load EOS token IDs from `config.json` +
+#     `generation_config.json` (Kimi-K2.5's `[EOS]` and `<|im_end|>` live in
+#     different files), exposed via `Tokenizer::eos_token_ids()` and consumed
+#     by `create_stop_decoder` to strip EOS before decoding.
+#   * smg PRs #1373, #1381 — DeepSeek V3.2/V4 chat-template encoders.
+#
+# To bump: replace `rev` with a newer smg sha, then `cargo update -p
+# llm-tokenizer`. Drop this `[patch]` block once smg publishes a release on
+# crates.io that includes these fixes.
+[patch.crates-io]
+llm-tokenizer = { git = "https://github.com/lightseekorg/smg.git", rev = "46cebe0591c013f8c6f387b16951ff0359dfe1ea" }

--- a/sgl-model-gateway/e2e_test/chat_completions/test_validation.py
+++ b/sgl-model-gateway/e2e_test/chat_completions/test_validation.py
@@ -102,6 +102,195 @@ class TestIgnoreEOS:
 
 
 # =============================================================================
+# EOS Token Stripping Tests (Llama 1B)
+#
+# Verify that EOS tokens are stripped from the gateway's decoded output even
+# when `skip_special_tokens=False`. gRPC backends return raw token IDs
+# including the EOS that ended generation; without the StopDecoder stripping
+# them at the token-id level, EOS strings like `<|eom_id|>` leak into
+# `message.content` (and tool-call arguments).
+#
+# This is the user-visible regression guard for the gateway-half wiring of
+# smg PR #1122 (`create_stop_decoder` consumes `tokenizer.eos_token_ids()`).
+# Ported from upstream smg `e2e_test/chat_completions/test_validation.py`.
+# =============================================================================
+
+
+@pytest.mark.model("llama-1b")
+@pytest.mark.gateway(
+    extra_args=["--tool-call-parser", "llama", "--history-backend", "memory"]
+)
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestEosTokenStripping:
+    """Verify EOS tokens are stripped from output by the gateway StopDecoder.
+
+    Llama-3.2-1B-Instruct lists `<|eom_id|>`, `<|eot_id|>`, `<|end_of_text|>`
+    as EOS tokens via `generation_config.json`; none should appear in
+    `message.content` or tool-call arguments under normal settings.
+    """
+
+    EOS_TOKENS = ["<|eom_id|>", "<|eot_id|>", "<|end_of_text|>"]
+
+    def _assert_no_eos(self, text: str, label: str) -> None:
+        for eos in self.EOS_TOKENS:
+            assert eos not in text, f"{label}: EOS token {eos} leaked into {text!r}"
+
+    def _assert_stopped_on_eos(self, choice, label: str) -> str:
+        """Precondition for any "no EOS leaked" assertion: the model must
+        have actually emitted EOS (finish_reason="stop") and returned
+        non-empty content. Without this, `_assert_no_eos("")` passes
+        vacuously and the test silently no-ops."""
+        assert choice.finish_reason == "stop", (
+            f"{label}: model hit {choice.finish_reason} before EOS — test "
+            f"inconclusive, raise max_tokens or shorten the prompt"
+        )
+        content = choice.message.content
+        assert content, f"{label}: expected non-empty content, got {content!r}"
+        return content
+
+    def test_no_eos_in_content_default(self, setup_backend):
+        """Default settings: EOS must not appear in content."""
+        _, model, client, _ = setup_backend
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hello in one sentence."}],
+            temperature=0,
+            max_tokens=50,
+        )
+        content = self._assert_stopped_on_eos(response.choices[0], "default")
+        self._assert_no_eos(content, "default")
+
+    def test_no_eos_in_content_skip_special_false(self, setup_backend):
+        """`skip_special_tokens=False`: EOS must still be stripped at the
+        token-id level by the StopDecoder. The published llm-tokenizer 1.3.2
+        leaks EOS here, which is the regression this PR's patch fixes."""
+        _, model, client, _ = setup_backend
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hello in one sentence."}],
+            temperature=0,
+            max_tokens=50,
+            extra_body={"skip_special_tokens": False},
+        )
+        content = self._assert_stopped_on_eos(
+            response.choices[0], "skip_special_tokens=False"
+        )
+        self._assert_no_eos(content, "skip_special_tokens=False")
+
+    def test_no_eos_in_streaming_content_skip_special_false(self, setup_backend):
+        """Streaming path: EOS must not leak into any delta or the aggregated
+        content. Exercises `process_streaming_chunks` (non-streaming tests
+        don't reach the per-index stop-decoder cache in streaming.rs)."""
+        _, model, client, _ = setup_backend
+        stream = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hello in one sentence."}],
+            temperature=0,
+            max_tokens=50,
+            stream=True,
+            extra_body={"skip_special_tokens": False},
+        )
+        aggregated = ""
+        finish_reason: str | None = None
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            if choice.delta and choice.delta.content:
+                self._assert_no_eos(choice.delta.content, "streaming delta")
+                aggregated += choice.delta.content
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+        assert finish_reason == "stop", (
+            f"streaming: model hit {finish_reason} before EOS — test " f"inconclusive"
+        )
+        assert aggregated, "streaming: aggregated content is empty"
+        self._assert_no_eos(aggregated, "streaming aggregated")
+
+    def test_no_eos_in_tool_call_with_tools(self, setup_backend):
+        """Tool-call arguments must not contain EOS — even with
+        `skip_special_tokens=False` and a tool-call-parser configured."""
+        _, model, client, _ = setup_backend
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "add",
+                    "description": "Compute the sum of two numbers",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "integer", "description": "A number"},
+                            "b": {"type": "integer", "description": "A number"},
+                        },
+                        "required": ["a", "b"],
+                    },
+                },
+            }
+        ]
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Compute (3+5)"}],
+            tools=tools,
+            tool_choice="required",
+            temperature=0,
+            max_tokens=200,
+            extra_body={"skip_special_tokens": False},
+        )
+        choice = response.choices[0]
+        # `tool_choice="required"` must produce at least one tool_call;
+        # without this guard, an empty tool_calls + empty content silently
+        # passes the test.
+        assert (
+            choice.message.tool_calls
+        ), f"tool_choice=required must produce tool_calls, got {choice.message!r}"
+        for tc in choice.message.tool_calls:
+            self._assert_no_eos(tc.function.arguments, "tool_call.arguments")
+        if choice.message.content:
+            self._assert_no_eos(choice.message.content, "fallback content")
+
+    def test_no_stop_trim_with_skip_special_true(self, setup_backend):
+        """`no_stop_trim=True` + default `skip_special_tokens=True`: EOS
+        is kept in the token-id list but decoded as an empty string, so it
+        must remain invisible in `content`."""
+        _, model, client, _ = setup_backend
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hello in one sentence."}],
+            temperature=0,
+            max_tokens=50,
+            extra_body={"no_stop_trim": True},
+        )
+        content = self._assert_stopped_on_eos(
+            response.choices[0], "no_stop_trim + skip_special=True"
+        )
+        self._assert_no_eos(content, "no_stop_trim + skip_special=True")
+
+    def test_no_stop_trim_with_skip_special_false(self, setup_backend):
+        """`no_stop_trim=True` + `skip_special_tokens=False`: EOS becomes a
+        VISIBLE stop, decoded into `content` (matches sglang behavior)."""
+        _, model, client, _ = setup_backend
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hello in one sentence."}],
+            temperature=0,
+            max_tokens=50,
+            extra_body={"no_stop_trim": True, "skip_special_tokens": False},
+        )
+        choice = response.choices[0]
+        content = choice.message.content
+        assert content is not None
+        assert choice.finish_reason == "stop", (
+            f"Model hit max_tokens before EOS — test inconclusive "
+            f"(finish_reason={choice.finish_reason})"
+        )
+        assert any(eos in content for eos in self.EOS_TOKENS), (
+            f"EOS must be visible with no_stop_trim=True + "
+            f"skip_special_tokens=False, got {content!r}"
+        )
+
+
+# =============================================================================
 # Large Max New Tokens Tests (Llama 8B)
 #
 # NOTE: This test verifies concurrent request handling with large token limits.

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -87,10 +87,13 @@ impl ChatPreparationStage {
         // Step 5: Create stop sequence decoder (build once, reuse in non-stream)
         let stop_decoder = utils::create_stop_decoder(
             &tokenizer,
-            request.stop.as_ref(),
-            request.stop_token_ids.as_ref(),
-            request.skip_special_tokens,
-            request.no_stop_trim,
+            &utils::StopParams {
+                stop: request.stop.clone(),
+                stop_token_ids: request.stop_token_ids.clone(),
+                skip_special_tokens: request.skip_special_tokens,
+                no_stop_trim: request.no_stop_trim,
+                ignore_eos: request.ignore_eos,
+            },
         );
 
         // Store results in context

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -57,13 +57,16 @@ impl GeneratePreparationStage {
         };
 
         // Create stop sequence decoder for generate requests
-        let params = request.sampling_params.as_ref();
+        let sampling = request.sampling_params.as_ref();
         let stop_decoder = utils::create_stop_decoder(
             &tokenizer,
-            params.and_then(|p| p.stop.as_ref()),
-            params.and_then(|p| p.stop_token_ids.as_ref()),
-            params.and_then(|p| p.skip_special_tokens).unwrap_or(true),
-            params.and_then(|p| p.no_stop_trim).unwrap_or(false),
+            &utils::StopParams {
+                stop: sampling.and_then(|p| p.stop.clone()),
+                stop_token_ids: sampling.and_then(|p| p.stop_token_ids.clone()),
+                skip_special_tokens: sampling.and_then(|p| p.skip_special_tokens).unwrap_or(true),
+                no_stop_trim: sampling.and_then(|p| p.no_stop_trim).unwrap_or(false),
+                ignore_eos: sampling.and_then(|p| p.ignore_eos).unwrap_or(false),
+            },
         );
 
         ctx.state.preparation = Some(PreparationOutput {

--- a/sgl-model-gateway/src/routers/grpc/regular/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/streaming.rs
@@ -19,10 +19,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
     protocols::{
         chat::{ChatCompletionRequest, ChatCompletionStreamResponse},
-        common::{
-            FunctionCallDelta, StringOrArray, Tool, ToolCallDelta, ToolChoice, ToolChoiceValue,
-            Usage,
-        },
+        common::{FunctionCallDelta, Tool, ToolCallDelta, ToolChoice, ToolChoiceValue, Usage},
         generate::GenerateRequest,
     },
     reasoning_parser::{ParserFactory as ReasoningParserFactory, ParserResult, ReasoningParser},
@@ -93,12 +90,13 @@ impl StreamingProcessor {
         use bytes::Bytes;
         use tokio::sync::mpsc;
 
-        let stop_params = (
-            chat_request.stop.clone(),
-            chat_request.stop_token_ids.clone(),
-            chat_request.skip_special_tokens,
-            chat_request.no_stop_trim,
-        );
+        let stop_params = utils::StopParams {
+            stop: chat_request.stop.clone(),
+            stop_token_ids: chat_request.stop_token_ids.clone(),
+            skip_special_tokens: chat_request.skip_special_tokens,
+            no_stop_trim: chat_request.no_stop_trim,
+            ignore_eos: chat_request.ignore_eos,
+        };
 
         // Create SSE channel
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -193,7 +191,7 @@ impl StreamingProcessor {
         mut grpc_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: utils::StopParams,
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -298,17 +296,9 @@ impl StreamingProcessor {
                     }
 
                     // Get or create stop decoder for this index
-                    let stop_decoder = stop_decoders.entry(index).or_insert_with(|| {
-                        let (ref stop, ref stop_token_ids, skip_special_tokens, no_stop_trim) =
-                            stop_params;
-                        utils::create_stop_decoder(
-                            &tokenizer,
-                            stop.as_ref(),
-                            stop_token_ids.as_ref(),
-                            skip_special_tokens,
-                            no_stop_trim,
-                        )
-                    });
+                    let stop_decoder = stop_decoders
+                        .entry(index)
+                        .or_insert_with(|| utils::create_stop_decoder(&tokenizer, &stop_params));
 
                     // Process tokens through stop decoder
                     let (chunk_text, _should_stop) =
@@ -612,7 +602,7 @@ impl StreamingProcessor {
         decode_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: utils::StopParams,
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {

--- a/sgl-model-gateway/src/routers/grpc/utils.rs
+++ b/sgl-model-gateway/src/routers/grpc/utils.rs
@@ -516,43 +516,76 @@ pub(crate) fn process_chat_messages(
     })
 }
 
-/// Create a StopSequenceDecoder from stop parameters
+/// Stop-decoder configuration bundle.
+///
+/// Three trailing booleans (`skip_special_tokens`, `no_stop_trim`,
+/// `ignore_eos`) in a positional signature are a silent-reorder footgun:
+/// a typo would compile cleanly and cause subtle decoding bugs. Construct
+/// via named fields instead.
+#[derive(Debug, Clone)]
+pub(crate) struct StopParams {
+    pub(crate) stop: Option<StringOrArray>,
+    pub(crate) stop_token_ids: Option<Vec<u32>>,
+    pub(crate) skip_special_tokens: bool,
+    pub(crate) no_stop_trim: bool,
+    pub(crate) ignore_eos: bool,
+}
+
+/// Create a StopSequenceDecoder from stop parameters.
+///
+/// EOS token IDs come from the tokenizer (`config.json` +
+/// `generation_config.json`) and are added as stop tokens unless
+/// `ignore_eos = true`. With `no_stop_trim = false` (default), EOS is
+/// hidden — stripped before decoding so it never reaches output text.
+/// Direction matches sglang's `no_stop_trim` (off by default, opt-in to
+/// keep EOS visible) and is the inverse polarity of vllm's
+/// `include_stop_str_in_output`.
 pub(crate) fn create_stop_decoder(
     tokenizer: &Arc<dyn Tokenizer>,
-    stop: Option<&StringOrArray>,
-    stop_token_ids: Option<&Vec<u32>>,
-    skip_special_tokens: bool,
-    no_stop_trim: bool,
+    params: &StopParams,
 ) -> StopSequenceDecoder {
-    // Extract stop sequences
-    let stop_sequences: Vec<String> = match stop {
+    let stop_sequences: Vec<String> = match params.stop.as_ref() {
         Some(StringOrArray::String(s)) => vec![s.clone()],
         Some(StringOrArray::Array(arr)) => arr.clone(),
         None => vec![],
     };
 
-    // Build stop sequence decoder
-    let mut builder =
-        StopSequenceDecoderBuilder::new(tokenizer.clone()).skip_special_tokens(skip_special_tokens);
+    let mut builder = StopSequenceDecoderBuilder::new(tokenizer.clone())
+        .skip_special_tokens(params.skip_special_tokens);
 
-    // Add stop sequences (visible if no_stop_trim is true, hidden otherwise)
     for seq in stop_sequences {
-        builder = if no_stop_trim {
+        builder = if params.no_stop_trim {
             builder.visible_stop_sequence(seq)
         } else {
             builder.stop_sequence(seq)
         };
     }
 
-    // Add stop token IDs (visible if no_stop_trim is true, hidden otherwise)
-    if let Some(token_ids) = stop_token_ids {
-        for &token_id in token_ids {
-            builder = if no_stop_trim {
-                builder.visible_stop_token(token_id)
-            } else {
-                builder.stop_token(token_id)
-            };
-        }
+    let eos_ids: &[u32] = if params.ignore_eos {
+        &[]
+    } else {
+        tokenizer.eos_token_ids()
+    };
+    let user_stops = params.stop_token_ids.as_deref().unwrap_or_default();
+
+    // Misconfigured tokenizers silently default `eos_token_ids()` to `&[]`
+    // (see llm-tokenizer's default trait impl). Without any stop token IDs
+    // or stop sequences, generation can only terminate via `max_tokens` —
+    // surface this so a regressed tokenizer registration is visible.
+    if !params.ignore_eos && eos_ids.is_empty() && user_stops.is_empty() {
+        warn!(
+            "create_stop_decoder: tokenizer reported no EOS ids and no \
+             stop_token_ids were provided; generation will rely on stop \
+             sequences or max_tokens to terminate"
+        );
+    }
+
+    for &token_id in eos_ids.iter().chain(user_stops.iter()) {
+        builder = if params.no_stop_trim {
+            builder.visible_stop_token(token_id)
+        } else {
+            builder.stop_token(token_id)
+        };
     }
 
     builder.build()
@@ -1237,5 +1270,188 @@ mod tests {
         assert_eq!(content_array.len(), 2);
         assert_eq!(content_array[0]["type"], "text");
         assert_eq!(content_array[1], json!({"type": "image"}));
+    }
+
+    // ---- create_stop_decoder — EOS handling ----
+
+    use crate::tokenizer::{
+        stop::SequenceDecoderOutput,
+        traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer},
+    };
+    use anyhow::Result;
+
+    /// Test-only tokenizer with caller-controlled EOS IDs. `decode` renders
+    /// each token id as `<id:N>` so a leaked EOS surfaces in the decoder's
+    /// output text — no real vocabulary required.
+    struct EosFakeTokenizer {
+        eos_ids: Vec<TokenIdType>,
+        special_tokens: SpecialTokens,
+    }
+
+    impl EosFakeTokenizer {
+        fn new(eos_ids: Vec<TokenIdType>) -> Self {
+            Self {
+                eos_ids,
+                special_tokens: SpecialTokens::default(),
+            }
+        }
+    }
+
+    impl Encoder for EosFakeTokenizer {
+        fn encode(&self, _: &str, _: bool) -> Result<Encoding> {
+            Ok(Encoding::Plain(vec![]))
+        }
+        fn encode_batch(&self, inputs: &[&str], _: bool) -> Result<Vec<Encoding>> {
+            Ok(inputs.iter().map(|_| Encoding::Plain(vec![])).collect())
+        }
+    }
+
+    impl Decoder for EosFakeTokenizer {
+        fn decode(&self, ids: &[TokenIdType], _: bool) -> Result<String> {
+            Ok(ids.iter().map(|id| format!("<id:{id}>")).collect())
+        }
+    }
+
+    impl Tokenizer for EosFakeTokenizer {
+        fn vocab_size(&self) -> usize {
+            1024
+        }
+        fn get_special_tokens(&self) -> &SpecialTokens {
+            &self.special_tokens
+        }
+        fn token_to_id(&self, _: &str) -> Option<TokenIdType> {
+            None
+        }
+        fn id_to_token(&self, _: TokenIdType) -> Option<String> {
+            None
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn eos_token_ids(&self) -> &[TokenIdType] {
+            &self.eos_ids
+        }
+    }
+
+    fn fake_tokenizer(eos: &[u32]) -> Arc<dyn Tokenizer> {
+        Arc::new(EosFakeTokenizer::new(eos.to_vec()))
+    }
+
+    fn params_for_test(stop_token_ids: Option<Vec<u32>>) -> StopParams {
+        StopParams {
+            stop: None,
+            stop_token_ids,
+            skip_special_tokens: true,
+            no_stop_trim: false,
+            ignore_eos: false,
+        }
+    }
+
+    /// Default arms (`ignore_eos=false`, `no_stop_trim=false`): every EOS the
+    /// tokenizer reports must be registered as a hidden stop, so feeding any
+    /// EOS id stops the decoder with no visible text.
+    #[test]
+    fn create_stop_decoder_strips_each_eos_id_by_default() {
+        let tok = fake_tokenizer(&[100, 200, 300]);
+        for &eos in &[100u32, 200, 300] {
+            let mut d = create_stop_decoder(&tok, &params_for_test(None));
+            assert_eq!(
+                d.process_token(eos).unwrap(),
+                SequenceDecoderOutput::Stopped,
+                "EOS id {eos} must trigger hidden stop"
+            );
+        }
+    }
+
+    /// `ignore_eos=true`: EOS ids must NOT be registered as stop tokens, so
+    /// feeding one passes through as text and lets the backend keep
+    /// generating.
+    #[test]
+    fn create_stop_decoder_skips_eos_when_ignore_eos_true() {
+        let tok = fake_tokenizer(&[100, 200]);
+        let params = StopParams {
+            skip_special_tokens: false,
+            ignore_eos: true,
+            ..params_for_test(None)
+        };
+        let mut d = create_stop_decoder(&tok, &params);
+        match d.process_token(100).unwrap() {
+            SequenceDecoderOutput::Text(_) | SequenceDecoderOutput::Held => {}
+            other => panic!("EOS must not stop when ignore_eos=true, got {other:?}"),
+        }
+        assert!(!d.is_stopped());
+    }
+
+    /// `no_stop_trim=true`: EOS ids must be registered as VISIBLE stops, so
+    /// the EOS string is decoded into the final output (matches sglang's
+    /// `no_stop_trim` semantic).
+    #[test]
+    fn create_stop_decoder_makes_eos_visible_when_no_stop_trim() {
+        let tok = fake_tokenizer(&[100]);
+        let params = StopParams {
+            skip_special_tokens: false,
+            no_stop_trim: true,
+            ..params_for_test(None)
+        };
+        let mut d = create_stop_decoder(&tok, &params);
+        match d.process_token(100).unwrap() {
+            SequenceDecoderOutput::StoppedWithText(text) => {
+                assert!(
+                    text.contains("<id:100>"),
+                    "visible stop must surface EOS in text, got {text:?}"
+                );
+            }
+            other => panic!("EOS must visibly stop with no_stop_trim=true, got {other:?}"),
+        }
+    }
+
+    /// `ignore_eos=true` + `no_stop_trim=true`: EOS ids are still NOT
+    /// registered (ignore_eos wins), so even the visible-stop builder path
+    /// shouldn't fire on an EOS id.
+    #[test]
+    fn create_stop_decoder_ignore_eos_wins_over_no_stop_trim() {
+        let tok = fake_tokenizer(&[100]);
+        let params = StopParams {
+            no_stop_trim: true,
+            ignore_eos: true,
+            ..params_for_test(None)
+        };
+        let mut d = create_stop_decoder(&tok, &params);
+        match d.process_token(100).unwrap() {
+            SequenceDecoderOutput::Text(_) | SequenceDecoderOutput::Held => {}
+            other => panic!("ignore_eos=true must suppress visible EOS stop, got {other:?}"),
+        }
+        assert!(!d.is_stopped());
+    }
+
+    /// User-provided `stop_token_ids` are still honored alongside the EOS ids
+    /// — the chain we build in `create_stop_decoder` mustn't drop them.
+    #[test]
+    fn create_stop_decoder_preserves_user_stop_token_ids() {
+        let tok = fake_tokenizer(&[]);
+        let mut d = create_stop_decoder(&tok, &params_for_test(Some(vec![777])));
+        assert_eq!(
+            d.process_token(777).unwrap(),
+            SequenceDecoderOutput::Stopped
+        );
+    }
+
+    /// Tokenizer with no EOS configured + no user stops + `ignore_eos=false`:
+    /// no stop tokens are registered, so an arbitrary token id passes
+    /// through as text. (The decoder also emits a `tracing::warn!`; we don't
+    /// assert on log output here.)
+    #[test]
+    fn create_stop_decoder_no_eos_no_stops_passes_through() {
+        let tok = fake_tokenizer(&[]);
+        let params = StopParams {
+            skip_special_tokens: false,
+            ..params_for_test(None)
+        };
+        let mut d = create_stop_decoder(&tok, &params);
+        match d.process_token(42).unwrap() {
+            SequenceDecoderOutput::Text(_) | SequenceDecoderOutput::Held => {}
+            other => panic!("no stops registered, decoder must not stop, got {other:?}"),
+        }
+        assert!(!d.is_stopped());
     }
 }


### PR DESCRIPTION
## Summary

- Wires `tokenizer.eos_token_ids()` into the gateway's `create_stop_decoder` and threads `ignore_eos` through chat/generate preparation and the streaming processor. Without this, EOS strings like `<|eom_id|>` leak into `message.content` and tool-call `function.arguments` when callers pass `skip_special_tokens=False`.
- Replaces the positional 5-tuple `stop_params` with a named `StopParams` struct — three trailing booleans (`skip_special_tokens`, `no_stop_trim`, `ignore_eos`) in a positional signature is a silent-reorder footgun.
- Emits `tracing::warn!` when the tokenizer reports no EOS ids and the user provided no `stop_token_ids` — a misconfigured tokenizer (default trait impl returns `&[]`) would otherwise be invisible.
- Pins `llm-tokenizer` to an upstream smg git sha via `[patch.crates-io]`. The published 1.3.2 doesn't have `Tokenizer::eos_token_ids()` (added in smg #1122); the pinned sha also picks up Kimi-K2/K2.5 and DeepSeek chat-template fixes (smg #1044, #1373, #1381). Drop the patch once crates.io has a release with these.

## Semantics

| `skip_special_tokens` | `no_stop_trim` | `ignore_eos` | EOS behavior |
| --- | --- | --- | --- |
| any | `false` (default) | `false` | hidden stop — EOS terminates and is stripped |
| any | `true` | `false` | visible stop — EOS terminates and is decoded into content |
| any | any | `true` | EOS not registered — generation continues until `max_tokens` |

`ignore_eos` wins over `no_stop_trim`. User-provided `stop_token_ids` are honored independently of EOS in all modes.

## Test plan

- [x] `cargo test -p sgl-model-gateway --lib` (370/370 passing locally, including 6 new `create_stop_decoder_*` unit tests)
- [x] `cargo clippy --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `pre-commit run` on changed files
- [ ] Python e2e: `pytest sgl-model-gateway/e2e_test/chat_completions/test_validation.py::TestEosTokenStripping -v` against a Llama-3.2-1B gateway

## New tests

**Rust** (`sgl-model-gateway/src/routers/grpc/utils.rs` — 6 tests with an `EosFakeTokenizer`):
- `create_stop_decoder_strips_each_eos_id_by_default`
- `create_stop_decoder_skips_eos_when_ignore_eos_true`
- `create_stop_decoder_makes_eos_visible_when_no_stop_trim`
- `create_stop_decoder_ignore_eos_wins_over_no_stop_trim`
- `create_stop_decoder_preserves_user_stop_token_ids`
- `create_stop_decoder_no_eos_no_stops_passes_through`

**Python** (`sgl-model-gateway/e2e_test/chat_completions/test_validation.py::TestEosTokenStripping` — 6 tests on Llama-3.2-1B):
- non-streaming default + non-streaming `skip_special_tokens=False`
- **streaming** `skip_special_tokens=False` (exercises `process_streaming_chunks`)
- tool-call with `tool_choice="required"` + `skip_special_tokens=False`
- `no_stop_trim=True` with both `skip_special_tokens` polarities

Each "no EOS leaked" assertion is gated on `finish_reason == "stop"` + non-empty content, so a `max_tokens` cap doesn't make the test pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)