### PR TITLE
perf(nvfp4): free unused source scales after weight processing

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1361,13 +1361,13 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
         input_scale_2 = layer.input_scale.max().to(torch.float32)
         weight_scale_2 = layer.weight_scale_2.max().to(torch.float32)
 
-        # Keep per-shard scales intact for hot reload; derive scalar params below.
         copy_or_rebind_param(
             layer, "alpha", (input_scale_2 * weight_scale_2).to(torch.float32)
         )
         copy_or_rebind_param(
             layer, "input_scale_inv", (1 / input_scale_2).to(torch.float32)
         )
+        del layer.input_scale, layer.weight_scale_2
 
         # Store original output size before any padding
         layer.output_size_per_partition = layer.weight.shape[0]
@@ -1421,6 +1421,7 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
             copy_or_rebind_param(layer, "weight_scale_interleaved", scale)
             copy_or_rebind_param(layer, "weight", weight)
             layer.weights_padding_cols = weights_padding_cols
+            del layer.weight_scale
             return
 
         # Pad weights for CUTLASS/FlashInfer kernel alignment (K and N divisible by 32)
@@ -1451,6 +1452,7 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
             else padded_scales.reshape(B, M_padded, K_padded)
         )
         copy_or_rebind_param(layer, "weight_scale_interleaved", padded_scales)
+        del layer.weight_scale
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1776,6 +1776,11 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             (1 / w2_input_scale).to(torch.float32),
         )
         del layer.w13_input_scale, layer.w2_input_scale
+        # TODO: w13_weight_scale_2 / w2_weight_scale_2 are also unused by apply()
+        # after this point. flashinfer_cutedsl reads them via hasattr() but has a
+        # mathematically-equivalent fallback through w13_input_scale_quant and
+        # g1_alphas. Kept for now to avoid a silent code-path switch and possible
+        # sub-ULP precision drift; revisit once the fallback is validated.
 
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         layer.dispatcher.set_quant_config(

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1775,6 +1775,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             "w2_input_scale_quant",
             (1 / w2_input_scale).to(torch.float32),
         )
+        del layer.w13_input_scale, layer.w2_input_scale
 
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         layer.dispatcher.set_quant_config(
@@ -1827,6 +1828,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
             # FlashInfer TRTLLM processing - handles both w13 and w2
             align_fp4_moe_weights_for_flashinfer_trtllm(layer)
+            del layer.w13_blockscale_swizzled, layer.w2_blockscale_swizzled
 
         else:
             # CUTLASS processing - handle w13 and w2 separately
@@ -1960,6 +1962,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                     intermediate_size_per_partition=inter_size,  # n
                     hidden_size=hidden_size,
                 )  # k
+            del layer.w13_weight_scale, layer.w2_weight_scale
 
     @property
     def load_up_proj_weight_first(self) -> bool:


### PR DESCRIPTION
## Motivation

After NVFP4 `process_weights_after_loading`, several source-side scale tensors are bound to the layer but never read by `apply()`:

**Linear (`ModelOptNvFp4LinearMethod`):**
- `layer.input_scale` — consumed into `alpha` and `input_scale_inv`
- `layer.weight_scale_2` — consumed into `alpha`
- `layer.weight_scale` — consumed into `weight_scale_interleaved` (both the FlashInfer-TRTLLM and CUTLASS branches converge on this)

**MoE (`ModelOptNvFp4FusedMoEMethod`):**
- `layer.w13_input_scale` / `layer.w2_input_scale` — consumed into `g{1,2}_alphas` and `w{13,2}_input_scale_quant`; not used in any backend's `apply()`.
- `layer.w13_weight_scale` / `layer.w2_weight_scale` — consumed into `*_blockscale_swizzled` for the CUTLASS / CuteDSL paths. **TRTLLM keeps these** (they get shuffled in place by `align_fp4_moe_weights_for_flashinfer_trtllm` and read by `apply()`).
- `layer.w13_blockscale_swizzled` / `layer.w2_blockscale_swizzled` — created with garbage in `create_weights` and never overwritten on the TRTLLM path; only CUTLASS / CuteDSL fills + uses them.

`w13_weight_scale_2` / `w2_weight_scale_2` are intentionally retained: `flashinfer_cutedsl.py:163-167,188-193` reads them via `hasattr` and falls back to a mathematically-equivalent path that may differ in sub-ULP precision — not worth the risk. A TODO is left in the code.

These all sit in GPU memory for the lifetime of the model. The MoE deletions dominate the savings.

## Modifications

`python/sglang/srt/layers/quantization/modelopt_quant.py`:

**`ModelOptNvFp4LinearMethod.process_weights_after_loading`:**
- `del layer.input_scale, layer.weight_scale_2` right after `alpha` and `input_scale_inv` are bound.
- `del layer.weight_scale` at the tail of both the FlashInfer-TRTLLM and CUTLASS branches once `weight_scale_interleaved` has been written.
- Drop the stale `# Keep per-shard scales intact for hot reload` comment — hot reload still works because the weight loader re-binds these source params before `process_weights_after_loading` re-runs.

