### PR TITLE
:memo: docs: add canonical URL to fix Google indexing lmsysorg.mintlify.app instead of docs.sglang.io

### DIFF
--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -4,7 +4,8 @@
   "name": "SGLang Documentation",
   "seo": {
     "metatags": {
-      "google-site-verification": "bX3ofyYQhraIpAYf4DpyZQXZO_G4xLR_RqeBAKnJA7g"
+      "google-site-verification": "bX3ofyYQhraIpAYf4DpyZQXZO_G4xLR_RqeBAKnJA7g",
+      "canonical": "https://docs.sglang.io"
     }
   },
   "redirects": [


### PR DESCRIPTION
## Motivation

Google Search results show `lmsysorg.mintlify.app` URLs instead of `docs.sglang.io` because no canonical signal was set. Mintlify serves docs from both domains, and without a canonical tag Google picked the older subdomain.

## Modifications

- `docs_new/docs.json`: add `"canonical": "https://docs.sglang.io"` to the `seo.metatags` block

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://sglang.readthedocs.io/en/latest/developer/contribute.html#formatting-your-code)
- [ ] Add unit tests according to the [Run and add unit tests](https://sglang.readthedocs.io/en/latest/developer/contribute.html#running-and-adding-unit-tests)
- [ ] Update documentation according to [Write documentations](https://sglang.readthedocs.io/en/latest/developer/contribute.html#writing-documentations)
- [ ] Provide accuracy and speed benchmark results
- [ ] Follow the SGLang code style guidance