### PR TITLE
spec: Optional spec_info.hidden_states; STANDALONE skips capture

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -53,7 +53,7 @@ class EagleDraftInputBuffers(ForwardInputBuffers):
     extend_seq_lens: torch.Tensor
     topk_p: torch.Tensor
     topk_index: torch.Tensor
-    hidden_states: torch.Tensor
+    hidden_states: Optional[torch.Tensor]
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
 
@@ -132,9 +132,14 @@ class EAGLEDraftCudaGraphRunner:
             extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
             topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
             topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
-            hidden_states = torch.zeros(
-                (self.max_bs, EagleDraftInput.hidden_size_for(self.eagle_worker)),
-                dtype=EagleDraftInput.dtype_for(self.eagle_worker),
+            _hidden_size = EagleDraftInput.hidden_size_for(self.eagle_worker)
+            hidden_states = (
+                torch.zeros(
+                    (self.max_bs, _hidden_size),
+                    dtype=EagleDraftInput.dtype_for(self.eagle_worker),
+                )
+                if _hidden_size is not None
+                else None
             )
 
             if self.require_gathered_buffer:
@@ -256,7 +261,11 @@ class EAGLEDraftCudaGraphRunner:
         out_cache_loc = buffers.out_cache_loc[: num_tokens * self.speculative_num_steps]
         positions = buffers.positions[:num_tokens]
         mrope_positions = buffers.mrope_positions[:, :num_tokens]
-        hidden_states = buffers.hidden_states[:num_seqs]
+        hidden_states = (
+            buffers.hidden_states[:num_seqs]
+            if buffers.hidden_states is not None
+            else None
+        )
         topk_p = buffers.topk_p[:num_seqs]
         topk_index = buffers.topk_index[:num_seqs]
 
@@ -409,7 +418,8 @@ class EAGLEDraftCudaGraphRunner:
             buffers.positions.zero_()
             buffers.topk_p.zero_()
             buffers.topk_index.zero_()
-            buffers.hidden_states.zero_()
+            if buffers.hidden_states is not None:
+                buffers.hidden_states.zero_()
             buffers.req_pool_indices.zero_()
 
         num_tokens = bs * self.num_tokens_per_bs
@@ -433,7 +443,11 @@ class EAGLEDraftCudaGraphRunner:
         )
         buffers.topk_p[:raw_bs].copy_(forward_batch.spec_info.topk_p)
         buffers.topk_index[:raw_bs].copy_(forward_batch.spec_info.topk_index)
-        buffers.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
+        if (
+            buffers.hidden_states is not None
+            and forward_batch.spec_info.hidden_states is not None
+        ):
+            buffers.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
         buffers.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
 
         # TODO(ch-wan): support num_token_non_padded

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -46,7 +46,7 @@ class EagleDraftExtendInputBuffers(ForwardInputBuffers):
     out_cache_loc: torch.Tensor
     positions: torch.Tensor
     mrope_positions: torch.Tensor
-    hidden_states: torch.Tensor
+    hidden_states: Optional[torch.Tensor]
     seq_lens: torch.Tensor
     seq_lens_cpu: torch.Tensor
     extend_seq_lens: torch.Tensor
@@ -132,12 +132,14 @@ class EAGLEDraftExtendCudaGraphRunner:
             positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
             mrope_positions = torch.zeros((3, self.max_num_token), dtype=torch.int64)
 
