### PR TITLE
[AMD] amd/deepseek_v4 integration 28/N use aiter greedy_sample for all-greedy sampling on ROCm

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -20,6 +20,7 @@ from sglang.srt.utils.common import (
     crash_on_warnings,
     get_bool_env_var,
     is_cuda,
+    is_hip,
     is_npu,
 )
 
@@ -32,6 +33,10 @@ if is_cuda():
         top_k_renorm_prob,
         top_p_renorm_prob,
     )
+
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
+if _use_aiter:
+    from aiter import greedy_sample as _aiter_greedy_sample
 
 if is_npu():
     import torch_npu
@@ -109,8 +114,13 @@ class Sampler(nn.Module):
         logits = self._preprocess_logits(logits, sampling_info)
 
         if sampling_info.is_all_greedy:
-            # Use torch.argmax if all requests use greedy sampling
-            batch_next_token_ids = torch.argmax(logits, -1)
+            if _use_aiter:
+                batch_next_token_ids = torch.empty(
+                    logits.shape[0], device=logits.device, dtype=torch.int32
+                )
+                _aiter_greedy_sample(batch_next_token_ids, logits)
+            else:
+                batch_next_token_ids = torch.argmax(logits, -1)
             if return_logprob:
                 original_logprobs = logprobs = torch.nn.functional.log_softmax(
                     logits, dim=-1

--- a/test/registered/ops/test_aiter_greedy_sample_amd.py
+++ b/test/registered/ops/test_aiter_greedy_sample_amd.py
@@ -1,0 +1,301 @@
+"""Unit tests for aiter greedy_sample kernel and Sampler integration.
+
+Validates that:
+1. aiter.greedy_sample produces identical results to torch.argmax (kernel level)
+2. Sampler.forward() correctly dispatches to aiter when _use_aiter=True
+3. The fallback to torch.argmax works when _use_aiter=False
+4. return_logprob path works with the aiter greedy branch
+
+The kernel is designed for production LLM inference (large vocab, bf16) and is
+used when SGLANG_USE_AITER=1 on ROCm.
+"""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.utils.common import is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=60, suite="stage-b-test-1-gpu-small-amd")
+
+
+def _mock_global_server_args(backend="pytorch"):
+    from sglang.srt.layers import sampler as sampler_mod
+    from sglang.srt.server_args import ServerArgs
+
+    sampler_mod.get_global_server_args = lambda: ServerArgs(
+        model_path="dummy",
+        sampling_backend=backend,
+    )
+
+    class _DummyTPGroup:
+        device_group = None
+
+    sampler_mod.get_tp_group = lambda: _DummyTPGroup()
+    sampler_mod.is_dp_attention_enabled = lambda: False
+
+
+def _make_sampling_info(batch_size, vocab_size, device="cuda"):
+    from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+
+    return SamplingBatchInfo(
+        temperatures=torch.ones(batch_size, 1, device=device, dtype=torch.float),
+        top_ps=torch.ones(batch_size, device=device),
+        top_ks=torch.zeros(batch_size, device=device, dtype=torch.int32),
+        min_ps=torch.zeros(batch_size, device=device),
+        is_all_greedy=True,
+        need_top_p_sampling=False,
+        need_top_k_sampling=False,
+        need_min_p_sampling=False,
+        vocab_size=vocab_size,
+        device=device,
+    )
+
+
+@unittest.skipUnless(is_hip(), "aiter greedy_sample requires ROCm")
+class TestAiterGreedySample(unittest.TestCase):
+    """Kernel-level correctness: aiter.greedy_sample vs torch.argmax."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from aiter import greedy_sample
+
+            cls.greedy_sample = staticmethod(greedy_sample)
+        except ImportError:
+            raise unittest.SkipTest("aiter not installed")
+        cls.device = "cuda"
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+
+    def _run_and_compare(self, batch_size, vocab_size):
+        logits = torch.randn(
+            batch_size, vocab_size, device=self.device, dtype=torch.bfloat16
+        )
+
+        expected = torch.argmax(logits, dim=-1)
+
+        actual = torch.empty(
+            logits.shape[0], device=logits.device, dtype=torch.int32
+        )
+        self.greedy_sample(actual, logits)
+
+        self.assertTrue(
+            torch.equal(actual.to(expected.dtype), expected),
+            f"Mismatch for shape ({batch_size}, {vocab_size}): "
+            f"expected={expected[:8].tolist()}, got={actual[:8].tolist()}",
+        )
+
+    def test_single_request(self):
+        self._run_and_compare(1, 32000)
+
+    def test_small_batch(self):
+        self._run_and_compare(4, 32000)
+
+    def test_medium_batch(self):
+        self._run_and_compare(32, 32000)
+
+    def test_large_batch(self):
+        self._run_and_compare(128, 32000)
+
+    def test_realistic_vocab_deepseek(self):
+        self._run_and_compare(64, 129280)
+
+    def test_realistic_vocab_llama3(self):
+        self._run_and_compare(64, 128256)
+
+    def test_realistic_vocab_qwen(self):
+        self._run_and_compare(64, 151936)
+
+    def test_various_batch_sizes(self):
+        configs = [
+            (1, 128256),
+            (2, 128256),
+            (8, 128256),
+            (16, 128256),
+            (32, 129280),
+            (64, 129280),
+            (128, 129280),
+            (256, 129280),
+        ]
+        for batch_size, vocab_size in configs:
+            with self.subTest(batch_size=batch_size, vocab_size=vocab_size):
+                self._run_and_compare(batch_size, vocab_size)
+
+    def test_tied_values(self):
+        vocab_size = 32000
+        logits = torch.zeros(8, vocab_size, device=self.device, dtype=torch.bfloat16)
+        logits[:, 0] = 1.0
+
+        expected = torch.argmax(logits, dim=-1)
+        actual = torch.empty(8, device=self.device, dtype=torch.int32)
+        self.greedy_sample(actual, logits)
+
+        self.assertTrue(torch.equal(actual.to(expected.dtype), expected))
+
+    def test_negative_logits(self):
+        vocab_size = 32000
+        logits = (
+            torch.randn(16, vocab_size, device=self.device, dtype=torch.bfloat16) - 5.0
+        )
+
+        expected = torch.argmax(logits, dim=-1)
+        actual = torch.empty(16, device=self.device, dtype=torch.int32)
+        self.greedy_sample(actual, logits)
+
+        self.assertTrue(torch.equal(actual.to(expected.dtype), expected))
+
+    def test_extreme_values(self):
+        vocab_size = 32000
+        logits = torch.randn(16, vocab_size, device=self.device, dtype=torch.bfloat16)
+        logits[0, 42] = 1e4
+        logits[1, 100] = -1e4
+
+        expected = torch.argmax(logits, dim=-1)
+        actual = torch.empty(16, device=self.device, dtype=torch.int32)
+        self.greedy_sample(actual, logits)
+
+        self.assertTrue(torch.equal(actual.to(expected.dtype), expected))
+
+
+@unittest.skipUnless(is_hip(), "aiter greedy_sample requires ROCm")
+class TestAiterGreedyIntegration(unittest.TestCase):
+    """Integration: Sampler.forward() with _use_aiter on/off."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from aiter import greedy_sample
+
+            cls._greedy_sample_fn = staticmethod(greedy_sample)
+        except ImportError:
+            raise unittest.SkipTest("aiter not installed")
+        cls.device = "cuda"
+
+    def setUp(self):
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+
+    def _run_sampler(
+        self, use_aiter, logits, sampling_info, return_logprob=False
+    ):
+        from sglang.srt.layers import sampler as sampler_mod
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+
+        _mock_global_server_args()
+
+        patches = {"_use_aiter": use_aiter}
+        if use_aiter:
+            patches["_aiter_greedy_sample"] = self._greedy_sample_fn
+
+        with mock.patch.multiple(sampler_mod, **patches):
+            sampler = sampler_mod.Sampler()
+            batch_size = logits.shape[0]
+            positions = torch.arange(
+                batch_size, device=self.device, dtype=torch.int32
+            )
+
+            return sampler.forward(
+                logits_output=LogitsProcessorOutput(
+                    next_token_logits=logits.clone()
+                ),
+                sampling_info=sampling_info,
+                return_logprob=return_logprob,
+                top_logprobs_nums=[0] * batch_size,
+                token_ids_logprobs=[None] * batch_size,
+                positions=positions,
+            )
+
+    def test_aiter_matches_argmax_through_sampler(self):
+        batch_size, vocab_size = 64, 129280
+        logits = torch.randn(
+            batch_size, vocab_size, device=self.device, dtype=torch.bfloat16
+        )
+        sampling_info = _make_sampling_info(batch_size, vocab_size, self.device)
+
+        out_aiter = self._run_sampler(True, logits, sampling_info)
+        out_argmax = self._run_sampler(False, logits, sampling_info)
+
+        self.assertTrue(
+            torch.equal(out_aiter.cpu(), out_argmax.cpu()),
+            f"Sampler mismatch: aiter={out_aiter[:8].tolist()}, "
+            f"argmax={out_argmax[:8].tolist()}",
+        )
+
+    def test_fallback_to_argmax_when_disabled(self):
+        batch_size, vocab_size = 32, 32000
+        logits = torch.randn(
+            batch_size, vocab_size, device=self.device, dtype=torch.bfloat16
+        )
+        sampling_info = _make_sampling_info(batch_size, vocab_size, self.device)
+
+        out = self._run_sampler(False, logits, sampling_info)
+        expected = torch.argmax(logits, dim=-1)
+
+        self.assertTrue(
+            torch.equal(out.cpu(), expected.cpu()),
+            "Fallback path should produce torch.argmax results",
+        )
+
+    def test_aiter_greedy_with_return_logprob(self):
+        batch_size, vocab_size = 16, 32000
+        logits = torch.randn(
+            batch_size, vocab_size, device=self.device, dtype=torch.bfloat16
+        )
+        sampling_info = _make_sampling_info(batch_size, vocab_size, self.device)
+
+        out_aiter = self._run_sampler(
+            True, logits, sampling_info, return_logprob=True
+        )
+        out_argmax = self._run_sampler(
+            False, logits, sampling_info, return_logprob=True
+        )
+
+        self.assertTrue(
+            torch.equal(out_aiter.cpu(), out_argmax.cpu()),
+            "Token IDs should match with return_logprob=True",
+        )
+
+    def test_aiter_output_dtype(self):
+        """Document that the aiter path returns int32 (vs int64 from argmax)."""
+        batch_size, vocab_size = 16, 32000
+        logits = torch.randn(
+            batch_size, vocab_size, device=self.device, dtype=torch.bfloat16
+        )
+        sampling_info = _make_sampling_info(batch_size, vocab_size, self.device)
+
+        out_aiter = self._run_sampler(True, logits, sampling_info)
+        out_argmax = self._run_sampler(False, logits, sampling_info)
+
+        self.assertEqual(out_aiter.dtype, torch.int32)
+        self.assertEqual(out_argmax.dtype, torch.int64)
+
+    def test_various_batch_sizes_through_sampler(self):
+        vocab_size = 129280
+        for batch_size in [1, 4, 16, 64, 128]:
+            with self.subTest(batch_size=batch_size):
+                logits = torch.randn(
+                    batch_size,
+                    vocab_size,
+                    device=self.device,
+                    dtype=torch.bfloat16,
+                )
+                sampling_info = _make_sampling_info(
+                    batch_size, vocab_size, self.device
+                )
+
+                out_aiter = self._run_sampler(True, logits, sampling_info)
+                out_argmax = self._run_sampler(False, logits, sampling_info)
+
+                self.assertTrue(
+                    torch.equal(out_aiter.cpu(), out_argmax.cpu()),
+                    f"Mismatch at batch_size={batch_size}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Update amd/deepseek_v4 integration branch

Following PRs have large set of conflict, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608

co-author: @hubertlu-tw [17095](https://github.com/sgl-project/sglang/pull/17095)
## Motivation

The Sampler's all-greedy path currently uses `torch.argmax`, which dispatches to a generic `reduce_kernel` (ArgMaxOps). On ROCm/MI300, this kernel takes ~40.2 us per call and accounts for 7.4% of total kernel time during decode.

aiter provides a specialized `greedy_sample` kernel optimized for the argmax-over-vocabulary use case. This PR replaces `torch.argmax` with `aiter.greedy_sample` when running on HIP with `SGLANG_USE_AITER` enabled.

## Modifications

- **`python/sglang/srt/layers/sampler.py`**:
  - Import `is_hip` and conditionally import `aiter.greedy_sample` when `SGLANG_USE_AITER` is set on HIP.
  - In the all-greedy sampling path, use `aiter.greedy_sample` (pre-allocating an int32 output tensor) instead of `torch.argmax`.
  - Falls back to `torch.argmax` on non-HIP backends or when aiter is not enabled.

- **`test/registered/ops/test_aiter_greedy_sample_amd.py`** :
  - **Kernel-level tests** (`TestAiterGreedySample`): validates `aiter.greedy_sample` produces identical results to `torch.argmax` across realistic LLM vocab sizes (32k–152k), various batch sizes (1–256), and edge cases (tied values, negative logits, extreme values).
  - **Sampler integration tests** (`TestAiterGreedyIntegration`): exercises `Sampler.forward()` through the actual `_use_aiter` code path via `mock.patch`, covering:
    - aiter vs argmax token-ID equivalence through the full sampler
    - fallback to `torch.argmax` when `_use_aiter=False`
    - `return_logprob=True` path (logprob gather uses `batch_next_token_ids`)
    - output dtype contract (aiter returns int32, argmax returns int64)
    - various batch sizes through the sampler
  - Registered in AMD CI: `register_amd_ci(est_time=60, suite="stage-b-test-1-gpu-small-amd")`
  
## Accuracy Tests

| Metric | Value |
|---|---|
| Accuracy | 0.905 |
| Invalid | 0.001 |
| Latency | 240.024 s |
| Output throughput | 536.122 token/s |

## Benchmarking and Profiling

Sampler greedy kernel replacement (per call, ~2,050 calls during decode):

| Kernel | Before (us) | After (us) |
|---|---|---|
| `reduce_kernel` (ArgMaxOps) | 40.2 | — |
| `aiter::greedy_sample_kernel` | — | 10.3 |
| **Savings** | | **29.9 us/call (74.4% reduction)** |
| **% of total kernel time** | 7.4% | 2.2% |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->