**`ModelOptNvFp4FusedMoEMethod.process_weights_after_loading`:**
- `del layer.w13_input_scale, layer.w2_input_scale` after `w{13,2}_input_scale_quant` are bound (unconditional).
- TRTLLM branch: `del layer.w13_blockscale_swizzled, layer.w2_blockscale_swizzled` after `align_fp4_moe_weights_for_flashinfer_trtllm` (those buffers are never filled on this path).
- non-TRTLLM (CUTLASS / CuteDSL) branch: `del layer.w13_weight_scale, layer.w2_weight_scale` at the end of the else-block once `*_blockscale_swizzled` (and optionally `*_blockscale_mma`) is set.

`ModelOptFp8LinearMethod` and `ModelOptFp8MoEMethod` are unchanged — they read `weight_scale` / `input_scale` directly in `apply()`.

## Accuracy Tests

TBD before merging — plan: run `lm_eval` (gsm8k) against `nvidia/Kimi-K2.5-NVFP4` with TRTLLM and CUTLASS FP4 backends, expect identical scores within noise vs main.

## Speed Tests and Profiling

No latency impact expected (these tensors aren't on any hot path).

### Memory savings — `nvidia/Kimi-K2.5-NVFP4` at TP=4 + DP-attn

Using Kimi-K2.5 constants (H=7168, num_heads=64, q_lora=1536, kv_lora=512, qk_nope=128, qk_rope=64, v_head=128, moe_intermediate=2048, **384 routed experts + 1 shared expert**, 61 hidden layers, **`first_k_dense_replace=1`** so **60 MoE layers**, NVFP4 group_size=16). Realistic deployment: TP=4 + DP-attn forces `moe_ep_size == attention_dp_size`, so EP=4 / `moe_tp=1`. (Per-rank memory is invariant under any valid `(moe_tp, moe_ep)` split at world_size=4 because `num_local_experts × intermediate_per_partition = const`.)

#### MoE method (routed experts) — dominant term

Per rank holds `num_local_experts = 384 / EP = 96` experts at full unsharded intermediate (`moe_tp=1`).

| tensor | shape per rank | fp8 bytes |
|---|---|---|
| `w13_weight_scale` | `[96, 4096, 448]` | 96 × 1,835,008 B ≈ **168 MiB / MoE layer** |
| `w2_weight_scale`  | `[96, 7168, 128]` | 96 × 917,504 B ≈ **84 MiB / MoE layer** |
| **per MoE layer** | | **~252 MiB** |
| **× 60 MoE layers** | | **~14.8 GiB / rank** (~15.1 GB) |

On the TRTLLM branch the freed tensors are `*_blockscale_swizzled` instead — same dimensions, padded layout, same order of magnitude.

`w13_input_scale` / `w2_input_scale` per-expert fp32 scalars: a few KB per layer, negligible.

#### Linear method (non-MoE linears)

`weight_scale` freed is `[N, K/16]` fp8; the two scalars are negligible. With Kimi-K2.5's `num_heads=64` and one dense-MLP layer:

| block | per-rank |
|---|---|
| Attention (×61, MLA): `fused_qkv_a` + `q_b_proj` + `kv_b_proj` + `o_proj` ≈ ~2.2 MB / layer | ~134 MB |
| Dense MLP (×1): `gate_up` + `down` ≈ 5.9 MB / layer | ~6 MB |
| MoE shared expert (×60): `gate_up` + `down` ≈ 0.66 MB / layer | ~40 MB |
| **Linear total** | **~180 MB / rank** |

#### Combined total — TP=4

| | per rank | aggregate (×4) |
|---|---|---|
| MoE | ~14.8 GiB | ~59 GiB |
| Linear | ~180 MB | ~720 MB |
| **Total** | **~15 GiB / rank** | **~60 GiB** |

(Linear-method savings are ~1% of the MoE term; the dominant win is the per-expert FP8 block scale.)

Caveats:
- The Linear-method numbers assume the listed linears all go through `ModelOptNvFp4LinearMethod`. `is_layer_excluded` (modelopt_quant.py:334) and the checkpoint's `quantization_config` can pull some out (commonly `lm_head`, routing gate, sometimes `kv_b_proj`).
- Easiest empirical check, drop in around `del layer.w13_weight_scale, layer.w2_weight_scale` at the end of the non-TRTLLM branch:
  ```python
  import torch
  before = torch.cuda.memory_allocated()
  del layer.w13_weight_scale, layer.w2_weight_scale
  torch.cuda.empty_cache()
  after = torch.cuda.memory_allocated()
  logger.info("MoE FP4 scale free saved %.2f MB", (before - after) / 2**20)
  ```
  Expected: ~252 MiB per MoE layer; cumulative ~15 GiB across all 60.
- TRTLLM-branch deletions (`*_blockscale_swizzled`) are the same magnitude per layer but freed from a different attribute.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)