-            hidden_states = torch.zeros(
-                (
-                    self.max_num_token,
-                    EagleDraftExtendInput.hidden_size_for(self.eagle_worker),
-                ),
-                dtype=EagleDraftExtendInput.dtype_for(self.eagle_worker),
+            _hidden_size = EagleDraftExtendInput.hidden_size_for(self.eagle_worker)
+            hidden_states = (
+                torch.zeros(
+                    (self.max_num_token, _hidden_size),
+                    dtype=EagleDraftExtendInput.dtype_for(self.eagle_worker),
+                )
+                if _hidden_size is not None
+                else None
             )
             self.seq_len_fill_value = (
                 self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
@@ -292,7 +294,11 @@ class EAGLEDraftExtendCudaGraphRunner:
         out_cache_loc = buffers.out_cache_loc[:num_tokens]
         positions = buffers.positions[:num_tokens]
         mrope_positions = buffers.mrope_positions[:, :num_tokens]
-        hidden_states = buffers.hidden_states[:num_tokens]
+        hidden_states = (
+            buffers.hidden_states[:num_tokens]
+            if buffers.hidden_states is not None
+            else None
+        )
         num_correct_drafts = buffers.num_correct_drafts[:bs]
         num_accept_tokens = buffers.num_accept_tokens[:bs]
         next_token_logits_buffer = buffers.next_token_logits_buffer[
@@ -462,7 +468,9 @@ class EAGLEDraftExtendCudaGraphRunner:
         buffers.out_cache_loc[:num_tokens].copy_(forward_batch.out_cache_loc)
         buffers.positions[:num_tokens].copy_(forward_batch.positions)
         if (
-            forward_batch.spec_info.hidden_states.shape[1]
+            buffers.hidden_states is not None
+            and forward_batch.spec_info.hidden_states is not None
+            and forward_batch.spec_info.hidden_states.shape[1]
             == buffers.hidden_states.shape[1]
         ):
             buffers.hidden_states[:num_tokens].copy_(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -796,17 +796,21 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             )
             return
 
-        if self.hidden_states is None:
+        # Detect idle stub by `bonus_tokens` length (idle inputs have
+        # shape[0] == 0 across all fields). Don't use `hidden_states is None`:
+        # for STANDALONE all non-idle inputs also have None hidden_states.
+        if len(self.bonus_tokens) == 0:
             self.hidden_states = spec_info.hidden_states
             self.bonus_tokens = spec_info.bonus_tokens
             self.topk_p = spec_info.topk_p
             self.topk_index = spec_info.topk_index
             return
-        if spec_info.hidden_states is None:
+        if len(spec_info.bonus_tokens) == 0:
             return
-        self.hidden_states = torch.cat(
-            [self.hidden_states, spec_info.hidden_states], axis=0
-        )
+        if self.hidden_states is not None and spec_info.hidden_states is not None:
+            self.hidden_states = torch.cat(
+                [self.hidden_states, spec_info.hidden_states], axis=0
+            )
         self.bonus_tokens = torch.cat(
             [self.bonus_tokens, spec_info.bonus_tokens], axis=0
         )

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -796,16 +796,16 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             )
             return
 
-        # Detect idle stub by `bonus_tokens` length (idle inputs have
+        # Detect idle stub by `topk_index` length (idle inputs have
         # shape[0] == 0 across all fields). Don't use `hidden_states is None`:
         # for STANDALONE all non-idle inputs also have None hidden_states.
-        if len(self.bonus_tokens) == 0:
+        if len(self.topk_index) == 0:
             self.hidden_states = spec_info.hidden_states
             self.bonus_tokens = spec_info.bonus_tokens
             self.topk_p = spec_info.topk_p
             self.topk_index = spec_info.topk_index
             return
-        if len(spec_info.bonus_tokens) == 0:
+        if len(spec_info.topk_index) == 0:
             return
         if self.hidden_states is not None and spec_info.hidden_states is not None:
             self.hidden_states = torch.cat(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -559,7 +559,11 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             batch.seq_lens_cpu.add_(num_accept_tokens_cpu)
 
             draft_extend_input = EagleDraftExtendInput(
-                hidden_states=batch.spec_info.hidden_states[accept_index],
+                hidden_states=(
+                    batch.spec_info.hidden_states[accept_index]
+                    if batch.spec_info.hidden_states is not None
+                    else None
+                ),
                 num_correct_drafts=num_correct_drafts,
                 num_accept_tokens=num_correct_drafts + 1,
                 num_accept_tokens_cpu=num_accept_tokens_list,
@@ -627,9 +631,11 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     unfinished_index_device
                 ]
                 draft_extend_input = EagleDraftExtendInput(
-                    hidden_states=batch.spec_info.hidden_states[
-                        unfinished_accept_index
-                    ],
+                    hidden_states=(
+                        batch.spec_info.hidden_states[unfinished_accept_index]
+                        if batch.spec_info.hidden_states is not None
+                        else None
+                    ),
                     num_accept_tokens_cpu=draft_input_num_accept_tokens_cpu,
                     num_correct_drafts=unfinished_num_correct_drafts,
                     num_accept_tokens=unfinished_num_correct_drafts + 1,
@@ -665,7 +671,9 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     topk_p: torch.Tensor = None
     topk_index: torch.Tensor = None
     # shape: (b, hidden_size) - one hidden per req, consumed by `draft` forward.
-    hidden_states: torch.Tensor = None
+    # None when the spec algorithm's draft doesn't read hidden_states
+    # (e.g., STANDALONE — vanilla LLM draft).
+    hidden_states: Optional[torch.Tensor] = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
     # Per-req bonus token (the "+1" target prediction at end of each accept
@@ -712,28 +720,37 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             pt += extend_len
 
     @classmethod
-    def hidden_size_for(cls, worker) -> int:
+    def hidden_size_for(cls, worker) -> Optional[int]:
         """Decode-phase `hidden_states` width: draft self-chain output
         (draft model writes its own last hidden back via `capture_for_decode`
-        and the draft loop)."""
+        and the draft loop). Returns None when the draft architecture doesn't
+        consume the field (e.g., STANDALONE)."""
+        if worker.speculative_algorithm.is_standalone():
+            return None
         return _draft_runner_of(worker).model_config.spec_hidden_size
 
     @classmethod
-    def dtype_for(cls, worker) -> torch.dtype:
+    def dtype_for(cls, worker) -> Optional[torch.dtype]:
+        if worker.speculative_algorithm.is_standalone():
+            return None
         return _draft_runner_of(worker).model_config.dtype
 
     @classmethod
     def create_idle_input(
         cls,
         device: torch.device,
-        hidden_size: int,
-        dtype: torch.dtype,
+        hidden_size: Optional[int],
+        dtype: Optional[torch.dtype],
         topk: int,
         capture_hidden_mode: CaptureHiddenMode,
     ):
         return cls(
             bonus_tokens=torch.empty((0,), device=device, dtype=torch.int32),
-            hidden_states=torch.empty((0, hidden_size), device=device, dtype=dtype),
+            hidden_states=(
+                torch.empty((0, hidden_size), device=device, dtype=dtype)
+                if hidden_size is not None
+                else None
+            ),
             topk_p=torch.empty((0, topk), device=device, dtype=torch.float32),
             topk_index=torch.empty((0, topk), device=device, dtype=torch.int64),
             capture_hidden_mode=capture_hidden_mode,
@@ -758,13 +775,15 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]
-            self.hidden_states = self.hidden_states[: len(new_indices)]
+            if self.hidden_states is not None:
+                self.hidden_states = self.hidden_states[: len(new_indices)]
             self.bonus_tokens = self.bonus_tokens[: len(new_indices)]
         else:
             # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
             self.topk_p = self.topk_p[new_indices]
             self.topk_index = self.topk_index[new_indices]
-            self.hidden_states = self.hidden_states[new_indices]
+            if self.hidden_states is not None:
+                self.hidden_states = self.hidden_states[new_indices]
             self.bonus_tokens = self.bonus_tokens[new_indices]
 
     def merge_batch(self, spec_info: "EagleDraftInput"):
@@ -805,8 +824,9 @@ class EagleDraftExtendInput(SpecInput):
     """
 
     # shape: (total_accepted, hidden_size). Sliced from verify-time hidden_states
-    # by accept_index; consumed by the draft-extend forward.
-    hidden_states: torch.Tensor = None
+    # by accept_index; consumed by the draft-extend forward. None when the spec
+    # algorithm's draft doesn't read hidden_states (e.g., STANDALONE).
+    hidden_states: Optional[torch.Tensor] = None
 
     # Per-req accept counts. `num_accept_tokens = num_correct_drafts + 1`.
     # Both kept for cuda-graph buffer indexing and the
@@ -845,9 +865,13 @@ class EagleDraftExtendInput(SpecInput):
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
     @classmethod
-    def hidden_size_for(cls, worker) -> int:
+    def hidden_size_for(cls, worker) -> Optional[int]:
         """Extend-phase `hidden_states` width: target's `spec_hidden_size`,
-        widened to `num_aux * target_hidden` for EAGLE-3 aux mode."""
+        widened to `num_aux * target_hidden` for EAGLE-3 aux mode. Returns
+        None when the draft architecture doesn't consume the field
+        (e.g., STANDALONE)."""
+        if worker.speculative_algorithm.is_standalone():
+            return None
         target_cfg = worker.target_worker.model_runner.model_config
         if not (
             worker.speculative_algorithm.is_eagle3()
@@ -868,19 +892,25 @@ class EagleDraftExtendInput(SpecInput):
         return target_hidden * num_aux
 
     @classmethod
-    def dtype_for(cls, worker) -> torch.dtype:
+    def dtype_for(cls, worker) -> Optional[torch.dtype]:
+        if worker.speculative_algorithm.is_standalone():
+            return None
         return worker.target_worker.model_runner.model_config.dtype
 
     @classmethod
     def create_idle_input(
         cls,
         device: torch.device,
-        hidden_size: int,
-        dtype: torch.dtype,
+        hidden_size: Optional[int],
+        dtype: Optional[torch.dtype],
         capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.LAST,
     ) -> "EagleDraftExtendInput":
         return cls(
-            hidden_states=torch.empty((0, hidden_size), device=device, dtype=dtype),
+            hidden_states=(
+                torch.empty((0, hidden_size), device=device, dtype=dtype)
+                if hidden_size is not None
+                else None
+            ),
             num_correct_drafts=torch.empty((0,), device=device, dtype=torch.int32),
             num_accept_tokens=torch.empty((0,), device=device, dtype=torch.int32),
             num_accept_tokens_cpu=[],

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1183,6 +1183,10 @@ class EAGLEWorker(TpModelWorker):
         )
 
         batch.return_hidden_states = False
+        # Verify-time construction of EagleDraftExtendInput uses the dataclass
+        # default (LAST); the worker overrides here so get_model_worker_batch()
+        # propagates the correct mode (NULL for STANDALONE).
+        draft_extend_input.capture_hidden_mode = draft_extend_capture_mode
         model_worker_batch = batch.get_model_worker_batch()
         assert model_worker_batch.capture_hidden_mode == draft_extend_capture_mode
         forward_batch = ForwardBatch.init_new(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -989,7 +989,10 @@ class EAGLEWorker(TpModelWorker):
         logits_output.next_token_logits = logits_output.next_token_logits[
             res.accepted_indices
         ]
-        logits_output.hidden_states = logits_output.hidden_states[res.accepted_indices]
+        if logits_output.hidden_states is not None:
+            logits_output.hidden_states = logits_output.hidden_states[
+                res.accepted_indices
+            ]
 
         if (
             self.target_worker.model_runner.hybrid_gdn_config is not None
@@ -1025,7 +1028,7 @@ class EAGLEWorker(TpModelWorker):
 
         num_correct_drafts = torch.tensor(
             res.num_correct_drafts_per_req_cpu,
-            device=logits_output.hidden_states.device,
+            device=logits_output.next_token_logits.device,
             dtype=torch.int64,
         )
         cumulative_num_accept_tokens = torch.cumsum(num_correct_drafts + 1, dim=0)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -622,9 +622,10 @@ class EagleDraftWorker(BaseDraftWorker):
         draft_logits_output.next_token_logits = draft_logits_output.next_token_logits[
             select_index
         ]
-        draft_logits_output.hidden_states = draft_logits_output.hidden_states[
-            select_index
-        ]
+        if draft_logits_output.hidden_states is not None:
+            draft_logits_output.hidden_states = draft_logits_output.hidden_states[
+                select_index
+            ]
         probs = torch.softmax(draft_logits_output.next_token_logits, dim=-1)
         ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
         ret_hidden_states = draft_logits_output.hidden_states

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -56,7 +56,11 @@ def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
     if server_args is None:
         server_args = get_global_server_args()
 
-    # TODO(lsyin): also skip when 1) step = 1 or 2) standalone draft model
+    # STANDALONE drafts don't consume `spec_info.hidden_states` (vanilla LLM).
+    # multi_layer_eagle handles hidden_states internally, not via FutureMap.
+    # TODO(lsyin): also skip when step == 1.
+    if server_args.speculative_algorithm == "STANDALONE":
+        return False
     return not server_args.enable_multi_layer_eagle
 
 
@@ -510,7 +514,7 @@ def _select_top_k_tokens_later(
     topk_index = topk_index.view(-1, topk_sq)
     input_ids = torch.gather(topk_index, 1, topk_cs_index).flatten()
 
-    if hidden_states.shape[0] > 0:
+    if hidden_states is not None and hidden_states.shape[0] > 0:
         flat_cs = topk_cs_index.flatten()
         batch_offsets = torch.arange(
             0, hidden_states.shape[0], step=topk, device=flat_cs.device

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -4,7 +4,6 @@ from sglang.srt.environ import envs
 from sglang.srt.utils import is_blackwell
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
-from sglang.test.kits.radix_cache_server_kit import run_radix_attention_test
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
 register_cuda_ci(est_time=249, suite="stage-b-test-2-gpu-large")
@@ -37,9 +36,11 @@ class TestNvidiaNemotronNanoV2NVFP4(GSM8KMixin, DefaultServerBase):
 
 class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase):
     gsm8k_accuracy_thres = 0.87
+    gsm8k_num_questions = 1400
     model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
-    # NemotronH + STANDALONE + radix cache requires spec v2 +
-    # `mamba-scheduler-strategy extra_buffer` (see server_args.py guard).
+    # NemotronH + STANDALONE requires spec v2 + radix cache disabled
+    # (NemotronH doesn't support mamba extra_buffer; see server_args.py
+    # `_handle_mamba_radix_cache` + nemotron_h_hook.py).
     other_args = [
         "--speculative-algorithm",
         "STANDALONE",
@@ -59,29 +60,26 @@ class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase)
         "2048",
         "--json-model-override-args",
         '{"vocab_size": 131072}',
-        "--mamba-scheduler-strategy",
-        "extra_buffer",
+        "--disable-radix-cache",
     ]
 
     @classmethod
     def setUpClass(cls):
         envs.SGLANG_ENABLE_SPEC_V2.set(True)
-        super().setUpClass()
+        with envs.SGLANG_TEST_RETRACT.override(True):
+            super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         envs.SGLANG_ENABLE_SPEC_V2.clear()
 
-    def test_radix_attention(self):
-        run_radix_attention_test(self.base_url)
-        assert self.process.poll() is None
-
 
 class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
     GSM8KMixin, DefaultServerBase
 ):
     gsm8k_accuracy_thres = 0.87
+    gsm8k_num_questions = 1400
     model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
     other_args = [
         "--speculative-algorithm",
@@ -104,23 +102,19 @@ class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
         '{"vocab_size": 131072}',
         "--mamba-ssm-dtype",
         "bfloat16",
-        "--mamba-scheduler-strategy",
-        "extra_buffer",
+        "--disable-radix-cache",
     ]
 
     @classmethod
     def setUpClass(cls):
         envs.SGLANG_ENABLE_SPEC_V2.set(True)
-        super().setUpClass()
+        with envs.SGLANG_TEST_RETRACT.override(True):
+            super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         envs.SGLANG_ENABLE_SPEC_V2.clear()
-
-    def test_radix_attention(self):
-        run_radix_attention_test(self.base_url)
-        assert self.process.poll() is None
 
 
 if __name__ == "__main__":

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -33,10 +33,6 @@ class TestNvidiaNemotronNanoV2NVFP4(GSM8KMixin, DefaultServerBase):
     other_args = ["--max-mamba-cache-size", "256"]
 
 
-@unittest.skip(
-    "STANDALONE speculative decoding does not yet support target and draft models "
-    "with different hidden sizes (Nemotron-9B: 4480, Llama-3.2-1B: 2048)"
-)
 class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase):
     gsm8k_accuracy_thres = 0.87
     model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
@@ -62,10 +58,6 @@ class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase)
     ]
 
 
-@unittest.skip(
-    "STANDALONE speculative decoding does not yet support target and draft models "
-    "with different hidden sizes (Nemotron-9B: 4480, Llama-3.2-1B: 2048)"
-)
 class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
     GSM8KMixin, DefaultServerBase
 ):

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -66,8 +66,7 @@ class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase)
     @classmethod
     def setUpClass(cls):
         envs.SGLANG_ENABLE_SPEC_V2.set(True)
-        with envs.SGLANG_TEST_RETRACT.override(True):
-            super().setUpClass()
+        super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
@@ -108,8 +107,7 @@ class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
     @classmethod
     def setUpClass(cls):
         envs.SGLANG_ENABLE_SPEC_V2.set(True)
-        with envs.SGLANG_TEST_RETRACT.override(True):
-            super().setUpClass()
+        super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.environ import envs
 from sglang.srt.utils import is_blackwell
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
@@ -37,6 +38,8 @@ class TestNvidiaNemotronNanoV2NVFP4(GSM8KMixin, DefaultServerBase):
 class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase):
     gsm8k_accuracy_thres = 0.87
     model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
+    # NemotronH + STANDALONE + radix cache requires spec v2 +
+    # `mamba-scheduler-strategy extra_buffer` (see server_args.py guard).
     other_args = [
         "--speculative-algorithm",
         "STANDALONE",
@@ -56,7 +59,19 @@ class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase)
         "2048",
         "--json-model-override-args",
         '{"vocab_size": 131072}',
+        "--mamba-scheduler-strategy",
+        "extra_buffer",
     ]
+
+    @classmethod
+    def setUpClass(cls):
+        envs.SGLANG_ENABLE_SPEC_V2.set(True)
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        envs.SGLANG_ENABLE_SPEC_V2.clear()
 
     def test_radix_attention(self):
         run_radix_attention_test(self.base_url)
@@ -89,7 +104,19 @@ class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
         '{"vocab_size": 131072}',
         "--mamba-ssm-dtype",
         "bfloat16",
+        "--mamba-scheduler-strategy",
+        "extra_buffer",
     ]
+
+    @classmethod
+    def setUpClass(cls):
+        envs.SGLANG_ENABLE_SPEC_V2.set(True)
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        envs.SGLANG_ENABLE_SPEC_V2.clear()
 
     def test_radix_attention(self):
         run_radix_attention_test(self.base_url)

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sglang.srt.environ import envs
 from sglang.srt.utils import is_blackwell
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
@@ -34,13 +33,13 @@ class TestNvidiaNemotronNanoV2NVFP4(GSM8KMixin, DefaultServerBase):
     other_args = ["--max-mamba-cache-size", "256"]
 
 
+@unittest.skip(
+    "STANDALONE speculative decoding does not yet support target and draft models "
+    "with different hidden sizes (Nemotron-9B: 4480, Llama-3.2-1B: 2048)"
+)
 class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase):
     gsm8k_accuracy_thres = 0.87
-    gsm8k_num_questions = 1400
     model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
-    # NemotronH + STANDALONE requires spec v2 + radix cache disabled
-    # (NemotronH doesn't support mamba extra_buffer; see server_args.py
-    # `_handle_mamba_radix_cache` + nemotron_h_hook.py).
     other_args = [
         "--speculative-algorithm",
         "STANDALONE",
@@ -60,25 +59,17 @@ class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase)
         "2048",
         "--json-model-override-args",
         '{"vocab_size": 131072}',
-        "--disable-radix-cache",
     ]
 
-    @classmethod
-    def setUpClass(cls):
-        envs.SGLANG_ENABLE_SPEC_V2.set(True)
-        super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        envs.SGLANG_ENABLE_SPEC_V2.clear()
-
-
+@unittest.skip(
+    "STANDALONE speculative decoding does not yet support target and draft models "
+    "with different hidden sizes (Nemotron-9B: 4480, Llama-3.2-1B: 2048)"
+)
 class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
     GSM8KMixin, DefaultServerBase
 ):
     gsm8k_accuracy_thres = 0.87
-    gsm8k_num_questions = 1400
     model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
     other_args = [
         "--speculative-algorithm",
@@ -101,18 +92,7 @@ class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
         '{"vocab_size": 131072}',
         "--mamba-ssm-dtype",
         "bfloat16",
-        "--disable-radix-cache",
     ]
-
-    @classmethod
-    def setUpClass(cls):
-        envs.SGLANG_ENABLE_SPEC_V2.set(True)
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        envs.SGLANG_ENABLE_SPEC_V2.clear()
 
 
 if __name__ == "__main__":

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -3,6 +3,7 @@ import unittest
 from sglang.srt.utils import is_blackwell
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.radix_cache_server_kit import run_radix_attention_test
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
 register_cuda_ci(est_time=249, suite="stage-b-test-2-gpu-large")
@@ -57,6 +58,10 @@ class TestNvidiaNemotronNanoV2SpeculativeDecoding(GSM8KMixin, DefaultServerBase)
         '{"vocab_size": 131072}',
     ]
 
+    def test_radix_attention(self):
+        run_radix_attention_test(self.base_url)
+        assert self.process.poll() is None
+
 
 class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
     GSM8KMixin, DefaultServerBase
@@ -85,6 +90,10 @@ class TestNvidiaNemotronNanoV2SpeculativeDecodingBF16Cache(
         "--mamba-ssm-dtype",
         "bfloat16",
     ]
+
+    def test_radix_attention(self):
+        run_radix_attention_test(self.base_url)
+        assert self.process.poll() is None
 
 
 if __name__ == "__main__":

--- a/test/registered/spec/test_standalone_speculative_decoding.py
+++ b/test/registered/spec/test_standalone_speculative_decoding.py
@@ -122,10 +122,6 @@ class TestStandaloneSpeculativeDecodingBase(CustomTestCase):
         print(f"{avg_spec_accept_length=}")
         self.assertGreater(avg_spec_accept_length, self.spec_decode_threshold)
 
-    def test_radix_attention(self):
-        run_radix_attention_test(self.base_url)
-        assert self.process.poll() is None
-
 
 class TestStandaloneV2SpeculativeDecodingBase(CustomTestCase):
 
@@ -186,10 +182,6 @@ class TestStandaloneV2SpeculativeDecodingBase(CustomTestCase):
         print(f"{avg_spec_accept_length=}")
         self.assertGreater(avg_spec_accept_length, self.spec_decode_threshold)
 
-    def test_radix_attention(self):
-        run_radix_attention_test(self.base_url)
-        assert self.process.poll() is None
-
 
 class TestStandaloneSpeculativeDecodingTriton(TestStandaloneSpeculativeDecodingBase):
 
@@ -213,6 +205,10 @@ class TestStandaloneV2SpeculativeDecodingTriton(
     @classmethod
     def get_server_args(cls):
         return DEFAULT_SERVER_ARGS_V2 + ["--attention-backend", "triton"]
+
+    def test_radix_attention(self):
+        run_radix_attention_test(self.base_url)
+        assert self.process.poll() is None
 
 
 class TestStandaloneV2SpeculativeDecodingFlashinfer(

--- a/test/registered/spec/test_standalone_speculative_decoding.py
+++ b/test/registered/spec/test_standalone_speculative_decoding.py
@@ -82,13 +82,12 @@ class TestStandaloneSpeculativeDecodingBase(CustomTestCase):
         envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
         envs.SGLANG_ENABLE_SPEC_V2.set(False)
         model = cls.model
-        with envs.SGLANG_TEST_RETRACT.override(True):
-            cls.process = popen_launch_server(
-                model,
-                cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-                other_args=cls.get_server_args(),
-            )
+        cls.process = popen_launch_server(
+            model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.get_server_args(),
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -148,13 +147,12 @@ class TestStandaloneV2SpeculativeDecodingBase(CustomTestCase):
         envs.SGLANG_JIT_DEEPGEMM_PRECOMPILE.set(False)
         envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
         model = cls.model
-        with envs.SGLANG_TEST_RETRACT.override(True):
-            cls.process = popen_launch_server(
-                model,
-                cls.base_url,
-                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-                other_args=cls.get_server_args(),
-            )
+        cls.process = popen_launch_server(
+            model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.get_server_args(),
+        )
 
     @classmethod
     def tearDownClass(cls):

--- a/test/registered/spec/test_standalone_speculative_decoding.py
+++ b/test/registered/spec/test_standalone_speculative_decoding.py
@@ -6,6 +6,7 @@ import requests
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.radix_cache_server_kit import run_radix_attention_test
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_STANDALONE,
@@ -81,12 +82,13 @@ class TestStandaloneSpeculativeDecodingBase(CustomTestCase):
         envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
         envs.SGLANG_ENABLE_SPEC_V2.set(False)
         model = cls.model
-        cls.process = popen_launch_server(
-            model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.get_server_args(),
-        )
+        with envs.SGLANG_TEST_RETRACT.override(True):
+            cls.process = popen_launch_server(
+                model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=cls.get_server_args(),
+            )
 
     @classmethod
     def tearDownClass(cls):
@@ -121,6 +123,10 @@ class TestStandaloneSpeculativeDecodingBase(CustomTestCase):
         print(f"{avg_spec_accept_length=}")
         self.assertGreater(avg_spec_accept_length, self.spec_decode_threshold)
 
+    def test_radix_attention(self):
+        run_radix_attention_test(self.base_url)
+        assert self.process.poll() is None
+
 
 class TestStandaloneV2SpeculativeDecodingBase(CustomTestCase):
 
@@ -142,12 +148,13 @@ class TestStandaloneV2SpeculativeDecodingBase(CustomTestCase):
         envs.SGLANG_JIT_DEEPGEMM_PRECOMPILE.set(False)
         envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
         model = cls.model
-        cls.process = popen_launch_server(
-            model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=cls.get_server_args(),
-        )
+        with envs.SGLANG_TEST_RETRACT.override(True):
+            cls.process = popen_launch_server(
+                model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=cls.get_server_args(),
+            )
 
     @classmethod
     def tearDownClass(cls):
@@ -180,6 +187,10 @@ class TestStandaloneV2SpeculativeDecodingBase(CustomTestCase):
         ]
         print(f"{avg_spec_accept_length=}")
         self.assertGreater(avg_spec_accept_length, self.spec_decode_threshold)
+
+    def test_radix_attention(self):
+        run_radix_attention_test(self.base_url)
+        assert self.process.poll() is None
 
 
 class TestStandaloneSpeculativeDecodingTriton(TestStandaloneSpeculativeDecodingBase):


### PR DESCRIPTION
Builds on #24926. STANDALONE workers now declare `spec_info_consumes_hidden_states=False`; `hidden_size_for / dtype_for` returns `None` for them, `spec_info.hidden_states` propagates as `None` through the entire pipeline (allocation / cat / copy_ / cuda graph buffer / FutureMap). Target verify capture_hidden_mode flips to NULL when not consumed, so no wasted target-side capture for STANDALONE either.

Addresses #21058 task 1a/1b consumer side.

## Scope
- Worker init: `spec_info_consumes_hidden_states` property on EAGLEWorker / EagleDraftWorker / EAGLEWorkerV2 (derived from `speculative_algorithm.is_standalone()`)
- Dataclass: `EagleDraftInput.hidden_states` / `EagleDraftExtendInput.hidden_states` become `Optional[torch.Tensor]`
- `hidden_size_for / dtype_for` classmethods return `Optional[...]`
- `create_idle_input` accepts `hidden_size=None` -> no allocation
- Cuda graph runners (decode + extend): buffer is `None` for non-consumes, `copy_` / `zero_` guarded
- `spec_utils.select_top_k_tokens` (later variant): `Optional` handling
- `spec_need_hidden_states()` predicate gates STANDALONE for FutureMap
- v1 + v2 target verify `capture_hidden_mode` flips to NULL when not consumed
- v1 + v2 draft extend / decode draft `capture_hidden_mode` likewise

## Roadmap
- **PR 1 (#24926)**: shape single source of truth on dataclass classmethod
- **PR 2 (this one)**: STANDALONE `hidden_states = None` end-to-end
- **PR 3** (next): producer-side skip - `capture_for_decode` + FutureMap when draft doesn't chain via spec_info field (Multi-layer EAGLE, step=1)