### PR TITLE
[AMD] Bump --timeout-per-file 1800->2400 for stage-b-test-1-gpu-small-amd

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -419,9 +419,9 @@ jobs:
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 60
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
   stage-b-test-1-gpu-small-amd-nondeterministic:
     name: ${{ format('stage-b-test-1-gpu-small-amd-nondeterministic (linux-{0}-1gpu-sglang)', inputs.runner_arch || (github.event_name == 'pull_request' && 'mi300' || 'mi325')) }}


### PR DESCRIPTION
## Summary

Bump `--timeout-per-file` from `1800` to `2400` (40 min) on the `stage-b-test-1-gpu-small-amd` invocation in `.github/workflows/pr-test-amd.yml`, and bump the corresponding step-level `timeout-minutes` from `45` to `60`. **One workflow file, +2/-2.**

No test code change. No registry change. The rocm720 variant (`pr-test-amd-rocm720.yml`, MI325 hardcoded) is left at `1800` — MI325 actual elapsed for this file is ~1000 s.

## Why 2400 (not 1800, not 3000): the data

I pulled `test_vlm_perf_5090.py` elapsed time from every recent shard-7 PR-CI run on MI300 plus a couple of references:

| label | hw | elapsed (s) | summary | job |
|---|---|---:|---|---|
| **24572-ORIGINAL-TIMEOUT** | **MI300** | **1801 (TIMEOUT)** | **0/8 passed** | [75240741847](https://github.com/sgl-project/sglang/actions/runs/25632853029/job/75240741847) |
| michaelzhang-ai/PR-25112 (this PR's prior verification run) | MI300 | 1471 | 8/8 passed | [76024416280](https://github.com/sgl-project/sglang/actions/runs/25846973132/job/76024416280) |
| fix/deepseek-v32-detector-narrow | MI300 | 1383 | 8/8 passed | [76058049938](https://github.com/sgl-project/sglang/actions/runs/25879179278/job/76058049938) |
| jialino/pyarray-tokens | MI300 | 1334 | 8/8 passed | [76082082345](https://github.com/sgl-project/sglang/actions/runs/25886303732/job/76082082345) |
| fix/async-mm-data-loading | MI300 | 1306 | 8/8 passed | [76066503726](https://github.com/sgl-project/sglang/actions/runs/25881627997/job/76066503726) |
| jialino/pyarray-tokens (older) | MI300 | 1277 | 8/8 passed | [76068048317](https://github.com/sgl-project/sglang/actions/runs/25882191845/job/76068048317) |
| feat/bcg-linear-attention | MI300 | 1258 | 8/8 passed | [76105461551](https://github.com/sgl-project/sglang/actions/runs/25889721636/job/76105461551) |
| libinta/xpu_lmcache | MI300 | 1216 | 8/8 passed | [76064659548](https://github.com/sgl-project/sglang/actions/runs/25881133774/job/76064659548) |
| hanming/out-cache-loc-swa | MI300 | 1204 | 8/8 passed | [76073775418](https://github.com/sgl-project/sglang/actions/runs/25883625402/job/76073775418) |
| lsyin/move-dead-tests-to-manual | MI300 | 1195 | 8/8 passed | [76096732833](https://github.com/sgl-project/sglang/actions/runs/25891107599/job/76096732833) |
| jialino/radix-cache-registry | MI300 | 1194 | 8/8 passed | [76071393309](https://github.com/sgl-project/sglang/actions/runs/25882991619/job/76071393309) |
| cheng/free-memory | MI300 | 1188 | 8/8 passed | [76098516352](https://github.com/sgl-project/sglang/actions/runs/25891898210/job/76098516352) |
| ci/nightly-tag-routing | MI300 | 1183 | 8/8 passed | [76059173068](https://github.com/sgl-project/sglang/actions/runs/25880484630/job/76059173068) |
| nightly-MI325-baseline | MI325 | 1000 | 8/8 passed | [75850659317](https://github.com/sgl-project/sglang/actions/runs/25817749454/job/75850659317) |

MI300 stats (n=13): `min=1183  max=1801  mean=1308  median=1258  stdev=172`

| Budget | Failures in this 14-run sample | Headroom over max observed |
|---:|---:|---:|
| **1800 s** | 1 / 14 (~7%) — the May 10 timeout, exactly at the rail | -1 s (no headroom) |
| **2400 s** | 0 / 14 | +599 s (33%) |
| **3000 s** | 0 / 14 | +1199 s (67%) |

A few observations:

- **The 1801 s timeout is not a mystery.** `mean + 3·stdev = 1308 + 3·172 = 1824 s` on the existing distribution, which lines up with the May 10 outlier. The file genuinely has a long upper tail; 1800 s is empirically borderline.
- **Every run has exactly 1 internal `retry()`.** `run_bench_serving` is wrapped in `retry(max_retries=1)`, the throughput-assertion-flake-then-retry pattern fires every single time, and the elapsed already includes that retry overhead.
- **2400 s clears all observed values with 33 % margin** and clears `mean + 3σ ≈ 1824 s` with 31 % margin, while keeping the diff small.

### Why the May 10 outlier was 620 s slower than the median

Phase-by-phase comparison of the May 10 timeout (1801 s) vs the fast 5/14 run (1183 s):

| Phase | May 10 (job 75240741847) | Fast run (job 76059173068) | Δ |
|---|---:|---:|---:|
| HF snapshot re-fetch (`will attempt download`) | ~90 s | ~21 s | **+69 s** |
| `Load weight end` (download + load) | `elapsed=95.74 s` | `elapsed=23.03 s` | +73 s |
| Server "fired up" → first non-stuck `Health check` | ~2 min (9 warnings × 20 s) | ~30 s (2 warnings) | **+90 s** |
| 1st throughput run (assertion failed both runs at this phase) | 8.5 min | 6.5 min | **+120 s** |
| 1st-run output throughput | 808 tok/s | 1043 tok/s | slower |
| Retry throughput (passed both runs) | 5990 tok/s | 9907 tok/s | slower |

Both runs hit `Local HF snapshot ... has no files matching ['*.safetensors']; will attempt download` (the runner pod's HF cache appears to ~always miss this filter), but on May 10 the actual fetch took ~4× longer and the post-`fired up` detokenizer warmup hung for ~90 s longer. The May 10 run wasn't broken — it was a slow runner pod where each of three small slowdowns (~70 s HF, ~90 s detokenizer warmup, ~120 s slower decode) compounded into ~620 s extra. That's exactly the kind of low-frequency tail event a 33 % timeout buffer absorbs.

## Why also bump `timeout-minutes`

The "Run test" step had `timeout-minutes: 45` (= 2700 s) which is below the new 2400 s per-file limit only when you account for the rest of the partition. Worst-case sizing: 40 min for the perf file + ~7 min for the other 7 files in the partition + ~2-3 min setup ≈ 50 min, so `timeout-minutes: 60` leaves comfortable headroom (the prior verification run finished shard 7 in 48 m 54 s end-to-end).

## Verification on this PR (prior commit)

The previous `--timeout-per-file 3000` revision of this PR ran shard 7 successfully on attempt 3 of run [25846973132](https://github.com/sgl-project/sglang/actions/runs/25846973132), [job 76024416280](https://github.com/sgl-project/sglang/actions/runs/25846973132/job/76024416280):

```
Begin (0/7): /sglang-checkout/test/registered/perf/test_vlm_perf_5090.py
…
End (0/7):
filename='/sglang-checkout/test/registered/perf/test_vlm_perf_5090.py', elapsed=1471, estimated_time=500.0
…
Ran 2 tests in 1463.648s
OK
…
Test Summary: 8/8 passed
```

`elapsed = 1471 s` is within the new 2400 s budget with 39 % headroom; `Ran 2 tests … OK` confirms the unittest-level outcome. CI for the new 2400 / 60 combination will run on this push.

## Scope

```diff
       - name: Run test
-        timeout-minutes: 45
+        timeout-minutes: 60
         run: |
-          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 1800 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
+          bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" python3 run_suite.py --hw amd --suite stage-b-test-1-gpu-small-amd --auto-partition-id ${{ matrix.part }} --auto-partition-size 14 --timeout-per-file 2400 ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
```

Other suites in `pr-test-amd.yml` (`stage-b-test-1-gpu-small-amd-nondeterministic`, `stage-b-test-1-gpu-large-amd`, `stage-b-test-2-gpu-large-amd`, `stage-b-test-large-8-gpu-35x-disaggregation-amd`) keep `--timeout-per-file 1800` and step `timeout-minutes: 45` unchanged. `pr-test-amd-rocm720.yml` (MI325) is also untouched.

## Test plan

- [x] Validated on this PR with `--timeout-per-file 3000` (prior commit): `test_vlm_perf_5090.py` finished in 1471 s; full shard 7 finished in 48 m 54 s; `Ran 2 tests in 1463.648s … OK`; shard `Test Summary: 8/8 passed`.
- [ ] CI on this push will exercise the actual 2400/60 values; expected to land in the same 1183-1471 s range.
- [x] No other suites or workflows touched.

> Footnote: the May 10 PR run that motivated this change was [job 75240741847 on PR #24572](https://github.com/sgl-project/sglang/actions/runs/25632853029/job/75240741847?pr=24572). Recent unrelated stage-A and stage-C-large failures observed on this PR's CI affect different suites that this change does not touch and are also failing on recent main runs.