### PR TITLE
fix(dsv4): align PD compress state layout

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -146,6 +146,32 @@ The generator currently picks values on the **conservative** side (mirroring an 
 - `max-throughput`: MTP disabled — at saturation the verify step costs more than it saves.
 - MTP currently requires `SGLANG_ENABLE_SPEC_V2=1`.
 
+**PD-Disagg with decode-side MTP**
+
+For DeepSeek-V4 PD disaggregation, the DSV4 compress-state layout must match
+between the prefill and decode servers. If the prefill server does not run
+speculative decoding but the decode server enables EAGLE/MTP, pass the decode
+server's speculative algorithm to the prefill server:
+
+```bash
+# Prefill server: no local speculative decoding.
+--disaggregation-mode prefill \
+--dsv4-pd-decode-speculative-algorithm EAGLE
+
+# Decode server: speculative decoding enabled.
+--disaggregation-mode decode \
+--speculative-algorithm EAGLE \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4
+```
+
+This keeps the prefill server's DSV4 compress-state ring layout compatible with
+decode-side MTP without starting speculative decoding on the prefill server. If
+you need to override the automatic layout selection explicitly, use
+`--dsv4-compress-state-layout speculative` or
+`--dsv4-compress-state-layout non-speculative`.
+
 <a id="hopper-note" />
 
 **Hopper (H200) note**

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -41,6 +41,28 @@ def get_compress_state_ring_size(
         return 8 if compress_ratio == 4 else 128
 
 
+def use_speculative_compress_state_layout(server_args) -> bool:
+    """Return whether DSV4 compress state should use MTP-compatible layout."""
+    layout = getattr(server_args, "dsv4_compress_state_layout", "auto")
+    if layout == "speculative":
+        return True
+    if layout == "non-speculative":
+        return False
+    if layout != "auto":
+        raise ValueError(f"Unknown DSV4 compress state layout: {layout}")
+
+    if server_args.speculative_algorithm is not None:
+        return True
+
+    decode_speculative_algorithm = getattr(
+        server_args, "dsv4_pd_decode_speculative_algorithm", None
+    )
+    if decode_speculative_algorithm is not None:
+        return decode_speculative_algorithm.lower() not in ("", "none", "null")
+
+    return server_args.disaggregation_mode != "null"
+
+
 class DeepSeekV4SingleKVPool(KVCache):
     def __init__(
         self,
@@ -473,7 +495,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     def get_ring_size(self, compress_ratio: int) -> int:
         server_args = get_global_server_args()
-        is_speculative = server_args.speculative_algorithm is not None
+        is_speculative = use_speculative_compress_state_layout(server_args)
         return get_compress_state_ring_size(compress_ratio, is_speculative)
 
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -420,6 +420,10 @@ class ServerArgs:
     schedule_conservativeness: float = 1.0
     page_size: Optional[int] = None
     swa_full_tokens_ratio: float = 0.8
+    dsv4_compress_state_layout: Literal["auto", "speculative", "non-speculative"] = (
+        "auto"
+    )
+    dsv4_pd_decode_speculative_algorithm: Optional[str] = None
     disable_hybrid_swa_memory: bool = False
     radix_eviction_policy: str = "lru"
     enable_prefill_delayer: bool = False
@@ -4827,6 +4831,32 @@ class ServerArgs:
             default=ServerArgs.swa_full_tokens_ratio,
             help="The ratio of SWA layer KV tokens / full layer KV tokens, regardless of the number of swa:full layers. It should be between 0 and 1. "
             "E.g. 0.5 means if each swa layer has 50 tokens, then each full layer has 100 tokens.",
+        )
+        parser.add_argument(
+            "--dsv4-compress-state-layout",
+            type=str,
+            choices=["auto", "speculative", "non-speculative"],
+            default=ServerArgs.dsv4_compress_state_layout,
+            help=(
+                "DeepSeek V4 compress-state ring layout. 'speculative' uses the "
+                "larger MTP-compatible layout without requiring speculative decoding "
+                "to run in this process. In 'auto', the layout follows local "
+                "speculative decoding, --dsv4-pd-decode-speculative-algorithm when "
+                "set, and otherwise falls back to the speculative-compatible layout "
+                "for PD disaggregation."
+            ),
+        )
+        parser.add_argument(
+            "--dsv4-pd-decode-speculative-algorithm",
+            type=str,
+            default=ServerArgs.dsv4_pd_decode_speculative_algorithm,
+            help=(
+                "DeepSeek V4 only. In PD disaggregation, pass the decode server's "
+                "speculative algorithm to the prefill server so DSV4 compress-state "
+                "layout can match decode without starting speculative decoding on "
+                "prefill. Use 'none' if decode does not enable speculative decoding. "
+                "If unset, PD keeps the conservative speculative-compatible layout."
+            ),
         )
         parser.add_argument(
             "--disable-hybrid-swa-memory",

--- a/test/registered/unit/mem_cache/test_deepseek_v4_memory_pool.py
+++ b/test/registered/unit/mem_cache/test_deepseek_v4_memory_pool.py
@@ -1,0 +1,108 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    get_compress_state_ring_size,
+    use_speculative_compress_state_layout,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestDeepSeekV4CompressStateLayout(unittest.TestCase):
+    def test_pd_uses_speculative_compatible_state_layout(self):
+        self.assertFalse(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm=None,
+                    disaggregation_mode="null",
+                    dsv4_compress_state_layout="auto",
+                    dsv4_pd_decode_speculative_algorithm=None,
+                )
+            )
+        )
+        self.assertTrue(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm="EAGLE",
+                    disaggregation_mode="null",
+                    dsv4_compress_state_layout="auto",
+                    dsv4_pd_decode_speculative_algorithm=None,
+                )
+            )
+        )
+        self.assertTrue(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm=None,
+                    disaggregation_mode="prefill",
+                    dsv4_compress_state_layout="auto",
+                    dsv4_pd_decode_speculative_algorithm=None,
+                )
+            )
+        )
+        self.assertTrue(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm=None,
+                    disaggregation_mode="decode",
+                    dsv4_compress_state_layout="auto",
+                    dsv4_pd_decode_speculative_algorithm=None,
+                )
+            )
+        )
+
+    def test_prefill_can_follow_decode_speculative_algorithm(self):
+        self.assertFalse(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm=None,
+                    disaggregation_mode="prefill",
+                    dsv4_compress_state_layout="auto",
+                    dsv4_pd_decode_speculative_algorithm="none",
+                )
+            )
+        )
+        self.assertTrue(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm=None,
+                    disaggregation_mode="prefill",
+                    dsv4_compress_state_layout="auto",
+                    dsv4_pd_decode_speculative_algorithm="EAGLE",
+                )
+            )
+        )
+
+    def test_explicit_layout_overrides_auto(self):
+        self.assertTrue(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm=None,
+                    disaggregation_mode="null",
+                    dsv4_compress_state_layout="speculative",
+                    dsv4_pd_decode_speculative_algorithm=None,
+                )
+            )
+        )
+        self.assertFalse(
+            use_speculative_compress_state_layout(
+                SimpleNamespace(
+                    speculative_algorithm="EAGLE",
+                    disaggregation_mode="decode",
+                    dsv4_compress_state_layout="non-speculative",
+                    dsv4_pd_decode_speculative_algorithm="EAGLE",
+                )
+            )
+        )
+
+    def test_speculative_layout_doubles_compress_state_ring_size(self):
+        self.assertEqual(get_compress_state_ring_size(4, is_speculative=False), 8)
+        self.assertEqual(get_compress_state_ring_size(4, is_speculative=True), 16)
+        self.assertEqual(get_compress_state_ring_size(128, is_speculative=False), 128)
+        self.assertEqual(get_compress_state_ring_size(128, is_speculative=True), 256)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek V4 PD disaggregation can run with asymmetric speculative decoding settings: the prefill server may run without speculative decoding, while the decode server enables EAGLE/MTP.

