### PR TITLE
DO NOT MERGE — CI sandbox for nonmech_scheduler

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1446,17 +1446,21 @@ class DecodeTransferQueue:
             decode_req.req.hidden_states_tensor = output_hidden_states
 
         if decode_req.req.return_logprob:
-            decode_req.req.output_token_logprobs_val.append(
+            decode_req.req.logprob.output_token_logprobs_val.append(
                 output_token_logprobs_val[0].item()
             )
-            decode_req.req.output_token_logprobs_idx.append(
+            decode_req.req.logprob.output_token_logprobs_idx.append(
                 output_token_logprobs_idx[0].item()
             )
-            decode_req.req.output_top_logprobs_val.append(
-                output_top_logprobs_val[: decode_req.req.top_logprobs_num].tolist()
+            decode_req.req.logprob.output_top_logprobs_val.append(
+                output_top_logprobs_val[
+                    : decode_req.req.logprob.top_logprobs_num
+                ].tolist()
             )
-            decode_req.req.output_top_logprobs_idx.append(
-                output_top_logprobs_idx[: decode_req.req.top_logprobs_num].tolist()
+            decode_req.req.logprob.output_top_logprobs_idx.append(
+                output_top_logprobs_idx[
+                    : decode_req.req.logprob.top_logprobs_num
+                ].tolist()
             )
 
         decode_req.kv_receiver.clear()

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -152,7 +152,8 @@ class DecodeReqToTokenPool:
             len(reusing) <= 1
         ), "only one chunked request may reuse req_pool_idx in a batch"
         assert all(
-            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in reusing
+            reqs[i].inflight_middle_chunks > 0 or reqs[i].kv_committed_len > 0
+            for i in reusing
         ), "reusing request must be chunked or have committed KV"
 
         need_size = len(reqs) - len(reusing)

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -85,8 +85,8 @@ class ScheduleBatchDisaggregationDecodeMixin:
         self.seq_lens_sum = sum(seq_lens)
 
         if self.return_logprob:
-            self.top_logprobs_nums = [r.top_logprobs_num for r in reqs]
-            self.token_ids_logprobs = [r.token_ids_logprob for r in reqs]
+            self.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]
+            self.token_ids_logprobs = [r.logprob.token_ids_logprob for r in reqs]
 
         self.extend_num_tokens = extend_num_tokens
         self.prefix_lens = [len(r.prefix_indices) for r in reqs]

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -124,7 +124,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
                     # Grammar accept_token can raise ValueError if the token is not in the grammar.
                     # This can happen if the grammar is not set correctly or the token is invalid.
                     # Use to_finish (not finished_reason) so that process_batch_result_prebuilt
-                    # handles the release via check_finished -> release_kv_cache in one place.
+                    # handles the release via update_finish_state -> release_kv_cache in one place.
                     error_message = f"Grammar accept_token failed for req {req.rid} with token {req.output_ids[-1]}: {e}"
                     req.to_finish = FINISH_ABORT(
                         error_message, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -586,7 +586,7 @@ class SchedulerDisaggregationPrefillMixin:
                     self.send_kv_chunk(req, last_chunk=False, end_idx=req.tmp_end_idx)
                 req.time_stats.set_last_chunked_prefill_finish_time()
 
-        can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+        can_run_cuda_graph = result.can_run_cuda_graph
         self.metrics_reporter.report_prefill_stats(
             batch=batch,
             prefill_stats=batch.prefill_stats,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -514,7 +514,7 @@ class SchedulerDisaggregationPrefillMixin:
         for i, (req, next_token_id) in enumerate(
             zip(batch.reqs, next_token_ids, strict=True)
         ):
-            if req.is_chunked <= 0:
+            if req.inflight_middle_chunks <= 0:
                 req.time_stats.set_prefill_finished_time()
 
                 # There is no output_ids for prefill
@@ -564,7 +564,7 @@ class SchedulerDisaggregationPrefillMixin:
                     req.grammar.finished = req.finished()
             else:
                 # being chunked reqs' prefill is not finished
-                req.is_chunked -= 1
+                req.inflight_middle_chunks -= 1
 
                 if req.return_logprob:
                     extend_logprob_start_len = extend_logprob_start_len_per_req[i]

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -263,26 +263,30 @@ class MetadataBuffers:
         self.cached_tokens[req.metadata_buffer_index][2] = req.cached_tokens_host
         self.cached_tokens[req.metadata_buffer_index][3] = req.cached_tokens_storage
         if req.return_logprob:
-            if req.output_token_logprobs_val:  # not none or empty list
+            if req.logprob.output_token_logprobs_val:  # not none or empty list
                 self.output_token_logprobs_val[req.metadata_buffer_index][0] = (
-                    req.output_token_logprobs_val[0]
+                    req.logprob.output_token_logprobs_val[0]
                 )
-            if req.output_token_logprobs_idx:  # not none or empty list
+            if req.logprob.output_token_logprobs_idx:  # not none or empty list
                 self.output_token_logprobs_idx[req.metadata_buffer_index][0] = (
-                    req.output_token_logprobs_idx[0]
+                    req.logprob.output_token_logprobs_idx[0]
                 )
 
-            if req.output_top_logprobs_val:  # not none or empty list
+            if req.logprob.output_top_logprobs_val:  # not none or empty list
                 self.output_top_logprobs_val[req.metadata_buffer_index][
-                    : len(req.output_top_logprobs_val[0])
+                    : len(req.logprob.output_top_logprobs_val[0])
                 ] = torch.tensor(
-                    req.output_top_logprobs_val[0], dtype=torch.float32, device="cpu"
+                    req.logprob.output_top_logprobs_val[0],
+                    dtype=torch.float32,
+                    device="cpu",
                 )
-            if req.output_top_logprobs_idx:  # not none or empty list
+            if req.logprob.output_top_logprobs_idx:  # not none or empty list
                 self.output_top_logprobs_idx[req.metadata_buffer_index][
-                    : len(req.output_top_logprobs_idx[0])
+                    : len(req.logprob.output_top_logprobs_idx[0])
                 ] = torch.tensor(
-                    req.output_top_logprobs_idx[0], dtype=torch.int32, device="cpu"
+                    req.logprob.output_top_logprobs_idx[0],
+                    dtype=torch.int32,
+                    device="cpu",
                 )
         # For PD + spec decode
         if req.hidden_states_tensor is not None:
@@ -635,9 +639,9 @@ def prepare_abort(req: Req, error_message: str, status_code=None):
     req.finished_reason = FINISH_ABORT(error_message, status_code)
 
     if req.return_logprob:
-        req.input_token_logprobs_val = []
-        req.input_token_logprobs_idx = []
-        req.input_top_logprobs_val = []
-        req.input_top_logprobs_idx = []
-        req.input_token_ids_logprobs_val = []
-        req.input_token_ids_logprobs_idx = []
+        req.logprob.input_token_logprobs_val = []
+        req.logprob.input_token_logprobs_idx = []
+        req.logprob.input_top_logprobs_val = []
+        req.logprob.input_top_logprobs_idx = []
+        req.logprob.input_token_ids_logprobs_val = []
+        req.logprob.input_token_ids_logprobs_idx = []

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -137,7 +137,7 @@ class SchedulerDllmMixin:
             self.tree_cache,
             self.token_to_kv_pool_allocator,
             self.running_batch,
-            self.new_token_ratio,
+            self.new_token_ratio_tracker.current,
             self.max_prefill_tokens,
             self.chunked_prefill_size,
             running_bs if self.is_mixed_chunk else 0,

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -200,7 +200,7 @@ class SchedulerDllmMixin:
 
         if can_run_list:
             self.dllm_manager.add_staging_reqs(can_run_list)
-            self.dllm_manager.increment_chunked_count()
+            self.dllm_manager.increment_inflight_middle_chunks()
 
         self.adder = adder
         self.can_run_list = can_run_list
@@ -338,10 +338,10 @@ class DllmManager:
             return True
         return len(self.waiting_queue) == 0
 
-    def increment_chunked_count(self) -> None:
+    def increment_inflight_middle_chunks(self) -> None:
         """Increment chunked count for all staging requests."""
         for req in self.staging_queue:
-            req.is_chunked += 1
+            req.inflight_middle_chunks += 1
 
     def filter_finished_reqs(self) -> None:
         """Remove finished requests from both queues."""

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -92,7 +92,7 @@ class SchedulerDllmMixin:
             self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
             self.token_to_kv_pool_allocator.free_group_end()
 
-        can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+        can_run_cuda_graph = result.can_run_cuda_graph
         self.metrics_reporter.report_prefill_stats(
             batch=batch,
             prefill_stats=batch.prefill_stats,

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -83,7 +83,7 @@ class SchedulerDllmMixin:
                 self.metrics_reporter.num_generated_tokens += new_tokens
 
                 req.output_ids.extend(next_token_ids)
-                req.check_finished(new_accepted_len=new_tokens)
+                req.update_finish_state(new_accepted_len=new_tokens)
 
                 if req.finished():
                     release_kv_cache(req, self.tree_cache)

--- a/python/sglang/srt/layers/utils/logprob.py
+++ b/python/sglang/srt/layers/utils/logprob.py
@@ -415,17 +415,28 @@ def add_output_logprobs_for_spec_v1(
     for req, num_tokens in zip(batch.reqs, num_tokens_per_req, strict=True):
         for _ in range(num_tokens):
             if req.return_logprob:
-                req.output_token_logprobs_val.append(next_token_logprobs[pt])
-                req.output_token_logprobs_idx.append(accept_tokens_list[pt])
-                if req.top_logprobs_num > 0:
+                req.logprob.output_token_logprobs_val.append(next_token_logprobs[pt])
+                req.logprob.output_token_logprobs_idx.append(accept_tokens_list[pt])
+                if req.logprob.top_logprobs_num > 0:
                     assert (
                         should_top_logprobs
                     ), "Inconsistent state: should_top_logprobs is False"
-                    req.output_top_logprobs_val.append(token_top_logprobs_val[pt])
-                    req.output_top_logprobs_idx.append(token_top_logprobs_idx[pt])
-                if req.token_ids_logprob is not None and should_token_ids_logprobs:
-                    req.output_token_ids_logprobs_val.append(token_ids_logprobs_val[pt])
-                    req.output_token_ids_logprobs_idx.append(token_ids_logprobs_idx[pt])
+                    req.logprob.output_top_logprobs_val.append(
+                        token_top_logprobs_val[pt]
+                    )
+                    req.logprob.output_top_logprobs_idx.append(
+                        token_top_logprobs_idx[pt]
+                    )
+                if (
+                    req.logprob.token_ids_logprob is not None
+                    and should_token_ids_logprobs
+                ):
+                    req.logprob.output_token_ids_logprobs_val.append(
+                        token_ids_logprobs_val[pt]
+                    )
+                    req.logprob.output_token_ids_logprobs_idx.append(
+                        token_ids_logprobs_idx[pt]
+                    )
             pt += 1
 
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -40,7 +40,17 @@ from enum import Enum, auto
 from functools import lru_cache
 from http import HTTPStatus
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -1379,6 +1389,12 @@ class Req(ReqDllmMixin):
         )
 
 
+class _MambaRadixCacheV2TrackEntry(NamedTuple):
+    track_mask: bool
+    track_index: int
+    track_seqlen: int
+
+
 @dataclasses.dataclass
 class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     """Store all information of a batch on the scheduler."""
@@ -1850,12 +1866,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req.is_retracted = False
 
             if get_global_server_args().enable_mamba_extra_buffer():
-                self._mamba_radix_cache_v2_req_prepare_for_extend(
-                    req,
-                    mamba_track_mask_cpu,
-                    mamba_track_indices_cpu,
-                    mamba_track_seqlens_cpu,
-                )
+                track_entry = self._mamba_radix_cache_v2_req_prepare_for_extend(req)
+                mamba_track_mask_cpu.append(track_entry.track_mask)
+                mamba_track_indices_cpu.append(track_entry.track_index)
+                mamba_track_seqlens_cpu.append(track_entry.track_seqlen)
 
             if self.return_logprob:
                 # Find input logprob token ids.
@@ -2001,10 +2015,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def _mamba_radix_cache_v2_req_prepare_for_extend(
         self,
         req: Req,
-        mamba_track_mask_cpu: List[bool],
-        mamba_track_indices_cpu: List[int],
-        mamba_track_seqlens_cpu: List[int],
-    ):
+    ) -> "_MambaRadixCacheV2TrackEntry":
         def _force_track_h(i: int) -> int:
             assert i % FLA_CHUNK_SIZE == 0
             # There are 3 cases for mamba_track_seqlen passed to mamba_track_seqlens_cpu:
@@ -2018,10 +2029,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         mamba_cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
         mask = req.extend_input_len >= mamba_cache_chunk_size
-        mamba_track_mask_cpu.append(mask)
-        mamba_track_indices_cpu.append(
-            req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
-        )
+        track_index = req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
         mamba_track_seqlen = -1
         if mask:
             # mamba_track_seqlen is used to calculate the indices to track in
@@ -2076,7 +2084,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     mamba_track_seqlen = _force_track_h(req.mamba_branching_seqlen)
                     mamba_track_seqlen_aligned = req.mamba_branching_seqlen
             req.mamba_last_track_seqlen = mamba_track_seqlen_aligned
-        mamba_track_seqlens_cpu.append(mamba_track_seqlen)
+        return _MambaRadixCacheV2TrackEntry(
+            track_mask=mask,
+            track_index=track_index,
+            track_seqlen=mamba_track_seqlen,
+        )
 
     def mix_with_running(self, running_batch: "ScheduleBatch"):
         self.forward_mode = ForwardMode.MIXED

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1022,11 +1022,11 @@ class Req(ReqDllmMixin):
             max_prefix_len = min(max_prefix_len, self.logprob_start_len)
         max_prefix_len = max(max_prefix_len, 0)
         token_ids = self.fill_ids[:max_prefix_len]
+        del max_prefix_len
 
         # Disable prefix caching when embed overrides are present: same token IDs
         # with different override vectors must not share cached KV values.
         if self.positional_embed_overrides is not None:
-            max_prefix_len = 0
             token_ids = []
 
         if tree_cache is not None:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2078,11 +2078,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req.mamba_last_track_seqlen = mamba_track_seqlen_aligned
         mamba_track_seqlens_cpu.append(mamba_track_seqlen)
 
-    def prepare_for_split_prefill(self):
-        self.prepare_for_extend()
-        # For split prefill, we need to set the forward mode to SPLIT_PREFILL
-        self.forward_mode = ForwardMode.SPLIT_PREFILL
-
     def mix_with_running(self, running_batch: "ScheduleBatch"):
         self.forward_mode = ForwardMode.MIXED
         running_bs = running_batch.batch_size()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -568,6 +568,27 @@ class MultimodalInputs:
         # other args would be kept intact
 
 
+@dataclasses.dataclass(slots=True, kw_only=True)
+class ReqLogprob:
+    top_logprobs_num: int
+    token_ids_logprob: Optional[List[int]]
+    input_token_logprobs_val: Optional[List[float]] = None
+    input_token_logprobs_idx: Optional[List[int]] = None
+    input_top_logprobs_val: Optional[List[List[float]]] = None
+    input_top_logprobs_idx: Optional[List[List[int]]] = None
+    input_token_ids_logprobs_val: Optional[List[List[float]]] = None
+    input_token_ids_logprobs_idx: Optional[List[List[int]]] = None
+    output_token_logprobs_val: Optional[list] = None
+    output_token_logprobs_idx: Optional[list] = None
+    output_top_logprobs_val: Optional[list] = None
+    output_top_logprobs_idx: Optional[list] = None
+    # Can contain either lists or GPU tensors (delayed copy optimization for prefill-only scoring)
+    output_token_ids_logprobs_val: Optional[List[Union[List[float], torch.Tensor]]] = (
+        None
+    )
+    output_token_ids_logprobs_idx: Optional[list] = None
+
+
 class Req(ReqDllmMixin):
     """The input and output status of a request."""
 
@@ -767,18 +788,14 @@ class Req(ReqDllmMixin):
         self.return_logprob = return_logprob
         # Start index to compute logprob from.
         self.logprob_start_len = 0
-        self.top_logprobs_num = top_logprobs_num
-        self.token_ids_logprob = token_ids_logprob
+        self.logprob = ReqLogprob(
+            top_logprobs_num=top_logprobs_num,
+            token_ids_logprob=token_ids_logprob,
+        )
 
         # Logprobs (return values)
         # True means the input logprob has been already sent to detokenizer.
         self.input_logprob_sent: bool = False
-        self.input_token_logprobs_val: Optional[List[float]] = None
-        self.input_token_logprobs_idx: Optional[List[int]] = None
-        self.input_top_logprobs_val: Optional[List[float]] = None
-        self.input_top_logprobs_idx: Optional[List[int]] = None
-        self.input_token_ids_logprobs_val: Optional[List[float]] = None
-        self.input_token_ids_logprobs_idx: Optional[List[int]] = None
         # Temporary holder to store input_token_logprobs.
         self.input_token_logprobs: Optional[List[Tuple[int]]] = None
         self.temp_input_top_logprobs_val: Optional[List[torch.Tensor]] = None
@@ -788,22 +805,14 @@ class Req(ReqDllmMixin):
 
         if return_logprob:
             # shape: (bs, 1)
-            self.output_token_logprobs_val = []
-            self.output_token_logprobs_idx = []
+            self.logprob.output_token_logprobs_val = []
+            self.logprob.output_token_logprobs_idx = []
             # shape: (bs, k)
-            self.output_top_logprobs_val = []
-            self.output_top_logprobs_idx = []
+            self.logprob.output_top_logprobs_val = []
+            self.logprob.output_top_logprobs_idx = []
             # Can contain either lists or GPU tensors (delayed copy optimization for prefill-only scoring)
-            self.output_token_ids_logprobs_val: List[
-                Union[List[float], torch.Tensor]
-            ] = []
-            self.output_token_ids_logprobs_idx = []
-        else:
-            self.output_token_logprobs_val = self.output_token_logprobs_idx = (
-                self.output_top_logprobs_val
-            ) = self.output_top_logprobs_idx = self.output_token_ids_logprobs_val = (
-                self.output_token_ids_logprobs_idx
-            ) = None
+            self.logprob.output_token_ids_logprobs_val = []
+            self.logprob.output_token_ids_logprobs_idx = []
         self.hidden_states: List[List[float]] = []
         self.hidden_states_tensor = None  # Note: use tensor instead of list to transfer hidden_states when PD + MTP
         self.output_topk_p = None
@@ -1954,8 +1963,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.multi_item_delimiter_indices = None
 
         if self.return_logprob:
-            self.top_logprobs_nums = [r.top_logprobs_num for r in reqs]
-            self.token_ids_logprobs = [r.token_ids_logprob for r in reqs]
+            self.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]
+            self.token_ids_logprobs = [r.logprob.token_ids_logprob for r in reqs]
 
         self.extend_logprob_start_lens = [r.extend_logprob_start_len for r in reqs]
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -56,6 +56,9 @@ from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
+    NewTokenRatioTracker,
+)
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -2229,16 +2232,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.filter_batch(keep_indices=sorted_indices)
 
         # Reqs in batch are filtered
-        total_decoded_tokens = sum(len(r.output_ids) for r in self.reqs)
-        total_max_new_tokens = sum(r.sampling_params.max_new_tokens for r in self.reqs)
-
         new_estimate_ratio = (
-            total_decoded_tokens
-            + envs.SGLANG_RETRACT_DECODE_STEPS.get() * len(self.reqs)
-        ) / (
-            total_max_new_tokens + 1
-        )  # avoid zero division
-        new_estimate_ratio = min(1.0, new_estimate_ratio)
+            NewTokenRatioTracker.estimate_new_token_ratio_after_retract(self.reqs)
+        )
 
         return retracted_reqs, new_estimate_ratio, reqs_to_abort
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1026,25 +1026,21 @@ class Req(ReqDllmMixin):
             )
             self.logprob_start_len = -1
 
