### PR TITLE
[Lint] Fix `Optional[X] = (None,)` typo defaults in two dataclasses

### DIFF
--- a/python/sglang/lang/ir.py
+++ b/python/sglang/lang/ir.py
@@ -30,9 +30,9 @@ class SglSamplingParams:
     presence_penalty: float = 0.0
     ignore_eos: bool = False
     return_logprob: Optional[bool] = None
-    logprob_start_len: Optional[int] = (None,)
-    top_logprobs_num: Optional[int] = (None,)
-    return_text_in_logprobs: Optional[bool] = (None,)
+    logprob_start_len: Optional[int] = None
+    top_logprobs_num: Optional[int] = None
+    return_text_in_logprobs: Optional[bool] = None
     json_schema: Optional[str] = None
 
     # for constrained generation, not included in to_xxx_kwargs

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -32,7 +32,7 @@ class HiCacheStorageConfig:
 
 @dataclass
 class HiCacheStorageExtraInfo:
-    prefix_keys: Optional[List[str]] = (None,)
+    prefix_keys: Optional[List[str]] = None
     extra_info: Optional[dict] = None
 
 


### PR DESCRIPTION
## Summary

A trailing comma in a dataclass field default silently turns `None` into the 1-tuple `(None,)` — Python parses `x: T = None,` the same as `x: T = (None,)`. Both are falsy, so the wrong value can sit there unnoticed until something iterates the field.

None of the four sites here actually exercise the default (callers always pass explicit values), so this is **hygiene, not a live bugfix**. But the annotations and the values now match.

Fixed:
- `python/sglang/srt/mem_cache/hicache_storage.py:35` — `HiCacheStorageExtraInfo.prefix_keys`
- `python/sglang/lang/ir.py:33-35` — `SglSamplingParams.{logprob_start_len, top_logprobs_num, return_text_in_logprobs}`

## Test plan

- [x] Confirmed no call site of any of the four fields was relying on the buggy default
- [x] All pre-commit hooks pass