### PR TITLE
Fast E2E accuracy test by numerical comparison

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -232,6 +232,7 @@ class Envs:
     SGLANG_DISABLE_OUTLINES_DISK_CACHE = EnvBool(False)
 
     # Test & Debug
+    SGLANG_ENABLE_FORCED_TOKEN_IDS = EnvBool(False)
     SGLANG_DETECT_SLOW_RANK = EnvBool(False)
     SGLANG_TEST_STUCK_DETOKENIZER = EnvFloat(0)
     SGLANG_TEST_STUCK_DP_CONTROLLER = EnvFloat(0)

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -201,6 +201,24 @@ class Sampler(nn.Module):
                 batch_next_token_ids,
             )
 
+        # Forced-token-ids debug feature: if any request supplied a
+        # forced_token_ids list, override the chosen token at this step with
+        # the request's forced value. Logprobs above were computed from the
+        # real distribution and remain untouched. The forced_next_token_ids
+        # tensor is populated per-forward by Scheduler.run_batch via
+        # SamplingBatchInfo.prepare_forced_next_token_ids; sentinel -1 means
+        # "no forcing for this slot at this step".
+        if (
+            sampling_info.has_any_forced
+            and sampling_info.forced_next_token_ids is not None
+        ):
+            forced = sampling_info.forced_next_token_ids
+            mask = forced.ge(0)
+            if mask.any():
+                batch_next_token_ids = torch.where(
+                    mask, forced.to(batch_next_token_ids.dtype), batch_next_token_ids
+                )
+
         self._sync_token_ids_across_tp(batch_next_token_ids, sampling_info)
 
         return batch_next_token_ids

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3002,6 +3002,13 @@ class Scheduler(
         if batch.forward_mode.is_prebuilt():
             return self._run_batch_prebuilt(batch)
 
+        # Refresh per-forward forced-token slots (no-op when no request has
+        # forced_token_ids set). Must run before copy_for_forward so the
+        # tensor rides through dataclasses.replace into the worker copy.
+        if batch.sampling_info is not None and batch.sampling_info.has_any_forced:
+            current_steps = [len(r.output_ids) for r in batch.reqs]
+            batch.sampling_info.prepare_forced_next_token_ids(current_steps)
+
         # Run forward
         if self.is_generation:
             if self.enable_overlap:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1070,6 +1070,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             sampling_kwargs = obj.sampling_params
         sampling_params = self.sampling_params_class(**sampling_kwargs)
+        sampling_params.resolve_forced_token_ids_path()
         sampling_params.normalize(self.tokenizer)
         sampling_params.verify(self.model_config.vocab_size)
 

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -72,6 +72,20 @@ class SamplingBatchInfo:
     # Handle logit bias
     logit_bias: Optional[torch.Tensor] = None
 
+    # Forced-token-ids debug feature. When any request supplies a
+    # `forced_token_ids` sampling-param, the Sampler overrides the chosen
+    # token at each step with the request's t_step value, while leaving
+    # logits / logprobs untouched. Gated server-side by the env var
+    # SGLANG_ENABLE_FORCED_TOKEN_IDS=1 (enforced in SamplingParams.verify).
+    has_any_forced: bool = False
+    # Per-request forced-token sequence (None for unforced requests). Set in
+    # from_schedule_batch and updated by filter_batch / merge_batch.
+    forced_token_ids_lists: Optional[List[Optional[List[int]]]] = None
+    # Per-batch tensor of shape [bs] populated at forward time:
+    # forced_next_token_ids[i] = forced_token_ids_lists[i][step_i] or -1.
+    # Sentinel -1 means "no forcing for this request at this step".
+    forced_next_token_ids: Optional[torch.Tensor] = None
+
     @classmethod
     def from_schedule_batch(cls, batch: ScheduleBatch, vocab_size: int):
         global_server_args = get_global_server_args()
@@ -151,6 +165,15 @@ class SamplingBatchInfo:
             merged_custom_logit_processor = None
             custom_params = None
 
+        # Forced-token-ids storage (per-request lists, never changes after this point
+        # except via filter_batch / merge_batch). The per-forward `forced_next_token_ids`
+        # tensor is populated separately by `prepare_forced_next_token_ids` before each
+        # sampler call, since the current decode step changes each forward.
+        forced_token_ids_lists = [r.sampling_params.forced_token_ids for r in reqs]
+        has_any_forced = any(ft is not None for ft in forced_token_ids_lists)
+        if not has_any_forced:
+            forced_token_ids_lists = None
+
         # Each penalizers will do nothing if they evaluate themselves as not required by looking at
         # the sampling_params of the requests (See {_is_required()} of each penalizers). So this
         # should not add hefty computation overhead other than simple checks.
@@ -186,6 +209,8 @@ class SamplingBatchInfo:
             custom_logit_processor=merged_custom_logit_processor,
             device=device,
             logit_bias=logit_bias,
+            has_any_forced=has_any_forced,
+            forced_token_ids_lists=forced_token_ids_lists,
         )
         ret.adjusted_from_schedule_batch(batch, vocab_size)
         return ret
@@ -206,6 +231,35 @@ class SamplingBatchInfo:
 
     def __len__(self):
         return len(self.temperatures)
+
+    def prepare_forced_next_token_ids(self, current_steps: List[int]):
+        """Populate `forced_next_token_ids` for the upcoming forward.
+
+        Called per forward by the scheduler. `current_steps[i]` is the
+        decode-step index of request i (i.e. `len(req.output_ids)` immediately
+        before this forward). For each request that has a `forced_token_ids`
+        list and is still within bounds, set the slot to the forced token id;
+        otherwise set the sentinel -1.
+        """
+        if not self.has_any_forced or self.forced_token_ids_lists is None:
+            self.forced_next_token_ids = None
+            return
+
+        bs = len(self.forced_token_ids_lists)
+        assert len(current_steps) == bs, (
+            f"current_steps length {len(current_steps)} does not match "
+            f"batch size {bs}"
+        )
+        slot_values: List[int] = [-1] * bs
+        for i, forced in enumerate(self.forced_token_ids_lists):
+            if forced is None:
+                continue
+            step = current_steps[i]
+            if 0 <= step < len(forced):
+                slot_values[i] = int(forced[step])
+        self.forced_next_token_ids = torch.tensor(
+            slot_values, dtype=torch.int64, device=self.device
+        )
 
     def update_regex_vocab_mask(self):
         if not self.grammars:
@@ -289,6 +343,20 @@ class SamplingBatchInfo:
 
         if self.logit_bias is not None:
             self.logit_bias = self.logit_bias[keep_indices_device]
+
+        if self.forced_token_ids_lists is not None:
+            self.forced_token_ids_lists = [
+                self.forced_token_ids_lists[i] for i in keep_indices
+            ]
+            self.has_any_forced = any(
+                ft is not None for ft in self.forced_token_ids_lists
+            )
+            if not self.has_any_forced:
+                self.forced_token_ids_lists = None
+            # forced_next_token_ids is per-forward and rebuilt by
+            # prepare_forced_next_token_ids; clear here so a stale tensor
+            # doesn't accidentally apply to the filtered batch.
+            self.forced_next_token_ids = None
 
         self.adjusted_filter_batch(keep_indices, keep_indices_device)
 
@@ -380,6 +448,16 @@ class SamplingBatchInfo:
         self.logit_bias = merge_bias_tensor(
             self.logit_bias, other.logit_bias, len(self), len(other), self.device, 0.0
         )
+
+        # Merge forced-token lists. Must run before the temperatures merge,
+        # since `len(self)` / `len(other)` are derived from those tensors.
+        if self.has_any_forced or other.has_any_forced:
+            self_lists = self.forced_token_ids_lists or [None] * len(self)
+            other_lists = other.forced_token_ids_lists or [None] * len(other)
+            merged = self_lists + other_lists
+            self.forced_token_ids_lists = merged
+            self.has_any_forced = any(ft is not None for ft in merged)
+            self.forced_next_token_ids = None
 
         # Note: because the __len()__ operator is defined on the temperatures tensor,
         # please make sure any merge operation with len(self) or len(other) is done before

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -14,8 +14,9 @@
 """Sampling parameters for text generation."""
 
 import logging
-import os
 from typing import Any, Dict, List, Optional, Union
+
+from sglang.srt.environ import envs
 
 # sre_parse is deprecated in Python 3.11+, use re._parser instead
 try:
@@ -25,11 +26,6 @@ except ImportError:
 
 _SAMPLING_EPS = 1e-6
 TOP_K_ALL = 1 << 30
-
-# Env var that gates the forced-token-ids debug feature server-side.
-# Without this, the server rejects any request carrying forced_token_ids /
-# forced_token_ids_path so arbitrary clients can't trigger forced decoding.
-SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV = "SGLANG_ENABLE_FORCED_TOKEN_IDS"
 
 logger = logging.getLogger(__name__)
 
@@ -193,10 +189,10 @@ class SamplingParams:
             )
         if (
             self.forced_token_ids is not None or self.forced_token_ids_path is not None
-        ) and os.environ.get(SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV) != "1":
+        ) and not envs.SGLANG_ENABLE_FORCED_TOKEN_IDS.get():
             raise ValueError(
-                f"forced_token_ids requires {SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV}=1 "
-                f"on the server."
+                "forced_token_ids requires SGLANG_ENABLE_FORCED_TOKEN_IDS=1 "
+                "on the server."
             )
         if self.forced_token_ids is not None:
             for tid in self.forced_token_ids:
