### PR TITLE
[PrefillDelayer] Add --prefill-delayer-check-interval to amortize all-gather

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -59,13 +59,20 @@ class PrefillDelayer:
         if self._max_delay_ms is None:
             self._max_delay_ms = 5000.0
         self._queue_trigger_enabled = self._queue_min_ratio is not None
+        # Negotiation cadence: run the cross-rank all-gather every N steps;
+        # on the other N-1 steps short-circuit to a delay decision without
+        # touching the collective. All ranks must use the same N so they
+        # skip/run the gather in lockstep.
+        self._check_interval = max(1, int(server_args.prefill_delayer_check_interval))
+        self._step_counter = 0
         logger.info(
             f"PrefillDelayer initialized with "
             f"max_delay_passes={self._max_delay_passes} "
             f"token_usage_low_watermark={self._token_usage_low_watermark} "
             f"queue_min_ratio={self._queue_min_ratio} "
             f"max_delay_ms={self._max_delay_ms} "
-            f"queue_trigger_enabled={self._queue_trigger_enabled}"
+            f"queue_trigger_enabled={self._queue_trigger_enabled} "
+            f"check_interval={self._check_interval}"
         )
         self.dp_size = dp_size
         self.enable_dp_attention = server_args.enable_dp_attention
@@ -115,6 +122,17 @@ class PrefillDelayer:
         max_running_requests: int = 0,
         waiting_queue_len: int = 0,
     ) -> _NegotiateOutput:
+        is_check_step = self._step_counter % self._check_interval == 0
+        self._step_counter += 1
+
+        if not is_check_step:
+            # Skip the collective and default to delay. Keeps wait-time
+            # bookkeeping in self._curr_state so metrics and the next real
+            # check still see a consistent running delay window.
+            out = self._build_skipped_check_output(prev_state=self._curr_state)
+            self._curr_state = out.next_state
+            return out
+
         out = self._negotiate_should_allow_prefill_pure(
             prev_state=self._curr_state,
             local_prefillable=local_prefillable,
@@ -126,6 +144,18 @@ class PrefillDelayer:
         )
         self._curr_state = out.next_state
         return out
+
+    @staticmethod
+    def _build_skipped_check_output(prev_state: Optional[_State]) -> _NegotiateOutput:
+        next_state = (prev_state or _State()).bump_delayed_count()
+        return _NegotiateOutput(
+            next_state=next_state,
+            input_estimation="skipped",
+            output_allow=False,
+            output_reason="skipped_check",
+            num_prefillable=0,
+            num_token_watermark_force_allow=0,
+        )
 
     # (Almost) pure function, do not modify self state
     def _negotiate_should_allow_prefill_pure(
@@ -373,6 +403,7 @@ def _record_single_pass_result(
                 "wait_success",
                 "no_wait",
                 "delay",
+                "skipped_check",
             }
 
     if metrics_collector is not None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -437,6 +437,7 @@ class ServerArgs:
     prefill_delayer_wait_seconds_buckets: Optional[List[float]] = None
     prefill_delayer_queue_min_ratio: Optional[float] = None
     prefill_delayer_max_delay_ms: Optional[float] = None
+    prefill_delayer_check_interval: int = 1
 
     # Runtime options
     device: Optional[str] = None
@@ -4901,6 +4902,17 @@ class ServerArgs:
                 "is force-released to bound worst-case TTFT. Only consulted when "
                 "--prefill-delayer-queue-min-ratio is set. Typical: 1000 ~ 5000; defaults to "
                 "5000 if unset."
+            ),
+        )
+        parser.add_argument(
+            "--prefill-delayer-check-interval",
+            type=int,
+            default=ServerArgs.prefill_delayer_check_interval,
+            help=(
+                "Run the cross-rank prefill-delayer negotiation (an all-gather) once every N "
+                "scheduler steps; on intervening steps prefill is delayed without a collective. "
+                "Default 1 preserves per-step behavior; increase to reduce gloo/NCCL overhead at "
+                "the cost of up to N-1 extra forward passes of TTFT latency."
             ),
         )
 

--- a/test/registered/scheduler/test_prefill_delayer.py
+++ b/test/registered/scheduler/test_prefill_delayer.py
@@ -65,6 +65,11 @@ class NegotiateTestCase:
     # to exercise the legacy slot-only code paths.
     queue_min_ratio: Optional[float] = None
     max_delay_ms: Optional[float] = None
+    check_interval: int = 1
+    # Optional per-call expectations; when set, each entry is checked against
+    # the corresponding call. The trailing call must still match
+    # expected_allow / expected_reason.
+    expected_per_call: Optional[List[tuple]] = None
 
 
 def _run_negotiate_test(rank, test_cases):
@@ -82,12 +87,13 @@ def _run_negotiate_test(rank, test_cases):
                 disable_overlap_schedule=False,
                 prefill_delayer_queue_min_ratio=case.queue_min_ratio,
                 prefill_delayer_max_delay_ms=case.max_delay_ms,