<img width="2712" height="1060" alt="42645f15-f864-48ec-bf63-4230d7487d1d" src="https://github.com/user-attachments/assets/f8e11518-a52f-4a28-8d6e-7e9b1cd6542a" />

For DSV4, the compress-state ring layout depends on whether the speculative-compatible layout is used. Before this change, a prefill server selected the non-speculative compress-state layout whenever speculative decoding was not enabled locally. In PD disaggregation, this can be wrong when the decode server uses EAGLE/MTP, because the prefill and decode servers then use different compress-state layouts and state transfer can break.

This PR lets a PD prefill server follow the decode server's speculative setting for the DSV4 compress-state layout without enabling speculative decoding on the prefill server itself.

## Modifications

- Add `--dsv4-compress-state-layout` to explicitly control the DSV4 compress-state ring layout:
  - `auto`
  - `speculative`
  - `non-speculative`
- Add `--dsv4-pd-decode-speculative-algorithm` so a PD prefill server can know whether the decode server enables speculative decoding.
- Add `use_speculative_compress_state_layout()` and use it when the DSV4 memory pool computes the compress-state ring size.
- Add unit tests covering:
  - normal non-PD non-speculative layout
  - local speculative decoding layout
  - PD prefill/decode speculative-compatible fallback
  - prefill following decode-side speculative algorithm
  - explicit layout override
  - c4/c128 ring-size differences between speculative and non-speculative layouts

Target scenario:

```text
P server:
  --disaggregation-mode prefill
  no --speculative-algorithm
  --dsv4-pd-decode-speculative-algorithm EAGLE

D server:
  --disaggregation-mode decode
  --speculative-algorithm EAGLE
```

In this setup, both sides use the speculative-compatible DSV4 compress-state layout.

## Accuracy Tests

This PR only changes DSV4 compress-state layout selection and CLI plumbing. It does not change model forward math, kernels, sampling, or logits.

Unit tests passed:

```bash
PYTHONPATH=python python test/registered/unit/mem_cache/test_deepseek_v4_memory_pool.py
```

Result:

```text
Ran 4 tests in 0.000s

OK
```

ServerArgs regression tests passed:

```bash
PYTHONPATH=python python test/registered/unit/server_args/test_server_args.py
```

Result:

```text
Ran 48 tests in 1.075s

OK
```

Manual layout check for the target PD setting:

```text
P_layout_spec True
D_layout_spec True
P_c4_ring 16 D_c4_ring 16
P_c128_ring 256 D_c128_ring 256
```

## Speed Tests and Profiling

No speed benchmark was run. This change only affects DSV4 compress-state layout selection during memory pool setup and does not add work to the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
