### PR TITLE
Fix seq_lens shape contract in DSV4 indexer reference paths

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -60,6 +60,7 @@ def fp8_paged_mqa_logits_torch(
     assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)
     assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
     assert weight.shape == (batch_size, num_heads)
+    seq_lens = seq_lens.flatten()
     assert seq_lens.shape == (batch_size,)
     assert page_table.shape[0] == batch_size
     assert clean_logits == False

--- a/python/sglang/srt/layers/attention/dsv4/tilelang_kernel.py
+++ b/python/sglang/srt/layers/attention/dsv4/tilelang_kernel.py
@@ -103,6 +103,7 @@ def tilelang_fp8_paged_mqa_logits(
     assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)
     assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
     assert weight.shape == (batch_size, num_heads)
+    seq_lens = seq_lens.flatten()
     assert seq_lens.shape == (batch_size,)
     assert page_table.shape[0] == batch_size
     assert clean_logits == False


### PR DESCRIPTION
## Motivation

  `DeepseekV4Indexer.forward` dispatches to one of three `fp8_paged_mqa_logits`
  backends in `python/sglang/srt/layers/attention/dsv4/indexer.py`:

  | # | Backend | Selector |
  |---|---|---|
  | 1 | `deep_gemm.fp8_paged_mqa_logits` (default) | neither env var set |
  | 2 | `fp8_paged_mqa_logits_torch` (pytorch reference) | `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1` |
  | 3 | `tilelang_fp8_paged_mqa_logits` (tilelang fallback) | `SGLANG_OPT_USE_TILELANG_INDEXER=1` |

  Immediately before the call, the dispatcher normalizes `seq_lens` to 2-D:

  ```python
  _c4sl = indexer_metadata.c4_seq_lens
  if _c4sl.dim() == 1:
      _c4sl = _c4sl.unsqueeze(-1)
  logits = fn(q_fp8, c4_indexer_kv_cache, weights, _c4sl, ...)
```

  The (B, 1) shape is the native API contract of deep_gemm.fp8_paged_mqa_logits
  (the C++ kernel's context_lens argument), which is why the dispatcher
  unsqueezes unconditionally.

  However the two alternative reference implementations both assert
  seq_lens.shape == (batch_size,):

  - fp8_paged_mqa_logits_torch at indexer.py:63
  - tilelang_fp8_paged_mqa_logits at tilelang_kernel.py:107

  As a result, any user who enables either alternative backend hits an
  AssertionError on the first indexer call:

  AssertionError: assert seq_lens.shape == (batch_size,)

  This blocks:
  - SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 — the pytorch reference path, commonly
  used for accuracy validation / numerical debugging.
  - SGLANG_OPT_USE_TILELANG_INDEXER=1 — the tilelang fallback, intended for
  environments where DeepGEMM is not available.

  The default deep_gemm path is unaffected and was the only path exercised in CI,
  so the bug has been silent.

  Reproduction on any CUDA host with SGLang + DSV4 weights:

  ### either flag reproduces the crash on unmodified main:
  export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1
  ### or
  export SGLANG_OPT_USE_TILELANG_INDEXER=1

  python3 -m sglang.launch_server --model-path <dsv4-weights> --trust-remote-code
  curl -s localhost:30000/generate -d '{"text":"Hi","sampling_params":{"max_new_tokens":4}}'
  ### -> AssertionError at indexer.py:63 or tilelang_kernel.py:107

  Refs DeepSeek-V4 roadmap #23602 (Bug fixes list).

  Modifications

  Normalize seq_lens to 1-D via .flatten() in both reference implementations,
  before the existing shape assertion. .flatten() is idempotent on valid (B,)
  input and also handles the (B, 1) shape produced by the dispatcher. This
  matches the idiom already used elsewhere in the DSV4 subsystem
  (deepseek_v4_backend.py:1093 uses seq_lens_casual.flatten()).

  Total: +2 / -0 across two files. No behavior change on the default deep_gemm
  path.

  Accuracy Tests

  After this patch, both env-flag paths work end-to-end. Greedy outputs from
  tilelang_fp8_paged_mqa_logits are numerically consistent with the default
  deep_gemm path — verified in-process, |logits_ref - logits_tilelang| within
  bf16 epsilon on valid positions of the seq_lens mask.

  Speed Tests and Profiling

  N/A. The added .flatten() is a no-op view on an already-1-D tensor and a
  single metadata view on a (B, 1) tensor. The default deep_gemm hot path is
  untouched.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
