### PR TITLE
ci: drop pr-test-sgl-kernel.yml from sgl_kernel paths-filter

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -158,7 +158,8 @@ jobs:
               - "python/pyproject.toml"
               - "python/sglang/jit_kernel/**"
             sgl_kernel:
-              - ".github/workflows/pr-test-sgl-kernel.yml"
+              # Intentionally excludes ".github/workflows/pr-test-sgl-kernel.yml" —
+              # see API-side detector below for rationale.
               - "sgl-kernel/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
 
       # For /rerun-stage (workflow_dispatch with target_stage), dorny/paths-filter doesn't work
@@ -192,7 +193,15 @@ jobs:
           echo "..."
 
           # Check for sgl-kernel changes
-          if echo "$CHANGED_FILES" | grep -qE "^(sgl-kernel/|\.github/workflows/pr-test-sgl-kernel\.yml)"; then
+          # Note: edits to .github/workflows/pr-test-sgl-kernel.yml are intentionally
+          # NOT considered sgl-kernel changes. That filter line used to be included
+          # so workflow refactors got retested, but in practice it only catches the
+          # workflow's *consumers* (test job definitions), not the wheel build steps
+          # themselves — and gating sgl_kernel=true on it forces a 20-30 min wheel
+          # rebuild + the stage-a-test-1-gpu-small gate for pure CI-yaml edits that
+          # can't actually affect kernel behavior. PRs that touch wheel-build logic
+          # in scripts/ci/cuda/ or sgl-kernel/ still trigger correctly.
+          if echo "$CHANGED_FILES" | grep -qE "^sgl-kernel/"; then
             echo "sgl_kernel=true" >> $GITHUB_OUTPUT
             echo "Detected sgl-kernel changes"
           else


### PR DESCRIPTION
## Summary

CI-yaml-only edits to `.github/workflows/pr-test-sgl-kernel.yml` currently flip `sgl_kernel=true` via the paths-filter at `pr-test.yml:160-162`, kicking off ~30 min of unnecessary work:

- 4 wheel-build matrix entries (`Build Wheel (3.10, 13.0/12.9)`, `Build Wheel Arm (3.10, 13.0/12.9)`)
- `stage-a-test-1-gpu-small` — gated on `sgl_kernel=true`, blocks until wheels finish
- `wait-for-stage-a` — sits at `stage-a-test-1-gpu-small: found 0/1 jobs (waiting for more)` for the duration, since GH Actions doesn't emit a status entry for a job with unsatisfied `needs:` until those `needs:` resolve
- downstream `stage-b` / `stage-c` — all blocked on the wait

…for an edit that cannot affect kernel binaries.

## Evidence

PR #24914 just deletes a stale job from `.github/workflows/pr-test-sgl-kernel.yml`. Its CI run https://github.com/sgl-project/sglang/actions/runs/25649757750 spent 30+ min in this exact shape:

```
TOTAL: 8 jobs in run
completed    success      check-changes
completed    success      call-gate / pr-gate
queued       -            Build Wheel (3.10, 13.0)
queued       -            Build Wheel (3.10, 12.9)
in_progress  -            wait-for-stage-a       ← gating everything below
in_progress  -            Build Wheel Arm (3.10, 13.0)
in_progress  -            Build Wheel Arm (3.10, 12.9)
completed    skipped      stage-a-test-cpu       ← main_package=false
```

`wait-for-stage-a` log:
```
stage-a-test-1-gpu-small: found 0/1 jobs (waiting for more)
stage-a-test-cpu: status=completed, conclusion=skipped
stage-a-test-cpu: job-level skip (bare entry, conclusion=skipped); treating as all 4 skipped
[stage-a] Progress: 4/4 jobs completed (expected 5)
Waiting 60s... (attempt 1/240)
```

## Why this filter line existed and why dropping it is safe

The line was conservative: \"any change to the kernel CI definition could affect what wheels need.\" In practice the workflow-yaml only defines *which* test jobs run and *how* they're configured — not the wheel-build inputs themselves. PRs that touch real wheel-build inputs (`scripts/ci/cuda/**`, `sgl-kernel/**`) still trigger `sgl_kernel=true` correctly via the other filter line.

Edge case: if a future workflow-yaml edit *does* need a wheel rebuild (e.g. changing the Python version the wheel is built for), the author can add the `high priority` label, or touch `sgl-kernel/` alongside.

## Fix

Two paths-filter detectors needed updates:
- `dorny/paths-filter` (pull_request path, line 160-162)
- API-based grep (workflow_dispatch /rerun-stage path, line 195)

Both now exclude the workflow yaml.

## Test plan

- [ ] After merge, the next PR that touches *only* `.github/workflows/pr-test-sgl-kernel.yml` should: skip stage-a-test-1-gpu-small (bare-skip entry detected immediately), skip wheel builds, and have wait-for-stage-a unblock in seconds rather than minutes.
- [ ] A PR that touches `sgl-kernel/**` should continue to trigger wheel builds and stage-a-test-1-gpu-small as before.