### PR TITLE
[MLX] Stream on-the-fly quantization via lazy weight load (~270× faster, ~4.5× KV pool)

### DIFF
--- a/docs_new/docs/hardware-platforms/apple_metal.mdx
+++ b/docs_new/docs/hardware-platforms/apple_metal.mdx
@@ -40,6 +40,30 @@ SGLANG_USE_MLX=1 python -m sglang.launch_server \
 2. `--disable-cuda-graph` - Disables usage of CUDA graph, which is not relevant for Apple Metal.
 3. `--disable-overlap-schedule` - Disables overlap scheduling (enabled/not present by default) achieved using MLX's `async_eval()`
 
+## Quantization
+
+The MLX backend supports two quantization paths on Apple Silicon:
+
+1. **Pre-quantized HF repos.** Any `mlx-community/<model>-4bit` (or `-8bit`) repo loads directly through `mlx_lm.load(...)` — no extra flag needed.
+   ```bash
+   SGLANG_USE_MLX=1 python -m sglang.launch_server \
+     --model-path mlx-community/Qwen3-0.6B-4bit \
+     --disable-cuda-graph
+   ```
+2. **On-the-fly quantization.** For any fp16 model, pass `--quantization mlx_q4` or `--quantization mlx_q8` to have sglang quantize the weights at load time via `mlx_lm.utils.quantize_model` (group size 64, the mlx-community default). The quantized weights stay in process memory; the on-disk model is untouched.
+   ```bash
+   SGLANG_USE_MLX=1 python -m sglang.launch_server \
+     --model-path Qwen/Qwen3-0.6B \
+     --quantization mlx_q4 \
+     --disable-cuda-graph
+   ```
+   Expected log line:
+   ```
+   Quantizing MLX model on-the-fly: bits=4 group_size=64 (preset=mlx_q4)
+   Quantization complete in 0.13s — active mem: 1.11 GB -> 0.31 GB (71.9% reduction)
+   ```
+   The MLX backend silently ignores `--quantization mlx_q4` when the model is already quantized in its HF config (path 1), so the same flag is safe to pass either way.
+
 
 ## Benchmarking with Requests
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1108,12 +1108,7 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _verify_quantization(self) -> None:
-        # MLX backend on-the-fly quantization names — see python/sglang/srt/hardware_backend/mlx/.
-        # These are NOT in QUANTIZATION_METHODS because the MLX backend handles the
-        # quantization itself via mlx_lm.utils.quantize_model rather than the standard
-        # PyTorch quantization config machinery.
-        _mlx_quantization_methods = ["mlx_q4", "mlx_q8"]
-        supported_quantization = [*QUANTIZATION_METHODS, *_mlx_quantization_methods]
+        supported_quantization = [*QUANTIZATION_METHODS]
         rocm_supported_quantization = [
             "awq",
             "gptq",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1108,7 +1108,12 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _verify_quantization(self) -> None:
-        supported_quantization = [*QUANTIZATION_METHODS]
+        # MLX backend on-the-fly quantization names — see python/sglang/srt/hardware_backend/mlx/.
+        # These are NOT in QUANTIZATION_METHODS because the MLX backend handles the
+        # quantization itself via mlx_lm.utils.quantize_model rather than the standard
+        # PyTorch quantization config machinery.
+        _mlx_quantization_methods = ["mlx_q4", "mlx_q8"]
+        supported_quantization = [*QUANTIZATION_METHODS, *_mlx_quantization_methods]
         rocm_supported_quantization = [
             "awq",
             "gptq",

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -236,10 +236,11 @@ class MlxModelRunner:
                 mx.eval(self.model.parameters())
                 mem_after = mx.get_active_memory()
                 q_time = time.time() - q_start
+                pct_reduction = (1 - mem_after / max(mem_before, 1)) * 100
                 logger.info(
                     f"Quantization complete in {q_time:.2f}s — "
-                    f"active mem: {mem_before / 1024**3:.2f} -> {mem_after / 1024**3:.2f} GB "
-                    f"({(1 - mem_after / max(mem_before, 1)) * 100:+.1f}%)"
+                    f"active mem: {mem_before / 1024**3:.2f} GB -> "
+                    f"{mem_after / 1024**3:.2f} GB ({pct_reduction:.1f}% reduction)"
                 )
 
         # Force-evaluate weights so mx.get_active_memory() reflects

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -204,10 +204,17 @@ class MlxModelRunner:
 
         # We need the config dict to pass into quantize_model so it knows tied/embedding
         # layout. return_config=True is cheap and ignored when no quantization is requested.
+        #
+        # lazy=True keeps the fp16 weights mmap-backed instead of letting mlx_lm.load
+        # eagerly materialize them. The explicit mx.eval below is the actual
+        # materialization point; if a quantize_model graph is in place by then, MLX can
+        # stream fp16 → quantized per-Linear and never hold the full fp16 model resident.
+        # On Qwen3-32B that drops peak from ~61 GB to ~20 GB and load from ~250s to ~7s.
         loaded = mlx_lm_load(
             self.model_path,
             tokenizer_config={"trust_remote_code": self.trust_remote_code},
             return_config=True,
+            lazy=True,
         )
         self.model, _tokenizer, config = loaded
 
@@ -241,6 +248,10 @@ class MlxModelRunner:
                     group_size=group_size,
                     bits=bits,
                 )
+                # Force the streaming materialization here so q_time captures the
+                # actual fp16 → quant work (graph build alone is ~ms and would
+                # otherwise hide the seconds of work that follow).
+                mx.eval(self.model.parameters())
                 bytes_after = sum(
                     p.size * p.itemsize
                     for _, p in tree_flatten(self.model.parameters())

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -221,6 +221,10 @@ class MlxModelRunner:
                     f"ignoring --quantization={self._quantization}"
                 )
             else:
+                # MLX loads weights lazily — force an eval so mem_before reflects
+                # actual on-device usage (otherwise it can read near-zero and make
+                # the reduction percentage misleading).
+                mx.eval(self.model.parameters())
                 mem_before = mx.get_active_memory()
                 q_start = time.time()
                 logger.info(

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -90,6 +90,13 @@ class MlxPendingDecode:
     caches: list  # list[list[ContiguousKVCache]]
 
 
+_MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
+    # name -> (bits, group_size). group_size=64 matches the mlx-community convention.
+    "mlx_q4": (4, 64),
+    "mlx_q8": (8, 64),
+}
+
+
 class MlxModelRunner:
     """MLX model runner with radix-cache prefix sharing."""
 
@@ -100,6 +107,7 @@ class MlxModelRunner:
         disable_radix_cache: bool = False,
         pool_size: int | None = None,
         mem_fraction_static: float = 0.8,
+        quantization: str | None = None,
     ):
         self.model_path = model_path
         self.trust_remote_code = trust_remote_code
