### PR TITLE
[PP] Fix PP prefix length consensus with HiCache

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -745,6 +745,9 @@ class Req(ReqDllmMixin):
         self.host_hit_length = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
+        # In PP prefill, all stages must agree on the prefix length to skip.
+        # This cap is populated by PP bootstrap consensus when needed.
+        self.pp_prefix_len_cap: Optional[int] = None
         # The node to lock until for swa radix tree lock ref
         self.swa_uuid_for_lock: Optional[int] = None
         # Whether the prefill-time SWA tree lock has been released early
@@ -987,6 +990,7 @@ class Req(ReqDllmMixin):
         self,
         tree_cache: Optional[BasePrefixCache] = None,
         cow_mamba: Optional[bool] = None,
+        prefix_len_cap: Optional[int] = None,
     ):
         if self.is_dllm():
             self._init_fill_ids_for_dllm()
@@ -1017,6 +1021,8 @@ class Req(ReqDllmMixin):
         if self.return_logprob and self.logprob_start_len >= 0:
             max_prefix_len = min(max_prefix_len, self.logprob_start_len)
         max_prefix_len = max(max_prefix_len, 0)
+        if prefix_len_cap is not None:
+            max_prefix_len = min(max_prefix_len, prefix_len_cap)
         token_ids = self.fill_ids[:max_prefix_len]
 
         # Disable prefix caching when embed overrides are present: same token IDs
@@ -1248,6 +1254,9 @@ class Req(ReqDllmMixin):
         self.indexer_topk = None
         self.last_node = None
         self.cache_protected_len = 0
+        self.last_host_node = None
+        self.host_hit_length = 0
+        self.pp_prefix_len_cap = None
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
         self.extend_input_len = 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2217,6 +2217,11 @@ class Scheduler(
                     prefix_keys,
                 )
 
+    def _get_req_pp_prefix_len_cap(self, req: Req) -> Optional[int]:
+        if self.pp_size <= 1 or not self.enable_hierarchical_cache:
+            return None
+        return req.pp_prefix_len_cap
+
     def _add_request_to_queue(self, req: Req, is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.NULL:
             if not self._set_or_validate_priority(req):
@@ -2719,7 +2724,10 @@ class Scheduler(
                     req.rid
                 )
 
-            req.init_next_round_input(self.tree_cache)
+            req.init_next_round_input(
+                self.tree_cache,
+                prefix_len_cap=self._get_req_pp_prefix_len_cap(req),
+            )
             res = adder.add_one_req(
                 req,
                 has_chunked_req=(self.chunked_req is not None),

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -742,7 +742,8 @@ class SchedulerPPMixin:
             (
                 good_consensus_bootstrapped_rids,
                 bad_consensus_bootstrapped_rids,
-            ) = bootstrapped_rids
+                pp_prefix_len_caps,
+            ) = self._pp_pd_unpack_bootstrapped_info(bootstrapped_rids)
             good_reqs, failed_reqs = (
                 self.disagg_prefill_bootstrap_queue.pop_bootstrapped(
                     return_failed_reqs=True,
@@ -750,9 +751,65 @@ class SchedulerPPMixin:
                     + bad_consensus_bootstrapped_rids,
                 )
             )
+            for req in good_reqs:
+                req.pp_prefix_len_cap = pp_prefix_len_caps.get(req.rid)
             self.waiting_queue.extend(good_reqs)
-            return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
+            return [
+                [req.rid for req in good_reqs],
+                [req.rid for req in failed_reqs],
+                {
+                    req.rid: req.pp_prefix_len_cap
+                    for req in good_reqs
+                    if req.pp_prefix_len_cap is not None
+                },
+            ]
         return None
+
+    def _pp_pd_unpack_bootstrapped_info(self: Scheduler, bootstrapped_info):
+        if len(bootstrapped_info) == 2:
+            good_bootstrapped_rids, bad_bootstrapped_rids = bootstrapped_info
+            pp_prefix_len_caps = {}
+        else:
+            (
+                good_bootstrapped_rids,
+                bad_bootstrapped_rids,
+                pp_prefix_len_caps,
+            ) = bootstrapped_info
+            pp_prefix_len_caps = pp_prefix_len_caps or {}
+        return good_bootstrapped_rids, bad_bootstrapped_rids, pp_prefix_len_caps
+
+    def _pp_pd_get_local_prefix_len_caps(self: Scheduler, rids: List[str]):
+        if not self.enable_hierarchical_cache:
+            return {}
+
+        rid_set = set(rids)
+        prefix_len_caps = {}
+        for req in self.disagg_prefill_bootstrap_queue.queue:
+            if req.rid not in rid_set:
+                continue
+            req.init_next_round_input(self.tree_cache)
+            prefix_len_caps[req.rid] = len(req.prefix_indices) + req.host_hit_length
+        return prefix_len_caps
+
+    def _pp_pd_merge_prefix_len_caps(
+        self: Scheduler,
+        rids: List[str],
+        prev_prefix_len_caps: Dict[str, int],
+        curr_prefix_len_caps: Dict[str, int],
+    ):
+        prefix_len_caps = {}
+        for rid in rids:
+            prev_len = prev_prefix_len_caps.get(rid)
+            curr_len = curr_prefix_len_caps.get(rid)
+            if prev_len is None:
+                cap = curr_len
+            elif curr_len is None:
+                cap = prev_len
+            else:
+                cap = min(prev_len, curr_len)
+            if cap is not None:
+                prefix_len_caps[rid] = cap
+        return prefix_len_caps
 
     def _pp_pd_get_bootstrapped_ids(self: Scheduler):
         # communicate pre-consensus bootstrapp reqs
@@ -764,12 +821,17 @@ class SchedulerPPMixin:
                 [KVPoll.WaitingForInput],
                 [KVPoll.Failed],
             )
