### PR TITLE
Fix SMG inbound W3C trace context extraction(#25159)

### DIFF
--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -25,12 +25,14 @@ use tokio::sync::{mpsc, oneshot};
 use tower::{Layer, Service};
 use tower_http::trace::{MakeSpan, OnRequest, OnResponse, TraceLayer};
 use tracing::{debug, error, field::Empty, info, info_span, warn, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub use crate::core::token_bucket::TokenBucket;
 use crate::{
     observability::{
         inflight_tracker::InFlightRequestTracker,
         metrics::{method_to_static_str, metrics_labels, Metrics},
+        otel_trace::extract_trace_context_http,
     },
     routers::error::extract_error_code_from_response,
     server::AppState,
@@ -273,7 +275,7 @@ impl<B> MakeSpan<B> for RequestSpan {
     fn make_span(&mut self, request: &Request<B>) -> Span {
         // Don't try to extract request ID here - it won't be available yet
         // The RequestIdLayer runs after TraceLayer creates the span
-        info_span!(
+        let span = info_span!(
             target: "smg::otel-trace",
             "http_request",
             method = %request.method(),
@@ -284,7 +286,13 @@ impl<B> MakeSpan<B> for RequestSpan {
             latency = Empty,
             error = Empty,
             module = "smg"
-        )
+        );
+
+        if let Some(parent_context) = extract_trace_context_http(request.headers()) {
+            span.set_parent(parent_context);
+        }
+
+        span
     }
 }
 

--- a/sgl-model-gateway/src/observability/otel_trace.rs
+++ b/sgl-model-gateway/src/observability/otel_trace.rs
@@ -10,7 +10,12 @@ use std::{
 
 use anyhow::Result;
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
-use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
+use opentelemetry::{
+    global,
+    propagation::Extractor,
+    trace::{TraceContextExt, TracerProvider as _},
+    Context as OtelContext, KeyValue,
+};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     propagation::TraceContextPropagator,
@@ -205,6 +210,29 @@ pub fn shutdown_otel() {
         ENABLED.store(false, Ordering::Release);
         eprintln!("[tracing] OpenTelemetry shut down");
     }
+}
+
+/// Extract W3C trace context from HTTP request headers.
+#[inline]
+pub fn extract_trace_context_http(headers: &HeaderMap) -> Option<OtelContext> {
+    struct HeaderExtractor<'a>(&'a HeaderMap);
+
+    impl Extractor for HeaderExtractor<'_> {
+        #[inline]
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).and_then(|value| value.to_str().ok())
+        }
+
+        #[inline]
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(HeaderName::as_str).collect()
+        }
+    }
+
+    let context =
+        global::get_text_map_propagator(|propagator| propagator.extract(&HeaderExtractor(headers)));
+
+    context.span().span_context().is_valid().then_some(context)
 }
 
 /// Inject W3C trace context headers into an HTTP request.

--- a/sgl-model-gateway/tests/otel_tracing_test.rs
+++ b/sgl-model-gateway/tests/otel_tracing_test.rs
@@ -1,18 +1,26 @@
 mod common;
 
 use std::{
+    convert::Infallible,
+    fmt,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
 
-use axum::{body::Body, extract::Request, http::StatusCode};
+use axum::{body::Body, extract::Request, http::StatusCode, response::Response as AxumResponse};
 use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType};
+use opentelemetry::{global, trace::TracerProvider as _};
 use opentelemetry_proto::tonic::collector::trace::v1::{
     trace_service_server::{TraceService, TraceServiceServer},
     ExportTraceServiceRequest, ExportTraceServiceResponse,
+};
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    propagation::TraceContextPropagator,
+    trace::{SimpleSpanProcessor, TracerProvider as SdkTracerProvider},
 };
 use portpicker::pick_unused_port;
 use serde_json::json;
@@ -20,15 +28,46 @@ use serial_test::serial;
 use smg::{
     config::{RouterConfig, TraceConfig},
     core::Job,
+    middleware,
     observability::{logging, otel_trace},
     routers::RouterFactory,
 };
 use tokio::sync::oneshot;
 use tonic::metadata::MetadataMap;
-use tonic_v12::{transport::Server, Request as TonicRequest, Response, Status};
-use tower::ServiceExt;
+use tonic_v12::{transport::Server, Request as TonicRequest, Response as TonicResponse, Status};
+use tower::{service_fn, ServiceExt};
 use tracing::info_span;
 use tracing_subscriber::prelude::*;
