### PR TITLE
[Rerank] Early-exit logprob scan and hoist math import

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_rerank.py
+++ b/python/sglang/srt/entrypoints/openai/serving_rerank.py
@@ -1,5 +1,6 @@
 import heapq
 import logging
+import math
 from typing import Any, Dict, List, Optional, Union
 
 from fastapi import Request
@@ -533,8 +534,6 @@ class OpenAIServingRerank(OpenAIServingBase):
 
     def _extract_score_from_logprobs(self, ret: Dict[str, Any]) -> float:
         """Extract reranking score from generation response with logprobs."""
-        import math
-
         # Get logprobs from the response
         meta_info = ret.get("meta_info", {})
         output_top_logprobs = meta_info.get("output_top_logprobs", [])
@@ -546,13 +545,19 @@ class OpenAIServingRerank(OpenAIServingBase):
         # Format: list of tuples (logprob, token_id, token_text)
         p_yes = 0.0
         p_no = 0.0
+        found_yes = False
+        found_no = False
 
         for item in top_logprobs:
             logprob, token_id = item[0], item[1]
             if token_id == self._yes_token_id:
                 p_yes = math.exp(logprob)
+                found_yes = True
             elif token_id == self._no_token_id:
                 p_no = math.exp(logprob)
+                found_no = True
+            if found_yes and found_no:
+                break
 
         return _qwen3_rerank_score(p_yes, p_no)
 


### PR DESCRIPTION
## Motivation

OpenAIServingRerank._extract_score_from_logprobs scans every entry of output_top_logprobs[0] (default 50 entries when top_logprobs_num=50 is set in the VL reranker path) even after both the yes and no token IDs have been matched. The function is called once per document on the
  Qwen3-VL reranker path, so for a 100-document rerank request that's ~100× the unnecessary iterations. Two small wins available: short-circuit the loop once both targets are found, and hoist the per-call import math to module scope.

## Modifications

python/sglang/srt/entrypoints/openai/serving_rerank.py:
  - Move import math from inside _extract_score_from_logprobs to the module-level import block.
  - Track found_yes / found_no flags inside the scan loop and break once both are set.         
                                                                                                                                                                                                                                                                                            No public API change, no behavior change on the returned score — the loop terminates after producing the same p_yes/p_no it would have produced previously (subsequent entries cannot reassign either, since the IDs are unique).

## Accuracy Tests

Not applicable — the function still returns the same _qwen3_rerank_score(p_yes, p_no) for any given logprobs input. No model outputs or kernel paths touched.

## Speed Tests and Profiling

Not separately benchmarked end-to-end: the saving is bounded by top_logprobs_num (default 50) per document and is off the GPU critical path. The change is a strict reduction in CPU work on the rerank response-assembly path — it cannot make anything slower.     

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
