### PR TITLE
[bench] Agentic support for `bench_serving.py`

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1145,8 +1145,10 @@ def _normalize_round_messages(turn: Any) -> Optional[List[Dict[str, str]]]:
     """
     if isinstance(turn, str):
         return [{"role": "user", "content": turn}]
-    if isinstance(turn, list) and turn and all(
-        isinstance(m, dict) and "role" in m and "content" in m for m in turn
+    if (
+        isinstance(turn, list)
+        and turn
+        and all(isinstance(m, dict) and "role" in m and "content" in m for m in turn)
     ):
         return [{"role": m["role"], "content": m["content"]} for m in turn]
     return None

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1136,6 +1136,22 @@ def calculate_metrics(
 MULTI_TURN_BACKENDS = {"sglang-oai-chat", "vllm-chat", "lmdeploy-chat"}
 
 
+def _normalize_round_messages(turn: Any) -> Optional[List[Dict[str, str]]]:
+    """Normalize a multi-turn round to a list of message dicts.
+
+    Accepts ``str`` (single user message) or ``List[Dict]`` with role/content
+    (e.g. multiple tool observations bundled into one round). Returns ``None``
+    on any other shape so callers can also use it as a predicate.
+    """
+    if isinstance(turn, str):
+        return [{"role": "user", "content": turn}]
+    if isinstance(turn, list) and turn and all(
+        isinstance(m, dict) and "role" in m and "content" in m for m in turn
+    ):
+        return [{"role": m["role"], "content": m["content"]} for m in turn]
+    return None
+
+
 def wrap_multi_turn_request_func(request_func: Callable, backend: str) -> Callable:
     assert (
         backend in MULTI_TURN_BACKENDS
@@ -1145,12 +1161,19 @@ def wrap_multi_turn_request_func(request_func: Callable, backend: str) -> Callab
         request_func_input: RequestFuncInput,
         pbar: Optional[tqdm] = None,
     ) -> List[RequestFuncOutput]:
-        prompts: List[str] = request_func_input.prompt
+        prompts = request_func_input.prompt
         prev_messages: List[Dict[str, str]] = []
         outputs = []
 
         for round_index in range(len(prompts)):
-            prev_messages.append({"role": "user", "content": prompts[round_index]})
+            normalized = _normalize_round_messages(prompts[round_index])
+            if normalized is None:
+                raise ValueError(
+                    f"Multi-turn round {round_index} must be a str or a "
+                    "non-empty List[Dict] of role/content messages, got: "
+                    f"{type(prompts[round_index]).__name__}"
+                )
+            prev_messages.extend(normalized)
 
             inner_input = replace(
                 copy.deepcopy(request_func_input), prompt=copy.deepcopy(prev_messages)
@@ -1198,14 +1221,13 @@ async def benchmark(
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
-    # Check for multi-turn: prompt is a list of strings (not OpenAI messages dicts)
-    # Multi-turn format: ["turn1", "turn2", ...] - list of strings
-    # OpenAI format: [{"role": "user", "content": "..."}, ...] - list of dicts
+    # Multi-turn iff prompt[0] is a valid per-round payload. Single-shot
+    # OpenAI messages (List[Dict]) is excluded since its first element is a dict.
     first_prompt = input_requests[0].prompt
     is_multi_turn = (
         isinstance(first_prompt, list)
-        and len(first_prompt) > 0
-        and isinstance(first_prompt[0], str)
+        and bool(first_prompt)
+        and _normalize_round_messages(first_prompt[0]) is not None
     )
     if is_multi_turn:
         request_func = wrap_multi_turn_request_func(request_func, backend=backend)

--- a/python/sglang/benchmark/datasets/autobench.py
+++ b/python/sglang/benchmark/datasets/autobench.py
@@ -109,6 +109,21 @@ def _normalize_prompt(row: Dict[str, Any]) -> Tuple[Any, str]:
         if (
             isinstance(prompt, list)
             and prompt
+            and all(
+                isinstance(item, list)
+                and item
+                and all(
+                    isinstance(m, dict) and "role" in m and "content" in m
+                    for m in item
+                )
+                for item in prompt
+            )
+        ):
+            # Multi-turn with N messages per round (e.g. tool observations).
+            return prompt, "multi_turn"
+        if (
+            isinstance(prompt, list)
+            and prompt
             and all(isinstance(item, int) for item in prompt)
         ):
             return prompt, "token_ids"

--- a/python/sglang/benchmark/datasets/autobench.py
+++ b/python/sglang/benchmark/datasets/autobench.py
@@ -113,8 +113,7 @@ def _normalize_prompt(row: Dict[str, Any]) -> Tuple[Any, str]:
                 isinstance(item, list)
                 and item
                 and all(
-                    isinstance(m, dict) and "role" in m and "content" in m
-                    for m in item
+                    isinstance(m, dict) and "role" in m and "content" in m for m in item
                 )
                 for item in prompt
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Extend `sglang.bench_serving` multi-turn support to allow **N messages per round** (not just one user string), so we can faithfully replay agentic / tool-using workloads (e.g. SWE-Smith) where each round bundles the user message plus multiple `tool` observations before the next assistant reply.

## Modifications

`bench_serving.py`
- Add `_normalize_round_messages(turn)`: accepts `str` (legacy) or `List[{role, content}]` (multi-message round); returns `None` for invalid shapes so callers can use it as a predicate.
- `wrap_multi_turn_request_func` extends the running history with the round's normalized messages instead of always appending a single `user` dict; assistant reply is still appended between rounds.
- Invalid round shapes now raise an explicit `ValueError`.
- Multi-turn detection in `benchmark()` is rebuilt on `_normalize_round_messages`, keeping single-shot OpenAI `List[Dict]` prompts unambiguous.

`benchmark/datasets/autobench.py`
- `_normalize_prompt` recognizes `List[List[{role, content}]]` as a `multi_turn` prompt (added after the existing `List[str]` branch).

Compatibility
- Existing `List[str]` multi-turn datasets and single-shot `List[Dict]` OpenAI prompts are unchanged.
- Only multi-turn chat backends (`sglang-oai-chat`, `vllm-chat`, `lmdeploy-chat`) are touched.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
