### PR TITLE
ci: merge sgl-kernel-build-wheels x86+arm into reusable workflow

### DIFF
--- a/.github/workflows/_pr-test-sgl-kernel-build.yml
+++ b/.github/workflows/_pr-test-sgl-kernel-build.yml
@@ -1,0 +1,101 @@
+name: PR Test - Build sgl-kernel Wheels
+
+# Reusable workflow that builds the sgl-kernel CUDA wheels for one
+# architecture / runner pool. Called twice from pr-test.yml: once for the
+# x86_64 runner pool, once for arm64. All architecture-specific values
+# (runner label, display name, artifact name suffix) are passed in via
+# inputs.
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: 'Runner label (e.g. x64-kernel-build-node, arm-kernel-build-node)'
+        type: string
+        required: true
+      job_display_name:
+        description: 'Display name shown in the Actions UI (e.g. "Build Wheel", "Build Wheel Arm")'
+        type: string
+        default: 'Build Wheel'
+      arch_suffix:
+        description: "Suffix appended to the upload-artifact name. '' for x86, '-aarch64' for arm."
+        type: string
+        default: ''
+      pr_head_sha:
+        type: string
+        default: ''
+      git_ref:
+        type: string
+        default: ''
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 240
+    strategy:
+      matrix:
+        include:
+          - python-version: "3.10"
+            cuda-version: "13.0"
+          - python-version: "3.10"
+            cuda-version: "12.9"
+    name: ${{ inputs.job_display_name }}
+    steps:
+      - name: Cleanup
+        run: |
+          if [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo rm -rf "$GITHUB_WORKSPACE"/* || true
+          else
+            echo "$GITHUB_WORKSPACE does not exist, nothing to clean"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+          ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
+
+      - uses: ./.github/actions/check-maintenance
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Free Docker disk space
+        run: |
+          set -x
+          # build.sh retags sgl-kernel-deps:cuda${CUDA_VERSION}-${PY_TAG}-${ARCH}
+          # on every run, leaving the previous image as a dangling <none>:<none>
+          # entry (~16-23 GB each). Prune them before building so the runner
+          # doesn't fill up. The local buildx cache at ~/.cache/sgl-kernel/buildx
+          # and the tagged sgl-kernel-deps image are not affected.
+          # `until=12h` avoids racing with a sibling matrix cell (cuda 12.9 vs
+          # 13.0) that may have just orphaned an image seconds ago.
+          docker image prune -f --filter "until=12h"
+          # Drop orphaned buildx builder volumes from past `docker buildx create`
+          # invocations. The active `sgl-kernel-builder` volume is held open and
+          # would fail to remove anyway, but skip it explicitly for clarity.
+          for v in $(docker volume ls -q | grep '^buildx_buildkit_' | grep -v '^buildx_buildkit_sgl-kernel-builder' || true); do
+            echo "Removing orphan buildx volume: $v"
+            docker volume rm "$v" || true
+          done
+          df -h /
+
+      - name: Build wheel for Python ${{ matrix.python-version }} and CUDA ${{ matrix.cuda-version }}
+        run: |
+          cd sgl-kernel
+          ./build.sh "${{ matrix.python-version }}" "${{ matrix.cuda-version }}"
+        env:
+          USE_CCACHE: 1
+
+      - name: Verify wheel artifacts
+        run: |
+          ls -alh sgl-kernel/dist
+          ls -alh sgl-kernel/dist/*.whl
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-python${{ matrix.python-version }}-cuda${{ matrix.cuda-version }}${{ inputs.arch_suffix }}
+          path: sgl-kernel/dist/*
+          if-no-files-found: error

--- a/.github/workflows/_pr-test-sgl-kernel-build.yml
+++ b/.github/workflows/_pr-test-sgl-kernel-build.yml
@@ -27,6 +27,25 @@ on:
       git_ref:
         type: string
         default: ''
+      skip_stage_health_check:
+        description: 'Forwarded from the caller workflow input of the same name. Not consumed inside this reusable workflow today, but mirrored so the resulting env context matches the inline-job baseline.'
+        type: boolean
+        default: false
+
+# Mirror the caller workflow's top-level env block. GitHub Actions does NOT
+# automatically inherit workflow-level env vars across the workflow_call
+# boundary, so anything pr-test.yml defines must be redeclared here for the
+# reusable jobs to see the same context. Most of these are not read by the
+# wheel-build path, but PR_TEST_BYPASS_MAINTENANCE_ON_MAIN is consumed by the
+# check-maintenance composite action and would otherwise be unset.
+env:
+  SGLANG_IS_IN_CI: true
+  SGLANG_CUDA_COREDUMP: "1"
+  SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
+  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check && 'true' || 'false' }}
+  FORCE_REBUILD_DEEPEP: '1'
+  PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+  USE_VENV: false
 
 jobs:
   build:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -461,71 +461,13 @@ jobs:
         (!inputs.target_stage && needs.call-gate.result == 'success') ||
         (inputs.target_stage && inputs.include_wheel_build)
       )
-    runs-on: x64-kernel-build-node
-    timeout-minutes: 240
-    strategy:
-      matrix:
-        include:
-          - python-version: "3.10"
-            cuda-version: "13.0"
-          - python-version: "3.10"
-            cuda-version: "12.9"
-    name: Build Wheel
-    steps:
-      - name: Cleanup
-        run: |
-          sudo rm -rf $GITHUB_WORKSPACE/* || true
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-          ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-maintenance
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free Docker disk space
-        run: |
-          set -x
-          # build.sh retags sgl-kernel-deps:cuda${CUDA_VERSION}-${PY_TAG}-${ARCH}
-          # on every run, leaving the previous image as a dangling <none>:<none>
-          # entry (~16-23 GB each). Prune them before building so the runner
-          # doesn't fill up. The local buildx cache at ~/.cache/sgl-kernel/buildx
-          # and the tagged sgl-kernel-deps image are not affected.
-          # `until=12h` avoids racing with a sibling matrix cell (cuda 12.9 vs
-          # 13.0) that may have just orphaned an image seconds ago.
-          docker image prune -f --filter "until=12h"
-          # Drop orphaned buildx builder volumes from past `docker buildx create`
-          # invocations. The active `sgl-kernel-builder` volume is held open and
-          # would fail to remove anyway, but skip it explicitly for clarity.
-          for v in $(docker volume ls -q | grep '^buildx_buildkit_' | grep -v '^buildx_buildkit_sgl-kernel-builder' || true); do
-            echo "Removing orphan buildx volume: $v"
-            docker volume rm "$v" || true
-          done
-          df -h /
-
-      - name: Build wheel for Python ${{ matrix.python-version }} and CUDA ${{ matrix.cuda-version }}
-        run: |
-          cd sgl-kernel
-          ./build.sh "${{ matrix.python-version }}" "${{ matrix.cuda-version }}"
-        env:
-          USE_CCACHE: 1
-
-      - name: Verify wheel artifacts
-        run: |
-          ls -alh sgl-kernel/dist
-          ls -alh sgl-kernel/dist/*.whl
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheel-python${{ matrix.python-version }}-cuda${{ matrix.cuda-version }}
-          path: sgl-kernel/dist/*
-          if-no-files-found: error
+    uses: ./.github/workflows/_pr-test-sgl-kernel-build.yml
+    with:
+      runs_on: x64-kernel-build-node
+      job_display_name: Build Wheel
+      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
+      git_ref: ${{ inputs.git_ref || '' }}
+    secrets: inherit
 
   sgl-kernel-build-wheels-arm:
     needs: [check-changes, call-gate]
@@ -543,66 +485,14 @@ jobs:
         (!inputs.target_stage && needs.call-gate.result == 'success') ||
         (inputs.target_stage && inputs.include_wheel_build)
       )
-    runs-on: arm-kernel-build-node
-    timeout-minutes: 240
-    strategy:
-      matrix:
-        include:
-          - python-version: "3.10"
-            cuda-version: "13.0"
-          - python-version: "3.10"
-            cuda-version: "12.9"
-    name: Build Wheel Arm
-    steps:
-      - name: Cleanup
-        run: |
-          if [ -d "$GITHUB_WORKSPACE" ]; then
-            sudo rm -rf "$GITHUB_WORKSPACE"/* || true
-          else
-            echo "$GITHUB_WORKSPACE does not exist, nothing to clean"
-          fi
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-          ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
-
-      - uses: ./.github/actions/check-maintenance
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free Docker disk space
-        run: |
-          set -x
-          # See sgl-kernel-build-wheels above for the rationale.
-          docker image prune -f --filter "until=12h"
-          for v in $(docker volume ls -q | grep '^buildx_buildkit_' | grep -v '^buildx_buildkit_sgl-kernel-builder' || true); do
-            echo "Removing orphan buildx volume: $v"
-            docker volume rm "$v" || true
-          done
-          df -h /
-
-      - name: Build wheel for Python ${{ matrix.python-version }} and CUDA ${{ matrix.cuda-version }}
-        run: |
-          cd sgl-kernel
-          ./build.sh "${{ matrix.python-version }}" "${{ matrix.cuda-version }}"
-        env:
-          USE_CCACHE: 1
-
-      - name: Verify wheel artifacts
-        run: |
-          ls -alh sgl-kernel/dist
-          ls -alh sgl-kernel/dist/*.whl
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheel-python${{ matrix.python-version }}-cuda${{ matrix.cuda-version }}-aarch64
-          path: sgl-kernel/dist/*
-          if-no-files-found: error
+    uses: ./.github/workflows/_pr-test-sgl-kernel-build.yml
+    with:
+      runs_on: arm-kernel-build-node
+      job_display_name: Build Wheel Arm
+      arch_suffix: '-aarch64'
+      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
+      git_ref: ${{ inputs.git_ref || '' }}
+    secrets: inherit
 
   call-sgl-kernel-tests:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -467,6 +467,7 @@ jobs:
       job_display_name: Build Wheel
       pr_head_sha: ${{ inputs.pr_head_sha || '' }}
       git_ref: ${{ inputs.git_ref || '' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   sgl-kernel-build-wheels-arm:
@@ -492,6 +493,7 @@ jobs:
       arch_suffix: '-aarch64'
       pr_head_sha: ${{ inputs.pr_head_sha || '' }}
       git_ref: ${{ inputs.git_ref || '' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   call-sgl-kernel-tests:


### PR DESCRIPTION
Merges `sgl-kernel-build-wheels` (x86) and `sgl-kernel-build-wheels-arm` into one parameterized reusable workflow `_pr-test-sgl-kernel-build.yml`. Caller-end behavior preserved; each caller stub passes runner / display name / arch suffix as inputs.

Mechanical refactor + 6-layer equivalence audit (script + auditor): https://gist.github.com/hnyls2002/72d7462e2c6b53a98386dd75daa3479b

Two declared collateral changes (everything else verified byte-identical via substitution + diff):
- x86 Cleanup step body adopts arm's defensive `if [ -d "$GITHUB_WORKSPACE" ]` guard. Behavior-equivalent on existing dirs (both `rm -rf ... || true`); arm form has cleaner stderr when the dir is absent.
- arm's "See sgl-kernel-build-wheels above" comments inside Free Docker disk space expand to the x86 detailed rationale (cross-reference no longer makes sense in a reusable workflow).

The audit script runs a 6-layer chain on the two committed files:
1. caller-side `needs:` + `if:` byte-identical to PR base
2. caller `with:` keys all declared in reusable inputs
3. reusable workflow's top-level `env:` keys mirror caller workflow exactly
4-5. reusable `jobs.build` body + caller inputs (substituted) diff against PR base inline job = exactly the 2 declared collateral hunks
6. reverse-roundtrip: revert collateral hunks + splice substituted body back into pr-test.yml -> sha256 == PR base pr-test.yml

Layer 6 is the strongest guarantee: PR #25135 is byte-recoverable to its base modulo the 2 declared collaterals. No hidden mutation.