### PR TITLE
Fix WARP_SIZE host/device mismatch in topk gating kernels on wave32 GPUs

### DIFF
--- a/sgl-kernel/csrc/moe/moe_topk_sigmoid_kernels.cu
+++ b/sgl-kernel/csrc/moe/moe_topk_sigmoid_kernels.cu
@@ -20,6 +20,23 @@ limitations under the License.
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/all.h>
 
+// HIP/CUDA expose WARP_SIZE as a context-dependent macro that expands to
+// different values in host vs device compile contexts on wave32 ROCm targets
+// (32 in device, 64 in host on RDNA gfx11xx/gfx12xx), which makes
+// __launch_bounds__(WARPS_PER_CTA * WARP_SIZE) and dim3(WARP_SIZE, ...)
+// disagree and produces hipErrorLaunchFailure on the first MoE forward. Use
+// our own identifier so the HIP WARP_SIZE macro cannot shadow it (a
+// `static constexpr int WARP_SIZE = 32;` at file scope silently has no effect
+// because the macro is expanded first).
+#if defined(USE_ROCM) && (defined(__gfx900__) || defined(__gfx906__) || \
+    defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || \
+    defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+static constexpr int kWarpSize = 64;  // CDNA wavefront
+#else
+static constexpr int kWarpSize = 32;  // CUDA / RDNA wave32
+#endif
+
+
 #ifndef USE_ROCM
 #include <cub/cub.cuh>
 #include <cub/util_type.cuh>
