### PR TITLE
Drop dead is_work_request and rename SenderWrapper for namesake-collision resolution

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -187,7 +187,7 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
     PrefillStats,
     SchedulerMetricsReporter,
 )
-from sglang.srt.managers.scheduler_components.output_sender import SenderWrapper
+from sglang.srt.managers.scheduler_components.output_sender import SchedulerOutputSender
 from sglang.srt.managers.scheduler_components.output_streamer import (
     SchedulerOutputStreamer,
 )
@@ -843,8 +843,8 @@ class Scheduler(
                     context, zmq.PUSH, port_args.detokenizer_ipc_name, False
                 )
 
-            self.send_to_tokenizer = SenderWrapper(send_to_tokenizer)
-            self.send_to_detokenizer = SenderWrapper(send_to_detokenizer)
+            self.send_to_tokenizer = SchedulerOutputSender(send_to_tokenizer)
+            self.send_to_detokenizer = SchedulerOutputSender(send_to_detokenizer)
 
             if self.server_args.sleep_on_idle:
                 self.idle_sleeper = IdleSleeper(
@@ -856,8 +856,8 @@ class Scheduler(
         else:
             self.recv_from_tokenizer = None
             self.recv_from_rpc = None
-            self.send_to_tokenizer = SenderWrapper(None)
-            self.send_to_detokenizer = SenderWrapper(None)
+            self.send_to_tokenizer = SchedulerOutputSender(None)
+            self.send_to_detokenizer = SchedulerOutputSender(None)
 
         if self.current_scheduler_metrics_enabled:
             self.send_metrics_from_scheduler = get_zmq_socket(
@@ -3732,18 +3732,6 @@ class Scheduler(
         self, schedule_batch: ScheduleBatch, batch_result: GenerationBatchResult
     ):
         pass
-
-
-def is_work_request(recv_req):
-    return isinstance(
-        recv_req,
-        (
-            TokenizedGenerateReqInput,
-            TokenizedEmbeddingReqInput,
-            BatchTokenizedGenerateReqInput,
-            BatchTokenizedEmbeddingReqInput,
-        ),
-    )
 
 
 def dispatch_event_loop(scheduler: Scheduler):

--- a/python/sglang/srt/managers/scheduler_components/output_sender.py
+++ b/python/sglang/srt/managers/scheduler_components/output_sender.py
@@ -2,10 +2,10 @@
 detokenizer output channel. Copies ``http_worker_ipc`` from recv_obj
 to output when needed (multi-http-worker IPC handoff).
 
-Note: there is a separate ``SenderWrapper`` class in
-``multi_tokenizer_mixin`` with a different signature. The namesake
-collision is resolved by a follow-up commit which renames this one
-to ``SchedulerOutputSender``.
+Note: ``multi_tokenizer_mixin`` has a different class also formerly
+named ``SenderWrapper`` (different signature, used by
+``tokenizer_manager``); this class was renamed from ``SenderWrapper``
+to ``SchedulerOutputSender`` to disambiguate.
 """
 
 from typing import Optional, Union
@@ -15,7 +15,7 @@ import zmq
 from sglang.srt.managers.io_struct import BaseBatchReq, BaseReq
 
 
-class SenderWrapper:
+class SchedulerOutputSender:
     def __init__(self, socket: zmq.Socket):
         self.socket = socket
 


### PR DESCRIPTION
## Summary

Two non-mech cleanups bundled into one commit:

1. **Delete** `is_work_request` in `scheduler.py` — codebase-wide grep shows zero callers. Dead code from a now-defunct dispatch path.
2. **Rename** `SenderWrapper` → `SchedulerOutputSender` (in the new `scheduler_components/output_sender.py` introduced by #24968). Motivation: `multi_tokenizer_mixin` has a different class *also* named `SenderWrapper` with a different signature, used by `tokenizer_manager`. The new name expresses the actual role.

Caller-site impact:
- `is_work_request`: pure deletion, no callers to update.
- `SchedulerOutputSender`: 4 callsites in `scheduler.py` + 1 import.

**Stacked on**: #24968 (which itself stacks on the V1 mech-scheduler chain).

## Test plan

- [ ] `ast.parse` clean for all touched files
- [ ] Pre-commit (`ruff` / `black` / `isort`) clean
- [ ] CI green on PR Test