### PR TITLE
[NPU]Bugfix:Set default values for npu_wrapper_preprocess parameters

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -414,7 +414,7 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
             nv=num_value_heads,
             intermediate_state=intermediate_state,
             cache_indices=cache_indices,
-            num_accept_tokens=num_accept_tokens,
+            num_accepted_tokens=num_accept_tokens,
             g=g,
         )
 

--- a/python/sglang/srt/hardware_backend/npu/modules/qwen_vl_processor.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/qwen_vl_processor.py
@@ -70,19 +70,19 @@ def npu_wrapper_preprocess(func):
     def _preprocess(
         self,
         images: list["torch.Tensor"],
-        do_resize: bool,
-        size: SizeDict,
-        interpolation: Optional["tvF.InterpolationMode"],
-        do_rescale: bool,
-        rescale_factor: float,
-        do_normalize: bool,
-        image_mean: float | list[float] | None,
-        image_std: float | list[float] | None,
-        patch_size: int,
-        temporal_patch_size: int,
-        merge_size: int,
-        disable_grouping: bool | None,
-        return_tensors: str | TensorType | None,
+        do_resize: bool = True,
+        size: SizeDict = None,
+        interpolation: Optional["tvF.InterpolationMode"] = None,
+        do_rescale: bool = True,
+        rescale_factor: float = 1 / 255.0,
+        do_normalize: bool = True,
+        image_mean: float | list[float] | None = None,
+        image_std: float | list[float] | None = None,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        merge_size: int = 2,
+        disable_grouping: bool | None = None,
+        return_tensors: str | TensorType | None = None,
         **kwargs,
     ):
         # Group images by size for batched resizing
@@ -103,7 +103,11 @@ def npu_wrapper_preprocess(func):
                 stacked_images = self.resize(
                     image=stacked_images,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    interpolation=interpolation,
+                    interpolation=(
+                        interpolation
+                        if interpolation is not None
+                        else tvF.InterpolationMode.BICUBIC
+                    ),
                 )
             resized_images_grouped[shape] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)

--- a/python/sglang/srt/hardware_backend/npu/modules/qwen_vl_processor.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/qwen_vl_processor.py
@@ -1,12 +1,7 @@
-from typing import Optional
-
 import torch
 import torchvision.transforms.v2.functional as tvF
 from transformers.image_processing_utils import BatchFeature
-from transformers.image_processing_utils_fast import (
-    group_images_by_shape,
-    reorder_images,
-)
+from transformers.image_transforms import group_images_by_shape, reorder_images
 from transformers.image_utils import (
     ChannelDimension,
     PILImageResampling,
@@ -63,26 +58,26 @@ def transform_patches_to_flatten(
     return flatten_patches
 
 
-# Func refers to transformers.models.qwen2_vl.image_processing_qwen2_vl_fast.py
-# Qwen2VLImageProcessorFast._preprocess
+# Func refers to transformers.models.qwen2_vl.image_processing_qwen2_vl.py
+# Qwen2VLImageProcessor._preprocess
 def npu_wrapper_preprocess(func):
 
     def _preprocess(
         self,
         images: list["torch.Tensor"],
-        do_resize: bool = True,
-        size: SizeDict = None,
-        interpolation: Optional["tvF.InterpolationMode"] = None,
-        do_rescale: bool = True,
-        rescale_factor: float = 1 / 255.0,
-        do_normalize: bool = True,
-        image_mean: float | list[float] | None = None,
-        image_std: float | list[float] | None = None,
-        patch_size: int = 14,
-        temporal_patch_size: int = 2,
-        merge_size: int = 2,
-        disable_grouping: bool | None = None,
-        return_tensors: str | TensorType | None = None,
+        do_resize: bool,
+        size: SizeDict,
+        resample: "PILImageResampling | tvF.InterpolationMode | int | None",
+        do_rescale: bool,
+        rescale_factor: float,
+        do_normalize: bool,
+        image_mean: float | list[float] | None,
+        image_std: float | list[float] | None,
+        patch_size: int,
+        temporal_patch_size: int,
+        merge_size: int,
+        disable_grouping: bool | None,
+        return_tensors: str | TensorType | None,
         **kwargs,
     ):
         # Group images by size for batched resizing
@@ -97,17 +92,13 @@ def npu_wrapper_preprocess(func):
                     height,
                     width,
                     factor=patch_size * merge_size,
-                    min_pixels=size["shortest_edge"],
-                    max_pixels=size["longest_edge"],
+                    min_pixels=size.shortest_edge,
+                    max_pixels=size.longest_edge,
                 )
                 stacked_images = self.resize(
                     image=stacked_images,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    interpolation=(
-                        interpolation
-                        if interpolation is not None
-                        else tvF.InterpolationMode.BICUBIC
-                    ),
+                    resample=resample,
                 )
             resized_images_grouped[shape] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)
