### PR TITLE
Fix AMX GQA extend attention

### DIFF
--- a/sgl-kernel/csrc/cpu/flash_attn.h
+++ b/sgl-kernel/csrc/cpu/flash_attn.h
@@ -134,9 +134,10 @@ struct flash_attn_softmax {
           v_prime + row * head_size_v,
           head_size_v);
 
-      // pad s_delta with 0 first and then convert to scalar_t
+      // Keep s_delta row-major for the following brgemm(P @ V), and only
+      // convert the columns that brgemm will consume.
       fill_stub(s_delta + row * BLOCK_N + n_size, 0.f, padded_n_size - n_size);
-      copy_stub<scalar_t, BLOCK_N>(s_delta2 + row * BLOCK_N, s_delta + row * BLOCK_N);
+      copy_stub<scalar_t>(s_delta2 + row * BLOCK_N, s_delta + row * BLOCK_N, 1.f, padded_n_size);
     }
   }
 };

--- a/test/srt/cpu/test_extend.py
+++ b/test/srt/cpu/test_extend.py
@@ -217,6 +217,18 @@ class TestExtendAttention(CustomTestCase):
             b_seq_len_extend=[5000],
         )
 
+    def test_extend_attention_gqa_partial_extend_with_prefix(self):
+        self._test_extend_attention_once(
+            B=1,
+            N_CTX=256,
+            H_Q=16,
+            H_KV=4,
+            D=128,
+            DV=96,
+            b_seq_len_prefix=[97],
+            b_seq_len_extend=[37],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fix the Intel AMX CPU extend attention path by preserving the logical row-major softmax probability layout consumed by the following `brgemm(P @ V)` step.

The previous generic conversion path wrote a full `BLOCK_N` packed block even though the GEMM only consumes `padded_n_size` columns. For GQA extend cases this can corrupt the effective probability layout and lead to invalid model output such as repeated `!` tokens.

## Modifications

- Convert only the columns consumed by brgemm via `copy_stub<scalar_t>(..., padded_n_size)` instead of the full `copy_stub<scalar_t, BLOCK_N>` path.
- Add a CPU extend-attention regression test covering GQA with a non-zero prefix and a partial extend length.

## Validation

- `pre-commit run --all-files`
- On Intel AMX host
  - `python -m unittest test.srt.cpu.test_extend.TestExtendAttention.test_extend_attention_gqa_partial_extend_with_prefix`
  - `python -m unittest test.srt.cpu.test_extend`

## Checklist

- [x] Format your code according to the Format code with pre-commit
  (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the Run and add unit tests
  (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to Write documentations
  (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to Test the accuracy
  (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and Benchmark the speed
  (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style guidance
  (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).