### PR TITLE
docker, ci: swap GB DeepEP source from fzyzcjy fork to deepseek-ai/DeepEP@hybrid-ep

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG BRANCH_TYPE=remote
 ARG GRACE_BLACKWELL=0
 ARG HOPPER_SBO=0
 
-ARG GRACE_BLACKWELL_DEEPEP_BRANCH=gb200_blog_part_2
+ARG GRACE_BLACKWELL_DEEPEP_BRANCH=hybrid-ep
 ARG HOPPER_SBO_DEEPEP_COMMIT=9f2fc4b3182a51044ae7ecb6610f7c9c3258c4d6
 ARG DEEPEP_COMMIT=9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee
 ARG BUILD_AND_DOWNLOAD_PARALLEL=8
@@ -270,9 +270,9 @@ WORKDIR /build
 # Clone DeepEP
 RUN set -eux; \
     if [ "$GRACE_BLACKWELL" = "1" ]; then \
-      git clone https://github.com/fzyzcjy/DeepEP.git && \
+      git clone https://github.com/deepseek-ai/DeepEP.git -b ${GRACE_BLACKWELL_DEEPEP_BRANCH} && \
       cd DeepEP && \
-      git checkout ${GRACE_BLACKWELL_DEEPEP_BRANCH} && \
+      git checkout d28bd676c2120573c9f1425f0c16c39faa4117e6 && \
       sed -i 's/#define NUM_CPU_TIMEOUT_SECS 100/#define NUM_CPU_TIMEOUT_SECS 1000/' csrc/kernels/configs.cuh && \
       sed -i 's/#define NUM_TIMEOUT_CYCLES 200000000000ull/#define NUM_TIMEOUT_CYCLES 2000000000000ull/' csrc/kernels/configs.cuh && \
       cd .. ; \

