### PR TITLE
docs: prepend SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 for H200 FP8 Flash max-throughput

### DIFF
--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -391,6 +391,9 @@ export const DeepSeekV4Deployment = () => {
       }
     } else if (recipe === "max-throughput") {
       if (hardware === "h200") {
+        if (!isBig) {
+          recipeEnv.push("SGLANG_JIT_DEEPGEMM_PRECOMPILE=0");
+        }
         recipeEnv.push(isBig
           ? "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=128"
           : "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256");


### PR DESCRIPTION
## Summary

- In the DeepSeek-V4 cookbook deployment command generator, prepend `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0` to the env block for the **H200 FP8 + Flash (small) + Max-Throughput** recipe so the generated `sglang serve` command skips the DeepGEMM JIT precompile out of the box.
- Scope is intentionally narrow: only `hardware === "h200"`, `!isBig` (Flash), `recipe === "max-throughput"`. Pro (big) max-throughput and other recipes/hardware paths are unchanged.

## Test plan

- [ ] Open the DeepSeek-V4 cookbook page in the local docs site and verify the **H200 (FP8) / Flash / Max-Throughput** selection shows `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \` in the env block of the rendered command.
- [ ] Confirm other combinations (Pro max-throughput, balanced, low-latency, B200/GB300/GB200, H200 FP4) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)