### PR TITLE
[CI] Temporarily disable multimodal-gen test_update_weights_from_disk (flaky)

### DIFF
--- a/python/sglang/multimodal_gen/test/run_suite.py
+++ b/python/sglang/multimodal_gen/test/run_suite.py
@@ -85,7 +85,9 @@ PARAMETRIZED_CASE_GROUPS = {
 STANDALONE_FILES = {
     "1-gpu": [
         "../cli/test_generate_t2i_perf.py",
-        "test_update_weights_from_disk.py",
+        # Temporarily disabled: 24 timeout failures since 2026-04-09 across
+        # multimodal-gen-test-1-gpu. Re-enable after the flakiness is fixed.
+        # "test_update_weights_from_disk.py",
     ],
     "2-gpu": [
         "test_disagg_server.py",
@@ -98,7 +100,8 @@ STANDALONE_FILES = {
 STANDALONE_FILE_EST_TIMES = {
     "1-gpu": {
         "../cli/test_generate_t2i_perf.py": 240.0,
-        "test_update_weights_from_disk.py": 480.0,
+        # See STANDALONE_FILES note above — temporarily disabled.
+        # "test_update_weights_from_disk.py": 480.0,
     },
     "2-gpu": {
         # Two disagg clusters × (~3 min startup + ~1 min generate) ≈ 8 min.


### PR DESCRIPTION
## Summary

Temporarily disable \`python/sglang/multimodal_gen/test/server/test_update_weights_from_disk.py\` in the \`multimodal-gen-test-1-gpu\` suite. The test has timed out **24 times** across CI runs since 2026-04-09, with the most recent failure 2026-05-07. All 24 incidents are categorized as \`timeout\` by the failure tracker (\`Job timed out while running this test\`), blocking per-commit signal on unrelated multimodal-gen changes.

## Change

Comment out the two entries in \`python/sglang/multimodal_gen/test/run_suite.py\` under the \`1-gpu\` suite:

- \`STANDALONE_FILES[\"1-gpu\"]\` — removes the test from the dispatched file list
- \`STANDALONE_FILE_EST_TIMES[\"1-gpu\"]\` — removes the corresponding 480 s estimate

The test file itself stays in the repo so this is a one-line uncomment to re-enable once the underlying timeout is fixed.

## Out of scope

The \`test/registered/rl/test_update_weights_from_disk.py\` per-commit variant (same filename, different test) is independently disabled under #14021 and is not affected by this change.

## Test plan

- [ ] Confirm \`multimodal-gen-test-1-gpu\` no longer dispatches \`test_update_weights_from_disk.py\` (will show fewer files in the suite's startup banner)
- [ ] Re-enable in a follow-up PR after the root cause of the timeout is fixed