### PR TITLE
[Session] Build _active_pool_idxs once per check cycle

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -160,20 +160,8 @@ class SchedulerRuntimeCheckerMixin:
                     idxs.add(req.req_pool_idx)
         return idxs
 
-    def _session_held_tokens(self: Scheduler) -> int:
-        return self.tree_cache.session_held_tokens(self._active_pool_idxs())
-
-    def _session_held_full_tokens(self: Scheduler) -> int:
-        return self.tree_cache.session_held_full_tokens(self._active_pool_idxs())
-
-    def _session_held_swa_tokens(self: Scheduler) -> int:
-        return self.tree_cache.session_held_swa_tokens(self._active_pool_idxs())
-
     def _session_held_req_count(self: Scheduler) -> int:
         return self.tree_cache.session_held_req_count()
-
-    def _session_held_mamba_slots(self: Scheduler) -> int:
-        return self.tree_cache.session_held_mamba_slots(self._active_pool_idxs())
 
     def get_pool_stats(self: Scheduler) -> PoolStats:
         if self.is_hybrid_swa:
@@ -308,19 +296,22 @@ class SchedulerRuntimeCheckerMixin:
         return leak, msg
 
     def _check_full_pool(
-        self: Scheduler, ps: PoolStats, uncached: int = 0
+        self: Scheduler,
+        ps: PoolStats,
+        active_pool_idxs: set,
+        uncached: int = 0,
     ) -> Tuple[bool, str]:
         if self.is_hybrid_swa:
             protected = self.tree_cache.full_protected_size()
-            session_held = self._session_held_full_tokens()
+            session_held = self.tree_cache.session_held_full_tokens(active_pool_idxs)
             total = self.full_tokens_per_layer
         elif self.is_hybrid_ssm and self.tree_cache.supports_mamba():
             protected = self.tree_cache.full_protected_size()
-            session_held = self._session_held_tokens()
+            session_held = self.tree_cache.session_held_tokens(active_pool_idxs)
             total = self.token_to_kv_pool_allocator.size
         else:
             protected = self.tree_cache.protected_size()
-            session_held = self._session_held_tokens()
+            session_held = self.tree_cache.session_held_tokens(active_pool_idxs)
             total = self.max_total_num_tokens
         return self._check_pool_invariant(
             "full",
@@ -333,25 +324,30 @@ class SchedulerRuntimeCheckerMixin:
         )
 
     def _check_swa_pool(
-        self: Scheduler, ps: PoolStats, uncached: int = 0
+        self: Scheduler,
+        ps: PoolStats,
+        active_pool_idxs: set,
+        uncached: int = 0,
     ) -> Tuple[bool, str]:
         return self._check_pool_invariant(
             "swa",
             ps.swa_available_size,
             ps.swa_evictable_size,
             self.tree_cache.swa_protected_size(),
-            self._session_held_swa_tokens(),
+            self.tree_cache.session_held_swa_tokens(active_pool_idxs),
             self.swa_tokens_per_layer,
             uncached,
         )
 
-    def _check_mamba_pool(self: Scheduler, ps: PoolStats) -> Tuple[bool, str]:
+    def _check_mamba_pool(
+        self: Scheduler, ps: PoolStats, active_pool_idxs: set
+    ) -> Tuple[bool, str]:
         leak, msg = self._check_pool_invariant(
             "mamba",
             ps.mamba_available_size,
             ps.mamba_evictable_size,
             self.tree_cache.mamba_protected_size(),
-            self._session_held_mamba_slots(),
+            self.tree_cache.session_held_mamba_slots(active_pool_idxs),
             self.req_to_token_pool.mamba_pool.size,
         )
         if leak:
@@ -434,12 +430,17 @@ class SchedulerRuntimeCheckerMixin:
 
         ps = self.get_pool_stats()
         full_uncached, swa_uncached = self._get_total_uncached_sizes()
+        active_pool_idxs = self._active_pool_idxs()
 
-        full_leak, full_msg = self._check_full_pool(ps, uncached=full_uncached)
+        full_leak, full_msg = self._check_full_pool(
+            ps, active_pool_idxs, uncached=full_uncached
+        )
 
         swa_leak, swa_msg = False, ""
         if self.is_hybrid_swa:
-            swa_leak, swa_msg = self._check_swa_pool(ps, uncached=swa_uncached)
+            swa_leak, swa_msg = self._check_swa_pool(
+                ps, active_pool_idxs, uncached=swa_uncached
+            )
 
         if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get() > 1:
             logger.info(f"[Mem Check (BUSY)] {full_msg}")
@@ -484,20 +485,25 @@ class SchedulerRuntimeCheckerMixin:
         self: Scheduler, ps: PoolStats, uncached: int = 0
     ) -> Tuple[bool, List[str]]:
         """Check memory invariant across all pools. Returns (has_leak, messages)."""
