### PR TITLE
spec: centralize EagleDraft{,Extend}Input.hidden_states shape

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -130,8 +130,8 @@ class EAGLEDraftCudaGraphRunner:
             topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
             topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
             hidden_states = torch.zeros(
-                (self.max_bs, self.model_runner.model_config.spec_hidden_size),
-                dtype=self.model_runner.dtype,
+                (self.max_bs, EagleDraftInput.hidden_size_for(self.eagle_worker)),
+                dtype=EagleDraftInput.dtype_for(self.eagle_worker),
             )
 
             if self.require_gathered_buffer:

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -132,35 +132,13 @@ class EAGLEDraftExtendCudaGraphRunner:
             positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
             mrope_positions = torch.zeros((3, self.max_num_token), dtype=torch.int64)
 
-            if (
-                self.eagle_worker.speculative_algorithm.is_eagle3()
-                and self.eagle_worker.eagle_use_aux_hidden_state
-            ):
-                hidden_states = torch.zeros(
-                    (
-                        self.max_num_token,
-                        (
-                            self.model_runner.model_config.hf_config.target_hidden_size
-                            * 3
-                            if hasattr(
-                                self.model_runner.model_config.hf_config,
-                                "target_hidden_size",
-                            )
-                            else self.model_runner.model_config.hidden_size * 3
-                        ),
-                    ),
-                    dtype=self.model_runner.dtype,
-                )
-            else:
-                # Use target config: hidden_states carries target output.
-                target_cfg = self.eagle_worker.target_worker.model_runner.model_config
-                hidden_states = torch.zeros(
-                    (
-                        self.max_num_token,
-                        target_cfg.spec_hidden_size,
-                    ),
-                    dtype=target_cfg.dtype,
-                )
+            hidden_states = torch.zeros(
+                (
+                    self.max_num_token,
+                    EagleDraftExtendInput.hidden_size_for(self.eagle_worker),
+                ),
+                dtype=EagleDraftExtendInput.dtype_for(self.eagle_worker),
+            )
             self.seq_len_fill_value = (
                 self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
             )

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -703,18 +703,13 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
     @classmethod
     def hidden_size_for(cls, worker: "EAGLEWorker") -> int:
-        """Wire-format hidden_size for `hidden_states` in the decode phase.
-
-        Decode-phase canonical: draft self-chain output. Each draft step
-        writes its own last hidden back via `capture_for_decode`, so the
-        producer is the draft model itself. Use this for idle placeholders
-        and cuda graph static buffers in the decode path.
-        """
+        """Decode-phase `hidden_states` width: draft self-chain output
+        (draft model writes its own last hidden back via `capture_for_decode`
+        and the draft loop)."""
         return worker.draft_model_runner.model_config.spec_hidden_size
 
     @classmethod
     def dtype_for(cls, worker: "EAGLEWorker") -> torch.dtype:
-        """Wire-format dtype for `hidden_states` in the decode phase."""
         return worker.draft_model_runner.model_config.dtype
 
     @classmethod
@@ -841,14 +836,10 @@ class EagleDraftExtendInput(SpecInput):
 
     @classmethod
     def hidden_size_for(cls, worker: "EAGLEWorker") -> int:
-        """Wire-format hidden_size for `hidden_states` in the extend phase.
-
-        Extend-phase canonical: target verify output (EAGLE paper's "feature").
-        Widened to `target.hidden_size * 3` for EAGLE-3 aux mode, which fuses
-        low/mid/high-level target features into a 3k-dimensional vector
-        before the draft's FC reduces it back to k. Use this for idle
-        placeholders and cuda graph static buffers in the extend path.
-        """
+        """Extend-phase `hidden_states` width: target verify output (EAGLE
+        paper's "feature"). Widened to `target.hidden_size * 3` for EAGLE-3
+        aux mode (low/mid/high features fused into a 3k-dim vector, reduced
+        by draft's FC)."""
         target_cfg = worker.target_worker.model_runner.model_config
         if (
             worker.speculative_algorithm.is_eagle3()
@@ -859,7 +850,6 @@ class EagleDraftExtendInput(SpecInput):
 
     @classmethod
     def dtype_for(cls, worker: "EAGLEWorker") -> torch.dtype:
-        """Wire-format dtype for `hidden_states` in the extend phase."""
         return worker.target_worker.model_runner.model_config.dtype
 
     @classmethod

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,7 +1,7 @@
 import logging
 from copy import copy
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -52,6 +52,9 @@ if is_cuda() or is_musa():
         top_p_renorm_prob,
         tree_speculative_sampling_target_only,
     )
+
+if TYPE_CHECKING:
+    from sglang.srt.speculative.eagle_worker import EAGLEWorker
 
 logger = logging.getLogger(__name__)
 
@@ -699,6 +702,22 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             pt += extend_len
 
     @classmethod
