### PR TITLE
Fix Gemma4 repeated tool call indices

### DIFF
--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -244,7 +244,6 @@ class Gemma4Detector(BaseFormatDetector):
         self.parsed_pos: int = 0
         self.is_inside_tool_call: bool = False
         self.current_func_name: Optional[str] = None
-        self._tool_indices: Optional[dict] = None
 
     @staticmethod
     def _extract_tool_calls(text: str) -> list:
@@ -286,11 +285,11 @@ class Gemma4Detector(BaseFormatDetector):
                 return StreamingParseResult(normal_text=text)
 
             tool_indices = self._get_tool_indices(tools)
-            for func_name, args_str in matches:
+            for call_index, (func_name, args_str) in enumerate(matches):
                 arguments = _parse_gemma4_args(args_str)
                 calls.append(
                     ToolCallItem(
-                        tool_index=tool_indices.get(func_name, -1),
+                        tool_index=call_index if func_name in tool_indices else -1,
                         name=func_name,
                         parameters=json.dumps(arguments, ensure_ascii=False),
                     )
@@ -316,8 +315,6 @@ class Gemma4Detector(BaseFormatDetector):
 
         calls = []
         normal_text_chunks = []
-        if self._tool_indices is None:
-            self._tool_indices = self._get_tool_indices(tools)
 
         try:
             while True:
@@ -377,9 +374,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                                 calls.append(
                                     ToolCallItem(
-                                        tool_index=self._tool_indices.get(
-                                            func_name, -1
-                                        ),
+                                        tool_index=self.current_tool_id,
                                         name=func_name,
                                         parameters="",
                                     )
@@ -408,9 +403,7 @@ class Gemma4Detector(BaseFormatDetector):
 
                             calls.append(
                                 ToolCallItem(
-                                    tool_index=self._tool_indices.get(
-                                        self.current_func_name, -1
-                                    ),
+                                    tool_index=self.current_tool_id,
                                     parameters=json.dumps(
                                         arguments, ensure_ascii=False
                                     ),

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -5107,6 +5107,15 @@ class TestGemma4Detector(unittest.TestCase):
         self.assertEqual(result.calls[1].name, "get_time")
         self.assertEqual(result.normal_text, "Some text ")
 
+    def test_detect_and_parse_repeated_calls_use_call_indices(self):
+        text = (
+            '<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>'
+            '<|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual([call.tool_index for call in result.calls], [0, 1])
+        self.assertEqual([call.name for call in result.calls], ["get_weather"] * 2)
+
     def test_parse_gemma4_args_empty(self):
         self.assertEqual(_parse_gemma4_args(""), {})
         self.assertEqual(_parse_gemma4_args("   "), {})
@@ -5216,6 +5225,23 @@ class TestGemma4Detector(unittest.TestCase):
         params1 = json.loads(tool_calls_by_index[1]["parameters"])
         self.assertEqual(params0["location"], "Tokyo")
         self.assertEqual(params1["timezone"], "UTC")
+
+    def test_streaming_repeated_tool_calls_use_call_indices(self):
+        chunks = [
+            '<|tool_call>call:get_weather{location:<|"|>',
+            'Tokyo<|"|>}<tool_call|>',
+            '<|tool_call>call:get_weather{location:<|"|>',
+            'Paris<|"|>}<tool_call|>',
+        ]
+
+        normal_text, tool_calls = self._collect_streaming(chunks)
+
+        self.assertEqual(normal_text, "")
+        self.assertEqual(sorted(tool_calls), [0, 1])
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+        self.assertEqual(tool_calls[1]["name"], "get_weather")
+        self.assertEqual(json.loads(tool_calls[0]["parameters"])["location"], "Tokyo")
+        self.assertEqual(json.loads(tool_calls[1]["parameters"])["location"], "Paris")
 
     def test_streaming_very_small_chunks(self):
         """Test streaming with character-by-character chunks."""


### PR DESCRIPTION
﻿## Summary
- use the response call order for Gemma4 tool-call indices instead of the requested tool position
- keep Gemma4 name and argument streaming chunks on the same call index
- add regressions for repeated calls to the same function in both non-streaming and streaming parser paths

Fixes #25073.

## To verify
- `python -m py_compile python/sglang/srt/function_call/gemma4_detector.py test/registered/unit/function_call/test_function_call_parser.py`
- `python -m black --check python/sglang/srt/function_call/gemma4_detector.py test/registered/unit/function_call/test_function_call_parser.py`
- `python -m ruff check --select=F401,F821 python/sglang/srt/function_call/gemma4_detector.py test/registered/unit/function_call/test_function_call_parser.py`
- `git diff --check`
- isolated Gemma4 repeated-call parser smoke test

I could not run the full pytest target on Windows because importing the test module pulls in Linux/server dependencies such as `resource` and the broader runtime stack before the parser tests are collected.
