### PR TITLE
Fix FP8 MoE kernel OOM on non-Hopper GPUs (L20/L40/RTX 4090) by adapt…

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -10,10 +10,12 @@ import torch
 import triton
 
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import get_device_name, is_hip
+from sglang.srt.utils import get_device_capability, get_device_name, is_hip
 
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
+# SM90+ (Hopper, Blackwell, ...) has >= 228KB shared memory; older GPUs have ~100KB
+_fp8_num_stages = 2 if _is_hip else (4 if get_device_capability()[0] >= 9 else 2)
 
 
 def get_config_file_name(
@@ -161,7 +163,7 @@ def get_default_config(
                 "BLOCK_SIZE_K": 128,
                 "GROUP_SIZE_M": 32,
                 "num_warps": 8,
-                "num_stages": 2 if _is_hip else 4,
+                "num_stages": _fp8_num_stages,
             }
             if M <= E:
                 config = {
@@ -170,7 +172,7 @@ def get_default_config(
                     "BLOCK_SIZE_K": 128,
                     "GROUP_SIZE_M": 1,
                     "num_warps": 4,
-                    "num_stages": 2 if _is_hip else 4,
+                    "num_stages": _fp8_num_stages,
                 }
         else:
             # Block-wise quant: BLOCK_SIZE_K must be divisible by block_shape[1]

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -15,7 +15,7 @@ from sglang.srt.utils import get_device_capability, get_device_name, is_hip
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
 # SM90+ (Hopper, Blackwell, ...) has >= 228KB shared memory; older GPUs have ~100KB
-_fp8_num_stages = 2 if _is_hip else (4 if get_device_capability()[0] >= 9 else 2)
+_fp8_num_stages = 4 if not _is_hip and get_device_capability()[0] >= 9 else 2
 
 
 def get_config_file_name(


### PR DESCRIPTION
### Motivation

The default FP8 fused MoE kernel config hardcodes `num_stages=4` for all non-HIP CUDA GPUs. This value was tuned for **SM90+ (Hopper: H100/H200)** which has **≥228KB** shared memory per SM, but causes an `OutOfResources` crash on **SM89 and below (Ada Lovelace: L20, L40, RTX 4090)** where shared memory is capped at **~100KB**.

```
triton.runtime.errors.OutOfResources: out of resource: shared memory,
Required: 147456, Hardware limit: 101376.
Reducing block sizes or `num_stages` may help.
```

This makes **all FP8 MoE tests fail** on these GPUs when no pre-tuned config file exists.

### Root Cause

With `BLOCK_SIZE_M=128, BLOCK_SIZE_N=256, BLOCK_SIZE_K=128, num_stages=4`, the Triton kernel needs **~144KB** of shared memory for pipeline buffers, exceeding the **99KB** hardware limit on Ada Lovelace GPUs.

| Config | Shared Memory | L20 Limit (99KB) |
|--------|--------------|-------------------|
| stages=4 | 144KB | ❌ OOM |
| stages=3 | 144KB | ❌ OOM |
| stages=2 | 96KB | ✅ OK |

### Fix

Introduce a module-level `_fp8_num_stages` that selects `num_stages` based on GPU compute capability (`major >= 9`):

- **SM90+** (Hopper, Blackwell, future archs): `num_stages=4` — unchanged, optimal for large shared memory
- **SM89 and below** (Ada Lovelace, Ampere, etc.): `num_stages=2` — fits within ~100KB shared memory
- **HIP (AMD)**: `num_stages=2` — unchanged

Uses `major >= 9` (not `== 9`) to be forward-compatible with Blackwell (SM100), SM120, and future architectures.

### Changes

Only **`fused_moe_triton_config.py`** is modified (3 lines):

```diff
-from sglang.srt.utils import get_device_name, is_hip
+from sglang.srt.utils import get_device_capability, get_device_name, is_hip

 _is_hip = is_hip()
+# SM90+ (Hopper, Blackwell, ...) has >= 228KB shared memory; older GPUs have ~100KB
+_fp8_num_stages = 2 if _is_hip else (4 if get_device_capability()[0] >= 9 else 2)

-                "num_stages": 2 if _is_hip else 4,
+                "num_stages": _fp8_num_stages,
```

### Test Results

**Before (NVIDIA L20, SM 8.9):**
```
96 failed, 1 passed — all FP8 subtests crash with OutOfResources
```

**After (NVIDIA L20, SM 8.9):**
```
GPU: NVIDIA L20 (SM (8, 9))
Running 12 FP8 test cases...
--------------------------------------------------------------------------------
  PASS  m=  1, n= 128, k= 128, e= 8, topk=2, dtype=  torch.float16
  PASS  m= 33, n= 128, k= 128, e= 8, topk=2, dtype=  torch.float16
  PASS  m= 33, n= 128, k= 128, e= 8, topk=2, dtype= torch.bfloat16
  PASS  m= 33, n=1024, k=1024, e= 8, topk=6, dtype=  torch.float16
  PASS  m= 33, n=1024, k=1024, e= 8, topk=6, dtype= torch.bfloat16
  PASS  m= 64, n= 128, k= 511, e= 8, topk=2, dtype=  torch.float16
  PASS  m= 64, n= 128, k= 511, e= 8, topk=6, dtype= torch.bfloat16
  PASS  m= 64, n=1024, k= 128, e= 8, topk=2, dtype=  torch.float16
  PASS  m=222, n= 128, k= 128, e= 8, topk=2, dtype=  torch.float16
  PASS  m=222, n= 128, k= 128, e=64, topk=6, dtype= torch.bfloat16
  PASS  m=222, n=1024, k=1024, e= 8, topk=2, dtype=  torch.float16
  PASS  m=222, n=1024, k=1024, e=64, topk=6, dtype= torch.bfloat16
--------------------------------------------------------------------------------
Results: 12 passed, 0 failed out of 12 tests
```