+                prefill_delayer_check_interval=case.check_interval,
             ),
             max_delay_passes=case.max_delay_passes,
             token_usage_low_watermark=case.token_usage_low_watermark,
         )
 
-        for call in case.calls:
+        for call_idx, call in enumerate(case.calls):
             if call.sleep_before_s > 0:
                 time.sleep(call.sleep_before_s)
 
@@ -106,6 +112,13 @@ def _run_negotiate_test(rank, test_cases):
                 token_usage=call.token_usage[rank],
                 **extra_kwargs,
             )
+
+            if case.expected_per_call is not None:
+                expected = case.expected_per_call[call_idx]
+                assert (result.output_allow, result.output_reason) == expected, (
+                    f"Case {case.name} rank {rank} call {call_idx}: "
+                    f"got ({result.output_allow}, {result.output_reason}), expected {expected}"
+                )
 
         assert (result.output_allow, result.output_reason) == (
             case.expected_allow,
@@ -299,6 +312,69 @@ _NEGOTIATE_TEST_CASES = [
                 waiting_queue_len=[1, 1, 1, 1],
                 max_running_requests=1024,
             )
+        ],
+        expected_allow=True,
+        expected_reason="no_wait",
+    ),
+    # check_interval > 1: only the 1st and (1+N)th calls run the cross-rank
+    # all-gather. Intervening calls short-circuit to delay/skipped_check
+    # without touching the collective. With check_interval=3, an all-
+    # prefillable workload sees: call0=allow, call1=skip, call2=skip,
+    # call3=allow.
+    NegotiateTestCase(
+        name="check_interval_skips_between_real_checks",
+        max_delay_passes=100,
+        token_usage_low_watermark=0.8,
+        check_interval=3,
+        calls=[
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+            ),
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+            ),
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+            ),
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+            ),
+        ],
+        expected_per_call=[
+            (True, "no_wait"),
+            (False, "skipped_check"),
+            (False, "skipped_check"),
+            # Real check sees the prev_state left over from the skipped
+            # delays and reports a successful wait.
+            (True, "wait_success"),
+        ],
+        expected_allow=True,
+        expected_reason="wait_success",
+    ),
+    # check_interval=1 is identical to legacy behavior: every call runs the
+    # gather and there are no skipped_check outputs.
+    NegotiateTestCase(
+        name="check_interval_one_is_legacy",
+        max_delay_passes=100,
+        token_usage_low_watermark=0.8,
+        check_interval=1,
+        calls=[
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+            ),
+            NegotiateCall(
+                prefillable=[True, True, True, True],
+                token_usage=[0.9, 0.9, 0.9, 0.9],
+            ),
+        ],
+        expected_per_call=[
+            (True, "no_wait"),
+            (True, "no_wait"),
         ],
         expected_allow=True,
         expected_reason="no_wait",


### PR DESCRIPTION
## Motivation

`PrefillDelayer` runs a cross-rank all-gather on **every** scheduler step to negotiate whether prefill should be delayed. On DP-attention setups using the gloo CPU collective (or NCCL on the overlap-schedule critical path), this per-step gather adds non-trivial scheduler overhead — especially in workloads where most steps would have skipped prefill anyway (decode-heavy phases, single-request prefills, etc.).

## Summary

- New server arg `--prefill-delayer-check-interval N` (default `1`, i.e. unchanged behavior).
- When `N > 1`, the cross-rank negotiation only runs on every Nth call to `_negotiate_should_allow_prefill`. The intervening N-1 calls short-circuit to a `delay` decision (`output_reason="skipped_check"`) without touching the collective.
- Wait-time bookkeeping (`_State.delayed_count`, `start_time`) is preserved across skipped steps, so the next real check sees a coherent prev_state and the metrics still report sensible `wait_seconds` / `forward_passes`.
- Adds two unit-test cases under `test/registered/scheduler/test_prefill_delayer.py`:
  - `check_interval_skips_between_real_checks` — verifies the skip/check pattern with `N=3`.
  - `check_interval_one_is_legacy` — verifies `N=1` reproduces the existing per-step semantics.

## Lockstep correctness

All DP-attention ranks call `get_new_batch_prefill` the same number of times per scheduler iteration (the existing collective already relies on this). Each rank ticks its local `_step_counter` once per call, so all ranks decide "check vs. skip" in lockstep — the all-gather is never called by a strict subset of ranks.

## Trade-offs

- Worst-case TTFT can grow by up to `N-1` forward passes.
- The `token_usage_low_watermark` "low-KV escape hatch" only fires on a real check, so memory-pressure relief is also coarsened by up to `N-1` passes. Operators should leave `N=1` (the default) unless their workload shows scheduler-side gather overhead.

## Test plan
- [x] `black --check`, `isort --check`, `ruff --select=F401,F821` clean on touched files.
- [x] Existing unit tests (`TestPrefillDelayerNegotiate`) cover the `N=1` case unchanged; new cases cover `N>1`.
- [ ] (Reviewer: please run the 8×H200 e2e suite — `TestPrefillDelayerThroughput*` and `TestPrefillDelayerAccuracy` — to confirm no regression at the default `N=1`.)