### PR TITLE
[Fix] DeepSeek-V3.2: build structural tag locally to encode both wrapper and invoke layers

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -1,10 +1,11 @@
 import json
 import logging
 import re
+from typing import List, Literal, Optional, Union
 
 from partial_json_parser.core.options import Allow
 
-from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -14,7 +15,29 @@ from sglang.srt.function_call.core_types import (
 )
 from sglang.srt.function_call.utils import _find_common_prefix, _partial_json_loads
 
+try:
+    from xgrammar import StructuralTag
+    from xgrammar.structural_tag import (
+        AnyTextFormat,
+        ConstStringFormat,
+        JSONSchemaFormat,
+        SequenceFormat,
+        TagFormat,
+        TagsWithSeparatorFormat,
+        TriggeredTagsFormat,
+    )
+except ImportError:
+    StructuralTag = None  # type: ignore
+
 logger = logging.getLogger(__name__)
+
+# Names mirror the DeepSeek-V3.2 official chat template tokens
+# (see encoding_dsv32.TOOLS_SYSTEM_TEMPLATE).
+_INVOKE_BEGIN_PREFIX = '<｜DSML｜invoke name="'
+_INVOKE_BEGIN_SUFFIX = '">\n'
+_THINK_TAG_END = "</think>"
+_THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
+_XML_STYLE = "deepseek_xml"
 
 
 class DeepSeekV32Detector(BaseFormatDetector):
@@ -368,5 +391,94 @@ class DeepSeekV32Detector(BaseFormatDetector):
             trigger="<｜DSML｜invoke",
         )
 
-    def get_structural_tag_name(self) -> str:
-        return "deepseek_v3_2"
+    def get_structural_tag(
+        self,
+        tools: Union[List[Tool], None] = None,
+        tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
+        thinking_mode: bool = False,
+    ) -> Optional["StructuralTag"]:
+        """
+        Build an xgrammar StructuralTag locally for DeepSeek-V3.2.
+
+        Both layers — the outer `<｜DSML｜function_calls｜>...` wrapper and
+        the inner `<｜DSML｜invoke>...</｜DSML｜invoke>` blocks — are encoded
+        directly in the grammar with a single-newline join between
+        consecutive invokes, matching DeepSeek-V3.2's official chat
+        template. This avoids two layered defects that surfaced with the
+        prior `xgrammar.get_model_structural_tag("deepseek_v3_2")` path:
+
+        - the xgrammar builtin template (pre mlc-ai/xgrammar#638) forced
+          a double-newline join, which deterministically collapsed
+          parallel tool calls to one at greedy decoding.
+        - falling back to the legacy structural tag (built from
+          `structure_info()`) only constrains the inner invoke block;
+          the outer wrapper is off-grammar and the model can skip it
+          under `at_least_one=True`, leaving `detect_and_parse` with no
+          `<｜DSML｜function_calls>` marker to anchor on.
+
+        Returning a fully-formed StructuralTag from the detector keeps
+        both fixes local to sglang and decoupled from the xgrammar
+        release cadence.
+        """
+        if not tools or StructuralTag is None:
+            return None
+
+        # `INVOKE_END` and the empty separator together yield a single `\n`
+        # between consecutive invokes — matching DeepSeek-V3.2's chat template
+        # `"\n".join(invoke_blocks)`.
+        function_calls_begin = self.bot_token + "\n"
+        invoke_end = self.invoke_end_token + "\n"
+
+        def _invoke_tag(tool: Tool) -> TagFormat:
+            return TagFormat(
+                begin=_INVOKE_BEGIN_PREFIX + tool.function.name + _INVOKE_BEGIN_SUFFIX,
+                content=JSONSchemaFormat(
+                    json_schema=tool.function.parameters or {},
+                    style=_XML_STYLE,
+                ),
+                end=invoke_end,
+            )
+
+        if isinstance(tool_choice, ToolChoice):
+            target = next(
+                (t for t in tools if t.function.name == tool_choice.function.name),
+                None,
+            )
+            if target is None:
+                return None
+            invoke_tags = [_invoke_tag(target)]
+            is_required = True
+        else:
+            invoke_tags = [_invoke_tag(t) for t in tools]
+            is_required = tool_choice == "required"
+
+        inner_tool_calls = TagsWithSeparatorFormat(
+            tags=invoke_tags, separator="", at_least_one=True
+        )
+
+        if is_required:
+            suffix_tag = SequenceFormat(
+                elements=[
+                    ConstStringFormat(value=function_calls_begin),
+                    inner_tool_calls,
+                    ConstStringFormat(value=self.eot_token),
+                ]
+            )
+        else:
+            suffix_tag = TriggeredTagsFormat(
+                triggers=[self.bot_token],
+                tags=[
+                    TagFormat(
+                        begin=function_calls_begin,
+                        content=inner_tool_calls,
+                        end=self.eot_token,
+                    )
+                ],
+                excludes=_THINK_EXCLUDE_TOKENS,
+            )
+
+        if not thinking_mode:
+            return StructuralTag(format=suffix_tag)
+
+        prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=_THINK_TAG_END)
+        return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))


