### PR TITLE
[Fix]: BCG support for RadixLinearAttention (Qwen3.5 / linear-attn hybrid models)

### DIFF
--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -22,6 +22,12 @@ from torch import nn
 
 from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.compilation.piecewise_context_manager import get_forward_context
+from sglang.srt.model_executor.breakable_cuda_graph.breakable_cuda_graph import (
+    eager_on_graph,
+)
+from sglang.srt.model_executor.breakable_cuda_graph.context import (
+    is_in_breakable_cuda_graph,
+)
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.utils.custom_op import register_custom_op
 
@@ -84,13 +90,22 @@ class RadixLinearAttention(nn.Module):
                 dtype=mixed_qkv.dtype,
                 device=mixed_qkv.device,
             )
-            unified_linear_attention_with_output(
-                mixed_qkv,
-                a,
-                b,
-                output,
-                self.layer_id,
-            )
+            if is_in_breakable_cuda_graph():
+                bcg_unified_linear_attention_with_output(
+                    mixed_qkv,
+                    a,
+                    b,
+                    output,
+                    self.layer_id,
+                )
+            else:
+                unified_linear_attention_with_output(
+                    mixed_qkv,
+                    a,
+                    b,
+                    output,
+                    self.layer_id,
+                )
             return output
         else:
             return get_attn_backend().forward(
@@ -136,3 +151,8 @@ def unified_linear_attention_with_output(
 
     output[:, :real_num_tokens].copy_(ret)
     return
+
+
+bcg_unified_linear_attention_with_output = eager_on_graph(True)(
+    unified_linear_attention_with_output
+)


### PR DESCRIPTION
## Motivation

`RadixAttention` has BCG wiring at `radix_attention.py:128` (from #22218). `RadixLinearAttention` does not — so under `--enable-breakable-cuda-graph` on hybrid linear-attn models (Qwen3.5, Qwen3-Next, Kimi-Linear, Bailing-MoE-Linear) the linear-attn kernels get captured into the segment cudagraph and the server silently produces wrong outputs.

This PR mirrors the `RadixAttention` pattern in `RadixLinearAttention`.

## Accuracy Tests

GSM8K, 1319 questions, 5-shot greedy, Qwen3.5-4B on H200 TP=1:

| Mode | Accuracy | Latency | Throughput |
|---|---:|---:|---:|
| PCG (torch.compile) | 86.1% | 71.7 s | 3251 tok/s |
| BCG, **before** this PR | **16.5%** | 27.7 s | 5578 tok/s |
| BCG, **with** this PR | **86.7%** | 55.7 s | 4122 tok/s |

### Launch

```bash
python -m sglang.launch_server \
    --model-path /path/to/Qwen3.5-4B \
    --port 33001 --trust-remote-code \
    --piecewise-cuda-graph-tokens 256 512 1024 2048 \
    --max-running-requests 128 --mem-fraction-static 0.7 \
    --enforce-piecewise-cuda-graph \
    --enable-breakable-cuda-graph
```

`--enforce-piecewise-cuda-graph` is required to bypass the multimodal auto-disable in `_handle_piecewise_cuda_graph`.

### Bench

```bash
python benchmark/gsm8k/bench_sglang.py \
    --data-path /path/to/gsm8k/test.jsonl \
    --num-questions 1319 --parallel 128 --port 33001
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26256197562](https://github.com/sgl-project/sglang/actions/runs/26256197562)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26256197551](https://github.com/sgl-project/sglang/actions/runs/26256197551)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->