### PR TITLE
[Fix] MiniCPM-V 4.6: skip legacy minicpmv conv template, fall back to…

### DIFF
--- a/python/sglang/srt/parser/conversation.py
+++ b/python/sglang/srt/parser/conversation.py
@@ -1150,10 +1150,17 @@ def match_qwen_chat_ml(model_path: str):
 
 @register_conv_template_matching_function
 def match_minicpm(model_path: str):
+    # MiniCPM-V 4.6 (and any future versions) ship a real HF jinja chat
+    # template that uses <|image_pad|> / <|video_pad|> instead of the legacy
+    # (<image>./</image>) placeholder. Returning None here lets the
+    # TemplateManager fall back to the HF tokenizer/processor template,
+    # which keeps the prompt aligned with the multimodal processor.
+    model_type = get_model_type(model_path)
+    if model_type == "minicpmv4_6":
+        return None
     match = re.search(r"minicpm-(v|o)", model_path, re.IGNORECASE)
     if match:
         return f"minicpm{match.group(1).lower()}"
-    model_type = get_model_type(model_path)
     return MODEL_TYPE_TO_TEMPLATE.get(model_type)
 
 


### PR DESCRIPTION
## Summary
`match_minicpm` matches the `minicpm-v` substring in `MiniCPM-V-4_6` paths and forces the legacy v2.6 conv template (`(<image>./</image>)`), but 4.6's processor and `chat_template.jinja` use `<|image_pad|>` / `<|video_pad|>` — so the prompt and the processor are out of sync and images are never expanded.
Returning `None` for `model_type == "minicpmv4_6"` lets the manager fall back to the HF jinja template. 2.6 / 4.0 / 4.5 / o-2.6 untouched. Verified end-to-end on `MiniCPM-V-4_6` (single-image, multi-image, text-only).
