### PR TITLE
[AMD] Document Mori XGMI for Single-Node PD Disaggregation

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -365,6 +365,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use FP8 for combine</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>"false"</code></td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>MORI_DISABLE_AUTO_XGMI</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Set to <code>0</code> to allow Mori to automatically use XGMI for same-node PD disaggregation when no active RDMA device is available.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>unset</code></td>
+    </tr>
 <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum number of dispatch tokens per rank for MORI-EP buffer allocation</td>


### PR DESCRIPTION
# Document Mori XGMI for Single-Node PD Disaggregation

## Summary

This PR has been rebased on top of `main` and minimized to documentation only.

It documents Mori's native environment variable for enabling same-node XGMI fallback:

```bash
MORI_DISABLE_AUTO_XGMI=0
```

No new SGLang-specific environment variable is introduced. In particular, this PR no longer adds or documents `SGLANG_MORI_USE_XGMI`.

Mori PDD still initializes the Mori IO backend through the existing RDMA backend path. When `MORI_DISABLE_AUTO_XGMI=0` is set and no active RDMA device is available, Mori can internally fall back to its XGMI path for same-node GPU-to-GPU KV cache transfer, as supported by ROCm/mori#316.

## Motivation

Single-node prefill/decode disaggregation can run with prefill and decode GPUs connected locally through XGMI/Infinity Fabric. In that deployment, requiring users to discover Mori's XGMI fallback environment variable from outside the SGLang docs is confusing.

Since Mori already owns the fallback behavior, this PR documents the Mori-native control directly instead of adding a duplicate SGLang wrapper env var.

## Changes

### Documentation

- Adds `MORI_DISABLE_AUTO_XGMI` to `docs_new/docs/references/environment_variables.mdx`.
- Documents that setting `MORI_DISABLE_AUTO_XGMI=0` allows Mori to automatically use XGMI for same-node PDD when no active RDMA device is available.

### Removed From Earlier Revision

The earlier revision of this PR added a SGLang-specific env var and implementation hooks. Those changes have been removed.

This PR no longer changes:

- `python/sglang/srt/environ.py`
- `python/sglang/srt/disaggregation/mori/conn.py`
- `test/manual/test_mori_transfer_engine_e2e.py`

## Behavior

| Env var | Behavior |
| --- | --- |
| `MORI_DISABLE_AUTO_XGMI` unset | Existing Mori behavior. |
| `MORI_DISABLE_AUTO_XGMI=0` | Allows Mori to fall back to same-node XGMI when no active RDMA device is available. |

SGLang does not create a separate XGMI backend and does not translate a SGLang-specific flag. Users configure Mori directly with the Mori env var.

## Usage

Single-node Mori PDD with XGMI fallback enabled:

```bash
# Prefill
MORI_DISABLE_AUTO_XGMI=0 python -m sglang.launch_server \
  --model-path meta-llama/Llama-3.1-8B-Instruct \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mori \
  --port 30000

# Decode
MORI_DISABLE_AUTO_XGMI=0 python -m sglang.launch_server \
  --model-path meta-llama/Llama-3.1-8B-Instruct \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mori \
  --base-gpu-id 1 \
  --port 30001
```

In the common single-host launch case, no extra Mori node ID setting is needed. Mori uses the host identity in its engine descriptors to decide whether peers are on the same node. If prefill and decode run in separate containers on the same host and those containers report different hostnames, set the same `MORI_IO_NODE_ID` in both containers so Mori still classifies the engines as same-node.

## How It Works

Mori PDD transfers GPU KV cache through `MoriKVManager.send_kvcache()`, which ultimately calls Mori IO `batch_write()`. The transfer calls are transport-agnostic; the selected Mori IO backend determines whether the copy uses RDMA or XGMI.

With XGMI fallback enabled:

```text
SGLang server args + env
  -> disaggregation_transfer_backend = mori
  -> MORI_DISABLE_AUTO_XGMI=0
  -> SGLang creates the existing Mori RDMA backend path
  -> Mori internally falls back to XGMI when no active RDMA device is present
  -> register GPU KV buffers
  -> batch_write() transfers KV cache over same-node XGMI/P2P
```

Auxiliary CPU metadata remains on the existing SGLang ZMQ/TCP path and does not require Mori IO.