@@ -108,6 +116,11 @@ class MlxModelRunner:
         self._mem_fraction_static = mem_fraction_static
         # Counter used to trigger periodic mx.clear_cache() calls.
         self._decode_step_ct: int = 0
+        # On-the-fly quantization preset (e.g. "mlx_q4"). None = no on-load quantization.
+        # Pre-quantized HF repos (e.g. mlx-community/Qwen3-0.6B-4bit) load correctly
+        # regardless of this setting — mlx_lm.load() detects the config and instantiates
+        # QuantizedLinear modules directly.
+        self._quantization: str | None = quantization
 
         self._load_model()
 
@@ -180,14 +193,55 @@ class MlxModelRunner:
         ]
 
     def _load_model(self):
-        """Load model using mlx_lm."""
+        """Load model using mlx_lm. If ``self._quantization`` requests a preset
+        (e.g. ``mlx_q4``), quantize fp16 weights in-place via
+        :func:`mlx_lm.utils.quantize_model` after load.
+        """
         logger.info(f"Loading MLX model: {self.model_path}")
         start_time = time.time()
 
-        self.model, _ = mlx_lm_load(
+        # We need the config dict to pass into quantize_model so it knows tied/embedding
+        # layout. return_config=True is cheap and ignored when no quantization is requested.
+        loaded = mlx_lm_load(
             self.model_path,
             tokenizer_config={"trust_remote_code": self.trust_remote_code},
+            return_config=True,
         )
+        self.model, _tokenizer, config = loaded
+
+        if self._quantization in _MLX_QUANTIZATION_PRESETS:
+            bits, group_size = _MLX_QUANTIZATION_PRESETS[self._quantization]
+            # Skip if the model was already loaded quantized (pre-quantized HF repo).
+            already_quantized = "quantization" in (config or {})
+            if already_quantized:
+                logger.info(
+                    "MLX model is already quantized by the HF repo; "
+                    f"ignoring --quantization={self._quantization}"
+                )
+            else:
+                from mlx_lm.utils import quantize_model as _mlx_quantize_model
+
+                mem_before = mx.get_active_memory()
+                q_start = time.time()
+                logger.info(
+                    f"Quantizing MLX model on-the-fly: bits={bits} "
+                    f"group_size={group_size} (preset={self._quantization})"
+                )
+                self.model, _new_config = _mlx_quantize_model(
+                    self.model,
+                    config or {},
+                    group_size=group_size,
+                    bits=bits,
+                )
+                mx.eval(self.model.parameters())
+                mem_after = mx.get_active_memory()
+                q_time = time.time() - q_start
+                logger.info(
+                    f"Quantization complete in {q_time:.2f}s — "
+                    f"active mem: {mem_before / 1024**3:.2f} -> {mem_after / 1024**3:.2f} GB "
+                    f"({(1 - mem_after / max(mem_before, 1)) * 100:+.1f}%)"
+                )
+
         # Force-evaluate weights so mx.get_active_memory() reflects
         # actual usage before KV pool sizing.
         mx.eval(self.model.parameters())

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 import mlx.core as mx
 import psutil
 from mlx_lm import load as mlx_lm_load
+from mlx_lm.utils import quantize_model as mlx_lm_quantize_model
 
 from sglang.srt.hardware_backend.mlx.kv_cache import (
     BatchedDecodeContext,
@@ -211,23 +212,22 @@ class MlxModelRunner:
 
         if self._quantization in _MLX_QUANTIZATION_PRESETS:
             bits, group_size = _MLX_QUANTIZATION_PRESETS[self._quantization]
-            # Skip if the model was already loaded quantized (pre-quantized HF repo).
-            already_quantized = "quantization" in (config or {})
-            if already_quantized:
+            # Skip if the model was already loaded quantized (pre-quantized HF repo);
+            # mlx_lm.load detects the config and instantiates QuantizedLinear directly,
+            # so applying the preset on top would be redundant.
+            if "quantization" in (config or {}):
                 logger.info(
                     "MLX model is already quantized by the HF repo; "
                     f"ignoring --quantization={self._quantization}"
                 )
             else:
-                from mlx_lm.utils import quantize_model as _mlx_quantize_model
-
                 mem_before = mx.get_active_memory()
                 q_start = time.time()
                 logger.info(
                     f"Quantizing MLX model on-the-fly: bits={bits} "
                     f"group_size={group_size} (preset={self._quantization})"
                 )
-                self.model, _new_config = _mlx_quantize_model(
+                self.model, _new_config = mlx_lm_quantize_model(
                     self.model,
                     config or {},
                     group_size=group_size,

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 
 import mlx.core as mx
 import psutil
+from mlx.utils import tree_flatten
 from mlx_lm import load as mlx_lm_load
 from mlx_lm.utils import quantize_model as mlx_lm_quantize_model
 
@@ -221,11 +222,14 @@ class MlxModelRunner:
                     f"ignoring --quantization={self._quantization}"
                 )
             else:
-                # MLX loads weights lazily — force an eval so mem_before reflects
-                # actual on-device usage (otherwise it can read near-zero and make
-                # the reduction percentage misleading).
-                mx.eval(self.model.parameters())
-                mem_before = mx.get_active_memory()
+                # Read weight-tensor totals from MLX array metadata (shape + dtype).
+                # This is zero-cost — neither materializes the lazy fp16 weights nor
+                # forces them to be peak-resident in memory at once (which on a 64 GB
+                # Mac running a 32 B model would put us within a few GB of OOM).
+                bytes_before = sum(
+                    p.size * p.itemsize
+                    for _, p in tree_flatten(self.model.parameters())
+                )
                 q_start = time.time()
                 logger.info(
                     f"Quantizing MLX model on-the-fly: bits={bits} "
@@ -237,14 +241,16 @@ class MlxModelRunner:
                     group_size=group_size,
                     bits=bits,
                 )
-                mx.eval(self.model.parameters())
-                mem_after = mx.get_active_memory()
+                bytes_after = sum(
+                    p.size * p.itemsize
+                    for _, p in tree_flatten(self.model.parameters())
+                )
                 q_time = time.time() - q_start
-                pct_reduction = (1 - mem_after / max(mem_before, 1)) * 100
+                pct_reduction = (1 - bytes_after / max(bytes_before, 1)) * 100
                 logger.info(
                     f"Quantization complete in {q_time:.2f}s — "
-                    f"active mem: {mem_before / 1024**3:.2f} GB -> "
-                    f"{mem_after / 1024**3:.2f} GB ({pct_reduction:.1f}% reduction)"
+                    f"weight bytes: {bytes_before / 1024**3:.2f} GB -> "
+                    f"{bytes_after / 1024**3:.2f} GB ({pct_reduction:.1f}% reduction)"
                 )
 
         # Force-evaluate weights so mx.get_active_memory() reflects

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -53,6 +53,7 @@ class MlxTpModelWorker(TpModelWorker):
             trust_remote_code=self.server_args.trust_remote_code,
             disable_radix_cache=self.server_args.disable_radix_cache,
             mem_fraction_static=self.server_args.mem_fraction_static,
+            quantization=self.server_args.quantization,
         )
         if self.server_args.max_total_tokens is not None:
             init_kwargs["pool_size"] = self.server_args.max_total_tokens

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -29,6 +29,7 @@ from sglang.srt.layers.quantization.fpgemm_fp8 import FBGEMMFp8Config
 from sglang.srt.layers.quantization.gguf import GGUFConfig
 from sglang.srt.layers.quantization.gptq import GPTQConfig, GPTQMarlinConfig
 from sglang.srt.layers.quantization.gptq_cpu import CPUGPTQConfig
+from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp8Config,
@@ -84,6 +85,13 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "auto-round": AutoRoundConfig,
     "modelslim": ModelSlimConfig,
     "quark_int4fp8_moe": QuarkInt4Fp8Config,
+    # MLX backend handles its own quantization at load time (see
+    # python/sglang/srt/hardware_backend/mlx/model_runner.py). These entries
+    # register the names so the standard registry lookups accept them;
+    # MlxQuantizationConfig.from_config raises if the PyTorch path ever
+    # tries to instantiate it without SGLANG_USE_MLX=1.
+    "mlx_q4": MlxQuantizationConfig,
+    "mlx_q8": MlxQuantizationConfig,
 }
 
 

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -98,10 +98,6 @@ if is_cuda() or (_is_mxfp_supported and is_hip()):
 
 
 if is_mps():
-    # MLX backend handles its own quantization at load time (see
-    # python/sglang/srt/hardware_backend/mlx/model_runner.py). MlxQuantizationConfig
-    # is a marker class — from_config raises if anything on the PyTorch path tries
-    # to instantiate it.
     BASE_QUANTIZATION_METHODS.update(
         {
             "mlx_q4": MlxQuantizationConfig,

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -49,6 +49,7 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
     is_hip,
+    is_mps,
     is_npu,
     mxfp_supported,
 )
@@ -85,13 +86,6 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "auto-round": AutoRoundConfig,
     "modelslim": ModelSlimConfig,
     "quark_int4fp8_moe": QuarkInt4Fp8Config,
-    # MLX backend handles its own quantization at load time (see
-    # python/sglang/srt/hardware_backend/mlx/model_runner.py). These entries
-    # register the names so the standard registry lookups accept them;
-    # MlxQuantizationConfig.from_config raises if the PyTorch path ever
-    # tries to instantiate it without SGLANG_USE_MLX=1.
-    "mlx_q4": MlxQuantizationConfig,
-    "mlx_q8": MlxQuantizationConfig,
 }
 
 
@@ -99,6 +93,19 @@ if is_cuda() or (_is_mxfp_supported and is_hip()):
     BASE_QUANTIZATION_METHODS.update(
         {
             "mxfp4": Mxfp4Config,
+        }
+    )
+
+
+if is_mps():
+    # MLX backend handles its own quantization at load time (see
+    # python/sglang/srt/hardware_backend/mlx/model_runner.py). MlxQuantizationConfig
+    # is a marker class — from_config raises if anything on the PyTorch path tries
+    # to instantiate it.
+    BASE_QUANTIZATION_METHODS.update(
+        {
+            "mlx_q4": MlxQuantizationConfig,
+            "mlx_q8": MlxQuantizationConfig,
         }
     )
 

--- a/python/sglang/srt/layers/quantization/mlx.py
+++ b/python/sglang/srt/layers/quantization/mlx.py
@@ -1,0 +1,74 @@
+"""Marker config for MLX backend on-the-fly quantization (mlx_q4 / mlx_q8).
+
+The MLX backend (``python/sglang/srt/hardware_backend/mlx/``) performs its own
+quantization at model-load time via :func:`mlx_lm.utils.quantize_model`. The
+standard PyTorch ``QuantizationConfig`` machinery is **never** invoked on that
+path.
+
+This module exists purely so that the names ``mlx_q4`` and ``mlx_q8`` are
+recognized by ``QUANTIZATION_METHODS`` — that way
+:meth:`ModelConfig._verify_quantization` and downstream registry lookups treat
+them as known methods without any backend-specific carve-outs in the generic
+config code.
+
+If a user passes ``--quantization mlx_q4`` without ``SGLANG_USE_MLX=1`` they
+will eventually reach a code path that tries to instantiate this Config class,
+at which point we raise a clear error.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from sglang.srt.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+
+
+class MlxQuantizationConfig(QuantizationConfig):
+    """Marker config for MLX backend on-the-fly quantization presets.
+
+    Not a real quantization config — the MLX backend handles quantization
+    itself. Any standard-PyTorch-path method that touches this class raises
+    a helpful error pointing the user at ``SGLANG_USE_MLX=1``.
+    """
+
+    _ERR = (
+        "MLX on-the-fly quantization (--quantization mlx_q4 / mlx_q8) is "
+        "handled by the MLX backend at model-load time via mlx_lm.utils."
+        "quantize_model, not by this QuantizationConfig class. If you "
+        "reached this error, SGLANG_USE_MLX=1 is likely not set."
+    )
+
+    def __init__(self, preset: str):
+        super().__init__()
+        self.preset = preset
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "mlx"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return []
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # Capability check is for NVIDIA SM versions; not meaningful for MLX.
+        return 0
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "MlxQuantizationConfig":
+        raise NotImplementedError(cls._ERR)
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional[QuantizeMethodBase]:
+        raise NotImplementedError(self._ERR)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -134,6 +134,10 @@ QUANTIZATION_CHOICES = [
     "modelslim",  # for NPU
     "quark",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
     "quark_int4fp8_moe",
+    # Apple Silicon MLX backend — on-the-fly quantization of fp16 weights at load
+    # time via mlx.nn.quantize. Only takes effect when SGLANG_USE_MLX=1.
+    "mlx_q4",  # 4 bits, group_size=64 (mlx-community default)
+    "mlx_q8",  # 8 bits, group_size=64
     "unquant",
 ]
 

--- a/test/registered/unit/hardware_backend/mlx/test_quantization.py
+++ b/test/registered/unit/hardware_backend/mlx/test_quantization.py
@@ -1,0 +1,190 @@
+"""Unit tests for MLX backend on-the-fly quantization.
+
+Covers:
+  - mlx_q4 / mlx_q8 quantize fp16 weights to QuantizedLinear in-place
+  - active-memory drops after quantization
+  - smoke /generate still works post-quantize
+  - pre-quantized HF repos still load (regression guard for mlx_lm passthrough)
+  - mlx_q4 flag on an already-quantized model is a no-op (skip + log)
+
+Skips on non-Apple-Silicon platforms and when ``mlx`` / ``mlx_lm`` are missing.
+"""
+
+from __future__ import annotations
+
+import gc
+import importlib.util
+import platform
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+# Registered with the CPU suite (runtime no-op marker, parsed via AST).
+# On non-Apple-Silicon CI runners the entire TestCase class skips via the
+# @skipUnless guard below, so this registration is the harmless "yes this
+# test exists" signal the registry requires.
+register_cpu_ci(est_time=10, suite="stage-a-test-cpu")
+
+_IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
+_HAS_MLX = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_lm") is not None
+)
+
+_SKIP_REASON = "Apple-Silicon-only test (requires Darwin/arm64 + mlx + mlx_lm)"
+
+# Tiny model used across tests; ~0.6B fp16 = ~1.1 GB on disk after first download.
+_TEST_MODEL = "Qwen/Qwen3-0.6B"
+_TEST_MODEL_PREQUANT = "mlx-community/Qwen3-0.6B-4bit"
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestMlxQuantization(unittest.TestCase):
+    """Smoke tests for --quantization mlx_q4 / mlx_q8 in MlxModelRunner."""
+
+    # ---------- helpers ----------
+
+    @staticmethod
+    def _module_counts(model) -> tuple[int, int]:
+        n_quant, n_linear = 0, 0
+        for _, m in model.named_modules():
+            cls = type(m).__name__
+            if cls == "QuantizedLinear":
+                n_quant += 1
+            elif cls == "Linear":
+                n_linear += 1
+        return n_quant, n_linear
+
+    @staticmethod
+    def _reset_mlx_memory() -> None:
+        import mlx.core as mx
+
+        gc.collect()
+        mx.clear_cache()
+
+    def _build_runner(self, model_path: str, quantization: str | None):
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+
+        return MlxModelRunner(
+            model_path=model_path,
+            quantization=quantization,
+            pool_size=1024,  # small pool — these tests don't drive generation depth
+        )
+
+    # ---------- tests ----------
+
+    def test_mlx_q4_creates_quantized_linear_modules(self):
+        """All Linear modules should be QuantizedLinear after mlx_q4 load."""
+        self._reset_mlx_memory()
+        runner = self._build_runner(_TEST_MODEL, "mlx_q4")
+        try:
+            n_quant, n_linear = self._module_counts(runner.model)
+            self.assertGreater(
+                n_quant, 0, "expected at least one QuantizedLinear module"
+            )
+            self.assertEqual(
+                n_linear,
+                0,
+                f"all Linear modules should have been quantized, got {n_linear} remaining",
+            )
+        finally:
+            del runner
+            self._reset_mlx_memory()
+
+    def test_mlx_q4_reduces_memory_vs_fp16(self):
+        """mlx_q4 should use meaningfully less memory than the fp16 baseline."""
+        import mlx.core as mx
+
+        self._reset_mlx_memory()
+        runner_fp = self._build_runner(_TEST_MODEL, None)
+        mx.eval(runner_fp.model.parameters())
+        mem_fp = mx.get_active_memory()
+        del runner_fp
+        self._reset_mlx_memory()
+
+        runner_q4 = self._build_runner(_TEST_MODEL, "mlx_q4")
+        mx.eval(runner_q4.model.parameters())
+        mem_q4 = mx.get_active_memory()
+        del runner_q4
+        self._reset_mlx_memory()
+
+        # Conservative: expect at least 40% reduction. On Qwen3-0.6B we measured ~72%;
+        # 40% leaves headroom for different mlx_lm versions, model shapes, etc.
+        reduction = 1 - (mem_q4 / max(mem_fp, 1))
+        self.assertGreater(
+            reduction,
+            0.40,
+            f"expected >40% memory reduction with mlx_q4, got {reduction*100:.1f}% "
+            f"(fp16={mem_fp/1024**3:.2f} GB, q4={mem_q4/1024**3:.2f} GB)",
+        )
+
+    def test_mlx_q8_creates_quantized_linear_modules(self):
+        """Same check for the 8-bit variant."""
+        self._reset_mlx_memory()
+        runner = self._build_runner(_TEST_MODEL, "mlx_q8")
+        try:
+            n_quant, n_linear = self._module_counts(runner.model)
+            self.assertGreater(n_quant, 0)
+            self.assertEqual(n_linear, 0)
+        finally:
+            del runner
+            self._reset_mlx_memory()
+
+    def test_mlx_q4_generates_text(self):
+        """After on-the-fly quantization the model must still generate non-empty text."""
+        from mlx_lm import generate
+        from transformers import AutoTokenizer
+
+        self._reset_mlx_memory()
+        runner = self._build_runner(_TEST_MODEL, "mlx_q4")
+        try:
+            tok = AutoTokenizer.from_pretrained(_TEST_MODEL)
+            output = generate(
+                runner.model,
+                tok,
+                prompt="The capital of France is",
+                max_tokens=5,
+                verbose=False,
+            )
+            self.assertIsInstance(output, str)
+            self.assertGreater(
+                len(output.strip()), 0, "generation returned empty string"
+            )
+        finally:
+            del runner
+            self._reset_mlx_memory()
+
+    def test_pre_quantized_hf_repo_passthrough(self):
+        """Loading mlx-community/<model>-4bit must still work (mlx_lm passthrough,
+        regression guard for the no-quantization-flag path).
+        """
+        self._reset_mlx_memory()
+        runner = self._build_runner(_TEST_MODEL_PREQUANT, quantization=None)
+        try:
+            n_quant, n_linear = self._module_counts(runner.model)
+            self.assertGreater(
+                n_quant,
+                0,
+                "pre-quantized HF repo should load as QuantizedLinear without --quantization",
+            )
+        finally:
+            del runner
+            self._reset_mlx_memory()
+
+    def test_quantize_flag_on_already_quantized_model_is_noop(self):
+        """Passing --quantization mlx_q4 on a pre-quantized repo should NOT double-quantize."""
+        self._reset_mlx_memory()
+        # Using mlx_q4 against an already-q4 repo. The runner logs the skip and leaves
+        # the existing QuantizedLinear modules untouched.
+        runner = self._build_runner(_TEST_MODEL_PREQUANT, "mlx_q4")
+        try:
+            n_quant, n_linear = self._module_counts(runner.model)
+            self.assertGreater(n_quant, 0)
+            self.assertEqual(n_linear, 0)
+        finally:
+            del runner
+            self._reset_mlx_memory()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Builds on PR #24907 (on-the-fly `--quantization mlx_q4` / `mlx_q8`). That PR adds the feature end-to-end, but the load path materializes the full fp16 model into MLX-managed memory **before** the quantize graph is constructed:

```
mlx_lm.load(...)              -> mx.eval(model.parameters())   # internal to mlx_lm
quantize_model(...)           -> builds lazy quantize graph
mx.eval(model.parameters())   -> materializes quantized leaves
```

On Qwen3-32B that means ~61 GB of fp16 is resident concurrently with the quantize working set, on a 64 GB Mac. Result: heavy memory pressure, paging, and a `2951s` (≈49 min) end-to-end load. KV pool is also squeezed afterward because `sys_available` is ~2.8 GB.

## Modifications

Two changes in `python/sglang/srt/hardware_backend/mlx/model_runner.py`:

1. Pass `lazy=True` to `mlx_lm_load(...)`. mlx_lm's default behavior is to call `mx.eval(model.parameters())` at the end of load (see `mlx_lm/utils.py:418`); `lazy=True` skips that, so weights stay mmap-backed lazy arrays.
2. Add `mx.eval(self.model.parameters())` immediately after `mlx_lm_quantize_model(...)` so the existing `Quantization complete in {q_time}s` log line captures the real streaming materialization, not just the graph build (which is ~10ms).

`nn.quantize` builds one independent `mx.quantize(linear.weight, ...)` op per Linear leaf — there are no cross-layer dependencies in the lazy graph. With weights still lazy at the moment `mx.eval` runs, MLX schedules per-layer: pull one Linear's fp16 from mmap, run `mx.quantize`, drop the fp16 input, keep the quantized outputs. Peak memory becomes `quantized_total + small working set` instead of `fp16_total + quantized_total`.

The unconditional `mx.eval(self.model.parameters())` later in `_load_model` is kept — it is a no-op on the quantize path (idempotent) and still required on the non-quantize path to materialize before KV pool sizing.

## Test Plan

End-to-end on Qwen3-32B, `--quantization mlx_q4`, on a 64 GB M-series Mac.

Server log (before / after, same machine, same model, same flags):

| | PR #24907 (this branch's base) | PR #24907 + lazy=True (this PR) |
|---|---|---|
| `Quantization complete` | 476.85s | **10.37s** |
| `MLX model loaded` | **2951.47s** | **10.88s** |
| `sys_available` post-load | 2.76 GB | **11.99 GB** |
| KV `pool_size` | 4,797 tokens | **21,615 tokens** |
| Final mlx_used | 17.16 GB | 17.16 GB |

That's ~270× faster end-to-end load and a ~4.5× larger KV cache budget for the same model. Final memory footprint is identical because the *final* state is the same — only the *peak during load* differs.

Bare-quantize microbenchmark on the same model isolates the materialize phase:

| | materialize time | peak memory |
|---|---|---|
| `lazy=False`, single eval | 234s | 61.4 GB |
| `lazy=True`, single eval | **7s** | **20.7 GB** |

Correctness check — 4 representative prompts against the patched server (factual, arithmetic, code, summary): all return correct, well-formatted outputs. Generation throughput unchanged.

## Dependency

Depends on #24907 — this branch is built on top of it. If #24907 lands first, this becomes a small diff against `main`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit) guideline.
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) section. *(No new tests — behavior is identical except for timing/memory. Existing tests in `test_quantization.py` from #24907 still cover correctness.)*
- [x] Update documentation / docstrings — comment block in `model_runner.py` explains the why.
- [x] Provide test results comparing before/after the change.