-        # NOTE: the matched length is at most 1 less than the input length to enable logprob computation
-        max_prefix_len = input_len - 1
-        if self.return_logprob and self.logprob_start_len >= 0:
-            max_prefix_len = min(max_prefix_len, self.logprob_start_len)
-        max_prefix_len = max(max_prefix_len, 0)
-        token_ids = self.fill_ids[:max_prefix_len]
-        del max_prefix_len
+        token_ids_to_match = self.fill_ids[: self._compute_max_prefix_len(input_len)]
 
         # Disable prefix caching when embed overrides are present: same token IDs
         # with different override vectors must not share cached KV values.
         if self.positional_embed_overrides is not None:
-            token_ids = []
+            token_ids_to_match = []
 
         if tree_cache is not None:
             if cow_mamba is None:
                 cow_mamba = tree_cache.supports_mamba()
             match_result = tree_cache.match_prefix(
                 MatchPrefixParams(
-                    key=RadixKey(token_ids=token_ids, extra_key=self.extra_key),
+                    key=RadixKey(
+                        token_ids=token_ids_to_match, extra_key=self.extra_key
+                    ),
                     req=self,
                     cow_mamba=cow_mamba,
                 )
@@ -1090,6 +1086,13 @@ class Req(ReqDllmMixin):
             )
 
         self.set_extend_input_len(len(self.fill_ids) - len(self.prefix_indices))
+
+    def _compute_max_prefix_len(self, input_len: int) -> int:
+        # NOTE: the matched length is at most 1 less than the input length to enable logprob computation
+        max_prefix_len = input_len - 1
+        if self.return_logprob and self.logprob_start_len >= 0:
+            max_prefix_len = min(max_prefix_len, self.logprob_start_len)
+        return max(max_prefix_len, 0)
 
     # Based on https://github.com/vllm-project/vllm/blob/7a64d24aad69e4d2548aa0bf528d9fe63428ab01/vllm/transformers_utils/detokenizer.py#L194-L313
     def init_incremental_detokenize(self):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1222,7 +1222,7 @@ class Req(ReqDllmMixin):
 
         return False
 
-    def check_finished(self, new_accepted_len: int = 1):
+    def update_finish_state(self, new_accepted_len: int = 1):
         if self.finished():
             return
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -773,7 +773,7 @@ class Req(ReqDllmMixin):
         # Whether or not if it is chunked. It increments whenever
         # it is chunked, and decrement whenever chunked request is
         # processed.
-        self.is_chunked = 0
+        self.inflight_middle_chunks = 0
 
         # For retraction
         self.is_retracted = False
@@ -1263,7 +1263,7 @@ class Req(ReqDllmMixin):
         self.temp_input_top_logprobs_val = None
         self.temp_input_top_logprobs_idx = None
         self.extend_logprob_start_len = 0
-        self.is_chunked = 0
+        self.inflight_middle_chunks = 0
         self.mamba_pool_idx = None
         self.mamba_ping_pong_track_buffer = None
         self.mamba_next_track_idx = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1774,9 +1774,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_num_tokens = extend_num_tokens
 
         # Allocate memory
-        out_cache_loc, req_pool_indices_tensor, req_pool_indices = alloc_for_extend(
-            self
-        )
+        out_cache_loc, req_pool_indices_tensor, _ = alloc_for_extend(self)
 
         # Set fields
         input_embeds = []
@@ -1792,7 +1790,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         mamba_track_seqlens_cpu = []
 
         for i, (req, seq_len, pre_len) in enumerate(zip(reqs, seq_lens, prefix_lens)):
-            req.req_pool_idx = req_pool_indices[i]
             assert seq_len - pre_len == req.extend_input_len
 
             req.extend_batch_idx += 1

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -960,7 +960,7 @@ class PrefillAdder:
         priority_sign = 1 if server_args.schedule_low_priority_values_first else -1
 
         # NOTE: A request finishes in two phases:
-        #   1) check_finished + release_kv_cache  (in process_batch_result)
+        #   1) update_finish_state + release_kv_cache  (in process_batch_result)
         #   2) filter out of batch                (in get_next_batch_to_run / update_running_batch)
         # Preemption runs between these two phases (inside get_new_batch_prefill),
         # so running_batch may still contain requests whose KV cache is already freed.

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -160,19 +160,17 @@ class SchedulePolicy:
 
     def calc_priority(
         self, waiting_queue: List[Req], running_batch: Optional[ScheduleBatch] = None
-    ) -> bool:
+    ) -> None:
         if self.policy == CacheAgnosticPolicy.FCFS:
             if self.enable_priority_scheduling:
                 SchedulePolicy._sort_by_priority_and_fcfs(
                     waiting_queue, self.priority_sign
                 )
-            return False
+            return
 
         policy = self._determine_active_policy(waiting_queue)
 
-        prefix_computed = False
         if isinstance(policy, CacheAwarePolicy):
-            prefix_computed = True
             temporary_deprioritized = self._compute_prefix_matches(
                 waiting_queue, policy
             )
@@ -200,7 +198,6 @@ class SchedulePolicy:
                     SchedulePolicy._sort_by_routing_key(waiting_queue, running_batch)
             else:
                 raise ValueError(f"Unknown CacheAgnostic Policy: {policy=}")
-        return prefix_computed
 
     def _determine_active_policy(self, waiting_queue: List[Req]) -> Policy:
         if self.policy == CacheAwarePolicy.LPM and len(waiting_queue) > 128:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2272,7 +2272,7 @@ class Scheduler(
         )
 
         if batch.return_logprob:
-            batch.top_logprobs_nums = [r.top_logprobs_num for r in reqs]
+            batch.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]
             batch.token_ids_logprobs = [list(r.origin_input_ids) for r in reqs]
 
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -33,7 +33,6 @@ import psutil
 import setproctitle
 import torch
 import torch.distributed
-import zmq
 from torch.cuda import Stream as CudaStream
 from torch.distributed import barrier
 
@@ -171,6 +170,9 @@ from sglang.srt.managers.scheduler_components.invariant_checker import (
     SchedulerInvariantChecker,
     create_scheduler_watchdog,
 )
+from sglang.srt.managers.scheduler_components.ipc_channels import (
+    SchedulerIpcChannels,
+)
 from sglang.srt.managers.scheduler_components.kv_events_publisher import (
     SchedulerKvEventsPublisher,
 )
@@ -185,7 +187,6 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
     PrefillStats,
     SchedulerMetricsReporter,
 )
-from sglang.srt.managers.scheduler_components.output_sender import SenderWrapper
 from sglang.srt.managers.scheduler_components.output_streamer import (
     SchedulerOutputStreamer,
 )
@@ -250,7 +251,6 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_tokenizer,
     get_tokenizer_from_processor,
 )