@@ -187,7 +204,7 @@ __launch_bounds__(TPB) __global__ void moeTopK(
 */
 
 template <typename T, int VPT, int NUM_EXPERTS, int WARPS_PER_CTA, int BYTES_PER_LDG>
-__launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__ void topkGatingSigmoid(
+__launch_bounds__(WARPS_PER_CTA* kWarpSize) __global__ void topkGatingSigmoid(
     const T* input,
     const bool* finished,
     float* output,
@@ -212,12 +229,12 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__ void topkGatingSigmoid(
 
   // Restrictions based on previous section.
   static_assert(VPT % ELTS_PER_LDG == 0, "The elements per thread must be a multiple of the elements per ldg");
-  static_assert(WARP_SIZE % THREADS_PER_ROW == 0, "The threads per row must cleanly divide the threads per warp");
+  static_assert(kWarpSize % THREADS_PER_ROW == 0, "The threads per row must cleanly divide the threads per warp");
   static_assert(THREADS_PER_ROW == (THREADS_PER_ROW & -THREADS_PER_ROW), "THREADS_PER_ROW must be power of 2");
-  static_assert(THREADS_PER_ROW <= WARP_SIZE, "THREADS_PER_ROW can be at most warp size");
+  static_assert(THREADS_PER_ROW <= kWarpSize, "THREADS_PER_ROW can be at most warp size");
 
   // We have NUM_EXPERTS elements per row. We specialize for small #experts
-  static constexpr int ELTS_PER_WARP = WARP_SIZE * VPT;
+  static constexpr int ELTS_PER_WARP = kWarpSize * VPT;
   static constexpr int ROWS_PER_WARP = ELTS_PER_WARP / ELTS_PER_ROW;
   static constexpr int ROWS_PER_CTA = WARPS_PER_CTA * ROWS_PER_WARP;
 
@@ -381,11 +398,11 @@ namespace detail {
 template <typename T, int EXPERTS, int BYTES_PER_LDG>
 struct TopkConstants {
   static constexpr int ELTS_PER_LDG = BYTES_PER_LDG / sizeof(T);
-  static_assert(EXPERTS / (ELTS_PER_LDG * WARP_SIZE) == 0 || EXPERTS % (ELTS_PER_LDG * WARP_SIZE) == 0, "");
-  static constexpr int VECs_PER_THREAD = MAX(1, EXPERTS / (ELTS_PER_LDG * WARP_SIZE));
+  static_assert(EXPERTS / (ELTS_PER_LDG * kWarpSize) == 0 || EXPERTS % (ELTS_PER_LDG * kWarpSize) == 0, "");
+  static constexpr int VECs_PER_THREAD = MAX(1, EXPERTS / (ELTS_PER_LDG * kWarpSize));
   static constexpr int VPT = VECs_PER_THREAD * ELTS_PER_LDG;
   static constexpr int THREADS_PER_ROW = EXPERTS / VPT;
-  static constexpr int ROWS_PER_WARP = WARP_SIZE / THREADS_PER_ROW;
+  static constexpr int ROWS_PER_WARP = kWarpSize / THREADS_PER_ROW;
 };
 }  // namespace detail
 
@@ -411,7 +428,7 @@ void topkGatingSigmoidLauncherHelper(
   const int num_warps = (num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
   const int num_blocks = (num_warps + WARPS_PER_TB - 1) / WARPS_PER_TB;
 
-  dim3 block_dim(WARP_SIZE, WARPS_PER_TB);
+  dim3 block_dim(kWarpSize, WARPS_PER_TB);
   topkGatingSigmoid<T, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG><<<num_blocks, block_dim, 0, stream>>>(
       input, finished, output, num_rows, indices, k, start_expert, end_expert, renormalize, correction_bias);
 }

--- a/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
+++ b/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
@@ -20,6 +20,23 @@ limitations under the License.
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/all.h>
 
+// HIP/CUDA expose WARP_SIZE as a context-dependent macro that expands to
+// different values in host vs device compile contexts on wave32 ROCm targets
+// (32 in device, 64 in host on RDNA gfx11xx/gfx12xx), which makes
+// __launch_bounds__(WARPS_PER_CTA * WARP_SIZE) and dim3(WARP_SIZE, ...)
+// disagree and produces hipErrorLaunchFailure on the first MoE forward. Use
+// our own identifier so the HIP WARP_SIZE macro cannot shadow it (a
+// `static constexpr int WARP_SIZE = 32;` at file scope silently has no effect
+// because the macro is expanded first).
+#if defined(USE_ROCM) && (defined(__gfx900__) || defined(__gfx906__) || \
+    defined(__gfx908__) || defined(__gfx90a__) || defined(__gfx940__) || \
+    defined(__gfx941__) || defined(__gfx942__) || defined(__gfx950__))
+static constexpr int kWarpSize = 64;  // CDNA wavefront
+#else
+static constexpr int kWarpSize = 32;  // CUDA / RDNA wave32
+#endif
+
+
 #ifndef USE_ROCM
 #include <cub/cub.cuh>
 #include <cub/util_type.cuh>
@@ -338,7 +355,7 @@ __launch_bounds__(TPB) __global__ void moeTopK(
 */
 
 template <typename T, int VPT, int NUM_EXPERTS, int WARPS_PER_CTA, int BYTES_PER_LDG>
-__launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__ void topkGatingSoftmax(
+__launch_bounds__(WARPS_PER_CTA* kWarpSize) __global__ void topkGatingSoftmax(
     const T* input,
     const bool* finished,
     float* output,
@@ -364,12 +381,12 @@ __launch_bounds__(WARPS_PER_CTA* WARP_SIZE) __global__ void topkGatingSoftmax(
 
   // Restrictions based on previous section.
   static_assert(VPT % ELTS_PER_LDG == 0, "The elements per thread must be a multiple of the elements per ldg");
-  static_assert(WARP_SIZE % THREADS_PER_ROW == 0, "The threads per row must cleanly divide the threads per warp");
+  static_assert(kWarpSize % THREADS_PER_ROW == 0, "The threads per row must cleanly divide the threads per warp");
   static_assert(THREADS_PER_ROW == (THREADS_PER_ROW & -THREADS_PER_ROW), "THREADS_PER_ROW must be power of 2");
-  static_assert(THREADS_PER_ROW <= WARP_SIZE, "THREADS_PER_ROW can be at most warp size");
+  static_assert(THREADS_PER_ROW <= kWarpSize, "THREADS_PER_ROW can be at most warp size");
 
   // We have NUM_EXPERTS elements per row. We specialize for small #experts
-  static constexpr int ELTS_PER_WARP = WARP_SIZE * VPT;
+  static constexpr int ELTS_PER_WARP = kWarpSize * VPT;
   static constexpr int ROWS_PER_WARP = ELTS_PER_WARP / ELTS_PER_ROW;
   static constexpr int ROWS_PER_CTA = WARPS_PER_CTA * ROWS_PER_WARP;
 
@@ -593,11 +610,11 @@ namespace detail {
 template <typename T, int EXPERTS, int BYTES_PER_LDG>
 struct TopkConstants {
   static constexpr int ELTS_PER_LDG = BYTES_PER_LDG / sizeof(T);
-  static_assert(EXPERTS / (ELTS_PER_LDG * WARP_SIZE) == 0 || EXPERTS % (ELTS_PER_LDG * WARP_SIZE) == 0, "");
-  static constexpr int VECs_PER_THREAD = MAX(1, EXPERTS / (ELTS_PER_LDG * WARP_SIZE));
+  static_assert(EXPERTS / (ELTS_PER_LDG * kWarpSize) == 0 || EXPERTS % (ELTS_PER_LDG * kWarpSize) == 0, "");
+  static constexpr int VECs_PER_THREAD = MAX(1, EXPERTS / (ELTS_PER_LDG * kWarpSize));
   static constexpr int VPT = VECs_PER_THREAD * ELTS_PER_LDG;
   static constexpr int THREADS_PER_ROW = EXPERTS / VPT;
-  static constexpr int ROWS_PER_WARP = WARP_SIZE / THREADS_PER_ROW;
+  static constexpr int ROWS_PER_WARP = kWarpSize / THREADS_PER_ROW;
 };
 }  // namespace detail
 
@@ -624,7 +641,7 @@ void topkGatingSoftmaxLauncherHelper(
   const int num_warps = (num_rows + ROWS_PER_WARP - 1) / ROWS_PER_WARP;
   const int num_blocks = (num_warps + WARPS_PER_TB - 1) / WARPS_PER_TB;
 
-  dim3 block_dim(WARP_SIZE, WARPS_PER_TB);
+  dim3 block_dim(kWarpSize, WARPS_PER_TB);
   topkGatingSoftmax<T, VPT, EXPERTS, WARPS_PER_TB, BYTES_PER_LDG><<<num_blocks, block_dim, 0, stream>>>(
       input,
       finished,


### PR DESCRIPTION
## Summary

`moe_topk_softmax_kernels.cu` and `moe_topk_sigmoid_kernels.cu` use `WARP_SIZE` in both the `__launch_bounds__` declaration **and** the host-side `dim3 block_dim(WARP_SIZE, WARPS_PER_TB)` launch, but neither file defines `WARP_SIZE` itself. HIP's `WARP_SIZE` macro expands to a different value depending on the compile context: on RDNA / wave32 targets (gfx1100/1101/1102/1151/1200/1201) it's **32 in device passes** but **64 in host passes**. The result is `__launch_bounds__(WARPS_PER_CTA * 32) = 128` paired with a `dim3(64, WARPS_PER_TB) = 256-thread launch`, which HIP rejects with `hipErrorLaunchFailure`. The failed launch leaves the GPU command stream in a faulted state, so the **next** kernel (`moe_align_block_size_kernel`) page-faults reading freed memory.

The traceback points at `moe_align_block_size`, which is misleading — that kernel is fine; it's just the next launch after the rejected one. To see the real source of the fault, enable `AMD_SERIALIZE_KERNEL=3 AMD_LOG_LEVEL=3` and look one kernel back:

```
:1:hip_module.cpp:311 : Launch params (64, 4, 1) are larger than launch bounds (128)
   for kernel _Z17topkGatingSoftmaxI14__hip_bfloat16Li8ELi256ELi4ELi16E...
:3:hip_module.cpp:791 : hipLaunchKernel: Returned hipErrorLaunchFailure
:3:rocvirtual.cpp:3828 : ShaderName : void moe_align_block_size_kernel<int>(...)
Memory access fault by GPU node-1 on address 0x7fc74d8ae000. Reason: Page not present.
```

A first-attempt fix using `static constexpr int WARP_SIZE = 32;` at file scope has no effect because HIP's `WARP_SIZE` is a macro and silently shadows the constexpr. This PR uses a renamed identifier (`kWarpSize`) that the HIP macro cannot reach, with an arch-aware constant: **64 on CDNA** (gfx9xx — MI100/MI200/MI300/MI350), **32 elsewhere** (CUDA, RDNA wave32). CDNA behavior is preserved.

## Repro

Any AWQ / GPTQ MoE checkpoint that routes through `CompressedTensorsWNA16TritonMoE` on a wave32 ROCm build. Tested on AMD Ryzen AI Max+ 395 / Radeon 8060S (gfx1151, Strix Halo, 61.7 GB GTT), ROCm 7.13 nightly, PyTorch 2.13:

- **Before this PR:** `cyankiwi/Qwen3.5-35B-A3B-AWQ-4bit` (256-expert MoE) loads cleanly to 22.84 GB GPU memory, GPU page-faults on first request.
- **After this PR:** model generates coherent output end-to-end.

```
prompt:  "Write one sentence about cats."
output:  "Thinking Process:\n\n1. **Analyze the Request:**\n   *   Topic: Cats. ..."
finish_reason=length  completion_tokens=50
```

## Test plan

- [x] AWQ-MoE checkpoint loads + generates on gfx1151 (`cyankiwi/Qwen3.5-35B-A3B-AWQ-4bit`)
- [x] No-MoE checkpoints still work on gfx1151 (`Qwen/Qwen3-0.6B`, `Qwen/Qwen3.5-4B`) — these never exercised this code path
- [x] Patch applies cleanly to current `main` (`git apply --check` passes)
- [x] Concurrent throughput on gfx1151 with this fix: 1 stream 11.6 tps, 4 streams 42.5 tps, 8 streams **80.1 tps** (per-stream throughput holds 10.0 tps at 8 concurrent — continuous batching scales near-linearly)
- [ ] CDNA validation requested from a maintainer with MI300 / MI350 access (the patch picks `kWarpSize = 64` for those targets, matching the value `WARP_SIZE` resolves to in host code today, so behavior should be identical — but I cannot verify directly)

## Why not just `#define WARP_SIZE 32`?

Two reasons:
1. CDNA targets currently work with the macro expanding to 64 on both sides — overriding to 32 would change their behavior.
2. The macro is set in HIP runtime headers transitively pulled in via `<torch/all.h>`, so a `#define` at file scope is order-dependent against include re-entry. A unique identifier sidesteps this entirely.

The sibling file `moe_fused_gate.cu` already uses `static constexpr int WARP_SIZE = 32;` (which works there only because that file doesn't include the HIP headers that trigger the macro shadow). Happy to switch this PR to that pattern instead if you'd prefer consistency with the sibling — let me know.

## Background

Discovered while bringing up SGLang on AMD Strix Halo (gfx1151, consumer Strix Halo APU). Build setup and other small patches (gfx1151 arch guard, RMSNorm fallback) live at https://github.com/JeremiahM37/strix-halo-sglang. None of those affect the issue fixed here; this is the only blocker for AWQ/GPTQ MoE inference on every consumer ROCm GPU I'm aware of.