### PR TITLE
ci: align torch CUDA wheel checks

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -277,7 +277,20 @@ install_sglang_kernel() {
     # TODO: Remove after torch 2.11 where cu13 is enabled by default
     TORCH_CUDA_VER=$(python3 -c "import torch; v=torch.version.cuda; parts=v.split('.'); print(f'cu{parts[0]}{parts[1]}')")
     echo "Detected torch CUDA version: ${TORCH_CUDA_VER}"
+    TORCHAUDIO_CUDA_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
+    TORCHVISION_CUDA_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
+    REINSTALL_TORCH=false
     if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
+        REINSTALL_TORCH=true
+    else
+        for cuda_ver in "${TORCHAUDIO_CUDA_VER}" "${TORCHVISION_CUDA_VER}"; do
+            if [ -n "${cuda_ver}" ] && [ "${cuda_ver}" != "${CU_VERSION}" ]; then
+                REINSTALL_TORCH=true
+                break
+            fi
+        done
+    fi
+    if [ "${REINSTALL_TORCH}" = true ]; then
         TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
         TORCHAUDIO_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
         TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/sgl-project/sglang/pull/24916. That PR moves the H20 runners to CUDA 13 by dropping the old `cu129` override.

One issue showed up during rollout: old workflow reruns can still install the torch stack from the `cu129` index on the same persistent runners. A later CUDA 13 run may see `torch` already aligned, but still have stale `torchaudio` / `torchvision` wheels from the old run. Then `ci_install_dependency.sh` skips the reinstall and the job fails later.

## Modifications

Include `torchaudio` and `torchvision` CUDA wheel suffixes in the existing torch CUDA alignment check. If `torch` is not aligned, reinstall immediately as before. If `torch` is aligned, also check `torchaudio` and `torchvision`; a mismatched CUDA suffix reuses the same reinstall path.

## Accuracy Tests

Not applicable. CI dependency installation only.

## Speed Tests and Profiling

Not applicable.

## Test Logs

The tested code path decides whether the existing reinstall path should run:

```bash
TORCHAUDIO_CUDA_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
TORCHVISION_CUDA_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
REINSTALL_TORCH=false
if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
    REINSTALL_TORCH=true
else
    for cuda_ver in "${TORCHAUDIO_CUDA_VER}" "${TORCHVISION_CUDA_VER}"; do
        if [ -n "${cuda_ver}" ] && [ "${cuda_ver}" != "${CU_VERSION}" ]; then
            REINSTALL_TORCH=true
            break
        fi
    done
fi
```
 temporary `python3 -m venv --without-pip`, `bash -euxo pipefail`:

```text
CU_VERSION  torch  torchaudio      torchvision      expected   actual
cu130       cu130  2.11.0          0.26.0           skip       skip
cu130       cu129  2.11.0          0.26.0           reinstall  reinstall
cu130       cu130  2.11.0+cu129    0.26.0+cu129     reinstall  reinstall
cu130       cu130  2.11.0+cu129    0.26.0           reinstall  reinstall
cu130       cu130  2.11.0          0.26.0+cu129     reinstall  reinstall
cu130       cu130  2.11.0+cu130    0.26.0+cu130     skip       skip
cu129       cu129  2.11.0+cu129    0.26.0+cu129     skip       skip
cu130       cu130  missing         missing          skip       skip
REMOTE_TEST_RC=0
```

Also ran:

```text
$ bash -n scripts/ci/cuda/ci_install_dependency.sh
# passed
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). Shell-only change; validated with `bash -n`.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Covered shell decision logic in isolated venvs and on both H20 runners.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
