### PR TITLE
[BugFix][FlashAttention Backend] Use attention tensor parallel size in FlashAttention backend

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -10,6 +10,7 @@ import triton.language as tl
 
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils.cp_utils import (
     cp_allgather_and_save_kv_cache,
@@ -190,10 +191,10 @@ class FlashAttentionBackend(AttentionBackend):
         self.head_dim = model_runner.model_config.head_dim
         self.num_attention_heads = (
             model_runner.model_config.hf_text_config.num_attention_heads
-            // model_runner.tp_size
+            // get_attention_tp_size()
         )
         self.num_kv_heads = model_runner.model_config.get_num_kv_heads(
-            model_runner.tp_size
+            get_attention_tp_size()
         )
         _softcapping = getattr(
             model_runner.model_config.hf_text_config, "attn_logit_softcapping", None


### PR DESCRIPTION
## Motivation

Fix FlashAttention DP attention head partitioning

## Modifications


This PR fixes FlashAttention backend head partitioning when DP attention is enabled.

Previously, FlashAttentionBackend used the global `model_runner.tp_size` to compute local attention heads and KV heads for FA3 scheduler metadata. With DP attention, the effective attention TP size can be smaller than the global TP size, for example `tp_size=2, dp_size=2` gives `attention_tp_size=1`. Using the global TP size undercounts local heads and can corrupt FlashAttention decode metadata, causing bad generations or CUDA illegal memory access.

This change uses `get_attention_tp_size()` instead, matching the existing behavior in other attention backends such as Triton and FlashInfer.

## Accuracy Tests

```bash
# TP2 + DPA2
sglang serve --model-path Qwen/Qwen3-30B-A3B-FP8 \
    --tp-size 2 \
    --enable-dp-attention \
    --dp-size 2 \
    --reasoning-parser qwen3 \
    --tool-call-parser qwen25 \
    --mem-fraction-static 0.8 \
    --host 0.0.0.0 \
    --port 8000
```


**Before:**
<img width="400" height="280" alt="image" src="https://github.com/user-attachments/assets/aa99e791-e5cf-4b17-a8dc-19aeeb75f147" />

**After:**
<img width="400" height="130" alt="image" src="https://github.com/user-attachments/assets/68097bce-2659-441a-83e7-3e25eebad34d" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
