### PR TITLE
fix(minimax_m2): buffer full <invoke> blocks in streaming parser

### DIFF
--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -43,15 +43,10 @@ class MinimaxM2Detector(BaseFormatDetector):
             r"<parameter name=\"(.*?)</parameter>|<parameter name=\"(.*?)$", re.DOTALL
         )
         self._buf: str = ""
-
-        # Streaming state variables
-        self._current_function_name: str = ""
-        self._current_parameters: Dict[str, Any] = {}
-        self._streamed_parameters: Dict[str, str] = (
-            {}
-        )  # Track what parameter content we've streamed
         self._in_tool_call: bool = False
         self._function_name_sent: bool = False
+        self._current_function_name: str = ""
+        self._current_parameters: Dict[str, Any] = {}
 
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
@@ -230,229 +225,168 @@ class MinimaxM2Detector(BaseFormatDetector):
         normal = ""
         calls: List[ToolCallItem] = []
 
-        # Build tool indices for validation
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
 
         while True:
-            # If we're not in a tool call and don't see a start token, return normal text
-            if not self._in_tool_call and self.tool_call_start_token not in self._buf:
-                normal += self._buf
-                self._buf = ""
-                break
-
-            # Look for tool call start
+            # State 1: outside any wrapper, look for <minimax:tool_call>.
             if not self._in_tool_call:
                 s = self._buf.find(self.tool_call_start_token)
                 if s == -1:
-                    normal += self._buf
-                    self._buf = ""
+                    # Hold any trailing prefix that might be the start of a
+                    # split start token; flush the rest as normal text.
+                    hold = self._ends_with_partial_token(
+                        self._buf, self.tool_call_start_token
+                    )
+                    if hold:
+                        normal += self._buf[:-hold]
+                        self._buf = self._buf[-hold:]
+                    else:
+                        normal += self._buf
+                        self._buf = ""
                     break
-
                 normal += self._buf[:s]
-                self._buf = self._buf[s:]
-
+                self._buf = self._buf[s + len(self.tool_call_start_token) :]
                 self._in_tool_call = True
                 self._function_name_sent = False
                 self._current_function_name = ""
                 self._current_parameters = {}
-                self._streamed_parameters = {}
-
-                # Remove the start token
-                self._buf = self._buf[len(self.tool_call_start_token) :]
                 continue
 
-            # We're in a tool call, try to parse function name if not sent yet
+            # State 2: inside a wrapper, no current invoke — find next
+            # <invoke name="..."> or the wrapper's closing tag.
             if not self._function_name_sent:
-                # Look for function name pattern: <invoke name=name>
-                function_match = re.search(r"<invoke name=\"([^>]+)\">", self._buf)
-                if function_match:
-                    function_name = function_match.group(1).strip()
-
-                    # Validate function name
-                    if function_name in self._tool_indices:
-                        self._current_function_name = function_name
-                        self._function_name_sent = True
-
-                        # Initialize tool call tracking
-                        if self.current_tool_id == -1:
-                            self.current_tool_id = 0
-
-                        # Ensure tracking arrays are large enough
-                        while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                            self.prev_tool_call_arr.append({})
-                        while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                            self.streamed_args_for_tool.append("")
-
-                        # Store tool call info
-                        self.prev_tool_call_arr[self.current_tool_id] = {
-                            "name": function_name,
-                            "arguments": {},
-                        }
-
-                        # Send tool name with empty parameters
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=function_name,
-                                parameters="",
-                            )
-                        )
-
-                        # Remove the processed function declaration
-                        self._buf = self._buf[function_match.end() :]
+                wrapper_end = self._buf.find(self.tool_call_end_token)
+                invoke_match = re.search(r'<invoke name="([^"]+)">', self._buf)
+                if invoke_match is None or (
+                    wrapper_end != -1 and wrapper_end < invoke_match.start()
+                ):
+                    if wrapper_end != -1:
+                        self._buf = self._buf[
+                            wrapper_end + len(self.tool_call_end_token) :
+                        ]
+                        self._in_tool_call = False
                         continue