@@ -218,10 +214,10 @@ class SamplingParams:
         """
         if self.forced_token_ids_path is None:
             return
-        if os.environ.get(SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV) != "1":
+        if not envs.SGLANG_ENABLE_FORCED_TOKEN_IDS.get():
             raise ValueError(
-                f"forced_token_ids_path requires "
-                f"{SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV}=1 on the server."
+                "forced_token_ids_path requires "
+                "SGLANG_ENABLE_FORCED_TOKEN_IDS=1 on the server."
             )
         if self.forced_token_ids is not None:
             raise ValueError(

--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -14,6 +14,7 @@
 """Sampling parameters for text generation."""
 
 import logging
+import os
 from typing import Any, Dict, List, Optional, Union
 
 # sre_parse is deprecated in Python 3.11+, use re._parser instead
@@ -24,6 +25,11 @@ except ImportError:
 
 _SAMPLING_EPS = 1e-6
 TOP_K_ALL = 1 << 30
+
+# Env var that gates the forced-token-ids debug feature server-side.
+# Without this, the server rejects any request carrying forced_token_ids /
+# forced_token_ids_path so arbitrary clients can't trigger forced decoding.
+SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV = "SGLANG_ENABLE_FORCED_TOKEN_IDS"
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +70,8 @@ class SamplingParams:
         stream_interval: Optional[int] = None,
         logit_bias: Optional[Dict[str, float]] = None,
         sampling_seed: Optional[int] = None,
+        forced_token_ids: Optional[List[int]] = None,
+        forced_token_ids_path: Optional[str] = None,
     ) -> None:
         # For non-optional params, treat None as "use default" so that callers
         # (e.g. /generate) can pass null without crashing verify().
@@ -108,6 +116,10 @@ class SamplingParams:
         self.stream_interval = stream_interval
         self.logit_bias = logit_bias
         self.sampling_seed = sampling_seed
+        self.forced_token_ids = (
+            [int(t) for t in forced_token_ids] if forced_token_ids else None
+        )
+        self.forced_token_ids_path = forced_token_ids_path
 
         # Process some special cases
         if 0 <= self.temperature < _SAMPLING_EPS:
@@ -174,6 +186,95 @@ class SamplingParams:
         ]  # since mutually exclusive, only one can be set
         if sum(x is not None for x in grammars) > 1:
             raise ValueError("Only one of regex, json_schema, or ebnf can be set.")
+
+        if self.forced_token_ids is not None and self.forced_token_ids_path is not None:
+            raise ValueError(
+                "Only one of forced_token_ids or forced_token_ids_path can be set."
+            )
+        if (
+            self.forced_token_ids is not None or self.forced_token_ids_path is not None
+        ) and os.environ.get(SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV) != "1":
+            raise ValueError(
+                f"forced_token_ids requires {SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV}=1 "
+                f"on the server."
+            )
+        if self.forced_token_ids is not None:
+            for tid in self.forced_token_ids:
+                if not 0 <= int(tid) < vocab_size:
+                    raise ValueError(
+                        f"forced_token_ids must be in [0, {vocab_size - 1}], got {tid}."
+                    )
+
+    # Maximum length of a forced_token_ids sequence loaded from disk. Bounds
+    # the work done at request admission. Forced sequences longer than this
+    # are rejected; raise this if your test legitimately needs more.
+    MAX_FORCED_TOKEN_IDS_LENGTH: int = 512 * 1024
+
+    def resolve_forced_token_ids_path(self):
+        """If forced_token_ids_path is set, load the tensor and populate
+        forced_token_ids. Must run before `verify()`. Validates the env-var
+        gate first so a path-only request doesn't trigger any disk I/O on
+        servers that haven't opted in.
+        """
+        if self.forced_token_ids_path is None:
+            return
+        if os.environ.get(SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV) != "1":
+            raise ValueError(
+                f"forced_token_ids_path requires "
+                f"{SGLANG_ENABLE_FORCED_TOKEN_IDS_ENV}=1 on the server."
+            )
+        if self.forced_token_ids is not None:
+            raise ValueError(
+                "Only one of forced_token_ids or forced_token_ids_path can be set."
+            )
+
+        # Lazy import: torch is heavy and SamplingParams is constructed in
+        # paths that don't otherwise need it.
+        import torch
+
+        path = self.forced_token_ids_path
+        try:
+            loaded = torch.load(path, map_location="cpu", weights_only=False)
+        except Exception as e:
+            raise ValueError(
+                f"Failed to load forced_token_ids_path={path!r}: {e}"
+            ) from e
+
+        # The artifact format produced by the branch_compare test is a dict
+        # with an "output_ids" key; accept either the dict or a bare tensor.
+        if isinstance(loaded, dict):
+            if "output_ids" not in loaded:
+                raise ValueError(
+                    f"forced_token_ids_path={path!r} dict has no 'output_ids' key"
+                )
+            tensor = loaded["output_ids"]
+        else:
+            tensor = loaded
+
+        if not isinstance(tensor, torch.Tensor):
+            raise ValueError(
+                f"forced_token_ids_path={path!r} did not contain a tensor "
+                f"(got {type(tensor).__name__})"
+            )
+        if tensor.dim() != 1:
+            raise ValueError(
+                f"forced_token_ids_path={path!r} tensor must be 1-D, "
+                f"got shape {tuple(tensor.shape)}"
+            )
+        if torch.is_floating_point(tensor) or tensor.dtype == torch.bool:
+            raise ValueError(
+                f"forced_token_ids_path={path!r} tensor must be an integer "
+                f"dtype, got {tensor.dtype}"
+            )
+        if tensor.numel() > self.MAX_FORCED_TOKEN_IDS_LENGTH:
+            raise ValueError(
+                f"forced_token_ids_path={path!r} length "
+                f"{tensor.numel()} exceeds MAX_FORCED_TOKEN_IDS_LENGTH "
+                f"({self.MAX_FORCED_TOKEN_IDS_LENGTH})"
+            )
+
+        self.forced_token_ids = [int(t) for t in tensor.tolist()]
+        self.forced_token_ids_path = None
 
     def normalize(self, tokenizer):
         # Process stop strings

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -896,7 +896,7 @@ class ServerArgs:
         # lags by one round, which causes a one-step shift in the forced
         # sequence. Force overlap off when the feature is enabled.
         if (
-            os.environ.get("SGLANG_ENABLE_FORCED_TOKEN_IDS") == "1"
+            envs.SGLANG_ENABLE_FORCED_TOKEN_IDS.get()
             and not self.disable_overlap_schedule
         ):
             logger.warning(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -891,6 +891,21 @@ class ServerArgs:
         Orchestrates the handling of various server arguments, ensuring proper configuration and validation.
         """
 
+        # The forced_token_ids debug feature reads `len(req.output_ids)` to
+        # pick the next forced token; in overlap-schedule mode that count
+        # lags by one round, which causes a one-step shift in the forced
+        # sequence. Force overlap off when the feature is enabled.
+        if (
+            os.environ.get("SGLANG_ENABLE_FORCED_TOKEN_IDS") == "1"
+            and not self.disable_overlap_schedule
+        ):
+            logger.warning(
+                "SGLANG_ENABLE_FORCED_TOKEN_IDS=1 forces "
+                "--disable-overlap-schedule (forced_token_ids step counter "
+                "is incompatible with overlap mode)."
+            )
+            self.disable_overlap_schedule = True
+
         self._maybe_download_model_for_runai()
 
         # Normalize load balancing defaults early (before dummy-model short-circuit).

--- a/test/manual/branch_compare/README.md
+++ b/test/manual/branch_compare/README.md
@@ -1,0 +1,81 @@
+# Branch vs Main Numerical-Divergence Test
+
+Compares per-step logit/logprob distributions between a **record** run on
+`main` and a **verify** run on a feature branch. The verify run is forced
+(via the `forced_token_ids` debug feature) to emit exactly main's token
+sequence at every step, so prefill and decode are both exercised on the
+branch with comparable inputs and small kernel differences show up as
+small distribution drift instead of catastrophic prefix divergence.
+
+## Prerequisites
+
+The test relies on the `forced_token_ids` debug feature in sglang core:
+- `SamplingParams.forced_token_ids` / `forced_token_ids_path`
+- `SamplingBatchInfo.prepare_forced_next_token_ids`
+- `Sampler.forward` override step
+
+These must be present on **both** branches under test (they land on `main`
+first as a generic feature; the branch under test inherits them via merge).
+
+Set `SGLANG_ENABLE_FORCED_TOKEN_IDS=1` in the server's environment for both
+phases. Without the env var, `forced_token_ids` requests are rejected at
+admission with no disk I/O.
+
+## Workflow
+
+```bash
+# === Phase 1: record on main ===
+git checkout main
+SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \
+python -m test.manual.branch_compare.run \
+    --mode record \
+    --artifact-dir /tmp/run1/main \
+    --model-path /models/llama3-70b \
+    --tp-size 8 \
+    --eval-name gpqa --num-examples 16 \
+    --max-new-tokens 1024 \
+    --topk-logprobs 128
+
+# === Phase 2: verify on branch ===
+git checkout my-feature-branch
+SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \
+python -m test.manual.branch_compare.run \
+    --mode verify \
+    --artifact-dir /tmp/run1/branch \
+    --record-dir   /tmp/run1/main \
+    --model-path /models/llama3-70b \
+    --tp-size 8 \
+    --max-new-tokens 1024 \
+    --topk-logprobs 128
+
+# === Compare ===
+python -m test.manual.branch_compare.compare \
+    --record-dir /tmp/run1/main \
+    --branch-dir /tmp/run1/branch \
+    --out-dir    /tmp/run1
+```
+
+`run.py` accepts every argument that `python -m sglang.launch_server`
+accepts (via `ServerArgs.add_cli_args`), so pass any production server
+config (`--quantization`, `--attention-backend`, `--mem-fraction-static`,
+`--enable-deterministic-inference`, etc.) through directly.
+
+If `--base-url` is set, the script attaches to an already-running server
+instead of launching one. The user is responsible for ensuring the server
+config matches between phases.
+
+## Output
+
+In `--out-dir`:
+- `summary.json` — aggregate cosine / abs-diff / rel-diff (mean, p50, p90, p99, min, max), per-prompt rollup, list of any steps where verify-side `output_ids` deviated from record-side.
+- `histograms.txt` — ASCII bin charts (cosine, abs-diff, rel-diff, common-top-K), also printed to stdout.
+
+## Limitations
+
+- Disagg and speculative decoding are not yet wired through. Use single-mode
+  TP-only servers for now.
+- The forced-tokens path-loader reads any path the (trusted) caller provides.
+  Don't enable `SGLANG_ENABLE_FORCED_TOKEN_IDS=1` on a server exposed to
+  untrusted clients.
+- PD-disagg caps top-K logprobs at 128. The script defaults to 128 to stay
+  safe; raise it for non-disagg deployments.

--- a/test/manual/branch_compare/README.md
+++ b/test/manual/branch_compare/README.md
@@ -1,11 +1,12 @@
-# Branch vs Main Numerical-Divergence Test
+# Branch vs Baseline Numerical-Divergence Test
 
 Compares per-step logit/logprob distributions between a **record** run on
-`main` and a **verify** run on a feature branch. The verify run is forced
-(via the `forced_token_ids` debug feature) to emit exactly main's token
-sequence at every step, so prefill and decode are both exercised on the
-branch with comparable inputs and small kernel differences show up as
-small distribution drift instead of catastrophic prefix divergence.
+the **baseline** (typically `main`) and a **verify** run on a feature
+branch. The verify run is forced (via the `forced_token_ids` debug
+feature) to emit exactly the baseline's token sequence at every step, so
+prefill and decode are both exercised on the branch with comparable
+inputs and small kernel differences show up as small distribution drift
+instead of catastrophic prefix divergence.
 
 ## Prerequisites
 
@@ -14,8 +15,7 @@ The test relies on the `forced_token_ids` debug feature in sglang core:
 - `SamplingBatchInfo.prepare_forced_next_token_ids`
 - `Sampler.forward` override step
 
