### PR TITLE
[gRPC] proto: add SubscribeKvEvents stream + KV event messages

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -34,6 +34,20 @@ service SglangService {
   rpc UpdateWeightsFromDisk(UpdateWeightsRequest) returns (UpdateWeightsResponse);
 }
 
+// Disaggregated prefill/decode rendezvous parameters.
+//
+// Carried on Generate/TextGenerate requests when the worker is part of a
+// disaggregated deployment. The prefill leg writes its KV cache to the
+// bootstrap server identified by (bootstrap_host, bootstrap_port) under
+// the room id; the decode leg fetches it from the same room. Both legs
+// receive the same `bootstrap_room` from the router so they rendezvous
+// on the KV transfer.
+message DisaggregatedParams {
+  string bootstrap_host = 1;
+  int32 bootstrap_port = 2;
+  int64 bootstrap_room = 3;
+}
+
 // Sampling parameters shared across text and tokenized RPCs.
 message SamplingParams {
   optional float temperature = 1;
@@ -68,6 +82,7 @@ message TextGenerateRequest {
   optional string routing_key = 10;
   optional int32 routed_dp_rank = 11;
   map<string, string> trace_headers = 12;
+  optional DisaggregatedParams disaggregated_params = 13;
 }
 
 message TextGenerateResponse {
@@ -90,6 +105,7 @@ message GenerateRequest {
   optional string routing_key = 9;
   optional int32 routed_dp_rank = 10;
   map<string, string> trace_headers = 11;
+  optional DisaggregatedParams disaggregated_params = 12;
 }
 
 message GenerateResponse {

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -20,6 +20,14 @@ service SglangService {
   rpc PauseGeneration(PauseGenerationRequest) returns (PauseGenerationResponse);
   rpc ContinueGeneration(ContinueGenerationRequest) returns (ContinueGenerationResponse);
 
+  // Subscribe to KV cache events for KV-aware routing. Server-streaming;
+  // long-lived. The server emits a `KvEventBatch` whenever blocks are
+  // stored/removed or the cache is cleared. Clients (e.g. an external
+  // router) consume the stream to maintain a worker-local view of the
+  // KV cache state. `start_sequence_number` lets clients resume after a
+  // disconnect without losing events that arrived while they were away.
+  rpc SubscribeKvEvents(SubscribeKvEventsRequest) returns (stream KvEventBatch);
+
   // OpenAI-compatible RPCs (JSON pass-through)
   rpc ChatComplete(OpenAIRequest) returns (stream OpenAIStreamChunk);
   rpc Complete(OpenAIRequest) returns (stream OpenAIStreamChunk);
@@ -309,3 +317,57 @@ message UpdateWeightsResponse {
   bool success = 1;
   string message = 2;
 }
+
+// ---- KV cache events (server-streaming subscription) ----
+
+message SubscribeKvEventsRequest {
+  // Resume from this sequence number (0 = start from the current head).
+  // A subscriber that reconnects with the last `sequence_number` it
+  // observed will receive all events generated since.
+  uint64 start_sequence_number = 1;
+}
+
+message KvEventBatch {
+  uint64 sequence_number = 1;
+  // Server wall-clock time at batch emission. Seconds since the Unix
+  // epoch as a double to avoid Timestamp dependency for this hot path.
+  double timestamp = 2;
+  repeated KvCacheEvent events = 3;
+  // Set on dp>1 deployments to identify which DP rank emitted the batch.
+  optional int32 dp_rank = 4;
+}
+
+message KvCacheEvent {
+  uint64 event_id = 1;
+  oneof data {
+    KvBlocksStored stored = 2;
+    KvBlocksRemoved removed = 3;
+    KvCacheCleared cleared = 4;
+  }
+}
+
+message KvBlocksStored {
+  repeated KvBlock blocks = 1;
+  // Block hash of the parent (the block this prefix-extends from), if any.
+  // Used by consumers to maintain a prefix-tree view of the cache.
+  optional int64 parent_block_hash = 2;
+}
+
+message KvBlock {
+  int64 block_hash = 1;
+  // Tokens covered by this block. Length is bounded by `block_size`.
+  repeated uint32 token_ids = 2;
+  int32 block_size = 3;
+  // LoRA-aware caches partition blocks by adapter id.
+  optional int64 lora_id = 4;
+  // 0 = device, 1 = host (offload), 2+ = storage tier. Reserved values
+  // let consumers ignore tiers they don't care about.
+  optional int32 cache_level = 5;
+}
+
+message KvBlocksRemoved {
+  repeated int64 block_hashes = 1;
+  optional int32 cache_level = 2;
+}
+
+message KvCacheCleared {}


### PR DESCRIPTION
## Summary

Adds a server-streaming `SubscribeKvEvents` RPC plus the message types needed for external KV-aware routing on top of the native `sglang.runtime.v1` gRPC service.

> **Stacked on #25185.** Until that PR merges, this PR's diff will show both commits. After it merges, GitHub will collapse the diff to just the KV-event additions.

## What changes

`proto/sglang/runtime/v1/sglang.proto`:

- New RPC: `rpc SubscribeKvEvents(SubscribeKvEventsRequest) returns (stream KvEventBatch)`
- New messages:
  - `SubscribeKvEventsRequest { uint64 start_sequence_number }`
  - `KvEventBatch { sequence_number, timestamp, events[], dp_rank }`
  - `KvCacheEvent { event_id, oneof { stored | removed | cleared } }`
  - `KvBlocksStored { blocks[], parent_block_hash }`
  - `KvBlock { block_hash, token_ids[], block_size, lora_id, cache_level }`
  - `KvBlocksRemoved { block_hashes[], cache_level }`
  - `KvCacheCleared {}`

Additions only — no existing field numbers change, no consumer is forced to subscribe.

## Why

KV-aware routers need a per-worker view of the cache to make prefix-aware placement decisions: which worker has the longest prefix match, which has just evicted blocks, which has just rotated its cache, and which DP rank produced each event. Today there's no native-gRPC way to subscribe to that — implementations have to fall back to ZMQ, the SMG proto, or HTTP polling.

Design notes worth flagging:

- **`start_sequence_number`** — a reconnecting subscriber passes the last sequence number it observed and receives everything since. Lets routers tolerate connection blips without re-priming the view from scratch.
- **`timestamp` as a `double` of seconds-since-epoch** rather than `google.protobuf.Timestamp` — keeps the hot path free of the WKT dependency. Happy to switch if reviewers prefer.
- **`cache_level`** — `0 = device, 1 = host (offload), 2+ = storage tier`. Consumers that don't care about CPU/storage tiers can filter on `cache_level == 0`. Reserved values give us room to add hierarchical storage tiers without breaking subscribers.
- **`lora_id` on `KvBlock`** — LoRA-aware caches partition blocks by adapter; routers that care need the partition key.

## Wire-format note

This PR is proto-only. Server-side wiring (publisher + RPC handler) will land in a follow-up against the in-flight server stack (#23506–#23509). A stub `subscribe_kv_events` that returns `Unimplemented` is enough to keep tonic's trait satisfied on consumers that only need the client side today.

## Test plan

- [x] `protoc` parses the file cleanly
- [x] `cargo check -p sglang-grpc` (tonic-generated bindings compile)
- [ ] Wire publisher on the SGLang side (follow-up PR against alexnails' stack)
- [ ] Validate a real router consumes the stream end-to-end (follow-up)