### PR TITLE
[AMD] Forward-merge cache-dit==1.3.0 pin onto amd/deepseek_v4 (cherry-pick #24924)

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -110,7 +110,7 @@ diffusion_hip = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer>=0.15.5",
-  "cache-dit==1.1.8",
+  "cache-dit==1.3.0",
   "addict",
 ]
 

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -103,7 +103,7 @@ diffusion_hip = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer>=0.15.5",
-  "cache-dit==1.1.8",
+  "cache-dit==1.3.0",
 ]
 
 # For Intel Gaudi(device : hpu) follow the installation guide

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -169,7 +169,7 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache pytest
 
   # Install cache-dit for qwen_image_t2i_cache_dit_enabled test (added in PR 16204)
-  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache cache-dit || echo "cache-dit installation failed"
+  docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade 'cache-dit==1.3.0' || echo "cache-dit installation failed"
 
   # Install accelerate for distributed training and inference support
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache accelerate || echo "accelerate installation failed"


### PR DESCRIPTION
## Summary

Cherry-pick of [#24924](https://github.com/sgl-project/sglang/pull/24924) (commit [`aeb8fefc25`](https://github.com/sgl-project/sglang/commit/aeb8fefc25ae9b75ac07d74bc399c6e26ab4ff67)) onto `amd/deepseek_v4`. Same 3 files, same 3-line diff, no conflicts. Author preserved.

## Why

`release-docker-amd-rocm720-nightly.yml` → `publish_dsv4 (gfx942-rocm720)` and `publish_dsv4 (gfx950-rocm720)` have been failing since 2026-05-11 with:

```
NameError: name 'bare_metal_version' is not defined
```

at `fast-hadamard-transform/setup.py:115` during the `[stage-4 22/27]` step of `docker/rocm.Dockerfile`.

Root cause (per amd-bot CI Daily Report [#68](https://github.com/bingxche/sglang-ci-bot/issues/68), cluster R20): `cache-dit==1.1.8` is still pinned on `amd/deepseek_v4`. During `[stage-4 14/27]` (`pip install -e "python[all_hip]"`), pip's resolver backtracks against the `diffusers==0.37.0` pin in `python/pyproject_other.toml`, then upgrades torch to the upstream **CUDA** wheel `torch-2.11.0+cu130`, uninstalling the pre-installed ROCm wheel `torch 2.9.1+rocm7.2.0.lw.git7e1940d4`. The follow-on FHT install (which uses `nvcc` detection) then crashes on this ROCm-only image.

The `Hot patch torch-ROCm` block in the Dockerfile runs at step 26/27 — **after** the FHT install at 22/27 — so it cannot save the build. PR [#24924](https://github.com/sgl-project/sglang/pull/24924) fixed this on `main` by pinning `cache-dit==1.3.0` (whose looser `diffusers>=0.36.0` no longer forces a torch re-resolution). The fix needs to be forward-merged into `amd/deepseek_v4`.

## A/B evidence

In the same workflow run [25671736869](https://github.com/sgl-project/sglang/actions/runs/25671736869):

- ❌ `publish_dsv4 (gfx950-rocm720)` — built from `amd/deepseek_v4` (`cache-dit==1.1.8`) → torch upgraded to `2.11.0+cu130` → FHT `NameError`.
- ✅ `publish (gfx950-rocm720)` — built from `main` (`cache-dit==1.3.0` after [#24924](https://github.com/sgl-project/sglang/pull/24924)) → `Requirement already satisfied: torch>=2.7.1 ... (2.9.1+rocm7.2.0.lw.git7e1940d4)`, no backtracking, FHT installs cleanly.

## Diff

- `python/pyproject_other.toml:106` — `cache-dit==1.1.8` → `cache-dit==1.3.0`
- `3rdparty/amd/wheel/sglang/pyproject.toml:113` — `cache-dit==1.1.8` → `cache-dit==1.3.0`
- `scripts/ci/amd/amd_ci_install_dependency.sh:172` — `pip install ... cache-dit` → `pip install ... --upgrade 'cache-dit==1.3.0'`

## Test plan

- [ ] Manually trigger `release-docker-amd-rocm720-nightly.yml` via `workflow_dispatch` after merge; confirm both `publish_dsv4 (gfx942-rocm720)` and `publish_dsv4 (gfx950-rocm720)` reach the end of stage-4 (FHT step prints `torch.__version__ = 2.9.1+rocm7.2.0...`).
- [ ] Verify `multimodal-gen-test-1-gpu-amd` no longer reports `AttributeError: ParallelismBackend.AUTO` in subsequent `pr-test-amd` runs (cluster R32 in [#68](https://github.com/bingxche/sglang-ci-bot/issues/68)).

## Follow-ups (out of scope)

Per the bot's "defense in depth" recommendation, moving the `TORCH_ROCM_FILE` hot-patch in `docker/rocm.Dockerfile` to run immediately after `pip install -e "python[all_hip]"` (instead of at step 26/27) would harden the build against future pip-resolver torch upgrades. Tracking separately.