### PR TITLE
[AMD] Diffusion test: per-case wait_deadline + harden port-free teardown

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -635,6 +635,13 @@ TWO_GPU_CASES = [
                 "--pipeline-class-name LTX2TwoStagePipeline",
                 "--component-attention-backends transformer=fa",
             ],
+            # Two-stage LTX-2.3 cold-start has been observed running close to the
+            # default 1200s budget on the AMD MI325 runner; intermittent boots
+            # that overrun caused the test to time out and leak the HTTP +
+            # scheduler ports into follow-on tests in the same shard (CI R31
+            # cluster). Give the boot a 2x budget so a slow-but-healthy run can
+            # complete instead of cascading port-unavailable errors.
+            startup_wait_secs=2400.0,
         ),
         DiffusionSamplingParams(prompt=T2V_PROMPT, extras={"seed": 42}),
         run_component_accuracy_check=False,

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -128,7 +128,14 @@ def diffusion_server(case: DiffusionTestCase) -> ServerContext:
     env_vars.update(server_args.env_vars)
 
     # start server
-    wait_deadline = float(os.environ.get("SGLANG_TEST_WAIT_SECS", "1200"))
+    # Per-case override (set on DiffusionServerArgs) takes precedence over the
+    # env var so a single slow model can have a longer budget without bumping
+    # every other case in the shard. Falls back to $SGLANG_TEST_WAIT_SECS or
+    # the historical default of 1200s.
+    if server_args.startup_wait_secs is not None:
+        wait_deadline = float(server_args.startup_wait_secs)
+    else:
+        wait_deadline = float(os.environ.get("SGLANG_TEST_WAIT_SECS", "1200"))
     logger.info(
         "[server-test] Starting server for test case: %s\n"
         "  Model: %s\n"

--- a/python/sglang/multimodal_gen/test/server/test_server_utils.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_utils.py
@@ -14,15 +14,19 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Iterable, Sequence
 from urllib.request import urlopen
 
+import psutil
 import pytest
 from openai import Client
 
 from sglang.multimodal_gen.benchmarks.compare_perf import calculate_upper_bound
 from sglang.multimodal_gen.runtime.platforms import current_platform
-from sglang.multimodal_gen.runtime.utils.common import kill_process_tree
+from sglang.multimodal_gen.runtime.utils.common import (
+    is_port_available,
+    kill_process_tree,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     globally_suppress_loggers,
     init_logger,
@@ -53,6 +57,67 @@ globally_suppress_loggers()
 # Tracks mesh output file paths from generate_mesh for later correctness validation.
 # Keyed by case_id, cleaned up after use.
 MESH_OUTPUT_PATHS: dict[str, str] = {}
+
+# Default sglang scheduler-port window used by ServerArgs._adjust_network_ports
+# (default scheduler_port=5555, jittered by random.randint(0, 100)). Any port in
+# this range may still be held by a lingering scheduler subprocess after a
+# previous test's teardown, which causes the next --strict-ports test in the
+# same shard to fail with `Scheduler port <N> is unavailable` before any test
+# code runs. We probe / reclaim this range as part of ServerContext.cleanup.
+_DEFAULT_SCHEDULER_PORT_RANGE: range = range(5555, 5656)
+
+
+def _force_kill_listeners_on_ports(ports: Iterable[int]) -> list[int]:
+    """Best-effort: kill any process holding a LISTEN socket on one of *ports*.
+
+    Returns the list of pids that were sent SIGKILL. Silently ignores permission
+    errors (psutil.net_connections needs root on some platforms) since this is a
+    last-resort fallback before bubbling up to the next test.
+    """
+    port_set = set(ports)
+    killed: list[int] = []
+    try:
+        connections = psutil.net_connections(kind="inet")
+    except (psutil.AccessDenied, PermissionError) as exc:
+        logger.debug(
+            "[server-test cleanup] psutil.net_connections denied: %s; "
+            "skipping listener sweep.",
+            exc,
+        )
+        return killed
+
+    for conn in connections:
+        if conn.status != psutil.CONN_LISTEN:
+            continue
+        if not conn.laddr or conn.laddr.port not in port_set:
+            continue
+        if not conn.pid:
+            continue
+        try:
+            proc = psutil.Process(conn.pid)
+            cmdline = " ".join(proc.cmdline()[:5])
+            proc.kill()
+            killed.append(conn.pid)
+            logger.warning(
+                "[server-test cleanup] Force-killed pid=%d holding port %d "
+                "after parent teardown (cmdline=%s ...)",
+                conn.pid,
+                conn.laddr.port,
+                cmdline,
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return killed
+
+
+def _wait_for_port_free(port: int, timeout: float) -> bool:
+    """Poll for *port* to become bind-able. Returns True if released in time."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if is_port_available(port):
+            return True
+        time.sleep(1)
+    return is_port_available(port)
 
 
 def _urlopen_with_retry(url: str, timeout: int = 30, max_retries: int = 3) -> bytes:
@@ -181,6 +246,51 @@ class ServerContext:
             self._cleanup_hf_cache_if_not_persistent()
         else:
             # Give the runtime a brief cooldown after server shutdown.
+            time.sleep(2)
+
+        # Make sure the HTTP and scheduler ports are actually released before
+        # the next --strict-ports test in this shard starts. kill_process_tree
+        # generally handles this, but a worker that escaped its process group
+        # (or a socket still in the kernel's release path) can leak the listen
+        # port and cascade-fail every subsequent test in the rerun shard. See
+        # CI R31 (LTX-2.3 two-stage 2gpus -> port 21000/5555 cascade).
+        self._wait_for_tracked_ports_free()
+
+    def _wait_for_tracked_ports_free(self) -> None:
+        """Block until self.port + scheduler-port window are released."""
+        # 60s covers both the typical TIME_WAIT delay and any race between
+        # kill_process_tree and the OS socket teardown. If a process is still
+        # holding the port after that, it's almost certainly a detached
+        # grandchild that we need to reap explicitly.
+        primary_timeout = 60.0
+        if not _wait_for_port_free(self.port, primary_timeout):
+            killed = _force_kill_listeners_on_ports([self.port])
+            if killed:
+                logger.warning(
+                    "[server-test cleanup] HTTP port %d was still held after "
+                    "%.0fs; force-killed pids=%s.",
+                    self.port,
+                    primary_timeout,
+                    killed,
+                )
+            # Give the OS another short window to flush the kernel state.
+            if not _wait_for_port_free(self.port, 15.0):
+                logger.warning(
+                    "[server-test cleanup] HTTP port %d still busy after "
+                    "force-kill; the next test may hit --strict-ports.",
+                    self.port,
+                )
+
+        # Scheduler subprocesses (default port window 5555..5655) sometimes
+        # outlive the parent server, so we sweep listeners in that window once
+        # and rely on the OS to release the sockets quickly afterwards.
+        scheduler_killed = _force_kill_listeners_on_ports(_DEFAULT_SCHEDULER_PORT_RANGE)
+        if scheduler_killed:
+            logger.warning(
+                "[server-test cleanup] Reaped %d lingering scheduler "
+                "subprocess(es) in the 5555-5655 window.",
+                len(scheduler_killed),
+            )
             time.sleep(2)
 
     def _cleanup_hf_cache_if_not_persistent(self) -> None:

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -188,6 +188,13 @@ class DiffusionServerArgs:
     text_encoder_cpu_offload: bool = False
     enable_warmup: bool = True
 
+    # Per-case override for how long we wait for the server to become ready.
+    # When None, the test harness falls back to $SGLANG_TEST_WAIT_SECS or its
+    # default. Use this for models whose cold-start consistently runs close to
+    # the default budget (e.g. LTX-2.3 two-stage on AMD), so a single slow boot
+    # doesn't leak the listening port into the next test in the shard.
+    startup_wait_secs: float | None = None
+
     extras: list[str] = field(default_factory=lambda: [])
     env_vars: dict[str, str] = field(default_factory=dict)
 


### PR DESCRIPTION
## Summary

Fixes CI cluster **R31** in [amd-bot/sglang-ci-bot#68](https://github.com/bingxche/sglang-ci-bot/issues/68): `test_diffusion_generation[ltx_2.3_two_stage_t2v_2gpus]` intermittently exceeds the 1200s server-startup budget on `linux-mi325-2gpu-sglang`, then leaks both the HTTP port (21000) and the scheduler-port window (5555..5655) into every follow-on test in the same `pr-test-amd` shard. A single slow boot cascaded into 4 ERRORs + a failed rerun shard on 2026-05-11.

## Evidence — from job [75423698561](https://github.com/sgl-project/sglang/actions/runs/25690010272/job/75423698561) (run [25690010272](https://github.com/sgl-project/sglang/actions/runs/25690010272), shard 0)

```
19:31:02  ltx_2.3_two_stage_t2v_2gpus      sglang serve ... --port 21000 --strict-ports ...
19:51:02  (1200s wait_deadline expires → TimeoutError → ctx.cleanup → kill_process_tree)
19:52:03  wan2_1_i2v_14b_720P_2gpu        sglang serve ... --port 21000 --strict-ports ...
19:52:17  RuntimeError: Scheduler port 5555 is unavailable and --strict-ports is enabled.
19:53:20  zimage_image_t2i_2_gpus         ...
19:53:40  RuntimeError: Scheduler port 5555 is unavailable ...
19:54:55  RuntimeError: HTTP port 21000 is unavailable ...
19:56:08  RuntimeError: HTTP port 21000 is unavailable ...
# rerun shard, same cascade:
19:57:42  RuntimeError: HTTP port 21000 is unavailable ...
19:58:54  RuntimeError: HTTP port 21000 is unavailable ...
20:00:06  RuntimeError: HTTP port 21000 is unavailable ...
```

So the actual cascade is **two** ports, not just 21000: an orphaned scheduler subprocess holds port 5555 for the first ~2 minutes, then the leaked HTTP listener holds port 21000 indefinitely. \`kill_process_tree\` reaches the main \`sglang serve\` process but a worker/scheduler subprocess that escaped its process group survives and keeps the listening socket open across teardown.

## Fix (two parts)

### 1. Per-case \`startup_wait_secs\` override

Add an optional \`startup_wait_secs\` field to \`DiffusionServerArgs\` and bump the LTX-2.3 two-stage case to \`2400.0\`. \`test_server_common.py\` prefers the per-case value, then \`\$SGLANG_TEST_WAIT_SECS\`, then the historical 1200s default — so a single slow model gets a longer budget without bumping the rest of the shard.

\`\`\`python
# python/sglang/multimodal_gen/test/server/testcase_configs.py
startup_wait_secs: float | None = None  # new field on DiffusionServerArgs

# python/sglang/multimodal_gen/test/server/gpu_cases.py
DiffusionTestCase(\"ltx_2.3_two_stage_t2v_2gpus\", DiffusionServerArgs(
    ...,
    startup_wait_secs=2400.0,
))

# python/sglang/multimodal_gen/test/server/test_server_common.py
if server_args.startup_wait_secs is not None:
    wait_deadline = float(server_args.startup_wait_secs)
else:
    wait_deadline = float(os.environ.get(\"SGLANG_TEST_WAIT_SECS\", \"1200\"))
\`\`\`

### 2. Harden \`ServerContext.cleanup\` to wait for tracked ports

After \`kill_process_tree\`, block until \`self.port\` (HTTP) becomes bind-able (up to 60s). If it doesn't, sweep \`psutil.net_connections\` for LISTEN sockets in \`{self.port} ∪ [5555, 5656)\` and \`SIGKILL\` any pid that still holds them — covers detached grandchild workers that escape the process tree. One extra 15s window covers the kernel socket-release race. Permission errors from \`psutil.net_connections\` are swallowed (test-only safeguard; degrades gracefully).

\`\`\`python
# python/sglang/multimodal_gen/test/server/test_server_utils.py
def cleanup(self):
    kill_process_tree(self.process.pid)
    ...
    self._wait_for_tracked_ports_free()  # new

def _wait_for_tracked_ports_free(self):
    if not _wait_for_port_free(self.port, 60.0):
        _force_kill_listeners_on_ports([self.port])
        _wait_for_port_free(self.port, 15.0)
    _force_kill_listeners_on_ports(range(5555, 5656))
\`\`\`

## Why this set of changes (and nothing more)

- The teardown-side fix is broadly applicable to **every** diffusion 1/2/4/8-GPU test in this suite — it converts a fragile failure mode (orphan listener → cascade) into a contained one (single slow test fails alone), so no other case will silently regress because of this same bug class.
- The per-case \`wait_deadline\` knob is a more conservative alternative than bumping the global \`SGLANG_TEST_WAIT_SECS=2400\` — only LTX-2.3 two-stage actually needs it, and the other 10 cases in this shard should keep failing fast if they regress.
- No production runtime code is changed; psutil and \`is_port_available\` are existing dependencies (\`runtime/utils/common.py\`).

## Out-of-scope follow-ups

- Underlying root cause (which sglang subprocess escapes the process group during early-boot kill) — needs a separate investigation; this PR contains the blast radius in the meantime.
- A similar \`startup_wait_secs\` budget bump could be considered for any other case that has shown \`Server not ready within 1200s\` more than once.

## Test plan

- [ ] Trigger \`pr-test-amd.yml\` on this PR; confirm \`multimodal-gen-test-2-gpu-amd (linux-mi325-2gpu-sglang, 0)\` either:
  - (a) passes \`ltx_2.3_two_stage_t2v_2gpus\` outright (new 2400s budget gives the LoRA-apply phase enough headroom), **or**
  - (b) if \`ltx_2.3_two_stage_t2v_2gpus\` still times out (>2400s — likely a real regression worth investigating), the **subsequent** tests in the same shard (\`wan2_1_i2v_14b_720P_2gpu\`, \`zimage_image_t2i_2_gpus\`, \`flux_image_t2i_2_gpus\`) start cleanly instead of failing on \`Scheduler port 5555 is unavailable\` / \`HTTP port 21000 is unavailable\`.
- [ ] Spot-check the cleanup logs for \`[server-test cleanup]\` messages — the warnings are intentionally explicit so future cascade incidents can be diagnosed from a single line in the CI log.