-These must be present on **both** branches under test (they land on `main`
-first as a generic feature; the branch under test inherits them via merge).
+These must be present on **both** branches under test.
 
 Set `SGLANG_ENABLE_FORCED_TOKEN_IDS=1` in the server's environment for both
 phases. Without the env var, `forced_token_ids` requests are rejected at
@@ -23,14 +23,20 @@ admission with no disk I/O.
 
 ## Workflow
 
+Run from `sglang-source/test/manual/` (so `branch_compare` is importable
+as a top-level package — `python -m test.manual.branch_compare.run`
+collides with Python's stdlib `test` package and won't work):
+
 ```bash
-# === Phase 1: record on main ===
+cd sglang-source/test/manual
+
+# === Phase 1: record baseline ===
 git checkout main
 SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \
-python -m test.manual.branch_compare.run \
+python -m branch_compare.run \
     --mode record \
     --artifact-dir /tmp/run1/main \
-    --model-path /models/llama3-70b \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
     --tp-size 8 \
     --eval-name gpqa --num-examples 16 \
     --max-new-tokens 1024 \
@@ -39,17 +45,17 @@ python -m test.manual.branch_compare.run \
 # === Phase 2: verify on branch ===
 git checkout my-feature-branch
 SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \
-python -m test.manual.branch_compare.run \
+python -m branch_compare.run \
     --mode verify \
     --artifact-dir /tmp/run1/branch \
     --record-dir   /tmp/run1/main \
-    --model-path /models/llama3-70b \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
     --tp-size 8 \
     --max-new-tokens 1024 \
     --topk-logprobs 128
 
 # === Compare ===
-python -m test.manual.branch_compare.compare \
+python -m branch_compare.compare \
     --record-dir /tmp/run1/main \
     --branch-dir /tmp/run1/branch \
     --out-dir    /tmp/run1
@@ -64,6 +70,33 @@ If `--base-url` is set, the script attaches to an already-running server
 instead of launching one. The user is responsible for ensuring the server
 config matches between phases.
 
+```bash
+# Terminal A: launch the server once (e.g. slow multi-node config) and
+# leave it running.
+SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \
+python -m sglang.launch_server \
+    --model-path meta-llama/Llama-3.1-8B-Instruct \
+    --tp-size 8 --port 30000
+
+# Terminal B: point both phases at the running server. Server args are
+# advisory in attach mode (recorded into meta.json but not used to launch).
+cd sglang-source/test/manual
+python -m branch_compare.run \
+    --mode record \
+    --artifact-dir /tmp/run1/main \
+    --base-url http://127.0.0.1:30000 \
+    --eval-name gpqa --num-examples 16 \
+    --max-new-tokens 1024 --topk-logprobs 128
+
+# then restart the server on the feature branch and:
+python -m branch_compare.run \
+    --mode verify \
+    --artifact-dir /tmp/run1/branch \
+    --record-dir   /tmp/run1/main \
+    --base-url http://127.0.0.1:30000 \
+    --max-new-tokens 1024 --topk-logprobs 128
+```
+
 ## Output
 
 In `--out-dir`:
@@ -72,8 +105,7 @@ In `--out-dir`:
 
 ## Limitations
 
-- Disagg and speculative decoding are not yet wired through. Use single-mode
-  TP-only servers for now.
+- Disagg and speculative decoding are WIP. Use agg servers without speculative decoding for now.
 - The forced-tokens path-loader reads any path the (trusted) caller provides.
   Don't enable `SGLANG_ENABLE_FORCED_TOKEN_IDS=1` on a server exposed to
   untrusted clients.

--- a/test/manual/branch_compare/artifacts.py
+++ b/test/manual/branch_compare/artifacts.py
@@ -1,0 +1,91 @@
+"""Read/write helpers for branch_compare artifacts.
+
+Layout under <artifact-dir>:
+    meta.json        - global metadata + per-prompt index
+    prompt_<i>.pt    - per-request torch tensors (output_ids + top-K)
+
+The per-request file format is also what the server's
+`forced_token_ids_path` loader reads on the verify phase: it accepts a
+dict with an "output_ids" key (1-D int tensor) or a bare 1-D int tensor.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+import torch
+
+
+def prompt_filename(idx: int) -> str:
+    return f"prompt_{idx}.pt"
+
+
+def write_meta(artifact_dir: str, meta: Dict[str, Any]) -> str:
+    os.makedirs(artifact_dir, exist_ok=True)
+    path = os.path.join(artifact_dir, "meta.json")
+    with open(path, "w") as f:
+        json.dump(meta, f, indent=2)
+    return path
+
+
+def read_meta(artifact_dir: str) -> Dict[str, Any]:
+    with open(os.path.join(artifact_dir, "meta.json")) as f:
+        return json.load(f)
+
+
+def write_prompt_artifact(
+    artifact_dir: str,
+    idx: int,
+    output_ids: List[int],
+    top_k_token_ids: List[List[int]],
+    top_k_logprobs: List[List[float]],
+    chosen_logprob: List[float],
+) -> str:
+    """Write a per-request torch artifact.
+
+    Tensors:
+      output_ids:        int64 [N]      (also serves as forced_token_ids on verify)
+      top_k_token_ids:   int32 [N, K]
+      top_k_logprobs:    bf16  [N, K]
+      chosen_logprob:    bf16  [N]
+    """
+    n = len(output_ids)
+    if n == 0:
+        k = 0
+    else:
+        k = len(top_k_token_ids[0]) if top_k_token_ids else 0
+
+    out = {
+        "output_ids": torch.tensor(output_ids, dtype=torch.int64),
+        "top_k_token_ids": (
+            torch.tensor(top_k_token_ids, dtype=torch.int32)
+            if k > 0
+            else torch.zeros((n, 0), dtype=torch.int32)
+        ),
+        "top_k_logprobs": (
+            torch.tensor(top_k_logprobs, dtype=torch.float32).to(torch.bfloat16)
+            if k > 0
+            else torch.zeros((n, 0), dtype=torch.bfloat16)
+        ),
+        "chosen_logprob": torch.tensor(chosen_logprob, dtype=torch.float32).to(
+            torch.bfloat16
+        ),
+    }
+    path = os.path.join(artifact_dir, prompt_filename(idx))
+    torch.save(out, path)
+    return path
+
+
+def read_prompt_artifact(artifact_dir: str, idx: int) -> Dict[str, torch.Tensor]:
+    path = os.path.join(artifact_dir, prompt_filename(idx))
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
+def absolute_logprobs_path(record_dir: str, idx: int) -> str:
+    """Return the absolute path the verify phase passes as
+    sampling_params.forced_token_ids_path. The server reads this file at
+    request admission and pulls out the `output_ids` 1-D tensor.
+    """
+    return os.path.abspath(os.path.join(record_dir, prompt_filename(idx)))

--- a/test/manual/branch_compare/compare.py
+++ b/test/manual/branch_compare/compare.py
@@ -215,10 +215,12 @@ def _bar(fraction: float, width: int) -> str:
     return out.ljust(width)
 
 
-def _fmt(v: float) -> str:
-    """Format a float for the bin-edge label column."""
+def _fmt(v: float, *, integer: bool = False) -> str:
+    """Format a value for the bin-edge label column."""
     if not np.isfinite(v):
         return "nan"
+    if integer:
+        return str(int(round(v)))
     av = abs(v)
     if av == 0.0:
         return "0"
@@ -246,9 +248,24 @@ def _ascii_histogram(
 
     lo = float(clean.min())
     hi = float(clean.max())
-    if lo == hi:
-        # Degenerate: every value identical. Print one row.
-        lines.append(f"  {_fmt(lo):>12s}  {_bar(1.0, width)} {clean.size}")
+    is_int = bool(np.all(clean == np.floor(clean)))
+
+    if lo == hi or _fmt(lo, integer=is_int) == _fmt(hi, integer=is_int):
+        # Range is zero, or so small that every bin edge renders to the
+        # same label at display precision. Collapse to one row.
+        lines.append(
+            f"  {_fmt(lo, integer=is_int):>12s}  {_bar(1.0, width)} {clean.size}"
+        )
+    elif is_int and (int(hi) - int(lo)) < n_bins:
+        # One bin per distinct integer value — no fractional edges.
+        ints = np.arange(int(lo), int(hi) + 1, dtype=np.int64)
+        counts = np.array([int((clean == v).sum()) for v in ints])
+        max_count = int(counts.max()) if counts.size else 0
+        for v, c in zip(ints, counts):
+            frac = (c / max_count) if max_count else 0.0
+            lines.append(
+                f"  {_fmt(int(v), integer=True):>12s}  {_bar(frac, width)} {int(c)}"
+            )
     else:
         edges = np.linspace(lo, hi, n_bins + 1)
         counts, _ = np.histogram(clean, bins=edges)
@@ -256,14 +273,16 @@ def _ascii_histogram(
         for i, c in enumerate(counts):
             edge_left = edges[i]
             frac = (c / max_count) if max_count else 0.0
-            lines.append(f"  {_fmt(edge_left):>12s}  {_bar(frac, width)} {int(c)}")
-        lines.append(f"  {_fmt(edges[-1]):>12s}  (upper edge)")
+            lines.append(
+                f"  {_fmt(edge_left, integer=is_int):>12s}  {_bar(frac, width)} {int(c)}"
+            )
+        lines.append(f"  {_fmt(edges[-1], integer=is_int):>12s}  (upper edge)")
 
     s = aggregates
     lines.append(
         f"  mean={_fmt(s['mean'])}  p50={_fmt(s['p50'])}  "
         f"p90={_fmt(s['p90'])}  p99={_fmt(s['p99'])}  "
-        f"min={_fmt(s['min'])}  max={_fmt(s['max'])}"
+        f"min={_fmt(s['min'], integer=is_int)}  max={_fmt(s['max'], integer=is_int)}"
     )
     return "\n".join(lines)
 

--- a/test/manual/branch_compare/compare.py
+++ b/test/manual/branch_compare/compare.py
@@ -1,7 +1,7 @@
 """Compute per-step divergence metrics from two branch_compare artifacts.
 
-Usage:
-    python -m test.manual.branch_compare.compare \\
+Usage (run from sglang-source/test/manual/):
+    python -m branch_compare.compare \\
         --record-dir DIR --branch-dir DIR --out-dir DIR
 
 Per (prompt, step) the comparator finds the intersection of main's top-K
@@ -21,10 +21,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from test.manual.branch_compare import artifacts
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
+from branch_compare import artifacts
 
 
 def _per_step_metrics(

--- a/test/manual/branch_compare/compare.py
+++ b/test/manual/branch_compare/compare.py
@@ -1,0 +1,284 @@
+"""Compute per-step divergence metrics from two branch_compare artifacts.
+
+Usage:
+    python -m test.manual.branch_compare.compare \\
+        --record-dir DIR --branch-dir DIR --out-dir DIR
+
+Per (prompt, step) the comparator finds the intersection of main's top-K
+token IDs with branch's top-K, looks up the logprob each side assigned to
+each common token, and computes:
+  - cosine similarity (log-prob vector dot product / norm product)
+  - mean absolute difference
+  - mean relative difference (denominator: max(|main|, eps))
+
+These per-step scalars are aggregated into mean/p50/p90/p99/min/max.
+The intersection size (`common_topk_count`) per step is also reported - if
+it dips below K, the rank ordering itself shifted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from test.manual.branch_compare import artifacts
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+
+def _per_step_metrics(
+    main_top_ids: np.ndarray,  # int32 [K]
+    main_top_lps: np.ndarray,  # float32 [K]
+    branch_top_ids: np.ndarray,  # int32 [K]
+    branch_top_lps: np.ndarray,  # float32 [K]
+) -> Tuple[float, float, float, int]:
+    """Return (cos, mean_abs, mean_rel, common_count)."""
+    branch_lookup: Dict[int, float] = {
+        int(t): float(lp) for t, lp in zip(branch_top_ids, branch_top_lps)
+    }
+    common_main_lps: List[float] = []
+    common_branch_lps: List[float] = []
+    for tid, lp in zip(main_top_ids, main_top_lps):
+        tid_int = int(tid)
+        if tid_int in branch_lookup:
+            common_main_lps.append(float(lp))
+            common_branch_lps.append(branch_lookup[tid_int])
+
+    common = len(common_main_lps)
+    if common < 2:
+        return float("nan"), float("nan"), float("nan"), common
+
+    m = np.asarray(common_main_lps, dtype=np.float64)
+    b = np.asarray(common_branch_lps, dtype=np.float64)
+    nm, nb = np.linalg.norm(m), np.linalg.norm(b)
+    if nm == 0.0 or nb == 0.0:
+        cos = 1.0
+    else:
+        cos = float(np.dot(m, b) / (nm * nb))
+
+    abs_d = np.abs(m - b)
+    mean_abs = float(abs_d.mean())
+    mean_rel = float((abs_d / np.maximum(np.abs(m), 1e-9)).mean())
+    return cos, mean_abs, mean_rel, common
+
+
+def _aggregate(values: List[float]) -> Dict[str, float]:
+    arr = np.asarray([v for v in values if not np.isnan(v)], dtype=np.float64)
+    if arr.size == 0:
+        return {
+            "mean": float("nan"),
+            "p50": float("nan"),
+            "p90": float("nan"),
+            "p99": float("nan"),
+            "min": float("nan"),
+            "max": float("nan"),
+            "n": 0,
+        }
+    return {
+        "mean": float(arr.mean()),
+        "p50": float(np.quantile(arr, 0.50)),
+        "p90": float(np.quantile(arr, 0.90)),
+        "p99": float(np.quantile(arr, 0.99)),
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+        "n": int(arr.size),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--record-dir", required=True)
+    parser.add_argument("--branch-dir", required=True)
+    parser.add_argument("--out-dir", required=True)
+    args = parser.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    record_meta = artifacts.read_meta(args.record_dir)
+    branch_meta = artifacts.read_meta(args.branch_dir)
+
+    record_by_idx = {p["idx"]: p for p in record_meta["prompts"]}
+
+    cos_all: List[float] = []
+    abs_all: List[float] = []
+    rel_all: List[float] = []
+    common_all: List[float] = []
+    per_prompt: List[Dict[str, Any]] = []
+
+    for entry in branch_meta["prompts"]:
+        idx = entry["idx"]
+        rec = record_by_idx.get(idx)
+        if rec is None:
+            print(f"[branch_compare] no record entry for idx={idx}, skipping")
+            continue
+
+        main_a = artifacts.read_prompt_artifact(args.record_dir, idx)
+        branch_a = artifacts.read_prompt_artifact(args.branch_dir, idx)
+
+        # Steps must match (verify is forced to record's length). Compare
+        # the shorter prefix if not (e.g. forcing-mismatch case).
+        n_steps = min(
+            main_a["top_k_token_ids"].shape[0],
+            branch_a["top_k_token_ids"].shape[0],
+        )
+
+        # Convert bf16 -> float32 for numpy.
+        main_top_lps_f32 = (
+            main_a["top_k_logprobs"].to(dtype=__import__("torch").float32).numpy()
+        )
+        branch_top_lps_f32 = (
+            branch_a["top_k_logprobs"].to(dtype=__import__("torch").float32).numpy()
+        )
+        main_top_ids = main_a["top_k_token_ids"].numpy()
+        branch_top_ids = branch_a["top_k_token_ids"].numpy()
+
+        prompt_cos: List[float] = []
+        prompt_abs: List[float] = []
+        prompt_rel: List[float] = []
+        for s in range(n_steps):
+            cos, mabs, mrel, common = _per_step_metrics(
+                main_top_ids[s],
+                main_top_lps_f32[s],
+                branch_top_ids[s],
+                branch_top_lps_f32[s],
+            )
+            cos_all.append(cos)
+            abs_all.append(mabs)
+            rel_all.append(mrel)
+            common_all.append(float(common))
+            prompt_cos.append(cos)
+            prompt_abs.append(mabs)
+            prompt_rel.append(mrel)
+
+        per_prompt.append(
+            {
+                "idx": idx,
+                "n_steps": n_steps,
+                "cosine": _aggregate(prompt_cos),
+                "abs_diff": _aggregate(prompt_abs),
+                "rel_diff": _aggregate(prompt_rel),
+            }
+        )
+
+    summary: Dict[str, Any] = {
+        "record_commit": record_meta.get("git_commit"),
+        "branch_commit": branch_meta.get("git_commit"),
+        "record_server_args": record_meta.get("server_args"),
+        "branch_server_args": branch_meta.get("server_args"),
+        "topk": record_meta.get("topk_logprobs"),
+        "cosine_similarity": _aggregate(cos_all),
+        "mean_abs_diff": _aggregate(abs_all),
+        "mean_rel_diff": _aggregate(rel_all),
+        "common_topk_count": _aggregate(common_all),
+        "failed_steps": branch_meta.get("failed_steps", []),
+        "per_prompt": per_prompt,
+    }
+
+    summary_path = os.path.join(args.out_dir, "summary.json")
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"[branch_compare] wrote {summary_path}")
+
+    # Terminal histograms (also archived to histograms.txt). Three panels
+    # share the same width / bin count for easy visual comparison.
+    hist_text = _render_histograms(
+        [
+            ("Cosine similarity", cos_all, summary["cosine_similarity"]),
+            ("Mean abs diff", abs_all, summary["mean_abs_diff"]),
+            ("Mean relative diff", rel_all, summary["mean_rel_diff"]),
+            ("Common top-K count", common_all, summary["common_topk_count"]),
+        ],
+        n_bins=24,
+        width=48,
+    )
+    print(hist_text)
+    hist_path = os.path.join(args.out_dir, "histograms.txt")
+    with open(hist_path, "w") as f:
+        f.write(hist_text)
+    print(f"[branch_compare] wrote {hist_path}")
+
+
+# --- ASCII histogram rendering ----------------------------------------------
+
+_BLOCKS = " ▏▎▍▌▋▊▉█"  # 0/8, 1/8, ..., 8/8 of a cell
+
+
+def _bar(fraction: float, width: int) -> str:
+    """Render a horizontal bar of `fraction` (0..1) using sub-block chars."""
+    fraction = max(0.0, min(1.0, fraction))
+    total_eighths = int(round(fraction * width * 8))
+    full = total_eighths // 8
+    rem = total_eighths % 8
+    out = "█" * full
+    if rem and full < width:
+        out += _BLOCKS[rem]
+    return out.ljust(width)
+
+
+def _fmt(v: float) -> str:
+    """Format a float for the bin-edge label column."""
+    if not np.isfinite(v):
+        return "nan"
+    av = abs(v)
+    if av == 0.0:
+        return "0"
+    if av < 1e-3 or av >= 1e4:
+        return f"{v:.3e}"
+    return f"{v:.6g}"
+
+
+def _ascii_histogram(
+    title: str,
+    values: List[float],
+    aggregates: Dict[str, float],
+    *,
+    n_bins: int = 24,
+    width: int = 48,
+) -> str:
+    """Render one labeled histogram + summary line as ASCII."""
+    clean = np.asarray([v for v in values if np.isfinite(v)], dtype=np.float64)
+    lines: List[str] = []
+    lines.append(f"=== {title} (n={clean.size}) ===")
+
+    if clean.size == 0:
+        lines.append("  (no data)")
+        return "\n".join(lines)
+
+    lo = float(clean.min())
+    hi = float(clean.max())
+    if lo == hi:
+        # Degenerate: every value identical. Print one row.
+        lines.append(f"  {_fmt(lo):>12s}  {_bar(1.0, width)} {clean.size}")
+    else:
+        edges = np.linspace(lo, hi, n_bins + 1)
+        counts, _ = np.histogram(clean, bins=edges)
+        max_count = int(counts.max()) if counts.size else 0
+        for i, c in enumerate(counts):
+            edge_left = edges[i]
+            frac = (c / max_count) if max_count else 0.0
+            lines.append(f"  {_fmt(edge_left):>12s}  {_bar(frac, width)} {int(c)}")
+        lines.append(f"  {_fmt(edges[-1]):>12s}  (upper edge)")
+
+    s = aggregates
+    lines.append(
+        f"  mean={_fmt(s['mean'])}  p50={_fmt(s['p50'])}  "
+        f"p90={_fmt(s['p90'])}  p99={_fmt(s['p99'])}  "
+        f"min={_fmt(s['min'])}  max={_fmt(s['max'])}"
+    )
+    return "\n".join(lines)
+
+
+def _render_histograms(
+    panels: List[Tuple[str, List[float], Dict[str, float]]],
+    *,
+    n_bins: int,
+    width: int,
+) -> str:
+    return "\n\n".join(
+        _ascii_histogram(title, vals, aggs, n_bins=n_bins, width=width)
+        for title, vals, aggs in panels
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/branch_compare/prompts.py
+++ b/test/manual/branch_compare/prompts.py
@@ -1,0 +1,195 @@
+"""Prompt loading for branch_compare.
+
+Two paths:
+  1. --eval-name {gpqa, mmlu, gsm8k, math, humaneval, mgsm, aime25,
+     longbench_v2}: instantiate the eval class from sglang.test.simple_eval_*
+     and run it with a RecordingSampler (returns dummy text, captures the
+     message_list). The captured messages become the prompts.
+  2. --prompts-file FILE: JSONL with `{"prompt": "..."}` per line.
+
+For --api chat we render the captured messages through the model's chat
+template via HF AutoTokenizer (client-side); the server receives plain
+text on /generate. This guarantees byte-identical input across phases.
+For --api completion, we send the last message's content unmodified (or
+the JSONL "prompt" field).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from sglang.test.simple_eval_common import SamplerBase
+
+
+@dataclass
+class Prompt:
+    text: str  # what we send to /generate (chat-templated if --api=chat)
+    messages: Optional[List[Dict[str, Any]]] = (
+        None  # original chat messages for traceability
+    )
+
+
+class RecordingSampler(SamplerBase):
+    """Captures every message_list passed in __call__, returns empty text.
+
+    Used to extract prompts from sglang.test.simple_eval_* classes without
+    actually running their grading.
+    """
+
+    def __init__(self):
+        self.captured: List[List[Dict[str, Any]]] = []
+        self.model = "branch-compare-recording-sampler"
+        # Some evals look up `_completion_tokens` on the sampler.
+        self._completion_tokens: List[int] = []
+
+    def __call__(self, message_list):
+        self.captured.append(message_list)
+        return ""
+
+    # Some evals expect ChatCompletionSampler-shaped helpers:
+    def _pack_message(self, role: str, content: Any) -> Dict[str, Any]:
+        return {"role": role, "content": content}
+
+
+def _load_eval(eval_name: str, num_examples: int, num_threads: int = 1):
+    """Mirror of the eval-name dispatch in sglang.test.run_eval."""
+    if eval_name == "mmlu":
+        from sglang.test.simple_eval_mmlu import MMLUEval
+
+        return MMLUEval(
+            "https://openaipublic.blob.core.windows.net/simple-evals/mmlu.csv",
+            num_examples,
+            num_threads,
+        )
+    if eval_name == "gpqa":
+        from sglang.test.simple_eval_gpqa import GPQAEval
+
+        return GPQAEval(
+            "https://openaipublic.blob.core.windows.net/simple-evals/gpqa_diamond.csv",
+            num_examples,
+            num_threads,
+        )
+    if eval_name == "math":
+        from sglang.test.simple_eval_common import ChatCompletionSampler
+        from sglang.test.simple_eval_math import MathEval
+
+        # Math eval needs a checker; supply a stub that always says equal.
+        # We never run the grading anyway (RecordingSampler captures and bails).
+        return MathEval(
+            "https://openaipublic.blob.core.windows.net/simple-evals/math_test.csv",
+            ChatCompletionSampler(model="gpt-4-turbo"),
+            num_examples,
+            num_threads,
+        )
+    if eval_name == "gsm8k":
+        from sglang.test.simple_eval_gsm8k import GSM8KEval
+
+        return GSM8KEval(num_examples=num_examples, num_threads=num_threads)
+    if eval_name == "humaneval":
+        from sglang.test.simple_eval_humaneval import HumanEval
+
+        return HumanEval(num_examples, num_threads)
+    if eval_name == "mgsm":
+        from sglang.test.simple_eval_mgsm import MGSMEval
+
+        return MGSMEval(num_examples, num_threads)
+    if eval_name == "aime25":
+        from sglang.test.simple_eval_aime25 import AIME25Eval
+
+        return AIME25Eval(num_examples, num_threads)
+    if eval_name == "longbench_v2":
+        from sglang.test.simple_eval_longbench_v2 import LongBenchV2Eval
+
+        return LongBenchV2Eval(
+            data_source="THUDM/LongBench-v2",
+            num_examples=num_examples,
+            num_threads=num_threads,
+        )
+    raise ValueError(f"Unsupported eval_name: {eval_name}")
+
+
+def _capture_messages_via_eval(
+    eval_name: str, num_examples: int
+) -> List[List[Dict[str, Any]]]:
+    """Run the eval with a RecordingSampler. Grading runs on dummy responses
+    and may print warnings; we only need the captured message_lists."""
+    eval_obj = _load_eval(eval_name, num_examples, num_threads=1)
+    sampler = RecordingSampler()
+    try:
+        eval_obj(sampler)
+    except Exception:
+        # Some evals try to grade dummy outputs and crash on the empty string;
+        # whatever was captured before the crash is still usable.
+        pass
+    return sampler.captured[:num_examples]
+
+
+def _apply_chat_template(tokenizer, messages: List[Dict[str, Any]]) -> str:
+    """Render messages to a string the same way the server would on
+    /v1/chat/completions, so that record/verify see byte-identical inputs.
+    """
+    return tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+
+
+def _last_user_content(messages: List[Dict[str, Any]]) -> str:
+    """For --api completion: pull the last user message's content as a
+    plain string."""
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            if isinstance(content, str):
+                return content
+            # Multimodal content list
+            if isinstance(content, list):
+                parts = [p.get("text", "") for p in content if isinstance(p, dict)]
+                return "".join(parts)
+    raise ValueError(f"No user message in {messages!r}")
+
+
+def load_prompts(
+    *,
+    eval_name: Optional[str],
+    num_examples: Optional[int],
+    prompts_file: Optional[str],
+    api: str,
+    tokenizer=None,
+) -> List[Prompt]:
+    if (eval_name is None) == (prompts_file is None):
+        raise ValueError("Exactly one of --eval-name or --prompts-file must be set")
+
+    if prompts_file is not None:
+        prompts: List[Prompt] = []
+        with open(prompts_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                text = obj["prompt"]
+                prompts.append(Prompt(text=text, messages=None))
+        return prompts
+
+    assert eval_name is not None and num_examples is not None
+    captured = _capture_messages_via_eval(eval_name, num_examples)
+    if not captured:
+        raise RuntimeError(
+            f"RecordingSampler captured no messages for eval={eval_name!r}; "
+            f"the eval may have crashed before invoking the sampler."
+        )
+
+    prompts = []
+    for messages in captured:
+        if api == "chat":
+            if tokenizer is None:
+                raise ValueError("--api chat requires a tokenizer")
+            text = _apply_chat_template(tokenizer, messages)
+        elif api == "completion":
+            text = _last_user_content(messages)
+        else:
+            raise ValueError(f"Unsupported --api: {api}")
+        prompts.append(Prompt(text=text, messages=messages))
+    return prompts

--- a/test/manual/branch_compare/run.py
+++ b/test/manual/branch_compare/run.py
@@ -1,15 +1,15 @@
 """branch_compare CLI: record / verify phases.
 
-Usage (record):
+Usage (run from sglang-source/test/manual/):
+
     SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \\
-    python -m test.manual.branch_compare.run \\
+    python -m branch_compare.run \\
         --mode record --artifact-dir DIR \\
         --model-path MODEL [--tp-size N] [...any server args...] \\
         --eval-name gpqa --num-examples 16
 
-Usage (verify):
     SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \\
-    python -m test.manual.branch_compare.run \\
+    python -m branch_compare.run \\
         --mode verify --artifact-dir DIR --record-dir RECORD_DIR \\
         --model-path MODEL [--tp-size N] [...any server args...]
 
@@ -28,17 +28,15 @@ import socket
 import subprocess
 import sys
 import time
-
-# Local imports work when invoked as `python -m test.manual.branch_compare.run`.
-from test.manual.branch_compare import artifacts
-from test.manual.branch_compare import prompts as prompts_mod
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from branch_compare import artifacts
+from branch_compare import prompts as prompts_mod
 
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import kill_process_tree
 from sglang.test.test_utils import popen_launch_server
-from sglang.utils import kill_process_tree
 
 DEFAULT_PORT = 30000
 TIMEOUT_LAUNCH = 600
@@ -63,12 +61,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--record-dir",
         default=None,
         help="(verify mode) Directory containing main's record artifact.",
-    )
-    g.add_argument(
-        "--port",
-        type=int,
-        default=None,
-        help="Server port. Default: free port (or 30000 if a free port can't be found).",
     )
     g.add_argument(
         "--base-url",
@@ -155,26 +147,32 @@ def _git_sha(cwd: str = ".") -> Tuple[str, bool]:
 def _server_args_passthrough(args: argparse.Namespace) -> List[str]:
     """Reconstruct the CLI list to forward to popen_launch_server.
 
-    We use ServerArgs.from_cli_args to build a populated ServerArgs, then
-    diff against the defaults to emit only what was actually changed.
+    Walk a fresh parser populated only by ServerArgs.add_cli_args and emit
+    flags whose value on `args` differs from the parser default. We can't go
+    through ServerArgs(...) construction because __post_init__ derives fields
+    (model_config, random_seed, kt_*, ...) that don't map back to CLI flags.
     """
-    server_args = ServerArgs.from_cli_args(args)
-    defaults = ServerArgs(model_path=server_args.model_path)
+    sa_parser = argparse.ArgumentParser(add_help=False)
+    ServerArgs.add_cli_args(sa_parser)
+
     out: List[str] = []
-    for field_name in vars(server_args):
-        cur = getattr(server_args, field_name)
-        default = getattr(defaults, field_name, None)
-        if field_name == "model_path":
-            continue  # popen_launch_server passes this as positional `model`
+    for action in sa_parser._actions:
+        dest = action.dest
+        if dest in ("help", "model_path"):
+            continue  # model_path is passed positionally to popen_launch_server
+        if not action.option_strings:
+            continue
+        if not hasattr(args, dest):
+            continue
+        cur = getattr(args, dest)
+        default = action.default
         if cur == default:
             continue
-        cli = "--" + field_name.replace("_", "-")
+        cli = action.option_strings[0]
         if isinstance(cur, bool):
             if cur and not default:
                 out.append(cli)
-            elif not cur and default:
-                # rare but possible: --no-X style (not common in sglang)
-                out.append(cli + "-disable")
+            # bool flags rarely have a paired --no-X; leave it alone otherwise
         elif isinstance(cur, list):
             for item in cur:
                 out += [cli, str(item)]

--- a/test/manual/branch_compare/run.py
+++ b/test/manual/branch_compare/run.py
@@ -28,6 +28,7 @@ import socket
 import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
@@ -115,6 +116,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--ack-large-artifacts",
         action="store_true",
         help="Required when projected artifact size exceeds 5 GB.",
+    )
+    g.add_argument(
+        "--num-threads",
+        type=int,
+        default=16,
+        help="Concurrent in-flight requests to the server. The server's "
+        "scheduler batches them internally, so higher values overlap "
+        "prompts and dramatically reduce wall time on multi-prompt runs.",
     )
 
     # Server pass-through. Last so server's own --help text reads naturally.
@@ -288,8 +297,8 @@ def cmd_record(args: argparse.Namespace, base_url: str) -> None:
     timestamp = datetime.datetime.utcnow().isoformat() + "Z"
     server_args_list = _server_args_passthrough(args)
 
-    prompt_records: List[Dict[str, Any]] = []
-    for i, p in enumerate(prompts_list):
+    def _record_one(i_p: Tuple[int, Any]) -> Dict[str, Any]:
+        i, p = i_p
         sp = _build_sampling_params(args, args.max_new_tokens)
         t0 = time.time()
         resp = _request(base_url, p.text, sp, args.topk_logprobs)
@@ -302,16 +311,17 @@ def cmd_record(args: argparse.Namespace, base_url: str) -> None:
             f"  [{i+1}/{n}] {len(out_ids)} steps, finish={finish}, {dt:.1f}s",
             flush=True,
         )
-        prompt_records.append(
-            {
-                "idx": i,
-                "prompt": p.text,
-                "messages": p.messages,
-                "logprobs_file": artifacts.prompt_filename(i),
-                "n_steps": len(out_ids),
-                "stop_reason": finish,
-            }
-        )
+        return {
+            "idx": i,
+            "prompt": p.text,
+            "messages": p.messages,
+            "logprobs_file": artifacts.prompt_filename(i),
+            "n_steps": len(out_ids),
+            "stop_reason": finish,
+        }
+
+    with ThreadPoolExecutor(max_workers=args.num_threads) as ex:
+        prompt_records = list(ex.map(_record_one, enumerate(prompts_list)))
 
     meta = {
         "phase": "record",
@@ -365,9 +375,9 @@ def cmd_verify(args: argparse.Namespace, base_url: str) -> None:
     timestamp = datetime.datetime.utcnow().isoformat() + "Z"
     server_args_list = _server_args_passthrough(args)
 
-    prompt_records: List[Dict[str, Any]] = []
-    failed_steps: List[Dict[str, Any]] = []
-    for entry in record_meta["prompts"]:
+    def _verify_one(
+        entry: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
         idx = entry["idx"]
         text = entry["prompt"]
         n_steps_record = entry["n_steps"]
@@ -386,14 +396,13 @@ def cmd_verify(args: argparse.Namespace, base_url: str) -> None:
         # Sanity: forcing must actually have taken.
         record_artifact = artifacts.read_prompt_artifact(record_dir_abs, idx)
         record_out_ids = record_artifact["output_ids"].tolist()
+        mismatch: Optional[Dict[str, Any]] = None
         if out_ids != record_out_ids:
             mismatch_step = next(
                 (k for k, (a, b) in enumerate(zip(out_ids, record_out_ids)) if a != b),
                 min(len(out_ids), len(record_out_ids)),
             )
-            failed_steps.append(
-                {"prompt_idx": idx, "first_mismatch_step": mismatch_step}
-            )
+            mismatch = {"prompt_idx": idx, "first_mismatch_step": mismatch_step}
             print(
                 f"  [{idx+1}/{n}] FORCED-TOKEN MISMATCH at step "
                 f"{mismatch_step}: forcing did not take.",
@@ -406,16 +415,20 @@ def cmd_verify(args: argparse.Namespace, base_url: str) -> None:
                 flush=True,
             )
 
-        prompt_records.append(
-            {
-                "idx": idx,
-                "prompt": text,
-                "messages": entry.get("messages"),
-                "logprobs_file": artifacts.prompt_filename(idx),
-                "n_steps": len(out_ids),
-                "stop_reason": finish,
-            }
-        )
+        record = {
+            "idx": idx,
+            "prompt": text,
+            "messages": entry.get("messages"),
+            "logprobs_file": artifacts.prompt_filename(idx),
+            "n_steps": len(out_ids),
+            "stop_reason": finish,
+        }
+        return record, mismatch
+
+    with ThreadPoolExecutor(max_workers=args.num_threads) as ex:
+        results = list(ex.map(_verify_one, record_meta["prompts"]))
+    prompt_records = [r for r, _ in results]
+    failed_steps = [m for _, m in results if m is not None]
 
     meta = {
         "phase": "verify",

--- a/test/manual/branch_compare/run.py
+++ b/test/manual/branch_compare/run.py
@@ -1,0 +1,507 @@
+"""branch_compare CLI: record / verify phases.
+
+Usage (record):
+    SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \\
+    python -m test.manual.branch_compare.run \\
+        --mode record --artifact-dir DIR \\
+        --model-path MODEL [--tp-size N] [...any server args...] \\
+        --eval-name gpqa --num-examples 16
+
+Usage (verify):
+    SGLANG_ENABLE_FORCED_TOKEN_IDS=1 \\
+    python -m test.manual.branch_compare.run \\
+        --mode verify --artifact-dir DIR --record-dir RECORD_DIR \\
+        --model-path MODEL [--tp-size N] [...any server args...]
+
+The script registers ServerArgs.add_cli_args so every server flag is
+accepted as pass-through and forwarded to popen_launch_server. If
+--base-url is set the script attaches to a running server instead of
+launching one (server args become advisory and are recorded in meta.json).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import socket
+import subprocess
+import sys
+import time
+
+# Local imports work when invoked as `python -m test.manual.branch_compare.run`.
+from test.manual.branch_compare import artifacts
+from test.manual.branch_compare import prompts as prompts_mod
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import popen_launch_server
+from sglang.utils import kill_process_tree
+
+DEFAULT_PORT = 30000
+TIMEOUT_LAUNCH = 600
+TIMEOUT_REQUEST = 3600
+LARGE_ARTIFACT_GB = 5.0
+
+
+# --------------------------- argparse ---------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="branch_compare: record / verify a server's per-step "
+        "logprobs for divergence comparison."
+    )
+
+    # Mode + I/O
+    g = parser.add_argument_group("branch_compare")
+    g.add_argument("--mode", choices=["record", "verify"], required=True)
+    g.add_argument("--artifact-dir", required=True)
+    g.add_argument(
+        "--record-dir",
+        default=None,
+        help="(verify mode) Directory containing main's record artifact.",
+    )
+    g.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Server port. Default: free port (or 30000 if a free port can't be found).",
+    )
+    g.add_argument(
+        "--base-url",
+        default=None,
+        help="Attach to a running server instead of launching one.",
+    )
+
+    # Prompts
+    g.add_argument(
+        "--eval-name",
+        default=None,
+        choices=[
+            "mmlu",
+            "gpqa",
+            "math",
+            "gsm8k",
+            "humaneval",
+            "mgsm",
+            "aime25",
+            "longbench_v2",
+        ],
+    )
+    g.add_argument("--num-examples", type=int, default=16)
+    g.add_argument(
+        "--prompts-file",
+        default=None,
+        help="Alternative to --eval-name: JSONL file with {'prompt': '...'} per line.",
+    )
+    g.add_argument(
+        "--api",
+        choices=["chat", "completion"],
+        default="chat",
+        help="chat applies the chat template client-side; completion sends raw text.",
+    )
+
+    # Generation
+    g.add_argument("--max-new-tokens", type=int, default=1024)
+    g.add_argument("--temperature", type=float, default=0.0)
+    g.add_argument("--top-p", type=float, default=1.0)
+    g.add_argument("--top-k", type=int, default=None)
+    g.add_argument("--min-p", type=float, default=None)
+    g.add_argument("--seed", type=int, default=None)
+    g.add_argument(
+        "--topk-logprobs",
+        type=int,
+        default=128,
+        help="K for top_logprobs_num. PD-disagg caps at 128; raise if you're "
+        "not in disagg mode.",
+    )
+
+    g.add_argument(
+        "--ack-large-artifacts",
+        action="store_true",
+        help="Required when projected artifact size exceeds 5 GB.",
+    )
+
+    # Server pass-through. Last so server's own --help text reads naturally.
+    ServerArgs.add_cli_args(parser)
+    return parser
+
+
+# --------------------------- helpers ---------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _git_sha(cwd: str = ".") -> Tuple[str, bool]:
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=cwd, text=True
+        ).strip()
+        diff = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=cwd, text=True
+        ).strip()
+        return sha, bool(diff)
+    except Exception:
+        return "unknown", False
+
+
+def _server_args_passthrough(args: argparse.Namespace) -> List[str]:
+    """Reconstruct the CLI list to forward to popen_launch_server.
+
+    We use ServerArgs.from_cli_args to build a populated ServerArgs, then
+    diff against the defaults to emit only what was actually changed.
+    """
+    server_args = ServerArgs.from_cli_args(args)
+    defaults = ServerArgs(model_path=server_args.model_path)
+    out: List[str] = []
+    for field_name in vars(server_args):
+        cur = getattr(server_args, field_name)
+        default = getattr(defaults, field_name, None)
+        if field_name == "model_path":
+            continue  # popen_launch_server passes this as positional `model`
+        if cur == default:
+            continue
+        cli = "--" + field_name.replace("_", "-")
+        if isinstance(cur, bool):
+            if cur and not default:
+                out.append(cli)
+            elif not cur and default:
+                # rare but possible: --no-X style (not common in sglang)
+                out.append(cli + "-disable")
+        elif isinstance(cur, list):
+            for item in cur:
+                out += [cli, str(item)]
+        else:
+            out += [cli, str(cur)]
+    return out
+
+
+def _project_artifact_size_gb(n_prompts: int, max_new_tokens: int, topk: int) -> float:
+    # bf16 logprobs (2B) + int32 token_ids (4B) per (step, k), plus int64 chosen_logprob (negligible)
+    bytes_per = (2 + 4) * topk
+    total = n_prompts * max_new_tokens * bytes_per
+    return total / (1024**3)
+
+
+def _load_tokenizer(model_path: str):
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+
+
+# --------------------------- HTTP ---------------------------
+
+
+def _request(
+    base_url: str,
+    text: str,
+    sampling_params: Dict[str, Any],
+    topk_logprobs: int,
+) -> Dict[str, Any]:
+    payload = {
+        "text": text,
+        "sampling_params": sampling_params,
+        "return_logprob": True,
+        "logprob_start_len": -1,
+        "top_logprobs_num": topk_logprobs,
+        "return_text_in_logprobs": False,
+        "stream": False,
+    }
+    r = requests.post(f"{base_url}/generate", json=payload, timeout=TIMEOUT_REQUEST)
+    r.raise_for_status()
+    return r.json()
+
+
+def _parse_response(
+    resp: Dict[str, Any],
+) -> Tuple[List[int], List[float], List[List[int]], List[List[float]], str]:
+    meta = resp["meta_info"]
+    output_token_logprobs = meta["output_token_logprobs"]  # [(lp, tid, None), ...]
+    output_top_logprobs = meta["output_top_logprobs"]  # [[(lp, tid, None), ... K], ...]
+
+    output_ids: List[int] = []
+    chosen_logprob: List[float] = []
+    for lp, tid, _ in output_token_logprobs:
+        output_ids.append(int(tid))
+        chosen_logprob.append(float(lp))
+
+    top_k_token_ids: List[List[int]] = []
+    top_k_logprobs: List[List[float]] = []
+    for step in output_top_logprobs:
+        top_k_token_ids.append([int(t[1]) for t in step])
+        top_k_logprobs.append([float(t[0]) for t in step])
+
+    finish_reason = (meta.get("finish_reason") or {}).get("type", "unknown")
+    return output_ids, chosen_logprob, top_k_token_ids, top_k_logprobs, finish_reason
+
+
+# --------------------------- record / verify ---------------------------
+
+
+def _build_sampling_params(
+    args: argparse.Namespace, max_new: int, forced_path: Optional[str] = None
+) -> Dict[str, Any]:
+    sp: Dict[str, Any] = {
+        "max_new_tokens": max_new,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+    }
+    if args.top_k is not None:
+        sp["top_k"] = args.top_k
+    if args.min_p is not None:
+        sp["min_p"] = args.min_p
+    if args.seed is not None:
+        sp["sampling_seed"] = args.seed
+    if forced_path is not None:
+        sp["forced_token_ids_path"] = forced_path
+    return sp
+
+
+def cmd_record(args: argparse.Namespace, base_url: str) -> None:
+    tokenizer = _load_tokenizer(args.model_path) if args.api == "chat" else None
+    prompts_list = prompts_mod.load_prompts(
+        eval_name=args.eval_name,
+        num_examples=args.num_examples,
+        prompts_file=args.prompts_file,
+        api=args.api,
+        tokenizer=tokenizer,
+    )
+    n = len(prompts_list)
+    proj_gb = _project_artifact_size_gb(n, args.max_new_tokens, args.topk_logprobs)
+    print(
+        f"[branch_compare] {n} prompts, projected artifact size ≤ {proj_gb:.2f} GB",
+        flush=True,
+    )
+    if proj_gb > LARGE_ARTIFACT_GB and not args.ack_large_artifacts:
+        raise SystemExit(
+            f"Projected artifact size ({proj_gb:.2f} GB) exceeds "
+            f"{LARGE_ARTIFACT_GB} GB. Re-run with --ack-large-artifacts to confirm."
+        )
+
+    os.makedirs(args.artifact_dir, exist_ok=True)
+    sha, dirty = _git_sha()
+    timestamp = datetime.datetime.utcnow().isoformat() + "Z"
+    server_args_list = _server_args_passthrough(args)
+
+    prompt_records: List[Dict[str, Any]] = []
+    for i, p in enumerate(prompts_list):
+        sp = _build_sampling_params(args, args.max_new_tokens)
+        t0 = time.time()
+        resp = _request(base_url, p.text, sp, args.topk_logprobs)
+        out_ids, chosen_lp, top_ids, top_lps, finish = _parse_response(resp)
+        dt = time.time() - t0
+        artifacts.write_prompt_artifact(
+            args.artifact_dir, i, out_ids, top_ids, top_lps, chosen_lp
+        )
+        print(
+            f"  [{i+1}/{n}] {len(out_ids)} steps, finish={finish}, {dt:.1f}s",
+            flush=True,
+        )
+        prompt_records.append(
+            {
+                "idx": i,
+                "prompt": p.text,
+                "messages": p.messages,
+                "logprobs_file": artifacts.prompt_filename(i),
+                "n_steps": len(out_ids),
+                "stop_reason": finish,
+            }
+        )
+
+    meta = {
+        "phase": "record",
+        "git_commit": sha,
+        "git_dirty": dirty,
+        "model_path": args.model_path,
+        "server_args": server_args_list,
+        "server_mode": "attached" if args.base_url else "launched",
+        "topk_logprobs": args.topk_logprobs,
+        "max_new_tokens": args.max_new_tokens,
+        "sampling": {
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "top_k": args.top_k,
+            "min_p": args.min_p,
+            "seed": args.seed,
+        },
+        "eval": {
+            "name": args.eval_name,
+            "num_examples": args.num_examples,
+            "api": args.api,
+            "prompts_file": args.prompts_file,
+        },
+        "timestamp": timestamp,
+        "prompts": prompt_records,
+    }
+    artifacts.write_meta(args.artifact_dir, meta)
+    print(f"[branch_compare] record artifact written to {args.artifact_dir}")
+
+
+def cmd_verify(args: argparse.Namespace, base_url: str) -> None:
+    if args.record_dir is None:
+        raise SystemExit("--record-dir is required for --mode verify")
+    record_meta = artifacts.read_meta(args.record_dir)
+    record_dir_abs = os.path.abspath(args.record_dir)
+    n = len(record_meta["prompts"])
+
+    proj_gb = _project_artifact_size_gb(n, args.max_new_tokens, args.topk_logprobs)
+    print(
+        f"[branch_compare] {n} prompts, projected artifact size ≤ {proj_gb:.2f} GB",
+        flush=True,
+    )
+    if proj_gb > LARGE_ARTIFACT_GB and not args.ack_large_artifacts:
+        raise SystemExit(
+            f"Projected artifact size ({proj_gb:.2f} GB) exceeds "
+            f"{LARGE_ARTIFACT_GB} GB. Re-run with --ack-large-artifacts to confirm."
+        )
+
+    os.makedirs(args.artifact_dir, exist_ok=True)
+    sha, dirty = _git_sha()
+    timestamp = datetime.datetime.utcnow().isoformat() + "Z"
+    server_args_list = _server_args_passthrough(args)
+
+    prompt_records: List[Dict[str, Any]] = []
+    failed_steps: List[Dict[str, Any]] = []
+    for entry in record_meta["prompts"]:
+        idx = entry["idx"]
+        text = entry["prompt"]
+        n_steps_record = entry["n_steps"]
+        forced_path = artifacts.absolute_logprobs_path(record_dir_abs, idx)
+        sp = _build_sampling_params(
+            args, max_new=n_steps_record, forced_path=forced_path
+        )
+        t0 = time.time()
+        resp = _request(base_url, text, sp, args.topk_logprobs)
+        out_ids, chosen_lp, top_ids, top_lps, finish = _parse_response(resp)
+        dt = time.time() - t0
+        artifacts.write_prompt_artifact(
+            args.artifact_dir, idx, out_ids, top_ids, top_lps, chosen_lp
+        )
+
+        # Sanity: forcing must actually have taken.
+        record_artifact = artifacts.read_prompt_artifact(record_dir_abs, idx)
+        record_out_ids = record_artifact["output_ids"].tolist()
+        if out_ids != record_out_ids:
+            mismatch_step = next(
+                (k for k, (a, b) in enumerate(zip(out_ids, record_out_ids)) if a != b),
+                min(len(out_ids), len(record_out_ids)),
+            )
+            failed_steps.append(
+                {"prompt_idx": idx, "first_mismatch_step": mismatch_step}
+            )
+            print(
+                f"  [{idx+1}/{n}] FORCED-TOKEN MISMATCH at step "
+                f"{mismatch_step}: forcing did not take.",
+                flush=True,
+            )
+        else:
+            print(
+                f"  [{idx+1}/{n}] {len(out_ids)} steps OK, finish={finish}, "
+                f"{dt:.1f}s",
+                flush=True,
+            )
+
+        prompt_records.append(
+            {
+                "idx": idx,
+                "prompt": text,
+                "messages": entry.get("messages"),
+                "logprobs_file": artifacts.prompt_filename(idx),
+                "n_steps": len(out_ids),
+                "stop_reason": finish,
+            }
+        )
+
+    meta = {
+        "phase": "verify",
+        "git_commit": sha,
+        "git_dirty": dirty,
+        "model_path": args.model_path,
+        "server_args": server_args_list,
+        "server_mode": "attached" if args.base_url else "launched",
+        "topk_logprobs": args.topk_logprobs,
+        "max_new_tokens": args.max_new_tokens,
+        "sampling": {
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "top_k": args.top_k,
+            "min_p": args.min_p,
+            "seed": args.seed,
+        },
+        "record_dir": record_dir_abs,
+        "record_git_commit": record_meta.get("git_commit"),
+        "timestamp": timestamp,
+        "prompts": prompt_records,
+        "failed_steps": failed_steps,
+    }
+    artifacts.write_meta(args.artifact_dir, meta)
+    print(
+        f"[branch_compare] verify artifact written to {args.artifact_dir}; "
+        f"{len(failed_steps)} prompts had forced-token mismatches."
+    )
+
+
+# --------------------------- main ---------------------------
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.model_path:
+        raise SystemExit("--model-path is required")
+
+    # Establish base_url and (if needed) launch the server.
+    proc = None
+    if args.base_url:
+        base_url = args.base_url.rstrip("/")
+    else:
+        port = args.port or _free_port() or DEFAULT_PORT
+        base_url = f"http://127.0.0.1:{port}"
+        # Pass through every server arg the user set (excluding our own group).
+        server_other_args = _server_args_passthrough(args)
+        # popen_launch_server passes the model as a positional + appends --port,
+        # so strip those if they snuck in.
+        server_other_args = [a for a in server_other_args if a not in ("--model-path",)]
+        if "--port" in server_other_args:
+            i = server_other_args.index("--port")
+            del server_other_args[i : i + 2]
+        env = os.environ.copy()
+        # Surface the env-var requirement so users who forget get a clear error.
+        if env.get("SGLANG_ENABLE_FORCED_TOKEN_IDS") != "1":
+            print(
+                "[branch_compare] WARNING: SGLANG_ENABLE_FORCED_TOKEN_IDS is "
+                "not set in the environment. The server will reject "
+                "forced_token_ids requests on the verify phase.",
+                file=sys.stderr,
+            )
+        proc = popen_launch_server(
+            args.model_path,
+            base_url,
+            timeout=TIMEOUT_LAUNCH,
+            other_args=server_other_args,
+            env=env,
+        )
+        print(f"[branch_compare] server launched at {base_url}", flush=True)
+
+    try:
+        if args.mode == "record":
+            cmd_record(args, base_url)
+        elif args.mode == "verify":
+            cmd_verify(args, base_url)
+        else:
+            raise SystemExit(f"Unknown mode: {args.mode}")
+    finally:
+        if proc is not None:
+            kill_process_tree(proc.pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/branch_compare/run.py
+++ b/test/manual/branch_compare/run.py
@@ -469,6 +469,14 @@ def main() -> None:
     if not args.model_path:
         raise SystemExit("--model-path is required")
 
+    if args.mode == "record" and args.record_dir is not None:
+        raise SystemExit(
+            "--record-dir is only valid in --mode verify "
+            "(record mode generates a fresh artifact; did you mean --mode verify?)"
+        )
+    if args.mode == "verify" and args.record_dir is None:
+        raise SystemExit("--mode verify requires --record-dir")
+
     # Establish base_url and (if needed) launch the server.
     proc = None
     if args.base_url:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Currently, tests fall roughly into two camps:
1. Unit tests with small scope for individual functions/kernels
2. Full E2E accuracy test, e.g., GPQA, taking hours and a lot of machine resources

The problem is 1 doesn't have enough coverage and 2 is painfully slow to run. This has two hugely negative consequences.

### Terrible dev cycle
The typical dev cycle is to
1. Make changes
2. Run unit tests
3. Repeat until 2 passes and **pray that the accuracy is correct**
4. Run GPQA (often over night) 
5. Debug and repeat 4

This is woefully inefficient. Ideally, we want tests that can finish in minutes. The situation is so dire that accuracy is considered a different class of problem to functionality.

### Insufficient server config coverage
Currently, only a tiny subset of possible server config is tested. There is an unimaginably large combination of models x hardware x parallelism x all other server args.
Only a select few are ran on a regular basis, causing all other combinations to go untested.

### Solution
The main reason GPQA is so slow is because it tests model performance on real question answering,
using that as a proxy for implementation correctness. Due to the inherently random nature of chain-of-thought and the very limited visibility during the inference process (we only check the answer), we have to run a huge amount of questions and let it reason for >100k tokens.

However, as a inference library that doesn't change the mathematical definition of the model, there is a better way: just compare the numerical output.
This PR introduces tools to do exactly that.

The main difficulty lies in the random sampling process. The logits of two forward passes are incomparable if their prefixes are not the same. This PR introduces a mechanism to force the sampled token to be identical in order to fix the prefix while exercising the rest of the inference stack without modification.

With the prefixes fixed, each output logit of two different config/branch should be almost identical. Simple metrics such as cosine similarity and number of common top-k tokens are sufficient to detect accuracy bugs, even with a single prompt at a low number of tokens.

The result of this design means each test can be ran in <10min, bottlenecked by server startup time, as opposed to multiple hours in GPQA.

See `test/manual/branch_compare/README.md` for how to run the new test.

Example output comparing meta-llama/Llama-3.1-8B-Instruct TP=4 to TP=2
<details>
  <summary>Click to expand</summary>

```
=== Cosine similarity (n=9791) ===
      0.998426                                                   1
      0.998491                                                   0
      0.998557                                                   0
      0.998622                                                   0
      0.998688                                                   0
      0.998753                                                   1
      0.998819                                                   0
      0.998884                                                   0
       0.99895                                                   0
      0.999015                                                   0
      0.999081                                                   0
      0.999146                                                   0
      0.999212                                                   1
      0.999277                                                   0
      0.999343                                                   0
      0.999408                                                   1
      0.999474                                                   0
      0.999539                                                   1
      0.999605                                                   0
       0.99967                                                   3
      0.999736                                                   4
      0.999801                                                   12
      0.999867  ▎                                                40
      0.999932  ████████████████████████████████████████████████ 9727
      0.999998  (upper edge)
  mean=0.99999  p50=0.999993  p90=0.999996  p99=0.999997  min=0.998426  max=0.999998

