### PR TITLE
[Docs] Fix SGLang Diffusion CLI option names

### DIFF
--- a/docs_new/docs/sglang-diffusion/api/cli.mdx
+++ b/docs_new/docs/sglang-diffusion/api/cli.mdx
@@ -80,7 +80,7 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 - `--tp-size &#123;N&#125;`: tensor parallelism size, mainly for encoders
 - `--sp-degree &#123;N&#125;`: sequence parallelism size
 - `--ulysses-degree &#123;N&#125;` and `--ring-degree &#123;N&#125;`: USP parallelism controls
-- `--attention-backend &#123;BACKEND&#125;`: attention backend for native SGLang pipelines
+- `--attention-backend &#123;BACKEND&#125;`: attention backend for native SGLang and diffusers pipelines
 - `--component-attention-backends &#123;MAP&#125;`: per-component attention backend overrides, for example `text_encoder=torch_sdpa,transformer=fa`
 - `--attention-backend-config &#123;CONFIG&#125;`: attention backend configuration
 
@@ -119,7 +119,7 @@ model_path: FastVideo/FastHunyuan-diffusers
 prompt: A beautiful woman in a red dress walking down a street
 output_path: outputs/
 num_gpus: 2
-sp_size: 2
+sp_degree: 2
 tp_size: 1
 num_frames: 45
 height: 720
@@ -127,7 +127,7 @@ width: 1280
 num_inference_steps: 6
 seed: 1024
 fps: 24
-precision: bf16
+dit_precision: bf16
 vae_precision: fp16
 vae_tiling: true
 vae_sp: true
@@ -242,7 +242,7 @@ Use `--backend diffusers` to force vanilla diffusers pipelines when no native SG
       <td>Choose native SGLang, force native, or force diffusers</td>
     </tr>
     <tr>
-      <td><code>--diffusers-attention-backend</code></td>
+      <td><code>--attention-backend</code></td>
       <td><code>flash</code>, <code>_flash_3_hub</code>, <code>sage</code>, <code>xformers</code>, <code>native</code></td>
       <td>Attention backend for diffusers pipelines</td>
     </tr>
@@ -281,7 +281,7 @@ sglang generate \
   --model-path AIDC-AI/Ovis-Image-7B \
   --backend diffusers \
   --trust-remote-code \
-  --diffusers-attention-backend flash \
+  --attention-backend flash \
   --prompt "A serene Japanese garden with cherry blossoms" \
   --height 1024 \
   --width 1024 \


### PR DESCRIPTION
Fix outdated SGLang Diffusion CLI option names.

This updates the docs to use `sp_degree`, `dit_precision`, and `--attention-backend`, matching the current runtime behavior.

Fixes part of #22622.