### PR TITLE
[Gemma 4] Add DFLASH speculative decoding support

### DIFF
--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -45,7 +45,10 @@ from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
-from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbeddingShardIndices,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
@@ -66,6 +69,25 @@ def get_attention_sliding_window_size(config):
 
 Gemma4MLP = Gemma3MLP
 Gemma4TextScaledWordEmbedding = Gemma3TextScaledWordEmbedding
+
+
+def _ensure_dflash_shard_indices(lm_head, vocab_size: int) -> None:
+    """Inject a tp=1 ShardIndices namespace into a non-vocab-parallel lm_head
+    so the SGLang DFLASH worker passes its `hasattr(lm_head, 'shard_indices')`
+    gate. Gemma 4 uses a tied embed_tokens (nn.Embedding) for lm_head, which
+    has no shard_indices on its own."""
+    if getattr(lm_head, "shard_indices", None) is not None:
+        return
+    lm_head.shard_indices = VocabParallelEmbeddingShardIndices(
+        padded_org_vocab_start_index=0,
+        padded_org_vocab_end_index=vocab_size,
+        padded_added_vocab_start_index=vocab_size,
+        padded_added_vocab_end_index=vocab_size,
+        org_vocab_start_index=0,
+        org_vocab_end_index=vocab_size,
+        added_vocab_start_index=vocab_size,
+        added_vocab_end_index=vocab_size,
+    )
 
 
 class Gemma4Router(nn.Module):
@@ -934,6 +956,7 @@ class Gemma4ForCausalLM(PreTrainedModel):
                 quant_config=quant_config,
                 prefix=add_prefix("lm_head", prefix),
             )
+        _ensure_dflash_shard_indices(self.lm_head, config.vocab_size)
         self.capture_aux_hidden_states = False
         self.post_init()
 
@@ -1134,6 +1157,16 @@ class Gemma4ForCausalLM(PreTrainedModel):
             # we plus 1 here because in sglang, for the ith layer, it takes the output
             # of the (i-1)th layer as aux hidden state
             self.model.layers_to_capture = [val + 1 for val in layer_ids]
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if layer_ids is None:
+            raise ValueError(
+                "DFLASH requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        # we plus 1 here because in sglang, for the ith layer, it takes the output
+        # of the (i-1)th layer as aux hidden state
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
 
 EntryClass = Gemma4ForCausalLM

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -49,7 +49,10 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.models.gemma4_audio import Gemma4AudioEncoder
-from sglang.srt.models.gemma4_causal import Gemma4TextModel
+from sglang.srt.models.gemma4_causal import (
+    Gemma4TextModel,
+    _ensure_dflash_shard_indices,
+)
 from sglang.srt.models.gemma4_vision import Gemma4VisionEncoder
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_processor
@@ -218,6 +221,12 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             quant_config,
             prefix=add_prefix("language_model", prefix),
         )
+        # Gemma 4 ties lm_head to the text embed_tokens; expose it so that
+        # speculative-decoding workers (e.g. DFLASH) can locate a vocab-parallel
+        # head. _ensure_dflash_shard_indices injects a tp=1 ShardIndices
+        # namespace onto the tied embedding for DFLASH's fast greedy path.
+        self.lm_head = self.language_model.embed_tokens
+        _ensure_dflash_shard_indices(self.lm_head, config.text_config.vocab_size)
 
         # Create logits processor for the multimodal model
         self.logits_processor = LogitsProcessor(config.text_config)