-                    else:
-                        # Invalid function name, reset state
-                        logger.warning(f"Invalid function name: {function_name}")
-                        self._reset_streaming_state()
-                        normal += self._buf
-                        self._buf = ""
-                        break
-                else:
-                    # Function name not complete yet, wait for more text
                     break
 
-            # Parse parameters incrementally
-            if self._function_name_sent:
-                # Process parameters and get any calls to emit
-                parameter_calls = self._parse_and_stream_parameters(self._buf, tools)
-                calls.extend(parameter_calls)
-
-                # Check if tool call is complete
-                if self.tool_call_function_end_token in self._buf:
-                    end_pos = self._buf.find(self.tool_call_function_end_token)
-
-                    # Add closing brace to complete the JSON object
-                    current_streamed = self.streamed_args_for_tool[self.current_tool_id]
-                    if current_streamed:
-                        # Count opening and closing braces to check if JSON is complete
-                        open_braces = current_streamed.count("{")
-                        close_braces = current_streamed.count("}")
-                        if open_braces > close_braces:
-                            calls.append(
-                                ToolCallItem(
-                                    tool_index=self.current_tool_id,
-                                    name=None,
-                                    parameters="}",
-                                )
-                            )
-                            self.streamed_args_for_tool[self.current_tool_id] = (
-                                current_streamed + "}"
-                            )
-
-                    # Complete the tool call
-                    self._buf = self._buf[
-                        end_pos + len(self.tool_call_function_end_token) :
-                    ]
-                    self._reset_streaming_state(True)
-                    self.current_tool_id += 1
-                    continue
-                else:
-                    # Tool call not complete yet, wait for more text
-                    break
-
-        return StreamingParseResult(normal_text=normal, calls=calls)
-
-    def _parse_and_stream_parameters(
-        self, text_to_parse: str, tools: List[Tool]
-    ) -> List[ToolCallItem]:
-        """
-        Parse complete parameter blocks from text and return any tool call items to emit.
-
-        This method:
-        1. Finds all complete <parameter> blocks
-        2. Parses them into a dictionary
-        3. Compares with current parameters and generates diff if needed
-        4. Updates internal state
-
-        Args:
-            text_to_parse: The text to search for parameter blocks
-
-        Returns:
-            List of ToolCallItem objects to emit (may be empty)
-        """
-        calls: List[ToolCallItem] = []
-
-        # Find all complete parameter patterns
-        param_matches = list(
-            re.finditer(
-                r"<parameter name=\"([^>]+)\">(.*?)</parameter>",
-                text_to_parse,
-                re.DOTALL,
-            )
-        )
-
-        # Build new parameters dictionary
-        new_params = {}
-        for match in param_matches:
-            param_name = match.group(1).strip()
-            param_value = match.group(2)
-            new_params[param_name] = self._parse_parameter(
-                self._current_function_name, param_name, param_value, tools
-            )
-
-        # Calculate parameter diff to stream with proper incremental JSON building
-        if new_params != self._current_parameters:
-            previous_args_json = self.streamed_args_for_tool[self.current_tool_id]
-
-            # Build incremental JSON properly
-            if not self._current_parameters:
-                # First parameter(s) - start JSON object but don't close it yet
-                items = []
-                for key, value in new_params.items():
-                    items.append(
-                        f"{json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}"
+                function_name = invoke_match.group(1).strip()
+                if function_name not in self._tool_indices:
+                    close = self._buf.find(
+                        self.tool_call_function_end_token, invoke_match.end()
                     )
-                json_fragment = "{" + ", ".join(items)
+                    if close == -1:
+                        break
+                    logger.warning("invalid tool call for %s dropped", function_name)
+                    self._buf = self._buf[
+                        close + len(self.tool_call_function_end_token) :
+                    ]
+                    continue
 
+                if self.current_tool_id == -1:
+                    self.current_tool_id = 0
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": function_name,
+                    "arguments": {},
+                }
                 calls.append(
                     ToolCallItem(
                         tool_index=self.current_tool_id,
-                        name=None,
-                        parameters=json_fragment,
+                        name=function_name,
+                        parameters="",
                     )
                 )