+        # Built once and threaded through so we don't re-walk last_batch /
+        # running_batch once per pool check.
+        active_pool_idxs = self._active_pool_idxs()
         has_leak = False
         messages = []
 
-        full_leak, full_msg = self._check_full_pool(ps, uncached=uncached)
+        full_leak, full_msg = self._check_full_pool(
+            ps, active_pool_idxs, uncached=uncached
+        )
         has_leak |= full_leak
         messages.append(full_msg)
 
         if self.is_hybrid_swa:
-            swa_leak, swa_msg = self._check_swa_pool(ps)
+            swa_leak, swa_msg = self._check_swa_pool(ps, active_pool_idxs)
             has_leak |= swa_leak
             messages.append(swa_msg)
 
         if self.is_hybrid_ssm and self.tree_cache.supports_mamba():
-            mamba_leak, mamba_msg = self._check_mamba_pool(ps)
+            mamba_leak, mamba_msg = self._check_mamba_pool(ps, active_pool_idxs)
             has_leak |= mamba_leak
             messages.append(mamba_msg)
 
@@ -513,7 +519,9 @@ class SchedulerRuntimeCheckerMixin:
 
         self.get_pool_stats().update_scheduler_stats(self.stats)
         self.stats.num_streaming_sessions = self._streaming_session_count()
-        self.stats.streaming_session_held_tokens = self._session_held_tokens()
+        self.stats.streaming_session_held_tokens = self.tree_cache.session_held_tokens(
+            self._active_pool_idxs()
+        )
 
         priority_enabled = self.enable_priority_scheduling
         self.stats.num_running_reqs = QueueCount.from_reqs(

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -651,7 +651,9 @@ class SchedulerMetricsMixin:
 
             # Streaming session metrics
             self.stats.num_streaming_sessions = self._streaming_session_count()
-            self.stats.streaming_session_held_tokens = self._session_held_tokens()
+            self.stats.streaming_session_held_tokens = (
+                self.tree_cache.session_held_tokens(self._active_pool_idxs())
+            )
 
             # Routing key metrics
             # (to reduce the overhead, we only compute this when all requests have routing_key)


### PR DESCRIPTION
## Motivation

SchedulerRuntimeCheckerMixin._check_all_pools and self_check_during_busy fan out to _check_full_pool / _check_swa_pool / _check_mamba_pool, each of which previously routed through its own _session_held_* wrapper. Every wrapper rebuilt the same _active_pool_idxs() set by walking
  both last_batch.reqs and running_batch.reqs.
                                  
  On a hybrid SWA+SSM model the set was therefore rebuilt 3 times per scheduler tick (plus once more in _check_req_pool's sibling code and again in _maybe_log_idle_metrics / SchedulerMetricsMixin.log_stats). The cost scales with active batch size and runs on every busy-state         
  self-check.

## Modifications

python/sglang/srt/managers/scheduler_runtime_checker_mixin.py:
  - _check_full_pool, _check_swa_pool, _check_mamba_pool now accept an active_pool_idxs: set argument and call tree_cache.session_held_*(active_pool_idxs) directly.                                                                                                                        
  - _check_all_pools and self_check_during_busy each build _active_pool_idxs() exactly once and thread it through.                                                  
  - _maybe_log_idle_metrics builds and uses it inline.                                                                                                                                                                                                                                      
  - Dead wrappers _session_held_tokens / _session_held_full_tokens / _session_held_swa_tokens / _session_held_mamba_slots are removed. _session_held_req_count stays — it intentionally takes no active_pool_idxs (req-pool accounting needs the full holding count, not just out-of-batch
  slots).                                                                                                                                                                                                                                                                                   
                                         
python/sglang/srt/observability/scheduler_metrics_mixin.py:
  - SchedulerMetricsMixin.log_stats now calls self.tree_cache.session_held_tokens(self._active_pool_idxs()) directly instead of the removed wrapper.                                                                                                                                        
                                                                                                                                                    
No behavior change: the set passed into session_held_* is identical to what the removed wrappers produced. The only effect is fewer redundant batch walks per tick.

## Accuracy Tests

Not applicable — pure scheduler bookkeeping refactor, no model outputs or kernel paths touched. session_held_* is used solely for memory-leak self-checks and Prometheus gauges. 

## Speed Tests and Profiling

Not separately benchmarked — the saving is in the scheduler check path (off the GPU critical path) and is a strict reduction in CPU work. Expected per-tick saving scales with len(last_batch.reqs) + len(running_batch.reqs): with hybrid SWA+SSM and ~100 reqs in flight, eliminates ~3× redundant batch walks per tick (~hundreds of Python attribute reads + set ops). Negligible vs end-to-end latency but a free win on hot scheduler code.   

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
