### PR TITLE
[Spec] Fix ngram metric off-by-1 in `num_accepted_drafts_per_req_cpu`

### DIFF
--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -328,8 +328,9 @@ class NGRAMWorker:
                     )
                     req.time_stats.set_spec_verify_end_time(accepted_tokens=accepted)
 
-            # Store accept_lens for per-request metrics
-            accept_lens = verify_input.num_accepted_drafts
+            # Store accept_lens (with bonus) for per-request metrics; downstream
+            # subtracts 1 to recover drafts-only counts.
+            accept_lens = verify_input.num_accepted_tokens
             if batch.return_logprob:
                 add_output_logprobs_for_spec_v1(batch, verify_input, logits_output)
             self._update_ngram_corpus(batch)


### PR DESCRIPTION
ngram path passed drafts-only (`verify_input.num_accepted_drafts`) as `accept_lens`; downstream `scheduler_output_processor_mixin` expected with-bonus and subtracted 1, producing drafts_only - 1. Switch to `verify_input.num_accepted_tokens` (already computed at `ngram_info.py:456` as `num_accepted_drafts + 1`). No effect on generation correctness or `spec_accept_length`; fixes `spec_accepted_drafts` / `spec_acceptance_histogram` reporting.