@@ -966,6 +975,16 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             # we plus 1 here because in sglang, for the ith layer, it takes the output
             # of the (i-1)th layer as aux hidden state
             self.language_model.layers_to_capture = [val + 1 for val in layer_ids]
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if layer_ids is None:
+            raise ValueError(
+                "DFLASH requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        # we plus 1 here because in sglang, for the ith layer, it takes the output
+        # of the (i-1)th layer as aux hidden state
+        self.language_model.layers_to_capture = [val + 1 for val in layer_ids]
 
 
 EntryClass = Gemma4ForConditionalGeneration


### PR DESCRIPTION
## Motivation

Adds DFLASH speculative decoding support for Gemma 4 (both `Gemma4ForCausalLM`
and `Gemma4ForConditionalGeneration`), mirroring the existing EAGLE3 capture
hook. Picks up @dcw02's invitation in #23000 to "put up a PR to add gemma 4
support to v1" — see https://github.com/sgl-project/sglang/pull/23000#issuecomment-4421249168.

Once merged, this unblocks `z-lab/gemma-4-31B-it-DFlash` and
`z-lab/gemma-4-26B-A4B-it-DFlash` against any Gemma 4 target.

## Changes

- **`gemma4_causal.py` / `gemma4_mm.py`**: add `set_dflash_layers_to_capture`
  next to the existing `set_eagle3_layers_to_capture`. Uses the same
  `model.layers_to_capture = [val + 1 for val in layer_ids]` convention.
  Unlike EAGLE3, DFLASH requires explicit `layer_ids` (the checkpoint's
  `dflash_config.target_layer_ids`), so `None` raises.

- **`_ensure_dflash_shard_indices` helper (in `gemma4_causal.py`)**:
  Gemma 4 ties `lm_head` to `embed_tokens` (a plain `nn.Embedding` subclass
  via `Gemma4TextScaledWordEmbedding`), so
  `dflash_worker._prepare_for_speculative_decoding` rejects it at
  `hasattr(lm_head, "shard_indices")`. The helper setattr-s a trivial
  `VocabParallelEmbeddingShardIndices` (tp=1, `num_added=0`) onto the tied
  head; the worker's fast path (`tp_size == 1 and num_added == 0`) then
  proceeds without touching the TP or added-vocab branches.

- **`Gemma4ForConditionalGeneration.lm_head`**: previously not exposed.
  Aliased to `self.language_model.embed_tokens` so the DFLASH worker can
  resolve it via `target_model.lm_head`. No state-dict impact (it's a
  pure attribute pointer, not a new submodule).

## Local verification

Verified on a fresh venv built from this branch
(`pip install ./python` from the branch tip),
single RTX 5090 (sm120), `attention-backend=triton`,
`kv-cache-dtype=fp8_e4m3`, `RedHatAI/gemma-4-31B-it-NVFP4` target,
`z-lab/gemma-4-31B-it-DFlash` drafter, temperature=0 short prompts:

| metric | value |
|---|---|
| code (100w) warm tok/s | **150.1** |
| haiku warm tok/s       | 79.5   |
| jp warm tok/s          | 63.5   |
| code accept length (peak) | **4.45** |
| code accept rate       | 0.23   |

Output quality looks healthy — e.g. haiku:
> Power in the chip, / Frames fly fast in every scene, / Future of the game.

Also smoke-tested extended scenarios that historically triggered the
vllm-project/vllm#41262 repetitive-token symptom for adjacent stacks:

- 600-token English long-form (`completion_tokens=600`): full essay
  on speculative decoding, no repetitive substring patterns
  (`30+ char × 4` regex match count = 0).
- 3-turn multi-turn conversation: assistant correctly recalls earlier
  user-stated fact across turns.
- 300-token Japanese long-form: structured markdown output with
  per-section labels (`**1. アーキテクチャ**` etc.), no degradation in
  the lower-accept-rate regime where JP normally sits.
- Streaming endpoint (SSE `chat/completions` with `stream=true`):
  DFlash multi-token chunks are delivered correctly through the
  streaming path.

For reference on the same box, NEXTN MTP gives ~84 tok/s on code
(this PR is ~1.79× on that workload), and vLLM main + MTP gives
~164 tok/s (this PR closes most of that gap on SGLang side).
Cross-checked the same patch shape on an earlier `bcf8d100` base
(`gemma4-mtp-fin` branch) where I first found the missing
`set_dflash_layers_to_capture` and the `shard_indices` gate — same
behavior (158.4 / 92.9 / 64.0 tok/s, accept length peak 4.47).

## Scope not yet exercised

- TP > 1 (single-GPU test box only)
- Long-context (verified at `--context-length 8192`, default
  `mem-fraction-static 0.75`)
- Non-greedy sampling (all of the above is `temperature=0`)
- The `/C`-loop / repetitive-token failure mode reported on
  vllm-project/vllm#41262 for `RedHatAI/gemma-4-31B-it-speculator.dflash`
  with TP=2 — not retested (this box is single-GPU)

Happy to extend testing if reviewers flag a specific gap.

## Related

- #23000 (Spec V2 DFlash Support) — orthogonal; this PR is purely v1 hook
  surface and does not touch V2 / overlap scheduling. V2 should compose
  cleanly with this since the target-side hook is shared.
