### PR TITLE
[diffusion] CI: fix nightly CI

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -697,7 +697,7 @@ jobs:
             --step-summary
 
       - name: Publish to sglang-ci-data
-        if: always() && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
+        if: always()
         env:
           GH_PAT_FOR_NIGHTLY_CI_DATA: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -697,7 +697,7 @@ jobs:
             --step-summary
 
       - name: Publish to sglang-ci-data
-        if: always()
+        if: always() && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
         env:
           GH_PAT_FOR_NIGHTLY_CI_DATA: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
         run: |

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -553,6 +553,8 @@ class LTX2SnapshotResidencyStrategy(LTX2TwoStageResidencyStrategy):
             if self._module_is_on_gpu(target_module):
                 self._record_component_ready("transformer")
             elif not self._snapshot_strategy.is_ready("transformer"):
+                if self._snapshot_low_vram_mode:
+                    self._release_stage2_for_low_vram()
                 self._snapshot_strategy.prefetch_component("transformer", target_module)
         else:
             self._record_component_ready("transformer")
@@ -622,6 +624,16 @@ class LTX2SnapshotResidencyStrategy(LTX2TwoStageResidencyStrategy):
         )
         if stage1_param is not None and stage1_param.device.type == "cuda":
             self._release_module_to_cpu_snapshot("transformer")
+
+    def _release_stage2_for_low_vram(self) -> None:
+        stage2_module = self.pipeline.get_module("transformer_2")
+        stage2_param = (
+            next(stage2_module.parameters(), None)
+            if stage2_module is not None
+            else None
+        )
+        if stage2_param is not None and stage2_param.device.type == "cuda":
+            self._release_module_to_cpu_snapshot("transformer_2")
 
     def _record_component_ready(self, module_name: str) -> None:
         self._snapshot_strategy.record_ready(

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -668,19 +668,37 @@ class ServerArgs(DisaggArgsMixin):
         )
 
         if self.strict_ports:
+            requested_ports = []
             if needs_http:
-                self._require_port(self.port, "HTTP")
-            self._require_port(self.scheduler_port, "Scheduler")
+                requested_ports.append((self.port, "HTTP"))
+            requested_ports.append((self.scheduler_port, "Scheduler"))
             if self.master_port is not None:
-                self._require_port(self.master_port, "Master")
+                requested_ports.append((self.master_port, "Master"))
+            seen_ports: dict[int, str] = {}
+            for port, name in requested_ports:
+                if port in seen_ports:
+                    raise RuntimeError(
+                        f"{name} port {port} duplicates {seen_ports[port]} port and "
+                        "--strict-ports is enabled."
+                    )
+                seen_ports[port] = name
+                self._require_port(port, name)
         else:
+            settled_ports: set[int] = set()
             if needs_http:
                 self.port = self.settle_port(self.port)
+                settled_ports.add(self.port)
             initial_scheduler_port = self.scheduler_port + (
                 random.randint(0, 100) if self.scheduler_port == 5555 else 0
             )
-            self.scheduler_port = self.settle_port(initial_scheduler_port)
-            self.master_port = self.settle_port(self.master_port, 37)
+            self.scheduler_port = self.settle_port(
+                initial_scheduler_port, avoid=settled_ports
+            )
+            settled_ports.add(self.scheduler_port)
+            if self.master_port is not None:
+                self.master_port = self.settle_port(
+                    self.master_port, 37, avoid=settled_ports
+                )
 
     def _adjust_parallelism(self):
         sp_unspecified = self.sp_degree is None
@@ -1369,16 +1387,21 @@ class ServerArgs(DisaggArgsMixin):
         return f"tcp://{scheduler_host}:{self.scheduler_port}"
 
     def settle_port(
-        self, port: int, port_inc: int = 42, max_attempts: int = 100
+        self,
+        port: int,
+        port_inc: int = 42,
+        max_attempts: int = 100,
+        avoid: set[int] | None = None,
     ) -> int:
         """
         Find an available port with retry logic.
         """
         attempts = 0
         original_port = port
+        avoid = avoid or set()
 
         while attempts < max_attempts:
