### PR TITLE
fix: prefix matching against matrix-expanded job names

### DIFF
--- a/.github/actions/check-stage-health/action.yml
+++ b/.github/actions/check-stage-health/action.yml
@@ -77,9 +77,13 @@ runs:
           const rootCauseFailures = jobs.filter(j => {
             if (j.status !== 'completed' || j.conclusion !== 'failure') return false;
             // h20 runners are flaky (dirty GPU state from prior runs); their failures
-            // should not cascade fast-fail to other stages. Exact match avoids
-            // accidentally matching the h200 job names.
-            if (j.name === 'stage-c-test-8-gpu-h20') {
+            // should not cascade fast-fail to other stages. j.name shape from
+            // listJobsForWorkflowRun: "<job-key>" + optional " / <reusable-job>"
+            // + optional " (<matrix>)". Split off the base job key before exact
+            // match so we cover both inline + reusable forms without confusing
+            // 'h20' with the 'h200' prefix.
+            const baseName = j.name.split(/[ /]/)[0];
+            if (baseName === 'stage-c-test-8-gpu-h20') {
               return false;
             }
             // If the failing step is the health check, it's a cascade — skip it

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -89,7 +89,11 @@ runs:
             if (spec.exact) {
               return jobName === spec.prefix;
             }
-            return jobName === spec.prefix || jobName.startsWith(spec.prefix + ' (');
+            // Match bare prefix or any GHA-rendered shard suffix. Inline matrix
+            // produces `<prefix> (<shard>)`; reusable-workflow callers produce
+            // `<prefix> / <called-job> (<shard>)`. Both have a space after the
+            // prefix, so a single ' '-delimited check covers both.
+            return jobName === spec.prefix || jobName.startsWith(spec.prefix + ' ');
           };
 
           // Use ETag conditional requests to avoid consuming rate limit when nothing changed.

--- a/.github/actions/wait-for-jobs/action.yml
+++ b/.github/actions/wait-for-jobs/action.yml
@@ -181,13 +181,16 @@ runs:
 
               if (matchingJobs.length < spec.expected_count) {
                 // Job-level `if:` is evaluated before matrix expansion. When it
-                // evaluates false, GitHub emits exactly one "skipped" entry using
-                // the un-expanded job name (bare prefix, no " (shard)" suffix)
-                // instead of N matrix entries. Detect that precise shape so we
-                // don't poll forever — and so we don't mistake a partially
+                // evaluates false, GitHub emits exactly one "skipped" entry
+                // without a "(shard)" suffix instead of N matrix entries. Two
+                // shapes are possible:
+                //   - inline matrix:     `<prefix>`
+                //   - reusable workflow: `<prefix> / <called-job>`
+                // Both lack the ` (` shard marker. Detect that precise shape so
+                // we don't poll forever — and so we don't mistake a partially
                 // materialized dynamic/reusable matrix for a skipped one.
                 const unexpandedSkip = matchingJobs.length === 1 &&
-                  matchingJobs[0].name === spec.prefix &&
+                  !matchingJobs[0].name.includes(' (') &&
                   matchingJobs[0].status === 'completed' &&
                   matchingJobs[0].conclusion === 'skipped';
                 if (unexpandedSkip) {


### PR DESCRIPTION
Two `.github/actions/*` files used overly-specific boundaries when matching `j.name` from `listJobsForWorkflowRun`. `j.name` is rendered by GHA in two forms:

- inline + matrix: `<job-key> (<shard>)`
- reusable-workflow + matrix: `<job-key> / <called-job> (<shard>)`

The right boundary after `<job-key>` is **always a space** — both forms have it. The two matchers below were keying on stricter suffixes (`' ('` or full equality) that miss one or both forms.

## Changes

- **`check-stage-health/action.yml`** — h20 cascade-fast-fail bypass used `j.name === 'stage-c-test-8-gpu-h20'` (exact match), which never matches the matrix-expanded name. Switch to splitting off the base job key (`j.name.split(/[ /]/)[0]`) before comparing.
- **`wait-for-jobs/action.yml`** — prefix match used `startsWith(prefix + ' (')`. Works for inline matrix today, but breaks for reusable-workflow callers where the rendered name is `<prefix> / run (<shard>)`. Switch to `startsWith(prefix + ' ')`.

Both fixes use the post-prefix space as the boundary, which holds across all observed GHA-rendered forms.