### PR TITLE
[LoRA] Enforce max_loras_per_batch at scheduler admission (fixes #23141)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2680,7 +2680,7 @@ class Scheduler(
             self._chunked_req_scheduled_last_iter = False
 
         if self.enable_lora:
-            running_loras = {req.lora_id for req in self.running_batch.reqs}
+            running_loras = self._collect_committed_lora_ids(adder.can_run_list)
 
             if self.lora_drainer:
                 self.lora_drainer.update_draining_state(
@@ -2866,6 +2866,23 @@ class Scheduler(
             return self.tp_worker.model_runner.lora_manager.validate_lora_batch(
                 new_lora_set
             )
+
+    def _collect_committed_lora_ids(
+        self, prefill_can_run_list: List[Req]
+    ) -> set[Optional[str]]:
+        """Collect lora_ids already committed to the next batch so admission
+        can correctly enforce ``max_loras_per_batch``.
+
+        Includes (a) reqs in the current running decode batch and (b) reqs
+        already placed into the prefill adder's can_run_list — notably the
+        chunked_req, which is admitted unconditionally before the waiting
+        queue is processed. Without (b) a chunked LoRA prefill is invisible
+        to admission, allowing the scheduler to admit N+1 distinct adapters
+        when ``max_loras_per_batch=N``. See sgl-project/sglang#23141.
+        """
+        committed = {req.lora_id for req in self.running_batch.reqs}
+        committed.update(r.lora_id for r in prefill_can_run_list)
+        return committed
 
     def update_running_batch(self, batch: ScheduleBatch) -> Optional[ScheduleBatch]:
         """Update the current running decoding batch."""

--- a/test/registered/unit/managers/test_scheduler_lora_admission.py
+++ b/test/registered/unit/managers/test_scheduler_lora_admission.py
@@ -1,0 +1,158 @@
+"""Regression tests for LoRA admission when chunked_req is present (#23141)."""
+
+import ast
+import inspect
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def _make_req(lora_id):
+    req = Req.__new__(Req)
+    req.lora_id = lora_id
+    req.sampling_params = SimpleNamespace(max_new_tokens=16, ignore_eos=False)
+    return req
+
+
+def _scheduler_with_lora(
+    *,
+    running_batch_loras,
+    max_loras_per_batch=2,
+    enable_overlap_loading=False,
+):
+    s = Scheduler.__new__(Scheduler)
+    s.enable_lora = True
+    s.lora_drainer = None
+    s.enable_lora_overlap_loading = enable_overlap_loading
+
+    s.running_batch = MagicMock()
+    s.running_batch.reqs = [_make_req(l) for l in running_batch_loras]
+
+    lora_mgr = MagicMock()
+    lora_mgr.max_loras_per_batch = max_loras_per_batch
+    lora_mgr.validate_lora_batch = MagicMock(
+        side_effect=lambda ids: len(ids) <= max_loras_per_batch
+    )
+    s.tp_worker = SimpleNamespace(model_runner=SimpleNamespace(lora_manager=lora_mgr))
+    return s
+
+
+class TestCollectCommittedLoraIds(CustomTestCase):
+    """``_collect_committed_lora_ids`` must report every lora_id that will
+    appear in the next batch so admission can enforce ``max_loras_per_batch``."""
+
+    def test_running_batch_only(self):
+        s = _scheduler_with_lora(running_batch_loras=["A", "B"])
+        self.assertEqual(s._collect_committed_lora_ids([]), {"A", "B"})
+
+    def test_includes_chunked_req_from_can_run_list(self):
+        s = _scheduler_with_lora(running_batch_loras=["A"])
+        chunked = _make_req("X")
+        self.assertEqual(s._collect_committed_lora_ids([chunked]), {"A", "X"})
+
+    def test_base_model_request_counted_as_distinct_uid(self):
+        # A base-model request (lora_id=None) is a distinct entry in the
+        # set computed by fetch_new_loras, so admission must see it too.
+        s = _scheduler_with_lora(running_batch_loras=[None])
+        chunked = _make_req("X")
+        self.assertEqual(s._collect_committed_lora_ids([chunked]), {None, "X"})
+
+
+class TestLoraAdmissionWithChunkedReq(CustomTestCase):
+    """End-to-end regression for #23141: when ``max_loras_per_batch=N`` and a
+    chunked LoRA prefill already sits in ``can_run_list``, admission must
+    reject a further distinct LoRA request that would form an (N+1)-th UID.
+    """
+
+    def test_rejects_new_adapter_when_chunked_fills_last_slot(self):
+        s = _scheduler_with_lora(running_batch_loras=["A"], max_loras_per_batch=2)
+        chunked_req = _make_req("X")
+        running_loras = s._collect_committed_lora_ids([chunked_req])
+
+        new_req = _make_req("B")
+        self.assertFalse(s._can_schedule_lora_req(new_req, running_loras))
+
+    def test_admits_request_with_same_adapter_as_chunked(self):
+        s = _scheduler_with_lora(running_batch_loras=["A"], max_loras_per_batch=2)
+        chunked_req = _make_req("X")
+        running_loras = s._collect_committed_lora_ids([chunked_req])
+
+        same_as_chunked = _make_req("X")
+        self.assertTrue(s._can_schedule_lora_req(same_as_chunked, running_loras))
+
+    def test_without_chunked_req_behavior_unchanged(self):
+        s = _scheduler_with_lora(running_batch_loras=["A"], max_loras_per_batch=2)
+        running_loras = s._collect_committed_lora_ids([])
+
+        new_req = _make_req("B")
+        self.assertTrue(s._can_schedule_lora_req(new_req, running_loras))
+
+    def test_base_plus_n_loras_at_cap_rejects_next(self):
+        # Mirrors Yunzez's N adapters + 1 base-model scenario: when the base
+        # request already occupies one UID slot, admission must reject the
+        # (N+1)-th distinct adapter regardless of whether it arrives via
+        # chunked_req or waiting_queue.
+        s = _scheduler_with_lora(running_batch_loras=[None], max_loras_per_batch=2)
+        chunked_req = _make_req("A")
+        running_loras = s._collect_committed_lora_ids([chunked_req])
+
+        new_req = _make_req("B")
+        self.assertFalse(s._can_schedule_lora_req(new_req, running_loras))
+
+    def test_overlap_loading_sees_chunked_lora_in_running_set(self):
+        # The overlap-loading branch consumes the same ``running_loras`` set
+        # that admission computes, so the chunked_req's adapter must be
+        # visible to ``try_overlap_load_lora`` as well.
+        s = _scheduler_with_lora(
+            running_batch_loras=["A"],
+            max_loras_per_batch=2,
+            enable_overlap_loading=True,
+        )
+        s.lora_overlap_loader = MagicMock()
+        s.lora_overlap_loader.try_overlap_load_lora.return_value = False
+
+        running_loras = s._collect_committed_lora_ids([_make_req("X")])
+        self.assertFalse(s._can_schedule_lora_req(_make_req("B"), running_loras))
+        s.lora_overlap_loader.try_overlap_load_lora.assert_called_once_with(
+            "B", {"A", "X"}
+        )
+
+
+class TestAdmissionCallSiteWiring(CustomTestCase):
+    """Source-level guard: the helper is only useful if admission actually
+    calls it with ``adder.can_run_list``. A silent revert of the call site
+    (re-inlining the old ``{req.lora_id for req in self.running_batch.reqs}``)
+    must trip this test even when the helper itself is left intact."""
+
+    def test_admission_invokes_helper_with_can_run_list(self):
+        src = inspect.getsource(Scheduler._get_new_batch_prefill_raw)
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "_collect_committed_lora_ids"
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.Attribute)
+                and node.args[0].attr == "can_run_list"
+            ):
+                return
+        self.fail(
+            "_get_new_batch_prefill_raw must call "
+            "self._collect_committed_lora_ids(adder.can_run_list); regressing "
+            "this call site silently re-introduces sgl-project/sglang#23141."
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #23141. Under concurrent requests to `> max_loras_per_batch` distinct adapters, `fetch_new_loras` asserts with `len(cur_uids) > max_loras_per_batch` and the scheduler dies with SIGQUIT. Cap was only enforced as a post-hoc invariant at model-runner level; scheduler admission missed one source of committed UIDs.

## Root cause

`_get_new_batch_prefill_raw` builds `running_loras` only from the running decode batch:

```python
running_loras = {req.lora_id for req in self.running_batch.reqs}
```

But before this line runs, `add_chunked_req` has already placed a chunked LoRA prefill into `adder.can_run_list`. That chunked_req is admitted unconditionally (no LoRA gate) yet is invisible to the subsequent waiting-queue admission. When the chunked_req carries a distinct adapter — common after retract/cancel churn under KV pressure — admission can validate a further new adapter against a cap that still has a free slot on paper, pushing the final batch's distinct uids to N+1. `fetch_new_loras` then hits its hard assert. This matches Yunzez's H100 reproducer (`--mem-fraction-static 0.30` + `cancel_prob=0.3`) where small KV pool + cancel-driven remap consistently force this path within 1-2 loops.

The "N adapters + 1 base-model request" shape from the original report is the same mechanism: the base request's `lora_id=None` is a distinct entry in the set `fetch_new_loras` computes, so it occupies a slot just like an adapter does. The fix preserves that semantics.

## Fix

Extract `_collect_committed_lora_ids(prefill_can_run_list)` that unions:
1. `lora_id`s of reqs in the running decode batch (pre-existing source)
2. `lora_id`s already in `adder.can_run_list` (newly added — covers the chunked_req)

Why iterate `adder.can_run_list` instead of reading `self.chunked_req.lora_id` directly:
- `add_chunked_req` may return `None` (KV pool can't fit), leaving the in-flight reference ambiguous; `adder.can_run_list` is the authoritative source of truth.
- Robust to any future change that pushes other reqs into the adder before the LoRA gate.

**Invariant the fix relies on**: at the call site, `adder.can_run_list` only contains a scheduled `chunked_req`. `PrefillAdder.__init__` initializes `can_run_list = []`, and the only mutation between construction and the LoRA admission line is `add_chunked_req`. `add_one_req` and priority-preemption mutations happen later, inside the `for req in waiting_queue` loop.

## Tests

`test/registered/unit/managers/test_scheduler_lora_admission.py` — CPU-only, registered into `stage-a-test-cpu`. 9 tests across three classes:

1. **`TestCollectCommittedLoraIds`** — helper unit semantics (running batch only / chunked included / `lora_id=None` counted as a distinct uid).
2. **`TestLoraAdmissionWithChunkedReq`** — admission decisions:
   - rejects new adapter when chunked fills the last slot
   - admits same adapter as chunked
   - unchanged behavior with no chunked_req (negative regression)
   - rejects (N+1)-th adapter when running batch holds the base-model `None` and chunked holds an adapter (Yunzez's mixed scenario)
   - the `enable_lora_overlap_loading=True` branch sees the same `running_loras` (verified via mock on `try_overlap_load_lora`)
3. **`TestAdmissionCallSiteWiring`** — AST-level guard: parses the source of `_get_new_batch_prefill_raw` and asserts a `Call` node with `_collect_committed_lora_ids(adder.can_run_list)` exists. A silent revert of the call site (re-inlining the old expression) trips this even if the helper is left intact.

## Out of scope (intentional, called out for reviewers)

- **`LoRADrainer` visibility**: `lora_drainer.update_draining_state` is still called with `self.running_batch.reqs` only. It does not see chunked_req either, but that path affects fairness, not correctness — the cap-enforcement crash is fixed by the admission change. Happy to file a follow-up.
- **`running_batch.reqs` may transiently contain finished requests**: `filter_batch` runs in `update_running_batch` only on the decode path; preemption between `process_batch_result` and the next prefill can leave finished reqs visible here. The helper preserves the **exact pre-existing semantics** of the line it replaces. If reviewers want stricter active-only filtering, that's a separate change to a long-standing assumption and probably belongs in a dedicated PR.
- **`running_loras.add(req.lora_id)` after non-CONTINUE `add_one_req`**: pre-existing local set is mutated even when the req was rejected, but the immediate `break` prevents reuse. Cosmetic, not functional.

## Validation

I don't have H100/A6000 access to run Yunzez's full repro. So far:
- logic traced through `scheduler.py` / `lora_manager.py` / `schedule_policy.py` / `lora_overlap_loader.py`
- 9 CPU unit tests covering helper semantics, admission decisions, the overlap-loading branch, and a call-site wiring guard
- Codex adversarial review pass before push

Maintainers with H100 are welcome to confirm against Yunzez's gist (`repro_lora_scheduler_crash.py`) — expected: server stays alive past loop ~10, no `lora_manager.py:282` assert.
