### PR TITLE
[CI] Bundle `check-changes` outputs + caller inputs into 2 JSON inputs

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -1,67 +1,61 @@
 name: PR Test Stage
-# Reusable workflow that owns one CUDA test stage. Caller (pr-test.yml) passes
-# (self_name, runner_config, runs_on, partitions, check_changes JSON, caller_inputs JSON)
-# and the per-commit/target_stage gating + matrix fanout + setup/run/teardown all
-# live here. Only stage-a-test-cpu still lives inline in pr-test.yml (bespoke
-# uv pip / protoc / rust-cache install path).
-#
-# `check_changes` = ${{ toJson(needs.check-changes.outputs) }} forwarded as-is.
-# `caller_inputs` = ${{ toJson(inputs) }} forwarded as-is.
-# `partitions` is kept as its own input (rather than read from check_changes)
-# so accessing it needs only one fromJson — the value itself is a JSON string,
-# which inside `check_changes` would become a JSON-escaped string requiring
-# nested fromJson. `partitions` is referenced 3x in job-level strategy/matrix
-# where step-resolution isn't available, so the inline expressions stay short.
+# Reusable workflow for one CUDA test stage. Caller pr-test.yml forwards
+# `check_changes` = toJson(needs.check-changes.outputs) and
+# `caller_inputs` = toJson(inputs) as bundles. `partitions` is forwarded
+# separately to keep matrix expressions single-fromJson — its value is itself
+# a JSON string, so reading it via `check_changes` would need double fromJson,
+# and matrix can't use step-resolved values. stage-a-test-cpu stays inline in
+# pr-test.yml (bespoke uv pip / protoc / rust-cache install).
 
 on:
   workflow_call:
     inputs:
       self_name:
-        description: 'Caller job key, used for $GITHUB_JOB-style gating + partitions[suite] lookup.'
+        description: 'Caller job key; used for partitions[suite] lookup and target_stage gating.'
         type: string
         required: true
       runner_config:
-        description: 'Looked up in scripts/ci/runner_configs.yml for install script / artifact version / install timeout.'
+        description: 'Key in scripts/ci/runner_configs.yml (install script / artifact version / install timeout).'
         type: string
         required: true
       runs_on:
-        description: 'Physical GHA runner label, e.g. "1-gpu-5090" or the b200_runner output from check-changes for B200 stages.'
+        description: 'GHA runner label. B200 stages pass needs.check-changes.outputs.b200_runner for dynamic selection.'
         type: string
         required: true
       check_changes:
-        description: 'JSON-encoded `needs.check-changes.outputs` bundle. Use fromJson(...) to read main_package / sgl_kernel / continue_on_error etc.'
+        description: 'toJson(needs.check-changes.outputs). Read via fromJson(...).main_package / sgl_kernel / continue_on_error etc.'
         type: string
         required: true
       caller_inputs:
-        description: 'JSON-encoded pr-test.yml workflow inputs bundle (toJson(inputs)). Reads target_stage / test_parallel_dispatch / pr_head_sha / git_ref / skip_stage_health_check.'
+        description: 'toJson(inputs) from pr-test.yml. Read via fromJson(...).target_stage / pr_head_sha / git_ref / skip_stage_health_check / test_parallel_dispatch.'
         type: string
         required: true
       partitions:
-        description: 'JSON from check-changes (size, arr, max_parallel per suite). Passed as its own input so single-level fromJson suffices in matrix expressions.'
+        description: 'check-changes.outputs.partitions raw — kept separate to avoid double-fromJson in matrix expressions.'
         type: string
         required: true
       run_timeout_minutes:
-        description: 'Per-suite wall-clock cap (minutes), enforced via bash `timeout` around run_suite.py.'
+        description: 'timeout-minutes for the Run test step.'
         type: string
         default: '30'
       timeout_per_file:
-        description: 'Optional run_suite.py --timeout-per-file value.'
+        description: 'run_suite.py --timeout-per-file value (empty = unset).'
         type: string
         default: ''
       warmup_deep_gemm_models:
-        description: 'Space-separated `model:gpus` list. Empty = skip DeepGEMM warmup.'
+        description: 'Space-separated `model:gpus` list; empty skips DeepGEMM warmup.'
         type: string
         default: ''
       warmup_server_models:
