### PR TITLE
ci: H200 conditional split + dsv4 est_time recalibration (h200 partition 6→2)

### DIFF
--- a/test/registered/8-gpu-models/test_deepseek_v32_indexcache.py
+++ b/test/registered/8-gpu-models/test_deepseek_v32_indexcache.py
@@ -13,7 +13,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=492, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=450, suite="nightly-8-gpu-h200", nightly=True)
 
 DEEPSEEK_V32_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2"
 

--- a/test/registered/8-gpu-models/test_deepseek_v3_mtp.py
+++ b/test/registered/8-gpu-models/test_deepseek_v3_mtp.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=309, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=300, stage="stage-c", runner_config="8-gpu-h200")
 
 FULL_DEEPSEEK_V3_MODEL_PATH = "deepseek-ai/DeepSeek-V3-0324"
 

--- a/test/registered/8-gpu-models/test_dsa_models_mtp.py
+++ b/test/registered/8-gpu-models/test_dsa_models_mtp.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 )
 
 register_cuda_ci(
-    est_time=1048,
+    est_time=1030,
     stage="stage-c",
     runner_config="8-gpu-h200",
 )

--- a/test/registered/8-gpu-models/test_mimo_models.py
+++ b/test/registered/8-gpu-models/test_mimo_models.py
@@ -6,7 +6,7 @@ from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 
-register_cuda_ci(est_time=610, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=500, stage="stage-c", runner_config="8-gpu-h200")
 
 
 class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):

--- a/test/registered/8-gpu-models/test_minimax_m25_basic.py
+++ b/test/registered/8-gpu-models/test_minimax_m25_basic.py
@@ -14,7 +14,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=307, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=290, stage="stage-c", runner_config="8-gpu-h200")
 
 MINIMAX_M25_MODEL_PATH = "MiniMaxAI/MiniMax-M2.5"
 

--- a/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_bf16.py
+++ b/test/registered/8-gpu-models/test_nvidia_nemotron_3_super_bf16.py
@@ -11,7 +11,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=376, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=370, suite="nightly-8-gpu-h200", nightly=True)
 
 NEMOTRON_3_SUPER_BF16_MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
 

--- a/test/registered/8-gpu-models/test_return_indexer_topk.py
+++ b/test/registered/8-gpu-models/test_return_indexer_topk.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=600, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=270, suite="nightly-8-gpu-h200", nightly=True)
 
 DEEPSEEK_V32_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2"
 

--- a/test/registered/8-gpu-models/test_step3p5_flash_chain_mtp.py
+++ b/test/registered/8-gpu-models/test_step3p5_flash_chain_mtp.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=663, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=480, suite="nightly-8-gpu-h200", nightly=True)
 
 STEP3P5_FLASH_MODEL_PATH = "stepfun-ai/Step-3.5-Flash"
 

--- a/test/registered/distributed/test_disaggregation_hybrid_attention.py
+++ b/test/registered/distributed/test_disaggregation_hybrid_attention.py
@@ -12,7 +12,7 @@ from sglang.test.test_utils import (
     popen_launch_pd_server,
 )
 
-register_cuda_ci(est_time=695, stage="stage-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=310, suite="nightly-8-gpu-h200", nightly=True)
 
 
 @unittest.skipIf(is_in_ci(), "Temporarily disable the flaky test.")

--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_b200.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=1800, stage="stage-c", runner_config="dsv4-4-gpu-b200")
+register_cuda_ci(est_time=700, stage="stage-c", runner_config="dsv4-4-gpu-b200")
 
 MODEL = "deepseek-ai/DeepSeek-V4-Flash"
 SERVER_LAUNCH_TIMEOUT = 3600

--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_h200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_h200.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=1800, stage="stage-c", runner_config="dsv4-8-gpu-h200")
+register_cuda_ci(est_time=370, stage="stage-c", runner_config="dsv4-8-gpu-h200")
 
 
 def _flashinfer_has_sm90_cutlass_mxfp4() -> bool:

--- a/test/registered/dsv4/test_deepseek_v4_flash_fp8_h200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp8_h200.py
@@ -22,7 +22,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=900, stage="stage-c", runner_config="dsv4-8-gpu-h200")
+register_cuda_ci(est_time=280, stage="stage-c", runner_config="dsv4-8-gpu-h200")
 
 MODEL_FP8 = "sgl-project/DeepSeek-V4-Flash-FP8"
 SERVER_LAUNCH_TIMEOUT = 3600

--- a/test/registered/lora/test_lora_tp.py
+++ b/test/registered/lora/test_lora_tp.py
@@ -30,7 +30,7 @@ from sglang.test.lora_utils import (
 from sglang.test.test_utils import CustomTestCase, is_in_ci
 
 register_cuda_ci(
-    est_time=190,
+    est_time=230,
     stage="stage-c",
     runner_config="8-gpu-h200",
 )


### PR DESCRIPTION
## What

1. Move 5 H200 8-GPU tests from per-commit (`stage-c-test-8-gpu-h200`) to `nightly-8-gpu-h200`. No tags — they fire only on the 3×/day scheduled cron via `--include-tags=*` wildcard pull-in. Mirrors the B200 split in #25203.
2. Recalibrate `est_time` for 8 remaining H200 / dsv4 tests from observed wall-clock (CI monitor dashboard). Most were over-provisioned 30-70%.

## Why

`stage-c-test-8-gpu-h200` was running 6 partitions per PR even though most of those tests don't gate the typical PR; same pattern that motivated #25203 on B200.

## Net effect

| Suite | size before | size after |
|---|---:|---:|
| `stage-c-test-8-gpu-h200` | 6 (5590s) | **2 (2650s)** |
| `stage-c-test-dsv4-8-gpu-h200` | 3 (3600s+) | **1 (900s)** |
| `stage-c-test-dsv4-4-gpu-b200` | 3 | 3 (unchanged; megamoe still 1800s) |

Coverage preserved: the 5 moved tests are pulled back in on the 3×/day scheduled cron via `*`.

## Tests moved (per-commit → nightly-8-gpu-h200, no tags)

| File | est_time |
|---|---:|
| `test_deepseek_v32_indexcache.py` | 492 → 450 |
| `test_nvidia_nemotron_3_super_bf16.py` | 376 → 370 |
| `test_return_indexer_topk.py` | 600 → 270 |
| `test_step3p5_flash_chain_mtp.py` | 663 → 480 |
| `test_disaggregation_hybrid_attention.py` | 695 → 310 |

## est_time recalibrated in place

| File | Old | New |
|---|---:|---:|
| `test_dsa_models_mtp.py` | 1048 | 1030 |
| `test_mimo_models.py` | 610 | 500 |
| `test_deepseek_v3_mtp.py` | 309 | 300 |
| `test_minimax_m25_basic.py` | 307 | 290 |
| `test_lora_tp.py` | 190 | 230 |
| `test_deepseek_v4_flash_fp4_h200.py` | 1800 | 370 |
| `test_deepseek_v4_flash_fp8_h200.py` | 900 | 280 |
| `test_deepseek_v4_flash_fp4_b200.py` | 1800 | 700 |

## Future

Same interim placement as #25203 — these belong on the merge-queue tier once that mechanism lands.

## Test plan

- [x] `compute_partitions.py` emits `size=2` for `stage-c-test-8-gpu-h200`, `size=1` for `stage-c-test-dsv4-8-gpu-h200`
- [x] Pre-commit hooks pass (incl. `check registered tests have CI registry`)
- [ ] Next scheduled cron exercises all 5 moved tests via `*` wildcard