### PR TITLE
Fix memory consumption when loading Mistral Medium 3.5

### DIFF
--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -17,7 +17,7 @@
 """Inference-only LLaMA model compatible with HuggingFace weights."""
 
 import logging
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -334,6 +334,7 @@ class LlamaModel(nn.Module):
         config: LlamaConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        decoder_layer_builder: Optional[Callable[[int, str], nn.Module]] = None,
     ) -> None:
         super().__init__()
         self.config = config
@@ -350,11 +351,14 @@ class LlamaModel(nn.Module):
         else:
             self.embed_tokens = PPMissingLayer()
 
+        if decoder_layer_builder is None:
+            decoder_layer_builder = lambda idx, prefix: LlamaDecoderLayer(
+                config=config, quant_config=quant_config, layer_id=idx, prefix=prefix
+            )
+
         self.layers, self.start_layer, self.end_layer = make_layers(
             config.num_hidden_layers,
-            lambda idx, prefix: LlamaDecoderLayer(
-                config=config, quant_config=quant_config, layer_id=idx, prefix=prefix
-            ),
+            decoder_layer_builder,
             pp_rank=self.pp_group.rank_in_group,
             pp_size=self.pp_group.world_size,
             prefix="model.layers",

--- a/python/sglang/srt/models/ministral3.py
+++ b/python/sglang/srt/models/ministral3.py
@@ -11,7 +11,7 @@ from sglang.srt.models.llama import (
     LlamaForCausalLM,
     LlamaModel,
 )
-from sglang.srt.utils import add_prefix, make_layers
+from sglang.srt.utils import add_prefix
 
 
 def _get_llama_4_attn_scale(
@@ -122,17 +122,17 @@ class Ministral3Model(LlamaModel):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
-        # Override layer creation to use Ministral3Attention
-        super().__init__(config, quant_config, prefix)
-
-        self.layers, self.start_layer, self.end_layer = make_layers(
-            config.num_hidden_layers,
-            lambda idx, prefix: Ministral3DecoderLayer(
-                config=config, quant_config=quant_config, layer_id=idx, prefix=prefix
+        # Build Ministral3 decoder layers once (LlamaModel supports a custom builder).
+        super().__init__(
+            config,
+            quant_config,
+            prefix,
+            decoder_layer_builder=lambda idx, prefix: Ministral3DecoderLayer(
+                config=config,
+                quant_config=quant_config,
+                layer_id=idx,
+                prefix=prefix,
             ),
-            pp_rank=self.pp_group.rank_in_group,
-            pp_size=self.pp_group.world_size,
-            prefix="model.layers",
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This solves #25160, which led to high memory consumption and an out of memory error when loading Mistral Medium 3.5 on one B200 GPU.

## Modifications

Previously the code instantiated a full Llama model when calling the superclass constructor, keeping it in memory while loading the actual Ministral model. This led to practically doubling the amount of memory necessary for the model weights. By providing a `decoder_layer_builder` to the superclass, it builds the Ministral model directly without other overhead.

cc @prodney

## Accuracy Tests

SGLang `main`, TP=2:

```
local-completions (base_url=http://localhost:3825,model=mistralai/Mistral-Medium-3.5-128B,tokenized_requests=False,,tokenizer_backend=None,num_concurrent=8,timeout=240,max_retries=3,stream=False), gen_kwargs: (temperature=0.01,top_p=0.9999999,max_gen_toks=8192), limit: 1000.0, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.938|±  |0.0076|
|     |       |strict-match    |     5|exact_match|↑  |0.880|±  |0.0103|
```

This branch, TP=1:

```
local-completions (base_url=http://localhost:3825,model=mistralai/Mistral-Medium-3.5-128B,tokenized_requests=False,,tokenizer_backend=None,num_concurrent=8,timeout=240,max_retries=3,stream=False), gen_kwargs: (temperature=0.01,top_p=0.9999999,max_gen_toks=8192), limit: 1000.0, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.935|±  |0.0078|
|     |       |strict-match    |     5|exact_match|↑  |0.879|±  |0.0103|
```

## Speed Tests and Profiling

No speed tests performed, as the changes are relevant only for loading.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
