### PR TITLE
[AMD] Pin cache-dit==1.3.0 in rocm.Dockerfile + AMD CI install script

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -110,7 +110,7 @@ diffusion_hip = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer>=0.15.5",
-  "cache-dit==1.1.8",
+  "cache-dit==1.3.0",
   "addict",
 ]
 

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -258,8 +258,7 @@ RUN pip install IPython \
     && pip install orjson \
     && pip install python-multipart \
     && pip install torchao==0.9.0 \
-    && pip install pybind11 \
-    && pip install cache-dit==1.3.0
+    && pip install pybind11
 
 RUN pip uninstall -y sgl_kernel sglang
 RUN git clone ${SGL_REPO} \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -258,7 +258,8 @@ RUN pip install IPython \
     && pip install orjson \
     && pip install python-multipart \
     && pip install torchao==0.9.0 \
-    && pip install pybind11
+    && pip install pybind11 \
+    && pip install cache-dit==1.3.0
 
 RUN pip uninstall -y sgl_kernel sglang
 RUN git clone ${SGL_REPO} \

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -103,7 +103,7 @@ diffusion_hip = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer>=0.15.5",
-  "cache-dit==1.1.8",
+  "cache-dit==1.3.0",
 ]
 
 # For Intel Gaudi(device : hpu) follow the installation guide

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -168,10 +168,7 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache huggingface_hub[hf_xet]
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache pytest
 
-  # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204).
-  # Pin to match python/pyproject.toml; --upgrade is required because the AMD CI
-  # image ships cache-dit==1.1.8, which lacks the `cache_dit.parallelism` module
-  # and `ParallelismBackend.AUTO` used by multimodal_gen/runtime/cache/cache_dit_integration.py.
+  # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204)
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade 'cache-dit==1.3.0' || echo "cache-dit installation failed"
 
   # Install accelerate for distributed training and inference support

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -168,8 +168,11 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache huggingface_hub[hf_xet]
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache pytest
 