-from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -552,8 +552,8 @@ class Scheduler(
         self.grammar_manager = GrammarManager(self)
 
         self.request_receiver = SchedulerRequestReceiver(
-            recv_from_tokenizer=self.recv_from_tokenizer,
-            recv_from_rpc=self.recv_from_rpc,
+            recv_from_tokenizer=self.ipc_channels.recv_from_tokenizer,
+            recv_from_rpc=self.ipc_channels.recv_from_rpc,
             recv_skipper=self.recv_skipper,
             input_blocker=self.input_blocker,
             mm_receiver=self.mm_receiver,
@@ -629,7 +629,7 @@ class Scheduler(
             attn_dp_rank=self.ps.attn_dp_rank,
             dp_rank=self.ps.dp_rank,
             tree_cache=self.tree_cache,
-            send_metrics_from_scheduler=self.send_metrics_from_scheduler,
+            send_metrics_from_scheduler=self.ipc_channels.send_metrics_from_scheduler,
             max_running_requests=self.max_running_requests,
             max_total_num_tokens=self.max_total_num_tokens,
             get_stats=lambda: self.metrics_reporter.stats,
@@ -658,7 +658,7 @@ class Scheduler(
         )
 
         self.output_streamer = SchedulerOutputStreamer(
-            send_to_detokenizer=self.send_to_detokenizer,
+            send_to_detokenizer=self.ipc_channels.send_to_detokenizer,
             tree_cache=self.tree_cache,
             ps=self.ps,
             server_args=self.server_args,
@@ -726,50 +726,21 @@ class Scheduler(
                     self.page_size = self.dllm_config.block_size
 
     def init_ipc_channels(self, port_args: PortArgs):
-        context = zmq.Context(2)
-        self.send_metrics_from_scheduler = None
-
-        if (
+        is_rank_zero = (
             self.ps.pp_rank == 0
             and self.ps.attn_tp_rank == 0
             and self.ps.attn_cp_rank == 0
-        ):
-            self.recv_from_tokenizer = get_zmq_socket(
-                context, zmq.PULL, port_args.scheduler_input_ipc_name, False
-            )
-            self.recv_from_rpc = get_zmq_socket(
-                context, zmq.DEALER, port_args.rpc_ipc_name, False
-            )
-
-            send_to_tokenizer = get_zmq_socket(
-                context, zmq.PUSH, port_args.tokenizer_ipc_name, False
-            )
-            if self.server_args.skip_tokenizer_init:
-                # Directly send to the TokenizerManager
-                send_to_detokenizer = get_zmq_socket(
-                    context, zmq.PUSH, port_args.tokenizer_ipc_name, False
-                )
-            else:
-                # Send to the DetokenizerManager
-                send_to_detokenizer = get_zmq_socket(
-                    context, zmq.PUSH, port_args.detokenizer_ipc_name, False
-                )
-
-            self.send_to_tokenizer = SenderWrapper(send_to_tokenizer)
-            self.send_to_detokenizer = SenderWrapper(send_to_detokenizer)
-        else:
-            self.recv_from_tokenizer = None
-            self.recv_from_rpc = None
-            self.send_to_tokenizer = SenderWrapper(None)
-            self.send_to_detokenizer = SenderWrapper(None)
-
-        if self.server_args.enable_metrics and (
-            self.ps.attn_tp_rank == 0
-            or self.server_args.enable_metrics_for_all_schedulers
-        ):
-            self.send_metrics_from_scheduler = get_zmq_socket(
-                context, zmq.PUSH, port_args.metrics_ipc_name, False
-            )
+        )
+        self.ipc_channels = SchedulerIpcChannels.create(
+            port_args=port_args,
+            is_rank_zero=is_rank_zero,
+            skip_tokenizer_init=self.server_args.skip_tokenizer_init,
+            metrics_enabled=self.server_args.enable_metrics
+            and (
+                self.ps.attn_tp_rank == 0
+                or self.server_args.enable_metrics_for_all_schedulers
+            ),
+        )
 
     def init_idle_sleeper(self) -> None:
         if (
@@ -780,8 +751,8 @@ class Scheduler(
         ):
             self.idle_sleeper = IdleSleeper(
                 sockets=[
-                    self.recv_from_tokenizer,
-                    self.recv_from_rpc,
+                    self.ipc_channels.recv_from_tokenizer,
+                    self.ipc_channels.recv_from_rpc,
                 ],
             )
         else:
@@ -919,7 +890,7 @@ class Scheduler(
 
             self.external_corpus_manager = ExternalCorpusManager(
                 self.draft_worker,
-                self.send_to_tokenizer.send_output,
+                self.ipc_channels.send_to_tokenizer.send_output,
             )
         else:
             self.external_corpus_manager = None
@@ -1660,10 +1631,10 @@ class Scheduler(
             output = self._request_dispatcher(recv_req)
             if output is not None:
                 if not isinstance(output, RpcReqOutput):
-                    self.send_to_tokenizer.send_output(output, recv_req)
+                    self.ipc_channels.send_to_tokenizer.send_output(output, recv_req)
                 else:
-                    if self.recv_from_rpc is not None:
-                        self.recv_from_rpc.send_pyobj(output)
+                    if self.ipc_channels.recv_from_rpc is not None:
+                        self.ipc_channels.recv_from_rpc.send_pyobj(output)
 
         self._check_pending_flush()
         if self.external_corpus_manager is not None:
@@ -2093,7 +2064,7 @@ class Scheduler(
                 rid=req.rid,
             )
             req.time_stats.trace_ctx.abort(abort_info=abort_req.finished_reason)
-            self.send_to_tokenizer.send_output(abort_req, req)
+            self.ipc_channels.send_to_tokenizer.send_output(abort_req, req)
             return False
         return True
 
@@ -2132,7 +2103,7 @@ class Scheduler(
                 req_to_abort = candidate_req
                 message = "The request is aborted by a higher priority request."
 
-        self.send_to_tokenizer.send_output(
+        self.ipc_channels.send_to_tokenizer.send_output(
             AbortReq(
                 finished_reason={
                     "type": "abort",
@@ -2158,7 +2129,7 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
-                self.send_to_tokenizer.send_output(
+                self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={
                             "type": "abort",
@@ -2750,7 +2721,7 @@ class Scheduler(
             self.new_token_ratio = new_token_ratio
             for req in reqs_to_abort:
                 abort_reason: FINISH_ABORT = req.to_finish
-                self.send_to_tokenizer.send_output(
+                self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason=abort_reason.to_json(),
                         rid=req.rid,
@@ -2971,7 +2942,7 @@ class Scheduler(
             tp_active_ranks_cpu = self.tp_group.active_ranks_cpu.detach().numpy()
             tp_active_ranks &= tp_active_ranks_cpu
             dp_active_ranks = tp_active_ranks.reshape(self.ps.dp_size, -1).prod(axis=1)
-            self.send_to_tokenizer.send_output(
+            self.ipc_channels.send_to_tokenizer.send_output(
                 ActiveRanksOutput(status=dp_active_ranks.tolist())
             )
 
@@ -3039,7 +3010,7 @@ class Scheduler(
             # Return some signal for the health check.
             # This is used to prevent the health check signal being blocked by long context prefill.
             # However, one minor issue is that this code path does not check the status of detokenizer manager.
-            self.send_to_tokenizer.send_output(
+            self.ipc_channels.send_to_tokenizer.send_output(
                 HealthCheckOutput(
                     http_worker_ipc=self.return_health_check_ipcs.popleft()
                 )
@@ -3054,7 +3025,7 @@ class Scheduler(
         if self.is_fully_idle():
             success = self.flush_cache()
             self._pending_flush = None
-            self.send_to_tokenizer.send_output(
+            self.ipc_channels.send_to_tokenizer.send_output(
                 FlushCacheReqOutput(success=success), pending_req
             )
             return
@@ -3064,7 +3035,7 @@ class Scheduler(
                 "Deferred flush_cache timed out while waiting for idle state."
             )
             self._pending_flush = None
-            self.send_to_tokenizer.send_output(
+            self.ipc_channels.send_to_tokenizer.send_output(
                 FlushCacheReqOutput(
                     success=False, message="Timed out waiting for idle state."
                 ),
@@ -3461,7 +3432,7 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
-            self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 release_kv_cache(req, self.tree_cache)
@@ -3521,7 +3492,7 @@ class Scheduler(
                     if recv_req.abort_all or decode_req.rid.startswith(recv_req.rid):
                         assert hasattr(decode_req, "kv_cache_cpu")
                         del decode_req.kv_cache_cpu
-                        self.send_to_tokenizer.send_output(
+                        self.ipc_channels.send_to_tokenizer.send_output(
                             AbortReq(rid=decode_req.rid), decode_req
                         )
                     else:
@@ -3683,7 +3654,7 @@ class Scheduler(
     def handle_freeze_gc(self, recv_req: FreezeGCReq):
         """Handle freeze_gc request: freeze scheduler's GC and forward to detokenizer."""
         freeze_gc("Scheduler")
-        self.send_to_detokenizer.send_output(recv_req, recv_req)
+        self.ipc_channels.send_to_detokenizer.send_output(recv_req, recv_req)
         return None
 
     def handle_dumper_control(self, recv_req: DumperControlReqInput):
@@ -3698,12 +3669,12 @@ class Scheduler(
                 response = dumper._http_manager.handle_request(
                     method=recv_req.method, body=recv_req.body
                 )
-            self.send_to_tokenizer.send_output(
+            self.ipc_channels.send_to_tokenizer.send_output(
                 DumperControlReqOutput(success=True, response=response), recv_req
             )
         except Exception as e:
             print(f"[Scheduler] handle_dumper_control error: {e}", flush=True)
-            self.send_to_tokenizer.send_output(
+            self.ipc_channels.send_to_tokenizer.send_output(
                 DumperControlReqOutput(success=False, response=[], error=str(e)),
                 recv_req,
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2577,7 +2577,7 @@ class Scheduler(
             self._chunked_req_scheduled_last_iter = True
 
         if self.chunked_req is not None:
-            self.chunked_req.is_chunked += 1
+            self.chunked_req.inflight_middle_chunks += 1
 
         set_time_batch(can_run_list, "set_forward_entry_time")
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2923,20 +2923,24 @@ class Scheduler(
                     pooled_hidden_states=pooler_output.pooled_hidden_states,
                 )
 
-        if (
+        self._maybe_report_active_ranks()
+
+        return ret
+
+    def _maybe_report_active_ranks(self) -> None:
+        if not (
             self.server_args.enable_dp_attention
             and self.server_args.elastic_ep_backend is not None
         ):
-            # Get the tensors indicating rank activeness
-            tp_active_ranks = self.tp_group.active_ranks.detach().cpu().numpy()
-            tp_active_ranks_cpu = self.tp_group.active_ranks_cpu.detach().numpy()
-            tp_active_ranks &= tp_active_ranks_cpu
-            dp_active_ranks = tp_active_ranks.reshape(self.ps.dp_size, -1).prod(axis=1)
-            self.ipc_channels.send_to_tokenizer.send_output(
-                ActiveRanksOutput(status=dp_active_ranks.tolist())
-            )
-
-        return ret
+            return
+        # Get the tensors indicating rank activeness
+        tp_active_ranks = self.tp_group.active_ranks.detach().cpu().numpy()
+        tp_active_ranks_cpu = self.tp_group.active_ranks_cpu.detach().numpy()
+        tp_active_ranks &= tp_active_ranks_cpu
+        dp_active_ranks = tp_active_ranks.reshape(self.ps.dp_size, -1).prod(axis=1)
+        self.ipc_channels.send_to_tokenizer.send_output(
+            ActiveRanksOutput(status=dp_active_ranks.tolist())
+        )
 
     def launch_batch_sample_if_needed(
         self, batch_result: GenerationBatchResult

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -384,6 +384,7 @@ class Scheduler(
 
         # Init inter-process communication
         self.init_ipc_channels(port_args)
+        self.init_idle_sleeper()
 
         self.mm_receiver = None
         self.disagg_prefill_bootstrap_queue = None
@@ -726,7 +727,6 @@ class Scheduler(
 
     def init_ipc_channels(self, port_args: PortArgs):
         context = zmq.Context(2)
-        self.idle_sleeper = None
         self.send_metrics_from_scheduler = None
 
         if (
@@ -757,14 +757,6 @@ class Scheduler(
 
             self.send_to_tokenizer = SenderWrapper(send_to_tokenizer)
             self.send_to_detokenizer = SenderWrapper(send_to_detokenizer)
-
-            if self.server_args.sleep_on_idle:
-                self.idle_sleeper = IdleSleeper(
-                    [
-                        self.recv_from_tokenizer,
-                        self.recv_from_rpc,
-                    ]
-                )
         else:
             self.recv_from_tokenizer = None
             self.recv_from_rpc = None
@@ -778,6 +770,22 @@ class Scheduler(
             self.send_metrics_from_scheduler = get_zmq_socket(
                 context, zmq.PUSH, port_args.metrics_ipc_name, False
             )
+
+    def init_idle_sleeper(self) -> None:
+        if (
+            self.ps.pp_rank == 0
+            and self.ps.attn_tp_rank == 0
+            and self.ps.attn_cp_rank == 0
+            and self.server_args.sleep_on_idle
+        ):
+            self.idle_sleeper = IdleSleeper(
+                sockets=[
+                    self.recv_from_tokenizer,
+                    self.recv_from_rpc,
+                ],
+            )
+        else:
+            self.idle_sleeper = None
 
     def init_tokenizer(self):
         server_args = self.server_args

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -187,6 +187,9 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
     PrefillStats,
     SchedulerMetricsReporter,
 )
+from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
+    NewTokenRatioTracker,
+)
 from sglang.srt.managers.scheduler_components.output_streamer import (
     SchedulerOutputStreamer,
 )
@@ -1080,19 +1083,9 @@ class Scheduler(
             and not self.server_args.disable_priority_preemption
         )
 
-        self.init_new_token_ratio = min(
-            envs.SGLANG_INIT_NEW_TOKEN_RATIO.get()
-            * self.server_args.schedule_conservativeness,
-            1.0,
+        self.new_token_ratio_tracker = NewTokenRatioTracker.from_server_args(
+            self.server_args
         )
-        self.min_new_token_ratio = min(
-            self.init_new_token_ratio * envs.SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR.get(),
-            1.0,
-        )
-        self.new_token_ratio_decay = (
-            self.init_new_token_ratio - self.min_new_token_ratio
-        ) / envs.SGLANG_NEW_TOKEN_RATIO_DECAY_STEPS.get()
-        self.new_token_ratio = self.init_new_token_ratio
 
     def init_soft_watchdog(self, server_args: ServerArgs):
         if (x := server_args.soft_watchdog_timeout) is not None:
@@ -2467,7 +2460,7 @@ class Scheduler(
             self.tree_cache,
             self.token_to_kv_pool_allocator,
             self.running_batch,
-            self.new_token_ratio,
+            self.new_token_ratio_tracker.current,
             self.max_prefill_tokens,
             chunked_prefill_size,
             running_bs if self.is_mixed_chunk else 0,
@@ -2691,7 +2684,7 @@ class Scheduler(
             TEST_RETRACT and self.forward_ct % TEST_RETRACT_INTERVAL == 0
         ):
             old_available_tokens = self.token_to_kv_pool_allocator.available_size()
-            old_ratio = self.new_token_ratio
+            old_ratio = self.new_token_ratio_tracker.current
             mamba_pool = getattr(self.tree_cache.req_to_token_pool, "mamba_pool", None)
             old_mamba_available = (
                 mamba_pool.available_size() if mamba_pool is not None else None
@@ -2718,7 +2711,7 @@ class Scheduler(
                         len(r.output_ids) for r in retracted_reqs
                     ),
                 )
-            self.new_token_ratio = new_token_ratio
+            self.new_token_ratio_tracker.current = new_token_ratio
             for req in reqs_to_abort:
                 abort_reason: FINISH_ABORT = req.to_finish
                 self.ipc_channels.send_to_tokenizer.send_output(
@@ -2746,10 +2739,7 @@ class Scheduler(
             for req in retracted_reqs:
                 self._add_request_to_queue(req, is_retracted=True)
         else:
-            self.new_token_ratio = max(
-                self.new_token_ratio - self.new_token_ratio_decay,
-                self.min_new_token_ratio,
-            )
+            self.new_token_ratio_tracker.decay_step()
 
         if batch.batch_size() < initial_bs:
             batch.batch_is_full = False
@@ -3126,7 +3116,7 @@ class Scheduler(
         self.kv_events_publisher.publish_kv_events()
 
         # reset token ratio
-        self.new_token_ratio = self.init_new_token_ratio
+        self.new_token_ratio_tracker.reset()
 
         # reset device timer window so idle time isn't counted
         self.metrics_reporter.reset_device_timer_window()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -103,7 +103,6 @@ from sglang.srt.managers.io_struct import (
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
     FlushCacheReqInput,
-    FlushCacheReqOutput,
     FreezeGCReq,
     GetInternalStateReq,
     GetInternalStateReqOutput,
@@ -164,6 +163,9 @@ from sglang.srt.managers.scheduler_components.batch_result_processor import (
 )
 from sglang.srt.managers.scheduler_components.dp_attn import (
     SchedulerDPAttnAdapter,
+)
+from sglang.srt.managers.scheduler_components.flush_wrapper import (
+    SchedulerFlushWrapper,
 )
 from sglang.srt.managers.scheduler_components.idle_sleeper import IdleSleeper
 from sglang.srt.managers.scheduler_components.invariant_checker import (
@@ -991,7 +993,11 @@ class Scheduler(
         self.last_batch: Optional[ScheduleBatch] = None
         self.forward_ct = 0
         self.return_health_check_ipcs: Deque[Optional[str]] = deque()
-        self._pending_flush: Optional[Tuple[FlushCacheReqInput, float]] = None
+        self.flush_wrapper = SchedulerFlushWrapper(
+            flush_cache=self.flush_cache,
+            is_fully_idle=self.is_fully_idle,
+            ipc_channels=self.ipc_channels,
+        )
         self.session_controller = SessionController(self.tree_cache)
         self.forward_sleep_time = None
         self._engine_paused = False
@@ -1355,7 +1361,7 @@ class Scheduler(
                 (TokenizedEmbeddingReqInput, self.handle_embedding_request),
                 (BatchTokenizedGenerateReqInput, self.handle_batch_generate_request),
                 (BatchTokenizedEmbeddingReqInput, self.handle_batch_embedding_request),
-                (FlushCacheReqInput, self.flush_cache_wrapped),
+                (FlushCacheReqInput, self.flush_wrapper.handle),
                 (ClearHiCacheReqInput, self.clear_hicache_storage_wrapped),
                 (AttachHiCacheStorageReqInput, self.attach_hicache_storage_wrapped),
                 (DetachHiCacheStorageReqInput, self.detach_hicache_storage_wrapped),
@@ -1629,7 +1635,7 @@ class Scheduler(
                     if self.ipc_channels.recv_from_rpc is not None:
                         self.ipc_channels.recv_from_rpc.send_pyobj(output)
 
-        self._check_pending_flush()
+        self.flush_wrapper.check_pending()
         if self.external_corpus_manager is not None:
             self.external_corpus_manager.check_pending_load()
 
@@ -3010,32 +3016,6 @@ class Scheduler(
                 )
             )
 
-    def _check_pending_flush(self):
-        if self._pending_flush is None:
-            return
-
-        pending_req, deadline = self._pending_flush
-
-        if self.is_fully_idle():
-            success = self.flush_cache()
-            self._pending_flush = None
-            self.ipc_channels.send_to_tokenizer.send_output(
-                FlushCacheReqOutput(success=success), pending_req
-            )
-            return
-
-        if time.monotonic() >= deadline:
-            logging.warning(
-                "Deferred flush_cache timed out while waiting for idle state."
-            )
-            self._pending_flush = None
-            self.ipc_channels.send_to_tokenizer.send_output(
-                FlushCacheReqOutput(
-                    success=False, message="Timed out waiting for idle state."
-                ),
-                pending_req,
-            )
-
     def add_external_corpus(
         self, recv_req: AddExternalCorpusReqInput
     ) -> Optional[AddExternalCorpusReqOutput]:
@@ -3065,25 +3045,6 @@ class Scheduler(
                 message="Ngram speculative decoding is not enabled.",
             )
         return self.external_corpus_manager.list(recv_req)
-
-    def flush_cache_wrapped(
-        self, recv_req: FlushCacheReqInput
-    ) -> Optional[FlushCacheReqOutput]:
-        if self._pending_flush is not None:
-            return FlushCacheReqOutput(
-                success=False,
-                message="Another flush_cache is already in progress.",
-            )
-
-        timeout_s = float(recv_req.timeout_s or 0.0)
-        if timeout_s <= 0.0:
-            return FlushCacheReqOutput(success=self.flush_cache())
-
-        if self.is_fully_idle():
-            return FlushCacheReqOutput(success=self.flush_cache())
-
-        self._pending_flush = (recv_req, time.monotonic() + timeout_s)
-        return None
 
     def clear_hicache_storage_wrapped(self, recv_req: ClearHiCacheReqInput):
         if self.enable_hierarchical_cache:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -324,7 +324,7 @@ class SchedulerBatchResultProcessor:
             batch.reqs, batch.return_logprob, skip_stream_req
         )
 
-        can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+        can_run_cuda_graph = result.can_run_cuda_graph
         self.metrics_reporter.report_prefill_stats(
             batch=batch,
             prefill_stats=batch.prefill_stats,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -558,31 +559,12 @@ class SchedulerBatchResultProcessor:
             result.can_run_cuda_graph,
         )
 
-        if batch.spec_algorithm.is_none() or batch.is_spec_v2:
-            if batch.is_spec_v2:
-                next_token_ids = self._resolve_spec_overlap_tokens(result, batch)
-            elif isinstance(next_token_ids, list):
-                pass  # MLX path: already a list[int], skip torch round-trip
-            else:
-                next_token_ids = next_token_ids.tolist()
-
-            if batch.return_logprob:
-                next_token_logprobs = logits_output.next_token_logprobs.tolist()
-                if logits_output.next_token_top_logprobs_val:
-                    logits_output.next_token_top_logprobs_val = [
-                        v.tolist() for v in logits_output.next_token_top_logprobs_val
-                    ]
-                    logits_output.next_token_top_logprobs_idx = [
-                        x.tolist() for x in logits_output.next_token_top_logprobs_idx
-                    ]
-
-                if logits_output.next_token_token_ids_logprobs_val:
-                    logits_output.next_token_token_ids_logprobs_val = [
-                        v.tolist()
-                        for v in logits_output.next_token_token_ids_logprobs_val
-                    ]
-        # else: Spec V1 — output_ids, check_finished, grammar, and reasoning tokens
-        # are already handled in the verify phase (eagle_info.py / ngram_info.py).
+        next_token_ids, next_token_logprobs = self._normalize_decode_outputs(
+            batch=batch,
+            result=result,
+            logits_output=logits_output,
+            next_token_ids=next_token_ids,
+        )
 
         self.metrics_reporter.num_generated_tokens += len(batch.reqs)
         if not batch.spec_algorithm.is_none():
@@ -671,6 +653,42 @@ class SchedulerBatchResultProcessor:
             running_batch=batch,
             num_correct_drafts=result.num_correct_drafts,
         )
+
+    def _normalize_decode_outputs(
+        self,
+        *,
+        batch: ScheduleBatch,
+        result: GenerationBatchResult,
+        logits_output: LogitsProcessorOutput,
+        next_token_ids: Union[torch.Tensor, List[int]],
+    ) -> Tuple[Union[List[int], List[List[int]]], Optional[List[float]]]:
+        next_token_logprobs = None
+        if batch.spec_algorithm.is_none() or batch.is_spec_v2:
+            if batch.is_spec_v2:
+                next_token_ids = self._resolve_spec_overlap_tokens(result, batch)
+            elif isinstance(next_token_ids, list):
+                pass  # MLX path: already a list[int], skip torch round-trip
+            else:
+                next_token_ids = next_token_ids.tolist()
+
+            if batch.return_logprob:
+                next_token_logprobs = logits_output.next_token_logprobs.tolist()
+                if logits_output.next_token_top_logprobs_val:
+                    logits_output.next_token_top_logprobs_val = [
+                        v.tolist() for v in logits_output.next_token_top_logprobs_val
+                    ]
+                    logits_output.next_token_top_logprobs_idx = [
+                        x.tolist() for x in logits_output.next_token_top_logprobs_idx
+                    ]
+
+                if logits_output.next_token_token_ids_logprobs_val:
+                    logits_output.next_token_token_ids_logprobs_val = [
+                        v.tolist()
+                        for v in logits_output.next_token_token_ids_logprobs_val
+                    ]
+        # else: Spec V1 — output_ids, check_finished, grammar, and reasoning tokens
+        # are already handled in the verify phase (eagle_info.py / ngram_info.py).
+        return next_token_ids, next_token_logprobs
 
     def _apply_decode_logprobs(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -256,29 +256,15 @@ class SchedulerBatchResultProcessor:
                     self._maybe_collect_customized_info(i, req, logits_output)
 
                     if batch.return_logprob:
-                        assert extend_logprob_start_len_per_req is not None
-                        assert extend_input_len_per_req is not None
-                        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
-                        extend_input_len = extend_input_len_per_req[i]
-
-                        num_input_logprobs = (
-                            self.logprob_result_processor.calculate_num_input_logprobs(
-                                req,
-                                extend_input_len,
-                                extend_logprob_start_len,
-                            )
+                        logprob_pt = self._apply_prefill_logprobs(
+                            req=req,
+                            i=i,
+                            logits_output=logits_output,
+                            extend_input_len_per_req=extend_input_len_per_req,
+                            extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
+                            next_token_ids=next_token_ids,
+                            logprob_pt=logprob_pt,
                         )
-
-                        if req.return_logprob:
-                            self.logprob_result_processor.add_logprob_return_values(
-                                i,
-                                req,
-                                logprob_pt,
-                                next_token_ids,
-                                num_input_logprobs,
-                                logits_output,
-                            )
-                        logprob_pt += num_input_logprobs
 
                     if (
                         req.return_hidden_states
@@ -319,25 +305,14 @@ class SchedulerBatchResultProcessor:
 
                     # Incrementally update input logprobs.
                     if batch.return_logprob:
-                        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
-                        extend_input_len = extend_input_len_per_req[i]
-                        if extend_logprob_start_len < extend_input_len:
-                            # Update input logprobs.
-                            num_input_logprobs = self.logprob_result_processor.calculate_num_input_logprobs(
-                                req,
-                                extend_input_len,
-                                extend_logprob_start_len,
-                            )
-                            if req.return_logprob:
-                                self.logprob_result_processor.add_input_logprob_return_values(
-                                    i,
-                                    req,
-                                    logits_output,
-                                    logprob_pt,
-                                    num_input_logprobs,
-                                    last_prefill_chunk=False,
-                                )
-                            logprob_pt += num_input_logprobs
+                        logprob_pt = self._apply_chunked_prefill_logprobs(
+                            req=req,
+                            i=i,
+                            logits_output=logits_output,
+                            extend_input_len_per_req=extend_input_len_per_req,
+                            extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
+                            logprob_pt=logprob_pt,
+                        )
 
                     req.time_stats.set_last_chunked_prefill_finish_time()
 
@@ -406,6 +381,73 @@ class SchedulerBatchResultProcessor:
             can_run_cuda_graph=can_run_cuda_graph,
             dp_cooperation_info=batch.dp_cooperation_info,
         )
+
+    def _apply_prefill_logprobs(
+        self,
+        *,
+        req: Req,
+        i: int,
+        logits_output: LogitsProcessorOutput,
+        extend_input_len_per_req: Optional[List[int]],
+        extend_logprob_start_len_per_req: Optional[List[int]],
+        next_token_ids: List[int],
+        logprob_pt: int,
+    ) -> int:
+        assert extend_logprob_start_len_per_req is not None
+        assert extend_input_len_per_req is not None
+        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
+        extend_input_len = extend_input_len_per_req[i]
+
+        num_input_logprobs = self.logprob_result_processor.calculate_num_input_logprobs(
+            req,
+            extend_input_len,
+            extend_logprob_start_len,
+        )
+
+        if req.return_logprob:
+            self.logprob_result_processor.add_logprob_return_values(
+                i,
+                req,
+                logprob_pt,
+                next_token_ids,
+                num_input_logprobs,
+                logits_output,
+            )
+        logprob_pt += num_input_logprobs
+        return logprob_pt
+
+    def _apply_chunked_prefill_logprobs(
+        self,
+        *,
+        req: Req,
+        i: int,
+        logits_output: LogitsProcessorOutput,
+        extend_input_len_per_req: Optional[List[int]],
+        extend_logprob_start_len_per_req: Optional[List[int]],
+        logprob_pt: int,
+    ) -> int:
+        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
+        extend_input_len = extend_input_len_per_req[i]
+        if extend_logprob_start_len < extend_input_len:
+            # Update input logprobs.
+            num_input_logprobs = (
+                self.logprob_result_processor.calculate_num_input_logprobs(
+                    req,
+                    extend_input_len,
+                    extend_logprob_start_len,
+                )
+            )
+            if req.return_logprob:
+                self.logprob_result_processor.add_input_logprob_return_values(
+                    i,
+                    req,
+                    logits_output,
+                    logprob_pt,
+                    num_input_logprobs,
+                    last_prefill_chunk=False,
+                )
+            logprob_pt += num_input_logprobs
+        return logprob_pt
 
     def _resolve_spec_overlap_tokens(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -656,23 +656,9 @@ class SchedulerBatchResultProcessor:
                 )
 
             if req.grammar is not None:
-                # FIXME: this try-except block is for handling unexpected xgrammar issue.
-                try:
-                    if batch.spec_algorithm.is_none():
-                        # Normal decode: single token
-                        req.grammar.accept_token(next_token_id)
-                    elif batch.is_spec_v2:
-                        # Speculative decode: next_token_id is a list of accepted tokens
-                        for token_id in next_token_id:
-                            req.grammar.accept_token(token_id)
-                except ValueError as e:
-                    # Grammar accept_token can raise ValueError if the token is not in the grammar.
-                    # This can happen if the grammar is not set correctly or the token is invalid.
-                    logger.error(
-                        f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
-                    )
-                    self.abort_request(AbortReq(rid=req.rid))
-                req.grammar.finished = req.finished()
+                self._apply_decode_grammar(
+                    req=req, next_token_id=next_token_id, batch=batch
+                )
 
         self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
         self.token_to_kv_pool_allocator.free_group_end()
@@ -726,6 +712,31 @@ class SchedulerBatchResultProcessor:
                 req.output_token_ids_logprobs_idx.append(
                     logits_output.next_token_token_ids_logprobs_idx[flat_idx]
                 )
+
+    def _apply_decode_grammar(
+        self,
+        *,
+        req: Req,
+        next_token_id: Union[int, List[int]],
+        batch: ScheduleBatch,
+    ) -> None:
+        # FIXME: this try-except block is for handling unexpected xgrammar issue.
+        try:
+            if batch.spec_algorithm.is_none():
+                # Normal decode: single token
+                req.grammar.accept_token(next_token_id)
+            elif batch.is_spec_v2:
+                # Speculative decode: next_token_id is a list of accepted tokens
+                for token_id in next_token_id:
+                    req.grammar.accept_token(token_id)
+        except ValueError as e:
+            # Grammar accept_token can raise ValueError if the token is not in the grammar.
+            # This can happen if the grammar is not set correctly or the token is invalid.
+            logger.error(
+                f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
+            )
+            self.abort_request(AbortReq(rid=req.rid))
+        req.grammar.finished = req.finished()
 
     def _handle_finished_req(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -286,25 +286,8 @@ class SchedulerBatchResultProcessor:
             if result.copy_done is not None:
                 result.copy_done.synchronize()
 
-            is_sparse = envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set()
-
-            embeddings = result.embeddings
+            embeddings = self._convert_embeddings(result=result)
             phs = result.pooled_hidden_states
-
-            if is_sparse:
-                batch_ids, token_ids = embeddings.indices()
-                values = embeddings.values()
-
-                embeddings = [{} for _ in range(embeddings.size(0))]
-                for i in range(batch_ids.shape[0]):
-                    embeddings[batch_ids[i].item()][token_ids[i].item()] = values[
-                        i
-                    ].item()
-            else:
-                if isinstance(embeddings, torch.Tensor):
-                    embeddings = embeddings.tolist()
-                else:
-                    embeddings = [tensor.tolist() for tensor in embeddings]
 
             if phs is not None:
                 if isinstance(phs, list):
@@ -347,6 +330,25 @@ class SchedulerBatchResultProcessor:
             can_run_cuda_graph=can_run_cuda_graph,
             dp_cooperation_info=batch.dp_cooperation_info,
         )
+
+    def _convert_embeddings(self, *, result: EmbeddingBatchResult) -> list:
+        is_sparse = envs.SGLANG_EMBEDDINGS_SPARSE_HEAD.is_set()
+
+        embeddings = result.embeddings
+
+        if is_sparse:
+            batch_ids, token_ids = embeddings.indices()
+            values = embeddings.values()
+
+            embeddings = [{} for _ in range(embeddings.size(0))]
+            for i in range(batch_ids.shape[0]):
+                embeddings[batch_ids[i].item()][token_ids[i].item()] = values[i].item()
+        else:
+            if isinstance(embeddings, torch.Tensor):
+                embeddings = embeddings.tolist()
+            else:
+                embeddings = [tensor.tolist() for tensor in embeddings]
+        return embeddings
 
     def _move_logprobs_to_cpu(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -270,30 +270,16 @@ class SchedulerBatchResultProcessor:
                         req.return_hidden_states
                         and logits_output.hidden_states is not None
                     ):
-                        req.hidden_states.append(
-                            logits_output.hidden_states[
-                                hidden_state_offset : (
-                                    hidden_state_offset := hidden_state_offset
-                                    + len(req.origin_input_ids)
-                                )
-                            ]
-                            .cpu()
-                            .clone()
-                            .tolist()
+                        hidden_state_offset = self._append_prefill_hidden_states(
+                            req=req,
+                            logits_output=logits_output,
+                            hidden_state_offset=hidden_state_offset,
                         )
 
                     if req.grammar is not None:
-                        # FIXME: this try-except block is for handling unexpected xgrammar issue.
-                        try:
-                            req.grammar.accept_token(next_token_id)
-                        except ValueError as e:
-                            # Grammar accept_token can raise ValueError if the token is not in the grammar.
-                            # This can happen if the grammar is not set correctly or the token is invalid.
-                            logger.error(
-                                f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
-                            )
-                            self.abort_request(AbortReq(rid=req.rid))
-                        req.grammar.finished = req.finished()
+                        self._apply_prefill_grammar(
+                            req=req, next_token_id=next_token_id
+                        )
 
                 else:
                     # being chunked reqs' prefill is not finished
@@ -415,6 +401,39 @@ class SchedulerBatchResultProcessor:
             )
         logprob_pt += num_input_logprobs
         return logprob_pt
+
+    def _append_prefill_hidden_states(
+        self,
+        *,
+        req: Req,
+        logits_output: LogitsProcessorOutput,
+        hidden_state_offset: int,
+    ) -> int:
+        req.hidden_states.append(
+            logits_output.hidden_states[
+                hidden_state_offset : (
+                    hidden_state_offset := hidden_state_offset
+                    + len(req.origin_input_ids)
+                )
+            ]
+            .cpu()
+            .clone()
+            .tolist()
+        )
+        return hidden_state_offset
+
+    def _apply_prefill_grammar(self, *, req: Req, next_token_id: int) -> None:
+        # FIXME: this try-except block is for handling unexpected xgrammar issue.
+        try:
+            req.grammar.accept_token(next_token_id)
+        except ValueError as e:
+            # Grammar accept_token can raise ValueError if the token is not in the grammar.
+            # This can happen if the grammar is not set correctly or the token is invalid.
+            logger.error(
+                f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
+            )
+            self.abort_request(AbortReq(rid=req.rid))
+        req.grammar.finished = req.finished()
 
     def _apply_chunked_prefill_logprobs(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -86,7 +86,7 @@ class SchedulerBatchResultProcessor:
             self.token_to_kv_pool_allocator.free_group_begin()
         for req in batch.reqs:
             req.time_stats.set_decode_prebuilt_finish_time()
-            req.check_finished()
+            req.update_finish_state()
             if req.finished():
                 req.time_stats.set_quick_finish_time()
                 if self.server_args.enable_hisparse:
@@ -223,7 +223,7 @@ class SchedulerBatchResultProcessor:
 
                     self._maybe_update_reasoning_tokens(req, next_token_id)
 
-                    req.check_finished()
+                    req.update_finish_state()
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
@@ -308,7 +308,7 @@ class SchedulerBatchResultProcessor:
                     req.time_stats.set_prefill_finished_time()
                     # Dummy output token for embedding models
                     req.output_ids.append(0)
-                    req.check_finished()
+                    req.update_finish_state()
 
                     if req.finished():
                         release_kv_cache(req, self.tree_cache)
@@ -578,7 +578,7 @@ class SchedulerBatchResultProcessor:
 
         self.token_to_kv_pool_allocator.free_group_begin()
 
-        # Spec V1 handles output_ids, check_finished, grammar, and reasoning tokens
+        # Spec V1 handles output_ids, update_finish_state, grammar, and reasoning tokens
         # in the verify phase. Non-spec and V2 handle them here in post-processing.
         is_spec_v1 = not batch.spec_algorithm.is_none() and not batch.is_spec_v2
 
@@ -618,7 +618,7 @@ class SchedulerBatchResultProcessor:
             # Update Mamba last track seqlen
             self._mamba_prefix_cache_update(req, batch, result, i)
             req.time_stats.set_last_decode_finish_time()
-            req.check_finished(new_accepted_len)
+            req.update_finish_state(new_accepted_len)
 
             self._handle_finished_req(req, i, logits_output)
 
@@ -686,7 +686,7 @@ class SchedulerBatchResultProcessor:
                         v.tolist()
                         for v in logits_output.next_token_token_ids_logprobs_val
                     ]
-        # else: Spec V1 — output_ids, check_finished, grammar, and reasoning tokens
+        # else: Spec V1 — output_ids, update_finish_state, grammar, and reasoning tokens
         # are already handled in the verify phase (eagle_info.py / ngram_info.py).
         return next_token_ids, next_token_logprobs
 

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -215,7 +215,7 @@ class SchedulerBatchResultProcessor:
                     # decode req in mixed batch or retracted req
                     continue
 
-                if req.is_chunked <= 0:
+                if req.inflight_middle_chunks <= 0:
                     req.time_stats.set_prefill_finished_time()
 
                     # req output_ids are set here
@@ -264,7 +264,7 @@ class SchedulerBatchResultProcessor:
 
                 else:
                     # being chunked reqs' prefill is not finished
-                    req.is_chunked -= 1
+                    req.inflight_middle_chunks -= 1
                     # There is only at most one request being currently chunked.
                     # Because this request does not finish prefill,
                     # we don't want to stream the request currently being chunked.
@@ -304,7 +304,7 @@ class SchedulerBatchResultProcessor:
                 req.embedding = embeddings[i]
                 if req.return_pooled_hidden_states and phs is not None:
                     req.pooled_hidden_state = phs[i]
-                if req.is_chunked <= 0:
+                if req.inflight_middle_chunks <= 0:
                     req.time_stats.set_prefill_finished_time()
                     # Dummy output token for embedding models
                     req.output_ids.append(0)
@@ -317,7 +317,7 @@ class SchedulerBatchResultProcessor:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                 else:
                     # being chunked reqs' prefill is not finished
-                    req.is_chunked -= 1
+                    req.inflight_middle_chunks -= 1
                     req.time_stats.set_last_chunked_prefill_finish_time()
 
         self.output_streamer.stream_output(

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -202,27 +202,7 @@ class SchedulerBatchResultProcessor:
 
             # Move next_token_ids and logprobs to cpu
             next_token_ids = next_token_ids.tolist()
-            if batch.return_logprob:
-                if logits_output.next_token_logprobs is not None:
-                    logits_output.next_token_logprobs = (
-                        logits_output.next_token_logprobs.tolist()
-                    )
-                if logits_output.input_token_logprobs is not None:
-                    logits_output.input_token_logprobs = tuple(
-                        logits_output.input_token_logprobs.tolist()
-                    )
-                if logits_output.next_token_top_logprobs_val:
-                    logits_output.next_token_top_logprobs_val = [
-                        v.tolist() for v in logits_output.next_token_top_logprobs_val
-                    ]
-                    logits_output.next_token_top_logprobs_idx = [
-                        x.tolist() for x in logits_output.next_token_top_logprobs_idx
-                    ]
-                if logits_output.next_token_token_ids_logprobs_val:
-                    logits_output.next_token_token_ids_logprobs_val = [
-                        v.tolist()
-                        for v in logits_output.next_token_token_ids_logprobs_val
-                    ]
+            self._move_logprobs_to_cpu(batch=batch, logits_output=logits_output)
 
             hidden_state_offset = 0
 
@@ -367,6 +347,33 @@ class SchedulerBatchResultProcessor:
             can_run_cuda_graph=can_run_cuda_graph,
             dp_cooperation_info=batch.dp_cooperation_info,
         )
+
+    def _move_logprobs_to_cpu(
+        self,
+        *,
+        batch: ScheduleBatch,
+        logits_output: LogitsProcessorOutput,
+    ) -> None:
+        if batch.return_logprob:
+            if logits_output.next_token_logprobs is not None:
+                logits_output.next_token_logprobs = (
+                    logits_output.next_token_logprobs.tolist()
+                )
+            if logits_output.input_token_logprobs is not None:
+                logits_output.input_token_logprobs = tuple(
+                    logits_output.input_token_logprobs.tolist()
+                )
+            if logits_output.next_token_top_logprobs_val:
+                logits_output.next_token_top_logprobs_val = [
+                    v.tolist() for v in logits_output.next_token_top_logprobs_val
+                ]
+                logits_output.next_token_top_logprobs_idx = [
+                    x.tolist() for x in logits_output.next_token_top_logprobs_idx
+                ]
+            if logits_output.next_token_token_ids_logprobs_val:
+                logits_output.next_token_token_ids_logprobs_val = [
+                    v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
+                ]
 
     def _apply_prefill_logprobs(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -641,36 +641,14 @@ class SchedulerBatchResultProcessor:
             self._handle_finished_req(req, i, logits_output)
 
             if req.return_logprob:
-                # Spec v1 handles logprobs inside its own worker.
-                # Normalize: non-spec has 1 token, spec v2 has multiple.
-                if batch.is_spec_v2:
-                    accepted_logprobs = next_token_logprobs[i]
-                    accepted_ids = next_token_id
-                    max_accept = len(accepted_logprobs)
-                else:
-                    accepted_logprobs = [next_token_logprobs[i]]
-                    accepted_ids = [next_token_id]
-                    max_accept = 1
-
-                for j, tok_id in enumerate(accepted_ids):
-                    req.output_token_logprobs_val.append(accepted_logprobs[j])
-                    req.output_token_logprobs_idx.append(tok_id)
-                    if req.top_logprobs_num > 0:
-                        flat_idx = i * max_accept + j
-                        req.output_top_logprobs_val.append(
-                            logits_output.next_token_top_logprobs_val[flat_idx]
-                        )
-                        req.output_top_logprobs_idx.append(
-                            logits_output.next_token_top_logprobs_idx[flat_idx]
-                        )
-                    if req.token_ids_logprob is not None:
-                        flat_idx = i * max_accept + j
-                        req.output_token_ids_logprobs_val.append(
-                            logits_output.next_token_token_ids_logprobs_val[flat_idx]
-                        )
-                        req.output_token_ids_logprobs_idx.append(
-                            logits_output.next_token_token_ids_logprobs_idx[flat_idx]
-                        )
+                self._apply_decode_logprobs(
+                    req=req,
+                    i=i,
+                    batch=batch,
+                    next_token_id=next_token_id,
+                    next_token_logprobs=next_token_logprobs,
+                    logits_output=logits_output,
+                )
 
             if req.return_hidden_states and logits_output.hidden_states is not None:
                 req.hidden_states.append(
@@ -707,6 +685,47 @@ class SchedulerBatchResultProcessor:
             running_batch=batch,
             num_correct_drafts=result.num_correct_drafts,
         )
+
+    def _apply_decode_logprobs(
+        self,
+        *,
+        req: Req,
+        i: int,
+        batch: ScheduleBatch,
+        next_token_id: Union[int, List[int]],
+        next_token_logprobs: list,
+        logits_output: LogitsProcessorOutput,
+    ) -> None:
+        # Spec v1 handles logprobs inside its own worker.
+        # Normalize: non-spec has 1 token, spec v2 has multiple.
+        if batch.is_spec_v2:
+            accepted_logprobs = next_token_logprobs[i]
+            accepted_ids = next_token_id
+            max_accept = len(accepted_logprobs)
+        else:
+            accepted_logprobs = [next_token_logprobs[i]]
+            accepted_ids = [next_token_id]
+            max_accept = 1
+
+        for j, tok_id in enumerate(accepted_ids):
+            req.output_token_logprobs_val.append(accepted_logprobs[j])
+            req.output_token_logprobs_idx.append(tok_id)
+            if req.top_logprobs_num > 0:
+                flat_idx = i * max_accept + j
+                req.output_top_logprobs_val.append(
+                    logits_output.next_token_top_logprobs_val[flat_idx]
+                )
+                req.output_top_logprobs_idx.append(
+                    logits_output.next_token_top_logprobs_idx[flat_idx]
+                )
+            if req.token_ids_logprob is not None:
+                flat_idx = i * max_accept + j
+                req.output_token_ids_logprobs_val.append(
+                    logits_output.next_token_token_ids_logprobs_val[flat_idx]
+                )
+                req.output_token_ids_logprobs_idx.append(
+                    logits_output.next_token_token_ids_logprobs_idx[flat_idx]
+                )
 
     def _handle_finished_req(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -712,22 +712,22 @@ class SchedulerBatchResultProcessor:
             max_accept = 1
 
         for j, tok_id in enumerate(accepted_ids):
-            req.output_token_logprobs_val.append(accepted_logprobs[j])
-            req.output_token_logprobs_idx.append(tok_id)
-            if req.top_logprobs_num > 0:
+            req.logprob.output_token_logprobs_val.append(accepted_logprobs[j])
+            req.logprob.output_token_logprobs_idx.append(tok_id)
+            if req.logprob.top_logprobs_num > 0:
                 flat_idx = i * max_accept + j
-                req.output_top_logprobs_val.append(
+                req.logprob.output_top_logprobs_val.append(
                     logits_output.next_token_top_logprobs_val[flat_idx]
                 )
-                req.output_top_logprobs_idx.append(
+                req.logprob.output_top_logprobs_idx.append(
                     logits_output.next_token_top_logprobs_idx[flat_idx]
                 )
-            if req.token_ids_logprob is not None:
+            if req.logprob.token_ids_logprob is not None:
                 flat_idx = i * max_accept + j
-                req.output_token_ids_logprobs_val.append(
+                req.logprob.output_token_ids_logprobs_val.append(
                     logits_output.next_token_token_ids_logprobs_val[flat_idx]
                 )
-                req.output_token_ids_logprobs_idx.append(
+                req.logprob.output_token_ids_logprobs_idx.append(
                     logits_output.next_token_token_ids_logprobs_idx[flat_idx]
                 )
 

--- a/python/sglang/srt/managers/scheduler_components/flush_wrapper.py
+++ b/python/sglang/srt/managers/scheduler_components/flush_wrapper.py
@@ -1,0 +1,65 @@
+import logging
+import time
+from typing import Callable, Optional, Tuple
+
+from sglang.srt.managers.io_struct import FlushCacheReqInput, FlushCacheReqOutput
+from sglang.srt.managers.scheduler_components.ipc_channels import (
+    SchedulerIpcChannels,
+)
+
+
+class SchedulerFlushWrapper:
+    def __init__(
+        self,
+        *,
+        flush_cache: Callable[[], bool],
+        is_fully_idle: Callable[[], bool],
+        ipc_channels: SchedulerIpcChannels,
+    ) -> None:
+        self._flush_cache = flush_cache
+        self._is_fully_idle = is_fully_idle
+        self._ipc_channels = ipc_channels
+        self._pending: Optional[Tuple[FlushCacheReqInput, float]] = None
+
+    def handle(self, recv_req: FlushCacheReqInput) -> Optional[FlushCacheReqOutput]:
+        if self._pending is not None:
+            return FlushCacheReqOutput(
+                success=False,
+                message="Another flush_cache is already in progress.",
+            )
+
+        timeout_s = float(recv_req.timeout_s or 0.0)
+        if timeout_s <= 0.0:
+            return FlushCacheReqOutput(success=self._flush_cache())
+
+        if self._is_fully_idle():
+            return FlushCacheReqOutput(success=self._flush_cache())
+
+        self._pending = (recv_req, time.monotonic() + timeout_s)
+        return None
+
+    def check_pending(self) -> None:
+        if self._pending is None:
+            return
+
+        pending_req, deadline = self._pending
+
+        if self._is_fully_idle():
+            success = self._flush_cache()
+            self._pending = None
+            self._ipc_channels.send_to_tokenizer.send_output(
+                FlushCacheReqOutput(success=success), pending_req
+            )
+            return
+
+        if time.monotonic() >= deadline:
+            logging.warning(
+                "Deferred flush_cache timed out while waiting for idle state."
+            )
+            self._pending = None
+            self._ipc_channels.send_to_tokenizer.send_output(
+                FlushCacheReqOutput(
+                    success=False, message="Timed out waiting for idle state."
+                ),
+                pending_req,
+            )

--- a/python/sglang/srt/managers/scheduler_components/ipc_channels.py
+++ b/python/sglang/srt/managers/scheduler_components/ipc_channels.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import zmq
+
+from sglang.srt.managers.scheduler_components.output_sender import SenderWrapper
+from sglang.srt.server_args import PortArgs
+from sglang.srt.utils.network import get_zmq_socket
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SchedulerIpcChannels:
+    recv_from_tokenizer: Optional[zmq.Socket]
+    recv_from_rpc: Optional[zmq.Socket]
+    send_to_tokenizer: SenderWrapper
+    send_to_detokenizer: SenderWrapper
+    send_metrics_from_scheduler: Optional[zmq.Socket]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        port_args: PortArgs,
+        is_rank_zero: bool,
+        skip_tokenizer_init: bool,
+        metrics_enabled: bool,
+    ) -> "SchedulerIpcChannels":
+        context = zmq.Context(2)
+
+        if is_rank_zero:
+            recv_from_tokenizer = get_zmq_socket(
+                context, zmq.PULL, port_args.scheduler_input_ipc_name, False
+            )
+            recv_from_rpc = get_zmq_socket(
+                context, zmq.DEALER, port_args.rpc_ipc_name, False
+            )
+
+            send_to_tokenizer_raw = get_zmq_socket(
+                context, zmq.PUSH, port_args.tokenizer_ipc_name, False
+            )
+            if skip_tokenizer_init:
+                # Directly send to the TokenizerManager
+                send_to_detokenizer_raw = get_zmq_socket(
+                    context, zmq.PUSH, port_args.tokenizer_ipc_name, False
+                )
+            else:
+                # Send to the DetokenizerManager
+                send_to_detokenizer_raw = get_zmq_socket(
+                    context, zmq.PUSH, port_args.detokenizer_ipc_name, False
+                )
+
+            send_to_tokenizer = SenderWrapper(send_to_tokenizer_raw)
+            send_to_detokenizer = SenderWrapper(send_to_detokenizer_raw)
+        else:
+            recv_from_tokenizer = None
+            recv_from_rpc = None
+            send_to_tokenizer = SenderWrapper(None)
+            send_to_detokenizer = SenderWrapper(None)
+
+        if metrics_enabled:
+            send_metrics_from_scheduler = get_zmq_socket(
+                context, zmq.PUSH, port_args.metrics_ipc_name, False
+            )
+        else:
+            send_metrics_from_scheduler = None
+
+        return cls(
+            recv_from_tokenizer=recv_from_tokenizer,
+            recv_from_rpc=recv_from_rpc,
+            send_to_tokenizer=send_to_tokenizer,
+            send_to_detokenizer=send_to_detokenizer,
+            send_metrics_from_scheduler=send_metrics_from_scheduler,
+        )

--- a/python/sglang/srt/managers/scheduler_components/logprob_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/logprob_result_processor.py
@@ -31,10 +31,10 @@ class SchedulerLogprobResultProcessor:
         # Process logprob values - handle multi-item scoring vs regular requests
         if is_multi_item_scoring:
             # Multi-item scoring: use all logprobs as-is
-            req.input_token_logprobs_val = input_token_logprobs
+            req.logprob.input_token_logprobs_val = input_token_logprobs
         else:
             # Regular request: add None at start, remove last (sampling token)
-            req.input_token_logprobs_val = [None] + input_token_logprobs[:-1]
+            req.logprob.input_token_logprobs_val = [None] + input_token_logprobs[:-1]
 
         # Process logprob indices based on scoring type
         if is_multi_item_scoring:
@@ -49,21 +49,21 @@ class SchedulerLogprobResultProcessor:
             input_token_logprobs_idx = req.origin_input_ids[req.logprob_start_len :]
 
         # Clip padded hash values from image tokens to prevent detokenization errors
-        req.input_token_logprobs_idx = [
+        req.logprob.input_token_logprobs_idx = [
             x if x < self.model_config.vocab_size - 1 else 0
             for x in input_token_logprobs_idx
         ]
 
     def _process_input_top_logprobs(self, req: Req) -> None:
         """Process input top logprobs."""
-        if req.top_logprobs_num <= 0:
+        if req.logprob.top_logprobs_num <= 0:
             return
 
         is_multi_item_scoring = self._is_multi_item_scoring(req)
 
         # Initialize arrays - multi-item scoring starts empty, others start with None
-        req.input_top_logprobs_val = [] if is_multi_item_scoring else [None]
-        req.input_top_logprobs_idx = [] if is_multi_item_scoring else [None]
+        req.logprob.input_top_logprobs_val = [] if is_multi_item_scoring else [None]
+        req.logprob.input_top_logprobs_idx = [] if is_multi_item_scoring else [None]
 
         # Extend arrays with temp values
         for val, idx in zip(
@@ -71,13 +71,13 @@ class SchedulerLogprobResultProcessor:
             req.temp_input_top_logprobs_idx,
             strict=True,
         ):
-            req.input_top_logprobs_val.extend(val)
-            req.input_top_logprobs_idx.extend(idx)
+            req.logprob.input_top_logprobs_val.extend(val)
+            req.logprob.input_top_logprobs_idx.extend(idx)
 
         # Remove last token (sampling token) for non multi-item scoring requests
         if not is_multi_item_scoring:
-            req.input_top_logprobs_val.pop()
-            req.input_top_logprobs_idx.pop()
+            req.logprob.input_top_logprobs_val.pop()
+            req.logprob.input_top_logprobs_idx.pop()
 
         # Clean up temp storage
         req.temp_input_top_logprobs_idx = None
@@ -85,14 +85,18 @@ class SchedulerLogprobResultProcessor:
 
     def _process_input_token_ids_logprobs(self, req: Req) -> None:
         """Process input token IDs logprobs."""
-        if req.token_ids_logprob is None:
+        if req.logprob.token_ids_logprob is None:
             return
 
         is_multi_item_scoring = self._is_multi_item_scoring(req)
 
         # Initialize arrays - multi-item scoring starts empty, others start with None
-        req.input_token_ids_logprobs_val = [] if is_multi_item_scoring else [None]
-        req.input_token_ids_logprobs_idx = [] if is_multi_item_scoring else [None]
+        req.logprob.input_token_ids_logprobs_val = (
+            [] if is_multi_item_scoring else [None]
+        )
+        req.logprob.input_token_ids_logprobs_idx = (
+            [] if is_multi_item_scoring else [None]
+        )
 
         # Process temp values - convert tensors to lists and extend arrays
         for val, idx in zip(
@@ -101,15 +105,15 @@ class SchedulerLogprobResultProcessor:
             strict=True,
         ):
             val_list = val.tolist() if isinstance(val, torch.Tensor) else val
-            req.input_token_ids_logprobs_val.extend(
+            req.logprob.input_token_ids_logprobs_val.extend(
                 val_list if isinstance(val_list, list) else [val_list]
             )
-            req.input_token_ids_logprobs_idx.extend(idx)
+            req.logprob.input_token_ids_logprobs_idx.extend(idx)
 
         # Remove last token (sampling token) for non multi-item scoring requests
         if not is_multi_item_scoring:
-            req.input_token_ids_logprobs_val.pop()
-            req.input_token_ids_logprobs_idx.pop()
+            req.logprob.input_token_ids_logprobs_val.pop()
+            req.logprob.input_token_ids_logprobs_idx.pop()
 
         # Clean up temp storage
         req.temp_input_token_ids_logprobs_idx = None
@@ -198,11 +202,11 @@ class SchedulerLogprobResultProcessor:
         if req.temp_input_token_ids_logprobs_idx is None:
             req.temp_input_token_ids_logprobs_idx = []
 
-        if req.input_token_logprobs_val is not None:
+        if req.logprob.input_token_logprobs_val is not None:
             # The input logprob has been already computed. It only happens
             # upon retract.
-            if req.top_logprobs_num > 0:
-                assert req.input_token_logprobs_val is not None
+            if req.logprob.top_logprobs_num > 0:
+                assert req.logprob.input_token_logprobs_val is not None
             return
 
         # Important for the performance.
@@ -213,11 +217,11 @@ class SchedulerLogprobResultProcessor:
         ]
         req.input_token_logprobs.extend(input_token_logprobs)
 
-        if req.top_logprobs_num > 0:
+        if req.logprob.top_logprobs_num > 0:
             req.temp_input_top_logprobs_val.append(output.input_top_logprobs_val[i])
             req.temp_input_top_logprobs_idx.append(output.input_top_logprobs_idx[i])
 
-        if req.token_ids_logprob is not None:
+        if req.logprob.token_ids_logprob is not None:
             req.temp_input_token_ids_logprobs_val.append(
                 output.input_token_ids_logprobs_val[i]
             )
@@ -228,10 +232,10 @@ class SchedulerLogprobResultProcessor:
         if last_prefill_chunk:
             input_token_logprobs = req.input_token_logprobs
             req.input_token_logprobs = None
-            assert req.input_token_logprobs_val is None
-            assert req.input_token_logprobs_idx is None
-            assert req.input_top_logprobs_val is None
-            assert req.input_top_logprobs_idx is None
+            assert req.logprob.input_token_logprobs_val is None
+            assert req.logprob.input_token_logprobs_idx is None
+            assert req.logprob.input_top_logprobs_val is None
+            assert req.logprob.input_top_logprobs_idx is None
 
             # Process all input logprob types using helper functions
             self._process_input_token_logprobs(req, input_token_logprobs)
@@ -241,14 +245,24 @@ class SchedulerLogprobResultProcessor:
 
             if req.return_logprob:
                 relevant_tokens_len = self._calculate_relevant_tokens_len(req)
-                assert len(req.input_token_logprobs_val) == relevant_tokens_len
-                assert len(req.input_token_logprobs_idx) == relevant_tokens_len
-                if req.top_logprobs_num > 0:
-                    assert len(req.input_top_logprobs_val) == relevant_tokens_len
-                    assert len(req.input_top_logprobs_idx) == relevant_tokens_len
-                if req.token_ids_logprob is not None:
-                    assert len(req.input_token_ids_logprobs_val) == relevant_tokens_len
-                    assert len(req.input_token_ids_logprobs_idx) == relevant_tokens_len
+                assert len(req.logprob.input_token_logprobs_val) == relevant_tokens_len
+                assert len(req.logprob.input_token_logprobs_idx) == relevant_tokens_len
+                if req.logprob.top_logprobs_num > 0:
+                    assert (
+                        len(req.logprob.input_top_logprobs_val) == relevant_tokens_len
+                    )
+                    assert (
+                        len(req.logprob.input_top_logprobs_idx) == relevant_tokens_len
+                    )
+                if req.logprob.token_ids_logprob is not None:
+                    assert (
+                        len(req.logprob.input_token_ids_logprobs_val)
+                        == relevant_tokens_len
+                    )
+                    assert (
+                        len(req.logprob.input_token_ids_logprobs_idx)
+                        == relevant_tokens_len
+                    )
 
     def add_logprob_return_values(
         self,
@@ -261,8 +275,8 @@ class SchedulerLogprobResultProcessor:
     ):
         """Attach logprobs to the return values."""
         if output.next_token_logprobs is not None:
-            req.output_token_logprobs_val.append(output.next_token_logprobs[i])
-            req.output_token_logprobs_idx.append(next_token_ids[i])
+            req.logprob.output_token_logprobs_val.append(output.next_token_logprobs[i])
+            req.logprob.output_token_logprobs_idx.append(next_token_ids[i])
 
         # Only add input logprobs if there are input tokens to process
         # Note: For prefill-only requests with default logprob_start_len, this will be 0,
@@ -279,20 +293,24 @@ class SchedulerLogprobResultProcessor:
         else:
             self._initialize_empty_logprob_containers(req)
 
-        if req.top_logprobs_num > 0:
-            req.output_top_logprobs_val.append(output.next_token_top_logprobs_val[i])
-            req.output_top_logprobs_idx.append(output.next_token_top_logprobs_idx[i])
+        if req.logprob.top_logprobs_num > 0:
+            req.logprob.output_top_logprobs_val.append(
+                output.next_token_top_logprobs_val[i]
+            )
+            req.logprob.output_top_logprobs_idx.append(
+                output.next_token_top_logprobs_idx[i]
+            )
 
         if (
-            req.token_ids_logprob is not None
+            req.logprob.token_ids_logprob is not None
             and output.next_token_token_ids_logprobs_val is not None
         ):
             # Convert GPU tensor to list if needed
             logprobs_val = output.next_token_token_ids_logprobs_val[i]
             if isinstance(logprobs_val, torch.Tensor):
                 logprobs_val = logprobs_val.tolist()
-            req.output_token_ids_logprobs_val.append(logprobs_val)
-            req.output_token_ids_logprobs_idx.append(
+            req.logprob.output_token_ids_logprobs_val.append(logprobs_val)
+            req.logprob.output_token_ids_logprobs_idx.append(
                 output.next_token_token_ids_logprobs_idx[i]
             )
 
@@ -305,15 +323,15 @@ class SchedulerLogprobResultProcessor:
         This is needed for prefill-only requests where the normal initialization
         flow might be bypassed, but downstream code expects these fields to be lists.
         """
-        if req.input_token_logprobs_val is None:
-            req.input_token_logprobs_val = []
-        if req.input_token_logprobs_idx is None:
-            req.input_token_logprobs_idx = []
-        if req.input_top_logprobs_val is None:
-            req.input_top_logprobs_val = []
-        if req.input_top_logprobs_idx is None:
-            req.input_top_logprobs_idx = []
-        if req.input_token_ids_logprobs_val is None:
-            req.input_token_ids_logprobs_val = []
-        if req.input_token_ids_logprobs_idx is None:
-            req.input_token_ids_logprobs_idx = []
+        if req.logprob.input_token_logprobs_val is None:
+            req.logprob.input_token_logprobs_val = []
+        if req.logprob.input_token_logprobs_idx is None:
+            req.logprob.input_token_logprobs_idx = []
+        if req.logprob.input_top_logprobs_val is None:
+            req.logprob.input_top_logprobs_val = []
+        if req.logprob.input_top_logprobs_idx is None:
+            req.logprob.input_top_logprobs_idx = []
+        if req.logprob.input_token_ids_logprobs_val is None:
+            req.logprob.input_token_ids_logprobs_val = []
+        if req.logprob.input_token_ids_logprobs_idx is None:
+            req.logprob.input_token_ids_logprobs_idx = []

--- a/python/sglang/srt/managers/scheduler_components/new_token_ratio_tracker.py
+++ b/python/sglang/srt/managers/scheduler_components/new_token_ratio_tracker.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
 
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
 
 
 @dataclass(slots=True, kw_only=True)
@@ -30,3 +36,16 @@ class NewTokenRatioTracker:
 
     def reset(self) -> None:
         self.current = self.init
+
+    @staticmethod
+    def estimate_new_token_ratio_after_retract(reqs: Sequence[Req]) -> float:
+        total_decoded_tokens = sum(len(r.output_ids) for r in reqs)
+        total_max_new_tokens = sum(r.sampling_params.max_new_tokens for r in reqs)
+
+        new_estimate_ratio = (
+            total_decoded_tokens + envs.SGLANG_RETRACT_DECODE_STEPS.get() * len(reqs)
+        ) / (
+            total_max_new_tokens + 1
+        )  # avoid zero division
+        new_estimate_ratio = min(1.0, new_estimate_ratio)
+        return new_estimate_ratio

--- a/python/sglang/srt/managers/scheduler_components/new_token_ratio_tracker.py
+++ b/python/sglang/srt/managers/scheduler_components/new_token_ratio_tracker.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from sglang.srt.environ import envs
+from sglang.srt.server_args import ServerArgs
+
+
+@dataclass(slots=True, kw_only=True)
+class NewTokenRatioTracker:
+    init: float
+    min: float
+    decay: float
+    current: float
+
+    @classmethod
+    def from_server_args(cls, server_args: ServerArgs) -> "NewTokenRatioTracker":
+        init = min(
+            envs.SGLANG_INIT_NEW_TOKEN_RATIO.get()
+            * server_args.schedule_conservativeness,
+            1.0,
+        )
+        min_ratio = min(
+            init * envs.SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR.get(),
+            1.0,
+        )
+        decay = (init - min_ratio) / envs.SGLANG_NEW_TOKEN_RATIO_DECAY_STEPS.get()
+        return cls(init=init, min=min_ratio, decay=decay, current=init)
+
+    def decay_step(self) -> None:
+        self.current = max(self.current - self.decay, self.min)
+
+    def reset(self) -> None:
+        self.current = self.init

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     Any,
     Callable,
@@ -123,58 +123,15 @@ class SchedulerOutputStreamer:
         skip_req: Optional[Req] = None,
         is_idle_batch: bool = False,
     ):
-        rids = []
-        http_worker_ipcs = []
-        finished_reasons: List[BaseFinishReason] = []
-
-        decoded_texts = []
-        decode_ids_list = []
-        read_offsets = []
-        output_ids = []
-
-        skip_special_tokens = []
-        spaces_between_special_tokens = []
-        no_stop_trim = []
-        prompt_tokens = []
-        reasoning_tokens = []
-        completion_tokens = []
-        cached_tokens = []
-        cached_tokens_details = []  # Detailed breakdown by cache source
-        spec_verify_ct = []
-        spec_num_correct_drafts = []
-        spec_correct_drafts_histogram = []
-        retraction_counts = []
-        output_hidden_states = None
+        acc = _GenerationStreamAccumulator(
+            return_logprob=return_logprob,
+            spec_algorithm=self.spec_algorithm,
+            disaggregation_mode=self.disaggregation_mode,
+            default_stream_interval=self.server_args.stream_interval,
+            default_force_stream_interval=DEFAULT_FORCE_STREAM_INTERVAL,
+            get_cached_tokens_details=self.get_cached_tokens_details,
+        )
         load = self.load_inquirer_get_loads(GetLoadsReqInput(include=["core"]))
-        routed_experts = None
-        indexer_topk = None
-        customized_info = {}
-
-        time_stats = []
-
-        if return_logprob:
-            input_token_logprobs_val = []
-            input_token_logprobs_idx = []
-            output_token_logprobs_val = []
-            output_token_logprobs_idx = []
-            input_top_logprobs_val = []
-            input_top_logprobs_idx = []
-            output_top_logprobs_val = []
-            output_top_logprobs_idx = []
-            input_token_ids_logprobs_val = []
-            input_token_ids_logprobs_idx = []
-            output_token_ids_logprobs_val = []
-            output_token_ids_logprobs_idx = []
-        else:
-            input_token_logprobs_val = input_token_logprobs_idx = (
-                output_token_logprobs_val
-            ) = output_token_logprobs_idx = input_top_logprobs_val = (
-                input_top_logprobs_idx
-            ) = output_top_logprobs_val = output_top_logprobs_idx = (
-                input_token_ids_logprobs_val
-            ) = input_token_ids_logprobs_idx = output_token_ids_logprobs_val = (
-                output_token_ids_logprobs_idx
-            ) = None
 
         for req in reqs:
             if req is skip_req:
@@ -216,44 +173,44 @@ class SchedulerOutputStreamer:
                 send_output_token_logprobs_offset = (
                     req.send_output_token_logprobs_offset
                 )
-                rids.append(req.rid)
-                http_worker_ipcs.append(req.http_worker_ipc)
-                finished_reasons.append(
+                acc.rids.append(req.rid)
+                acc.http_worker_ipcs.append(req.http_worker_ipc)
+                acc.finished_reasons.append(
                     req.finished_reason.to_json() if req.finished_reason else None
                 )
-                decoded_texts.append(req.decoded_text)
+                acc.decoded_texts.append(req.decoded_text)
                 decode_ids, read_offset = req.init_incremental_detokenize()
 
-                decode_ids_list.append(decode_ids[req.send_decode_id_offset :])
+                acc.decode_ids_list.append(decode_ids[req.send_decode_id_offset :])
 
                 # Exclude the tokens after stop condition
                 output_ids_ = req.output_ids_through_stop
 
                 req.send_decode_id_offset = len(decode_ids)
-                read_offsets.append(read_offset)
-                output_ids.append(output_ids_[send_token_offset:])
+                acc.read_offsets.append(read_offset)
+                acc.output_ids.append(output_ids_[send_token_offset:])
                 req.send_token_offset = len(output_ids_)
-                skip_special_tokens.append(req.sampling_params.skip_special_tokens)
-                spaces_between_special_tokens.append(
+                acc.skip_special_tokens.append(req.sampling_params.skip_special_tokens)
+                acc.spaces_between_special_tokens.append(
                     req.sampling_params.spaces_between_special_tokens
                 )
-                no_stop_trim.append(req.sampling_params.no_stop_trim)
-                prompt_tokens.append(len(req.origin_input_ids))
-                reasoning_tokens.append(req.reasoning_tokens)
-                completion_tokens.append(len(output_ids_))
-                cached_tokens.append(req.cached_tokens)
+                acc.no_stop_trim.append(req.sampling_params.no_stop_trim)
+                acc.prompt_tokens.append(len(req.origin_input_ids))
+                acc.reasoning_tokens.append(req.reasoning_tokens)
+                acc.completion_tokens.append(len(output_ids_))
+                acc.cached_tokens.append(req.cached_tokens)
 
                 # Collect detailed cache breakdown if available
-                cached_tokens_details.append(self.get_cached_tokens_details(req))
+                acc.cached_tokens_details.append(self.get_cached_tokens_details(req))
 
-                retraction_counts.append(req.retraction_count)
+                acc.retraction_counts.append(req.retraction_count)
 
-                time_stats.append(req.time_stats)
+                acc.time_stats.append(req.time_stats)
 
                 if not self.spec_algorithm.is_none():
-                    spec_verify_ct.append(req.spec_verify_ct)
-                    spec_num_correct_drafts.append(req.spec_num_correct_drafts)
-                    spec_correct_drafts_histogram.append(
+                    acc.spec_verify_ct.append(req.spec_verify_ct)
+                    acc.spec_num_correct_drafts.append(req.spec_num_correct_drafts)
+                    acc.spec_correct_drafts_histogram.append(
                         req.spec_correct_drafts_histogram
                     )
 
@@ -266,84 +223,82 @@ class SchedulerOutputStreamer:
                         # Only send when input logprobs have been computed (after prefill)
                         and req.input_token_logprobs_val is not None
                     ):
-                        input_token_logprobs_val.append(req.input_token_logprobs_val)
-                        input_token_logprobs_idx.append(req.input_token_logprobs_idx)
-                        input_top_logprobs_val.append(req.input_top_logprobs_val)
-                        input_top_logprobs_idx.append(req.input_top_logprobs_idx)
-                        input_token_ids_logprobs_val.append(
+                        acc.input_token_logprobs_val.append(
+                            req.input_token_logprobs_val
+                        )
+                        acc.input_token_logprobs_idx.append(
+                            req.input_token_logprobs_idx
+                        )
+                        acc.input_top_logprobs_val.append(req.input_top_logprobs_val)
+                        acc.input_top_logprobs_idx.append(req.input_top_logprobs_idx)
+                        acc.input_token_ids_logprobs_val.append(
                             req.input_token_ids_logprobs_val
                         )
-                        input_token_ids_logprobs_idx.append(
+                        acc.input_token_ids_logprobs_idx.append(
                             req.input_token_ids_logprobs_idx
                         )
                         req.input_logprob_sent = True
                     else:
-                        input_token_logprobs_val.append([])
-                        input_token_logprobs_idx.append([])
-                        input_top_logprobs_val.append([])
-                        input_top_logprobs_idx.append([])
-                        input_token_ids_logprobs_val.append([])
-                        input_token_ids_logprobs_idx.append([])
+                        acc.input_token_logprobs_val.append([])
+                        acc.input_token_logprobs_idx.append([])
+                        acc.input_top_logprobs_val.append([])
+                        acc.input_top_logprobs_idx.append([])
+                        acc.input_token_ids_logprobs_val.append([])
+                        acc.input_token_ids_logprobs_idx.append([])
 
                     if req.return_logprob:
                         logprob_end = max(len(output_ids_), 1)
-                        output_token_logprobs_val.append(
+                        acc.output_token_logprobs_val.append(
                             req.output_token_logprobs_val[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_token_logprobs_idx.append(
+                        acc.output_token_logprobs_idx.append(
                             req.output_token_logprobs_idx[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_top_logprobs_val.append(
+                        acc.output_top_logprobs_val.append(
                             req.output_top_logprobs_val[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_top_logprobs_idx.append(
+                        acc.output_top_logprobs_idx.append(
                             req.output_top_logprobs_idx[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_token_ids_logprobs_val.append(
+                        acc.output_token_ids_logprobs_val.append(
                             req.output_token_ids_logprobs_val[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
-                        output_token_ids_logprobs_idx.append(
+                        acc.output_token_ids_logprobs_idx.append(
                             req.output_token_ids_logprobs_idx[
                                 send_output_token_logprobs_offset:logprob_end
                             ]
                         )
                         req.send_output_token_logprobs_offset = logprob_end
                     else:
-                        output_token_logprobs_val.append([])
-                        output_token_logprobs_idx.append([])
-                        output_top_logprobs_val.append([])
-                        output_top_logprobs_idx.append([])
-                        output_token_ids_logprobs_val.append([])
-                        output_token_ids_logprobs_idx.append([])
+                        acc.output_token_logprobs_val.append([])
+                        acc.output_token_logprobs_idx.append([])
+                        acc.output_top_logprobs_val.append([])
+                        acc.output_top_logprobs_idx.append([])
+                        acc.output_token_ids_logprobs_val.append([])
+                        acc.output_token_ids_logprobs_idx.append([])
 
                 if req.return_hidden_states:
-                    if output_hidden_states is None:
-                        output_hidden_states = []
-                    output_hidden_states.append(req.hidden_states)
+                    acc.output_hidden_states.append(req.hidden_states)
                 if req.return_routed_experts:
-                    if routed_experts is None:
-                        routed_experts = []
-                    routed_experts.append(req.routed_experts)
+                    acc.routed_experts.append(req.routed_experts)
                 if req.return_indexer_topk:
-                    if indexer_topk is None:
-                        indexer_topk = []
-                    indexer_topk.append(req.indexer_topk)
+                    acc.indexer_topk.append(req.indexer_topk)
 
                 if req.customized_info is not None:
                     for k, v in req.customized_info.items():
-                        if k not in customized_info:
-                            customized_info[k] = []
-                        customized_info[k].append(
+                        if k not in acc.customized_info:
+                            acc.customized_info[k] = []
+                        acc.customized_info[k].append(
                             v[send_token_offset : len(output_ids_)]
                         )
 
@@ -354,51 +309,51 @@ class SchedulerOutputStreamer:
             ):
                 req.log_time_stats()
 
-        dp_ranks = [self.ps.dp_rank] * len(rids) if rids else None
+        dp_ranks = [self.ps.dp_rank] * len(acc.rids) if acc.rids else None
 
         # Send to detokenizer
         if reqs or is_idle_batch:
             self.send_to_detokenizer.send_output(
                 BatchTokenIDOutput(
-                    rids=rids,
-                    http_worker_ipcs=http_worker_ipcs,
-                    spec_verify_ct=spec_verify_ct,
-                    spec_num_correct_drafts=spec_num_correct_drafts,
-                    spec_correct_drafts_histogram=spec_correct_drafts_histogram,
-                    time_stats=time_stats,
-                    finished_reasons=finished_reasons,
-                    decoded_texts=decoded_texts,
-                    decode_ids=decode_ids_list,
-                    read_offsets=read_offsets,
-                    output_ids=output_ids,
-                    skip_special_tokens=skip_special_tokens,
-                    spaces_between_special_tokens=spaces_between_special_tokens,
-                    no_stop_trim=no_stop_trim,
-                    prompt_tokens=prompt_tokens,
-                    reasoning_tokens=reasoning_tokens,
-                    completion_tokens=completion_tokens,
-                    cached_tokens=cached_tokens,
-                    cached_tokens_details=cached_tokens_details,
-                    input_token_logprobs_val=input_token_logprobs_val,
-                    input_token_logprobs_idx=input_token_logprobs_idx,
-                    output_token_logprobs_val=output_token_logprobs_val,
-                    output_token_logprobs_idx=output_token_logprobs_idx,
-                    input_top_logprobs_val=input_top_logprobs_val,
-                    input_top_logprobs_idx=input_top_logprobs_idx,
-                    output_top_logprobs_val=output_top_logprobs_val,
-                    output_top_logprobs_idx=output_top_logprobs_idx,
-                    input_token_ids_logprobs_val=input_token_ids_logprobs_val,
-                    input_token_ids_logprobs_idx=input_token_ids_logprobs_idx,
-                    output_token_ids_logprobs_val=output_token_ids_logprobs_val,
-                    output_token_ids_logprobs_idx=output_token_ids_logprobs_idx,
+                    rids=acc.rids,
+                    http_worker_ipcs=acc.http_worker_ipcs,
+                    spec_verify_ct=acc.spec_verify_ct,
+                    spec_num_correct_drafts=acc.spec_num_correct_drafts,
+                    spec_correct_drafts_histogram=acc.spec_correct_drafts_histogram,
+                    time_stats=acc.time_stats,
+                    finished_reasons=acc.finished_reasons,
+                    decoded_texts=acc.decoded_texts,
+                    decode_ids=acc.decode_ids_list,
+                    read_offsets=acc.read_offsets,
+                    output_ids=acc.output_ids,
+                    skip_special_tokens=acc.skip_special_tokens,
+                    spaces_between_special_tokens=acc.spaces_between_special_tokens,
+                    no_stop_trim=acc.no_stop_trim,
+                    prompt_tokens=acc.prompt_tokens,
+                    reasoning_tokens=acc.reasoning_tokens,
+                    completion_tokens=acc.completion_tokens,
+                    cached_tokens=acc.cached_tokens,
+                    cached_tokens_details=acc.cached_tokens_details,
+                    input_token_logprobs_val=acc.input_token_logprobs_val,
+                    input_token_logprobs_idx=acc.input_token_logprobs_idx,
+                    output_token_logprobs_val=acc.output_token_logprobs_val,
+                    output_token_logprobs_idx=acc.output_token_logprobs_idx,
+                    input_top_logprobs_val=acc.input_top_logprobs_val,
+                    input_top_logprobs_idx=acc.input_top_logprobs_idx,
+                    output_top_logprobs_val=acc.output_top_logprobs_val,
+                    output_top_logprobs_idx=acc.output_top_logprobs_idx,
+                    input_token_ids_logprobs_val=acc.input_token_ids_logprobs_val,
+                    input_token_ids_logprobs_idx=acc.input_token_ids_logprobs_idx,
+                    output_token_ids_logprobs_val=acc.output_token_ids_logprobs_val,
+                    output_token_ids_logprobs_idx=acc.output_token_ids_logprobs_idx,
                     output_token_entropy_val=None,
-                    output_hidden_states=output_hidden_states,
-                    routed_experts=routed_experts,
-                    indexer_topk=indexer_topk,
-                    customized_info=customized_info,
+                    output_hidden_states=acc.output_hidden_states or None,
+                    routed_experts=acc.routed_experts or None,
+                    indexer_topk=acc.indexer_topk or None,
+                    customized_info=acc.customized_info,
                     placeholder_tokens_idx=None,
                     placeholder_tokens_val=None,
-                    retraction_counts=retraction_counts,
+                    retraction_counts=acc.retraction_counts,
                     load=load,
                     dp_ranks=dp_ranks,
                 )
@@ -468,3 +423,75 @@ class SchedulerOutputStreamer:
                 pooled_hidden_states=stacked_phs,
             )
         )
+
+
+@dataclass(slots=True, kw_only=True)
+class _GenerationStreamAccumulator:
+    return_logprob: bool
+    spec_algorithm: Any
+    disaggregation_mode: DisaggregationMode
+    default_stream_interval: int
+    default_force_stream_interval: int
+    get_cached_tokens_details: Callable[[Req], Optional[dict]]
+
+    rids: list = field(default_factory=list)
+    http_worker_ipcs: list = field(default_factory=list)
+    finished_reasons: list = field(default_factory=list)
+    decoded_texts: list = field(default_factory=list)
+    decode_ids_list: list = field(default_factory=list)
+    read_offsets: list = field(default_factory=list)
+    output_ids: list = field(default_factory=list)
+    skip_special_tokens: list = field(default_factory=list)
+    spaces_between_special_tokens: list = field(default_factory=list)
+    no_stop_trim: list = field(default_factory=list)
+    prompt_tokens: list = field(default_factory=list)
+    reasoning_tokens: list = field(default_factory=list)
+    completion_tokens: list = field(default_factory=list)
+    cached_tokens: list = field(default_factory=list)
+    cached_tokens_details: list = field(
+        default_factory=list
+    )  # Detailed breakdown by cache source
+    spec_verify_ct: list = field(default_factory=list)
+    spec_num_correct_drafts: list = field(default_factory=list)
+    spec_correct_drafts_histogram: list = field(default_factory=list)
+    retraction_counts: list = field(default_factory=list)
+    output_hidden_states: list = field(default_factory=list)
+    routed_experts: list = field(default_factory=list)
+    indexer_topk: list = field(default_factory=list)
+    customized_info: dict = field(default_factory=dict)
+    time_stats: list = field(default_factory=list)
+    input_token_logprobs_val: Optional[list] = None
+    input_token_logprobs_idx: Optional[list] = None
+    output_token_logprobs_val: Optional[list] = None
+    output_token_logprobs_idx: Optional[list] = None
+    input_top_logprobs_val: Optional[list] = None
+    input_top_logprobs_idx: Optional[list] = None
+    output_top_logprobs_val: Optional[list] = None
+    output_top_logprobs_idx: Optional[list] = None
+    input_token_ids_logprobs_val: Optional[list] = None
+    input_token_ids_logprobs_idx: Optional[list] = None
+    output_token_ids_logprobs_val: Optional[list] = None
+    output_token_ids_logprobs_idx: Optional[list] = None
+
+    def __post_init__(self) -> None:
+        if self.return_logprob:
+            self.input_token_logprobs_val = []
+            self.input_token_logprobs_idx = []
+            self.output_token_logprobs_val = []
+            self.output_token_logprobs_idx = []
+            self.input_top_logprobs_val = []
+            self.input_top_logprobs_idx = []
+            self.output_top_logprobs_val = []
+            self.output_top_logprobs_idx = []
+            self.input_token_ids_logprobs_val = []
+            self.input_token_ids_logprobs_idx = []
+            self.output_token_ids_logprobs_val = []
+            self.output_token_ids_logprobs_idx = []
+
+    def accept(self, *, req: Req) -> None:
+        raise NotImplementedError
+
+    def to_payload(
+        self, *, load, dp_rank: int, is_idle_batch: bool, has_reqs: bool
+    ) -> Optional[BatchTokenIDOutput]:
+        raise NotImplementedError

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -136,171 +136,12 @@ class SchedulerOutputStreamer:
         for req in reqs:
             if req is skip_req:
                 continue
+            if req.finished() and req.finished_output:
+                # With the overlap schedule, a request will try to output twice and hit this line twice
+                # because of the one additional delayed token. This "continue" prevented the dummy output.
+                continue
 
-            if req.finished():
-                if req.finished_output:
-                    # With the overlap schedule, a request will try to output twice and hit this line twice
-                    # because of the one additional delayed token. This "continue" prevented the dummy output.
-                    continue
-                req.finished_output = True
-                if req.finished_len is None:
-                    req.finished_len = len(req.output_ids)
-                should_output = True
-            else:
-                if req.stream:
-                    stream_interval = (
-                        req.sampling_params.stream_interval
-                        or self.server_args.stream_interval
-                    )
-
-                    # origin stream_interval logic
-                    should_output = (
-                        len(req.output_ids) % stream_interval == 1
-                        if stream_interval > 1
-                        else len(req.output_ids) % stream_interval == 0
-                    )
-
-                    if should_output:
-                        # check_match_stop_str_prefix if  tail_str's suffix match stop_str prefix
-                        should_output &= not req.check_match_stop_str_prefix()
-                else:
-                    should_output = (
-                        len(req.output_ids) % DEFAULT_FORCE_STREAM_INTERVAL == 0
-                    )
-
-            if should_output:
-                send_token_offset = req.send_token_offset
-                send_output_token_logprobs_offset = (
-                    req.send_output_token_logprobs_offset
-                )
-                acc.rids.append(req.rid)
-                acc.http_worker_ipcs.append(req.http_worker_ipc)
-                acc.finished_reasons.append(
-                    req.finished_reason.to_json() if req.finished_reason else None
-                )
-                acc.decoded_texts.append(req.decoded_text)
-                decode_ids, read_offset = req.init_incremental_detokenize()
-
-                acc.decode_ids_list.append(decode_ids[req.send_decode_id_offset :])
-
-                # Exclude the tokens after stop condition
-                output_ids_ = req.output_ids_through_stop
-
-                req.send_decode_id_offset = len(decode_ids)
-                acc.read_offsets.append(read_offset)
-                acc.output_ids.append(output_ids_[send_token_offset:])
-                req.send_token_offset = len(output_ids_)
-                acc.skip_special_tokens.append(req.sampling_params.skip_special_tokens)
-                acc.spaces_between_special_tokens.append(
-                    req.sampling_params.spaces_between_special_tokens
-                )
-                acc.no_stop_trim.append(req.sampling_params.no_stop_trim)
-                acc.prompt_tokens.append(len(req.origin_input_ids))
-                acc.reasoning_tokens.append(req.reasoning_tokens)
-                acc.completion_tokens.append(len(output_ids_))
-                acc.cached_tokens.append(req.cached_tokens)
-
-                # Collect detailed cache breakdown if available
-                acc.cached_tokens_details.append(self.get_cached_tokens_details(req))
-
-                acc.retraction_counts.append(req.retraction_count)
-
-                acc.time_stats.append(req.time_stats)
-
-                if not self.spec_algorithm.is_none():
-                    acc.spec_verify_ct.append(req.spec_verify_ct)
-                    acc.spec_num_correct_drafts.append(req.spec_num_correct_drafts)
-                    acc.spec_correct_drafts_histogram.append(
-                        req.spec_correct_drafts_histogram
-                    )
-
-                if return_logprob:
-                    if (
-                        req.return_logprob
-                        and not req.input_logprob_sent
-                        # Decode server does not send input logprobs
-                        and self.disaggregation_mode != DisaggregationMode.DECODE
-                        # Only send when input logprobs have been computed (after prefill)
-                        and req.input_token_logprobs_val is not None
-                    ):
-                        acc.input_token_logprobs_val.append(
-                            req.input_token_logprobs_val
-                        )
-                        acc.input_token_logprobs_idx.append(
-                            req.input_token_logprobs_idx
-                        )
-                        acc.input_top_logprobs_val.append(req.input_top_logprobs_val)
-                        acc.input_top_logprobs_idx.append(req.input_top_logprobs_idx)
-                        acc.input_token_ids_logprobs_val.append(
-                            req.input_token_ids_logprobs_val
-                        )
-                        acc.input_token_ids_logprobs_idx.append(
-                            req.input_token_ids_logprobs_idx
-                        )
-                        req.input_logprob_sent = True
-                    else:
-                        acc.input_token_logprobs_val.append([])
-                        acc.input_token_logprobs_idx.append([])
-                        acc.input_top_logprobs_val.append([])
-                        acc.input_top_logprobs_idx.append([])
-                        acc.input_token_ids_logprobs_val.append([])
-                        acc.input_token_ids_logprobs_idx.append([])
-
-                    if req.return_logprob:
-                        logprob_end = max(len(output_ids_), 1)
-                        acc.output_token_logprobs_val.append(
-                            req.output_token_logprobs_val[
-                                send_output_token_logprobs_offset:logprob_end
-                            ]
-                        )
-                        acc.output_token_logprobs_idx.append(
-                            req.output_token_logprobs_idx[
-                                send_output_token_logprobs_offset:logprob_end
-                            ]
-                        )
-                        acc.output_top_logprobs_val.append(
-                            req.output_top_logprobs_val[
-                                send_output_token_logprobs_offset:logprob_end
-                            ]
-                        )
-                        acc.output_top_logprobs_idx.append(
-                            req.output_top_logprobs_idx[
-                                send_output_token_logprobs_offset:logprob_end
-                            ]
-                        )
-                        acc.output_token_ids_logprobs_val.append(
-                            req.output_token_ids_logprobs_val[
-                                send_output_token_logprobs_offset:logprob_end
-                            ]
-                        )
-                        acc.output_token_ids_logprobs_idx.append(
-                            req.output_token_ids_logprobs_idx[
-                                send_output_token_logprobs_offset:logprob_end
-                            ]
-                        )
-                        req.send_output_token_logprobs_offset = logprob_end
-                    else:
-                        acc.output_token_logprobs_val.append([])
-                        acc.output_token_logprobs_idx.append([])
-                        acc.output_top_logprobs_val.append([])
-                        acc.output_top_logprobs_idx.append([])
-                        acc.output_token_ids_logprobs_val.append([])
-                        acc.output_token_ids_logprobs_idx.append([])
-
-                if req.return_hidden_states:
-                    acc.output_hidden_states.append(req.hidden_states)
-                if req.return_routed_experts:
-                    acc.routed_experts.append(req.routed_experts)
-                if req.return_indexer_topk:
-                    acc.indexer_topk.append(req.indexer_topk)
-
-                if req.customized_info is not None:
-                    for k, v in req.customized_info.items():
-                        if k not in acc.customized_info:
-                            acc.customized_info[k] = []
-                        acc.customized_info[k].append(
-                            v[send_token_offset : len(output_ids_)]
-                        )
+            acc.accept(req=req)
 
             if (
                 req.finished()
@@ -489,7 +330,158 @@ class _GenerationStreamAccumulator:
             self.output_token_ids_logprobs_idx = []
 
     def accept(self, *, req: Req) -> None:
-        raise NotImplementedError
+        if req.finished():
+            assert not req.finished_output
+            req.finished_output = True
+            if req.finished_len is None:
+                req.finished_len = len(req.output_ids)
+            should_output = True
+        else:
+            if req.stream:
+                stream_interval = (
+                    req.sampling_params.stream_interval or self.default_stream_interval
+                )
+
+                # origin stream_interval logic
+                should_output = (
+                    len(req.output_ids) % stream_interval == 1
+                    if stream_interval > 1
+                    else len(req.output_ids) % stream_interval == 0
+                )
+
+                if should_output:
+                    # check_match_stop_str_prefix if  tail_str's suffix match stop_str prefix
+                    should_output &= not req.check_match_stop_str_prefix()
+            else:
+                should_output = (
+                    len(req.output_ids) % self.default_force_stream_interval == 0
+                )
+
+        if not should_output:
+            return
+
+        send_token_offset = req.send_token_offset
+        send_output_token_logprobs_offset = req.send_output_token_logprobs_offset
+        self.rids.append(req.rid)
+        self.http_worker_ipcs.append(req.http_worker_ipc)
+        self.finished_reasons.append(
+            req.finished_reason.to_json() if req.finished_reason else None
+        )
+        self.decoded_texts.append(req.decoded_text)
+        decode_ids, read_offset = req.init_incremental_detokenize()
+
+        self.decode_ids_list.append(decode_ids[req.send_decode_id_offset :])
+
+        # Exclude the tokens after stop condition
+        output_ids_ = req.output_ids_through_stop
+
+        req.send_decode_id_offset = len(decode_ids)
+        self.read_offsets.append(read_offset)
+        self.output_ids.append(output_ids_[send_token_offset:])
+        req.send_token_offset = len(output_ids_)
+        self.skip_special_tokens.append(req.sampling_params.skip_special_tokens)
+        self.spaces_between_special_tokens.append(
+            req.sampling_params.spaces_between_special_tokens
+        )
+        self.no_stop_trim.append(req.sampling_params.no_stop_trim)
+        self.prompt_tokens.append(len(req.origin_input_ids))
+        self.reasoning_tokens.append(req.reasoning_tokens)
+        self.completion_tokens.append(len(output_ids_))
+        self.cached_tokens.append(req.cached_tokens)
+
+        # Collect detailed cache breakdown if available
+        self.cached_tokens_details.append(self.get_cached_tokens_details(req))
+
+        self.retraction_counts.append(req.retraction_count)
+
+        self.time_stats.append(req.time_stats)
+
+        if not self.spec_algorithm.is_none():
+            self.spec_verify_ct.append(req.spec_verify_ct)
+            self.spec_num_correct_drafts.append(req.spec_num_correct_drafts)
+            self.spec_correct_drafts_histogram.append(req.spec_correct_drafts_histogram)
+
+        if self.return_logprob:
+            if (
+                req.return_logprob
+                and not req.input_logprob_sent
+                # Decode server does not send input logprobs
+                and self.disaggregation_mode != DisaggregationMode.DECODE
+                # Only send when input logprobs have been computed (after prefill)
+                and req.input_token_logprobs_val is not None
+            ):
+                self.input_token_logprobs_val.append(req.input_token_logprobs_val)
+                self.input_token_logprobs_idx.append(req.input_token_logprobs_idx)
+                self.input_top_logprobs_val.append(req.input_top_logprobs_val)
+                self.input_top_logprobs_idx.append(req.input_top_logprobs_idx)
+                self.input_token_ids_logprobs_val.append(
+                    req.input_token_ids_logprobs_val
+                )
+                self.input_token_ids_logprobs_idx.append(
+                    req.input_token_ids_logprobs_idx
+                )
+                req.input_logprob_sent = True
+            else:
+                self.input_token_logprobs_val.append([])
+                self.input_token_logprobs_idx.append([])
+                self.input_top_logprobs_val.append([])
+                self.input_top_logprobs_idx.append([])
+                self.input_token_ids_logprobs_val.append([])
+                self.input_token_ids_logprobs_idx.append([])
+
+            if req.return_logprob:
+                logprob_end = max(len(output_ids_), 1)
+                self.output_token_logprobs_val.append(
+                    req.output_token_logprobs_val[
+                        send_output_token_logprobs_offset:logprob_end
+                    ]
+                )
+                self.output_token_logprobs_idx.append(
+                    req.output_token_logprobs_idx[
+                        send_output_token_logprobs_offset:logprob_end
+                    ]
+                )
+                self.output_top_logprobs_val.append(
+                    req.output_top_logprobs_val[
+                        send_output_token_logprobs_offset:logprob_end
+                    ]
+                )
+                self.output_top_logprobs_idx.append(
+                    req.output_top_logprobs_idx[
+                        send_output_token_logprobs_offset:logprob_end
+                    ]
+                )
+                self.output_token_ids_logprobs_val.append(
+                    req.output_token_ids_logprobs_val[
+                        send_output_token_logprobs_offset:logprob_end
+                    ]
+                )
+                self.output_token_ids_logprobs_idx.append(
+                    req.output_token_ids_logprobs_idx[
+                        send_output_token_logprobs_offset:logprob_end
+                    ]
+                )
+                req.send_output_token_logprobs_offset = logprob_end
+            else:
+                self.output_token_logprobs_val.append([])
+                self.output_token_logprobs_idx.append([])
+                self.output_top_logprobs_val.append([])
+                self.output_top_logprobs_idx.append([])
+                self.output_token_ids_logprobs_val.append([])
+                self.output_token_ids_logprobs_idx.append([])
+
+        if req.return_hidden_states:
+            self.output_hidden_states.append(req.hidden_states)
+        if req.return_routed_experts:
+            self.routed_experts.append(req.routed_experts)
+        if req.return_indexer_topk:
+            self.indexer_topk.append(req.indexer_topk)
+
+        if req.customized_info is not None:
+            for k, v in req.customized_info.items():
+                if k not in self.customized_info:
+                    self.customized_info[k] = []
+                self.customized_info[k].append(v[send_token_offset : len(output_ids_)])
 
     def to_payload(
         self, *, load, dp_rank: int, is_idle_batch: bool, has_reqs: bool

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -108,8 +108,6 @@ class SchedulerOutputStreamer:
     def _trigger_crash_for_tests(self, crash_threshold: int):
         # Crash trigger: crash after stream_output is called N times
         # This is used for testing purposes.
-        if not hasattr(self, "_test_stream_output_count"):
-            self._test_stream_output_count = 0
         self._test_stream_output_count += 1
         if self._test_stream_output_count >= crash_threshold:
             raise RuntimeError(

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -142,13 +142,7 @@ class SchedulerOutputStreamer:
                 continue
 
             acc.accept(req=req)
-
-            if (
-                req.finished()
-                and self.ps.attn_tp_rank == 0
-                and self.server_args.enable_request_time_stats_logging
-            ):
-                req.log_time_stats()
+            self._maybe_log_time_stats(req=req)
 
         dp_ranks = [self.ps.dp_rank] * len(acc.rids) if acc.rids else None
 
@@ -199,6 +193,14 @@ class SchedulerOutputStreamer:
                     dp_ranks=dp_ranks,
                 )
             )
+
+    def _maybe_log_time_stats(self, *, req: Req) -> None:
+        if (
+            req.finished()
+            and self.ps.attn_tp_rank == 0
+            and self.server_args.enable_request_time_stats_logging
+        ):
+            req.log_time_stats()
 
     def _stream_output_embedding(self, reqs: List[Req]):
         rids = []

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -368,17 +368,21 @@ class _GenerationStreamAccumulator:
                 # Decode server does not send input logprobs
                 and self.disaggregation_mode != DisaggregationMode.DECODE
                 # Only send when input logprobs have been computed (after prefill)
-                and req.input_token_logprobs_val is not None
+                and req.logprob.input_token_logprobs_val is not None
             ):
-                self.input_token_logprobs_val.append(req.input_token_logprobs_val)
-                self.input_token_logprobs_idx.append(req.input_token_logprobs_idx)
-                self.input_top_logprobs_val.append(req.input_top_logprobs_val)
-                self.input_top_logprobs_idx.append(req.input_top_logprobs_idx)
+                self.input_token_logprobs_val.append(
+                    req.logprob.input_token_logprobs_val
+                )
+                self.input_token_logprobs_idx.append(
+                    req.logprob.input_token_logprobs_idx
+                )
+                self.input_top_logprobs_val.append(req.logprob.input_top_logprobs_val)
+                self.input_top_logprobs_idx.append(req.logprob.input_top_logprobs_idx)
                 self.input_token_ids_logprobs_val.append(
-                    req.input_token_ids_logprobs_val
+                    req.logprob.input_token_ids_logprobs_val
                 )
                 self.input_token_ids_logprobs_idx.append(
-                    req.input_token_ids_logprobs_idx
+                    req.logprob.input_token_ids_logprobs_idx
                 )
                 req.input_logprob_sent = True
             else:
@@ -392,32 +396,32 @@ class _GenerationStreamAccumulator:
             if req.return_logprob:
                 logprob_end = max(len(output_ids_), 1)
                 self.output_token_logprobs_val.append(
-                    req.output_token_logprobs_val[
+                    req.logprob.output_token_logprobs_val[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )
                 self.output_token_logprobs_idx.append(
-                    req.output_token_logprobs_idx[
+                    req.logprob.output_token_logprobs_idx[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )
                 self.output_top_logprobs_val.append(
-                    req.output_top_logprobs_val[
+                    req.logprob.output_top_logprobs_val[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )
                 self.output_top_logprobs_idx.append(
-                    req.output_top_logprobs_idx[
+                    req.logprob.output_top_logprobs_idx[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )
                 self.output_token_ids_logprobs_val.append(
-                    req.output_token_ids_logprobs_val[
+                    req.logprob.output_token_ids_logprobs_val[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )
                 self.output_token_ids_logprobs_idx.append(
-                    req.output_token_ids_logprobs_idx[
+                    req.logprob.output_token_ids_logprobs_idx[
                         send_output_token_logprobs_offset:logprob_end
                     ]
                 )

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -144,55 +144,15 @@ class SchedulerOutputStreamer:
             acc.accept(req=req)
             self._maybe_log_time_stats(req=req)
 
-        dp_ranks = [self.ps.dp_rank] * len(acc.rids) if acc.rids else None
-
         # Send to detokenizer
-        if reqs or is_idle_batch:
-            self.send_to_detokenizer.send_output(
-                BatchTokenIDOutput(
-                    rids=acc.rids,
-                    http_worker_ipcs=acc.http_worker_ipcs,
-                    spec_verify_ct=acc.spec_verify_ct,
-                    spec_num_correct_drafts=acc.spec_num_correct_drafts,
-                    spec_correct_drafts_histogram=acc.spec_correct_drafts_histogram,
-                    time_stats=acc.time_stats,
-                    finished_reasons=acc.finished_reasons,
-                    decoded_texts=acc.decoded_texts,
-                    decode_ids=acc.decode_ids_list,
-                    read_offsets=acc.read_offsets,
-                    output_ids=acc.output_ids,
-                    skip_special_tokens=acc.skip_special_tokens,
-                    spaces_between_special_tokens=acc.spaces_between_special_tokens,
-                    no_stop_trim=acc.no_stop_trim,
-                    prompt_tokens=acc.prompt_tokens,
-                    reasoning_tokens=acc.reasoning_tokens,
-                    completion_tokens=acc.completion_tokens,
-                    cached_tokens=acc.cached_tokens,
-                    cached_tokens_details=acc.cached_tokens_details,
-                    input_token_logprobs_val=acc.input_token_logprobs_val,
-                    input_token_logprobs_idx=acc.input_token_logprobs_idx,
-                    output_token_logprobs_val=acc.output_token_logprobs_val,
-                    output_token_logprobs_idx=acc.output_token_logprobs_idx,
-                    input_top_logprobs_val=acc.input_top_logprobs_val,
-                    input_top_logprobs_idx=acc.input_top_logprobs_idx,
-                    output_top_logprobs_val=acc.output_top_logprobs_val,
-                    output_top_logprobs_idx=acc.output_top_logprobs_idx,
-                    input_token_ids_logprobs_val=acc.input_token_ids_logprobs_val,
-                    input_token_ids_logprobs_idx=acc.input_token_ids_logprobs_idx,
-                    output_token_ids_logprobs_val=acc.output_token_ids_logprobs_val,
-                    output_token_ids_logprobs_idx=acc.output_token_ids_logprobs_idx,
-                    output_token_entropy_val=None,
-                    output_hidden_states=acc.output_hidden_states or None,
-                    routed_experts=acc.routed_experts or None,
-                    indexer_topk=acc.indexer_topk or None,
-                    customized_info=acc.customized_info,
-                    placeholder_tokens_idx=None,
-                    placeholder_tokens_val=None,
-                    retraction_counts=acc.retraction_counts,
-                    load=load,
-                    dp_ranks=dp_ranks,
-                )
-            )
+        payload = acc.to_payload(
+            load=load,
+            dp_rank=self.ps.dp_rank,
+            is_idle_batch=is_idle_batch,
+            has_reqs=bool(reqs),
+        )
+        if payload is not None:
+            self.send_to_detokenizer.send_output(payload)
 
     def _maybe_log_time_stats(self, *, req: Req) -> None:
         if (
@@ -488,4 +448,49 @@ class _GenerationStreamAccumulator:
     def to_payload(
         self, *, load, dp_rank: int, is_idle_batch: bool, has_reqs: bool
     ) -> Optional[BatchTokenIDOutput]:
-        raise NotImplementedError
+        if not (has_reqs or is_idle_batch):
+            return None
+        dp_ranks = [dp_rank] * len(self.rids) if self.rids else None
+        return BatchTokenIDOutput(
+            rids=self.rids,
+            http_worker_ipcs=self.http_worker_ipcs,
+            spec_verify_ct=self.spec_verify_ct,
+            spec_num_correct_drafts=self.spec_num_correct_drafts,
+            spec_correct_drafts_histogram=self.spec_correct_drafts_histogram,
+            time_stats=self.time_stats,
+            finished_reasons=self.finished_reasons,
+            decoded_texts=self.decoded_texts,
+            decode_ids=self.decode_ids_list,
+            read_offsets=self.read_offsets,
+            output_ids=self.output_ids,
+            skip_special_tokens=self.skip_special_tokens,
+            spaces_between_special_tokens=self.spaces_between_special_tokens,
+            no_stop_trim=self.no_stop_trim,
+            prompt_tokens=self.prompt_tokens,
+            reasoning_tokens=self.reasoning_tokens,
+            completion_tokens=self.completion_tokens,
+            cached_tokens=self.cached_tokens,
+            cached_tokens_details=self.cached_tokens_details,
+            input_token_logprobs_val=self.input_token_logprobs_val,
+            input_token_logprobs_idx=self.input_token_logprobs_idx,
+            output_token_logprobs_val=self.output_token_logprobs_val,
+            output_token_logprobs_idx=self.output_token_logprobs_idx,
+            input_top_logprobs_val=self.input_top_logprobs_val,
+            input_top_logprobs_idx=self.input_top_logprobs_idx,
+            output_top_logprobs_val=self.output_top_logprobs_val,
+            output_top_logprobs_idx=self.output_top_logprobs_idx,
+            input_token_ids_logprobs_val=self.input_token_ids_logprobs_val,
+            input_token_ids_logprobs_idx=self.input_token_ids_logprobs_idx,
+            output_token_ids_logprobs_val=self.output_token_ids_logprobs_val,
+            output_token_ids_logprobs_idx=self.output_token_ids_logprobs_idx,
+            output_token_entropy_val=None,
+            output_hidden_states=self.output_hidden_states or None,
+            routed_experts=self.routed_experts or None,
+            indexer_topk=self.indexer_topk or None,
+            customized_info=self.customized_info,
+            placeholder_tokens_idx=None,
+            placeholder_tokens_val=None,
+            retraction_counts=self.retraction_counts,
+            load=load,
+            dp_ranks=dp_ranks,
+        )

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -71,6 +71,20 @@ class SchedulerRequestReceiver:
             if not self.recv_skipper.handle(self.get_last_forward_mode()):
                 return []
 
+        recv_reqs = self._pull_raw_reqs()
+
+        if self.input_blocker is not None:
+            recv_reqs = self.input_blocker.handle(recv_reqs)
+
+        recv_reqs = self._broadcast_reqs_across_ranks(recv_reqs)
+
+        recv_reqs = self._apply_mm_receiver(recv_reqs)
+
+        self._finalize_shm_features(recv_reqs)
+
+        return recv_reqs
+
+    def _pull_raw_reqs(self) -> Optional[List]:
         if self.ps.pp_rank == 0:
             if self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0:
                 recv_reqs = []
@@ -106,10 +120,9 @@ class SchedulerRequestReceiver:
                 )
             else:
                 recv_reqs = None
+        return recv_reqs
 
-        if self.input_blocker is not None:
-            recv_reqs = self.input_blocker.handle(recv_reqs)
-
+    def _broadcast_reqs_across_ranks(self, recv_reqs: Optional[List]) -> List:
         if self.server_args.enable_dp_attention:
             if self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0:
                 work_reqs, control_reqs = self._split_work_and_control_reqs(recv_reqs)
@@ -169,7 +182,9 @@ class SchedulerRequestReceiver:
                 self.tp_cpu_group,
                 src=self.tp_group.ranks[0],
             )
+        return recv_reqs
 
+    def _apply_mm_receiver(self, recv_reqs: List) -> List:
         # Process MM requests under EPD-disaggregation mode
         if (
             self.ps.pp_rank == 0
@@ -185,7 +200,9 @@ class SchedulerRequestReceiver:
                 )
                 prepare_abort(req, error_msg, status_code=status_code)
                 self.stream_output([req], req.return_logprob)
+        return recv_reqs
 
+    def _finalize_shm_features(self, recv_reqs: Optional[List]) -> None:
         # Unwrap shared memory features AFTER all broadcasts complete,
         # so that ShmPointerMMData metadata (not full tensor data) is what
         # gets serialized during broadcast_pyobj.
@@ -213,8 +230,6 @@ class SchedulerRequestReceiver:
                 barrier(group=self.tp_cpu_group)
             for req in recv_reqs:
                 unwrap_shm_features(req)
-
-        return recv_reqs
 
     def _split_work_and_control_reqs(self, recv_reqs: List):
         work_reqs = [

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -260,6 +260,10 @@ class EmbeddingBatchResult:
     pooled_hidden_states: Optional[torch.Tensor] = None
     copy_done: Optional[torch.cuda.Event] = None
 
+    @property
+    def can_run_cuda_graph(self) -> bool:
+        return False
+
     def copy_to_cpu(self):
         """Copy embeddings and pooled hidden states to CPU for overlap scheduling."""
         if isinstance(self.embeddings, torch.Tensor):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -165,10 +165,11 @@ class ReqToTokenPool:
         # https://github.com/sgl-project/sglang/pull/20476
         # if not any(r.is_dllm() for r in reqs):
         #     assert (
-        #         sum(1 for i in reusing if reqs[i].is_chunked > 0) <= 1
+        #         sum(1 for i in reusing if reqs[i].inflight_middle_chunks > 0) <= 1
         #     ), "only one chunked request may reuse req_pool_idx in a batch"
         assert all(
-            reqs[i].is_chunked > 0 or reqs[i].kv_committed_len > 0 for i in reusing
+            reqs[i].inflight_middle_chunks > 0 or reqs[i].kv_committed_len > 0
+            for i in reusing
         ), "reusing request must be chunked or have committed KV"
 
         need_size = len(reqs) - len(reusing)

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -403,7 +403,7 @@ class DFlashVerifyInput(SpecInput):
                 token_id = int(token_id)
                 req.output_ids.append(token_id)
                 appended += 1
-                req.check_finished()
+                req.update_finish_state()
                 if req.finished():
                     break
                 if req.grammar is not None:

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -438,7 +438,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 req.output_ids.append(id)
                 if req.require_reasoning and think_end_id is not None:
                     req.update_reasoning_tokens(id, think_end_id)
-                req.check_finished()
+                req.update_finish_state()
                 if not req.finished() and req.grammar is not None:
                     try:
                         req.grammar.accept_token(id)
@@ -447,7 +447,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                             f"{i=}, {req=}\n" f"{accept_index=}\n" f"{predict=}\n"
                         )
                         raise e
-                    req.check_finished()
+                    req.update_finish_state()
                 if req.finished():
                     has_finished = True
                     # set all tokens after finished token to -1 and break

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -172,7 +172,7 @@ class NgramVerifyInput(SpecInput):
                 req.output_ids.append(id)
                 if req.require_reasoning and think_end_id is not None:
                     req.update_reasoning_tokens(id, think_end_id)
-                req.check_finished()
+                req.update_finish_state()
                 if req.finished():
                     has_finished = True
                     # set all tokens after finished token to -1 and break

--- a/test/manual/test_forward_split_prefill.py
+++ b/test/manual/test_forward_split_prefill.py
@@ -15,7 +15,7 @@ import torch
 from sglang.bench_one_batch import TreeCacheNamespace
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import PortArgs, ServerArgs
@@ -115,10 +115,10 @@ class TestForwardSplitPrefill(CustomTestCase):
             enable_overlap=False,
             spec_algorithm=SpeculativeAlgorithm.NONE,
         )
+        batch.prepare_for_extend()
         if is_split_prefill:
-            batch.prepare_for_split_prefill()
-        else:
-            batch.prepare_for_extend()
+            # For split prefill, we need to set the forward mode to SPLIT_PREFILL
+            batch.forward_mode = ForwardMode.SPLIT_PREFILL
 
         # Create forward batch
         forward_batch = ForwardBatch.init_new(batch, self.model_runner)

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -52,7 +52,7 @@ def _make_req(rid="test-req-0", origin_input_ids=None, output_ids=None):
         finished_reason=None,
         hisparse_staging=False,
         staging=False,
-        is_chunked=0,
+        inflight_middle_chunks=0,
     )
     req.finished = lambda: req.finished_reason is not None
     return req

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -30,7 +30,7 @@ class TestDisaggregationPriorityQueueing(unittest.TestCase):
         scheduler.model_config = SimpleNamespace(num_key_value_heads=8)
         scheduler.disagg_prefill_bootstrap_queue = MagicMock()
         scheduler.disagg_decode_prealloc_queue = MagicMock()
-        scheduler.send_to_tokenizer = MagicMock()
+        scheduler.ipc_channels = MagicMock()
         return scheduler
 
     def _new_req(self, priority=None):
@@ -72,7 +72,7 @@ class TestDisaggregationPriorityQueueing(unittest.TestCase):
         scheduler._add_request_to_queue(req)
 
         scheduler.disagg_decode_prealloc_queue.add.assert_not_called()
-        scheduler.send_to_tokenizer.send_output.assert_called_once()
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_called_once()
         req.time_stats.trace_ctx.abort.assert_called_once()
 
 

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -33,7 +33,7 @@ def _make_req(
     req.prefix_indices = prefix_indices
     req.req_pool_idx = req_pool_idx
     req.extend_input_len = extend_input_len
-    req.is_chunked = 0
+    req.inflight_middle_chunks = 0
     req.host_hit_length = 0
     req.cache_protected_len = 0
     req.skip_radix_cache_insert = False

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -16,7 +16,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
     def _new_scheduler(self) -> Scheduler:
         scheduler = Scheduler.__new__(Scheduler)
         scheduler._pending_flush = None
-        scheduler.send_to_tokenizer = MagicMock()
+        scheduler.ipc_channels = MagicMock()
         scheduler.flush_cache = MagicMock(return_value=True)
         scheduler.is_fully_idle = MagicMock(return_value=False)
         return scheduler
@@ -82,7 +82,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
 
         self.assertIsNone(scheduler._pending_flush)
         scheduler.flush_cache.assert_called_once()
-        out = scheduler.send_to_tokenizer.send_output.call_args.args[0]
+        out = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args.args[0]
         self.assertTrue(out.success)
 
     def test_pending_flush_expires_on_timeout(self):
@@ -95,7 +95,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
 
         self.assertIsNone(scheduler._pending_flush)
         scheduler.flush_cache.assert_not_called()
-        out = scheduler.send_to_tokenizer.send_output.call_args.args[0]
+        out = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args.args[0]
         self.assertFalse(out.success)
 
     def test_pending_flush_survives_before_deadline(self):
@@ -107,7 +107,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
             Scheduler._check_pending_flush(scheduler)
 
         self.assertIsNotNone(scheduler._pending_flush)
-        scheduler.send_to_tokenizer.send_output.assert_not_called()
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -8,6 +8,9 @@ maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.io_struct import FlushCacheReqInput
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.flush_wrapper import (
+    SchedulerFlushWrapper,
+)
 
 register_cpu_ci(est_time=14, suite="base-a-test-cpu")
 
@@ -15,10 +18,14 @@ register_cpu_ci(est_time=14, suite="base-a-test-cpu")
 class TestSchedulerFlushCache(unittest.TestCase):
     def _new_scheduler(self) -> Scheduler:
         scheduler = Scheduler.__new__(Scheduler)
-        scheduler._pending_flush = None
         scheduler.ipc_channels = MagicMock()
         scheduler.flush_cache = MagicMock(return_value=True)
         scheduler.is_fully_idle = MagicMock(return_value=False)
+        scheduler.flush_wrapper = SchedulerFlushWrapper(
+            flush_cache=scheduler.flush_cache,
+            is_fully_idle=scheduler.is_fully_idle,
+            ipc_channels=scheduler.ipc_channels,
+        )
         return scheduler
 
     def test_immediate_flush_no_timeout(self):
@@ -26,9 +33,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
         scheduler = self._new_scheduler()
         scheduler.flush_cache.return_value = False
 
-        output = Scheduler.flush_cache_wrapped(
-            scheduler, FlushCacheReqInput(timeout_s=None)
-        )
+        output = scheduler.flush_wrapper.handle(FlushCacheReqInput(timeout_s=None))
 
         self.assertFalse(output.success)
         scheduler.flush_cache.assert_called_once()
@@ -38,9 +43,7 @@ class TestSchedulerFlushCache(unittest.TestCase):
         scheduler = self._new_scheduler()
         scheduler.is_fully_idle.return_value = True
 
-        output = Scheduler.flush_cache_wrapped(
-            scheduler, FlushCacheReqInput(timeout_s=5.0)
-        )
+        output = scheduler.flush_wrapper.handle(FlushCacheReqInput(timeout_s=5.0))
 
         self.assertTrue(output.success)
         scheduler.flush_cache.assert_called_once()
@@ -50,22 +53,25 @@ class TestSchedulerFlushCache(unittest.TestCase):
         scheduler = self._new_scheduler()
         req = FlushCacheReqInput(timeout_s=3.0)
 
-        with patch("sglang.srt.managers.scheduler.time.monotonic", return_value=10.0):
-            output = Scheduler.flush_cache_wrapped(scheduler, req)
+        with patch(
+            "sglang.srt.managers.scheduler_components.flush_wrapper.time.monotonic",
+            return_value=10.0,
+        ):
+            output = scheduler.flush_wrapper.handle(req)
 
         self.assertIsNone(output)
-        pending_req, deadline = scheduler._pending_flush
+        pending_req, deadline = scheduler.flush_wrapper._pending
         self.assertIs(pending_req, req)
         self.assertEqual(deadline, 13.0)
 
     def test_rejects_when_already_pending(self):
         """Any new request is rejected while another is pending."""
         scheduler = self._new_scheduler()
-        scheduler._pending_flush = (FlushCacheReqInput(timeout_s=10.0), 999.0)
+        scheduler.flush_wrapper._pending = (FlushCacheReqInput(timeout_s=10.0), 999.0)
 
         for timeout in [None, 5.0]:
-            output = Scheduler.flush_cache_wrapped(
-                scheduler, FlushCacheReqInput(timeout_s=timeout)
+            output = scheduler.flush_wrapper.handle(
+                FlushCacheReqInput(timeout_s=timeout)
             )
             self.assertFalse(output.success)
             self.assertIn("already in progress", output.message)
@@ -76,11 +82,11 @@ class TestSchedulerFlushCache(unittest.TestCase):
         scheduler = self._new_scheduler()
         scheduler.is_fully_idle.return_value = True
         req = FlushCacheReqInput(timeout_s=1.0)
-        scheduler._pending_flush = (req, 111.0)
+        scheduler.flush_wrapper._pending = (req, 111.0)
 
-        Scheduler._check_pending_flush(scheduler)
+        scheduler.flush_wrapper.check_pending()
 
-        self.assertIsNone(scheduler._pending_flush)
+        self.assertIsNone(scheduler.flush_wrapper._pending)
         scheduler.flush_cache.assert_called_once()
         out = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args.args[0]
         self.assertTrue(out.success)
@@ -88,12 +94,15 @@ class TestSchedulerFlushCache(unittest.TestCase):
     def test_pending_flush_expires_on_timeout(self):
         scheduler = self._new_scheduler()
         req = FlushCacheReqInput(timeout_s=1.0)
-        scheduler._pending_flush = (req, 99.0)
+        scheduler.flush_wrapper._pending = (req, 99.0)
 
-        with patch("sglang.srt.managers.scheduler.time.monotonic", return_value=100.0):
-            Scheduler._check_pending_flush(scheduler)
+        with patch(
+            "sglang.srt.managers.scheduler_components.flush_wrapper.time.monotonic",
+            return_value=100.0,
+        ):
+            scheduler.flush_wrapper.check_pending()
 
-        self.assertIsNone(scheduler._pending_flush)
+        self.assertIsNone(scheduler.flush_wrapper._pending)
         scheduler.flush_cache.assert_not_called()
         out = scheduler.ipc_channels.send_to_tokenizer.send_output.call_args.args[0]
         self.assertFalse(out.success)
@@ -101,12 +110,15 @@ class TestSchedulerFlushCache(unittest.TestCase):
     def test_pending_flush_survives_before_deadline(self):
         scheduler = self._new_scheduler()
         req = FlushCacheReqInput(timeout_s=5.0)
-        scheduler._pending_flush = (req, 101.0)
+        scheduler.flush_wrapper._pending = (req, 101.0)
 
-        with patch("sglang.srt.managers.scheduler.time.monotonic", return_value=100.0):
-            Scheduler._check_pending_flush(scheduler)
+        with patch(
+            "sglang.srt.managers.scheduler_components.flush_wrapper.time.monotonic",
+            return_value=100.0,
+        ):
+            scheduler.flush_wrapper.check_pending()
 
-        self.assertIsNotNone(scheduler._pending_flush)
+        self.assertIsNotNone(scheduler.flush_wrapper._pending)
         scheduler.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
 
 


### PR DESCRIPTION
Chain branch CI test only. Do not merge.

Tracking the entire `tom_refactor_202605a/primary/nonmech_scheduler` chain against `main`. Currently includes:

- 4 commits in `python/sglang/srt/managers/scheduler_components/request_receiver.py` (extract `_pull_raw_reqs`, `_broadcast_reqs_across_ranks`, `_apply_mm_receiver`, `_finalize_shm_features` from `recv_requests`).

Cumulative diff vs `main` is what CI needs to validate.























































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26069949945](https://github.com/sgl-project/sglang/actions/runs/26069949945)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26069949887](https://github.com/sgl-project/sglang/actions/runs/26069949887)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->