### PR TITLE
fix(rerank): close request generator after first result

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_rerank.py
+++ b/python/sglang/srt/entrypoints/openai/serving_rerank.py
@@ -241,6 +241,17 @@ class OpenAIServingRerank(OpenAIServingBase):
 
         return None
 
+    async def _generate_one(
+        self,
+        req: Union[GenerateReqInput, EmbeddingReqInput],
+        raw_request: Request,
+    ) -> Any:
+        generator = self.tokenizer_manager.generate_request(req, raw_request)
+        try:
+            return await generator.__anext__()
+        finally:
+            await generator.aclose()
+
     def _convert_to_internal_request(
         self,
         request: V1RerankReqInput,
@@ -303,9 +314,7 @@ class OpenAIServingRerank(OpenAIServingBase):
                     "If you are serving a decoder-only reranker (e.g., Qwen3-Reranker), "
                     "please provide the corresponding --chat-template and launch without --is-embedding."
                 )
-            ret = await self.tokenizer_manager.generate_request(
-                adapted_request, raw_request
-            ).__anext__()
+            ret = await self._generate_one(adapted_request, raw_request)
         except ValueError as e:
             return self.create_error_response(str(e))
 
@@ -443,9 +452,7 @@ class OpenAIServingRerank(OpenAIServingBase):
                 )
 
                 # Execute generation request
-                ret = await self.tokenizer_manager.generate_request(
-                    gen_request, raw_request
-                ).__anext__()
+                ret = await self._generate_one(gen_request, raw_request)
 
                 # Extract yes/no probabilities from logprobs
                 score = self._extract_score_from_logprobs(ret)

--- a/test/registered/prefill_only/test_serving_rerank.py
+++ b/test/registered/prefill_only/test_serving_rerank.py
@@ -45,6 +45,25 @@ class _DummyTokenizerManager:
         raise AssertionError("generate_request should not be called in this unit test")
 
 
+class _ClosableAsyncGen:
+    def __init__(self, result):
+        self.result = result
+        self.closed = False
+        self._yielded = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._yielded:
+            raise StopAsyncIteration
+        self._yielded = True
+        return self.result
+
+    async def aclose(self):
+        self.closed = True
+
+
 @unittest.skipIf(OpenAIServingRerank is None, "fastapi/torch is not installed")
 class TestOpenAIServingRerankUnit(unittest.TestCase):
     def setUp(self):
@@ -75,6 +94,25 @@ class TestOpenAIServingRerankUnit(unittest.TestCase):
         adapted, processed = handler._convert_to_internal_request(req)
         self.assertIs(adapted, req)
         self.assertIs(processed, req)
+
+    def test_generate_one_closes_async_generator(self):
+        class _TM(_DummyTokenizerManager):
+            def __init__(self):
+                self.server_args = object()
+                self.model_config = _DummyModelConfig()
+                self.tokenizer = _DummyTokenizer()
+                self.last_generator = None
+
+            def generate_request(self, *_args, **_kwargs):
+                self.last_generator = _ClosableAsyncGen({"ok": True})
+                return self.last_generator
+
+        tm = _TM()
+        handler = OpenAIServingRerank(tm)
+        ret = asyncio.run(handler._generate_one(Mock(), Mock()))
+        self.assertEqual(ret, {"ok": True})
+        self.assertIsNotNone(tm.last_generator)
+        self.assertTrue(tm.last_generator.closed)
 
     def test_build_rerank_response_embedding_list_uses_first_scalar(self):
         req = V1RerankReqInput(


### PR DESCRIPTION
## Problem

`/v1/rerank` consumes only the first item from `tokenizer_manager.generate_request(...)`, but the async generator was never closed explicitly. On rerank error paths, this can leave request state alive longer than expected and delay GPU memory release, which matches the observed pattern where a 400 response is followed by OOM on the next rerank request.

## Change

- Add a helper that awaits the first result and always calls `aclose()` in `finally`.
- Use it in both rerank code paths that consume a single generation result.
- Add unit coverage for explicit generator cleanup.

## Impact

This makes rerank request cleanup deterministic and reduces the chance of request-state / GPU-memory leakage after a bad request.