### PR TITLE
Fix CUDA IMA on Blackwell for DRAFT_EXTEND_V2 + trtllm_mha

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -442,6 +442,38 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
 
             self.draft_extend_metadata[bs] = metadata
+        elif forward_mode.is_draft_extend_v2():
+            # DRAFT_EXTEND_V2 routes through the decode kernel (uniform
+            # q_len_per_req = num_tokens_per_bs), so metadata mirrors
+            # TARGET_VERIFY: cache_seqlens_int32 includes the queries.
+            num_tokens_per_bs = num_tokens // bs
+            metadata.cache_seqlens_int32 = self.draft_extend_metadata["cache_seqlens"][
+                :bs
+            ]
+            metadata.cache_seqlens_int32.copy_(seq_lens + num_tokens_per_bs)
+
+            metadata.cu_seqlens_q = torch.arange(
+                0,
+                bs * num_tokens_per_bs + 1,
+                num_tokens_per_bs,
+                dtype=torch.int32,
+                device=device,
+            )
+            metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
+                : (bs + 1)
+            ]
+            metadata.max_seq_len_q = num_tokens_per_bs
+            metadata.max_seq_len_k = seq_lens.max().item() + num_tokens_per_bs
+
+            metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
+            self._bind_swa_page_table(
+                metadata,
+                self.draft_extend_metadata,
+                "swa_page_table",
+                bs,
+            )
+
+            self.draft_extend_metadata[bs] = metadata
         self.forward_metadata = metadata
 
     def init_forward_metadata_replay_cuda_graph(
@@ -547,6 +579,30 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
             self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
+        elif forward_mode.is_draft_extend_v2():
+            # See `init_forward_metadata_capture_cuda_graph` — DRAFT_EXTEND_V2
+            # uses TARGET_VERIFY-style metadata so it can share the decode
+            # kernel. `num_tokens_per_req` is set by the V2 worker on
+            # spec_info (always uniform = speculative_num_steps + 1).
+            num_tokens_per_bs = spec_info.num_tokens_per_req
+            metadata = self.draft_extend_metadata[bs]
+            metadata.cache_seqlens_int32.copy_(seq_lens + num_tokens_per_bs)
+
+            metadata.max_seq_len_q = num_tokens_per_bs
+            metadata.max_seq_len_k = seq_lens_cpu.max().item() + num_tokens_per_bs
+            metadata.cu_seqlens_k[1:].copy_(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
+            )
+
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
+            page_indices = self.req_to_token[
+                req_pool_indices[:, None],
+                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
+            ]
+            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
+            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
         self.forward_metadata = metadata
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:
@@ -640,6 +696,37 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 0,
                 batch_size * self.speculative_num_draft_tokens + 1,
                 self.speculative_num_draft_tokens,
+                dtype=torch.int32,
+                device=device,
+            )
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
+                (1, 0),
+            )
+            metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : metadata.max_seq_len_k
+            ]
+
+        elif forward_batch.forward_mode.is_draft_extend_v2():
+            # DRAFT_EXTEND_V2 uses the same decode kernel as TARGET_VERIFY.
+            # Every request extends by a uniform `num_tokens_per_req`
+            # (= `speculative_num_steps + 1`), set by the V2 worker on
+            # spec_info (`eagle_worker_v2.py` / `multi_layer_eagle_worker_v2.py`).
+            # Metadata mirrors the TARGET_VERIFY branch above, with
+            # `num_tokens_per_req` substituted for `speculative_num_draft_tokens`,
+            # so `cache_seqlens_int32` covers the just-written query K/V slots.
+            num_tokens_per_req = forward_batch.spec_info.num_tokens_per_req
+            metadata.cache_seqlens_int32 = (
+                forward_batch.seq_lens + num_tokens_per_req
+            ).to(torch.int32)
+            metadata.max_seq_len_q = num_tokens_per_req
+            metadata.max_seq_len_k = (
+                forward_batch.seq_lens_cpu.max().item() + num_tokens_per_req
+            )
+            metadata.cu_seqlens_q = torch.arange(
+                0,
+                batch_size * num_tokens_per_req + 1,
+                num_tokens_per_req,
                 dtype=torch.int32,
                 device=device,
             )
