### PR TITLE
[NPU] Support model DeepSeek-OCR and DeepSeek-OCR-2

### DIFF
--- a/python/sglang/srt/models/deepseek.py
+++ b/python/sglang/srt/models/deepseek.py
@@ -39,7 +39,6 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.triton_utils import fused_moe
 from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
@@ -50,14 +49,22 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.utils import add_prefix, cpu_has_amx_support, is_cpu
+from sglang.srt.utils import add_prefix, cpu_has_amx_support, is_cpu, is_npu
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
+_is_npu = is_npu()
+
 if _is_cpu and _is_cpu_amx_available:
     import sgl_kernel  # noqa: F401
 
+if _is_npu:
+    from sglang.srt.hardware_backend.npu.quantization.fused_moe_method_npu import (
+        fused_moe_npu as fused_moe,
+    )
+else:
+    from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 
 class DeepseekMLP(nn.Module):
 
@@ -202,7 +209,7 @@ class DeepseekMoE(nn.Module):
                 True,  # is_vnni
             )
         else:
-            final_hidden_states = fused_moe.fused_moe(
+            final_hidden_states = fused_moe(
                 hidden_states,
                 w1=self.w1,
                 w2=self.w2,

--- a/python/sglang/srt/models/deepseek.py
+++ b/python/sglang/srt/models/deepseek.py
@@ -66,6 +66,7 @@ if _is_npu:
 else:
     from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
 
+
 class DeepseekMLP(nn.Module):
 
     def __init__(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Support DeepSeek-OCR and DeepSeek-OCR-2 model on NPU platform.

## Modifications

In NPU environment, `fused_moe_npu` from `sglang.srt.hardware_backend.npu.quantization.fused_moe_method_npu` should be used in `DeepseekMoE::forward()`.

## Accuracy Tests
Run the following command to start the SGLang inference service:
```
#!/bin/bash

export PYTHONPATH=/root/RemoteDev/sglang/python:$PYTHONPATH
export SGLANG_LOG_PATH=/root/run_scripts/DeepSeek-OCR-2/sglang.log
rm -rf $SGLANG_LOG_PATH

python -m sglang.launch_server \
--model-path  /home/weights/DeepSeek-OCR \
--enable-multimodal \
--mm-attention-backend ascend_attn \
--port 9090 \
--tp-size 1 \
--mem-fraction-static 0.7 \
--base-gpu-id 12 \
--max-total-tokens 4096 \
--attention-backend ascend \
--device npu \
--disable-cuda-graph \
--page-size 128 \
--skip-server-warmup
```
Run the following curl command to test the model performance:
```
root@localhost:/root/run_scripts/DeepSeek-OCR-2#curl -sS http://127.0.0.1:9090/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-ai/DeepSeek-OCR-2",
    "messages": [
      {
        "role": "user",
        "content": [
          { "type": "text", "text": "Describe the image." },
          { "type": "image_url", "image_url": { "url": "/root/run_scripts/DeepSeek-OCR-2/image.jpg" } }
        ]
      }
    ],
    "max_tokens": 256,
    "temperature": 0
  }'

root@localhost:/root/run_scripts/DeepSeek-OCR-2#{"id":"bb8bce24258d41a0bd91dbf97cd2a229","object":"chat.completion","created":1778741658,"model":"deepseek-ai/DeepSeek-OCR-2","choices":[{"index":0,"message":{"role":"assistant","content":":\nThree people are sitting around a table, looking at a laptop. The woman on the left is smiling and looking at the laptop. The woman in the middle is also smiling and looking at the laptop. The man on the right is looking at the laptop and smiling. There are two laptops on the table. There are two glasses of water on the table. There is a notebook and a pen on the table. The background is a wall with a plant in the corner. The style of the image is a photograph.","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":1}],"usage":{"prompt_tokens":868,"total_tokens":973,"completion_tokens":105,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
```
Use `evalscope` to test the model's accuracy on the OmniDocBench dataset:
```
evalscope eval --model /home/weight/DeepSeek-OCR-2/ --api-url http://127.0.0.1:9090/v1  --api-key EMPTY --eval-type openai_api --datasets omni_doc_bench --timeout 1800 --generation-config '{"max_tokens": 512}' --eval-batch-size 64
```
<img width="1693" height="720" alt="Deepseek-OCR模型精度结果" src="https://github.com/user-attachments/assets/7bef97af-dcd3-46c6-87c4-56b3f5946785" />
<img width="1696" height="607" alt="Deepseek-OCR-2模型精度结果" src="https://github.com/user-attachments/assets/a613ffd0-3989-41ca-94c2-f521e037056a" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #25849636245](https://github.com/sgl-project/sglang/actions/runs/25849636245)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->