-            if is_port_available(port):
+            if port not in avoid and is_port_available(port):
                 if attempts > 0:
                     logger.info(
                         f"Port {original_port} was unavailable, using port {port} instead"

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -149,7 +149,9 @@
             "frameworks": {
                 "sglang": {
                     "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2 --vae-cpu-offload",
-                    "extra_env": {}
+                    "extra_env": {
+                        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
+                    }
                 }
             }
         },

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -148,11 +148,8 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2 --vae-cpu-offload",
-                    "extra_env": {
-                        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
-                        "SGLANG_LTX2_SNAPSHOT_RELEASE_EMPTY_CACHE": "true"
-                    }
+                    "serve_args": "--enable-torch-compile --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
+                    "extra_env": {}
                 }
             }
         },

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -148,7 +148,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
+                    "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
                     "extra_env": {}
                 }
             }

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -150,7 +150,8 @@
                 "sglang": {
                     "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2 --vae-cpu-offload",
                     "extra_env": {
-                        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"
+                        "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+                        "SGLANG_LTX2_SNAPSHOT_RELEASE_EMPTY_CACHE": "true"
                     }
                 }
             }

--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -148,7 +148,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline",
+                    "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2 --vae-cpu-offload",
                     "extra_env": {}
                 }
             }

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -774,9 +774,8 @@ def run_single(
                     sys.stdout.write(f"  [server] {line}")
                     sys.stdout.flush()
                     fh.write(line)
-                    if (
-                        not server_error
-                        and any(pattern in line for pattern in SERVER_FATAL_ERROR_PATTERNS)
+                    if not server_error and any(
+                        pattern in line for pattern in SERVER_FATAL_ERROR_PATTERNS
                     ):
                         server_error["message"] = line.strip()
                         try:

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -40,11 +41,18 @@ CONFIGS_PATH = Path(__file__).parent / "comparison_configs.json"
 INSTALL_SCRIPT = Path(__file__).parents[1] / "install_comparison_frameworks.sh"
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 30000
+SGLANG_MASTER_PORT_OFFSET = 5
+SGLANG_SCHEDULER_PORT_OFFSET = 55
 HEALTH_TIMEOUT = (
     2400  # seconds (40 min — FLUX.2-dev needs ~10 min download + torch.compile)
 )
 REQUEST_TIMEOUT = 1200  # seconds
 GPU_CLEAR_WAIT = 15  # seconds between framework runs
+SERVER_FATAL_ERROR_PATTERNS = (
+    "CUDA out of memory",
+    "torch.OutOfMemoryError",
+    "OutOfMemoryError",
+)
 
 # Frameworks that need separate installation (conflict with sglang's deps)
 INSTALLABLE_FRAMEWORKS = {"vllm-omni", "lightx2v"}
@@ -69,6 +77,11 @@ def _build_sglang_cmd(case: dict, fw_cfg: dict, port: int) -> list[str]:
         str(port),
         "--host",
         DEFAULT_HOST,
+        "--strict-ports",
+        "--master-port",
+        str(port + SGLANG_MASTER_PORT_OFFSET),
+        "--scheduler-port",
+        str(port + SGLANG_SCHEDULER_PORT_OFFSET),
     ]
     if case["num_gpus"] > 1:
         cmd += ["--num-gpus", str(case["num_gpus"])]
@@ -240,29 +253,48 @@ def wait_for_health(
 KILLALL_SCRIPT = Path(__file__).parents[3] / "killall_sglang.sh"
 
 
-def kill_server(proc: subprocess.Popen) -> None:
-    """Kill server process tree and clean up GPU processes."""
-    if proc.poll() is not None:
-        return
-    try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-    except (ProcessLookupError, PermissionError):
-        pass
-    try:
-        proc.wait(timeout=30)
-    except subprocess.TimeoutExpired:
+def _is_port_available(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
-        proc.wait(timeout=10)
-    # Use killall_sglang.sh for thorough cleanup (esp. multi-GPU workers)
+            sock.bind((DEFAULT_HOST, port))
+        except OSError:
+            return False
+    return True
+
+
+def _require_ports_available(ports: list[int]) -> None:
+    unavailable = [port for port in ports if not _is_port_available(port)]
+    if unavailable:
+        raise RuntimeError(f"Required port(s) unavailable before launch: {unavailable}")
+
+
+def _cleanup_sglang_processes() -> None:
     if KILLALL_SCRIPT.exists():
         subprocess.run(
             ["bash", str(KILLALL_SCRIPT)],
             timeout=30,
             capture_output=True,
         )
+
+
+def kill_server(proc: subprocess.Popen) -> None:
+    """Kill server process tree and clean up GPU processes."""
+    if proc.poll() is None:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+            proc.wait(timeout=10)
+    # Use killall_sglang.sh for thorough cleanup (esp. multi-GPU workers)
+    _cleanup_sglang_processes()
 
 
 # ---------------------------------------------------------------------------
@@ -711,9 +743,20 @@ def run_single(
     log_file = log_dir / f"{case['id']}_{framework}.log"
     log_fh = open(log_file, "w", encoding="utf-8", buffering=1)
     log_thread = None
+    server_error = {}
 
     proc = None
     try:
+        if framework == "sglang":
+            _cleanup_sglang_processes()
+            _require_ports_available(
+                [
+                    port,
+                    port + SGLANG_MASTER_PORT_OFFSET,
+                    port + SGLANG_SCHEDULER_PORT_OFFSET,
+                ]
+            )
+
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -731,6 +774,15 @@ def run_single(
                     sys.stdout.write(f"  [server] {line}")
                     sys.stdout.flush()
                     fh.write(line)
+                    if (
+                        not server_error
+                        and any(pattern in line for pattern in SERVER_FATAL_ERROR_PATTERNS)
+                    ):
+                        server_error["message"] = line.strip()
+                        try:
+                            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                        except (ProcessLookupError, PermissionError):
+                            pass
             except ValueError:
                 pass  # pipe closed
 
@@ -752,7 +804,7 @@ def run_single(
             try:
                 send_request(base_url, warmup_case, framework, config)
             except Exception as e:
-                print(f"  Warmup request {wi} failed (non-fatal): {e}")
+                raise RuntimeError(f"Warmup request {wi} failed: {e}") from e
 
         # Measured request — pass perf_dump_path for SGLang server-side timing
         if perf_dump_path and os.path.exists(perf_dump_path):
@@ -764,8 +816,8 @@ def run_single(
         result["latency_s"] = round(latency, 3)
 
     except Exception as e:
-        result["error"] = str(e)
-        print(f"  ERROR: {e}")
+        result["error"] = server_error.get("message", str(e))
+        print(f"  ERROR: {result['error']}")
     finally:
         if proc:
             kill_server(proc)

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -51,7 +51,6 @@ GPU_CLEAR_WAIT = 15  # seconds between framework runs
 SERVER_FATAL_ERROR_PATTERNS = (
     "CUDA out of memory",
     "torch.OutOfMemoryError",
-    "OutOfMemoryError",
 )
 
 # Frameworks that need separate installation (conflict with sglang's deps)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Changes

- Make SGLang comparison runs use strict deterministic ports:
  - pass `--strict-ports`
  - derive dedicated HTTP / master / scheduler ports
  - preflight-check required ports before launch
  - clean up leftover SGLang processes before/after each comparison case

- Improve failure handling in `run_comparison.py`:
  - warmup request failures are now fatal
  - server-side CUDA OOM is detected from logs
  - the current server process group is terminated immediately
  - the case is reported as failed instead of hanging until timeout / NCCL timeout

- Fix LTX-2.3 two-stage snapshot residency with `--cfg-parallel-size 2`:
  - in low-VRAM snapshot mode, release stage2 DiT before request-tail stage1 DiT prefetch
  - this reduces the transient post-decode memory peak that caused OOM
  - keeps CFG parallel size 2 and does not add VAE offload / allocator env workarounds

- Harden `server_args` port settling:
  - strict mode now rejects duplicated HTTP / scheduler / master ports
  - non-strict fallback avoids settling different services onto the same port

- Adjust nightly workflow publishing:
  - skip `sglang-ci-data` publishing for manual non-main `workflow_dispatch` runs, avoiding permission noise during validation
## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25950822039](https://github.com/sgl-project/sglang/actions/runs/25950822039)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->