### PR TITLE
Register SWA unit tests under unit/mem_cache

### DIFF
--- a/test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py
+++ b/test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py
@@ -12,7 +12,10 @@ from unittest.mock import MagicMock
 import torch
 
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
 
 
 def _make_self(*, page_size: int, full_available: int, swa_available: int):

--- a/test/registered/unit/mem_cache/test_swa_lock_release_lifecycle.py
+++ b/test/registered/unit/mem_cache/test_swa_lock_release_lifecycle.py
@@ -27,7 +27,10 @@ from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool, SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sglang.srt.utils import get_device
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=12, suite="stage-b-test-1-gpu-small")
 
 
 def _build_tree(


### PR DESCRIPTION
Promote two SWA unit tests from `test/manual/dsv4/` to `test/registered/unit/mem_cache/` so they run in CI.