@@ -177,7 +168,7 @@ def npu_wrapper_preprocess(func):
 
 
 # Func refers to transformers.models.qwen3_vl.video_processing_qwen3_vl.py
-# Qwen3VLVideoProcessorFast._preprocess
+# Qwen3VLVideoProcessor._preprocess
 def npu_wrapper_video_preprocess(func):
 
     def _preprocess(
@@ -186,7 +177,7 @@ def npu_wrapper_video_preprocess(func):
         do_convert_rgb: bool = True,
         do_resize: bool = True,
         size: SizeDict | None = None,
-        interpolation: PILImageResampling = PILImageResampling.BICUBIC,
+        resample: "PILImageResampling | tvF.InterpolationMode | int | None" = PILImageResampling.BICUBIC,
         do_rescale: bool = True,
         rescale_factor: float = 1 / 255.0,
         do_normalize: bool = True,
@@ -218,7 +209,7 @@ def npu_wrapper_video_preprocess(func):
                 stacked_videos = self.resize(
                     stacked_videos,
                     size=SizeDict(height=resized_height, width=resized_width),
-                    interpolation=interpolation,
+                    resample=resample,
                 )
                 stacked_videos = stacked_videos.view(
                     B, T, C, resized_height, resized_width
@@ -301,7 +292,7 @@ def npu_apply_qwen_image_preprocess_patch():
     if _npu_preprocess_patched:
         return
     apply_module_patch(
-        "transformers.models.qwen2_vl.image_processing_qwen2_vl_fast.Qwen2VLImageProcessorFast",
+        "transformers.models.qwen2_vl.image_processing_qwen2_vl.Qwen2VLImageProcessor",
         "_preprocess",
         [npu_wrapper_preprocess],
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes NPU compatibility with the current Qwen VL processor APIs and the Ascend GDN update path.

The NPU image preprocessing patch was still targeting `Qwen2VLImageProcessorFast` and the older fast-processor helper APIs. With the current Transformers processor path, the patched `_preprocess` implementation needs to match `Qwen2VLImageProcessor` instead:

- helper functions are imported from `transformers.image_transforms`
- resize uses the `resample` argument instead of `interpolation`
- `SizeDict` values are accessed through attributes such as `shortest_edge` and `longest_edge`

Without this alignment, applying the NPU preprocessing patch can fail at runtime due to API/signature mismatches. This PR also fixes the Ascend GDN backend call to use the expected keyword name `num_accepted_tokens`.

## Modifications

- Switch the Qwen2-VL image preprocessing patch target from `Qwen2VLImageProcessorFast` to `Qwen2VLImageProcessor`.
- Import `group_images_by_shape` and `reorder_images` from `transformers.image_transforms`.
- Rename preprocessing resize arguments from `interpolation` to `resample` for Qwen image and video processors.
- Use `SizeDict.shortest_edge` and `SizeDict.longest_edge` when computing resized image dimensions.
- Rename the Ascend GDN update keyword argument from `num_accept_tokens` to `num_accepted_tokens`.

## Accuracy Tests

Validated on Ascend NPU with Qwen3.6-27B.

Environment:

- Node: `192.168.25.218`
- Container: `lph-0504`
- Model: `/home/weight/Qwen3.6-27B`
- Devices: `14,15`
- TP size: `2`
- Attention backend: `ascend`
- Speculative decoding: `NEXTN`
- Max running requests: `54`

GSM8K accuracy, first 216 questions:

- `temperature=0`
- `max_tokens=1500`
- Exact match on final numeric answer

```text
Completed: 216
Failed: 0
Correct: 205
Accuracy: 94.91%
```

## Speed Tests and Profiling

Random 3.5K input / 1.5K output.

Settings:

- Input length: `3500`
- Output length: `1500`
- Num prompts: `216`
- Max concurrency: `54`

```text
Successful requests: 216
Benchmark duration: 491.48 s
Input token throughput: 1538.21 tok/s
Output token throughput: 659.23 tok/s
Total token throughput: 2197.44 tok/s
Mean TTFT: 33514.32 ms
Mean TPOT: 55.20 ms
Median TPOT: 56.20 ms
P99 TPOT: 78.48 ms
Accept length: 3.22
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.