### PR TITLE
fix(compressed-tensors): respect ignore list with ".linear" submodule suffix

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
@@ -169,6 +169,16 @@ def _is_equal_or_regex_match(
     elif check_contains:
         if target.lower() in value.lower():
             return True
+        # Also match when ``target`` is a path-extension of ``value`` (i.e.,
+        # ``target`` starts with ``value + "."``). compressed-tensors
+        # checkpoints sometimes include a submodule suffix such as ``.linear``
+        # in the ``ignore`` list (e.g., ``...q_proj.linear``) while the runtime
+        # ``layer_name`` is the parent layer without the suffix (e.g., the
+        # unfused shard ``...q_proj`` derived from ``qkv_proj`` via
+        # ``packed_modules_mapping``). The ``.`` path separator prevents
+        # over-matching (e.g., ``q`` does not match ``q_proj.linear``).
+        if target.lower().startswith(value.lower() + "."):
+            return True
     elif target == value:
         return True
     return False

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_ignore.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_ignore.py
@@ -1,0 +1,175 @@
+"""Unit tests for compressed-tensors ``should_ignore_layer`` — no server, no model loading.
+
+Covers the case where the ``ignore`` list in a checkpoint's
+``quantization_config`` contains submodule paths (e.g., ``...q_proj.linear``)
+while the runtime layer name is the parent layer (e.g., ``...q_proj``), which
+typically arises when a model's ``packed_modules_mapping`` expands a fused
+layer (e.g., ``qkv_proj``) into shard names. This pattern appears in NVFP4 VLM
+checkpoints where the vision tower is kept in BF16 via the ``ignore`` list.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+import unittest
+
+from sglang.srt.layers.quantization.compressed_tensors.utils import (
+    _is_equal_or_regex_match,
+    should_ignore_layer,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestIsEqualOrRegexMatch(CustomTestCase):
+    """Direct tests for the substring/path-prefix matcher."""
+
+    def test_exact_match(self):
+        self.assertTrue(
+            _is_equal_or_regex_match(
+                "model.layers.0.self_attn.q_proj", "model.layers.0.self_attn.q_proj"
+            )
+        )
+
+    def test_exact_mismatch(self):
+        self.assertFalse(_is_equal_or_regex_match("foo", "bar"))
+
+    def test_regex_match(self):
+        self.assertTrue(
+            _is_equal_or_regex_match(
+                "model.layers.5.self_attn.q_proj", "re:.*layers\\.\\d+.*q_proj"
+            )
+        )
+
+    def test_regex_no_match(self):
+        self.assertFalse(
+            _is_equal_or_regex_match("model.layers.5.self_attn.q_proj", "re:.*o_proj")
+        )
+
+    def test_check_contains_substring_match(self):
+        # Existing behavior: target is a substring of value.
+        self.assertTrue(
+            _is_equal_or_regex_match(
+                "model.layers.0.self_attn.q_proj",
+                "self_attn.q_proj",
+                check_contains=True,
+            )
+        )
+
+    def test_check_contains_path_extension_match(self):
+        # New behavior: target is a path-extension of value (i.e., target
+        # starts with value + "."). This covers compressed-tensors checkpoints
+        # whose ignore list uses ".linear" submodule suffix while the runtime
+        # layer name is the parent layer.
+        self.assertTrue(
+            _is_equal_or_regex_match(
+                "model.vision_tower.encoder.layers.0.self_attn.q_proj",
+                "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear",
+                check_contains=True,
+            )
+        )
+
+    def test_check_contains_no_over_match_on_partial_token(self):
+        # Path-extension match must respect the "." path boundary; a partial
+        # token like "q" should NOT match "q_proj.linear".
+        self.assertFalse(
+            _is_equal_or_regex_match(
+                "model.layers.0.self_attn.q",
+                "model.layers.0.self_attn.q_proj.linear",
+                check_contains=True,
+            )
+        )
+
+    def test_check_contains_disjoint_names(self):
+        self.assertFalse(
+            _is_equal_or_regex_match(
+                "model.layers.0.self_attn.q_proj",
+                "model.layers.0.mlp.gate_proj.linear",
+                check_contains=True,
+            )
+        )
+
+
+class TestShouldIgnoreLayerLinearSuffix(CustomTestCase):
+    """End-to-end ``should_ignore_layer`` cases for the ``.linear`` suffix pattern.
+
+    These cases mirror what happens when a VLM checkpoint
+    (e.g., ``RedHatAI/gemma-4-31B-it-NVFP4``,
+    ``cyankiwi/gemma-4-31B-it-AWQ-4bit``) lists every vision tower projection
+    with a ``.linear`` suffix in ``quantization_config.ignore``, and a model
+    such as Gemma 4 fuses Q/K/V into ``qkv_proj`` via
+    ``packed_modules_mapping``.
+    """
+
+    FUSED_MAPPING = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    VISION_IGNORE = [
+        "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear",
+        "model.vision_tower.encoder.layers.0.self_attn.k_proj.linear",
+        "model.vision_tower.encoder.layers.0.self_attn.v_proj.linear",
+        "model.vision_tower.encoder.layers.0.self_attn.o_proj.linear",
+        "model.vision_tower.encoder.layers.0.mlp.gate_proj.linear",
+        "model.vision_tower.encoder.layers.0.mlp.up_proj.linear",
+        "model.vision_tower.encoder.layers.0.mlp.down_proj.linear",
+    ]
+
+    def test_fused_qkv_proj_is_ignored_when_all_shards_have_linear_suffix(self):
+        """Fused qkv_proj layer should be ignored when each shard's path
+        appears in the ignore list with a ``.linear`` submodule suffix."""
+        self.assertTrue(
+            should_ignore_layer(
+                "model.vision_tower.encoder.layers.0.self_attn.qkv_proj",
+                ignore=self.VISION_IGNORE,
+                fused_mapping=self.FUSED_MAPPING,
+            )
+        )
+
+    def test_fused_gate_up_proj_is_ignored_when_all_shards_have_linear_suffix(self):
+        """Fused gate_up_proj layer should be ignored when both shards
+        appear in the ignore list with a ``.linear`` submodule suffix."""
+        self.assertTrue(
+            should_ignore_layer(
+                "model.vision_tower.encoder.layers.0.mlp.gate_up_proj",
+                ignore=self.VISION_IGNORE,
+                fused_mapping=self.FUSED_MAPPING,
+            )
+        )
+
+    def test_unfused_o_proj_is_ignored_with_linear_suffix(self):
+        """Non-fused linear (e.g., o_proj) should also be ignored when its
+        ``.linear`` submodule path is in the ignore list."""
+        self.assertTrue(
+            should_ignore_layer(
+                "model.vision_tower.encoder.layers.0.self_attn.o_proj",
+                ignore=self.VISION_IGNORE,
+                fused_mapping=self.FUSED_MAPPING,
+            )
+        )
+
+    def test_language_model_layer_not_ignored(self):
+        """Language-model layers (not in ignore list) should remain quantized."""
+        self.assertFalse(
+            should_ignore_layer(
+                "model.language_model.layers.0.self_attn.qkv_proj",
+                ignore=self.VISION_IGNORE,
+                fused_mapping=self.FUSED_MAPPING,
+            )
+        )
+
+    def test_other_vision_layer_not_in_ignore_is_not_ignored(self):
+        """Vision layers from a layer index not present in the ignore list
+        should not be ignored (sanity check that match is path-specific)."""
+        self.assertFalse(
+            should_ignore_layer(
+                "model.vision_tower.encoder.layers.5.self_attn.qkv_proj",
+                ignore=self.VISION_IGNORE,
+                fused_mapping=self.FUSED_MAPPING,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #24927.

VLM checkpoints quantized via `compressed-tensors` (e.g., `RedHatAI/gemma-4-31B-it-NVFP4`, `cyankiwi/gemma-4-31B-it-AWQ-4bit`) follow the standard pattern where **only the language model is quantized** and the **vision tower is kept in BF16** via `quantization_config.ignore`. The ignore entries include a `.linear` submodule suffix (added by llm-compressor's `CompressedLinear` wrapper), e.g.:

```jsonc
"ignore": [
  "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear",
  "model.vision_tower.encoder.layers.0.self_attn.k_proj.linear",
  // ... 192 entries for Gemma 4
]
```

Meanwhile, SGLang's Gemma 4 model uses `packed_modules_mapping` to expand a fused `qkv_proj` into shard names **without** the `.linear` suffix:

```
runtime layer_name:  ...vision_tower.encoder.layers.0.self_attn.q_proj
ignore entry:        ...vision_tower.encoder.layers.0.self_attn.q_proj.linear
```

`_is_equal_or_regex_match(check_contains=True)` performs `target in value` — but here `target` (with `.linear`) is **longer** than `value` (without it), so the substring check fails. The vision tower gets the NVFP4 (or AWQ) scheme applied, and during forward `flashinfer.gemm.mm_fp4` rejects the 3D image activations:

```
ValueError: mm_fp4 accepts 2d tensors, got torch.Size([1, 2520, 576])
```

vLLM avoids this entirely because it builds the Gemma 4 vision tower via `transformers.AutoModel`, which doesn't go through the compressed-tensors quant scheme at all; SGLang's native vision tower is the only path that exercises this code with `.linear`-suffixed ignore entries.

## Modifications

Add a **path-extension match** in `_is_equal_or_regex_match`: if `target` starts with `value + "."`, treat it as a match. The `.` path separator prevents over-match (e.g., `q` does **not** match `q_proj.linear`).

Files:
- `python/sglang/srt/layers/quantization/compressed_tensors/utils.py` — 4 lines of new logic + comment.
- `test/registered/unit/layers/quantization/test_compressed_tensors_ignore.py` — new unit-test file with 13 cases:
  - 8 direct cases for `_is_equal_or_regex_match` (exact, regex, substring, **new path-extension**, no-over-match on partial token, disjoint names).
  - 5 end-to-end cases for `should_ignore_layer` exercising the fused `qkv_proj`/`gate_up_proj` shard expansion against an ignore list with `.linear` suffixes, plus negative cases for language-model layers and a vision layer index not in the ignore list.

The new tests are registered with `register_cpu_ci(est_time=2, suite="stage-a-test-cpu")` so they run in CPU CI.

## Accuracy Tests

Tested with `RedHatAI/gemma-4-31B-it-NVFP4` on RTX 5090 (sm120):

- **Before**: warmup crashes with `ValueError: mm_fp4 accepts 2d tensors`. `--skip-server-warmup` survives startup but image requests fail at the same site.
- **After**: warmup + CUDA-graph capture complete normally. The vision tower is loaded as BF16 (the `Some weights are not initialized from checkpoints: vision_tower.*` log is consistent with the patched fused-vs-shard name resolution and reflects layout fusion, not missing weights). Smoke responses:
  - Text — *"Write a haiku about GPU computing"* → 19 tokens, **0.44 s** warm.
  - Image OCR — synthetic invoice PNG (7 lines: invoice number, date, recipient, three line items, total, due date) → **complete extraction** in 105 tokens, **2.29 s** warm.

## Speed Tests and Profiling

This change only affects the `compressed-tensors`/`ignore` matching logic at model load time; it is not on the inference hot path and should not change steady-state throughput. The reduction in workaround flags (the patch lets you drop `--skip-server-warmup` and `--disable-cuda-graph` previously needed to dodge the crash) restores warm-state performance to the level expected without those flags.

## Checklist

- [x] Format with pre-commit (black + isort applied locally on touched files).
- [x] Add unit tests (new file under `test/registered/unit/layers/quantization/`, 13 cases, all pass locally on Python 3.12 + sglang 0.5.11 source).
- [ ] Update documentation — not applicable; this is a bug fix in internal matching logic.
- [x] Provide accuracy results — included above; speed is unchanged on the hot path.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

Per the PR template, pinging Merge Oncalls and CODEOWNERS for `/python/sglang/srt/layers/quantization`. The patch is intentionally minimal (a single extra match condition with a path-boundary guard) and is covered by direct unit tests; please trigger CI when convenient.
