### PR TITLE
fix: Capture cuda graph failed when dp attention enabled for flashinfer_backend

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -543,6 +543,20 @@ class FlashInferAttnBackend(AttentionBackend):
             cuda_graph_kv_indices.clone() for _ in range(self.num_wrappers - 1)
         ]
 
+        # PR #20978 pads max_bs beyond pool_size for higher cuda-graph coverage.
+        # Reallocate indptr / last_page_len buffers so they fit the padded max_bs. 
+        if max_bs > self.kv_indptr[0].shape[0] - 1:
+            for i in range(self.num_wrappers):
+                self.kv_indptr[i] = torch.zeros(
+                    (max_bs + 1,),
+                    dtype=torch.int32, 
+                    device=self.kv_indptr[i].device, 
+                )
+            self.kv_last_page_len = torch.ones(
+                (max_bs,), dtype=torch.int32, device=self.kv_last_page_len.device
+            )
+            self.indices_updater_decode.kv_last_page_len = self.kv_last_page_len
+
         # Ensure tensors are properly allocated
         for i in range(self.num_wrappers):
             # Force allocation by performing a small operation


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Motivation

  When --cuda-graph-bs specifies batch sizes that exceed req_to_token_pool.size, FlashInferAttnBackend crashes during CUDA graph capture. The crash occurs because kv_indptr and kv_last_page_len are allocated in __init__ with capacity req_to_token_pool.size + 1, but init_cuda_graph_state receives a max_bs computed from max(capture_bs) in CudaGraphRunner, which can be larger than the pool size. The CUDA graph then writes through these undersized buffers, causing out-of-bounds access.

  This commonly affects configurations with --enable-dp-attention where larger --cuda-graph-bs values are used to improve coverage, or environments where --disable-cuda-graph-padding is not set and the default padding stretches max_bs beyond the pool limit.

## Modifications
  
  python/sglang/srt/layers/attention/flashinfer_backend.py — FlashInferAttnBackend.init_cuda_graph_state
  
  Detect when the incoming max_bs exceeds the existing kv_indptr buffer capacity (shape[0] - 1), and reallocate both kv_indptr and kv_last_page_len to match the required size. Also update indices_updater_decode.kv_last_page_len to reference the new buffer, avoiding a stale pointer to freed memory.

  if max_bs > self.kv_indptr[0].shape[0] - 1:
      for i in range(self.num_wrappers):
          self.kv_indptr[i] = torch.zeros(
              (max_bs + 1,), dtype=torch.int32, device=self.kv_indptr[i].device
          )
      self.kv_last_page_len = torch.ones(
          (max_bs,), dtype=torch.int32, device=self.kv_last_page_len.device
      )
      self.indices_updater_decode.kv_last_page_len = self.kv_last_page_len

  - All num_wrappers copies of kv_indptr are reallocated, consistent with how they were created in __init__.
  - kv_last_page_len is reallocated at the new size and the reference in indices_updater_decode is refreshed.
  - The check uses self.kv_indptr[0].shape[0] - 1 (first wrapper's capacity) as the baseline, since all wrappers share the same initial size.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
