### PR TITLE
amd/deepseek_v4 integration 19/N fuse input_layernorm + FP8 per-128 group quant for attention path 0511

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -81,10 +81,11 @@ from sglang.srt.utils import (
     log_info_on_rank0,
     make_layers,
     maybe_torch_compile,
+    is_gfx95_supported,
+    is_hip,
 )
 
 logger = logging.getLogger(__name__)
-
 from sglang.srt.environ import envs
 
 MOE_BIT_WISE_EQUAL_MODE = False
@@ -92,8 +93,30 @@ ATTN_BIT_WISE_EQUAL_MODE = False
 COMPRESSOR_BIT_WISE_EQUAL_MODE = False
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 
-if _is_hip:
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
+_is_gfx95_supported = is_gfx95_supported()
+
+if _use_aiter:
     from aiter import rope_rotate_activation
+    if is_gfx95_supported():
+        from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
+
+
+def _fused_rmsnorm_fp8_quant(hidden_states, weight, eps):
+    x_quant, x_bf16, _, _ = fused_rms_fp8_group_quant(
+        hidden_states,
+        weight,
+        eps,
+        inp2=None,
+        inp2_weight=None,
+        inp2_epsilon=None,
+        group_size=128,
+        dtype_quant=torch.float8_e4m3fn,
+        res1=None,
+        output_unquantized_inp1=True,
+    )
+    return x_quant, x_bf16
+
 
 _FREQS_CIS_TO_COS_SIN: dict[
     Tuple[int, torch.dtype, torch.device], Tuple[torch.Tensor, torch.Tensor]
@@ -1642,9 +1665,10 @@ class MQALayer(nn.Module):
         attn_backend: DeepseekV4Backend,
         freqs_cis: Optional[torch.Tensor] = None,
         q_out: Optional[torch.Tensor] = None,
+        x_quant=None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # [bs, q_lora_rank]
-        q, _ = self.wq_a(x)
+        # fp8 tuple: Fp8LinearMethod.apply handles isinstance(x, tuple), skips per1x128 quant
+        q, _ = self.wq_a(x_quant if x_quant is not None else x)
         # [bs, q_lora_rank]
         q = self.q_norm(q)
         q_lora = q  # only used for indexer
@@ -1654,9 +1678,8 @@ class MQALayer(nn.Module):
         # [bs, n_local_heads, head_dim]
         q = rms_normalize_triton(q, self.eps)
 
-        # [bs, head_dim]
-        kv, _ = self.wkv(x)
-        # [bs, head_dim]
+        # fp8 tuple: same as wq_a
+        kv, _ = self.wkv(x_quant if x_quant is not None else x)
         kv = self.kv_norm(kv)
 
         fused_rope(
@@ -1694,6 +1717,7 @@ class MQALayer(nn.Module):
                 forward_batch=forward_batch,
             )
 
+        # indexer/compressor: bf16 only (linear_bf16_fp32 needs .dtype)
         if self.indexer is not None:
             self.indexer(
                 x=x,
@@ -1716,6 +1740,7 @@ class MQALayer(nn.Module):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         debug_return_kv: bool = False,
+        x_quant=None,
     ) -> torch.Tensor:
         if not get_attn_tp_context().input_scattered and x.shape[0] == 0:
             assert (
@@ -1751,7 +1776,8 @@ class MQALayer(nn.Module):
             )
         else:
             q, kv = self._forward_prepare(
-                x, positions, forward_batch, attn_backend, freqs_cis, q_out
+                x, positions, forward_batch, attn_backend, freqs_cis, q_out,
+                x_quant=x_quant,
             )
 
         # for TP attention, use the padded q, since q_out is set to the correct slice
@@ -2045,12 +2071,21 @@ class DeepseekV4DecoderLayer(nn.Module):
         hidden_states, post, comb = self.hc_pre(
             hidden_states, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
         )  # -> [n, d]
-        hidden_states = self.input_layernorm(hidden_states)
+        if _use_aiter and _is_gfx95_supported:
+            x_quant, hidden_states = _fused_rmsnorm_fp8_quant(
+                hidden_states,
+                self.input_layernorm.weight,
+                self.input_layernorm.variance_epsilon,
+            )
+        else:
+            x_quant = None
+            hidden_states = self.input_layernorm(hidden_states)
 
         hidden_states = self.self_attn(
             x=hidden_states,
             positions=positions,
             forward_batch=forward_batch,
+            x_quant=x_quant,
         )
 
         hidden_states = self.hc_post(hidden_states, residual, post, comb)


### PR DESCRIPTION
## Motivation

Update amd/deepseek_v4 integration branch

Following PRs have large set of conflict, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608


Fuse RMSNorm + per-128 FP8 group quantization into a single kernel (`fused_rms_fp8_group_quant`) for the `input_layernorm` → attention path in `DeepseekV4DecoderLayer`. On gfx950 (MI355) with `SGLANG_USE_AITER=1`, this eliminates 2 redundant `dynamic_per_group_scaled_quant_kernel` calls per layer (`wq_a` and `wkv`), saving ~90 quant kernel launches across 45 layers.

The fused kernel produces both an FP8 tuple `(data, scale)` for FP8 linear layers and a BF16 output for compressor/indexer consumers. `Fp8LinearMethod.apply()` already handles `isinstance(x, tuple)` to skip internal quantization.

### Consumer compatibility

| Consumer | Accepts FP8 tuple? | Reason |
|---|---|---|
| `wq_a` / `wkv` | Yes | `Fp8LinearMethod.apply` has `isinstance(x, tuple)` → uses `x[0]` + `x[1]` directly, skips `per1x128_quant` |
| `indexer` | No | Calls `linear_bf16_fp32(x, w)` internally → accesses `x.dtype`, tuple has no `.dtype` |
| `compressor` | No | Same as indexer |
| `cp_all_gather` | No | Calls `x.contiguous()`, tuple has no `.contiguous()` |

## Modifications

- **Module-level gating** (`deepseek_v4.py`): Compute `_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()` and `_is_gfx95_supported = is_gfx95_supported()` once at module top. Import `fused_rms_fp8_group_quant` inside nested `if _use_aiter:` / `if is_gfx95_supported():` gate.
- **Helper function** `_fused_rmsnorm_fp8_quant(hidden_states, weight, eps)`: Wraps `fused_rms_fp8_group_quant` call with `group_size=128, dtype_quant=torch.float8_e4m3fn`, returns `(x_quant, x_bf16)`.
- **`DeepseekV4DecoderLayer.forward()`**: Conditional path — when `_use_aiter and _is_gfx95_supported`, calls fused kernel and passes `x_quant` as optional kwarg to `self.self_attn()`. Otherwise falls back to `self.input_layernorm(hidden_states)` with `x_quant=None`.
- **`MQALayer.forward()` / `_forward_prepare()`**: Added `x_quant=None` optional kwarg. At the `wq_a` and `wkv` call sites, uses `x_quant if x_quant is not None else x` inline — no variable reassignment, original `x` stays available for compressor/indexer/cp_all_gather consumers.

## Accuracy Tests

GSM8K 5-shot, 2000 questions, parallel 1000:

```
Accuracy: 0.909
Invalid: 0.003
Latency: 412.603 s
Output throughput: 311.765 token/s
```

## Speed Tests and Profiling

Profiling confirms the fused kernel activates correctly:
- `fused_rms_fp8_group_quant` kernel appears ~305 times in trace (once per layer per forward)
- `dynamic_per_group_scaled_quant_kernel` count drops from 2,376 → 1,370 (~1,006 calls eliminated)
- Remaining quant calls are from: `post_attention_layernorm` → MoE path (out of scope, follow-up), `q_norm`/`kv_norm`, and `wq_b`/`wo_b`/shared experts (not fed by `input_layernorm`)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