-                self.streamed_args_for_tool[self.current_tool_id] = json_fragment
+                self._current_function_name = function_name
+                self._current_parameters = {}
+                self._function_name_sent = True
+                self._buf = self._buf[invoke_match.end() :]
+                continue
 
-            else:
-                # Additional parameters - add them incrementally
-                new_keys = set(new_params.keys()) - set(self._current_parameters.keys())
-                if new_keys:
-                    # Build the continuation part (no closing brace yet)
-                    continuation_parts = []
-                    for key in new_keys:
-                        value = new_params[key]
-                        continuation_parts.append(
-                            f"{json.dumps(key, ensure_ascii=False)}: {json.dumps(value, ensure_ascii=False)}"
+            # State 3: inside an invoke, stream parameters incrementally.
+            invoke_close_pos = self._buf.find(self.tool_call_function_end_token)
+            param_match = re.search(
+                r'<parameter name="([^"]+)">(.*?)</parameter>',
+                self._buf,
+                re.DOTALL,
+            )
+
+            # Only accept a <parameter> match that ends inside the current
+            # invoke. Otherwise it belongs to the next invoke and would
+            # cross-contaminate this call's arguments.
+            if param_match is not None and (
+                invoke_close_pos == -1 or param_match.end() <= invoke_close_pos
+            ):
+                pname = param_match.group(1).strip()
+                pval = param_match.group(2).lstrip("\n").rstrip("\n")
+                value = self._parse_parameter(
+                    self._current_function_name, pname, pval, tools
+                )
+                if pname not in self._current_parameters:
+                    if not self._current_parameters:
+                        fragment = (
+                            "{"
+                            + json.dumps(pname, ensure_ascii=False)
+                            + ": "
+                            + json.dumps(value, ensure_ascii=False)
                         )
-
-                    json_fragment = ", " + ", ".join(continuation_parts)
-
+                    else:
+                        fragment = (
+                            ", "
+                            + json.dumps(pname, ensure_ascii=False)
+                            + ": "
+                            + json.dumps(value, ensure_ascii=False)
+                        )
                     calls.append(
                         ToolCallItem(
                             tool_index=self.current_tool_id,
                             name=None,
-                            parameters=json_fragment,
+                            parameters=fragment,
                         )
                     )
-                    self.streamed_args_for_tool[self.current_tool_id] = (
-                        previous_args_json + json_fragment
+                    self.streamed_args_for_tool[self.current_tool_id] += fragment
+                    self._current_parameters[pname] = value
+                    self.prev_tool_call_arr[self.current_tool_id]["arguments"] = (
+                        dict(self._current_parameters)
                     )
+                self._buf = self._buf[param_match.end() :]
+                continue
 
-            # Update current state
-            self._current_parameters = new_params
-            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = new_params
+            if invoke_close_pos != -1:
+                # Close the JSON object — opening "{" if no params arrived.
+                current_streamed = self.streamed_args_for_tool[self.current_tool_id]
+                if not current_streamed:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters="{}",
+                        )
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] = "{}"
+                else:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters="}",
+                        )
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] += "}"
+                self._buf = self._buf[
+                    invoke_close_pos + len(self.tool_call_function_end_token) :
+                ]
+                self.current_tool_id += 1
+                self._function_name_sent = False
+                self._current_parameters = {}
+                continue
 
-        return calls
+            # No complete parameter, no </invoke> — wait for more text.
+            break
 
