### PR TITLE
fix: duplicated "for" in sampling docstrings and linear comment

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/linear.py
@@ -939,7 +939,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
 
-        # Special case for for AQLM codebooks.
+        # Special case for AQLM codebooks.
         elif is_metadata:
             # metadata indicates fixed size concatenated along dim 0
             shard_size = loaded_weight.shape[0]

--- a/sgl-kernel/python/sgl_kernel/sampling.py
+++ b/sgl-kernel/python/sgl_kernel/sampling.py
@@ -37,7 +37,7 @@ def top_k_renorm_probs(
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
     top_k: Union[torch.Tensor, int]
-        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-k threshold for for
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-k threshold for
         for re-normalizing probabilities, should be in ``(0, num_classes)``.
         If a scalar, the same threshold is used for all requests.
         If a tensor, each request has its own threshold.
@@ -88,7 +88,7 @@ def top_p_renorm_probs(
     probs: torch.Tensor
         Probabilities, shape ``(batch_size, num_classes)``.
     top_p: Union[torch.Tensor, float]
-        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-p threshold for for
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the top-p threshold for
         re-normalizing probabilities, should be in ``(0, 1)``.
         If a scalar, the same threshold is used for all requests.
         If a tensor, each request has its own threshold.


### PR DESCRIPTION
Three one-line typo fixes for duplicated "for" in docstrings/comments:
- `sgl-kernel/python/sgl_kernel/sampling.py` (line 40, top-k threshold docstring) — "representing the top-k threshold for for" → "representing the top-k threshold for"
- `sgl-kernel/python/sgl_kernel/sampling.py` (line 91, top-p threshold docstring) — "representing the top-p threshold for for" → "representing the top-p threshold for"
- `python/sglang/multimodal_gen/runtime/layers/linear.py` — "# Special case for for AQLM codebooks." → "# Special case for AQLM codebooks."

No code/behavior change.