### PR TITLE
[Fix] Disable shared expert fusion for GLM5 AutoRound INT4 MoE

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2435,8 +2435,14 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                 "Only Deepseek V3/R1 on AMD-platform with capability >= gfx942(MI30x) "
                 "can use shared experts fusion optimization under expert parallelism."
             )
-        elif self.quant_config and self.quant_config.get_name() == "w4afp8":
-            disable_reason = "Deepseek V3/R1 W4AFP8 model uses different quant method for routed experts and shared experts."
+        elif self.quant_config and self.quant_config.get_name() in {
+            "auto-round",
+            "w4afp8",
+        }:
+            disable_reason = (
+                "Deepseek V3/R1 AutoRound/W4AFP8 model uses different quant "
+                "method for routed experts and shared experts."
+            )
 
         if disable_reason is not None:
             server_args.disable_shared_experts_fusion = True


### PR DESCRIPTION
## Motivation

GLM-5 DSA AutoRound MoE checkpoints can quantize routed experts to INT4 while keeping shared experts in FP16/BF16. In this case, fusing shared experts into the routed MoE kernel makes them share the same fused MoE quantization assumptions.

On a GLM-5 INT4 mixed AutoRound checkpoint, enabling shared expert fusion produces incorrect first-token logits. The first generated token becomes `iko`, and the top-logprob distribution is abnormally flat. Disabling shared expert fusion removes this failure mode.

## Modifications

- Disable shared expert fusion when `quant_config.get_name()` is `auto-round` in the `DeepseekV2ForCausalLM` shared expert fusion gate.
- Keep the existing W4AFP8 behavior in the same guard, since W4AFP8 also uses different quantization methods for routed experts and shared experts.
- This is the path used by `GlmMoeDsaForCausalLM`, which subclasses `DeepseekV2ForCausalLM` and calls `determine_num_fused_shared_experts("GlmMoeDsaForCausalLM")`.
- Modified file:
  - `python/sglang/srt/models/deepseek_v2.py`

## Accuracy Tests

I ran a targeted regression check on a GLM-5 INT4 mixed AutoRound checkpoint. This is not a full accuracy validation because I have not compared the output logits against a reference implementation.

Prompt:

```json
{"text":"你好，请用一句话介绍你自己。","sampling_params":{"max_new_tokens":16,"temperature":0,"skip_special_tokens":false},"return_logprob":true,"top_logprobs_num":5}
```

With shared expert fusion enabled on this mixed-quant AutoRound checkpoint:

- First token: `23565 -> iko`
- First token logprob: about `-5.56`
- The output repeatedly generated `iko`
- The first-token top-logprob distribution was abnormally flat

With shared expert fusion disabled:

- The `iko` repetition disappeared
- First token logprob changed to about `-1.55`
- The output became a coherent Chinese fragment:

```text
?

我是个普通人，但我也是个不普通的人。
我是个普通人，因为我
```

Additional debugging checks:

- Tensor dumps for early and late layers showed no NaN/Inf.
- CPU recomputation of logits from the dumped final hidden state and checkpoint `lm_head.weight` matched SGLang logits, which suggests the issue is before `lm_head`, not in logits gather or logits processing.

This PR only disables a path that is demonstrably bad for the tested GLM-5 DSA mixed-quant AutoRound checkpoint. It does not claim full model accuracy parity with a reference implementation.

## Speed Tests and Profiling

Not run.

This change disables shared expert fusion for AutoRound/W4AFP8 checkpoints on the `DeepseekV2ForCausalLM` shared expert fusion path, where routed experts and shared experts can use different quantization formats. The concrete regression was reproduced on a GLM-5 DSA INT4 mixed AutoRound checkpoint. Since the fused path is numerically suspect for this configuration, I did not benchmark it as a valid performance baseline.

For models that do not use `auto-round` or `w4afp8`, this PR does not change the shared expert fusion path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes:

- I did not add a unit test because this behavior depends on the interaction between model architecture, quantization config, and large checkpoint weight layout. A mocked unit test would mostly duplicate implementation details without validating the actual mixed-quant failure mode.
- I did not update documentation because this is a model-path correctness guard rather than a user-facing feature or API change.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
