### PR TITLE
[Spec] Drop Rule 5 (`_len` / `_lens` ban) from speculative naming rule

### DIFF
--- a/.claude/rules/speculative-naming.md
+++ b/.claude/rules/speculative-naming.md
@@ -63,17 +63,7 @@ Each form has its own marker. **Never mix** (no `num_X_ct`, no `num_accept_rate`
 | **Rate / ratio** | `X_rate` | Fractional value in `[0, 1]` | `accept_rate` |
 | **Tokens / content array** | no prefix | The actual token data, not a count | `accept_tokens`, `correct_drafts`, `bonus_token` |
 
-## Rule 5 — Avoid `length` / `lens` internally
-
-Internal code uses `num_X` for counts (Rule 4), not `length` / `lens`.
-
-The only allowed `_length` name is `accept_length` (paper-aligned external metric, see Rule 3 exception). Outside kernel signatures, never write `accept_lens` / `accepted_length` / `commit_lens`.
-
-### Exception: Triton kernel signatures
-
-Triton kernel parameters (and their inner scalar loads) may use `_lens` / `_len` to align with the broader PyTorch ecosystem (`seq_lens`, `cu_seqlens_q`). Example: `accept_lens` (kernel param, `[bs]`) and `accept_len = tl.load(accept_lens + pid)` (scalar inside kernel) are OK. The wrapping Python code that calls the kernel still uses `num_accept_tokens`.
-
-## Rule 6 — Drop redundant `_token_id` / `_token_ids` suffix in spec scope
+## Rule 5 — Drop redundant `_token_id` / `_token_ids` suffix in spec scope
 
 `_id` / `_ids` and `_token` / `_tokens` are both fine. But don't combine — `_token_id` / `_token_ids` is redundant **inside spec decoding**, because spec code only ever deals with vocab integers.
 
@@ -93,7 +83,7 @@ The semantic differs by scope:
 | `out_token_ids` | `out_tokens` |
 | `_resolve_spec_overlap_token_ids` | `_resolve_spec_overlap_tokens` |
 
-## Rule 7 — Singular vs plural
+## Rule 6 — Singular vs plural
 
 Plural for any non-scalar tensor (`[bs]`-shaped, flat, or multi-dim); singular only for scalars (kernel `tl.load` results, single-int locals). Applies to all spec-decoding tensors (tokens, indices, etc.).
 
@@ -115,3 +105,4 @@ These rules apply to **spec-decoding-specific** identifiers. Pre-existing or fra
 - **Request-level state**: `req.input_ids`, `req.output_ids`, `req.origin_input_ids`, `next_token_ids` (`model_runner.sample` output)
 - **Frozen C++ kwargs**: `accept_token_num` (sgl-kernel)
 - **Non-token IDs**: `req_id`, `gpu_id`, `layer_id`, `program_id`
+- **`_len` / `_lens` names**: `num_X` is preferred for counts (Rule 4), but `_len` / `_lens` names are acceptable. Triton kernel params in particular often use `_lens` / `_len` to align with the PyTorch ecosystem (`seq_lens`, `cu_seqlens_q`). Rule 1 still requires the `-ed`-less form (`accept_length` OK, `accepted_length` not).


### PR DESCRIPTION
Relaxes `.claude/rules/speculative-naming.md` — `num_X` stays the preferred form for counts per Rule 4, but `_len` / `_lens` names are no longer banned. They're idiomatic in spec scalar names (`accept_len`, `ema_accept_len`) and already align with the PyTorch ecosystem in Triton kernel signatures.

- Remove Rule 5 entirely (was: `Avoid length / lens internally`)
- Renumber Rule 6 (token_id suffix) -> Rule 5
- Renumber Rule 7 (singular vs plural) -> Rule 6
- Add one out-of-scope bullet documenting the relaxed stance

Rule 1 (drop `-ed`) still rules out `accepted_length`. No source-code changes; doc-only.