### PR TITLE
fix: pass save model RPC kwargs

### DIFF
--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -196,23 +196,25 @@ class SchedulerUpdateWeightsMixin:
             traceback.print_exc()
             return CheckWeightsReqOutput(success=False, message=f"{e}")
 
-    def save_remote_model(self: Scheduler, params):
-        url = params["url"]
-
+    def save_remote_model(self: Scheduler, url: str, draft_url: str | None = None):
         self.tp_worker.model_runner.save_remote_model(url)
 
         if self.draft_worker is not None:
-            draft_url = params.get("draft_url", None)
             assert (
                 draft_url is not None
             ), "draft_url must be provided when draft model is enabled"
             self.draft_worker.model_runner.save_remote_model(draft_url)
 
-    def save_sharded_model(self: Scheduler, params):
+    def save_sharded_model(
+        self: Scheduler,
+        path: str,
+        pattern: str | None = None,
+        max_size: int | None = None,
+    ):
         self.tp_worker.model_runner.save_sharded_model(
-            path=params["path"],
-            pattern=params["pattern"],
-            max_size=params["max_size"],
+            path=path,
+            pattern=pattern,
+            max_size=max_size,
         )
 
 

--- a/test/registered/unit/managers/test_scheduler_update_weights_mixin.py
+++ b/test/registered/unit/managers/test_scheduler_update_weights_mixin.py
@@ -1,0 +1,51 @@
+from sglang.srt.managers.scheduler_update_weights_mixin import (
+    SchedulerUpdateWeightsMixin,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+
+class _ModelRunner:
+    def __init__(self):
+        self.remote_calls = []
+        self.sharded_calls = []
+
+    def save_remote_model(self, url):
+        self.remote_calls.append(url)
+
+    def save_sharded_model(self, path, pattern=None, max_size=None):
+        self.sharded_calls.append((path, pattern, max_size))
+
+
+class _Worker:
+    def __init__(self):
+        self.model_runner = _ModelRunner()
+
+
+class _Scheduler(SchedulerUpdateWeightsMixin):
+    def __init__(self, draft_worker=None):
+        self.tp_worker = _Worker()
+        self.draft_worker = draft_worker
+
+
+def test_save_sharded_model_accepts_rpc_kwargs():
+    scheduler = _Scheduler()
+
+    scheduler.save_sharded_model(
+        path="/tmp/model", pattern="model-*.safetensors", max_size=1024
+    )
+
+    assert scheduler.tp_worker.model_runner.sharded_calls == [
+        ("/tmp/model", "model-*.safetensors", 1024)
+    ]
+
+
+def test_save_remote_model_accepts_rpc_kwargs_with_draft_worker():
+    draft_worker = _Worker()
+    scheduler = _Scheduler(draft_worker=draft_worker)
+
+    scheduler.save_remote_model(url="s3://main", draft_url="s3://draft")
+
+    assert scheduler.tp_worker.model_runner.remote_calls == ["s3://main"]
+    assert draft_worker.model_runner.remote_calls == ["s3://draft"]


### PR DESCRIPTION
﻿Fixes #25156.

## Summary
- make scheduler save model RPC handlers accept the keyword parameters sent by the engine RPC path
- keep draft-model remote saves using the explicit draft_url argument
- add a focused unit test for save_remote_model and save_sharded_model kwargs

## Test plan
- python -m black --check python/sglang/srt/managers/scheduler_update_weights_mixin.py test/registered/unit/managers/test_scheduler_update_weights_mixin.py
- python -m ruff check --select=F401,F821 python/sglang/srt/managers/scheduler_update_weights_mixin.py test/registered/unit/managers/test_scheduler_update_weights_mixin.py
- python -m py_compile python/sglang/srt/managers/scheduler_update_weights_mixin.py test/registered/unit/managers/test_scheduler_update_weights_mixin.py
- git diff --check
- Select-String secret scan on changed files

## Local note
- I also tried running the new pytest file on Windows with PYTHONPATH=python, but collection is blocked by SGLang's POSIX-only top-level import of resource. The checks above cover formatting, import names, syntax, whitespace, and changed-file secret scanning locally.