@@ -848,23 +935,16 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        # NOTE: DRAFT_EXTEND_V2 cannot reuse the TARGET_VERIFY path here.
-        # `trtllm_batch_decode_with_kv_cache` reads `seq_lens` as the *total*
-        # per-request length (KV cache + draft query tokens).
-        # `init_forward_metadata` sets
-        # `cache_seqlens_int32 = seq_lens + speculative_num_draft_tokens` only
-        # on the `is_target_verify()` branch. DRAFT_EXTEND_V2 has no dedicated
-        # branch and falls into the generic `else`, where
-        # `cache_seqlens_int32 = forward_batch.seq_lens.to(int32)` — KV only,
-        # no query tokens. Routing DRAFT_EXTEND_V2 through the decode kernel
-        # with that metadata makes the kernel read past the populated KV cache
-        # and triggers a CUDA illegal-memory-access on Blackwell.
-        #
-        # If `init_forward_metadata` is later updated to align DRAFT_EXTEND_V2
-        # metadata with TARGET_VERIFY semantics (and matching branches are
-        # added to `init_forward_metadata_{capture,replay}_cuda_graph`),
-        # re-broaden this predicate to recover decode-kernel performance.
-        if forward_batch.forward_mode.is_target_verify():
+        # Both TARGET_VERIFY and DRAFT_EXTEND_V2 have a uniform per-request
+        # query length, so they share the trtllm decode kernel. Their dedicated
+        # branches in `init_forward_metadata` (and the matching cuda-graph
+        # capture/replay branches) build `cache_seqlens_int32` to include the
+        # just-written query K/V slots — required by the decode kernel, which
+        # reads `seq_lens` as the *total* per-request length (KV + queries).
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -848,10 +848,23 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        # NOTE: DRAFT_EXTEND_V2 cannot reuse the TARGET_VERIFY path here.
+        # `trtllm_batch_decode_with_kv_cache` reads `seq_lens` as the *total*
+        # per-request length (KV cache + draft query tokens).
+        # `init_forward_metadata` sets
+        # `cache_seqlens_int32 = seq_lens + speculative_num_draft_tokens` only
+        # on the `is_target_verify()` branch. DRAFT_EXTEND_V2 has no dedicated
+        # branch and falls into the generic `else`, where
+        # `cache_seqlens_int32 = forward_batch.seq_lens.to(int32)` — KV only,
+        # no query tokens. Routing DRAFT_EXTEND_V2 through the decode kernel
+        # with that metadata makes the kernel read past the populated KV cache
+        # and triggers a CUDA illegal-memory-access on Blackwell.
+        #
+        # If `init_forward_metadata` is later updated to align DRAFT_EXTEND_V2
+        # metadata with TARGET_VERIFY semantics (and matching branches are
+        # added to `init_forward_metadata_{capture,replay}_cuda_graph`),
+        # re-broaden this predicate to recover decode-kernel performance.
+        if forward_batch.forward_mode.is_target_verify():
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -442,38 +442,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
 
             self.draft_extend_metadata[bs] = metadata
-        elif forward_mode.is_draft_extend_v2():
-            # DRAFT_EXTEND_V2 routes through the decode kernel (uniform
-            # q_len_per_req = num_tokens_per_bs), so metadata mirrors
-            # TARGET_VERIFY: cache_seqlens_int32 includes the queries.
-            num_tokens_per_bs = num_tokens // bs
-            metadata.cache_seqlens_int32 = self.draft_extend_metadata["cache_seqlens"][
-                :bs
-            ]
-            metadata.cache_seqlens_int32.copy_(seq_lens + num_tokens_per_bs)
-
-            metadata.cu_seqlens_q = torch.arange(
-                0,
-                bs * num_tokens_per_bs + 1,
-                num_tokens_per_bs,
-                dtype=torch.int32,
-                device=device,
-            )
-            metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
-                : (bs + 1)
-            ]
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.max_seq_len_k = seq_lens.max().item() + num_tokens_per_bs
-
-            metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
-            self._bind_swa_page_table(
-                metadata,
-                self.draft_extend_metadata,
-                "swa_page_table",
-                bs,
-            )
-
-            self.draft_extend_metadata[bs] = metadata
         self.forward_metadata = metadata
 
     def init_forward_metadata_replay_cuda_graph(
@@ -579,30 +547,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ]
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
             self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-        elif forward_mode.is_draft_extend_v2():
