### PR TITLE
[AMD] mitigate NCCL init flake in stage-b 2-GPU AMD jobs

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -517,10 +517,22 @@ jobs:
 
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Test RCCL multi-GPU communication
+        timeout-minutes: 5
+        run: |
+          echo "Testing RCCL multi-GPU communication with debug info..."
+          docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=2 scripts/ci/amd/test_rccl_multi_gpu.py"
+
       - name: Run test
         timeout-minutes: 30
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            -e NCCL_CUMEM_ENABLE=0 \
+            -e NCCL_NVLS_ENABLE=0 \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -w "/sglang-checkout/test" \
+            python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 1800 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
 
   multimodal-gen-test-1-gpu-amd-rocm720:
     needs: [check-changes]

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -573,10 +573,21 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
+      - name: Test RCCL multi-GPU communication
+        timeout-minutes: 5
+        run: |
+          echo "Testing RCCL multi-GPU communication with debug info..."
+          docker exec ci_sglang bash -c "cd /sglang-checkout && NCCL_DEBUG=INFO RCCL_DEBUG=INFO torchrun --nproc_per_node=2 scripts/ci/amd/test_rccl_multi_gpu.py"
+
       - name: Run test
         timeout-minutes: 45
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            -e NCCL_CUMEM_ENABLE=0 \
+            -e NCCL_NVLS_ENABLE=0 \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -w "/sglang-checkout/test" \
+            python3 run_suite.py --hw amd --suite stage-b-test-2-gpu-large-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 2 --timeout-per-file 2700 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   multimodal-gen-test-1-gpu-amd:
     name: ${{ format('multimodal-gen-test-1-gpu-amd (linux-{0}-1gpu-sglang, {1})', inputs.runner_arch || 'mi325', matrix.part) }}


### PR DESCRIPTION
The stage-b-test-2-gpu-large-amd job has been intermittently failing on mi300 runners with:

  RuntimeError: NCCL error: unhandled cuda error
    (in PyNcclCommunicator.__init__ -> ncclCommInitRank)

Both the test-internal retry and the suite-level wrapper were unable to recover, because the failure surfaces as a RuntimeError, which is in the NON_RETRIABLE_PATTERNS list in python/sglang/test/ci/ci_utils.py. The 2-GPU job was the only multi-GPU AMD job without any preflight check or NCCL/RCCL workaround env vars.

Apply the same mitigations already used by the larger AMD jobs:

* Add an RCCL preflight torchrun check (matches stage-c-test-large-8-gpu-amd at .github/workflows/pr-test-amd.yml line 979). When the GPU pair is unhealthy this fails fast in <5 minutes with NCCL_DEBUG/RCCL_DEBUG output instead of waiting >14 minutes for model loading and exhausting the test-level retry on a benign infra issue.

* Pass NCCL_CUMEM_ENABLE=0, NCCL_NVLS_ENABLE=0, RCCL_MSCCL_ENABLE=0 when invoking run_suite.py (matches stage-c-test-4-gpu-amd at .github/workflows/pr-test-amd.yml lines 925-927). These flags are the established AMD-side workaround for ROCm/RCCL initialization races.

Apply the same change to .github/workflows/pr-test-amd-rocm720.yml so the two AMD workflows stay aligned.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