-    def _reset_streaming_state(self, still_in_tool_call: bool = False):
-        """Reset streaming state for the next tool call"""
-        self._in_tool_call = still_in_tool_call
-        self._function_name_sent = False
-        self._current_function_name = ""
-        self._current_parameters = {}
-        self._streamed_parameters = {}
+        return StreamingParseResult(normal_text=normal, calls=calls)
         self.current_tool_name_sent = False
 
     def _extract(self, text: str, tools: List[Tool]) -> Tuple[str, List[ToolCallItem]]:

--- a/test/registered/unit/function_call/test_minimax_m2_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m2_detector.py
@@ -1,0 +1,392 @@
+"""Unit tests for MinimaxM2Detector."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.minimax_m2 import MinimaxM2Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "stage-a-test-cpu")
+
+
+def _make_tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="bash",
+                description="Run a shell command",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                        "description": {"type": "string"},
+                    },
+                    "required": ["command"],
+                },
+            ),
+        ),
+        Tool(
+            type="function",
+            function=Function(
+                name="get_weather",
+                description="Get weather",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "unit": {"type": "string"},
+                    },
+                    "required": ["city"],
+                },
+            ),
+        ),
+    ]
+
+
+def _stream(detector, tools, chunks):
+    all_calls = []
+    all_normal = ""
+    for ch in chunks:
+        result = detector.parse_streaming_increment(ch, tools)
+        all_calls.extend(result.calls)
+        all_normal += result.normal_text or ""
+    return all_normal, all_calls
+
+
+def _merge_by_index(calls):
+    # Merge deltas the way an OpenAI-compatible client does: same tool_index
+    # accumulates name + parameters into one tool_call.
+    merged = {}
+    for c in calls:
+        slot = merged.setdefault(c.tool_index, {"name": None, "args": ""})
+        if c.name is not None:
+            slot["name"] = c.name
+        if c.parameters:
+            slot["args"] += c.parameters
+    return merged
+
+
+class TestMinimaxM2Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = _make_tools()
+
+    # ==================== has_tool_call ====================
+
+    def test_has_tool_call_true(self):
+        text = '<minimax:tool_call><invoke name="bash"><parameter name="command">ls</parameter></invoke></minimax:tool_call>'
+        self.assertTrue(MinimaxM2Detector().has_tool_call(text))
+
+    def test_has_tool_call_false_plain_text(self):
+        self.assertFalse(MinimaxM2Detector().has_tool_call("Just a normal reply."))
+
+    # ==================== detect_and_parse (non-streaming) ====================
+
+    def test_non_streaming_single_call(self):
+        det = MinimaxM2Detector()
+        text = '<minimax:tool_call><invoke name="bash"><parameter name="command">ls -la</parameter></invoke></minimax:tool_call>'
+        result = det.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "bash")
+        self.assertEqual(json.loads(result.calls[0].parameters), {"command": "ls -la"})
+
+    def test_non_streaming_multiple_params(self):
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">cat foo</parameter>'
+            '<parameter name="description">read file</parameter>'
+            "</invoke></minimax:tool_call>"
+        )
+        result = det.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(
+            json.loads(result.calls[0].parameters),
+            {"command": "cat foo", "description": "read file"},
+        )
+
+    # ==================== Streaming ====================
+
+    def test_streaming_one_chunk(self):
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">cat | head -100</parameter>'
+            '<parameter name="description">Run tests</parameter>'
+            "</invoke></minimax:tool_call>"
+        )
+        normal, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(normal, "")
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(
+            json.loads(merged[0]["args"]),
+            {"command": "cat | head -100", "description": "Run tests"},
+        )
+
+    def test_streaming_split_at_param_boundaries(self):
+        det = MinimaxM2Detector()
+        chunks = [
+            '<minimax:tool_call><invoke name="bash">',
+            '<parameter name="command">cat | head -100</parameter>',
+            '<parameter name="description">Run tests</parameter>',
+            "</invoke></minimax:tool_call>",
+        ]
+        _, calls = _stream(det, self.tools, chunks)
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(
+            json.loads(merged[0]["args"]),
+            {"command": "cat | head -100", "description": "Run tests"},
+        )
+
+    def test_streaming_split_inside_param_value(self):
+        det = MinimaxM2Detector()
+        chunks = [
+            '<minimax:tool_call><invoke name="bash"><parameter name="command">cat',
+            ' | head -100</parameter><parameter name="description">Run',
+            " tests</parameter></invoke></minimax:tool_call>",
+        ]
+        _, calls = _stream(det, self.tools, chunks)
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(
+            json.loads(merged[0]["args"]),
+            {"command": "cat | head -100", "description": "Run tests"},
+        )
+
+    def test_streaming_char_by_char(self):
+        # Chunks shorter than "<minimax:tool_call>" must be buffered, not
+        # flushed as normal text.
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">ls</parameter>'
+            "</invoke></minimax:tool_call>"
+        )
+        normal, calls = _stream(det, self.tools, list(text))
+        merged = _merge_by_index(calls)
+        self.assertEqual(normal, "")
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "ls"})
+
+    def test_streaming_two_parallel_tool_calls(self):
+        # #23071: two invokes in the same chunk must not share parameter
+        # values via re.finditer scanning across boundaries.
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">A</parameter>'
+            "</invoke></minimax:tool_call>"
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">B</parameter>'
+            "</invoke></minimax:tool_call>"
+        )
+        _, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "A"})
+        self.assertEqual(merged[1]["name"], "bash")
+        self.assertEqual(json.loads(merged[1]["args"]), {"command": "B"})
+
+    def test_streaming_no_double_emission_for_same_tool(self):
+        # #23071: one invoke must stay on one tool_index, and the merged
+        # args must be a single well-formed JSON object.
+        det = MinimaxM2Detector()
+        chunks = [
+            '<minimax:tool_call><invoke name="bash"><parameter name="command">cat | head -100</parameter><',
+            'parameter name="description">Run tests</parameter></invoke></minimax:tool_call>',
+        ]
+        _, calls = _stream(det, self.tools, chunks)
+        for c in calls:
+            self.assertEqual(c.tool_index, 0)
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(
+            json.loads(merged[0]["args"]),
+            {"command": "cat | head -100", "description": "Run tests"},
+        )
+
+    def test_streaming_normal_text_then_tool(self):
+        det = MinimaxM2Detector()
+        chunks = [
+            "Sure, running it now. ",
+            '<minimax:tool_call><invoke name="bash">',
+            '<parameter name="command">ls</parameter>',
+            "</invoke></minimax:tool_call>",
+        ]
+        normal, calls = _stream(det, self.tools, chunks)
+        merged = _merge_by_index(calls)
+        self.assertEqual(normal, "Sure, running it now. ")
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "ls"})
+
+    def test_streaming_invalid_tool_name_dropped(self):
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="not_a_real_tool">'
+            '<parameter name="x">y</parameter>'
+            "</invoke></minimax:tool_call>"
+        )
+        _, calls = _stream(det, self.tools, [text])
+        self.assertEqual(len(calls), 0)
+
+    def test_streaming_partial_start_token_held(self):
+        # A chunk ending with a strict prefix of the start token must be
+        # held in the buffer, not flushed.
+        det = MinimaxM2Detector()
+        normal1, calls1 = _stream(det, self.tools, ["<minimax:tool_"])
+        self.assertEqual(calls1, [])
+        self.assertNotIn("<minimax:tool_", normal1)
+        normal2, calls2 = _stream(
+            det,
+            self.tools,
+            [
+                'call><invoke name="bash"><parameter name="command">ls</parameter></invoke></minimax:tool_call>'
+            ],
+        )
+        merged = _merge_by_index(calls2)
+        self.assertEqual(normal2, "")
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "ls"})
+
+    def test_streaming_two_invokes_in_one_wrapper(self):
+        # #23071: distinct param values across two invokes inside a single
+        # <minimax:tool_call>. Old code's re.finditer scanned across both
+        # invokes and overwrote the first invoke's parameters with the
+        # second's. The first invoke must keep its own values.
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call>'
+            '<invoke name="bash"><parameter name="command">FIRST</parameter></invoke>'
+            '<invoke name="bash">'
+            '<parameter name="command">SECOND</parameter>'
+            '<parameter name="description">D</parameter>'
+            '</invoke>'
+            '</minimax:tool_call>'
+        )
+        _, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "FIRST"})
+        self.assertEqual(
+            json.loads(merged[1]["args"]),
+            {"command": "SECOND", "description": "D"},
+        )
+
+    def test_streaming_two_separate_wrappers_distinct_params(self):
+        # Same data-corruption shape as the previous test, but with each
+        # invoke in its own wrapper.
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">FIRST</parameter>'
+            '</invoke></minimax:tool_call>'
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">SECOND</parameter>'
+            '<parameter name="description">D</parameter>'
+            '</invoke></minimax:tool_call>'
+        )
+        _, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "FIRST"})
+        self.assertEqual(
+            json.loads(merged[1]["args"]),
+            {"command": "SECOND", "description": "D"},
+        )
+
+    def test_streaming_invalid_invoke_does_not_drop_following_valid_invoke(
+        self,
+    ):
+        # Old code dumped the entire buffer into normal text on an invalid
+        # tool name, silently swallowing any valid invoke that came after.
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bogus">'
+            '<parameter name="x">y</parameter>'
+            '</invoke></minimax:tool_call>'
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">VALID</parameter>'
+            '</invoke></minimax:tool_call>'
+        )
+        _, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "VALID"})
+
+    def test_streaming_invoke_with_no_parameters(self):
+        # Empty <invoke></invoke> must yield args = "{}", not "" — clients
+        # call json.loads() on the merged args and "" is not valid JSON.
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash"></invoke></minimax:tool_call>'
+        )
+        _, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["name"], "bash")
+        self.assertEqual(json.loads(merged[0]["args"]), {})
+
+    def test_streaming_duplicate_parameter_keeps_first(self):
+        # Model glitch: same parameter appears twice. Take the first
+        # occurrence and ignore the duplicate (rather than re-emitting).
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="bash">'
+            '<parameter name="command">FIRST</parameter>'
+            '<parameter name="command">SECOND</parameter>'
+            '</invoke></minimax:tool_call>'
+        )
+        _, calls = _stream(det, self.tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(json.loads(merged[0]["args"]), {"command": "FIRST"})
+
+    def test_streaming_multi_param_types(self):
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="set_config",
+                    description="Configure",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "count": {"type": "integer"},
+                            "ratio": {"type": "number"},
+                            "enabled": {"type": "boolean"},
+                        },
+                    },
+                ),
+            )
+        ]
+        det = MinimaxM2Detector()
+        text = (
+            '<minimax:tool_call><invoke name="set_config">'
+            '<parameter name="count">3</parameter>'
+            '<parameter name="ratio">0.5</parameter>'
+            '<parameter name="enabled">true</parameter>'
+            "</invoke></minimax:tool_call>"
+        )
+        _, calls = _stream(det, tools, [text])
+        merged = _merge_by_index(calls)
+        self.assertEqual(len(merged), 1)
+        args = json.loads(merged[0]["args"])
+        self.assertEqual(args["count"], 3)
+        self.assertEqual(args["ratio"], 0.5)
+        self.assertIs(args["enabled"], True)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Fixes #23071. Four issues in `parse_streaming_increment` combined to break streaming output for the MiniMax M2 parser:

1. When a chunk was shorter than `<minimax:tool_call>` the buffer was cleared every call, so token-by-token streams never saw the start tag and the whole tool call leaked into normal text.
2. `_parse_and_stream_parameters` ran `re.finditer` over the whole buffer, so a parameter from a later `<invoke>` overwrote a same-named parameter on the current one — the first invoke's data ended up wrong.
3. The buffer was never trimmed of already-emitted `<parameter>` blocks, so a partial follow-up chunk could re-enter the "first parameter" branch and re-emit content the client had already received.
4. An invalid tool name dumped the entire buffer into normal text, silently swallowing any valid invoke that came after it. Empty  `<invoke></invoke>` emitted `args=""` instead of `args="{}"`, which isn't valid JSON.

Fix is surgical, not architectural:

- Hold a partial start token in the buffer instead of flushing it.
- Bound the parameter scan to the current invoke (up to `</invoke>`).
- Trim the buffer past each parameter and each invoke as they emit.
- Skip past an invalid invoke instead of dumping the whole buffer.
- Emit `"{}"` for an invoke with no parameters.

Incremental streaming is preserved — `name` goes out as soon as `<invoke>` is seen, each parameter as it closes, the closing brace at `</invoke>`. Same contract as the rest of the detectors.

The non-streaming path (`_extract` / `_parse_block`) is unchanged.

## Tests

New file `test/registered/unit/function_call/test_minimax_m2_detector.py` (no server, no model load, runs on CPU CI). 19 tests covering the four bug classes above, single-chunk / boundary-aligned / mid-value / char-by-char chunking, and tool-with-no-params / duplicate-param / mixed-type / invalid-name cases.

```
$ pytest test/registered/unit/function_call/test_minimax_m2_detector.py -v
============================= test session starts ==============================
platform linux -- Python 3.13.3, pytest-9.0.3, pluggy-1.6.0 -- /home/gorilla/sgl-test/bin/python3
cachedir: .pytest_cache
rootdir: /home/gorilla/Documents/sglang/test
configfile: pytest.ini
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 19 items

test_has_tool_call_false_plain_text PASSED
test_has_tool_call_true PASSED
test_non_streaming_multiple_params PASSED
test_non_streaming_single_call PASSED
test_streaming_char_by_char PASSED
test_streaming_duplicate_parameter_keeps_first PASSED
test_streaming_invalid_invoke_does_not_drop_following_valid_invoke PASSED
test_streaming_invalid_tool_name_dropped PASSED
test_streaming_invoke_with_no_parameters PASSED
test_streaming_multi_param_types PASSED
test_streaming_no_double_emission_for_same_tool PASSED
test_streaming_normal_text_then_tool PASSED
test_streaming_one_chunk PASSED
test_streaming_partial_start_token_held PASSED
test_streaming_split_at_param_boundaries PASSED
test_streaming_split_inside_param_value PASSED
test_streaming_two_invokes_in_one_wrapper PASSED
test_streaming_two_parallel_tool_calls PASSED
test_streaming_two_separate_wrappers_distinct_params PASSED

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
<frozen importlib._bootstrap>:488
  DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

======================== 19 passed, 2 warnings in 5.23s ========================
```

(SWIG DeprecationWarnings come from my local interpreter, not from
sglang or the test.)

The following tests fail on `main` and pass after this change — the
explicit regression set:

- `test_streaming_char_by_char`
- `test_streaming_partial_start_token_held`
- `test_streaming_two_parallel_tool_calls`
- `test_streaming_two_invokes_in_one_wrapper`
- `test_streaming_two_separate_wrappers_distinct_params`
- `test_streaming_invalid_invoke_does_not_drop_following_valid_invoke`
- `test_streaming_invoke_with_no_parameters`

The rest of `test/registered/unit/function_call/` still passes.

## related PR

- #23301 streams string parameters token-by-token. 
 That's a separate, bigger UX change, this PR doesn't preclude it.


Fixes #23071