### PR TITLE
Support Gemma 4 compressed-tensors AWQ MoE

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -11,7 +11,7 @@ _is_cuda = is_cuda()
 if _is_cuda:
     from sgl_kernel import moe_sum_reduce
 
-    from sglang.jit_kernel.activation import silu_and_mul
+    from sglang.jit_kernel.activation import gelu_tanh_and_mul, silu_and_mul
     from sglang.jit_kernel.moe_wna16_marlin import moe_wna16_marlin_gemm
 
 
@@ -72,6 +72,7 @@ def fused_marlin_moe(
     inplace: bool = False,
     routed_scaling_factor: Optional[float] = None,
     clamp_limit: Optional[float] = None,
+    activation: str = "silu",
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -217,13 +218,19 @@ def fused_marlin_moe(
     )
 
     if clamp_limit is not None:
+        if activation != "silu":
+            raise ValueError("clamp_limit is only supported for SiLU/SwiGLU")
         swiglu_limit_func(
             intermediate_cache2,
             intermediate_cache1.view(-1, 2 * N),
             clamp_limit,
         )
-    else:
+    elif activation == "silu":
         silu_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    elif activation == "gelu_pytorch_tanh":
+        gelu_tanh_and_mul(intermediate_cache1.view(-1, 2 * N), intermediate_cache2)
+    else:
+        raise ValueError(f"Unsupported activation: {activation!r}")
 
     if expert_map is not None:
         intermediate_cache3.zero_()

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -382,9 +382,10 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
         )
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
-        assert (
-            self.moe_runner_config.activation == "silu"
-        ), "Only SiLU activation is supported."
+        assert self.moe_runner_config.activation in (
+            "silu",
+            "gelu_pytorch_tanh",
+        ), f"Unsupported activation: {self.moe_runner_config.activation!r}"
 
         x = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
@@ -419,6 +420,7 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             num_bits=self.num_bits,
             is_k_full=self.is_k_full,
             routed_scaling_factor=self.moe_runner_config.routed_scaling_factor,
+            activation=self.moe_runner_config.activation,
         )
         return StandardCombineInput(hidden_states=output)
 
@@ -484,7 +486,7 @@ class CompressedTensorsWNA16TritonMoE(CompressedTensorsWNA16MoE):
     ) -> "CombineInput":
         assert (
             self.moe_runner_config.activation == "silu"
-        ), "Only SiLU activation is supported."
+        ), "Only SiLU activation is supported by the Triton WNA16 MoE path."
 
         quant_info = self.get_triton_quant_info(layer)
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -57,6 +57,11 @@ from sglang.srt.utils import add_prefix, make_layers
 
 logger = logging.getLogger(__name__)
 
+_PER_EXPERT_COMPRESSED_MOE_RE = re.compile(
+    r"^(.+?\.moe\.experts\.)(\d+)\.(gate_proj|up_proj|down_proj)"
+    r"\.(weight_packed|weight_scale|weight_shape)$"
+)
+
 
 # Aligned with HF's implementation, using sliding window inclusive with the last token
 # SGLang assumes exclusive
@@ -1021,6 +1026,24 @@ class Gemma4ForCausalLM(PreTrainedModel):
             name = name.replace(".router.per_expert_scale", ".moe.per_expert_scale")
             if ".experts." in name and ".moe.experts." not in name:
                 name = name.replace(".experts.", ".moe.experts.")
+
+            per_expert_match = _PER_EXPERT_COMPRESSED_MOE_RE.match(name)
+            if per_expert_match:
+                prefix, expert_id_str, proj, suffix = per_expert_match.groups()
+                expert_id = int(expert_id_str)
+                if proj in ("gate_proj", "up_proj"):
+                    target_name = f"{prefix}w13_{suffix}"
+                    shard_id = "w1" if proj == "gate_proj" else "w3"
+                else:
+                    target_name = f"{prefix}w2_{suffix}"
+                    shard_id = "w2"
+                if target_name in params_dict:
+                    param = params_dict[target_name]
+                    param.weight_loader(
+                        param, loaded_weight, target_name, shard_id, expert_id
+                    )
+                    loaded_params.add(target_name)
+                    continue
 
             # attention_k_eq_v: full-attention layers have no v_proj in the
             # checkpoint (K and V share weights).  When we see a k_proj weight


### PR DESCRIPTION
## Summary

Adds the missing pieces needed to serve Gemma 4 text-only compressed-tensors AWQ MoE checkpoints through SGLang's Marlin WNA16 MoE path:

- allow `gelu_pytorch_tanh` in the compressed-tensors WNA16 Marlin MoE path
- dispatch Marlin MoE activation to `gelu_tanh_and_mul` for Gemma 4
- load per-expert compressed MoE checkpoint tensors such as `experts.{i}.gate_proj.weight_packed` into SGLang's fused `w13` / `w2` MoE parameters

## Why

Gemma 4 MoE uses `gelu_pytorch_tanh`, but the WNA16 Marlin MoE path was SiLU-only. Compressed-tensors AWQ checkpoints can also store expert tensors per expert/projection, while SGLang's fused MoE module expects fused `w13` / `w2` parameters.

Without these changes, Gemma 4 AWQ serving either rejects the activation path or fails during expert weight loading.

## Validation

- `python3 -m py_compile` on the three changed files
- Applied equivalent local patches on a 4x A100-80GB box
- Loaded text-only Gemma 4 AWQ as `quant=compressed-tensors`
- Served 3 independent SGLang OpenAI-compatible chat endpoints on A100 GPUs with `--context-length 32768`
- Smoke-tested `/v1/chat/completions` successfully

