### PR TITLE
fix: SGLANG_RADIX_FORCE_MISS chunk-cache passthrough

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -152,13 +152,10 @@ class MatchResult(NamedTuple):
 
 
 def zero_match_result(tree_cache, match_result: "MatchResult") -> "MatchResult":
-    root = getattr(tree_cache, "root_node", None)
-    if root is None:
-        raise RuntimeError(
-            f"SGLANG_RADIX_FORCE_MISS is not supported by {type(tree_cache).__name__} "
-            "(no `root_node` attribute). Disable the flag or use a cache backend "
-            "that exposes a tree root."
-        )
+    if tree_cache.is_chunk_cache():
+        # Chunk caches' match_prefix already returns a miss; no root_node to walk back to.
+        return match_result
+    root = tree_cache.root_node
     return match_result._replace(
         # [:0] keeps dtype and device of the original tensor (e.g. CUDA int64)
         # without allocating a fresh empty tensor.

--- a/test/registered/unit/mem_cache/test_radix_force_miss.py
+++ b/test/registered/unit/mem_cache/test_radix_force_miss.py
@@ -55,20 +55,18 @@ class TestZeroMatchResult(unittest.TestCase):
         self.assertEqual(zeroed.device_indices.dtype, match.device_indices.dtype)
         self.assertEqual(zeroed.device_indices.device, match.device_indices.device)
 
-    def test_no_root_node_raises(self):
-        # tree_cache without a root_node: must raise loudly rather than silently
-        # leak cache hits past the gate.
-        class _NoRoot:
-            pass
+    def test_chunk_cache_is_passthrough(self):
+        class _StubChunkCache:
+            def is_chunk_cache(self) -> bool:
+                return True
 
         original = MatchResult(
-            device_indices=torch.tensor([7, 8, 9], dtype=torch.int64),
-            last_device_node="sentinel-device",
-            last_host_node="sentinel-host",
-            host_hit_length=4,
+            device_indices=torch.empty((0,), dtype=torch.int64),
+            last_device_node=None,
+            last_host_node=None,
+            host_hit_length=0,
         )
-        with self.assertRaisesRegex(RuntimeError, "SGLANG_RADIX_FORCE_MISS"):
-            zero_match_result(_NoRoot(), original)
+        self.assertIs(zero_match_result(_StubChunkCache(), original), original)
 
 
 class TestMatchPrefixForReqForceMiss(unittest.TestCase):


### PR DESCRIPTION
zero_match_result() raises RuntimeError when called on caches without a root_node (ChunkCache, SWAChunkCache). DeepSeek-V4 disagg uses SWAChunkCache on prefill workers, so SGLANG_RADIX_FORCE_MISS=1 crashes the scheduler the first time match_prefix runs through the gate.

Chunk caches have no prefix matching by design - match_prefix already returns empty device_indices and last_*_node=None, so the FORCE_MISS flag has nothing to zero. Make the helper a no-op on chunk caches via the existing is_chunk_cache() predicate instead of trying to reach through to a tree root that doesn't exist.

Tree caches (RadixCache, SwaRadixCache) keep the exact same behavior, with the brittle getattr/RuntimeError replaced by a direct attribute access since the is_chunk_cache() branch already filters out everything that lacks root_node.

Test: flip test_no_root_node_raises to test_chunk_cache_is_passthrough.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
