### PR TITLE
Fix scheduler admission for near-full KV requests

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1852,13 +1852,24 @@ class Scheduler(
             self.external_corpus_manager.check_pending_load()
 
     def init_req_max_new_tokens(self, req):
-        req.sampling_params.max_new_tokens = min(
-            (
-                req.sampling_params.max_new_tokens
-                if req.sampling_params.max_new_tokens is not None
-                else 1 << 30
+        input_len = len(req.origin_input_ids)
+        # Keep this bound consistent with PrefillAdder's admission budget:
+        # ceil_page(input_len) + max_new_tokens + page_size must be strictly
+        # smaller than max_total_num_tokens. Otherwise a request can be accepted
+        # into the waiting queue but can never be scheduled, blocking the queue
+        # and eventually making health checks fail.
+        paged_input_len = -(-input_len // self.page_size) * self.page_size
+        req.sampling_params.max_new_tokens = max(
+            0,
+            min(
+                (
+                    req.sampling_params.max_new_tokens
+                    if req.sampling_params.max_new_tokens is not None
+                    else 1 << 30
+                ),
+                self.max_req_len - input_len - 1,
+                self.max_total_num_tokens - paged_input_len - self.page_size - 1,
             ),
-            self.max_req_len - len(req.origin_input_ids) - 1,
         )
 
     def _process_and_broadcast_mm_inputs(


### PR DESCRIPTION
## Motivation

A near-full KV request can be accepted into the waiting queue but later fail prefill admission forever.

The original `init_req_max_new_tokens()` clamps `max_new_tokens` only by `max_req_len - input_len - 1`. However, prefill admission uses a stricter KV budget that includes page alignment and one extra page overhead:

```text
ceil_page(input_len) + max_new_tokens + page_size
```

When these two checks disagree, a request can become unschedulable after it is already in the waiting queue. With FCFS scheduling, such a request can block the queue, produce no scheduler output, and eventually make `/health` fail because the tokenizer manager receives no response from the detokenizer for 20 seconds.

This was reproduced with GLM-5.1-FP8, TP8, `max_total_num_tokens=64384`, and random serving benchmark cases around 61200/3000 and 61200/6800.

## Modifications

Clamp `max_new_tokens` using the same KV budget constraint as prefill admission:

```text
max_new_tokens <= max_total_num_tokens - ceil_page(input_len) - page_size - 1
```

This prevents requests from being accepted into the waiting queue if they can never pass prefill admission.

## Accuracy Tests

This change does not modify model forward computation, kernels, sampling math, or output logits. It only changes scheduler admission bounds.

## Speed Tests and Profiling

No speed regression is expected. The added work is one integer page-alignment calculation per request initialization.

Manual validation after narrowing the patch to this single scheduler admission fix:

Server:

```bash
python -m sglang.launch_server \
  --model-path /models/preset/zai-org/GLM-5.1-FP8/v1.0 \
  --tokenizer-path /models/preset/zai-org/GLM-5.1-FP8/v1.0 \
  --served-model-name GLM-5.1-FP8 \
  --host 127.0.0.1 \
  --port 31000 \
  --tensor-parallel-size 8 \
  --max-total-tokens 64384 \
  --mem-fraction-static 0.85 \
  --trust-remote-code \
  --log-level debug
```

Benchmarks:

```bash
python python/sglang/bench_serving.py \
  --backend sglang-oai-chat \
  --host 127.0.0.1 \
  --port 31000 \
  --model GLM-5.1-FP8 \
  --served-model-name GLM-5.1-FP8 \
  --tokenizer /models/preset/zai-org/GLM-5.1-FP8/v1.0 \
  --dataset-name random \
  --random-input-len 61200 \
  --random-output-len 3000 \
  --random-range-ratio 1.0 \
  --num-prompts 16 \
  --request-rate inf \
  --max-concurrency 8 \
  --output-details \
  --disable-tqdm \
  --ready-check-timeout-sec 0
```

Result: 16/16 successful requests. `/health` stayed 200 throughout the run.

```bash
python python/sglang/bench_serving.py \
  --backend sglang-oai-chat \
  --host 127.0.0.1 \
  --port 31000 \
  --model GLM-5.1-FP8 \
  --served-model-name GLM-5.1-FP8 \
  --tokenizer /models/preset/zai-org/GLM-5.1-FP8/v1.0 \
  --dataset-name random \
  --random-input-len 61200 \
  --random-output-len 6800 \
  --random-range-ratio 1.0 \
  --num-prompts 16 \
  --request-rate inf \
  --max-concurrency 8 \
  --output-details \
  --disable-tqdm \
  --ready-check-timeout-sec 0
```

Result: 16/16 successful requests. `/health` stayed 200 throughout the run.

## Checklist

- [x] Format-sensitive code path kept minimal.
- [x] Manual reproduction and validation completed.
- [x] No model accuracy-impacting code changed.
- [ ] Add unit test if maintainers request a targeted scheduler regression test.