### PR TITLE
[gRPC] Expose multimodal flag + tokenizer metadata via get_init_info

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -559,6 +559,10 @@ class DataParallelController:
 
         self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
+        # Retain the full first child init dict so callers that build
+        # the upstream handshake (run_data_parallel_controller_process,
+        # below) can forward every field — not just the two limits.
+        self.scheduler_init_info = scheduler_info[0]
 
     def maybe_external_dp_rank_routing(self, req: Req):
         if req.routed_dp_rank is not None:
@@ -649,10 +653,12 @@ def run_data_parallel_controller_process(
             proc.pid for proc in controller.scheduler_procs if proc is not None
         ]
         pipe_writer.send(
+            # Spread the first child scheduler's full init dict (status +
+            # both max_* limits + the multimodal/tokenizer metadata added
+            # by the get_init_info patch above) so dp_size > 1 doesn't
+            # strip them before they reach the gRPC servicer.
             {
-                "status": "ready",
-                "max_total_num_tokens": controller.max_total_num_tokens,
-                "max_req_input_len": controller.max_req_input_len,
+                **controller.scheduler_init_info,
                 SCHEDULER_PIDS_ARG: scheduler_pids,
             }
         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1503,6 +1503,10 @@ class Scheduler(
         hf_cfg = self.model_config.hf_config
         pad_id = getattr(hf_cfg, "pad_token_id", None)
         bos_id = getattr(hf_cfg, "bos_token_id", None)
+        # `hf_eos_token_id` is annotated Optional[Set[int]] but the
+        # producer accepts int/list/None inputs; coerce defensively.
+        eos_ids = self.model_config.hf_eos_token_id
+        eos_token_ids = sorted([eos_ids] if isinstance(eos_ids, int) else eos_ids or [])
         result_dict = {
             "status": "ready",
             "max_total_num_tokens": self.max_total_num_tokens,
@@ -1510,7 +1514,7 @@ class Scheduler(
             "is_generation": self.is_generation,
             "supports_vision": self.model_config.is_multimodal,
             "vocab_size": self.model_config.vocab_size,
-            "eos_token_ids": sorted(self.model_config.hf_eos_token_id or []),
+            "eos_token_ids": eos_token_ids,
             # int32 proto field; coerce missing IDs to the smg-grpc-servicer
             # int defaults (0 for pad, 1 for bos) so encoding doesn't crash
             # on `None`.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1494,10 +1494,28 @@ class Scheduler(
         This method provides the initialization info needed by the tokenizer manager
         and other components to verify the scheduler is ready.
         """
+        # Fields below `max_req_input_len` are read by smg-grpc-servicer's
+        # GetModelInfo bridge (sglang/server.py:81-97, servicer.py:325-329)
+        # out of scheduler_info via .get(..., default). Without them the
+        # gateway sees defaults — supports_vision in particular is always
+        # False, which makes multimodal workers invisible to image/audio
+        # routing. They are no-ops for HTTP-mode consumers.
+        hf_cfg = self.model_config.hf_config
+        pad_id = getattr(hf_cfg, "pad_token_id", None)
+        bos_id = getattr(hf_cfg, "bos_token_id", None)
         result_dict = {
             "status": "ready",
             "max_total_num_tokens": self.max_total_num_tokens,
             "max_req_input_len": self.max_req_input_len,
+            "is_generation": self.is_generation,
+            "supports_vision": self.model_config.is_multimodal,
+            "vocab_size": self.model_config.vocab_size,
+            "eos_token_ids": sorted(self.model_config.hf_eos_token_id or []),
+            # int32 proto field; coerce missing IDs to the smg-grpc-servicer
+            # int defaults (0 for pad, 1 for bos) so encoding doesn't crash
+            # on `None`.
+            "pad_token_id": pad_id if pad_id is not None else 0,
+            "bos_token_id": bos_id if bos_id is not None else 1,
         }
 
         return result_dict


### PR DESCRIPTION
## Summary

- `Scheduler.get_init_info()` now emits `is_generation`, `supports_vision`, `vocab_size`, `eos_token_ids`, `pad_token_id`, and `bos_token_id` alongside the existing three keys, sourced from `self.model_config` and `self.is_generation`.
- `DataParallelController.run_data_parallel_controller_process` now spreads the first child scheduler's full init dict into the upstream pipe send instead of rebuilding it from scratch, so DP-mode workers don't strip the new fields.

## Why

`GetModelInfo` over `--grpc-mode` was reporting `supports_vision: false` for every model — including genuinely multimodal models like `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8` (architecture `NemotronH_Nano_Omni_Reasoning_V3`, which **is** registered in `multimodal_model_archs` at `python/sglang/srt/configs/model_config.py:1518`).

Root cause is a long-standing dialect mismatch between SGLang's scheduler and the smg-grpc-servicer it talks to:

- `smg_grpc_servicer/sglang/server.py:81-97` builds the `model_info` dict that `GetModelInfo` returns by reading `scheduler_info.get("supports_vision", False)`, `.get("vocab_size", 128256)`, `.get("eos_token_ids", [])`, `.get("pad_token_id", 0)`, `.get("bos_token_id", 1)`.
- `smg_grpc_servicer/sglang/servicer.py:325-329` also reads `scheduler_info.get("is_generation")`.
- But `Scheduler.get_init_info()` only ever returned `{status, max_total_num_tokens, max_req_input_len}`. Every other key was absent, so all six reads silently fell back to their hardcoded defaults.

The bug has been present since #10283 (the original gRPC server PR) and was carried forward through #20478 (the standalone-package extraction). It went unnoticed because most `--grpc-mode` deployments to date have been text-only LLMs where `supports_vision: false` happened to be the correct answer.

The vLLM servicer counterpart at `smg_grpc_servicer/vllm/servicer.py:268-275` reads these same fields directly from `model_config.is_multimodal_model`, etc.; the SGLang bridge was written expecting them via `scheduler_info`, but SGLang's scheduler never put them there.

## What the patch does

### `Scheduler.get_init_info()` (scheduler.py)

Adds six new keys to the dict it sends up the IPC pipe, sourced from objects that already exist on the scheduler at the time the pipe send runs:

| Key | Source | Notes |
|---|---|---|
| `is_generation` | `self.is_generation` | set in `init_tokenizer()` before scheduler is exposed |
| `supports_vision` | `self.model_config.is_multimodal` | mirrors vLLM's `is_multimodal_model` |
| `vocab_size` | `self.model_config.vocab_size` | |
| `eos_token_ids` | `sorted(self.model_config.hf_eos_token_id or [])` | `sorted()` for deterministic wire order; set→list conversion needed for proto `repeated int32` |
| `pad_token_id` | `getattr(hf_config, "pad_token_id", None)` (coerced) | `None`-coerced to 0 (proto `int32` can't carry None) |
| `bos_token_id` | `getattr(hf_config, "bos_token_id", None)` (coerced) | `None`-coerced to 1 |

The `None`-coercion uses `x if x is not None else default` rather than `x or default`, which correctly passes through a legitimate `pad_token_id = 0` (common in many models).

### `DataParallelController` (data_parallel_controller.py)

When `dp_size > 1`, the SGLang gRPC launcher spawns `run_data_parallel_controller_process` instead of per-rank schedulers. The controller previously rebuilt the upstream handshake dict from scratch with just `{status, max_total_num_tokens, max_req_input_len, SCHEDULER_PIDS_ARG}`, which would silently strip every field this PR adds to `get_init_info()`. The fix:

1. Cache the first child scheduler's full init dict on the controller as `self.scheduler_init_info`.
2. Replace the hand-built dict in `run_data_parallel_controller_process` with `{**controller.scheduler_init_info, SCHEDULER_PIDS_ARG: scheduler_pids}`.

The existing `self.max_total_num_tokens` / `self.max_req_input_len` attributes are kept in place because `python/sglang/srt/ray/engine.py:285-286` reads them.

> Note: the Ray DP path at `ray/engine.py:283-288` has the same bug shape (it also constructs a stripped-down dict by hand) but isn't on the `--grpc-mode` critical path. Left for a follow-up.

## Test plan

- [x] Verified live against `sglang serve --grpc-mode` on a DGX Spark worker serving `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8`. `GetModelInfo` before vs after:

  | Field | Before (defaults) | After (real values) |
  |---|---|---|
  | `supports_vision` | `false` | `true` |
  | `vocab_size` | `128256` | `131072` |
  | `eos_token_ids` | `[]` | `[2, 11]` |
  | `is_generation` | implicit fallback | `true` |
  | `pad_token_id` | `0` (default) | `0` (real, coincidence) |
  | `bos_token_id` | `1` (default) | `1` (real, coincidence) |

- [x] Pre-commit (`isort` / `ruff` / `black` / `codespell`) clean on the two changed files.
- [x] Patch applies cleanly against `main` (`5227b0766`) and the v0.5.11 release tag.
- [ ] No unit tests added — `get_init_info` returns a snapshot of objects that themselves have coverage elsewhere; the meaningful end-to-end signal is the gRPC `GetModelInfo` round-trip, which lives outside this repo in the smg-grpc-servicer package. Happy to add a unit test in `test/registered/unit/managers/test_scheduler_init_info.py` if reviewers prefer.
- [ ] HTTP mode regression — the `tokenizer_manager` only reads `max_req_input_len` from the init dict (`http_server.py:222`), so the additional keys are no-ops for HTTP consumers.

## Related

- Original gRPC server PR (introduced the dialect mismatch): #10283
- gRPC servicer extracted into standalone package: #20478
- smg-grpc-servicer PR that added these fields to vLLM (without realizing SGLang didn't expose them either): lightseekorg/smg#870