-            # See `init_forward_metadata_capture_cuda_graph` — DRAFT_EXTEND_V2
-            # uses TARGET_VERIFY-style metadata so it can share the decode
-            # kernel. `num_tokens_per_req` is set by the V2 worker on
-            # spec_info (always uniform = speculative_num_steps + 1).
-            num_tokens_per_bs = spec_info.num_tokens_per_req
-            metadata = self.draft_extend_metadata[bs]
-            metadata.cache_seqlens_int32.copy_(seq_lens + num_tokens_per_bs)
-
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.max_seq_len_k = seq_lens_cpu.max().item() + num_tokens_per_bs
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
         self.forward_metadata = metadata
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:
@@ -696,37 +640,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 0,
                 batch_size * self.speculative_num_draft_tokens + 1,
                 self.speculative_num_draft_tokens,
-                dtype=torch.int32,
-                device=device,
-            )
-            metadata.cu_seqlens_k = torch.nn.functional.pad(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
-                (1, 0),
-            )
-            metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
-                forward_batch.req_pool_indices, : metadata.max_seq_len_k
-            ]
-
-        elif forward_batch.forward_mode.is_draft_extend_v2():
-            # DRAFT_EXTEND_V2 uses the same decode kernel as TARGET_VERIFY.
-            # Every request extends by a uniform `num_tokens_per_req`
-            # (= `speculative_num_steps + 1`), set by the V2 worker on
-            # spec_info (`eagle_worker_v2.py` / `multi_layer_eagle_worker_v2.py`).
-            # Metadata mirrors the TARGET_VERIFY branch above, with
-            # `num_tokens_per_req` substituted for `speculative_num_draft_tokens`,
-            # so `cache_seqlens_int32` covers the just-written query K/V slots.
-            num_tokens_per_req = forward_batch.spec_info.num_tokens_per_req
-            metadata.cache_seqlens_int32 = (
-                forward_batch.seq_lens + num_tokens_per_req
-            ).to(torch.int32)
-            metadata.max_seq_len_q = num_tokens_per_req
-            metadata.max_seq_len_k = (
-                forward_batch.seq_lens_cpu.max().item() + num_tokens_per_req
-            )
-            metadata.cu_seqlens_q = torch.arange(
-                0,
-                batch_size * num_tokens_per_req + 1,
-                num_tokens_per_req,
                 dtype=torch.int32,
                 device=device,
             )
@@ -935,16 +848,23 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        # Both TARGET_VERIFY and DRAFT_EXTEND_V2 have a uniform per-request
-        # query length, so they share the trtllm decode kernel. Their dedicated
-        # branches in `init_forward_metadata` (and the matching cuda-graph
-        # capture/replay branches) build `cache_seqlens_int32` to include the
-        # just-written query K/V slots — required by the decode kernel, which
-        # reads `seq_lens` as the *total* per-request length (KV + queries).
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        # NOTE: DRAFT_EXTEND_V2 cannot reuse the TARGET_VERIFY path here.
+        # `trtllm_batch_decode_with_kv_cache` reads `seq_lens` as the *total*
+        # per-request length (KV cache + draft query tokens).
+        # `init_forward_metadata` sets
+        # `cache_seqlens_int32 = seq_lens + speculative_num_draft_tokens` only
+        # on the `is_target_verify()` branch. DRAFT_EXTEND_V2 has no dedicated
+        # branch and falls into the generic `else`, where
+        # `cache_seqlens_int32 = forward_batch.seq_lens.to(int32)` — KV only,
+        # no query tokens. Routing DRAFT_EXTEND_V2 through the decode kernel
+        # with that metadata makes the kernel read past the populated KV cache
+        # and triggers a CUDA illegal-memory-access on Blackwell.
+        #
+        # If `init_forward_metadata` is later updated to align DRAFT_EXTEND_V2
+        # metadata with TARGET_VERIFY semantics (and matching branches are
+        # added to `init_forward_metadata_{capture,replay}_cuda_graph`),
+        # re-broaden this predicate to recover decode-kernel performance.
+        if forward_batch.forward_mode.is_target_verify():
             o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q,
                 kv_cache=kv_cache,


### PR DESCRIPTION
## Summary

Fixes a CUDA illegal-memory-access on Blackwell when DRAFT_EXTEND_V2 + trtllm_mha is used (originally surfaced by Qwen3.5 + EAGLE + DP-attention + multimodal in the GB300 nightly suite).