+            pp_prefix_len_caps = self._pp_pd_get_local_prefix_len_caps(
+                good_bootstrapped_rids
+            )
         else:
             # Other ranks, receive the bootstrap reqs info from the previous rank and ensure the consensus
             prev_bootstrapped_rids = self._pp_recv_pyobj_from_prev_stage()
-            prev_good_bootstrapped_rids, prev_bad_bootstrapped_rids = (
-                prev_bootstrapped_rids
-            )
+            (
+                prev_good_bootstrapped_rids,
+                prev_bad_bootstrapped_rids,
+                prev_prefix_len_caps,
+            ) = self._pp_pd_unpack_bootstrapped_info(prev_bootstrapped_rids)
             curr_good_bootstrapped_rids, curr_bad_bootstrapped_rids = self.get_rids(
                 self.disagg_prefill_bootstrap_queue.queue,
                 True,
@@ -782,7 +844,15 @@ class SchedulerPPMixin:
             bad_bootstrapped_rids = list(
                 set(prev_bad_bootstrapped_rids) | set(curr_bad_bootstrapped_rids)
             )
-        return [good_bootstrapped_rids, bad_bootstrapped_rids]
+            curr_prefix_len_caps = self._pp_pd_get_local_prefix_len_caps(
+                good_bootstrapped_rids
+            )
+            pp_prefix_len_caps = self._pp_pd_merge_prefix_len_caps(
+                good_bootstrapped_rids,
+                prev_prefix_len_caps,
+                curr_prefix_len_caps,
+            )
+        return [good_bootstrapped_rids, bad_bootstrapped_rids, pp_prefix_len_caps]
 
     def _pp_pd_get_prefill_transferred_ids(self: Scheduler):
         # get the current stage transfer success


### PR DESCRIPTION
## Motivation

In PP prefill with hierarchical cache, each PP stage can observe a different local prefix hit length. If a later stage skips more tokens than an earlier stage can provide, the stage can read the wrong number of tail tokens and hit a shape mismatch under dynamic chunking.

This PR makes PP bootstrap agree on the prefix length cap across stages before requests enter the waiting queue.

## Modifications

- Add `Req.pp_prefix_len_cap` and pass it into `init_next_round_input` so prefix matching is capped by the PP consensus length.
- During PP prefill bootstrap, collect each stage local prefix length as `len(prefix_indices) + host_hit_length` when hierarchical cache is enabled.
- Propagate and merge the caps across PP stages with `min(...)`, then attach the resulting cap to the bootstrapped requests.
- Keep backward-compatible unpacking for older two-field bootstrap payloads.

## Accuracy Tests

- `python3 -m compileall -q python/sglang/srt/managers/schedule_batch.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/scheduler_pp_mixin.py`

## Speed Tests and Profiling

- Not run. The change adds small Python-side bootstrap metadata handling for PP + hierarchical cache; no kernel or model forward path changes.
