### PR TITLE
Add minosfuture to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -881,6 +881,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "minosfuture": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "mmangkad": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- Add `minosfuture` to `.github/CI_PERMISSIONS.json` with CI permissions (tag run CI label, rerun failed CI, rerun stage) and 60-minute cooldown.

## Test plan
- [x] Verified JSON is valid and entry is alphabetically sorted