### PR DESCRIPTION
## Summary

Fixes two layered regressions in the DeepSeek-V3.2 nightly tool-call test (`test/registered/8-gpu-models/test_deepseek_v32.py::test_deepseek_v32_all_variants`). Both are addressed by overriding `DeepSeekV32Detector.get_structural_tag` to construct a complete `xgrammar.StructuralTag` locally — encoding the outer `<｜DSML｜function_calls｜>` wrapper and the inner `<｜DSML｜invoke>` blocks together with a single-newline join that matches DeepSeek-V3.2's chat template.

## Regressions addressed

**A. `parallel: expected >= 2 tool calls, got 1`** — introduced by #21722.
#21722 routed V3.2 through `xgrammar.get_model_structural_tag("deepseek_v3_2", ...)`. The xgrammar builtin template (`INVOKE_END = "</｜DSML｜invoke>\n"` + `separator = "\n"`) forces a double-newline between consecutive invoke blocks, but the V3.2 chat template joins them with a single `\n`. At `temperature=0` the model deterministically closed `</｜DSML｜function_calls｜>` rather than emitting the out-of-distribution `\n\n<｜DSML｜invoke` continuation — exactly one tool call where two were requested. Tracked upstream at [mlc-ai/xgrammar#637](https://github.com/mlc-ai/xgrammar/issues/637) / [mlc-ai/xgrammar#638](https://github.com/mlc-ai/xgrammar/pull/638).

**B. `list index out of range`** — introduced by #21593, masked by #21722.
The legacy fallback path built from `structure_info()` only triggers on the inner `<｜DSML｜invoke` block; the outer wrapper cannot be expressed in `LegacyStructuralTagResponseFormat(structures, triggers, at_least_one)`. Under `tool_choice="required"` with `at_least_one=True` the model was pushed straight into the inner trigger and could legitimately skip the wrapper, but `detect_and_parse` short-circuited to `calls=[]` whenever the wrapper marker was absent, causing 6 sub-tests (basic_format / required / specific / strict / multiturn / thinking) to index into an empty `tool_calls`.

## Fix

`DeepSeekV32Detector.get_structural_tag` is overridden to build a `xgrammar.StructuralTag` directly:

- **outer wrapper** encoded as `ConstStringFormat(...)` ... `ConstStringFormat(...)` for `tool_choice="required"`/named, or wrapped in a `TriggeredTagsFormat` for `tool_choice="auto"`
- **inner invokes** as `TagsWithSeparatorFormat(tags=..., separator="", at_least_one=True)` where each `TagFormat` ends with `"</｜DSML｜invoke>\n"` — total inter-invoke gap is a single `\n`, matching the chat template
- optional `<think>...</think>` prefix when `thinking_mode=True`

Returning a non-None `StructuralTag` short-circuits `FunctionCallParser.get_structure_constraint`'s xgrammar-builtin and legacy-tag branches (the dispatch added in #21722), so neither defect can fire for V3.2 regardless of the installed xgrammar release.

`DeepSeekV4Detector` inherits `get_structural_tag` unchanged — V4 still uses its own builtin template, out of scope.

## Verification

**Devbox (8× H200, stock xgrammar 0.2.0 from PyPI):**

| Variant | Score | Tool Call |
|---|---|---|
| DP8 | 0.969 | **9/9 PASS** |
| DP8+MTP | 0.965 | **9/9 PASS** |
| TP8 | 0.963 | **9/9 PASS** |
| TP8+MTP | 0.962 | **9/9 PASS** |

`test_deepseek_v32_nsa_backends` also PASSED (Scores 0.967 × 3).

The fix is verified self-contained — stock xgrammar 0.2.0 was used, not [mlc-ai/xgrammar#638](https://github.com/mlc-ai/xgrammar/pull/638).

**CI (`/rerun-test`):** [run 25922898996](https://github.com/sgl-project/sglang/actions/runs/25922898996/job/76196336773) — 36/36 PASS across all four variants. Workflow `conclusion=failure` only because the GH Action `Run test` step has a 60-min hard timeout (test takes ~70 min). The nightly workflow uses `--timeout-per-file=18000` (5h) so this won't bite there.

## Follow-up

xgrammar [#638](https://github.com/mlc-ai/xgrammar/pull/638) fixes the original template-level defect at upstream. After it releases and sglang pins it, the V3.2 override here can be removed to put V3.2 back on the xgrammar builtin path; the two paths are equivalent at that point.
