### PR TITLE
[Apple Silicon] [MLX] Auto-detect MLX-format quantization_config dict

### DIFF
--- a/python/sglang/srt/layers/quantization/mlx.py
+++ b/python/sglang/srt/layers/quantization/mlx.py
@@ -1,19 +1,27 @@
-"""Marker config for MLX backend on-the-fly quantization (mlx_q4 / mlx_q8).
+"""Marker config and auto-detect hook for MLX backend quantization presets.
 
 The MLX backend (``python/sglang/srt/hardware_backend/mlx/``) performs its own
-quantization at model-load time via :func:`mlx_lm.utils.quantize_model`. The
-standard PyTorch ``QuantizationConfig`` machinery is **never** invoked on that
+quantization at model load time via :func:`mlx_lm.utils.quantize_model`. The
+standard PyTorch ``QuantizationConfig`` machinery is never invoked on that
 path.
 
-This module exists purely so that the names ``mlx_q4`` and ``mlx_q8`` are
-recognized by ``QUANTIZATION_METHODS`` — that way
-:meth:`ModelConfig._verify_quantization` and downstream registry lookups treat
-them as known methods without any backend-specific carve-outs in the generic
-config code.
+This module serves two purposes:
 
-If a user passes ``--quantization mlx_q4`` without ``SGLANG_USE_MLX=1`` they
-will eventually reach a code path that tries to instantiate this Config class,
-at which point we raise a clear error.
+1. Registry registration. Listing ``mlx_q4`` and ``mlx_q8`` in
+   ``QUANTIZATION_METHODS`` lets :meth:`ModelConfig._verify_quantization`
+   recognize them as known methods without backend-specific exceptions in
+   the generic config code.
+
+2. Auto-detection for mlx-community HF repos.
+   :meth:`override_quantization_method` claims ``config.json`` blocks of
+   the form ``{"group_size": <int>, "bits": <int>}`` with no
+   ``quant_method`` key and resolves them to the matching preset.
+   Already-quantized mlx-community repos load on Apple Silicon without the
+   user passing ``--quantization`` on the CLI. Resolves #25119.
+
+The PyTorch path constructors (``from_config``, ``get_quant_method``) raise
+``NotImplementedError`` with a clear pointer to ``SGLANG_USE_MLX=1``, since
+this class is not a real PyTorch quantization implementation.
 """
 
 from __future__ import annotations
@@ -67,6 +75,48 @@ class MlxQuantizationConfig(QuantizationConfig):
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "MlxQuantizationConfig":
         raise NotImplementedError(cls._ERR)
+
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg, user_quant) -> Optional[str]:
+        """Auto-detect mlx-community-shape quantization configs.
+
+        mlx-community models ship ``config.json`` with::
+
+            "quantization_config": {"group_size": <int>, "bits": <int>}
+
+        No ``quant_method`` key, no other identifying field. Without this
+        override, :meth:`ModelConfig._verify_quantization` cannot match the
+        shape to any registered method and raises ``Unknown quantization
+        method`` (see #25119). Match it here and return the preset whose
+        bit-width agrees, so pre-quantized HF repos load on Apple Silicon
+        without the user having to pass ``--quantization`` on the CLI.
+
+        Returns ``None`` for any input that does not look like a bare MLX
+        preset: non-dict, dict with an explicit ``quant_method``, missing
+        keys, non-integer values, or unsupported bit-width. Also defers to
+        any explicit ``--quantization`` CLI choice (``user_quant``) per the
+        registry contract: CLI selection takes priority over auto-detect.
+        """
+        if user_quant is not None:
+            # User passed --quantization explicitly; respect that choice
+            # regardless of the HF config shape. Matches the moe_wna16 /
+            # modelopt convention.
+            return None
+        if not isinstance(hf_quant_cfg, dict):
+            return None
+        if "quant_method" in hf_quant_cfg:
+            # Configs that declare a quant_method belong to whichever method
+            # registers under that name; do not hijack them.
+            return None
+        bits = hf_quant_cfg.get("bits")
+        group_size = hf_quant_cfg.get("group_size")
+        if not isinstance(bits, int) or not isinstance(group_size, int):
+            return None
+        if bits == 4:
+            return "mlx_q4"
+        if bits == 8:
+            return "mlx_q8"
+        return None
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str

--- a/test/registered/unit/hardware_backend/mlx/test_quantization.py
+++ b/test/registered/unit/hardware_backend/mlx/test_quantization.py
@@ -17,6 +17,7 @@ import importlib.util
 import platform
 import unittest
 
+from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 
 # Registered with the CPU suite (runtime no-op marker, parsed via AST).
@@ -184,6 +185,93 @@ class TestMlxQuantization(unittest.TestCase):
         finally:
             del runner
             self._reset_mlx_memory()
+
+
+class TestMlxQuantizationOverride(unittest.TestCase):
+    """Pure-logic tests for ``MlxQuantizationConfig.override_quantization_method``.
+
+    The override is a classmethod over a dict; no mlx / Apple Silicon
+    dependency. Runs on every CI platform and guards #25119 from regression.
+    """
+
+    def test_mlx_q4_dict_config_autodetect(self):
+        """Bare {group_size, bits=4} dict maps to mlx_q4."""
+        result = MlxQuantizationConfig.override_quantization_method(
+            {"group_size": 64, "bits": 4}, None
+        )
+        self.assertEqual(result, "mlx_q4")
+
+    def test_mlx_q8_dict_config_autodetect(self):
+        """Bare {group_size, bits=8} dict maps to mlx_q8."""
+        result = MlxQuantizationConfig.override_quantization_method(
+            {"group_size": 32, "bits": 8}, None
+        )
+        self.assertEqual(result, "mlx_q8")
+
+    def test_non_mlx_dict_not_matched(self):
+        """Dicts with an explicit quant_method belong to that method, not ours."""
+        # modelopt-style: explicit quant_method takes priority.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"quant_method": "modelopt", "bits": 4, "group_size": 64}, None
+            )
+        )
+        # gptq-style: same.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"quant_method": "gptq", "bits": 4, "group_size": 128}, None
+            )
+        )
+
+    def test_non_dict_not_matched(self):
+        """Non-dict inputs and malformed dicts return None."""
+        # None / string inputs.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(None, None)
+        )
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method("mlx_q4", None)
+        )
+        # Missing keys.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method({"bits": 4}, None)
+        )
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method({"group_size": 64}, None)
+        )
+        # Non-integer values.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"bits": "4", "group_size": 64}, None
+            )
+        )
+        # Unsupported bit-width.
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"bits": 2, "group_size": 64}, None
+            )
+        )
+
+    def test_user_quant_explicit_defers_to_user(self):
+        """When the user passes --quantization explicitly, defer to that choice."""
+        # User chose mlx_q8 explicitly, even though config dict shape suggests q4
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, "mlx_q8"
+            )
+        )
+        # User chose mlx_q4 explicitly with matching config
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, "mlx_q4"
+            )
+        )
+        # User chose something completely different
+        self.assertIsNone(
+            MlxQuantizationConfig.override_quantization_method(
+                {"group_size": 64, "bits": 4}, "fp8"
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #25119.

mlx-community pre-quantized HF repos like `mlx-community/Qwen3-30B-A3B-4bit` failed to load on the MLX backend because their `config.json` ships `quantization_config: {"group_size": <int>, "bits": <int>}` with no `quant_method` key. `ModelConfig._verify_quantization` could not match the shape to any registered method and raised `Unknown quantization method`.

This PR adds `override_quantization_method` to `MlxQuantizationConfig` so the registry auto-detection recognizes the mlx-community shape and maps it to `mlx_q4` / `mlx_q8` (both registered upstream in #24907). Lives entirely in `layers/quantization/mlx.py` — zero changes to backend-agnostic code.

## Motivation

#24907 landed `mlx_q4` / `mlx_q8` as preset names and registered `MlxQuantizationConfig` under the `is_mps()` block. That unblocked on-the-fly quantization via `--quantization mlx_q4` on any fp16 HF model.

The remaining failure mode is **pre-quantized** mlx-community models. Their `config.json` looks like this:

```json
{
  "quantization_config": {
    "group_size": 64,
    "bits": 4
  }
}
```

No `quant_method` key. No other identifying field. `_verify_quantization` extracts `quant_method = quant_cfg.get("quant_method", "")` → `""`, iterates over registered methods asking each `override_quantization_method(quant_cfg, None)`, and none claim the shape because `MlxQuantizationConfig` inherits the base `override_quantization_method` (returns `None`).

Result on `main` today:

```
ValueError: Unknown quantization method: . Must be one of ['fp8', 'mxfp8', ...]
```

The trailing period after the colon is the empty `quant_method` value. The bug surfaces on every mlx-community pre-quantized repo, which is the most common way users load quantized MLX models today.

## Modifications

Two files. +139 / −0. Zero changes to backend-agnostic code.

| File | Change |
|---|---|
| `python/sglang/srt/layers/quantization/mlx.py` | +42. New `override_quantization_method` classmethod on `MlxQuantizationConfig`. Recognizes the mlx-community shape (`group_size` + `bits`, no `quant_method`), maps `bits=4` → `mlx_q4`, `bits=8` → `mlx_q8`. Defers to explicit `--quantization` (`user_quant`) and to configs that declare their own `quant_method`. Returns `None` for non-matching inputs. |
| `test/registered/unit/hardware_backend/mlx/test_quantization.py` | +97. New `TestMlxQuantizationOverride` class with 5 tests. Pure-logic against the classmethod; no mlx / Apple Silicon dependency, runs on every CI platform. |

Note on the Design:

`override_quantization_method` is the existing extension point in `QuantizationConfig` (`base_config.py:166`) used by `awq`, `gptq`, `modelopt`, `moe_wna16`, and others. Walking each existing override against the mlx-community dict shape (`{"group_size": 64, "bits": 4}`, `user_quant=None`):

| Override | Why it returns `None` for the MLX shape |
|---|---|
| AWQ | early-out on `not _is_cuda` |
| GPTQ | early-out on `not _is_cuda` |
| MarlinConfig | needs `checkpoint_format == "marlin"` |
| moe_wna16 | needs `user_quant == "moe_wna16"` |
| petit | needs `_is_hip` and `quant_method == "modelopt"` |
| modelopt × 3 | needs `quant_algo` or `quant_method == "modelopt_mixed"` |

No earlier method claims the shape, so registration order is not load-bearing. The fix follows the same convention @damahua used in #24907 per @yeahdongcn's review feedback: backend-specific code in the backend-specific file, no carve-outs in `model_config.py`.

How to Use It:

Before:
```bash
SGLANG_USE_MLX=1 python -m sglang.bench_one_batch \
  --model-path mlx-community/Qwen3-30B-A3B-4bit \
  --trust-remote-code --disable-radix-cache \
  --tp-size 1 --batch-size 1 --input-len 60 --output-len 100
# ValueError: Unknown quantization method: .
```

After:
```bash
SGLANG_USE_MLX=1 python -m sglang.bench_one_batch \
  --model-path mlx-community/Qwen3-30B-A3B-4bit \
  --trust-remote-code --disable-radix-cache \
  --tp-size 1 --batch-size 1 --input-len 60 --output-len 100
# Model loads, decode median 72.30 tok/s
```

No CLI change required. Existing `--quantization mlx_q4` / `mlx_q8` paths from #24907 are unaffected (explicit user choice defers via the `user_quant is not None` guard).

## Accuracy Tests

This PR does not change the inference forward path — only fixes config-validation gating. Once the model loads, decode uses the same MLX quantized weight path as pre-#25119 (which already worked for pre-quantized mlx-community models when bypassed via the cached-config workaround). No accuracy delta.

## Speed Tests

Single-trial decode on Qwen3-30B-A3B-4bit, M4 Pro 24GB, bs=1, input-len 60, output-len 100, with the bug-trigger `quantization_config` dict injected into the cached `config.json`:

| Metric | Value |
|---|---|
| Model load | 6.90 s |
| Decode median | 72.30 tok/s |

Within the session noise band against an unrelated 5-trial paired baseline measured earlier the same day (74.4 tok/s, σ ≈ 1.5). Override fires once at config-validation time and has no measurable impact on steady-state decode.

## Unit Tests

5/5 pass in 0.831 s (Apple Silicon M4 Pro 24GB, Python 3.11):

```
test_mlx_q4_dict_config_autodetect                              PASSED
test_mlx_q8_dict_config_autodetect                              PASSED
test_non_mlx_dict_not_matched                                     PASSED
test_non_dict_not_matched                                             PASSED
test_user_quant_explicit_defers_to_user                        PASSED
```

The new `TestMlxQuantizationOverride` class is pure-logic against the classmethod (no `mlx` or Apple Silicon dependency), so it runs on every CI platform alongside damahua's existing platform-skipped integration tests.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).

No docs change in this PR — the `apple_metal.mdx` Quantization section @damahua added in #24907 covers both flag-based and pre-quantized loading paths; pre-quantized was already documented as working there, and now actually works.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

## AI Usage

The main code logic was written by me. Claude was used to discuss design decisions, review the CUDA reference at `sgl-kernel/csrc/moe/cutlass_moe/w4a8/`, analyze multi-trial benchmarks, and polish the PR description. Everything was verified and understood by me.