=== Mean abs diff (n=9791) ===
     0.0113189  ████████████████████████████████████████████████ 5275
     0.0475979  ███████████████▍                                 1683
     0.0838769  ████████████▊                                    1403
      0.120156  ████████▍                                        914
      0.156435  █                                                109
      0.192714  █▎                                               137
      0.228993  █▊                                               195
      0.265272  ▍                                                42
      0.301551  ▏                                                7
       0.33783                                                   6
      0.374109                                                   3
      0.410388                                                   4
      0.446667                                                   3
      0.482946                                                   1
      0.519225                                                   0
      0.555504                                                   2
      0.591783                                                   2
      0.628062                                                   0
      0.664341                                                   2
       0.70062                                                   2
      0.736899                                                   0
      0.773178                                                   0
      0.809457                                                   0
      0.845736                                                   1
      0.882015  (upper edge)
  mean=0.0687263  p50=0.0443221  p90=0.129935  p99=0.257  min=0.0113189  max=0.882015

=== Mean relative diff (n=9791) ===
     6.622e-04  ████████████████████████████████████████████████ 9784
     0.0402116                                                   5
     0.0797611                                                   0
      0.119311                                                   0
       0.15886                                                   0
      0.198409                                                   0
      0.237959                                                   0
      0.277508                                                   0
      0.317058                                                   0
      0.356607                                                   0
      0.396157                                                   0
      0.435706                                                   0
      0.475256                                                   0
      0.514805                                                   0
      0.554355                                                   0
      0.593904                                                   0
      0.633453                                                   0
      0.673003                                                   0
      0.712552                                                   0
      0.752102                                                   0
      0.791651                                                   0
      0.831201                                                   0
       0.87075                                                   0
        0.9103                                                   2
      0.949849  (upper edge)
  mean=0.00533257  p50=0.00377409  p90=0.00999762  p99=0.0153933  min=6.622e-04  max=0.949849

