### PR TITLE
[Bug Fix] gemma4 tool-call parser: use call sequence as tool_index, not tool position

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -244,7 +244,6 @@ class Gemma4Detector(BaseFormatDetector):
         self.parsed_pos: int = 0
         self.is_inside_tool_call: bool = False
         self.current_func_name: Optional[str] = None
-        self._tool_indices: Optional[dict] = None
 
     @staticmethod
     def _extract_tool_calls(text: str) -> list:
@@ -285,12 +284,11 @@ class Gemma4Detector(BaseFormatDetector):
             if not matches:
                 return StreamingParseResult(normal_text=text)
 
-            tool_indices = self._get_tool_indices(tools)
-            for func_name, args_str in matches:
+            for i, (func_name, args_str) in enumerate(matches):
                 arguments = _parse_gemma4_args(args_str)
                 calls.append(
                     ToolCallItem(
-                        tool_index=tool_indices.get(func_name, -1),
+                        tool_index=i,
                         name=func_name,
                         parameters=json.dumps(arguments, ensure_ascii=False),
                     )
@@ -316,8 +314,6 @@ class Gemma4Detector(BaseFormatDetector):
 
         calls = []
         normal_text_chunks = []
-        if self._tool_indices is None:
-            self._tool_indices = self._get_tool_indices(tools)
 
         try:
             while True:
@@ -377,9 +373,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                                 calls.append(
                                     ToolCallItem(
-                                        tool_index=self._tool_indices.get(
-                                            func_name, -1
-                                        ),
+                                        tool_index=self.current_tool_id,
                                         name=func_name,
                                         parameters="",
                                     )
@@ -408,9 +402,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                             calls.append(
                                 ToolCallItem(
-                                    tool_index=self._tool_indices.get(
-                                        self.current_func_name, -1
-                                    ),
+                                    tool_index=self.current_tool_id,
                                     parameters=json.dumps(
                                         arguments, ensure_ascii=False
                                     ),

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -4748,10 +4748,48 @@ class TestGemma4Detector(unittest.TestCase):
         self.assertEqual(len(result.calls), 0)
 
     def test_detect_and_parse_unknown_tool_index(self):
+        # tool_index is the position of the call in the response, not the
+        # position of the function in the tools list, so unknown tools still
+        # get a valid sequential index.
         text = '<|tool_call>call:unknown_func{arg:<|"|>val<|"|>}<tool_call|>'
         result = self.detector.detect_and_parse(text, self.tools)
         self.assertEqual(len(result.calls), 1)
-        self.assertEqual(result.calls[0].tool_index, -1)
+        self.assertEqual(result.calls[0].tool_index, 0)
+
+    def test_detect_and_parse_repeated_calls_get_sequential_indices(self):
+        # Regression: multiple calls to the same function must each get a
+        # distinct, sequential tool_index (OpenAI streaming protocol requires
+        # tool_calls[i].index to be the position of the call in the array).
+        text = (
+            '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>'
+            '<|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>'
+            '<|tool_call>call:get_weather{location:<|"|>Berlin<|"|>}<tool_call|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 3)
+        self.assertEqual([c.tool_index for c in result.calls], [0, 1, 2])
+
+    def test_streaming_repeated_calls_get_sequential_indices(self):
+        # Regression for streaming path: three calls to the same function
+        # split across chunks must each emit a distinct sequential tool_index
+        # on both the name chunk and the args chunk.
+        self.detector = Gemma4Detector()
+        chunks = [
+            '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>',
+            '<|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>',
+            '<|tool_call>call:get_weather{location:<|"|>Berlin<|"|>}<tool_call|>',
+        ]
+        name_indices = []
+        args_indices = []
+        for chunk in chunks:
+            res = self.detector.parse_streaming_increment(chunk, self.tools)
+            for call in res.calls:
+                if call.name is not None:
+                    name_indices.append(call.tool_index)
+                else:
+                    args_indices.append(call.tool_index)
+        self.assertEqual(name_indices, [0, 1, 2])
+        self.assertEqual(args_indices, [0, 1, 2])
 
     def test_detect_and_parse_nested_object(self):
         text = '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>,details:{temp:25,unit:<|"|>celsius<|"|>}}<tool_call|>'


### PR DESCRIPTION
## Summary
- Fixes #25073: `Gemma4Detector` was setting `ToolCallItem.tool_index` to the function's position in the request's `tools` list, so multiple calls to the same function collapsed onto one `tool_call` index on the OpenAI client side (all argument deltas merged into the first call), even though each call got a unique `id`.
- Use `self.current_tool_id` for the streaming path and `enumerate(matches)` for the non-streaming path, matching the convention already used by `deepseekv3/v31/v32`, `glm4_moe`/`glm47_moe`, `kimik2` (streaming), `minimax_m2`, `step3`, `qwen3_coder`, `hunyuan` (streaming), and called out explicitly in `lfm2_detector.py:153` / `pythonic_detector.py:102` ("Use the call index in the response, not tool position").
- Remove the now-unused `self._tool_indices` cache on `Gemma4Detector`.

## Test plan
- [x] Updated `test_detect_and_parse_unknown_tool_index` — unknown tools now get a sequential `tool_index` (was `-1`, which would have been propagated to the OpenAI `tool_calls[*].index` field).
- [x] New `test_detect_and_parse_repeated_calls_get_sequential_indices` — three calls to the same function get `tool_index 0, 1, 2` in the non-streaming path.
- [x] New `test_streaming_repeated_calls_get_sequential_indices` — three calls to the same function get `tool_index 0, 1, 2` on both the name chunk and the args chunk in the streaming path.
- [x] Existing `TestGemma4Detector` tests still pass (`test_detect_and_parse`, `test_parse_streaming_increment`, `test_nested_array_streaming`, `test_detect_and_parse_multiple_calls`, etc.).
- [x] Walked the user-reported scenario (1× `get_menu` + 3× `add_to_cart`) through the real detector with byte-chunked streaming and a client-side reassembly emulation — produces 4 distinct `tool_calls` with the correct names and arguments.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30093580055](https://github.com/sgl-project/sglang/actions/runs/30093580055)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30093579959](https://github.com/sgl-project/sglang/actions/runs/30093579959)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->