### PR TITLE
Add libertyeagle to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -804,6 +804,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "libertyeagle": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "liupeng374": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -797,14 +797,14 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
-    "lifuhuang": {
+    "libertyeagle": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "can_rerun_stage": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
-    "libertyeagle": {
+    "lifuhuang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "can_rerun_stage": true,


### PR DESCRIPTION
## Summary
- Add `libertyeagle` to `.github/CI_PERMISSIONS.json` with CI permissions (tag run CI label, rerun failed CI, rerun stage) and 60-minute cooldown.

## Test plan
- [x] Verified JSON is valid and entry is alphabetically ordered