=== Common top-K count (n=9791) ===
            98                                                   1
            99                                                   0
           100                                                   0
           102                                                   1
           103                                                   0
           104                                                   0
           106                                                   1
           107                                                   0
           108                                                   1
           109                                                   0
           110                                                   1
           112                                                   0
           113                                                   3
           114                                                   4
           116                                                   2
           117                                                   6
           118  ▏                                                11
           119  ▏                                                15
           120  ▏                                                11
           122  ▎                                                29
           123  ██▏                                              253
           124  ███████▌                                         899
           126  ███████████████████████▏                         2780
           127  ████████████████████████████████████████████████ 5773
           128  (upper edge)
  mean=126.527  p50=127  p90=128  p99=128  min=98  max=128
```

</details>
As expected, they are virtually identical.

Example output comparing meta-llama/Llama-3.1-8B-Instruct to RedHatAI/Llama-3.2-1B-Instruct-FP8 (simulating accuracy bugs)
<details>
  <summary>Click to expand</summary>

```
=== Cosine similarity (n=9791) ===
      0.849969                                                   1
      0.856168                                                   0
      0.862368                                                   0
      0.868568                                                   0
      0.874767                                                   0
      0.880967                                                   1
      0.887167                                                   1
      0.893366                                                   0
      0.899566                                                   0
      0.905766                                                   1
      0.911965                                                   2
      0.918165                                                   0
      0.924365                                                   0
      0.930564                                                   2
      0.936764                                                   2
      0.942964  ▏                                                8
      0.949163  ▏                                                14
      0.955363  ▎                                                25
      0.961563  ▊                                                70
      0.967762  █▋                                               154
      0.973962  ████▍                                            418
      0.980162  ███████████▉                                     1133
      0.986361  ███████████████████████████████████▊             3400
      0.992561  ████████████████████████████████████████████████ 4559
      0.998761  (upper edge)
  mean=0.99031  p50=0.992184  p90=0.996103  p99=0.997609  min=0.849969  max=0.998761

