### PR TITLE
[Bench] Add MEM profile activity to bench_serving

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2154,8 +2154,9 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         default=["CPU", "GPU"],
-        choices=["CPU", "GPU", "CUDA_PROFILER", "XPU"],
-        help="Profiler activities to capture: CPU, GPU, XPU, CUDA_PROFILER.",
+        choices=["CPU", "GPU", "CUDA_PROFILER", "XPU", "MEM"],
+        help="Profiler activities to capture: CPU, GPU, XPU, CUDA_PROFILER, MEM "
+        "(MEM dumps a torch.cuda.memory snapshot, viewable at https://pytorch.org/memory_viz).",
     )
     parser.add_argument(
         "--profile-start-step",


### PR DESCRIPTION
## Summary
- Add `MEM` as an option to `--profile-activities` in `bench_serving.py` to enable memory profiling.
- `MEM` dumps a `torch.cuda.memory` snapshot, viewable at https://pytorch.org/memory_viz.

## Motivation
Enables memory profiling alongside existing CPU/GPU/CUDA_PROFILER/XPU activities, so users can capture memory snapshots during serving benchmarks without separate tooling.

## Test plan
- [ ] Run `python -m sglang.bench_serving --help` and confirm `MEM` appears in `--profile-activities` choices.
- [ ] Run a benchmark with `--profile --profile-activities MEM` and confirm a memory snapshot file is produced and loads at https://pytorch.org/memory_viz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)