### PR TITLE
Fix FA3 cross-attention batched-decode for per-request varlen encoder

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -547,28 +547,37 @@ class FlashAttentionBackend(AttentionBackend):
             if forward_batch.forward_mode == ForwardMode.EXTEND:
                 self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
 
-        # Encoder metadata for cross attention
+        # Encoder metadata for cross attention. Supports per-request varlen
+        # encoder lengths (e.g. MossVL with different image sizes per request).
         if forward_batch.encoder_lens is not None:
-            assert (
-                forward_batch.encoder_lens.numel() == 1
-            ), "Only encoder size 1 is supported for now"
-
             metadata.encoder_lens_int32 = forward_batch.encoder_lens.to(torch.int32)
             metadata.encoder_cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(metadata.encoder_lens_int32, dim=0, dtype=torch.int32),
                 (1, 0),
             )
             metadata.encoder_max_seq_len_k = metadata.encoder_lens_int32.max().item()
+
+            # Cross-attn page_table: per-request rows. cache_seqlens
+            # (encoder_lens_int32) caps per-request reads so any garbage past
+            # encoder_lens[i] is never consumed.
             metadata.encoder_page_table = self.req_to_token_pool.req_to_token[
                 forward_batch.req_pool_indices, : metadata.encoder_max_seq_len_k
             ]
 
-            # Currently only support forward_batch.encoder_lens.numel() == 1
+            # Self-attn (text) page_table: text starts at per-request offset
+            # encoder_lens[i], NOT at a single max. Use a fancy-index gather.
+            text_max = metadata.max_seq_len_k
+            arange_text = torch.arange(
+                text_max, device=forward_batch.req_pool_indices.device
+            )
+            text_col = forward_batch.encoder_lens.long().unsqueeze(
+                1
+            ) + arange_text.unsqueeze(
+                0
+            )  # (bs, max_seq_len_k)
+            text_row = forward_batch.req_pool_indices.unsqueeze(1).expand(-1, text_max)
             metadata.page_table = self.req_to_token_pool.req_to_token[
-                forward_batch.req_pool_indices,
-                metadata.encoder_max_seq_len_k : (
-                    metadata.encoder_max_seq_len_k + metadata.max_seq_len_k
-                ),
+                text_row, text_col
             ]
 
         if self.use_sliding_window_kv_pool:
@@ -2312,25 +2321,25 @@ class FlashAttentionBackend(AttentionBackend):
             metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
 
         if encoder_lens is not None:
-            # Only support encoder size 1 for now
-            metadata.encoder_max_seq_len_k = encoder_lens[0]
-            metadata.encoder_lens_int32.copy_(encoder_lens[:1])
-            metadata.encoder_cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.encoder_lens_int32, dim=0, dtype=torch.int32)
+            # Per-request varlen encoder support (e.g. MossVL different images).
+            metadata.encoder_max_seq_len_k = int(encoder_lens.max().item())
+            metadata.encoder_lens_int32[:bs].copy_(encoder_lens[:bs].to(torch.int32))
+            metadata.encoder_cu_seqlens_k[1 : bs + 1].copy_(
+                torch.cumsum(metadata.encoder_lens_int32[:bs], dim=0, dtype=torch.int32)
             )
 
