### PR TITLE
amd/deepseek_v4 integration 22/N enable SGLANG_OPT_DPSK_V4_RADIX=1 on ROCm

### DIFF
--- a/python/sglang/srt/mem_cache/base_swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/base_swa_memory_pool.py
@@ -1,0 +1,33 @@
+import abc
+from typing import List, Tuple
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class BaseSWAKVPool(KVCache):
+    """ABC for SWA-like KV pools.
+
+    Subclasses expose a `swa_kv_pool` sub-pool plus a full -> swa index
+    mapping. Used by `SWATokenToKVPoolAllocator` and the disagg paths to
+    handle SWA state separately from the full KV state.
+    """
+
+    swa_kv_pool: KVCache
+
+    @abc.abstractmethod
+    def register_mapping(self, full_to_swa_index_mapping: torch.Tensor) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def set_swa_loc(self, loc: torch.Tensor) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_state_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
@@ -17,6 +17,7 @@ from sglang.srt.mem_cache.compress_state import (
     DeepSeekV4CompressState,
     KVAndScore,
 )
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import ceil_div
@@ -404,7 +405,7 @@ class DeepSeekV4LayerItem(NamedTuple):
     compress_kv_pool: Optional[DeepSeekV4SingleKVPool] = None
 
 
-class DeepSeekV4TokenToKVPool(KVCache):
+class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     def __init__(
         self,
@@ -527,6 +528,11 @@ class DeepSeekV4TokenToKVPool(KVCache):
 
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
+
+    def set_swa_loc(self, loc: torch.Tensor) -> None:
+        # No-op: DSv4 caches its own SWA loc via _should_cache_swa + cached_loc
+        # in set_swa_key_buffer_radix_fused; we ignore main's precomputed loc.
+        pass
 
     def get_ring_size(self, compress_ratio: int) -> int:
         server_args = get_global_server_args()

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -9,6 +9,7 @@ from sglang.srt.mem_cache.allocator import (
     PagedTokenToKVPoolAllocator,
     TokenToKVPoolAllocator,
 )
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVCache, MHATokenToKVPool
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
 from sglang.srt.utils import is_npu
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 GB = 1024 * 1024 * 1024
 
 
-class SWAKVPool(KVCache):
+class SWAKVPool(BaseSWAKVPool):
     """KV cache with separate pools for full and SWA attention layers."""
 
     def __init__(
@@ -253,29 +254,32 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         page_size: int,
         dtype: torch.dtype,
         device: str,
-        kvcache: SWAKVPool,
+        kvcache: BaseSWAKVPool,
         need_sort: bool,
     ):
-        assert isinstance(kvcache, SWAKVPool)
+        assert isinstance(kvcache, BaseSWAKVPool)
         self._size_full = size
         self._size_swa = size_swa
         self.dtype = dtype
         self.device = device
         self.page_size = page_size
 
+        full_kv_pool = getattr(kvcache, "full_kv_pool", None)
+        swa_kv_pool = getattr(kvcache, "swa_kv_pool", None)
+
         if page_size == 1:
             self.full_attn_allocator = TokenToKVPoolAllocator(
                 size,
                 dtype,
                 device,
-                kvcache.full_kv_pool,
+                full_kv_pool,
                 need_sort,
             )
             self.swa_attn_allocator = TokenToKVPoolAllocator(
                 size_swa,
                 dtype,
                 device,
-                kvcache.swa_kv_pool,
+                swa_kv_pool,
                 need_sort,
             )
         else:
@@ -288,7 +292,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 page_size,
                 dtype,
                 device,
-                kvcache.full_kv_pool,
+                full_kv_pool,
                 need_sort,
             )
             self.swa_attn_allocator = PagedTokenToKVPoolAllocatorClass(
@@ -296,7 +300,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 page_size,
                 dtype,
                 device,
-                kvcache.swa_kv_pool,
+                swa_kv_pool,
                 need_sort,
             )
         # Note: append one more item of value -1 in the end so -1 maps to -1.

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -651,19 +651,10 @@ class ModelRunnerKVCacheMixin:
                         need_sort=need_sort,
                     )
             else:
-                if self.is_hybrid_swa and not is_v4_model:
+                if self.is_hybrid_swa:
                     self.token_to_kv_pool_allocator = SWATokenToKVPoolAllocator(
                         self.full_max_total_num_tokens,
                         self.swa_max_total_num_tokens,
-                        page_size=self.page_size,
-                        dtype=self.kv_cache_dtype,
-                        device=self.device,
-                        kvcache=self.token_to_kv_pool,
-                        need_sort=need_sort,
-                    )
-                elif is_v4_model:
-                    self.token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
-                        self.max_total_num_tokens,
                         page_size=self.page_size,
                         dtype=self.kv_cache_dtype,
                         device=self.device,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Update amd/deepseek_v4 integration branch

Following PRs have large set of conflict, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608


## Motivation

Enable `SGLANG_OPT_DPSK_V4_RADIX=1` (paged SWA + prefix cache) on ROCm. The blocker was that V4 was previously routed through `PagedTokenToKVPoolAllocator`, which never populates `full_to_swa_index_mapping`; with radix=1 the SWA path needs that mapping. This PR routes V4 through the standard `SWATokenToKVPoolAllocator` so the mapping is built like any other SWA model.

Also requires `SGLANG_OPT_USE_OLD_COMPRESSOR=false` and removing `--disable-radix-cache` from the launch script.

## Modifications

<!-- Detail the changes made in this pull request. -->

- New `python/sglang/srt/mem_cache/base_swa_memory_pool.py`: `BaseSWAKVPool` ABC; both `SWAKVPool` and `DeepSeekV4TokenToKVPool` now implement it. The ABC only requires `swa_kv_pool` (not `full_kv_pool`) since V4 has no separate physical full pool.
- Modified `python/sglang/srt/mem_cache/swa_memory_pool.py`: `SWATokenToKVPoolAllocator` pulls `full_kv_pool` via `getattr(kvcache, "full_kv_pool", None)` so V4 plugs in cleanly.
- Modified `python/sglang/srt/mem_cache/deepseekv4_memory_pool.py`: `DeepSeekV4TokenToKVPool` inherits `BaseSWAKVPool` and adds a no-op `set_swa_loc` (V4 caches its own SWA loc internally).
- Modified `python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py`: drop the `is_v4_model` branch that previously routed V4 to `PagedTokenToKVPoolAllocator` and bypassed the SWA path.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

GSM8K 200-question 5-shot on DeepSeek-V4-Flash, 8x MI350X TP=8: **0.925 (radix=1) vs 0.930 (radix=0)** — within noise, zero invalid.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Prefix-share workload (`gsp 8x16`, 2K system prompt) on DeepSeek-V4-Flash, 8x MI350X TP=8: **TTFT P50 5355ms → 1682ms (-69%)**.

Decode-heavy workloads regress on TPOT (+56%); paged decode performance is a follow-up.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