+
+#[derive(Clone, Default)]
+struct TestSpanExporter {
+    spans: Arc<Mutex<Vec<SpanData>>>,
+}
+
+impl TestSpanExporter {
+    fn get_finished_spans(&self) -> Vec<SpanData> {
+        self.spans.lock().expect("spans mutex poisoned").clone()
+    }
+}
+
+impl fmt::Debug for TestSpanExporter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TestSpanExporter").finish_non_exhaustive()
+    }
+}
+
+impl SpanExporter for TestSpanExporter {
+    fn export(
+        &mut self,
+        mut batch: Vec<SpanData>,
+    ) -> futures_util::future::BoxFuture<'static, ExportResult> {
+        self.spans
+            .lock()
+            .expect("spans mutex poisoned")
+            .append(&mut batch);
+        Box::pin(std::future::ready(Ok(())))
+    }
+}
 
 #[derive(Clone)]
 struct TestOtelCollector {
@@ -52,7 +91,7 @@ impl TraceService for TestOtelCollector {
     async fn export(
         &self,
         request: TonicRequest<ExportTraceServiceRequest>,
-    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+    ) -> Result<TonicResponse<ExportTraceServiceResponse>, Status> {
         let req = request.into_inner();
 
         let mut total_spans = 0;
@@ -65,7 +104,7 @@ impl TraceService for TestOtelCollector {
 
         self.span_count.fetch_add(total_spans, Ordering::SeqCst);
 
-        Ok(Response::new(ExportTraceServiceResponse {
+        Ok(TonicResponse::new(ExportTraceServiceResponse {
             partial_success: None,
         }))
     }
@@ -91,6 +130,53 @@ async fn start_collector(
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     Ok(collector)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_000_http_request_span_extracts_inbound_traceparent() {
+    const INBOUND_TRACE_ID: &str = "3dac15ca145787138ee68247fda9258b";
+    const INBOUND_PARENT_SPAN_ID: &str = "892bf5320fe1ac06";
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let exporter = TestSpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(SimpleSpanProcessor::new(Box::new(exporter.clone())))
+        .build();
+    let tracer = provider.tracer("smg-test");
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    let app = tower::ServiceBuilder::new()
+        .layer(middleware::create_logging_layer())
+        .service(service_fn(|_request: Request<Body>| async {
+            Ok::<AxumResponse, Infallible>(AxumResponse::new(Body::empty()))
+        }));
+
+    let traceparent = format!("00-{}-{}-01", INBOUND_TRACE_ID, INBOUND_PARENT_SPAN_ID);
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("traceparent", traceparent)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "Request should succeed");
+    drop(response);
+
+    let spans = exporter.get_finished_spans();
+    let http_span = spans
+        .iter()
+        .find(|span| span.name == "http_request")
+        .expect("expected exported http_request span");
+
+    assert_eq!(
+        http_span.span_context.trace_id().to_string(),
+        INBOUND_TRACE_ID
+    );
+    assert_eq!(http_span.parent_span_id.to_string(), INBOUND_PARENT_SPAN_ID);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

Fixes #25159.

  `sgl-model-gateway` currently injects W3C trace context into outbound HTTP/gRPC requests, but it does not extract the parent context from inbound HTTP headers.

  As a result, when SMG receives a request with an existing `traceparent` header, the `http_request` span is exported as a new root span. This breaks end-to-end distributed
  tracing across ingress/gateway/backend, and downstream requests follow SMG's newly generated trace id instead of the upstream trace id.

## Modifications

This PR fixes inbound W3C trace context propagation for `sgl-model-gateway`.

  Changes:
  - Add an HTTP `HeaderMap` extractor for W3C Trace Context.
  - Extract inbound context from `traceparent` / `tracestate` through the global OpenTelemetry propagator.
  - Set the extracted context as the parent of the SMG `http_request` span when it is valid.
  - Add a regression test that sends an inbound request with:

  traceparent: 00-3dac15ca145787138ee68247fda9258b-892bf5320fe1ac06-01

  and verifies that the exported SMG http_request span keeps:

  trace_id: 3dac15ca145787138ee68247fda9258b
  parent_span_id: 892bf5320fe1ac06

## Accuracy Tests

Not applicable. This PR does not affect model outputs, kernels, model forward logic, or decoding behavior.

## Speed Tests and Profiling

Not applicable. This PR only changes OpenTelemetry trace parent extraction for HTTP server spans and does not affect inference execution paths.

  The following tests were run:

  cargo test test_000_http_request_span_extracts_inbound_traceparent --test otel_tracing_test -- --nocapture
  cargo test --test otel_tracing_test -- --nocapture
  cargo test --lib
  cargo fmt -- --check

  Results:

  - otel_tracing_test: 12 passed
  - cargo test --lib: 364 passed
  - cargo fmt -- --check: passed

## Checklist

  - [x] Format your code according to the Format code with pre-commit (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the Run and add unit tests (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [x] Update documentation according to Write documentations (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable; no user-facing configuration or API change.
  - [x] Provide accuracy and speed benchmark results according to Test the accuracy (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and Benchmark the speed (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable; no model accuracy or inference speed impact.
  - [x] Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