-            metadata.encoder_page_table[:, : metadata.encoder_max_seq_len_k].copy_(
+            metadata.encoder_page_table[:bs, : metadata.encoder_max_seq_len_k].copy_(
                 self.req_to_token[req_pool_indices, : metadata.encoder_max_seq_len_k]
             )
 
-            # Update the regular page table
-            page_table = self.req_to_token[
-                req_pool_indices,
-                metadata.encoder_max_seq_len_k : (
-                    metadata.encoder_max_seq_len_k + metadata.max_seq_len_k
-                ),
-            ]
-            metadata.page_table[:, : metadata.max_seq_len_k].copy_(page_table)
+            # Self-attn (text) page_table: per-request offset = encoder_lens[i].
+            text_max = metadata.max_seq_len_k
+            arange_text = torch.arange(text_max, device=req_pool_indices.device)
+            text_col = encoder_lens[:bs].long().unsqueeze(1) + arange_text.unsqueeze(0)
+            text_row = req_pool_indices.unsqueeze(1).expand(-1, text_max)
+            metadata.page_table[:bs, :text_max].copy_(
+                self.req_to_token[text_row, text_col]
+            )
 
         self.forward_metadata = metadata
         self.forward_metadata_spec_decode_expand = metadata_expand


### PR DESCRIPTION
## Motivation

The FA3 attention backend's cross-attention metadata builder only supports `encoder_lens.numel() == 1` (asserted in the non-cuda-graph path) and reuses `encoder_lens[0]` for the entire batch in the cuda-graph replay path. For multimodal encoder-decoder models that mix requests with **different encoder lengths in one batch** (e.g. MossVL with different images per request), only request 0 gets correct cross-attention; the rest read scrambled KV cache slots and produce garbage tokens.

This is observable in batched RL rollouts: a `geo3k`-style benchmark on MossVL with diverse image sizes shows 0/12/28/36/25% garbage outputs at bs = 4/8/32/64/128.

## Modifications

`python/sglang/srt/layers/attention/flashattention_backend.py`, two places:

1. **`init_forward_metadata`** (non cuda-graph path)
   - Drop the `assert encoder_lens.numel() == 1` and the `# Currently only support ...` comment.
   - Build the self-attn (text) `page_table` with a **per-request** offset `encoder_lens[i]` via fancy indexing, instead of using a single global `encoder_max_seq_len_k` offset for all rows.

2. **`init_forward_metadata_replay_cuda_graph`** (cuda-graph replay path)
   - `encoder_max_seq_len_k = encoder_lens.max().item()` (was `encoder_lens[0]`).
   - Copy the full `encoder_lens[:bs]` into the int32 / cu_seqlens buffers (was `encoder_lens[:1]`).
   - Build the self-attn (text) `page_table` with a per-request offset via the same fancy-index gather.

The `flashinfer` backend already handles per-request varlen encoder via `create_flashinfer_kv_indices_triton` and is not affected.

## Accuracy Tests

Minimal reproducer: a MossVL server with diverse-image batched requests.

```
python3 -m sglang.launch_server --model-path Moss-VL-8B-Instruct \
    --tp 1 --dp 1 --trust-remote-code \
    --prefill-attention-backend flashinfer \
    --decode-attention-backend fa3 \
    --skip-server-warmup
```

Firing N concurrent requests via `/generate` (each with a different image and a math-reasoning prompt) and classifying outputs by a simple garbage heuristic (≥ 20 repeated chars / `YouYouYou` / `MUST MUST MUST` / low alpha ratio):

| bs | before | after this PR | flashinfer (decode) |
|---:|---:|---:|---:|
| 8 | 12% garbage | **0%** | 0% |
| 32 | 28% garbage | **0%** | 0% |
| 64 | 36% garbage | **0%** | 0% |
| 128 | 25% garbage | **0%** | 0% |

## Speed Tests and Profiling

No measurable change. The two new fancy-index gathers replace single-slice gathers and run on the same device with the same total element count; both metadata builders are O(bs) work that happens once per forward, dominated by the much larger attention kernels that follow.

## Checklist

- [x] Format your code according to the Format code with pre-commit (isort / ruff / black / codespell all clean).
- [ ] Add unit tests according to the Run and add unit tests (no existing unit test covers cross-attn varlen encoder; happy to add one in a follow-up if requested — see Accuracy Tests section for a reproducer).
- [ ] Update documentation
- [x] Provide accuracy and speed benchmark results (above).
- [x] Follow the SGLang code style guidance.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26400174743](https://github.com/sgl-project/sglang/actions/runs/26400174743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26400174685](https://github.com/sgl-project/sglang/actions/runs/26400174685)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->