### PR TITLE
[NPU]Add FP8 Quantization for NPU

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
@@ -1,11 +1,12 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 from torch.nn.parameter import Parameter
 
 from sglang.srt.hardware_backend.npu.utils import NPUACLFormat, npu_format_cast
 from sglang.srt.layers.quantization.base_config import LinearMethodBase
+from sglang.srt.utils import is_npu_before_atlas_a5
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -51,6 +52,61 @@ def _get_float4_e2m1fn_x2_dtype():
         if npu_dtype is not None:
             return npu_dtype
     return getattr(torch, "float4_e2m1fn_x2", None)
+
+
+def process_block_fp8_weight_npu(layer: torch.nn.Module) -> None:
+    """Transpose block-FP8 weight and scale tensors for Ascend matmul."""
+    if is_npu_before_atlas_a5():
+        # Older Ascend devices consume FP8 bit patterns through soft-FP8
+        # kernels, whose weight input is represented as uint8.
+        weight = layer.weight.data.view(torch.uint8).transpose(-1, -2).contiguous()
+        scale = layer.weight_scale_inv.data.transpose(-1, -2).contiguous()
+    else:
+        weight = layer.weight.data.transpose(-1, -2)
+        scale = layer.weight_scale_inv.data.transpose(-1, -2)
+
+    layer.weight.data = weight
+    layer.weight_scale_inv.data = scale
+
+
+def fp8_matmul_npu(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    block_size: List[int],
+    weight_scale: torch.Tensor,
+    input_scale: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run a [128, 128] block-FP8 linear layer on Ascend NPU."""
+    del input_scale, bias
+
+    if block_size != [128, 128]:
+        raise ValueError("fp8_matmul_npu only supports block_size == [128, 128]")
+
+    original_shape = input.shape
+    input_2d = input.reshape(-1, original_shape[-1]).contiguous()
+
+    if is_npu_before_atlas_a5():
+        output_2d = torch.ops.npu.softfp8_w8a16_matmul(
+            input_2d, weight, weight_scale, "bf16"
+        )
+    else:
+        input_fp8, input_scale = torch.ops.npu.npu_dynamic_block_quant(
+            input_2d,
+            dst_type=torch.float8_e4m3fn,
+            row_block_size=1,
+            col_block_size=128,
+        )
+        output_2d = torch.ops.npu.npu_quant_matmul(
+            input_fp8,
+            weight,
+            scale=weight_scale,
+            pertoken_scale=input_scale,
+            output_dtype=torch.bfloat16,
+            group_sizes=(1, 128, 128),
+        )
+
+    return output_2d.reshape(*original_shape[:-1], output_2d.shape[-1])
 
 
 class _NPULinearMethodBase(LinearMethodBase):

--- a/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
@@ -78,8 +78,6 @@ def fp8_matmul_npu(
     bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Run a [128, 128] block-FP8 linear layer on Ascend NPU."""
-    del input_scale, bias
-
     if block_size != [128, 128]:
         raise ValueError("fp8_matmul_npu only supports block_size == [128, 128]")
 
@@ -91,12 +89,18 @@ def fp8_matmul_npu(
             input_2d, weight, weight_scale, "bf16"
         )
     else:
-        input_fp8, input_scale = torch.ops.npu.npu_dynamic_block_quant(
-            input_2d,
-            dst_type=torch.float8_e4m3fn,
-            row_block_size=1,
-            col_block_size=128,
-        )
+        if input_scale is None:
+            input_fp8, input_scale = torch.ops.npu.npu_dynamic_block_quant(
+                input_2d,
+                dst_type=torch.float8_e4m3fn,
+                row_block_size=1,
+                col_block_size=128,
+            )
+        else:
+            input_fp8 = input_2d
+            input_scale = input_scale.reshape(
+                input_2d.shape[0], input_2d.shape[1] // 128
+            )
         output_2d = torch.ops.npu.npu_quant_matmul(
             input_fp8,
             weight,

--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -170,16 +170,8 @@ class NPUW8A8BlockFP8MoEMethod(_NPUMoEMethodBase):
             processed_weight = weight.data.transpose(1, 2)
             processed_scale = scale.data.transpose(1, 2)
 
-        setattr(
-            layer,
-            f"{weight_prefix}_weight",
-            torch.nn.Parameter(processed_weight, requires_grad=False),
-        )
-        setattr(
-            layer,
-            f"{weight_prefix}_weight_scale_inv",
-            torch.nn.Parameter(processed_scale, requires_grad=False),
-        )
+        weight.data = processed_weight
+        scale.data = processed_scale
 
         if weight_prefix == "w13":
             self._set_dispatcher_output_dtype(layer, "bf16")
@@ -221,6 +213,10 @@ class NPUW8A8BlockFP8MoEMethod(_NPUMoEMethodBase):
                 dst_type=torch.float8_e4m3fn,
                 row_block_size=1,
                 col_block_size=128,
+            )
+        elif pertoken_scale is not None:
+            pertoken_scale = pertoken_scale.reshape(
+                hidden_states.shape[0], hidden_states.shape[1] // 128
             )
 
         return self.matmul.forward(

--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -6,6 +6,7 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.utils import npu_format_cast
 from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
+from sglang.srt.utils import is_npu_before_atlas_a5
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -139,6 +140,100 @@ class _NPUMoEMethodBase(FusedMoEMethodBase):
         if bias is None:
             bias = getattr(quant_info, f"{weight_prefix}_weight_bias", None)
         return {"bias": [bias]} if bias is not None else {}
+
+
+# ---------------------------------------------------------------------------
+#  NPUW8A8BlockFP8MoEMethod
+# ---------------------------------------------------------------------------
+class NPUW8A8BlockFP8MoEMethod(_NPUMoEMethodBase):
+    """[128, 128] block-FP8 MoE kernel for Ascend NPU."""
+
+    def __init__(self):
+        super().__init__(quant_config=None)
+        self.matmul = GroupedMatmul()
+
+    def process_weights_after_loading(
+        self, layer: torch.nn.Module, weight_prefix: str
+    ) -> None:
+        self._validate_weight_prefix(layer, weight_prefix)
+
+        weight = getattr(layer, f"{weight_prefix}_weight")
+        scale = getattr(layer, f"{weight_prefix}_weight_scale_inv")
+
+        if is_npu_before_atlas_a5():
+            # Soft-FP8 kernels consume the raw E4M3 bit patterns as uint8.
+            processed_weight = (
+                weight.data.view(torch.uint8).transpose(1, 2).contiguous()
+            )
+            processed_scale = scale.data.transpose(1, 2).contiguous()
+        else:
+            processed_weight = weight.data.transpose(1, 2)
+            processed_scale = scale.data.transpose(1, 2)
+
+        setattr(
+            layer,
+            f"{weight_prefix}_weight",
+            torch.nn.Parameter(processed_weight, requires_grad=False),
+        )
+        setattr(
+            layer,
+            f"{weight_prefix}_weight_scale_inv",
+            torch.nn.Parameter(processed_scale, requires_grad=False),
+        )
+
+        if weight_prefix == "w13":
+            self._set_dispatcher_output_dtype(layer, "bf16")
+
+    def apply(
+        self,
+        quant_info: "AscendQuantInfo",
+        hidden_states: torch.Tensor,
+        expert_tokens: torch.Tensor,
+        pertoken_scale: Optional[torch.Tensor],
+        output_dtype: torch.dtype,
+        weight_prefix: str,
+        group_list_type: int,
+    ) -> torch.Tensor:
+        weight = getattr(quant_info, f"{weight_prefix}_weight")
+        weight_scale = getattr(quant_info, f"{weight_prefix}_weight_scale")
+        expert_tokens = expert_tokens.to(torch.int64)
+
+        if is_npu_before_atlas_a5():
+            if hidden_states.dtype != torch.bfloat16:
+                raise ValueError("Soft-FP8 MoE only supports bfloat16 activations")
+            if output_dtype != torch.bfloat16:
+                raise ValueError("Soft-FP8 MoE only supports bfloat16 output")
+            if pertoken_scale is not None:
+                raise ValueError("Soft-FP8 MoE does not accept activation scales")
+            if group_list_type == 1:
+                expert_tokens = expert_tokens.cumsum(dim=0)
+            return torch.ops.npu.softfp8_w8a16_grouped_matmul(
+                hidden_states,
+                weight,
+                weight_scale,
+                expert_tokens,
+                "bf16",
+            )
+
+        if pertoken_scale is None:
+            hidden_states, pertoken_scale = torch.ops.npu.npu_dynamic_block_quant(
+                hidden_states,
+                dst_type=torch.float8_e4m3fn,
+                row_block_size=1,
+                col_block_size=128,
+            )
+
+        return self.matmul.forward(
+            quant_info,
+            weight_prefix,
+            hidden_states,
+            expert_tokens,
+            output_dtype,
+            group_list_type=group_list_type,
+            transposed=True,
+            scale=[weight_scale],
+            per_token_scale=[pertoken_scale],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -362,6 +362,23 @@ class Fp8Config(QuantizationConfig):
 
             fp8_method = Fp8MoEMethod(self)
 
+            if (
+                _is_npu
+                and fp8_method.block_quant
+                and not fp8_method.use_mxfp8
+                and not fp8_method.is_fp4_expert
+            ):
+                if self.weight_block_size != [128, 128]:
+                    raise ValueError(
+                        "NPU block-FP8 MoE only supports weight_block_size=[128, 128]"
+                    )
+                from sglang.srt.hardware_backend.npu.quantization.moe_methods import (
+                    NPUW8A8BlockFP8MoEMethod,
+                )
+
+                layer.w13_kernel = NPUW8A8BlockFP8MoEMethod()
+                layer.w2_kernel = NPUW8A8BlockFP8MoEMethod()
+
             if self.is_fp4_experts and self.dequant_fp4_to_fp8:
                 assert (
                     get_moe_runner_backend().is_auto()
@@ -643,6 +660,13 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.weight_scale_inv = torch.nn.Parameter(
                 layer.weight_scale_inv.data, requires_grad=False
             )
+            return
+        elif _is_npu:
+            from sglang.srt.hardware_backend.npu.quantization.linear_method_npu import (
+                process_block_fp8_weight_npu,
+            )
+
+            process_block_fp8_weight_npu(layer)
             return
         else:
             # Requantize block scales to UE8M0 when DeepGEMM is the active runner.
@@ -1315,6 +1339,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w2_input_scale = None
 
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
+        if _is_npu and not self.use_mxfp8 and not self.is_fp4_expert:
+            layer.w13_kernel.process_weights_after_loading(layer, "w13")
+            layer.w2_kernel.process_weights_after_loading(layer, "w2")
+            return
+
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
             gu_intv = envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
@@ -2020,7 +2049,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 align_fp8_moe_weights_for_flashinfer_trtllm(layer)
 
         if hasattr(layer, "dispatcher"):
-            layer.dispatcher.set_quant_config({"weight_dtype": layer.w13_weight.dtype})
+            dispatcher_config = {"weight_dtype": layer.w13_weight.dtype}
+            if (
+                _is_npu
+                and self.block_quant
+                and not self.use_mxfp8
+                and not self.is_fp4_expert
+            ):
+                dispatcher_config["dispatcher_output_dtype"] = "bf16"
+            layer.dispatcher.set_quant_config(dispatcher_config)
 
     def process_weights_hip_int4(self, layer: Module):
         # TODO: _use_aiter: add after triton kernel added
@@ -2101,6 +2138,22 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
 
+        if (
+            _is_npu
+            and self.block_quant
+            and not self.use_mxfp8
+            and not self.is_fp4_expert
+        ):
+            moe_runner_config.layer = layer
+            if moe_runner_backend.is_auto():
+                moe_runner_backend = MoeRunnerBackend.ASCEND
+            if not moe_runner_backend.is_ascend():
+                raise ValueError(
+                    "NPU block-FP8 MoE requires the ascend MoE runner backend"
+                )
+            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            return
+
         if moe_runner_backend.is_auto():
             if self.is_deepgemm_moe_runner_backend_enabled():
                 moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
@@ -2157,6 +2210,24 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         x = dispatch_output.hidden_states
         moe_runner_config = self.moe_runner_config
+
+        if (
+            _is_npu
+            and self.block_quant
+            and not self.use_mxfp8
+            and not self.is_fp4_expert
+        ):
+            from sglang.srt.layers.moe.moe_runner.ascend import AscendQuantInfo
+
+            quant_info = AscendQuantInfo(
+                w13_weight=layer.w13_weight,
+                w2_weight=layer.w2_weight,
+                w13_weight_scale=layer.w13_weight_scale_inv,
+                w2_weight_scale=layer.w2_weight_scale_inv,
+                w13_weight_bias=getattr(layer, "w13_weight_bias", None),
+                w2_weight_bias=getattr(layer, "w2_weight_bias", None),
+            )
+            return self.runner.run(dispatch_output, quant_info)
 
         if use_intel_amx_backend(layer):
             from sglang.srt.layers.moe.topk import apply_topk_weights_cpu

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -48,6 +48,8 @@ from sglang.srt.utils import (
     is_gfx95_supported,
     is_hip,
     is_musa,
+    is_npu,
+    is_npu_before_atlas_a5,
     is_sm90_supported,
     is_sm100_supported,
     is_sm120_supported,
@@ -64,6 +66,7 @@ _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _is_gfx95_supported = is_gfx95_supported()
 _is_musa = is_musa()
+_is_npu = is_npu()
 
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
@@ -579,6 +582,12 @@ def _dispatch_auto_backend() -> Callable:
         return cutlass_w8a8_block_fp8_linear_with_fallback
     elif _use_aiter:
         return aiter_w8a8_block_fp8_linear
+    elif _is_npu:
+        from sglang.srt.hardware_backend.npu.quantization.linear_method_npu import (
+            fp8_matmul_npu,
+        )
+
+        return fp8_matmul_npu
     else:
         return triton_w8a8_block_fp8_linear
 
@@ -1372,6 +1381,34 @@ def block_quant_dequant(
     and the block size.
     The output is an unquantized tensor with dtype.
     """
+    if _is_npu and is_npu_before_atlas_a5():
+        # Older Ascend devices expose serialized E4M3FN values as raw bytes.
+        # Decode on CPU before applying the block scales.
+        x_uint8 = x_q_block.view(torch.uint8).cpu()
+        bits = x_uint8.to(torch.int32)
+        sign = (bits >> 7) & 0x1
+        exponent = (bits >> 3) & 0xF
+        mantissa = bits & 0x7
+
+        sign_value = torch.where(sign == 1, -1.0, 1.0).to(torch.float32)
+        normal = torch.ldexp(
+            1.0 + mantissa.to(torch.float32) / 8.0,
+            exponent.to(torch.int32) - 7,
+        )
+        subnormal = torch.ldexp(
+            mantissa.to(torch.float32) / 8.0,
+            torch.full_like(exponent, -6, dtype=torch.int32),
+        )
+        x_fp32 = torch.where(exponent == 0, subnormal, normal) * sign_value
+
+        block_n, block_k = block_size[0], block_size[1]
+        *_, n, k = x_q_block.shape
+        scale = x_s.cpu().repeat_interleave(block_n, dim=-2).repeat_interleave(
+            block_k, dim=-1
+        )
+        output = x_fp32 * scale[..., :n, :k].to(torch.float32)
+        return output.to(dtype=dtype, device=x_q_block.device)
+
     block_n, block_k = block_size[0], block_size[1]
     *_, n, k = x_q_block.shape
 

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -573,7 +573,7 @@ class DeepseekV2WeightLoaderMixin:
                         )
 
                     if (
-                        (_is_cuda or _is_musa or _is_xpu)
+                        (_is_cuda or _is_musa or _is_xpu or _is_npu)
                         and weight_block_size[0] == 128
                         and weight_block_size[1] == 128
                     ):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -186,6 +186,18 @@ def is_npu() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_npu_before_atlas_a5() -> bool:
+    """Return whether the current Ascend device predates the Atlas A5 series."""
+    if not hasattr(torch, "npu"):
+        return False
+
+    import torch_npu
+
+    device_name = torch_npu.npu.get_device_name(0)
+    return not device_name.startswith("Ascend950")
+
+
+@lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()
     return (


### PR DESCRIPTION
## Motivation

SGLang currently lacks Ascend NPU support for [128, 128] block-wise FP8 quantization in both linear and MoE layers. This format is different from the existing MXFP8 path and requires dedicated NPU weight layouts, activation quantization, and matmul kernels.
The previous MoE implementation was based on the legacy fused NPU MoE path and was no longer compatible with the refactored AscendRunner architecture. This PR updates the implementation to the latest main branch while preserving the required block-FP8 linear support.

## Modifications

- Add [128, 128] block-FP8 linear support for Ascend NPU
--.Use soft-FP8 W8A16 matmul on Ascend devices before Atlas A5.
-- Use dynamic block-FP8 activation quantization and W8A8 quantized matmul on Atlas A5.
-- Transpose block-FP8 weights and scales into the layouts expected by the NPU kernels.

- Add NPUW8A8BlockFP8MoEMethod for block-FP8 MoE execution.
-- Integrate with the refactored AscendRunner and GroupedMatmul components.
-- Dynamically quantize MoE activations on Atlas A5.
-- Preserve the soft-FP8 W8A16 fallback for older Ascend devices.
-- Reuse the common Ascend TP and DeepEP dispatch/combine pipeline.

- Register the Ascend runner and NPU-specific MoE kernels through the existing Fp8MoEMethod.
- Add device detection to distinguish Atlas A5 from earlier Ascend hardware.
- Support block-FP8 dequantization when loading DeepSeek MLA weights on NPU.
- Keep the existing MXFP8 implementation unchanged.

## Accuracy Tests

Tested with Qwen3-30B-A3B-FP8:
```sglang.test.run_eval with eval_name='gsm8k' instead.
metrics = run_eval(args)
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [05:19<00:00,  4.13it/s]
Accuracy: 0.898
Invalid: 0.000
Latency: 319.837 s
Output throughput: 528.966 token/s
metrics={'accuracy': np.float64(0.8976497346474602), 'invalid': np.float64(0.0), 'latency': 319.83706596, 'output_throughput': 528.9662081291061}
metrics['accuracy']=np.float64(0.8976497346474602)
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29810919747](https://github.com/sgl-project/sglang/actions/runs/29810919747)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29810919534](https://github.com/sgl-project/sglang/actions/runs/29810919534)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->