--- a/scripts/ci/cuda/ci_install_deepep.sh
+++ b/scripts/ci/cuda/ci_install_deepep.sh
@@ -99,11 +99,10 @@ apt-get install -y --no-install-recommends libfabric-dev || {
 DEEPEP_DIR=/root/.cache/deepep
 rm -rf ${DEEPEP_DIR}
 if [ "$GRACE_BLACKWELL" = "1" ]; then
-    # We use Tom's DeepEP fork for GB200 for now, which supports fp4 dispatch.
-    GRACE_BLACKWELL_DEEPEP_BRANCH=gb200_blog_part_2
-    git clone https://github.com/fzyzcjy/DeepEP.git ${DEEPEP_DIR} && \
+    GRACE_BLACKWELL_DEEPEP_BRANCH=hybrid-ep
+    git clone https://github.com/deepseek-ai/DeepEP.git -b ${GRACE_BLACKWELL_DEEPEP_BRANCH} ${DEEPEP_DIR} && \
     pushd ${DEEPEP_DIR} && \
-    git checkout ${GRACE_BLACKWELL_DEEPEP_BRANCH} && \
+    git checkout d28bd676c2120573c9f1425f0c16c39faa4117e6 && \
     sed -i 's/#define NUM_CPU_TIMEOUT_SECS 100/#define NUM_CPU_TIMEOUT_SECS 1000/' csrc/kernels/configs.cuh && \
     popd
 else


### PR DESCRIPTION
## Motivation

Move the **Grace Blackwell** DeepEP build path off the personal `fzyzcjy/DeepEP@gb200_blog_part_2` fork and onto upstream `deepseek-ai/DeepEP@hybrid-ep`, where DeepSeek's active DeepEP work lands. This gets the GB300 staging image (`lmsysorg/sglang-staging:deepseek-v4-grace-blackwell-dev_arm64`) onto a maintained upstream source.

## Modifications

Two files, GB-only paths:

**`docker/Dockerfile`** — 3-line change:
- Default `GRACE_BLACKWELL_DEEPEP_BRANCH=gb200_blog_part_2` → `hybrid-ep`.
- Clone URL `https://github.com/fzyzcjy/DeepEP.git` → `https://github.com/deepseek-ai/DeepEP.git`, now using `-b ${GRACE_BLACKWELL_DEEPEP_BRANCH}` at clone time.
- Inline `git checkout d28bd676c2120573c9f1425f0c16c39faa4117e6` to pin against the moving `hybrid-ep` branch.

**`scripts/ci/cuda/ci_install_deepep.sh`** — mirror the same change in the CI install script's GB block. Without this, CI would re-install `fzyzcjy/DeepEP@gb200_blog_part_2` at test time even though the image already contains hybrid-ep, defeating the swap.

No other Dockerfile stages change. The default `DEEPEP_COMMIT` (non-GB / non-HOPPER_SBO path) is intentionally **not** touched in this PR; this PR only updates what the GB image / GB CI consumes.

Notes on pieces that **do not** need changing:
- `libibverbs-dev` (which supplies `mlx5dv.h` that `hybrid-ep` unconditionally includes; the fork compiled without IB linkage) is already in the base apt set and in `DEEPEP_SYSTEM_DEPS`.
- `CHOSEN_TORCH_CUDA_ARCH_LIST` for CUDA 12.8.1+ already includes `10.0` (Blackwell sm_100), so the new `hybrid_ep_cpp` extension builds correctly without arch tweaks.
- The two timeout-constant `sed` commands still apply unchanged against `hybrid-ep`.

⚠️ **CI coverage caveat:** SGLang CI runs the default `DEEPEP_COMMIT` path (`9af0e0d0…`) on most jobs, not the `GRACE_BLACKWELL=1` path that this PR modifies. CI greens on the default path will **not** exercise the hybrid-ep build; the GB-only CI job (which sources the install script above) will.

## Accuracy Tests

DSv4-Pro 8p1d disagg recipe, sa-bench random ISL 8192 / OSL 1024, 40,960 requests: 0 crashes, output distribution unchanged vs the fork.

## Speed Tests and Profiling

### 1. DSv4-Pro disagg recipe (production workload)

GB300 staging image with the hybrid-ep wheel swapped in; 8p1d-dep4-dep16 c4096 recipe:

| Metric | fork (baseline) | hybrid-ep (this PR) | Δ |
|---|---|---|---|
| Throughput / GPU | 9734 tok/s | ~9710 tok/s | ±0.25% |
| Prefill weight-load mem | 233.71 GB | 233.71 GB | 0 |
| Prefill KV pool free | 24.81 GB | 24.81 GB | 0 |
| Decode CUDA-graph capture | 5.02 GB / 399.52 s | 5.02 GB / 398.85 s | 0 / -0.67 s |
| Decode `max_total_num_tokens` | 21,478,400 | 21,478,400 | 0 |

Byte-equivalent footprint at every memory milestone. Throughput delta is within run-to-run noise — clean drop-in on the disagg path.

### 2. Qwen3-30B-A3B-NVFP4 unified engine (direct kernel A/B)

To stress-test the new `hybrid_ep_cpp` kernels through the FP4 dispatch path (`moe_a2a_backend=deepep`, `moe_runner_backend=flashinfer_cutedsl`, `deepep_mode=low_latency`, ep=tp=4). Same image (nightly `cu13-20260513-4fb40bff`), only the `deep_ep` wheel changes between runs. Bench: `sglang.bench_one_batch_server`, ISL 16 / OSL 256:

| batch | fork latency / output tput | hybrid-ep latency / output tput | Δ |
|---|---|---|---|
| 1 | 1.58 s / 175 tok/s | 1.54 s / 180 tok/s | -2.5% lat, +2.7% tput |
| 16 | 2.11 s / 2513 tok/s | 2.07 s / 2548 tok/s | -1.9% lat, +1.4% tput |
| 64 | 2.59 s / 9178 tok/s | 2.55 s / 9305 tok/s | -1.5% lat, +1.4% tput |

Hybrid-ep is ~1–2% faster across the board, consistently in the same direction — no NVFP4-dispatch regression on the new kernels.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). _(N/A — build wiring change.)_
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). _(N/A.)_
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).