-        description: 'Space-separated `model:gpus` list. Empty = skip server-CUDA-graph warmup.'
+        description: 'Space-separated `model:gpus` list; empty skips server-CUDA-graph warmup.'
         type: string
         default: ''
       warmup_timeout_minutes:
-        description: 'Wall-clock cap for each warmup step (DeepGEMM + server). Default 25min; bump for stages with large cold-cache warmup model lists.'
+        description: 'timeout-minutes for each warmup step. Bump for stages with large cold-cache model lists.'
         type: string
         default: '25'
       extra_pytest_path:
-        description: 'Optional pytest path to run after the suite (stage-b-test-4-gpu-b200 uses this for FA4 jit_kernel tests). Empty = skip.'
+        description: 'pytest path to run after the suite (b200 FA4 jit_kernel tests). Empty skips.'
         type: string
         default: ''
 
@@ -79,10 +73,9 @@ env:
 
 jobs:
   run:
-    # Mirror the inline gating that used to live in pr-test.yml on every CUDA
-    # stage job. target_stage takes precedence; otherwise default per-commit
-    # gating runs the stage on schedule / parallel-dispatch / non-failed PR
-    # with main_package or sgl_kernel changes.
+    # target_stage takes precedence; otherwise default per-commit gating
+    # runs on schedule / parallel-dispatch / non-failed PR with main_package
+    # or sgl_kernel changes.
     if: |
       always() &&
       (
@@ -96,8 +89,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 240
     env:
-      # Only stage-c-test-8-gpu-h20 needs the RDMA device list. Empty for
-      # everyone else (env var unset, harmless).
+      # Only stage-c-test-8-gpu-h20 needs the RDMA device list.
       SGLANG_CI_RDMA_ALL_DEVICES: ${{ inputs.runner_config == '8-gpu-h20' && 'mlx5_1,mlx5_2,mlx5_3,mlx5_4' || '' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -1,9 +1,17 @@
 name: PR Test Stage
 # Reusable workflow that owns one CUDA test stage. Caller (pr-test.yml) passes
-# (self_name, runner_config, runs_on, partitions, ...) and the
-# per-commit/target_stage gating + matrix fanout + setup/run/teardown all live
-# here. Only stage-a-test-cpu still lives inline in pr-test.yml (bespoke
+# (self_name, runner_config, runs_on, partitions, check_changes JSON, caller_inputs JSON)
+# and the per-commit/target_stage gating + matrix fanout + setup/run/teardown all
+# live here. Only stage-a-test-cpu still lives inline in pr-test.yml (bespoke
 # uv pip / protoc / rust-cache install path).
+#
+# `check_changes` = ${{ toJson(needs.check-changes.outputs) }} forwarded as-is.
+# `caller_inputs` = ${{ toJson(inputs) }} forwarded as-is.
+# `partitions` is kept as its own input (rather than read from check_changes)
+# so accessing it needs only one fromJson — the value itself is a JSON string,
+# which inside `check_changes` would become a JSON-escaped string requiring
+# nested fromJson. `partitions` is referenced 3x in job-level strategy/matrix
+# where step-resolution isn't available, so the inline expressions stay short.
 
 on:
   workflow_call:
@@ -20,30 +28,18 @@ on:
         description: 'Physical GHA runner label, e.g. "1-gpu-5090" or the b200_runner output from check-changes for B200 stages.'
         type: string
         required: true
-      target_stage:
-        description: 'Forwarded from pr-test.yml inputs.target_stage (used by /rerun-stage to skip everything except the targeted stage).'
+      check_changes:
+        description: 'JSON-encoded `needs.check-changes.outputs` bundle. Use fromJson(...) to read main_package / sgl_kernel / continue_on_error etc.'
         type: string
-        default: ''
-      test_parallel_dispatch:
-        description: 'Forwarded from pr-test.yml inputs.test_parallel_dispatch.'
+        required: true
+      caller_inputs:
+        description: 'JSON-encoded pr-test.yml workflow inputs bundle (toJson(inputs)). Reads target_stage / test_parallel_dispatch / pr_head_sha / git_ref / skip_stage_health_check.'
         type: string
-        default: 'false'
+        required: true
       partitions:
-        description: 'JSON from check-changes (size, arr, max_parallel per suite).'
+        description: 'JSON from check-changes (size, arr, max_parallel per suite). Passed as its own input so single-level fromJson suffices in matrix expressions.'
         type: string
         required: true
-      main_package:
-        description: 'check-changes.outputs.main_package — gates the default per-commit run.'
-        type: string
-        required: true
-      sgl_kernel:
-        description: 'check-changes.outputs.sgl_kernel — both gates the run and forwarded to the install/download steps.'
-        type: string
-        required: true
-      continue_on_error_flag:
-        description: 'Empty or `--continue-on-error`; forwarded to run_suite.py.'
-        type: string
-        default: ''
       run_timeout_minutes:
         description: 'Per-suite wall-clock cap (minutes), enforced via bash `timeout` around run_suite.py.'
         type: string
@@ -68,18 +64,6 @@ on:
         description: 'Optional pytest path to run after the suite (stage-b-test-4-gpu-b200 uses this for FA4 jit_kernel tests). Empty = skip.'
         type: string
         default: ''
-      pr_head_sha:
-        description: 'Forwarded from pr-test.yml inputs.pr_head_sha (for /rerun-stage on fork PRs).'
-        type: string
-        default: ''
-      git_ref:
-        description: 'Forwarded from pr-test.yml inputs.git_ref (for workflow_call from main).'
-        type: string
-        default: ''
-      skip_stage_health_check:
-        description: 'Forwarded from pr-test.yml inputs.skip_stage_health_check (release branch cut bypass).'
-        type: boolean
-        default: false
 
 # Mirror pr-test.yml top-level env. Reusable workflows do NOT inherit caller's
 # workflow-level env across the workflow_call boundary, so anything pr-test.yml
@@ -88,7 +72,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check && 'true' || 'false' }}
+  SKIP_STAGE_HEALTH_CHECK: ${{ fromJson(inputs.caller_inputs).skip_stage_health_check && 'true' || 'false' }}
   FORCE_REBUILD_DEEPEP: '1'
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
@@ -102,11 +86,11 @@ jobs:
     if: |
       always() &&
       (
-        (inputs.target_stage == inputs.self_name) ||
+        (fromJson(inputs.caller_inputs).target_stage == inputs.self_name) ||
         (
-          !inputs.target_stage &&
-          ((github.event_name == 'schedule' || inputs.test_parallel_dispatch == 'true') || (!failure() && !cancelled())) &&
-          (inputs.main_package == 'true' || inputs.sgl_kernel == 'true')
+          !fromJson(inputs.caller_inputs).target_stage &&
+          ((github.event_name == 'schedule' || fromJson(inputs.caller_inputs).test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
+          (fromJson(inputs.check_changes).main_package == 'true' || fromJson(inputs.check_changes).sgl_kernel == 'true')
         )
       )
     runs-on: ${{ inputs.runs_on }}
@@ -123,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.pr_head_sha || inputs.git_ref || github.sha }}
+          ref: ${{ fromJson(inputs.caller_inputs).pr_head_sha || fromJson(inputs.caller_inputs).git_ref || github.sha }}
 
       - name: Resolve runner_config
         id: rc
@@ -134,7 +118,7 @@ jobs:
       - uses: ./.github/actions/check-maintenance
 
       - name: Download artifacts (v4)
-        if: ${{ inputs.sgl_kernel == 'true' && steps.rc.outputs.artifact_version == 'v4' }}
+        if: ${{ fromJson(inputs.check_changes).sgl_kernel == 'true' && steps.rc.outputs.artifact_version == 'v4' }}
         uses: actions/download-artifact@v4
         with:
           path: sgl-kernel/dist/
@@ -142,7 +126,7 @@ jobs:
           pattern: wheel-python3.10-cuda*
 
       - name: Download artifacts (v6)
-        if: ${{ inputs.sgl_kernel == 'true' && steps.rc.outputs.artifact_version == 'v6' }}
+        if: ${{ fromJson(inputs.check_changes).sgl_kernel == 'true' && steps.rc.outputs.artifact_version == 'v6' }}
         uses: actions/download-artifact@v6
         with:
           path: sgl-kernel/dist/
@@ -152,7 +136,7 @@ jobs:
       - name: Install dependencies
         timeout-minutes: ${{ fromJson(steps.rc.outputs.install_timeout) }}
         run: |
-          CUSTOM_BUILD_SGL_KERNEL=${{ inputs.sgl_kernel }} bash ${{ steps.rc.outputs.install }}
+          CUSTOM_BUILD_SGL_KERNEL=${{ fromJson(inputs.check_changes).sgl_kernel }} bash ${{ steps.rc.outputs.install }}
 
       - name: Warmup DeepGEMM JIT Compilation
         if: inputs.warmup_deep_gemm_models != ''
@@ -174,7 +158,7 @@ jobs:
       - name: Run test
         timeout-minutes: ${{ fromJson(inputs.run_timeout_minutes) }}
         env:
-          CONTINUE_ON_ERROR_FLAG: ${{ inputs.continue_on_error_flag }}
+          CONTINUE_ON_ERROR_FLAG: ${{ fromJson(inputs.check_changes).continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test
           python3 run_suite.py --hw cuda --suite ${{ inputs.self_name }} \

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -244,6 +244,9 @@ jobs:
     with:
       sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
       b200_runner: ${{ needs.check-changes.outputs.b200_runner }}
+      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
+      git_ref: ${{ inputs.git_ref || '' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   # =============================================== jit-kernel ====================================================

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -202,6 +202,9 @@ jobs:
     with:
       runs_on: x64-kernel-build-node
       job_display_name: Build Wheel
+      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
+      git_ref: ${{ inputs.git_ref || '' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   sgl-kernel-build-wheels-arm:
@@ -225,6 +228,9 @@ jobs:
       runs_on: arm-kernel-build-node
       job_display_name: Build Wheel Arm
       arch_suffix: '-aarch64'
+      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
+      git_ref: ${{ inputs.git_ref || '' }}
+      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   call-sgl-kernel-tests:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -202,9 +202,6 @@ jobs:
     with:
       runs_on: x64-kernel-build-node
       job_display_name: Build Wheel
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   sgl-kernel-build-wheels-arm:
@@ -228,9 +225,6 @@ jobs:
       runs_on: arm-kernel-build-node
       job_display_name: Build Wheel Arm
       arch_suffix: '-aarch64'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   call-sgl-kernel-tests:
@@ -244,9 +238,6 @@ jobs:
     with:
       sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
       b200_runner: ${{ needs.check-changes.outputs.b200_runner }}
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   # =============================================== jit-kernel ====================================================
@@ -283,16 +274,10 @@ jobs:
       self_name: stage-a-test-1-gpu-small
       runner_config: 1-gpu-small
       runs_on: 1-gpu-5090
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       run_timeout_minutes: '10'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-a-test-cpu:
@@ -375,15 +360,9 @@ jobs:
       self_name: stage-b-test-1-gpu-small
       runner_config: 1-gpu-small
       runs_on: 1-gpu-5090
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   # Runs on H100 (80GB, SM90) - tests that don't pass on 5090 (FA3, FP8, high VRAM, etc.)
@@ -395,16 +374,10 @@ jobs:
       self_name: stage-b-test-1-gpu-large
       runner_config: 1-gpu-large
       runs_on: 1-gpu-h100
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       timeout_per_file: '1800'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-b-test-2-gpu-large:
@@ -415,15 +388,9 @@ jobs:
       self_name: stage-b-test-2-gpu-large
       runner_config: 2-gpu-large
       runs_on: 2-gpu-h100
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-b-test-4-gpu-b200:
@@ -434,17 +401,11 @@ jobs:
       self_name: stage-b-test-4-gpu-b200
       runner_config: 4-gpu-b200
       runs_on: ${{ needs.check-changes.outputs.b200_runner }}
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       run_timeout_minutes: '40'
       extra_pytest_path: 'python/sglang/jit_kernel/tests/test_flash_attention_4.py'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   call-multimodal-gen-tests:
@@ -488,15 +449,9 @@ jobs:
       self_name: stage-c-test-4-gpu-h100
       runner_config: 4-gpu-h100
       runs_on: 4-gpu-h100
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-8-gpu-h200:
@@ -507,12 +462,9 @@ jobs:
       self_name: stage-c-test-8-gpu-h200
       runner_config: 8-gpu-h200
       runs_on: 8-gpu-h200
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       # Per-model TP must match the test's launch in test/registered/ -- see
       # FALLBACK_ARGS in scripts/ci/cuda/warmup_deep_gemm.py for extra dp/ep
       # flags. Only models that actually invoke DeepGEMM kernels at runtime
@@ -520,9 +472,6 @@ jobs:
       # Server CUDA Graph warmup is combined into this step (warmup_server_models unset).
       warmup_deep_gemm_models: 'deepseek-ai/DeepSeek-V3-0324:8 deepseek-ai/DeepSeek-V3.2:8 zai-org/GLM-5-FP8:8 XiaomiMiMo/MiMo-V2-Flash:4 XiaomiMiMo/MiMo-V2.5:8'
       warmup_timeout_minutes: '60'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-8-gpu-h20:
@@ -533,15 +482,9 @@ jobs:
       self_name: stage-c-test-8-gpu-h20
       runner_config: 8-gpu-h20
       runs_on: 8-gpu-h20
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-deepep-4-gpu-h100:
@@ -552,17 +495,11 @@ jobs:
       self_name: stage-c-test-deepep-4-gpu-h100
       runner_config: deepep-4-gpu-h100
       runs_on: 4-gpu-h100
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       warmup_deep_gemm_models: 'lmsys/sglang-ci-dsv3-test:4'
       warmup_server_models: 'lmsys/sglang-ci-dsv3-test:4'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-deepep-8-gpu-h200:
@@ -573,18 +510,12 @@ jobs:
       self_name: stage-c-test-deepep-8-gpu-h200
       runner_config: deepep-8-gpu-h200
       runs_on: 8-gpu-h200-deepep
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       run_timeout_minutes: '45'
       warmup_deep_gemm_models: 'deepseek-ai/DeepSeek-V3-0324:8 deepseek-ai/DeepSeek-V3.2:8'
       warmup_server_models: 'deepseek-ai/DeepSeek-V3-0324:8'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-4-gpu-b200:
@@ -595,16 +526,10 @@ jobs:
       self_name: stage-c-test-4-gpu-b200
       runner_config: 4-gpu-b200
       runs_on: ${{ needs.check-changes.outputs.b200_runner }}
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       timeout_per_file: '1800'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-dsv4-4-gpu-b200:
@@ -615,16 +540,10 @@ jobs:
       self_name: stage-c-test-dsv4-4-gpu-b200
       runner_config: dsv4-4-gpu-b200
       runs_on: ${{ needs.check-changes.outputs.b200_runner }}
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       timeout_per_file: '1800'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   stage-c-test-dsv4-8-gpu-h200:
@@ -635,16 +554,10 @@ jobs:
       self_name: stage-c-test-dsv4-8-gpu-h200
       runner_config: dsv4-8-gpu-h200
       runs_on: 8-gpu-h200
-      target_stage: ${{ inputs.target_stage || '' }}
-      test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
+      check_changes: ${{ toJson(needs.check-changes.outputs) }}
+      caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
-      main_package: ${{ needs.check-changes.outputs.main_package }}
-      sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
-      continue_on_error_flag: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
       timeout_per_file: '1800'
-      pr_head_sha: ${{ inputs.pr_head_sha || '' }}
-      git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
     secrets: inherit
 
   pr-test-finish:


### PR DESCRIPTION
Collapse 9 individually-forwarded inputs (4 from `check-changes.outputs` + 5 from pr-test workflow `inputs.*`) into 2 JSON bundle inputs (`check_changes`, `caller_inputs`) plus `partitions` standalone. Each CUDA stage caller stub shrinks from ~18 lines to ~12 lines.

## Why partitions stays standalone

`partitions` is itself a JSON string (GHA outputs are always strings). Inside `toJson(needs.check-changes.outputs)`, it becomes a JSON-escaped string requiring nested fromJson to read. Since `partitions` is referenced 3x in job-level `strategy.matrix` where step-resolution isn't available, the inline expressions stay short by keeping `partitions` as its own input.

## Equivalence verification

Python script concretizes all GHA contexts (`inputs.*`, `needs.check-changes.outputs.*`) to fixed fixture values, renders the effective reusable-workflow step list for both forms (main + PR), and compares byte-for-byte. 14/14 CUDA stages PASS:

https://gist.github.com/hnyls2002/73d317161cc2b29b63df1080970b6585