### PR TITLE
Fix Triton PP dynamic chunking shape mismatch

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -136,9 +136,10 @@ class TritonAttnBackend(AttentionBackend):
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
             self.swa_v_head_dim = None
         else:
-            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[
-                -1
-            ]
+            start_layer = getattr(model_runner.token_to_kv_pool, "start_layer", 0)
+            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(
+                start_layer
+            ).shape[-1]
             self.swa_v_head_dim = None
         self.max_context_len = model_runner.model_config.context_len
         self.device = model_runner.device
@@ -215,7 +216,7 @@ class TritonAttnBackend(AttentionBackend):
 
         if not self.skip_prefill:
             self.qo_indptr = torch.zeros(
-                (max_bs + 1,), dtype=torch.int64, device=model_runner.device
+                (max_bs + 1,), dtype=torch.int32, device=model_runner.device
             )
 
             self.mask_indptr = torch.zeros(


### PR DESCRIPTION
## Motivation

Dynamic chunking with Triton attention can hit a shape mismatch in PP deployments. The Triton backend currently derives `v_head_dim` from layer 0 and allocates `qo_indptr` as int64, but PP-local KV pools may start at a non-zero layer and the Triton extend path expects int32 indptr tensors.

## Modifications

- Derive `v_head_dim` from `token_to_kv_pool.start_layer` when available, instead of always reading layer 0.
- Allocate `qo_indptr` as `torch.int32` to match the Triton attention kernels and existing kernel tests.

## Accuracy Tests

- Not run. This is a targeted PP/dynamic chunking runtime fix that requires the affected GPU deployment to reproduce.

## Speed Tests and Profiling

- Not run. The change only adjusts metadata buffer dtype and the layer used to infer `v_head_dim`.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