+    def hidden_size_for(cls, worker: "EAGLEWorker") -> int:
+        """Wire-format hidden_size for `hidden_states` in the decode phase.
+
+        Decode-phase canonical: draft self-chain output. Each draft step
+        writes its own last hidden back via `capture_for_decode`, so the
+        producer is the draft model itself. Use this for idle placeholders
+        and cuda graph static buffers in the decode path.
+        """
+        return worker.draft_model_runner.model_config.spec_hidden_size
+
+    @classmethod
+    def dtype_for(cls, worker: "EAGLEWorker") -> torch.dtype:
+        """Wire-format dtype for `hidden_states` in the decode phase."""
+        return worker.draft_model_runner.model_config.dtype
+
+    @classmethod
     def create_idle_input(
         cls,
         device: torch.device,
@@ -819,6 +838,29 @@ class EagleDraftExtendInput(SpecInput):
 
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
+
+    @classmethod
+    def hidden_size_for(cls, worker: "EAGLEWorker") -> int:
+        """Wire-format hidden_size for `hidden_states` in the extend phase.
+
+        Extend-phase canonical: target verify output (EAGLE paper's "feature").
+        Widened to `target.hidden_size * 3` for EAGLE-3 aux mode, which fuses
+        low/mid/high-level target features into a 3k-dimensional vector
+        before the draft's FC reduces it back to k. Use this for idle
+        placeholders and cuda graph static buffers in the extend path.
+        """
+        target_cfg = worker.target_worker.model_runner.model_config
+        if (
+            worker.speculative_algorithm.is_eagle3()
+            and worker.eagle_use_aux_hidden_state
+        ):
+            return target_cfg.hidden_size * 3
+        return target_cfg.spec_hidden_size
+
+    @classmethod
+    def dtype_for(cls, worker: "EAGLEWorker") -> torch.dtype:
+        """Wire-format dtype for `hidden_states` in the extend phase."""
+        return worker.target_worker.model_runner.model_config.dtype
 
     @classmethod
     def create_idle_input(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,7 +1,7 @@
 import logging
 from copy import copy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -53,10 +53,19 @@ if is_cuda() or is_musa():
         tree_speculative_sampling_target_only,
     )
 
-if TYPE_CHECKING:
-    from sglang.srt.speculative.eagle_worker import EAGLEWorker
-
 logger = logging.getLogger(__name__)
+
+
+def _draft_runner_of(worker):
+    """Draft model_runner accessor that handles v1 / v2 worker naming.
+
+    v1 (`EAGLEWorker` and subclasses) exposes the draft model_runner as
+    `model_runner` (the worker itself runs the draft model);
+    v2 (`EagleDraftWorker` and subclasses) exposes it as `draft_runner`.
+    """
+    return (
+        worker.draft_runner if hasattr(worker, "draft_runner") else worker.model_runner
+    )
 
 
 @dataclass
@@ -702,15 +711,15 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             pt += extend_len
 
     @classmethod
-    def hidden_size_for(cls, worker: "EAGLEWorker") -> int:
+    def hidden_size_for(cls, worker) -> int:
         """Decode-phase `hidden_states` width: draft self-chain output
         (draft model writes its own last hidden back via `capture_for_decode`
         and the draft loop)."""
-        return worker.draft_model_runner.model_config.spec_hidden_size
+        return _draft_runner_of(worker).model_config.spec_hidden_size
 
     @classmethod
-    def dtype_for(cls, worker: "EAGLEWorker") -> torch.dtype:
-        return worker.draft_model_runner.model_config.dtype
+    def dtype_for(cls, worker) -> torch.dtype:
+        return _draft_runner_of(worker).model_config.dtype
 
     @classmethod
     def create_idle_input(
@@ -835,7 +844,7 @@ class EagleDraftExtendInput(SpecInput):
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
     @classmethod
-    def hidden_size_for(cls, worker: "EAGLEWorker") -> int:
+    def hidden_size_for(cls, worker) -> int:
         """Extend-phase `hidden_states` width: target verify output (EAGLE
         paper's "feature"). Widened to `target.hidden_size * 3` for EAGLE-3
         aux mode (low/mid/high features fused into a 3k-dim vector, reduced
@@ -849,7 +858,7 @@ class EagleDraftExtendInput(SpecInput):
         return target_cfg.spec_hidden_size
 
     @classmethod
-    def dtype_for(cls, worker: "EAGLEWorker") -> torch.dtype:
+    def dtype_for(cls, worker) -> torch.dtype:
         return worker.target_worker.model_runner.model_config.dtype
 
     @classmethod

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -727,8 +727,8 @@ class EAGLEWorker(TpModelWorker):
     def _draft_preprocess_idle(self, batch: ScheduleBatch):
         batch.spec_info = EagleDraftInput.create_idle_input(
             device=self.device,
-            hidden_size=self.model_config.spec_hidden_size,
-            dtype=self.model_config.dtype,
+            hidden_size=EagleDraftInput.hidden_size_for(self),
+            dtype=EagleDraftInput.dtype_for(self),
             topk=self.topk,
             capture_hidden_mode=CaptureHiddenMode.LAST,
         )
@@ -1130,17 +1130,10 @@ class EAGLEWorker(TpModelWorker):
             # All reqs finished this verify; swap to an idle ExtendInput.
             batch = batch.copy()
             batch.prepare_for_idle()
-            target_cfg = self.target_worker.model_runner.model_config
-            hidden_size = (
-                target_cfg.hidden_size * 3
-                if self.speculative_algorithm.is_eagle3()
-                and self.eagle_use_aux_hidden_state
-                else target_cfg.spec_hidden_size
-            )
             draft_extend_input = EagleDraftExtendInput.create_idle_input(
                 device=self.device,
-                hidden_size=hidden_size,
-                dtype=target_cfg.dtype,
+                hidden_size=EagleDraftExtendInput.hidden_size_for(self),
+                dtype=EagleDraftExtendInput.dtype_for(self),
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
             batch.spec_info = draft_extend_input


### PR DESCRIPTION
Centralize the `hidden_states` shape decision on `EagleDraftInput` (decode phase) and `EagleDraftExtendInput` (extend phase) — single source of truth for the field's wire-format shape and dtype.

Adds `hidden_size_for(worker)` and `dtype_for(worker)` classmethods on each dataclass. The 4 idle-placeholder / cuda-graph-buffer call sites that previously each reconstructed the shape from `model_config` + algorithm + aux-flag now route through the classmethod.

`hidden_size_for` returns the producer-determined shape:
- decode phase = draft's `spec_hidden_size` (draft self-chain output)
- extend phase = target's `spec_hidden_size`, widened to `target.hidden_size * 3` for EAGLE-3 aux mode

No behavior change for correctly configured EAGLE / EAGLE3 / STANDALONE.

## How `spec_info.hidden_states` is used across spec algorithms

| Category | Behavior | Examples |
|----------|----------|----------|
| Chain | worker writes draft output back to field each step | EAGLE-1/3, FrozenKV MTP |
| Non-chain | written once by target verify, draft chains internally | Multi-layer EAGLE, MIMO |
| No-consume | field unread by draft | STANDALONE |

PR 1 just centralizes the shape decision — it doesn't gate behavior on these categories. PR 2 / PR 3 (below) will.

## Scope

This PR routes the v1 `EAGLEWorker` call sites; the v2 `EagleDraftWorker` cuda graph runner shares `eagle_draft_cuda_graph_runner.py` and is also covered:
- `eagle_worker.py:_draft_preprocess_idle`
- `eagle_worker.py:forward_draft_extend_after_decode` idle fallback
- `eagle_draft_cuda_graph_runner.py` decode static buffer (used by both v1 and v2)
- `eagle_draft_extend_cuda_graph_runner.py` extend static buffer (used by both v1 and v2, EAGLE-3 aux if/else folded into helper)

`StandaloneWorker` (v1) and `StandaloneDraftWorker` (v2) are covered via inheritance / shared runner. `MultiLayerEagleWorker(V2)` / `FrozenKVMTPWorker(V2)` have their own `create_idle_input` call sites — follow-up PRs will route them through the same classmethod.

## Roadmap

- **PR 1 (this one)**: classmethod = single source of truth for shape. No behavior change.
- **PR 2**: `hidden_states` becomes `Optional`. `hidden_size_for` returns `None` for No-consume (STANDALONE), propagating `None` through allocation / cat / copy_. Addresses #21058 task 1a/1b consumer side.
- **PR 3**: worker-level guard for `capture_for_decode` / FutureMap when the draft doesn't chain via the field (Non-chain + step=1 cases). Addresses #21058 task 1a/1b producer side.

## Follow-up tech-debt cleanups (out of this PR's scope)

This PR exposes some pre-existing inconsistencies that should be cleaned up separately:

1. **`_draft_runner_of(worker)` helper in `eagle_info.py`** — v1 `EAGLEWorker` exposes the draft model_runner as `worker.model_runner` (inherited from `TpModelWorker` since v1 worker runs the draft itself); v2 `EagleDraftWorker` exposes it as `worker.draft_runner` (worker wraps an inner draft worker, runner is on the wrapped one). The `hasattr`-based helper is a band-aid. Proper fix is to unify the v1 / v2 worker attribute naming — e.g., introduce a `SpecWorker` protocol with a uniform `draft_runner` property, both v1 and v2 implement it.
2. Same pattern applies to other shared attributes (`speculative_algorithm`, `eagle_use_aux_hidden_state`, `target_worker`) — currently each worker subclass re-declares them. A protocol/abstract base class would enforce the common surface.
