### PR TITLE
fix(swa_radix): handle redundant chunk stash for mixed prefill

### DIFF
--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -507,6 +507,34 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
         values = kv_indices[: len(radix_key)].to(dtype=torch.int64, copy=True)
         old_prefix_len = req.cache_protected_len
 
+        # Stash-redundancy detection: when stash_chunked_request was called at
+        # the start of this frame, it may already have cached the page-aligned
+        # prefix plus an unaligned tail. If this function is invoked again for
+        # the same final chunk, there is no new page-aligned content to insert.
+        if old_prefix_len > len(radix_key):
+            match_result = self.match_prefix(MatchPrefixParams(key=radix_key))
+            new_indices = match_result.device_indices
+            new_last_node = match_result.last_device_node
+
+            self.dec_lock_ref(
+                req.last_node,
+                DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock),
+                skip_swa=req.swa_prefix_lock_released,
+            )
+            req.swa_prefix_lock_released = False
+            result = self.inc_lock_ref(new_last_node)
+
+            req.cache_protected_len = len(new_indices)
+            if len(new_indices) < len(kv_indices):
+                req.prefix_indices = torch.cat(
+                    [new_indices, kv_indices[len(new_indices) :]]
+                )
+            else:
+                req.prefix_indices = new_indices
+            req.last_node = new_last_node
+            req.swa_uuid_for_lock = result.swa_uuid_for_lock
+            return
+
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
         result = self.insert(


### PR DESCRIPTION
## Motivation

`cache_unfinished_req` can be called twice for the same chunked request when mixed chunked prefill stashes a request at the start of a frame and the final chunk still fits in that frame. In that case, the first call already cached the page-aligned prefix plus the unaligned tail. The second call can see `old_prefix_len` larger than the current page-aligned radix key length, while `match_prefix` can only return the page-aligned portion. This trips the existing prefix-length assertion in `SWARadixCache`.

This shows up with SWA radix cache enabled under mixed chunked prefill with small per-DP chunks.

## Modifications

Add a stash-redundancy branch in `SWARadixCache.cache_unfinished_req`:

- detect `old_prefix_len > len(radix_key)`
- skip radix insertion because there is no new page-aligned content to insert
- refresh the request lock on the matched node
- rebuild `req.prefix_indices` from the matched prefix plus the current request-slot KV indices

## Accuracy Tests

Setup: DeepSeek-V4-Pro, B300, DP=8 / EP=8 / TP=8, mixed chunked prefill enabled, DP attention enabled, SWA radix cache enabled, `chunked-prefill-size=16384`, `swa-full-tokens-ratio=0.075`, SGLang dev CU13 container.

Result JSON:

```json
{
  "score:std": 0.15893963650952372,
  "score": 0.9740655987795576,
  "latency": 510.4231988489628,
  "output_throughput": 1194.2305940925175
}
```

Full `benchmark.out`:

```text
real-time non-blocking time  (microseconds, -R) unlimited
core file size              (blocks, -c) unlimited
data seg size               (kbytes, -d) unlimited
scheduling priority                 (-e) 0
file size                   (blocks, -f) unlimited
pending signals                     (-i) 977446
max locked memory           (kbytes, -l) unlimited
max memory size             (kbytes, -m) 910163968
open files                          (-n) 1048576
pipe size                (512 bytes, -p) 8
POSIX message queues         (bytes, -q) 819200
real-time priority                  (-r) 0
stack size                  (kbytes, -s) 8192
cpu time                   (seconds, -t) unlimited
max user processes                  (-u) unlimited
virtual memory              (kbytes, -v) unlimited
file locks                          (-x) unlimited
GSM8K Config: endpoint=http://localhost:8000; num_examples=1319; max_tokens=14000; num_threads=128; num_shots=8; temperature=default; top_p=default; top_k=default
Running GSM8K evaluation...
/usr/local/lib/python3.12/dist-packages/torchao/quantization/quant_api.py:1731: SyntaxWarning: invalid escape sequence '\.'
  """Configuration class for applying different quantization configs to modules or parameters based on their fully qualified names (FQNs).
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl:   0%|          | 0.00/237k [00:00<?, ?B/s]
/tmp/test.jsonl: 390kB [00:00, 3.94MB/s]
/tmp/test.jsonl: 732kB [00:00, 6.17MB/s]
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=14000 self.reasoning_effort=None self.extra_body=None
  0%|          | 0/1311 [00:00<?, ?it/s]
  0%|          | 1/1311 [01:35<34:50:26, 95.75s/it]
  0%|          | 5/1311 [02:06<7:32:21, 20.78s/it]
  1%|          | 13/1311 [02:30<2:56:47,  8.17s/it]
  7%|▋         | 86/1311 [02:56<23:00,  1.13s/it]
  7%|▋         | 92/1311 [02:59<21:42,  1.07s/it]
  9%|▊         | 112/1311 [08:15<1:53:21,  5.67s/it]
 48%|████▊     | 633/1311 [08:30<05:21,  2.11it/s]
100%|██████████| 1311/1311 [08:30<00:00,  2.57it/s]
Total latency: 510.423 s
Score: 0.974
Output throughput: 1194.231 token/s
[METRIC] gsm8k_score=0.9740655987795576 labels={"model": "deepseek-ai/DeepSeek-V4-Pro", "eval": "gsm8k"}
[METRIC] gsm8k_latency=510.4231988489628 labels={"model": "deepseek-ai/DeepSeek-V4-Pro", "eval": "gsm8k"}
Writing report to /tmp/gsm8k_deepseek-ai_DeepSeek-V4-Pro.html
{'score:std': np.float64(0.15893963650952372), 'score': np.float64(0.9740655987795576), 'latency': 510.4231988489628, 'output_throughput': 1194.2305940925175}
Writing results to /tmp/gsm8k_deepseek-ai_DeepSeek-V4-Pro.json
Results saved to: /logs/accuracy/gsm8k_deepseek-ai_DeepSeek-V4-Pro.json
GSM8K evaluation complete
```

## Speed Tests and Profiling

Not included. This PR is a correctness fix for a SWA radix cache assertion hit by mixed chunked prefill.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