PR #24566 added `is_draft_extend_v2()` to the trtllm decode-kernel branch in `TRTLLMHAAttnBackend.forward_extend` as a perf optimization. The decode kernel `flashinfer.decode.trtllm_batch_decode_with_kv_cache` requires `seq_lens` to be the **total** per-request length (KV cache + the K/V of the new query tokens, which must already be written to the cache before the kernel runs) and a uniform `q_len_per_req`. PR #24566 did not add a dedicated `DRAFT_EXTEND_V2` branch to `init_forward_metadata`, so the metadata fell into the catchall `else` branch and produced prefill-shaped metadata — KV-only `cache_seqlens_int32`, narrower page_table — which the decode kernel interpreted incorrectly and faulted on Blackwell.

This PR narrows the decode-kernel branch in `forward_extend` back to `is_target_verify()` only. DRAFT_EXTEND_V2 now takes the prefill kernel (`trtllm_batch_context_with_kv_cache`), which already had correctly-shaped metadata from the eager `init_forward_metadata` else branch (`extend_seq_lens` → `cu_seqlens_q`, KV-only `seq_lens`).

## Why this is correctness-only (not the full root-cause fix)

PR #24566 was a perf optimization; this PR reverts the optimization for DRAFT_EXTEND_V2 without recovering it. The full root-cause fix would be to give DRAFT_EXTEND_V2 a dedicated decode-kernel metadata branch in `init_forward_metadata` plus matching CUDA-graph capture/replay branches, then re-broaden the predicate.

I attempted that fix (commit `bef8ec60a`, since reverted) — added the three symmetric DRAFT_EXTEND_V2 branches mirroring TARGET_VERIFY with `num_tokens_per_req = speculative_num_steps + 1` substituted for `speculative_num_draft_tokens`, and re-broadened the predicate. The CUDA graph capture phase passed cleanly (the new branch didn't fault during capture), but **inference still hit the CUDA IMA within 8 seconds of the first request** on the same failing config — the asynchronous IMA surfaced at `eagle_info_v2.py:167 prepare_for_decode` on the next stream sync.

The metadata fix is insufficient: even with `cache_seqlens_int32 = seq_lens + num_tokens_per_req`, the decode kernel is reading from KV positions where DRAFT_EXTEND_V2's K/V layout doesn't match the kernel's contract. Likely deeper issues: `out_cache_loc` slot assignment for DRAFT_EXTEND_V2 may not place K/V at the positions the decode kernel expects, or `forward_batch.seq_lens` semantics differ between TARGET_VERIFY (pre-draft-write) and DRAFT_EXTEND_V2 (post-verify-update) in a way that breaks the kernel's "queries occupy the last `q_len_per_req` slots of `[0, seq_lens)`" assumption.

Reverted commit `bef8ec60a` (-97 / +17). Leaving the perf-recovery work as a follow-up that needs deeper investigation of the V2 draft-extend KV-write path before re-trying.

## Verification

- Pre-commit on the touched file: passed
- Manual repro on GB300 debug pod (`debug-kangyan-zhou`, `gcp-radixark-02`): gsm8k 200q, accuracy **0.975**, no IMA, all 4 schedulers alive at end
- Validation of attempted root-cause fix on same pod: IMA reproduced, 8s after gsm8k start; documented above

## Follow-ups (separate PRs)

1. Per-commit B200 test exercising trtllm_mha + EAGLE + spec_v2. `test/registered/4-gpu-models/test_qwen35_fp4_mtp_v2.py` uses `--speculative-algorithm NEXTN`, which per `spec_info.py:88-95` is not in `is_eagle()` and never enters DRAFT_EXTEND_V2. A sibling test with `--speculative-algorithm EAGLE` (otherwise identical, registered to `stage-c-test-4-gpu-b200`) would catch this exact regression at PR time.
2. Recover PR #24566's decode-kernel perf optimization for DRAFT_EXTEND_V2 properly — requires deeper investigation than just shaping `init_forward_metadata` to match TARGET_VERIFY. Likely needs to verify or change the `out_cache_loc` assignment so K/V positions match the decode kernel's "queries at `[seq_lens - q_len_per_req, seq_lens)`" contract, and/or wait for a flashinfer-side change.

## Test plan

- [x] Pre-commit on the touched file
- [x] Manually validated on GB300 debug pod: gsm8k 200q accuracy 0.975, no IMA
- [ ] CI (per-commit B200 suite via `stage-c-test-4-gpu-b200`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)