### PR TITLE
[AMD] Run jit kernel PR test through run_suite.py register mechanism

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -327,7 +327,7 @@ jobs:
       - name: Run JIT kernel unit tests
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" python3 -m pytest -q python/sglang/jit_kernel/tests/test_store_cache.py
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-kernel-unit-1-gpu-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-small-amd-rocm720:
     needs: [check-changes]

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -327,7 +327,7 @@ jobs:
       - name: Run JIT kernel unit tests
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-kernel-unit-1-gpu-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ inputs.continue_on_error && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-small-amd-rocm720:
     needs: [check-changes]

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Run JIT kernel unit tests
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-kernel-unit-1-gpu-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite jit-kernel-unit-test-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   # =============================================== Wait Jobs for Sequential PR Execution ====================================================
   # These jobs poll GitHub API to wait for previous stages to complete.

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Run JIT kernel unit tests
         timeout-minutes: 10
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout" python3 -m pytest -q python/sglang/jit_kernel/tests/test_store_cache.py
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-kernel-unit-1-gpu-amd ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   # =============================================== Wait Jobs for Sequential PR Execution ====================================================
   # These jobs poll GitHub API to wait for previous stages to complete.

--- a/python/sglang/jit_kernel/tests/test_store_cache.py
+++ b/python/sglang/jit_kernel/tests/test_store_cache.py
@@ -10,7 +10,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, suite="stage-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
-register_amd_ci(est_time=28, suite="stage-b-kernel-unit-1-gpu-amd")
+register_amd_ci(est_time=55, suite="jit-kernel-unit-test-amd")
 
 BS_LIST = [2**n for n in range(0, 15)]
 BS_LIST += [x + 1 + i for i, x in enumerate(BS_LIST)]

--- a/python/sglang/jit_kernel/tests/test_store_cache.py
+++ b/python/sglang/jit_kernel/tests/test_store_cache.py
@@ -6,10 +6,11 @@ import torch
 
 from sglang.jit_kernel.kvcache import can_use_store_cache, store_cache
 from sglang.jit_kernel.utils import get_ci_test_range
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, suite="stage-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=28, suite="stage-b-kernel-unit-1-gpu-amd")
 
 BS_LIST = [2**n for n in range(0, 15)]
 BS_LIST += [x + 1 + i for i, x in enumerate(BS_LIST)]

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -32,7 +32,7 @@ PER_COMMIT_SUITES = {
         "stage-b-test-large-8-gpu-35x-disaggregation-amd",
         "stage-b-test-1-gpu-large-amd",
         "stage-b-test-2-gpu-large-amd",
-        "stage-b-kernel-unit-1-gpu-amd",
+        "jit-kernel-unit-test-amd",
         "stage-c-test-4-gpu-amd",
         "stage-c-test-large-8-gpu-amd",
         "stage-c-test-large-8-gpu-amd-mi35x",

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -32,6 +32,7 @@ PER_COMMIT_SUITES = {
         "stage-b-test-large-8-gpu-35x-disaggregation-amd",
         "stage-b-test-1-gpu-large-amd",
         "stage-b-test-2-gpu-large-amd",
+        "stage-b-kernel-unit-1-gpu-amd",
         "stage-c-test-4-gpu-amd",
         "stage-c-test-large-8-gpu-amd",
         "stage-c-test-large-8-gpu-amd-mi35x",


### PR DESCRIPTION
## Motivation

The AMD `jit-kernel-unit-test-amd` PR job currently uses a hardcoded `pytest` invocation on a single test file (`test_store_cache.py`), bypassing the `run_suite.py` registration mechanism that all other AMD/CUDA CI jobs use. This makes it inconsistent with NVIDIA's equivalent job (`stage-b-kernel-unit-1-gpu-large`) and hard to extend — adding a new jit kernel test to AMD CI requires editing the workflow file rather than just adding a `register_amd_ci(...)` call to the test.

## Modifications

- `python/sglang/jit_kernel/tests/test_store_cache.py`: add `register_amd_ci(est_time=28, suite="stage-b-kernel-unit-1-gpu-amd")` alongside the existing `register_cuda_ci(...)` registrations.
- `test/run_suite.py`: add `"jit-kernel-unit-test-amd"` to `PER_COMMIT_SUITES[HWBackend.AMD]`.
- `.github/workflows/pr-test-amd.yml` and `.github/workflows/pr-test-amd-rocm720.yml`: replace the hardcoded `pytest -q test_store_cache.py` invocation with `run_suite.py --hw amd --suite jit-kernel-unit-test-amd`, matching how the rest of the AMD PR jobs are structured.

Behavior is unchanged: the new suite contains exactly `test_store_cache.py` (the only jit kernel test that has been registered for AMD), so the same tests run as before. Future additions only require adding a `register_amd_ci(...)` line to the new test file — no workflow edit needed.

## Accuracy Tests

<img width="337" height="78" alt="image" src="https://github.com/user-attachments/assets/8ed0f998-2e6c-4b69-b6a8-d4695751f250" />

https://github.com/sgl-project/sglang/actions/runs/25677716728/job/75380410652

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
