### PR TITLE
[Refactor] Remove dead key_convert_fn / convert_to_bigram_key

### DIFF
--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -44,7 +44,7 @@ from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.events import KVCacheEventMixin
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
-from sglang.srt.mem_cache.utils import convert_to_bigram_key, split_node_hash_value
+from sglang.srt.mem_cache.utils import split_node_hash_value
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -352,11 +352,6 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
             self.device = self.token_to_kv_pool_allocator.device
         else:
             self.device = torch.device("cpu")
-
-        if self.is_eagle:
-            self.key_convert_fn = convert_to_bigram_key
-        else:
-            self.key_convert_fn = lambda key: key
 
         if params.enable_metrics:
             self.init_metrics_collector()

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -37,7 +37,6 @@ from sglang.srt.mem_cache.unified_cache_components import (
     TreeComponent,
     get_and_increase_time_counter,
 )
-from sglang.srt.mem_cache.utils import convert_to_bigram_key
 from sglang.srt.session.streaming_session import StreamingSession
 
 if TYPE_CHECKING:
@@ -225,10 +224,6 @@ class UnifiedRadixCache(BasePrefixCache):
         self.hicache_anchor_kv_shared_indices_pools: list[
             tuple[PoolName, PoolHitPolicy]
         ] = []
-        if self.is_eagle:
-            self.key_convert_fn = convert_to_bigram_key
-        else:
-            self.key_convert_fn = lambda key: key
 
         # Streaming session: embedded StreamingSession with self as inner.
         # Always on -- zero overhead when no streaming session is open (the

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -373,16 +373,6 @@ def maybe_init_custom_mem_pool(
         return False, None, None
 
 
-def convert_to_bigram_key(tokens: List[int]) -> List[Tuple[int, int]]:
-    # EAGLE uses bigram keys in the radix tree since draft sequence is the one-token-shifted version of target
-    # [1, 2, 3, 4] -> [(1,2), (2,3), (3,4)]
-    if len(tokens) and isinstance(tokens[0], tuple):
-        return tokens
-    if len(tokens) < 2:
-        return []
-    return [(tokens[i], tokens[i + 1]) for i in range(len(tokens) - 1)]
-
-
 def get_hash_str(token_ids: List[int], prior_hash: Optional[str] = None) -> str:
     hasher = hashlib.sha256()
 


### PR DESCRIPTION
## Summary

- PR #23106 (\"Make EAGLE bigram key an O(1) view on \`RadixKey\`\") migrated all real call sites of \`self.key_convert_fn(token_ids)\` to \`RadixKey.maybe_to_bigram_view(self.is_eagle, ...)\` plus the \`is_bigram=self.is_eagle\` constructor argument, but the \`self.key_convert_fn = convert_to_bigram_key\` assignments in \`UnifiedRadixCache.__init__\` and \`SWARadixCache.__init__\` were left behind. The attribute is never read anywhere now — a repo-wide \`grep\` (including \`test/\`) confirms zero call sites.
- Removes the two dead assignments, the now-unused \`convert_to_bigram_key\` import from \`unified_radix_cache.py\` and \`swa_radix_cache.py\`, and the \`convert_to_bigram_key\` helper itself in \`mem_cache/utils.py\` (its last consumers were the two dead assignments).
- Runtime behavior unchanged. Bigram conversion already flows through \`RadixKey\`'s O(1) view path.

Diff scope: 3 files, +1/-21.

## Test plan

- [x] \`grep -rn 'convert_to_bigram_key\|key_convert_fn' .\` returns no matches after the change
- [x] Import smoke test: \`unified_radix_cache\`, \`swa_radix_cache\`, \`radix_cache\`, and \`mem_cache.utils\` all import cleanly; \`convert_to_bigram_key\` is gone from \`utils\`
- [x] Pre-commit hooks pass (isort, ruff, black-jupyter, codespell, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)