### PR TITLE
[PD] Rate limit prefill inflight polling warnings

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -56,10 +56,7 @@ from sglang.srt.mem_cache.common import (
     release_kv_cache,
 )
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, NSATokenToKVPool
-from sglang.srt.observability.req_time_stats import (
-    monotonic_time,
-    set_schedule_time_batch,
-)
+from sglang.srt.observability.req_time_stats import set_schedule_time_batch
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -68,28 +65,6 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
 logger = logging.getLogger(__name__)
-
-
-def _log_prefill_inflight_poll_warning(
-    self: Scheduler,
-    req: Req,
-    message: str,
-) -> None:
-    now = monotonic_time()
-    warning_state = getattr(self, "_prefill_inflight_poll_warning_state", None)
-    if warning_state is None:
-        warning_state = {}
-        self._prefill_inflight_poll_warning_state = warning_state
-
-    warning_interval_s = 1.0
-    last_log_time, suppressed = warning_state.get(req.rid, (0.0, 0))
-    if last_log_time > 0 and now - last_log_time < warning_interval_s:
-        warning_state[req.rid] = (last_log_time, suppressed + 1)
-        return
-
-    suppressed_msg = f", suppressed_repeats={suppressed}" if suppressed else ""
-    logger.warning(f"{message}{suppressed_msg}")
-    warning_state[req.rid] = (now, 0)
 
 
 def release_req_to_metadata_buffer(
@@ -638,9 +613,7 @@ class SchedulerDisaggregationPrefillMixin:
                     KVPoll.Success,
                     KVPoll.Failed,
                 ):
-                    _log_prefill_inflight_poll_warning(
-                        self,
-                        req,
+                    logger.warning_once(
                         f"PP rank {self.pp_rank}: unexpected poll state {poll} for rid {req.rid} "
                         f"from consensus; treating as undone",
                     )
@@ -673,9 +646,7 @@ class SchedulerDisaggregationPrefillMixin:
                 if self.enable_metrics:
                     self.metrics_collector.increment_transfer_failed_reqs()
             else:
-                _log_prefill_inflight_poll_warning(
-                    self,
-                    req,
+                logger.warning_once(
                     f"Unexpected polling state {poll} for rid {req.rid} in inflight queue; "
                     f"treating as undone",
                 )
@@ -683,8 +654,6 @@ class SchedulerDisaggregationPrefillMixin:
 
         for req in done_reqs:
             req.time_stats.set_completion_time()
-            if hasattr(self, "_prefill_inflight_poll_warning_state"):
-                self._prefill_inflight_poll_warning_state.pop(req.rid, None)
 
         for req in done_reqs:
             if isinstance(req.finished_reason, FINISH_ABORT):

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -56,7 +56,10 @@ from sglang.srt.mem_cache.common import (
     release_kv_cache,
 )
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, NSATokenToKVPool
-from sglang.srt.observability.req_time_stats import set_schedule_time_batch
+from sglang.srt.observability.req_time_stats import (
+    monotonic_time,
+    set_schedule_time_batch,
+)
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
@@ -65,6 +68,28 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
 logger = logging.getLogger(__name__)
+
+
+def _log_prefill_inflight_poll_warning(
+    self: Scheduler,
+    req: Req,
+    message: str,
+) -> None:
+    now = monotonic_time()
+    warning_state = getattr(self, "_prefill_inflight_poll_warning_state", None)
+    if warning_state is None:
+        warning_state = {}
+        self._prefill_inflight_poll_warning_state = warning_state
+
+    warning_interval_s = 1.0
+    last_log_time, suppressed = warning_state.get(req.rid, (0.0, 0))
+    if last_log_time > 0 and now - last_log_time < warning_interval_s:
+        warning_state[req.rid] = (last_log_time, suppressed + 1)
+        return
+
+    suppressed_msg = f", suppressed_repeats={suppressed}" if suppressed else ""
+    logger.warning(f"{message}{suppressed_msg}")
+    warning_state[req.rid] = (now, 0)
 
 
 def release_req_to_metadata_buffer(
@@ -613,9 +638,11 @@ class SchedulerDisaggregationPrefillMixin:
                     KVPoll.Success,
                     KVPoll.Failed,
                 ):
-                    logger.warning(
+                    _log_prefill_inflight_poll_warning(
+                        self,
+                        req,
                         f"PP rank {self.pp_rank}: unexpected poll state {poll} for rid {req.rid} "
-                        f"from consensus; treating as undone"
+                        f"from consensus; treating as undone",
                     )
                     undone_reqs.append(req)
                     continue
@@ -646,14 +673,17 @@ class SchedulerDisaggregationPrefillMixin:
                 if self.enable_metrics:
                     self.metrics_collector.increment_transfer_failed_reqs()
             else:
-                logger.warning(
+                _log_prefill_inflight_poll_warning(
+                    self,
+                    req,
                     f"Unexpected polling state {poll} for rid {req.rid} in inflight queue; "
-                    f"treating as undone"
+                    f"treating as undone",
                 )
                 undone_reqs.append(req)
 
         for req in done_reqs:
             req.time_stats.set_completion_time()
+            getattr(self, "_prefill_inflight_poll_warning_state", {}).pop(req.rid, None)
 
         for req in done_reqs:
             if isinstance(req.finished_reason, FINISH_ABORT):

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -683,7 +683,8 @@ class SchedulerDisaggregationPrefillMixin:
 
         for req in done_reqs:
             req.time_stats.set_completion_time()
-            getattr(self, "_prefill_inflight_poll_warning_state", {}).pop(req.rid, None)
+            if hasattr(self, "_prefill_inflight_poll_warning_state"):
+                self._prefill_inflight_poll_warning_state.pop(req.rid, None)
 
         for req in done_reqs:
             if isinstance(req.finished_reason, FINISH_ABORT):


### PR DESCRIPTION
## Motivation

In disaggregated prefill, `process_disagg_prefill_inflight_queue` polls inflight KV senders on every scheduler loop. If a request remains in a transient non-terminal polling state, the same warning can be emitted repeatedly for the same `rid` within a short time.

The request is still treated as undone and can complete normally later, so this warning is useful as a signal but too noisy when printed every loop.

This is the output of the current code in this case.
<img width="1407" height="332" alt="image" src="https://github.com/user-attachments/assets/96a44691-5ae4-4d62-84b4-656fbff5703d" />


## Modifications

- Use `logger.warning_once` for prefill inflight unexpected polling state warnings.
- Keep the existing warning semantics, but suppress duplicate identical warning messages.
- Apply the same `warning_once` behavior to both the PP consensus path and the generic prefill inflight unexpected-state path.

## Accuracy Tests

N/A. This PR only changes warning/logging behavior.

## Speed Tests and Profiling

N/A. No inference hot-path behavior is changed beyond de-duplicating repeated warning logs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