=== Mean abs diff (n=9791) ===
      0.638822  ████████████▋                                    390
       1.25352  ███████████████████████████████████████████████▌ 1462
       1.86821  ████████████████████████████████████████████████ 1477
       2.48291  ██████████████████████████████████████████████▏  1421
        3.0976  █████████████████████████████████████████▌       1276
       3.71229  ██████████████████████████████████▊              1068
       4.32699  ████████████████████████████                     863
       4.94168  ████████████████████▏                            621
       5.55638  █████████████▉                                   427
       6.17107  ██████████▋                                      327
       6.78577  ██████▊                                          207
       7.40046  ███▉                                             118
       8.01516  ██▎                                              68
       8.62985  ▉                                                27
       9.24455  ▌                                                17
       9.85924  ▍                                                11
       10.4739  ▎                                                9
       11.0886                                                   0
       11.7033                                                   0
        12.318                                                   0
       12.9327                                                   1
       13.5474                                                   0
       14.1621                                                   0
       14.7768                                                   1
       15.3915  (upper edge)
  mean=3.46691  p50=3.15625  p90=5.86687  p99=8.25417  min=0.638822  max=15.3915

=== Mean relative diff (n=9791) ===
     0.0582342  ████████████████████████████████████████████████ 9789
       2398.89                                                   1
       4797.72                                                   0
       7196.54                                                   0
       9595.37                                                   0
     1.199e+04                                                   0
     1.439e+04                                                   0
     1.679e+04                                                   0
     1.919e+04                                                   0
     2.159e+04                                                   0
     2.399e+04                                                   0
     2.639e+04                                                   0
     2.879e+04                                                   0
     3.118e+04                                                   0
     3.358e+04                                                   0
     3.598e+04                                                   0
     3.838e+04                                                   0
     4.078e+04                                                   0
     4.318e+04                                                   0
     4.558e+04                                                   0
     4.798e+04                                                   0
     5.038e+04                                                   0
     5.277e+04                                                   0
     5.517e+04                                                   1
     5.757e+04  (upper edge)
  mean=9.82278  p50=0.293954  p90=1.6804  p99=41.5029  min=0.0582342  max=5.757e+04

