### PR TITLE
[Disagg] Add retry with exponential backoff for prefill bootstrap register

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -336,7 +336,7 @@ class CommonKVManager(BaseKVManager):
         info.required_prefill_response_num = required_prefill_response_num
 
     def register_to_bootstrap(self):
-        """Register prefill server info to bootstrap server via HTTP POST."""
+        """Register prefill server info to bootstrap server via HTTP PUT."""
         if self.dist_init_addr:
             # Multi-node case: bootstrap server's host is dist_init_addr
             host = NetworkAddress.parse(self.dist_init_addr).resolved().host
@@ -364,18 +364,33 @@ class CommonKVManager(BaseKVManager):
             "load_balance_method": self.server_args.load_balance_method,
         }
 
-        try:
-            response = requests.put(url, json=payload, timeout=5)
-            if response.status_code == 200:
-                logger.debug("Prefill successfully registered to bootstrap server.")
-            else:
-                logger.error(
-                    f"Prefill instance failed to connect to bootstrap server: {response.status_code}, {response.text}"
+        max_retries, initial_delay, max_delay = 5, 1.0, 30.0
+        for attempt in range(max_retries):
+            try:
+                response = requests.put(url, json=payload, timeout=5)
+                if response.status_code == 200:
+                    logger.debug("Prefill successfully registered to bootstrap server.")
+                    return
+                logger.warning(
+                    f"Prefill register attempt {attempt + 1}/{max_retries} failed: status {response.status_code}"
                 )
-        except Exception as e:
-            logger.error(
-                f"Prefill instance failed to register to bootstrap server: {e}"
+            except Exception as e:
+                # Walk to root cause to skip misleading urllib3 wrapper messages
+                cause = e
+                while cause.__cause__ is not None:
+                    cause = cause.__cause__
+                logger.warning(
+                    f"Prefill register attempt {attempt + 1}/{max_retries} failed: {cause}"
+                )
+            if attempt == max_retries - 1:
+                break
+            delay = min(initial_delay * (2**attempt), max_delay) * (
+                0.75 + 0.25 * (time.monotonic() % 1)
             )
+            time.sleep(delay)
+        logger.error(
+            f"Prefill instance failed to register to bootstrap server after {max_retries} retries"
+        )
 
     @cache
     def _connect(self, endpoint: str, is_ipv6: bool = False):

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -1,0 +1,226 @@
+"""Unit tests for srt/disaggregation/common/conn — register_to_bootstrap retry logic."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestRegisterToBootstrap(CustomTestCase):
+    """Tests for CommonKVManager.register_to_bootstrap retry/backoff behavior."""
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_succeeds_on_first_attempt(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_put.return_value = mock_response
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        mock_put.assert_called_once()
+        mock_time.sleep.assert_not_called()
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_succeeds_after_retries(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        mock_put.side_effect = [fail_resp, fail_resp, success_resp]
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        self.assertEqual(mock_put.call_count, 3)
+        self.assertEqual(mock_time.sleep.call_count, 2)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_all_retries_exhausted(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+        mock_put.return_value = fail_resp
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        self.assertEqual(mock_put.call_count, 5)
+        # Sleep is only called between attempts, not after the final failure
+        self.assertEqual(mock_time.sleep.call_count, 4)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_exception_with_nested_cause(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+
+        root_exc = ConnectionRefusedError("connection refused")
+        inner_exc = OSError("os error")
+        inner_exc.__cause__ = root_exc
+        outer_exc = Exception("wrapped")
+        outer_exc.__cause__ = inner_exc
+
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        mock_put.side_effect = [outer_exc, success_resp]
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        self.assertEqual(mock_put.call_count, 2)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_exception_with_no_cause(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+
+        exc = ConnectionError("plain connection error")
+        exc.__cause__ = None
+
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        mock_put.side_effect = [exc, success_resp]
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        self.assertEqual(mock_put.call_count, 2)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_backoff_delay_exponential(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+        mock_put.return_value = fail_resp
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        # With monotonic() = 0.0, jitter factor = 0.75 + 0.25 * (0.0 % 1) = 0.75
+        # delay = min(1.0 * 2^attempt, 30.0) * 0.75
+        # Sleep happens only between attempts (attempt 0..3), not after the final failure
+        expected_calls = [call(0.75), call(1.5), call(3.0), call(6.0)]
+        self.assertEqual(mock_time.sleep.call_args_list, expected_calls)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_jitter_never_exceeds_max_delay(self, mock_put, mock_time):
+        """Guard against operator-precedence regressions in the jitter factor.
+
+        The jitter factor must stay in [0.75, 1.0), so a delay capped at
+        max_delay must never exceed max_delay after applying jitter.
+        """
+        # monotonic() returns a value whose fractional part is close to 1.
+        # If the parentheses around `time.monotonic() % 1` were dropped, the
+        # jitter factor could grow up to ~1.75 and blow past max_delay.
+        mock_time.monotonic.return_value = 999.9999
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+        mock_put.return_value = fail_resp
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        max_delay = 30.0
+        for sleep_call in mock_time.sleep.call_args_list:
+            actual_delay = sleep_call[0][0]
+            self.assertLess(actual_delay, max_delay)
+            self.assertGreaterEqual(actual_delay, 0.75)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_payload_contains_required_fields(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        mock_put.return_value = success_resp
+
+        mgr = self._make_manager()
+        mgr.register_to_bootstrap()
+
+        call_kwargs = mock_put.call_args
+        payload = call_kwargs[1]["json"]
+        required_fields = [
+            "attn_tp_size",
+            "attn_tp_rank",
+            "attn_cp_size",
+            "attn_cp_rank",
+            "attn_dp_size",
+            "attn_dp_rank",
+            "pp_size",
+            "pp_rank",
+            "system_dp_size",
+            "system_dp_rank",
+            "rank_ip",
+            "rank_port",
+            "page_size",
+            "kv_cache_dtype",
+        ]
+        for field in required_fields:
+            self.assertIn(field, payload)
+
+    @patch("sglang.srt.disaggregation.common.conn.time")
+    @patch("sglang.srt.disaggregation.common.conn.requests.put")
+    def test_url_with_dist_init_addr(self, mock_put, mock_time):
+        mock_time.monotonic.return_value = 0.0
+        success_resp = MagicMock()
+        success_resp.status_code = 200
+        mock_put.return_value = success_resp
+
+        mgr = self._make_manager(dist_init_addr="10.0.0.1:12345")
+        mgr.register_to_bootstrap()
+
+        url_used = mock_put.call_args[0][0]
+        self.assertIn("10.0.0.1", url_used)
+
+    def _make_manager(self, dist_init_addr=None):
+        """Create a lightweight mock manager that has the attributes needed
+        by register_to_bootstrap, without going through CommonKVManager.__init__
+        (which requires zmq, ServerArgs model resolution, etc.)."""
+        from sglang.srt.disaggregation.common.conn import CommonKVManager
+
+        mgr = MagicMock(spec=CommonKVManager)
+        # Bind the real method to the mock
+        mgr.register_to_bootstrap = CommonKVManager.register_to_bootstrap.__get__(
+            mgr, CommonKVManager
+        )
+
+        # Set attributes that register_to_bootstrap reads
+        mgr.dist_init_addr = dist_init_addr
+        mgr.bootstrap_host = "127.0.0.1"
+        mgr.bootstrap_port = 8765
+        mgr.attn_tp_size = 1
+        mgr.attn_tp_rank = 0
+        mgr.attn_cp_size = 1
+        mgr.attn_cp_rank = 0
+        mgr.attn_dp_size = 1
+        mgr.attn_dp_rank = 0
+        mgr.pp_size = 1
+        mgr.pp_rank = 0
+        mgr.system_dp_size = 1
+        mgr.system_dp_rank = 0
+        mgr.local_ip = "127.0.0.1"
+        mgr.rank_port = 12345
+
+        mgr.kv_args = MagicMock()
+        mgr.kv_args.page_size = 16
+
+        mgr.server_args = MagicMock()
+        mgr.server_args.kv_cache_dtype = "auto"
+        mgr.server_args.load_balance_method = "follow_bootstrap_room"
+
+        return mgr
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

  In PD disaggregation mode, the prefill scheduler calls `register_to_bootstrap()` to publish its rank/IP/port info to the bootstrap server **as part of scheduler init**, while the bootstrap server itself is started a bit later in the prefill HTTP server bring-up. There is no synchronization between the two — the registration just fires once with no retry, and the original implementation logs the failure and moves on.

  For **large models** the weight-loading and CUDA-graph capture stages take long enough that the bootstrap server is already up by the time `register_to_bootstrap()` runs, so the race never surfaces.
  For **small models** (e.g. `Qwen3-0.6B`), prefill init finishes in a few seconds and races ahead of the bootstrap server, producing exactly this sequence:

  [16:37:43] Prefill instance failed to register to bootstrap server:
             ... Failed to establish a new connection: [Errno 111] Connection refused
  [16:37:45] CommonKVBootstrapServer started successfully on 0.0.0.0:8998   ← 2s too late
  [16:37:48] The server is fired up and ready to roll!
  ...
  [16:42:02] Prefill bootstrap failed for request ... KVTransferError: Aborted by AbortReq.

  The decode side then just sees `Failed to get prefill server info: 503, Prefill server not fully registered yet (0 workers registered)` repeatedly and gives up after 15 attempts:

  [16:41:36] Could not fetch prefill parallel info from 127.0.0.1:8998 after 15 attempts
  [16:41:36] Decode handshake failed for request ... Aborted by AbortReq.
  [16:41:36] INFO: 127.0.0.1:48566 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error

  The prefill instance is never registered, every request 500s, and the only way to recover is to restart the prefill instance. Since the registration is a one-shot HTTP call with no retry, the failure is silent unless someone reads the early log lines.

  ## Modifications

  `python/sglang/srt/disaggregation/common/conn.py` — `CommonKVManager.register_to_bootstrap`:

  - Wrap the `requests.put(...)` call in a retry loop: **up to 5 attempts** with exponential backoff (`1s → 2s → 4s → 8s → 16s`, capped at `30s`) and jitter (`0.75 ~ 1.0` of the base delay).
  - Sleep only **between** attempts — after the final attempt fails, the loop logs and exits immediately instead of blocking on a wasted sleep.
  - On exception, walk `__cause__` to surface the underlying socket error (`Connection refused`, `No route to host`, ...) instead of the wrapping `urllib3` `MaxRetryError`, which is much easier to read in logs.
  - Demote per-attempt failures from `error` to `warning`; only the final exhaustion is logged at `error`.
  - Fix the misleading docstring (`POST` → `PUT`; the call has always been a `PUT`).

  `test/registered/unit/disaggregation/test_register_to_bootstrap.py` — new unit tests covering:

  - success on first attempt (no sleep);
  - success after retries (sleep between attempts only);
  - exhaustion of all retries;
  - exception with nested `__cause__` chain;
  - exception with no cause;
  - exact backoff schedule (deterministic via mocked `time.monotonic`);
  - jitter factor stays in `[0.75, 1.0)` so delay never exceeds `max_delay` (regression guard against operator-precedence mistakes);
  - payload contains all required fields;
  - URL host derives from `dist_init_addr` in the multi-node case.

  Tests are registered to the `stage-a-test-cpu` suite (CPU-only, ~5s).

  ## Accuracy Tests

  Not applicable — this PR only changes startup-time HTTP retry logic for bootstrap registration. It does not touch the model forward path, kernels, KV transfer, or sampling.

  ## Speed Tests and Profiling

  Not applicable for steady-state inference. The change only affects prefill startup behavior. Repro logs from a 1×prefill / 1×decode setup on `Qwen/Qwen3-0.6B` (mooncake backend, mlx5_bond_0/1):

  **Before fix** — registration fires before bootstrap server is up, single attempt, no retry:

  [16:37:43] Prefill instance failed to register to bootstrap server: Connection refused
  [16:37:45] CommonKVBootstrapServer started successfully on 0.0.0.0:8998
  ...
  [16:41:36] Could not fetch prefill parallel info from 127.0.0.1:8998 after 15 attempts
  [16:41:36] INFO: 127.0.0.1:48566 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error

  **After fix** — first attempt fails, second attempt succeeds ~1s later, request goes through:

  [16:34:37] Prefill register attempt 1/5 failed: Connection refused
  [16:34:38] CommonKVBootstrapServer started successfully on 0.0.0.0:8998
  [16:34:42] The server is fired up and ready to roll!
  ...
  [16:35:11] INFO: 127.0.0.1:44402 - "POST /v1/chat/completions HTTP/1.1" 200 OK

  `Qwen3-8B` continues to work as before (registration already succeeded on first attempt because weight loading is slow enough to mask the race).

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the
  speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

  ## Review and Merge Process

  1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
  2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
  3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
     - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
  4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