-  # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204)
-  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache cache-dit || echo "cache-dit installation failed"
+  # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204).
+  # Pin to match python/pyproject.toml; --upgrade is required because the AMD CI
+  # image ships cache-dit==1.1.8, which lacks the `cache_dit.parallelism` module
+  # and `ParallelismBackend.AUTO` used by multimodal_gen/runtime/cache/cache_dit_integration.py.
+  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade 'cache-dit==1.3.0' || echo "cache-dit installation failed"
 
   # Install accelerate for distributed training and inference support
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache accelerate || echo "accelerate installation failed"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Fix R10 in [sglang-ci-bot daily report bingxche/sglang-ci-bot#67](https://github.com/bingxche/sglang-ci-bot/issues/67): every `multimodal-gen-test-{1,2}-gpu-amd[-rocm720]` job has been red for 2+ days (~4 jobs/run) with two paired symptoms that share one root cause:

- 1-GPU (`qwen_image_t2i_cache_dit_scm_config_diffusers_1gpu`):
  ```
  RuntimeError: cache-dit>=1.2.0 is required for --cache-dit-config. Please upgrade cache-dit.
  ```
- 2-GPU (`wan2_1_t2v` parametrization):
  ```
  AttributeError: ParallelismBackend.AUTO
  ```

Reproduced in the most recent scheduled run on `main` ([run 25644554985 / job 75270857375](https://github.com/sgl-project/sglang/actions/runs/25644554985/job/75270857375), 2026-05-11 00:48 UTC) — first failing log line is verbatim the `RuntimeError` above.

### Why now (2 days, not 4 months)

The hard `cache-dit>=1.2.0` runtime check was added back in [#16662](https://github.com/sgl-project/sglang/pull/16662) (2026-01-22), and `python/pyproject.toml` was bumped to `1.3.0` in [#20361](https://github.com/sgl-project/sglang/pull/20361) (2026-03-17). AMD CI stayed green that whole time because no AMD test actually exercised `--cache-dit-config`. That changed when [#19213](https://github.com/sgl-project/sglang/pull/19213) "[diffusion] CI: add cache-dit CI tests" landed on **2026-05-10 05:38 UTC** (~49 h before this PR), which added the new `qwen_image_t2i_cache_dit_scm_config_diffusers_1gpu` case that does pass `--cache-dit-config`. From that moment on, the version skew between the AMD ROCm image (`cache-dit==1.1.8`) and `python/pyproject.toml` (`==1.3.0`) became a hard failure.

### Root cause (verified against the tree)

The `cache-dit==1.1.8` shipped in AMD CI images is **not** inherited from a base image — it is actively installed by the ROCm Dockerfile itself. The chain:

1. `docker/rocm.Dockerfile:279-281` does `mv python/pyproject_other.toml python/pyproject.toml && pip install -e "python[srt_hip,diffusion_hip]"`.
2. `python/pyproject_other.toml:106` (the `diffusion_hip` extra) pinned `cache-dit==1.1.8`.
3. So every newly built ROCm image gets 1.1.8 baked in, regardless of `python/pyproject.toml` (which pins 1.3.0).
4. `python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py:34` does `from cache_dit.parallelism import ParallelismBackend, ParallelismConfig` and uses `ParallelismBackend.AUTO` — both added in cache-dit 1.2.0+. Hence the runtime failure.
5. `scripts/ci/amd/amd_ci_install_dependency.sh:172` ran `pip install cache-dit` (no `--upgrade`, no version), which is a no-op against the preinstalled 1.1.8 — so the script could not paper over the toml mismatch either.

A previous revision of this PR added `pip install cache-dit==1.3.0` directly to the Dockerfile, but [code review by Cursor Automation](https://github.com/sgl-project/sglang/pull/24924#pullrequestreview-3478920406) correctly flagged that change as a no-op: the very next `RUN` block (line 281) re-installs `diffusion_hip`, which downgrades 1.3.0 back to 1.1.8. That commit has been reverted; this PR now fixes the source of the pin instead.

### Why NVIDIA was unaffected

NVIDIA CI installs the diffusion extra via `pip install -e "python[dev,runai,tracing,diffusion]"` (`scripts/ci/cuda/ci_install_dependency.sh:227-232`), which resolves against `python/pyproject.toml` (already at 1.3.0). The AMD path resolves against `python/pyproject_other.toml`, which had drifted — that's the bypass this PR closes.

## Modifications

Three small surgical edits, plus a preserved bridge fix in the install script:

1. `python/pyproject_other.toml` — bump `diffusion_hip` from `cache-dit==1.1.8` to `cache-dit==1.3.0`. This is the actual source of truth that the ROCm Dockerfile resolves at image build time.
2. `3rdparty/amd/wheel/sglang/pyproject.toml` — bump `diffusion_hip` from `cache-dit==1.1.8` to `cache-dit==1.3.0`, so the `amd-sglang` wheel stays in sync.
3. `scripts/ci/amd/amd_ci_install_dependency.sh` — change `pip install cache-dit` to `pip install --upgrade 'cache-dit==1.3.0'`. This is a bridge fix: any AMD CI runner still pulling an image built before the toml bump lands will be force-upgraded at job start. Once new images are built (≤24 h via the nightly image release workflows), this line becomes a no-op (pip sees 1.3.0 already installed and exits).

Out of scope but worth noting: `diffusion_musa` in both `python/pyproject_other.toml:131` and `3rdparty/amd/wheel/sglang/pyproject.toml:146` still pins `cache-dit==1.1.8`. The MUSA CI is a separate pipeline (`pr-test-musa.yml`) and not in this hotfix's blast radius. Tracked as a follow-up.

5 commits, 5 net lines changed across 3 files (the previous revision's Dockerfile edit was reverted in commit `723fdd3f`).

## Validation criteria
https://github.com/sgl-project/sglang/actions/runs/25648379091
<img width="1945" height="1601" alt="image" src="https://github.com/user-attachments/assets/9651242e-c2ba-4d10-baaf-b9e56f4dad16" />
Test passed.

## Accuracy Tests

N/A — install-only change, no model code touched.

## Speed Tests and Profiling

N/A — install-only change.

## Checklist

- [x] Surgical fix; no production code changed.
- [x] Version pin matches `python/pyproject.toml` (single source of truth) across `pyproject_other.toml` and the amd-sglang wheel pyproject.
- [x] Reverted the no-op Dockerfile edit after review feedback.
- [x] Bridge fix in install script keeps existing images green until next image rebuild.
- [x] Validated end-to-end (see Validation criteria above).

## Follow-up (out of scope here)

A cleaner architectural fix would be to have `scripts/ci/amd/amd_ci_install_dependency.sh` install via `pip install -e "python[diffusion]"` (the way NVIDIA CI does), removing the hand-rolled `cache-dit / accelerate / pytest / huggingface_hub` lines entirely. That would make `python/pyproject.toml` the single source of truth for AMD too. Also, `diffusion_musa` should be bumped to 1.3.0 for symmetry. Tracked separately, not part of this hotfix.

## Review and Merge Process

1. Ping Merge Oncalls.
2. CODEOWNERS approval (AMD CI / Docker).
3. Trigger AMD CI (`/rerun-failed-ci` or `/tag-and-rerun-ci`).
4. Merge once the listed jobs are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1a0aacf-48b7-4e00-8bd8-f42fe789bd1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1a0aacf-48b7-4e00-8bd8-f42fe789bd1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

