### PR TITLE
[AMD] avoid aiter re-installing triton in amd_install_dependency

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -304,9 +304,12 @@ if [[ "${NEED_REBUILD}" == "true" ]]; then
     fi
 
     # build AITER
+    # AITER_USE_SYSTEM_TRITON=1 prevents aiter's setup.py from uninstalling the
+    # ROCm-tuned triton shipped in the CI image and replacing it with a generic
+    # triton wheel from PyPI (introduced in ROCm/aiter#3086).
     docker exec ci_sglang bash -c "
         cd /sgl-workspace/aiter && \
-        GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
+        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
     "
 
     echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -304,12 +304,17 @@ if [[ "${NEED_REBUILD}" == "true" ]]; then
     fi
 
     # build AITER
-    # AITER_USE_SYSTEM_TRITON=1 prevents aiter's setup.py from uninstalling the
-    # ROCm-tuned triton shipped in the CI image and replacing it with a generic
-    # triton wheel from PyPI (introduced in ROCm/aiter#3086).
+    # Use `pip install -e .` instead of `python3 setup.py develop` so aiter's
+    # setup.py runs inside a PEP 517 isolated build environment. After
+    # ROCm/aiter#3086, aiter's setup.py unconditionally invokes
+    # .github/scripts/install_triton.sh, which `pip uninstall`s the host's
+    # triton and `pip install`s a replacement; build isolation contains those
+    # operations to the throwaway build venv so the ROCm-tuned triton shipped
+    # in the CI image is preserved. AITER_USE_SYSTEM_TRITON=1 is also set as
+    # a backstop in case build isolation is disabled (e.g. --no-build-isolation).
     docker exec ci_sglang bash -c "
         cd /sgl-workspace/aiter && \
-        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
+        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} pip install --config-settings editable_mode=compat -e .
     "
 
     echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -304,17 +304,9 @@ if [[ "${NEED_REBUILD}" == "true" ]]; then
     fi
 
     # build AITER
-    # Use `pip install -e .` instead of `python3 setup.py develop` so aiter's
-    # setup.py runs inside a PEP 517 isolated build environment. After
-    # ROCm/aiter#3086, aiter's setup.py unconditionally invokes
-    # .github/scripts/install_triton.sh, which `pip uninstall`s the host's
-    # triton and `pip install`s a replacement; build isolation contains those
-    # operations to the throwaway build venv so the ROCm-tuned triton shipped
-    # in the CI image is preserved. AITER_USE_SYSTEM_TRITON=1 is also set as
-    # a backstop in case build isolation is disabled (e.g. --no-build-isolation).
     docker exec ci_sglang bash -c "
         cd /sgl-workspace/aiter && \
-        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} pip install --config-settings editable_mode=compat -e .
+        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
     "
 
     echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Avoid `aiter` from re-installing triton during the AMD CI aiter rebuild.

## Modifications

`scripts/ci/amd/amd_ci_install_dependency.sh`: set `AITER_USE_SYSTEM_TRITON=1` on the aiter rebuild command so the image's existing triton is kept.

## Verification

[Run 25676429617](https://github.com/sgl-project/sglang/actions/runs/25676429617):

```
[aiter] AITER_USE_SYSTEM_TRITON=1, keeping existing triton==3.4.0+git02502c86
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de26ea21-6a5d-4bb2-8174-363c52cb30c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de26ea21-6a5d-4bb2-8174-363c52cb30c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

