### PR TITLE
fix(rerank): support multimodal documents in return_documents

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1136,7 +1136,7 @@ class V1RerankReqInput(BaseModel):
 
 class RerankResponse(BaseModel):
     score: float
-    document: Optional[str] = None
+    document: Optional[RerankContent] = None
     index: int
     meta_info: Optional[dict] = None
 

--- a/test/registered/prefill_only/test_serving_rerank.py
+++ b/test/registered/prefill_only/test_serving_rerank.py
@@ -116,6 +116,31 @@ class TestOpenAIServingRerankUnit(unittest.TestCase):
         self.assertAlmostEqual(res[1].score, 0.2)
         self.assertAlmostEqual(res[2].score, 0.1)
 
+    def test_build_rerank_response_multimodal_return_documents_true(self):
+        query = [
+            {"type": "text", "text": "Find similar images to this:"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/query.jpeg"},
+            },
+        ]
+        multimodal_doc = [
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/similar.jpeg"},
+            }
+        ]
+        req = V1RerankReqInput(
+            query=query,
+            documents=["text-doc", multimodal_doc],
+            return_documents=True,
+        )
+        scores = [0.2, 0.9]
+        res = self.handler._build_rerank_response(scores, req)
+        self.assertEqual(res[0].index, 1)
+        self.assertEqual(res[0].document, multimodal_doc)
+        self.assertAlmostEqual(res[0].score, 0.9)
+
     def test_helper_is_qwen3_reranker_template(self):
         self.assertTrue(
             _is_qwen3_reranker_template(


### PR DESCRIPTION
## Problem

`/v1/rerank` accepts multimodal `documents` (for example image URLs), but `RerankResponse.document` was typed as `string`. When `return_documents=true` (the default), the server tried to serialize a multimodal document back into a string field and returned 400.

## Change

- Widen `RerankResponse.document` to accept rerank content (`str` or multimodal content parts).
- Add unit coverage for returning multimodal documents with `return_documents=true`.

## Impact

This makes multimodal rerank responses compatible with `return_documents=true` and removes the response validation failure on valid requests.