### PR TITLE
Return 400 instead of 500 for invalid /v1/responses requests

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1664,12 +1664,11 @@ async def v1_score_request(request: ScoringRequest, raw_request: Request):
 
 
 @app.post("/v1/responses", dependencies=[Depends(validate_json_request)])
-async def v1_responses_request(request: dict, raw_request: Request):
+async def v1_responses_request(request: ResponsesRequest, raw_request: Request):
     """Endpoint for the responses API with reasoning support."""
 
-    request_obj = ResponsesRequest(**request)
     result = await raw_request.app.state.openai_serving_responses.create_responses(
-        request_obj, raw_request
+        request, raw_request
     )
 
     # Handle streaming responses

--- a/test/registered/openai_server/basic/test_openai_server.py
+++ b/test/registered/openai_server/basic/test_openai_server.py
@@ -727,6 +727,29 @@ class TestOpenAIServerv1Responses(CustomTestCase):
         self.assertIn("type", body["error"])
         self.assertIn("code", body["error"])
 
+    def test_invalid_tools_error(self):
+        url = f"{self.base_url}/responses"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "input": "Hi",
+            "tools": [{"type": "some_invalid_tool_type"}],
+        }
+        r = requests.post(url, headers=headers, json=payload)
+        self.assertEqual(r.status_code, 400)
+        body = r.json()
+        self.assertIn("error", body)
+        self.assertIn("message", body["error"])
+        self.assertIn(
+            "Input should be 'web_search_preview' or 'code_interpreter'",
+            body["error"]["message"],
+        )
+        self.assertIn("type", body["error"])
+        self.assertIn("code", body["error"])
+
     def test_penalty(self):
         url = f"{self.base_url}/responses"
         headers = {


### PR DESCRIPTION
## Refiling Note

This PR re-files the same change previously proposed in https://github.com/sgl-project/sglang/pull/22980 so it can get fresh reviewer attention.

Please review this PR instead of the old one. I am re-filing it on top of the latest `main` because the earlier PR appears to have been overlooked.

The original PR description is kept intact below.

## Motivation

We use `sglang-model-gateway` in front of SGLang workers. In production, some requests reaching `/v1/responses` were effectively malformed for the worker's current `ResponsesRequest` validation, even though they can be legitimate in the broader OpenAI-compatible ecosystem and may be related to other SGLang compatibility gaps such as https://github.com/sgl-project/sglang/pull/16806.

Because `/v1/responses` manually instantiated `ResponsesRequest` inside the route handler, these requests could raise a raw Pydantic validation error and surface as a `500` from the worker instead of a client error. The `500`s then caused `sglang-model-gateway` circuit breakers to trip, which amplified the impact into a wider outage.

This change makes the worker return a normal validation error response instead of an internal server error for invalid `/v1/responses` bodies.

## Modifications

- Change the `/v1/responses` FastAPI handler to accept `ResponsesRequest` directly instead of `dict`.
- Remove the manual `ResponsesRequest(**request)` construction inside the route so request validation happens in FastAPI's normal validation path.
- Add a regression test that sends an invalid tool type and asserts the endpoint returns a `400` error payload instead of failing with `500`.

## Accuracy Tests

Not applicable. This change only affects request validation and error handling.

## Speed Tests and Profiling

Not applicable. This change does not affect inference execution.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [N/A] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [N/A] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->