=== Common top-K count (n=9791) ===
             9                                                   2
            14                                                   0
            18                                                   1
            23  ▎                                                10
            27  ▍                                                12
            32  █                                                33
            36  █▉                                               65
            41  ██▎                                              76
            46  ████▎                                            148
            50  ██████▋                                          228
            55  █████████████                                    447
            59  █████████████████                                585
            64  ██████████████████████████████▊                  1058
            69  ████████████████████████████████████████▊        1405
            73  ███████████████████████████████████████          1346
            78  ████████████████████████████████████████████████ 1654
            82  █████████████████████████████████                1138
            87  ██████████████████████████▊                      922
            92  ████████████▉                                    442
            96  ████▌                                            156
           101  █▎                                               43
           105  ▍                                                14
           110  ▏                                                3
           114  ▏                                                3
           119  (upper edge)
  mean=74.9094  p50=76  p90=89  p99=99  min=9  max=119
```

</details>
In this case, the clearest signal that the model is "wrong" is there are on average only ~75 common tokens out of the top 128.


## Modifications

Modifications to core runtime
```py
python/sglang/srt/environ.py
python/sglang/srt/layers/sampler.py
python/sglang/srt/managers/scheduler.py
python/sglang/srt/managers/tokenizer_manager.py
python/sglang/srt/sampling/sampling_batch_info.py
python/sglang/srt/sampling/sampling_params.py
python/sglang/srt/server_args.py
```
These changes are no-op unless `SGLANG_ENABLE_FORCED_TOKEN_IDS=1`.

New test files
```py
test/manual/branch_compare/README.md
test/manual/branch_compare/__init__.py
test/manual/branch_compare/artifacts.py
test/manual/branch_compare/compare.py
test/manual/branch_compare/prompts.py
test/manual/branch_compare/run.py
```
These are completely independent to the rest of SGLang.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
3. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
4. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
5. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.














<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27124116242](https://github.com/sgl-project/sglang/actions/runs/27124116242)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27124115998](https://github.com/sgl-project/sglang/actions/runs/27124115998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->