### PR TITLE
Fix Eagle draft decode positions

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -347,7 +347,7 @@ class EAGLEDraftCudaGraphRunner:
             )
             set_is_extend_in_batch(False)
 
-            # Backup two fields, which will be modified in-place in `draft_forward`.
+            # Backup fields that are modified in-place in `draft_forward`.
             output_cache_loc_backup = forward_batch.out_cache_loc
             hidden_states_backup = forward_batch.spec_info.hidden_states
 
@@ -355,6 +355,7 @@ class EAGLEDraftCudaGraphRunner:
 
             forward_batch.out_cache_loc = output_cache_loc_backup
             forward_batch.spec_info.hidden_states = hidden_states_backup
+            forward_batch.positions.sub_(self.eagle_worker.speculative_num_steps - 1)
             return ret
 
         self.deepep_adapter.capture(is_extend_in_batch=False)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -869,7 +869,6 @@ class EAGLEWorker(TpModelWorker):
             ):
                 out_cache_loc = out_cache_loc.contiguous()
             forward_batch.out_cache_loc = out_cache_loc[i]
-            forward_batch.positions.add_(1)
             forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
             spec_info.hidden_states = hidden_states
 
@@ -889,6 +888,7 @@ class EAGLEWorker(TpModelWorker):
             if self.hot_token_id is not None:
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
+            forward_batch.positions.add_(1)
 
         parent_list, top_scores_index, draft_tokens = organize_draft_results(
             score_list, token_list, parents_list, self.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -457,7 +457,6 @@ class EagleDraftWorker(BaseDraftWorker):
             # Set inputs
             forward_batch.input_ids = input_ids
             forward_batch.out_cache_loc = out_cache_loc[i]
-            forward_batch.positions.add_(1)
             forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
             spec_info.hidden_states = hidden_states
 
@@ -477,6 +476,7 @@ class EagleDraftWorker(BaseDraftWorker):
             if self.hot_token_id is not None:
                 topk_index = self.hot_token_id[topk_index]
             hidden_states = logits_output.hidden_states
+            forward_batch.positions.add_(1)
 
         # Organize the results
         score_list = torch.cat(score_list, dim=1).flatten(


### PR DESCRIPTION
## Summary
- Fix incorrect RoPE position IDs in Eagle speculative decoding draft decode steps.
- Move the in-place `forward_batch.positions.add_(1)` from **before** each draft decode forward to **after**, so the current forward sees the correct position.
- Restore positions after CUDA graph capture (`forward_batch.positions.sub_(speculative_num_steps - 1)`) since `draft_forward` mutates the shared ForwardBatch.
- Applies to both `eagle_worker.py` (v1) and `eagle_worker_v2.py` (v2).

## Before (incorrect positions)
```
draft extend for prefill forward positions=tensor([0, 1, 2, 3, 4, 5, 6])
draft decode forward positions=tensor([8])    # wrong, should be 7
draft decode forward positions=tensor([9])    # wrong, should be 8
draft extend for decode forward positions=tensor([ 7,  8,  9, 10])
```

## After (correct positions)
```
draft extend for prefill forward positions=tensor([0, 1, 2, 3, 4, 5, 6])
draft decode forward positions=tensor([7])    # correct
draft decode forward positions=tensor([8])    # correct
draft extend for decode forward positions=tensor([ 7,  8,  9, 10])
```

## Original commits

- `3978d1d0`

## Test plan
- [x] Verified position IDs are correct in draft decode steps with debug logging
- [ ] Run Eagle speculative decoding e2e test
