### PR TITLE
[MLX] bench_one_batch: thread --quantization through to MlxModelRunner

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -531,6 +531,7 @@ class _MlxBenchRunner:
             trust_remote_code=server_args.trust_remote_code,
             disable_radix_cache=True,
             mem_fraction_static=server_args.mem_fraction_static,
+            quantization=server_args.quantization,
         )
         if server_args.max_total_tokens is not None:
             init_kwargs["pool_size"] = server_args.max_total_tokens


### PR DESCRIPTION
## Motivation

`_MlxBenchRunner.__init__` in `bench_one_batch.py` constructs an `MlxModelRunner` directly but never forwards `server_args.quantization`. Running

```bash
SGLANG_USE_MLX=1 python -m sglang.bench_one_batch \
    --model-path Qwen/Qwen3-32B --quantization mlx_q4 ...
```

silently drops the flag, the runner loads the model as plain fp16, and on a memory-constrained Apple Silicon host (e.g. 64 GB Mac running a 32B model) the bench OOMs without any indication that `--quantization` was ignored.

The production path through `MlxTpModelWorker` already forwards `server_args.quantization` correctly (added in #24907). The bench harness is the only other caller and was missed because `_MlxBenchRunner` predates the `quantization` kwarg.

Flagged by @jlee5814 — thanks!

## Modifications

`python/sglang/bench_one_batch.py`: include `quantization=server_args.quantization` in the `init_kwargs` dict that's unpacked into `MlxModelRunner(...)`. One line, no other changes.

## Test Plan

Before, on a 64 GB M-series Mac:

```bash
SGLANG_USE_MLX=1 python -m sglang.bench_one_batch \
    --model-path Qwen/Qwen3-32B --quantization mlx_q4 \
    --device mps --trust-remote-code --disable-radix-cache \
    --tp-size 1 --batch-size 1 --input-len 60 --output-len 100
# Loads 61 GB fp16 → swaps → eventually killed / OOM
```

After:

```bash
# Same command. MlxModelRunner sees quantization="mlx_q4",
# applies on-the-fly mx.quantize, model fits in ~17 GB.
```

No CLI change. The CI test surface in `test/registered/unit/hardware_backend/mlx/` already covers `MlxModelRunner(quantization=...)` end-to-end via the unit tests in `test_quantization.py` (#24907); the bench harness was the only remaining caller that wasn't threading the kwarg through.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(No new tests — the kwarg passthrough is exercised by the existing `MlxModelRunner(quantization=...)` unit tests from #24907.)*
- [x] Update documentation. *(N/A — bench docstrings already describe `--quantization`.)*
- [x] Provide accuracy and speed benchmark results. *(One-line plumbing fix; no inference-path change.)*
- [x] Follow the [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
