### PR TITLE
[SMG] Fix matrix-sibling concurrency collision in PR Test (SMG)

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -270,9 +270,13 @@ jobs:
     # Self-hosted GPU runners are scarce; serialize per hardware type so
     # 2-gpu-h100 and 4-gpu-h100 each run one job at a time across all
     # in-flight PRs. Queue rather than cancel — different refs shouldn't
-    # interrupt each other.
+    # interrupt each other. Include matrix.name in the group so siblings
+    # within the same run don't collide: GitHub keeps only one pending job
+    # per concurrency group, so matrix entries sharing a group (e.g.
+    # benchmarks + chat-completions-4gpu on 4-gpu-h100) would evict each
+    # other regardless of cancel-in-progress: false.
     concurrency:
-      group: pr-test-rust-${{ matrix.runner }}
+      group: pr-test-rust-${{ matrix.runner }}-${{ matrix.name }}
       cancel-in-progress: false
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

The `gateway-e2e` matrix job in `.github/workflows/pr-test-rust.yml` declared `concurrency.group: pr-test-rust-${{ matrix.runner }}` with `cancel-in-progress: false`. Two matrix entries share `4-gpu-h100` (`benchmarks` + `chat-completions-4gpu`) and two share `2-gpu-h100` (`e2e` + `chat-completions`), so each pair resolved to the **same group inside a single workflow run**.

GitHub Actions allows at most one running and one pending job per concurrency group; any new entrant evicts the previously pending one — `cancel-in-progress: false` only protects the *running* job, not the *pending* one ([docs](https://docs.github.com/en/actions/using-jobs/using-concurrency)). So within one PR run, whichever 4-gpu-h100 matrix entry queued second would unconditionally cancel its sibling. The cancelled job's `started_at == completed_at` and no `runner_name` is ever assigned.

Real hit: [run 25819208690](https://github.com/sgl-project/sglang/actions/runs/25819208690/job/75858031282) — `benchmarks` was cancelled at `18:55:23Z` the moment `chat-completions-4gpu` became eligible; the workflow ended with conclusion `cancelled` even though every other job succeeded.

The fix scopes the group per matrix entry by appending `${{ matrix.name }}`. Each entry now has its own pending slot. Cross-PR serialization for the same `(hardware, matrix entry)` tuple is preserved (different PRs' `benchmarks` jobs on `4-gpu-h100` still share group `pr-test-rust-4-gpu-h100-benchmarks`), and runner-label scarcity continues to gate physical parallelism on the h100 pool — so no risk of overloading the scarce runners.

## Test plan

- [ ] CI on this PR should show **all four** `gateway-e2e` matrix entries (`benchmarks`, `e2e`, `chat-completions`, `chat-completions-4gpu`) either succeeding or queueing — none cancelled-before-running.
- [ ] Confirm runner-label scarcity still serializes execution (no more than 1 `4-gpu-h100` job actually running at a time across the matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)