### PR TITLE
fix: prevent infinite Gumbel noise in seeded sampling 

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -580,9 +580,10 @@ def multinomial_with_seed(
 
     # NOTE (sehoon): it is critical to keep gumbel noise calculation in float64 to avoid numerical instability.
     # keeping logprobs in float64 is less critical, but we found it's still safer to keep it in float64.
-    x = hashed.to(torch.float64) / torch.iinfo(torch.uint32).max
+    # Use midpoint binning (hash + 0.5) / 2^32 to map into open (0, 1), avoiding -log(-log(1.0)) = +inf.
+    x = (hashed.to(torch.float64) + 0.5) / (2.0**32)
 
-    # x is a uniform sample in [0, 1]. get gumbel noise from it.
+    # x is a uniform sample in (0, 1). get gumbel noise from it.
     # which is equivalent to -log(-log(x))
     # keep everything in in-place operations to avoid unnecessary memory allocations.
     x.log_().clamp_(min=torch.finfo(x.dtype).min).neg_()  # -log(x)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #25106.

When using seeded/deterministic sampling, the Gumbel noise is computed by hashing `(seed, position, token_id)` to a uint32 and converting it to a float. The old code divided by `2^32 - 1` which means a hash of `0xFFFFFFFF` maps to exactly `1.0`. Feeding `1.0` into `-log(-log(x))` gives `+inf`, which causes that token to always win argmax no matter how low its logprob is. We confirmed the bug is reproducible with `seed=7847, position=12345, token_id=1208` on an A100.

## Modifications

Changed the uint32 to float conversion in `multinomial_with_seed` from:

```python
x = hashed.to(torch.float64) / torch.iinfo(torch.uint32).max
```

to:

```python
x = (hashed.to(torch.float64) + 0.5) / (2.0**32)
```

This maps all `2^32` hash values into the open interval `(0, 1)` using midpoint binning, so the Gumbel transform is always finite. The change has no effect on normal hash values since the numerical difference is under `2.3e-10`. Only requests that previously hit the `0xFFFFFFFF` hash are affected


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
