### PR TITLE
spec: defer verify() idle hidden_size to worker fixup

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -252,10 +252,14 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
+            # Defer hidden_states shape decision to the worker fixup in
+            # `forward_draft_extend_after_decode`, which has the worker
+            # reference and uses `EagleDraftExtendInput.hidden_size_for(worker)`
+            # (single source of truth incl. EAGLE-3 aux widening).
             draft_extend_input = EagleDraftExtendInput.create_idle_input(
                 device=batch.device,
-                hidden_size=batch.model_config.spec_hidden_size,
-                dtype=batch.model_config.dtype,
+                hidden_size=None,
+                dtype=None,
                 capture_hidden_mode=CaptureHiddenMode.LAST,
             )
             return EagleVerifyOutput.create_idle(
@@ -645,10 +649,14 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     req_pool_indices=batch.req_pool_indices[unfinished_index_device],
                 )
             else:
+                # All reqs in this batch finished at verify; the worker fixup
+                # (see EAGLEWorker.forward_draft_extend_after_decode) rebuilds
+                # this stub with `EagleDraftExtendInput.hidden_size_for(worker)`
+                # so the column shape is irrelevant here.
                 draft_extend_input = EagleDraftExtendInput.create_idle_input(
                     device=batch.device,
-                    hidden_size=batch.model_config.spec_hidden_size,
-                    dtype=batch.model_config.dtype,
+                    hidden_size=None,
+                    dtype=None,
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
 

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -252,10 +252,9 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         accepted token logits.
         """
         if batch.forward_mode.is_idle():
-            # Defer hidden_states shape decision to the worker fixup in
-            # `forward_draft_extend_after_decode`, which has the worker
-            # reference and uses `EagleDraftExtendInput.hidden_size_for(worker)`
-            # (single source of truth incl. EAGLE-3 aux widening).
+            # hidden_size=None: worker fixup in forward_draft_extend_after_decode
+            # rebuilds via EagleDraftExtendInput.hidden_size_for(worker)
+            # (single source incl. EAGLE-3 aux widening).
             draft_extend_input = EagleDraftExtendInput.create_idle_input(
                 device=batch.device,
                 hidden_size=None,
@@ -649,10 +648,8 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     req_pool_indices=batch.req_pool_indices[unfinished_index_device],
                 )
             else:
-                # All reqs in this batch finished at verify; the worker fixup
-                # (see EAGLEWorker.forward_draft_extend_after_decode) rebuilds
-                # this stub with `EagleDraftExtendInput.hidden_size_for(worker)`
-                # so the column shape is irrelevant here.
+                # hidden_size=None: worker fixup rebuilds via
+                # EagleDraftExtendInput.hidden_size_for(worker) (single source).
                 draft_extend_input = EagleDraftExtendInput.create_idle_input(
                     device=batch.device,
                     hidden_size=None,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1162,12 +1162,10 @@ class EAGLEWorker(TpModelWorker):
             else CaptureHiddenMode.LAST
         )
         if draft_extend_input.input_ids.shape[0] == 0:
-            # Rebuild the idle ExtendInput stub here (single source for
-            # hidden_states width via `hidden_size_for(self)`, incl. EAGLE-3
-            # aux widening). Covers two stub origins:
-            #   - `verify()` Site 1: fully-idle batch (DP attn rank w/o reqs)
-            #   - `verify()` Site 2: active batch, all reqs finished at verify
-            # `prepare_for_idle()` is idempotent when already idle.
+            # Single source for hidden_size via hidden_size_for(self) (incl.
+            # EAGLE-3 aux widening). Two stub origins from verify(): fully-idle
+            # batch (DP attn rank w/o reqs) and active batch with all reqs
+            # finished. prepare_for_idle() is idempotent on already-idle.
             batch = batch.copy()
             batch.prepare_for_idle()
             draft_extend_input = EagleDraftExtendInput.create_idle_input(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1161,8 +1161,13 @@ class EAGLEWorker(TpModelWorker):
             if self.speculative_algorithm.is_standalone()
             else CaptureHiddenMode.LAST
         )
-        if not input_is_idle and draft_extend_input.input_ids.shape[0] == 0:
-            # All reqs finished this verify; swap to an idle ExtendInput.
+        if draft_extend_input.input_ids.shape[0] == 0:
+            # Rebuild the idle ExtendInput stub here (single source for
+            # hidden_states width via `hidden_size_for(self)`, incl. EAGLE-3
+            # aux widening). Covers two stub origins:
+            #   - `verify()` Site 1: fully-idle batch (DP attn rank w/o reqs)
+            #   - `verify()` Site 2: active batch, all reqs finished at verify
+            # `prepare_for_idle()` is idempotent when already idle.
             batch = batch.copy()
             batch.prepare_for_idle()
             draft_extend_input = EagleDraftExtendInput.create_idle_input(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -707,10 +707,9 @@ class MultiLayerEagleWorker(TpModelWorker):
             else CaptureHiddenMode.LAST
         )
         if draft_extend_input.input_ids.shape[0] == 0:
-            # Single source for hidden_states width via `hidden_size_for(self)`
-            # (incl. EAGLE-3 aux widening). Covers both `verify()` Site 1
-            # (fully-idle) and Site 2 (active w/ all reqs finished).
-            # `prepare_for_idle()` is idempotent when already idle.
+            # Single source for hidden_size via hidden_size_for(self) (incl.
+            # EAGLE-3 aux widening). Two stub origins from verify(): fully-idle
+            # batch and active batch with all reqs finished.
             batch = batch.copy()
             batch.prepare_for_idle()
             draft_extend_input = EagleDraftExtendInput.create_idle_input(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -706,7 +706,11 @@ class MultiLayerEagleWorker(TpModelWorker):
             if self.speculative_algorithm.is_standalone()
             else CaptureHiddenMode.LAST
         )
-        if not input_is_idle and draft_extend_input.input_ids.shape[0] == 0:
+        if draft_extend_input.input_ids.shape[0] == 0:
+            # Single source for hidden_states width via `hidden_size_for(self)`
+            # (incl. EAGLE-3 aux widening). Covers both `verify()` Site 1
+            # (fully-idle) and Site 2 (active w/ all reqs finished).
+            # `prepare_for_idle()` is idempotent when already idle.
             batch = batch.copy()
             batch.prepare_for_idle()
             draft_extend_input = EagleDraftExtendInput.create_idle_input(


### PR DESCRIPTION
Schema cleanup: `EagleVerifyInput.verify()` idle stubs no longer compute `hidden_size` locally from `batch.model_config.spec_hidden_size`; they hand off to the worker fixup in `forward_draft_extend_after_decode`, which rebuilds via `EagleDraftExtendInput.hidden_size_for(self)` (single source, incl. EAGLE-3 aux widening). Behaviorally neutral (rows=0).