### PR TITLE
ci: dynamic partition + LPT from live sglang-ci-stats model

### DIFF
--- a/.github/workflows/_pr-test-check-changes.yml
+++ b/.github/workflows/_pr-test-check-changes.yml
@@ -255,10 +255,8 @@ jobs:
       - name: Fetch live partition model
         if: steps.partition-model-sha.outputs.sha != ''
         run: |
-          # SHA already resolved -> shards expect this fetch to succeed.
-          # Hard-fail (with curl --retry) instead of soft fallback so we
-          # don't get cross-shard LPT divergence when one shard's curl
-          # transiently fails while others succeed.
+          # SHA resolved -> require fetch (curl --retry). Soft fallback
+          # would risk cross-shard LPT divergence on transient curl flake.
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ steps.partition-model-sha.outputs.sha }}/model.json"
           curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \

--- a/.github/workflows/_pr-test-check-changes.yml
+++ b/.github/workflows/_pr-test-check-changes.yml
@@ -241,32 +241,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Pin every shard in this PR run to the same immutable partition
-          # model.json commit, even if the upstream cron commits a new
-          # version mid-flight. Soft fail: empty SHA -> downstream curl is
-          # skipped -> static fallback in both dispatch and runtime.
+          # Pin all shards to one immutable commit so dispatch and every
+          # runtime LPT use the same model snapshot. Soft fail -> static.
           SHA=$(gh api repos/sgl-project/sglang-ci-stats/commits/main --jq '.sha' 2>/dev/null || true)
           if [[ -n "$SHA" ]]; then
             echo "Pinned sglang-ci-stats@$SHA"
             echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::Could not resolve sglang-ci-stats SHA; falling back to in-source est_time everywhere"
+            echo "::warning::Could not resolve sglang-ci-stats SHA; using in-source est_time"
             echo "sha=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fetch live partition model
         if: steps.partition-model-sha.outputs.sha != ''
         run: |
-          # Use the SHA-pinned raw URL so this fetch and every downstream
-          # stage's fetch land on the same immutable file. compute_partitions
-          # treats a missing /tmp/partition-model.json as "fall back to
-          # in-source est_time + (coeff=1, bias=0)".
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ steps.partition-model-sha.outputs.sha }}/model.json"
           if curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json; then
             echo "Fetched partition-model.json ($(wc -c < /tmp/partition-model.json) bytes)"
           else
-            echo "::warning::Failed to fetch partition-model.json from $URL; compute_partitions will fall back to in-source est_time"
+            echo "::warning::Failed to fetch $URL; using in-source est_time"
           fi
 
       - name: Compute partitions

--- a/.github/workflows/_pr-test-check-changes.yml
+++ b/.github/workflows/_pr-test-check-changes.yml
@@ -255,13 +255,15 @@ jobs:
       - name: Fetch live partition model
         if: steps.partition-model-sha.outputs.sha != ''
         run: |
+          # SHA already resolved -> shards expect this fetch to succeed.
+          # Hard-fail (with curl --retry) instead of soft fallback so we
+          # don't get cross-shard LPT divergence when one shard's curl
+          # transiently fails while others succeed.
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ steps.partition-model-sha.outputs.sha }}/model.json"
-          if curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json; then
-            echo "Fetched partition-model.json ($(wc -c < /tmp/partition-model.json) bytes)"
-          else
-            echo "::warning::Failed to fetch $URL; using in-source est_time"
-          fi
+          curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \
+            "$URL" -o /tmp/partition-model.json
+          echo "Fetched partition-model.json ($(wc -c < /tmp/partition-model.json) bytes)"
 
       - name: Compute partitions
         id: partitions

--- a/.github/workflows/_pr-test-check-changes.yml
+++ b/.github/workflows/_pr-test-check-changes.yml
@@ -34,6 +34,8 @@ on:
         value: ${{ jobs.run.outputs.multimodal_gen }}
       partitions:
         value: ${{ jobs.run.outputs.partitions }}
+      partition_model_sha:
+        value: ${{ jobs.run.outputs.partition_model_sha }}
       b200_runner:
         value: ${{ jobs.run.outputs.b200_runner }}
       enable_retry:
@@ -60,6 +62,7 @@ jobs:
       jit_kernel: ${{ steps.filter-api.outputs.jit_kernel || steps.filter.outputs.jit_kernel || steps.run-mode.outputs.run_all_tests }}
       multimodal_gen: ${{ steps.filter-api.outputs.multimodal_gen || steps.filter.outputs.multimodal_gen || steps.run-mode.outputs.run_all_tests }}
       partitions: ${{ steps.partitions.outputs.partitions }}
+      partition_model_sha: ${{ steps.partition-model-sha.outputs.sha }}
       b200_runner: ${{ steps.set-runner.outputs.b200_runner }}
       enable_retry: ${{ steps.set-retry.outputs.enable_retry }}
       continue_on_error: ${{ steps.set-continue-on-error.outputs.continue_on_error }}
@@ -233,6 +236,39 @@ jobs:
           fi
           echo "full=$FULL" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve sglang-ci-stats SHA
+        id: partition-model-sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Pin every shard in this PR run to the same immutable partition
+          # model.json commit, even if the upstream cron commits a new
+          # version mid-flight. Soft fail: empty SHA -> downstream curl is
+          # skipped -> static fallback in both dispatch and runtime.
+          SHA=$(gh api repos/sgl-project/sglang-ci-stats/commits/main --jq '.sha' 2>/dev/null || true)
+          if [[ -n "$SHA" ]]; then
+            echo "Pinned sglang-ci-stats@$SHA"
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not resolve sglang-ci-stats SHA; falling back to in-source est_time everywhere"
+            echo "sha=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch live partition model
+        if: steps.partition-model-sha.outputs.sha != ''
+        run: |
+          # Use the SHA-pinned raw URL so this fetch and every downstream
+          # stage's fetch land on the same immutable file. compute_partitions
+          # treats a missing /tmp/partition-model.json as "fall back to
+          # in-source est_time + (coeff=1, bias=0)".
+          rm -f /tmp/partition-model.json
+          URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ steps.partition-model-sha.outputs.sha }}/model.json"
+          if curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json; then
+            echo "Fetched partition-model.json ($(wc -c < /tmp/partition-model.json) bytes)"
+          else
+            echo "::warning::Failed to fetch partition-model.json from $URL; compute_partitions will fall back to in-source est_time"
+          fi
+
       - name: Compute partitions
         id: partitions
         run: |
@@ -243,6 +279,7 @@ jobs:
           # See scripts/ci/utils/compute_partitions.py.
           python3 scripts/ci/utils/compute_partitions.py \
             --full-parallel ${{ steps.parallel-mode.outputs.full }} \
+            --partition-model-file /tmp/partition-model.json \
             >> "$GITHUB_OUTPUT"
 
       - name: Set B200 runner tag

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -35,9 +35,9 @@ on:
         type: string
         required: true
       run_timeout_minutes:
-        description: 'timeout-minutes for the Run test step.'
+        description: 'timeout-minutes for the Run test step. Required so compute_partitions.py can read it from pr-test.yml without a duplicated default constant.'
         type: string
-        default: '30'
+        required: true
       timeout_per_file:
         description: 'run_suite.py --timeout-per-file value (empty = unset).'
         type: string

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -150,14 +150,10 @@ jobs:
       - name: Fetch live partition model
         if: fromJson(inputs.check_changes).partition_model_sha != ''
         run: |
-          # Same SHA-pinned URL check-changes used, so this shard's LPT
-          # bucketing uses the exact `est` snapshot dispatch sized the stage
-          # with. Soft fail: missing file -> run_suite.py falls back to
-          # in-source est_time for LPT.
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ fromJson(inputs.check_changes).partition_model_sha }}/model.json"
           curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json \
-            || echo "::warning::Failed to fetch partition-model.json from $URL; LPT will use in-source est_time"
+            || echo "::warning::Failed to fetch $URL; LPT will use in-source est_time"
 
       - name: Run test
         timeout-minutes: ${{ fromJson(inputs.run_timeout_minutes) }}

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -147,6 +147,18 @@ jobs:
           [ -f "${SGLANG_CI_VENV_PATH:-/dev/null}/env.sh" ] && source "${SGLANG_CI_VENV_PATH}/env.sh"
           python3 scripts/ci/cuda/warmup_server.py ${{ inputs.warmup_server_models }}
 
+      - name: Fetch live partition model
+        if: fromJson(inputs.check_changes).partition_model_sha != ''
+        run: |
+          # Same SHA-pinned URL check-changes used, so this shard's LPT
+          # bucketing uses the exact `est` snapshot dispatch sized the stage
+          # with. Soft fail: missing file -> run_suite.py falls back to
+          # in-source est_time for LPT.
+          rm -f /tmp/partition-model.json
+          URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ fromJson(inputs.check_changes).partition_model_sha }}/model.json"
+          curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json \
+            || echo "::warning::Failed to fetch partition-model.json from $URL; LPT will use in-source est_time"
+
       - name: Run test
         timeout-minutes: ${{ fromJson(inputs.run_timeout_minutes) }}
         env:
@@ -156,6 +168,7 @@ jobs:
           python3 run_suite.py --hw cuda --suite ${{ inputs.self_name }} \
             --auto-partition-id ${{ matrix.partition }} \
             --auto-partition-size ${{ fromJson(inputs.partitions)[inputs.self_name].size }} \
+            --partition-model-file /tmp/partition-model.json \
             ${{ inputs.timeout_per_file && format('--timeout-per-file {0}', inputs.timeout_per_file) || '' }} \
             $CONTINUE_ON_ERROR_FLAG
 

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -150,10 +150,13 @@ jobs:
       - name: Fetch live partition model
         if: fromJson(inputs.check_changes).partition_model_sha != ''
         run: |
+          # SHA already resolved by check-changes -> hard-fail (with curl
+          # --retry) instead of soft fallback so all shards stay on the
+          # same partition model snapshot.
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ fromJson(inputs.check_changes).partition_model_sha }}/model.json"
-          curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json \
-            || echo "::warning::Failed to fetch $URL; LPT will use in-source est_time"
+          curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \
+            "$URL" -o /tmp/partition-model.json
 
       - name: Run test
         timeout-minutes: ${{ fromJson(inputs.run_timeout_minutes) }}

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -150,9 +150,8 @@ jobs:
       - name: Fetch live partition model
         if: fromJson(inputs.check_changes).partition_model_sha != ''
         run: |
-          # SHA already resolved by check-changes -> hard-fail (with curl
-          # --retry) instead of soft fallback so all shards stay on the
-          # same partition model snapshot.
+          # SHA resolved by check-changes -> require fetch (curl --retry)
+          # so all shards stay on the same snapshot.
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ fromJson(inputs.check_changes).partition_model_sha }}/model.json"
           curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -352,13 +352,29 @@ jobs:
         run: |
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 
+      - name: Fetch live partition model
+        if: needs.check-changes.outputs.partition_model_sha != ''
+        run: |
+          # Same SHA-pinned URL check-changes used, so this shard's LPT
+          # bucketing uses the exact `est` snapshot dispatch sized the
+          # stage with. Soft fail: missing file -> run_suite.py falls back
+          # to in-source est_time for LPT.
+          rm -f /tmp/partition-model.json
+          URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ needs.check-changes.outputs.partition_model_sha }}/model.json"
+          curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json \
+            || echo "::warning::Failed to fetch partition-model.json from $URL; LPT will use in-source est_time"
+
       - name: Run test
         timeout-minutes: 10
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          python3 run_suite.py --hw cpu --suite stage-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }} $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cpu --suite stage-a-test-cpu \
+            --auto-partition-id ${{ matrix.partition }} \
+            --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }} \
+            --partition-model-file /tmp/partition-model.json \
+            $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)
   stage-b-test-1-gpu-small:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -355,14 +355,10 @@ jobs:
       - name: Fetch live partition model
         if: needs.check-changes.outputs.partition_model_sha != ''
         run: |
-          # Same SHA-pinned URL check-changes used, so this shard's LPT
-          # bucketing uses the exact `est` snapshot dispatch sized the
-          # stage with. Soft fail: missing file -> run_suite.py falls back
-          # to in-source est_time for LPT.
           rm -f /tmp/partition-model.json
           URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ needs.check-changes.outputs.partition_model_sha }}/model.json"
           curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json \
-            || echo "::warning::Failed to fetch partition-model.json from $URL; LPT will use in-source est_time"
+            || echo "::warning::Failed to fetch $URL; LPT will use in-source est_time"
 
       - name: Run test
         timeout-minutes: 10

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -358,10 +358,7 @@ jobs:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          python3 run_suite.py --hw cpu --suite stage-a-test-cpu \
-            --auto-partition-id ${{ matrix.partition }} \
-            --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }} \
-            $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cpu --suite stage-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }} $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)
   stage-b-test-1-gpu-small:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -552,6 +552,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '45'
       timeout_per_file: '1800'
     secrets: inherit
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -372,6 +372,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
     secrets: inherit
 
   # Runs on H100 (80GB, SM90) - tests that don't pass on 5090 (FA3, FP8, high VRAM, etc.)
@@ -386,6 +387,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
       timeout_per_file: '1800'
     secrets: inherit
 
@@ -400,6 +402,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
     secrets: inherit
 
   stage-b-test-4-gpu-b200:
@@ -461,6 +464,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
     secrets: inherit
 
   stage-c-test-8-gpu-h200:
@@ -474,6 +478,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
       # Per-model TP must match the test's launch in test/registered/ -- see
       # FALLBACK_ARGS in scripts/ci/cuda/warmup_deep_gemm.py for extra dp/ep
       # flags. Only models that actually invoke DeepGEMM kernels at runtime
@@ -494,6 +499,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
     secrets: inherit
 
   stage-c-test-deepep-4-gpu-h100:
@@ -507,6 +513,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
       warmup_deep_gemm_models: 'lmsys/sglang-ci-dsv3-test:4'
       warmup_server_models: 'lmsys/sglang-ci-dsv3-test:4'
     secrets: inherit
@@ -538,6 +545,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
       timeout_per_file: '1800'
     secrets: inherit
 
@@ -567,6 +575,7 @@ jobs:
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
+      run_timeout_minutes: '30'
       timeout_per_file: '1800'
     secrets: inherit
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -352,14 +352,6 @@ jobs:
         run: |
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 
-      - name: Fetch live partition model
-        if: needs.check-changes.outputs.partition_model_sha != ''
-        run: |
-          rm -f /tmp/partition-model.json
-          URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ needs.check-changes.outputs.partition_model_sha }}/model.json"
-          curl --fail --silent --show-error --max-time 15 "$URL" -o /tmp/partition-model.json \
-            || echo "::warning::Failed to fetch $URL; LPT will use in-source est_time"
-
       - name: Run test
         timeout-minutes: 10
         env:
@@ -369,7 +361,6 @@ jobs:
           python3 run_suite.py --hw cpu --suite stage-a-test-cpu \
             --auto-partition-id ${{ matrix.partition }} \
             --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }} \
-            --partition-model-file /tmp/partition-model.json \
             $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -297,11 +297,9 @@ def auto_partition(
     estimated times using a greedy algorithm (LPT heuristic), and return the
     partition for the specified rank.
 
-    `live_est` (optional): map from `CIRegistry.filename` to override est
-    seconds (from sglang-ci-stats' model.json p90). Files absent fall back
-    to the in-source `est_time` literal. Both the sort key and the LPT sum
-    use this effective est so a stale in-source value can't push a long
-    file into a shard where it'll blow MAX_PARTITION_SECONDS.
+    `live_est` (optional): `filename -> est seconds` overrides (from
+    sglang-ci-stats `model.json` p90); files absent fall back to in-source
+    `est_time`. Used by both the sort key and the LPT sum.
     """
     if not files or size <= 0:
         return []

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -287,17 +287,33 @@ def ut_parse_one_file(filename: str) -> Tuple[List[CIRegistry], bool]:
     return visitor.registries, visitor.has_main_entry
 
 
-def auto_partition(files: List[CIRegistry], rank: int, size: int) -> List[CIRegistry]:
+def auto_partition(
+    files: List[CIRegistry],
+    rank: int,
+    size: int,
+    live_est: Optional[dict] = None,
+) -> List[CIRegistry]:
     """Partition files into `size` sublists with approximately equal sums of
     estimated times using a greedy algorithm (LPT heuristic), and return the
     partition for the specified rank.
+
+    `live_est` (optional): map from `CIRegistry.filename` to override est
+    seconds (from sglang-ci-stats' model.json p90). Files absent fall back
+    to the in-source `est_time` literal. Both the sort key and the LPT sum
+    use this effective est so a stale in-source value can't push a long
+    file into a shard where it'll blow MAX_PARTITION_SECONDS.
     """
     if not files or size <= 0:
         return []
 
+    def est_of(f: CIRegistry) -> float:
+        if live_est is not None and f.filename in live_est:
+            return live_est[f.filename]
+        return f.est_time
+
     # Sort by estimated_time descending; filename as tie-breaker for
     # deterministic partitioning regardless of glob ordering.
-    sorted_files = sorted(files, key=lambda f: (-f.est_time, f.filename))
+    sorted_files = sorted(files, key=lambda f: (-est_of(f), f.filename))
 
     partitions: List[List[CIRegistry]] = [[] for _ in range(size)]
     partition_sums = [0.0] * size
@@ -306,7 +322,7 @@ def auto_partition(files: List[CIRegistry], rank: int, size: int) -> List[CIRegi
     for file in sorted_files:
         min_sum_idx = min(range(size), key=partition_sums.__getitem__)
         partitions[min_sum_idx].append(file)
-        partition_sums[min_sum_idx] += file.est_time
+        partition_sums[min_sum_idx] += est_of(file)
 
     if rank < size:
         return partitions[rank]

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -297,9 +297,8 @@ def auto_partition(
     estimated times using a greedy algorithm (LPT heuristic), and return the
     partition for the specified rank.
 
-    `live_est` (optional): `filename -> est seconds` overrides (from
-    sglang-ci-stats `model.json` p90); files absent fall back to in-source
-    `est_time`. Used by both the sort key and the LPT sum.
+    `live_est`: optional `filename -> est seconds` overrides; missing
+    files fall back to in-source `est_time`.
     """
     if not files or size <= 0:
         return []

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -1,8 +1,17 @@
-"""Sum CIRegistry est_time per per-commit suite and emit one $GITHUB_OUTPUT line
+"""Sum est_time per per-commit suite and emit one $GITHUB_OUTPUT line
 keyed by suite name. Consumed by pr-test.yml stage jobs as
 `fromJson(needs.check-changes.outputs.partitions)['<suite>']`.
 
     partitions={"stage-b-test-1-gpu-small": {"size": 8, "arr": [0,...,7], "max_parallel": 2}, ...}
+
+Per-shard wall-clock estimate, when a live model is available:
+
+    pred_shard_wall = coeff * sum(est[file] for file in shard) + bias
+
+where `est`, `coeff`, `bias` come from sglang-ci-stats' `model.json`. Each
+falls back independently to (a) the in-source `register_X_ci(est_time=N)`
+literal for a missing per-file `est`, and (b) `(coeff=1.0, bias=0.0)` for
+a missing per-suite fit.
 """
 
 import argparse
@@ -41,12 +50,12 @@ _STAGE_A_OVERRIDES = {
 
 # Per-partition wall-clock target. ~20 min avg naive; worst-case LPT 4/3
 # imbalance is ~27 min, still below the 30-min job-level timeout that acts
-# as the real safety net. No LPT slop applied — we lean on the runtime
+# as the real safety net. No LPT slop applied -- we lean on the runtime
 # timeout + the explicit MAX_PARTITION_SECONDS sanity check rather than
 # padding partition count.
 TARGET_SECONDS = 20 * 60
 
-# Hard ceiling. Exceeded → raise, forcing the maintainer to split a slow file
+# Hard ceiling. Exceeded -> raise, forcing the maintainer to split a slow file
 # or bump TARGET_SECONDS deliberately.
 MAX_PARTITION_SECONDS = 30 * 60
 
@@ -70,12 +79,33 @@ def discover_files(repo_root: str) -> list[str]:
     return files
 
 
+def load_partition_model(path):
+    """Read sglang-ci-stats' model.json. Returns None when path is missing
+    or unparsable -- the caller falls back to (in-source est, coeff=1,
+    bias=0) on a per-suite / per-file basis.
+
+    Note the upstream file is called `model.json`; the `partition_model_*`
+    naming in sglang disambiguates against ML model checkpoints."""
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def compute_max_parallel(size: int) -> int:
     return max(size // 4, 1)
 
 
-def compute_partitions(tests, full_parallel=False):
+def compute_partitions(tests, repo_root, partition_model=None, full_parallel=False):
     """Group per-commit tests by suite and emit partition metadata.
+
+    `partition_model` (optional): parsed `model.json` from sglang-ci-stats.
+    Each missing key falls back independently: a file absent from
+    `partition_model["est"][suite]` keeps its in-source `est_time`; a
+    suite absent from `partition_model["fit"]` uses `(coeff=1.0, bias=0.0)`.
 
     `full_parallel=True` (scheduled cron or `high priority` PR) sets
     max_parallel = size, lifting the matrix-fanout throttle.
@@ -88,24 +118,50 @@ def compute_partitions(tests, full_parallel=False):
             continue
         suite_tests[t.effective_suite].append(t)
 
+    est_table = (partition_model or {}).get("est", {})
+    fit_table = (partition_model or {}).get("fit", {})
+
     result = {}
     for suite, group in suite_tests.items():
-        total = sum(t.est_time for t in group)
+        live_est = est_table.get(suite, {})
+        total = 0.0
+        for t in group:
+            relpath = os.path.relpath(t.filename, repo_root)
+            total += live_est.get(relpath, t.est_time)
+
+        fit = fit_table.get(suite)
+        coeff = fit["coeff"] if fit else 1.0
+        bias = fit["bias"] if fit else 0.0
+
+        # Each shard pays `bias` once (setup / install / warmup overhead),
+        # so the per-shard budget for actual test elapsed is
+        # (TARGET - bias) / coeff. Solve:
+        #     coeff * (total / size) + bias <= TARGET
+        # ->  size >= coeff * total / (TARGET - bias)
         if suite in _STAGE_A_OVERRIDES:
             size = _STAGE_A_OVERRIDES[suite]
             max_parallel = size
         else:
-            size = max(1, math.ceil(total / TARGET_SECONDS))
+            budget = TARGET_SECONDS - bias
+            if budget <= 0:
+                raise RuntimeError(
+                    f"Suite {suite!r}: fit bias={bias}s >= TARGET={TARGET_SECONDS}s. "
+                    "Raise TARGET_SECONDS or investigate why this suite's overhead "
+                    "alone exceeds the per-shard budget."
+                )
+            size = max(1, math.ceil(coeff * total / budget))
             max_parallel = size if full_parallel else compute_max_parallel(size)
-        # Check naive average (total/size). LPT can be ~4/3 of that in
-        # worst case; the 30-min job timeout enforces the real ceiling at
-        # runtime. This build-time check fails fast on egregious misconfigs.
-        if total / size > MAX_PARTITION_SECONDS:
+        # Predicted per-shard wall on naive average (total/size). LPT can
+        # be ~4/3 of that in worst case; the 30-min job timeout enforces
+        # the real ceiling at runtime. This build-time check fails fast
+        # on egregious misconfigs (e.g. stage-a override fixed too small).
+        pred_per_shard = coeff * (total / size) + bias
+        if pred_per_shard > MAX_PARTITION_SECONDS:
             raise RuntimeError(
-                f"Suite {suite!r}: total est_time {total:.0f}s / size {size} "
-                f"= {total / size:.0f}s exceeds MAX_PARTITION_SECONDS "
-                f"({MAX_PARTITION_SECONDS}s). Split a slow file or raise "
-                f"TARGET_SECONDS deliberately."
+                f"Suite {suite!r}: predicted shard wall {pred_per_shard:.0f}s "
+                f"(coeff={coeff} * total={total:.0f}/size={size} + bias={bias}) "
+                f"exceeds MAX_PARTITION_SECONDS ({MAX_PARTITION_SECONDS}s). "
+                f"Split a slow file or raise TARGET_SECONDS deliberately."
             )
         result[suite] = {
             "size": size,
@@ -130,14 +186,25 @@ def main():
         default="false",
         help="Lift the max_parallel throttle (set by schedule / `high priority`)",
     )
+    parser.add_argument(
+        "--partition-model-file",
+        default=None,
+        help="Path to sglang-ci-stats model.json (omit/missing -> static fallback)",
+    )
     args = parser.parse_args()
 
     files = discover_files(args.repo_root)
     # Warn-not-fail on unregistered files: run_suite.py catches this at
     # test-execution time with sanity_check=True; dispatch should keep going.
     all_tests = collect_tests(files, sanity_check=False)
+    partition_model = load_partition_model(args.partition_model_file)
 
-    result = compute_partitions(all_tests, full_parallel=(args.full_parallel == "true"))
+    result = compute_partitions(
+        all_tests,
+        repo_root=args.repo_root,
+        partition_model=partition_model,
+        full_parallel=(args.full_parallel == "true"),
+    )
     payload = json.dumps(result, separators=(",", ":"), sort_keys=True)
     if args.output_format == "gha":
         print(f"partitions={payload}")
@@ -148,9 +215,20 @@ def main():
     if summary_path:
         with open(summary_path, "a") as f:
             f.write("## Partitions\n\n")
+            if partition_model is None:
+                src_note = (
+                    "live partition model unavailable -- "
+                    "all suites fall back to in-source est_time + (coeff=1, bias=0)"
+                )
+            else:
+                src_note = (
+                    f"live partition model: "
+                    f"`data_as_of={partition_model.get('data_as_of')}`, "
+                    f"`n_runs={partition_model.get('n_runs')}`"
+                )
             f.write(
                 f"`full_parallel={args.full_parallel}` "
-                f"(`size//4` throttle is lifted when true)\n\n"
+                f"(`size//4` throttle is lifted when true); {src_note}\n\n"
             )
             f.write("| Suite | size | max_parallel |\n")
             f.write("|---|---:|---:|\n")

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -109,7 +109,7 @@ def load_partition_model(path):
 
 
 def compute_max_parallel(size: int) -> int:
-    return max(size // 4, 1)
+    return max(size // 3, 1)
 
 
 def compute_partitions(
@@ -251,7 +251,7 @@ def main():
                 )
             f.write(
                 f"`full_parallel={args.full_parallel}` "
-                f"(`size//4` throttle is lifted when true); {src_note}\n\n"
+                f"(`size//3` throttle is lifted when true); {src_note}\n\n"
             )
             f.write("| Suite | size | max_parallel |\n")
             f.write("|---|---:|---:|\n")

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -3,15 +3,6 @@ keyed by suite name. Consumed by pr-test.yml stage jobs as
 `fromJson(needs.check-changes.outputs.partitions)['<suite>']`.
 
     partitions={"stage-b-test-1-gpu-small": {"size": 8, "arr": [0,...,7], "max_parallel": 2}, ...}
-
-Per-shard wall-clock estimate, when a live model is available:
-
-    pred_shard_wall = coeff * sum(est[file] for file in shard) + bias
-
-where `est`, `coeff`, `bias` come from sglang-ci-stats' `model.json`. Each
-falls back independently to (a) the in-source `register_X_ci(est_time=N)`
-literal for a missing per-file `est`, and (b) `(coeff=1.0, bias=0.0)` for
-a missing per-suite fit.
 """
 
 import argparse
@@ -80,12 +71,7 @@ def discover_files(repo_root: str) -> list[str]:
 
 
 def load_partition_model(path):
-    """Read sglang-ci-stats' model.json. Returns None when path is missing
-    or unparsable -- the caller falls back to (in-source est, coeff=1,
-    bias=0) on a per-suite / per-file basis.
-
-    Note the upstream file is called `model.json`; the `partition_model_*`
-    naming in sglang disambiguates against ML model checkpoints."""
+    """Read sglang-ci-stats' model.json; None on missing/unparsable."""
     if not path or not os.path.exists(path):
         return None
     try:
@@ -102,10 +88,9 @@ def compute_max_parallel(size: int) -> int:
 def compute_partitions(tests, repo_root, partition_model=None, full_parallel=False):
     """Group per-commit tests by suite and emit partition metadata.
 
-    `partition_model` (optional): parsed `model.json` from sglang-ci-stats.
-    Each missing key falls back independently: a file absent from
-    `partition_model["est"][suite]` keeps its in-source `est_time`; a
-    suite absent from `partition_model["fit"]` uses `(coeff=1.0, bias=0.0)`.
+    `partition_model` (optional): sglang-ci-stats `model.json`. Per-file
+    `est` and per-suite `(coeff, bias)` fit; either may be missing and
+    falls back to (in-source `est_time`, `(1.0, 0.0)`) independently.
 
     `full_parallel=True` (scheduled cron or `high priority` PR) sets
     max_parallel = size, lifting the matrix-fanout throttle.
@@ -133,11 +118,7 @@ def compute_partitions(tests, repo_root, partition_model=None, full_parallel=Fal
         coeff = fit["coeff"] if fit else 1.0
         bias = fit["bias"] if fit else 0.0
 
-        # Each shard pays `bias` once (setup / install / warmup overhead),
-        # so the per-shard budget for actual test elapsed is
-        # (TARGET - bias) / coeff. Solve:
-        #     coeff * (total / size) + bias <= TARGET
-        # ->  size >= coeff * total / (TARGET - bias)
+        # Each shard pays `bias` once, so size >= coeff*total / (TARGET-bias).
         if suite in _STAGE_A_OVERRIDES:
             size = _STAGE_A_OVERRIDES[suite]
             max_parallel = size
@@ -154,7 +135,7 @@ def compute_partitions(tests, repo_root, partition_model=None, full_parallel=Fal
         # Predicted per-shard wall on naive average (total/size). LPT can
         # be ~4/3 of that in worst case; the 30-min job timeout enforces
         # the real ceiling at runtime. This build-time check fails fast
-        # on egregious misconfigs (e.g. stage-a override fixed too small).
+        # on egregious misconfigs.
         pred_per_shard = coeff * (total / size) + bias
         if pred_per_shard > MAX_PARTITION_SECONDS:
             raise RuntimeError(
@@ -216,14 +197,10 @@ def main():
         with open(summary_path, "a") as f:
             f.write("## Partitions\n\n")
             if partition_model is None:
-                src_note = (
-                    "live partition model unavailable -- "
-                    "all suites fall back to in-source est_time + (coeff=1, bias=0)"
-                )
+                src_note = "no live model -- static est_time + (coeff=1, bias=0)"
             else:
                 src_note = (
-                    f"live partition model: "
-                    f"`data_as_of={partition_model.get('data_as_of')}`, "
+                    f"live model `data_as_of={partition_model.get('data_as_of')}`, "
                     f"`n_runs={partition_model.get('n_runs')}`"
                 )
             f.write(

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -43,17 +43,14 @@ _STAGE_A_OVERRIDES = {
 
 _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
 
-# Mirror `_pr-test-stage.yml` `inputs.run_timeout_minutes.default`. Keep
-# in sync if that default ever changes (last touched 2026-05-13).
-_RUN_TIMEOUT_MIN_DEFAULT = 30
-
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
     """Map `self_name -> run_timeout_minutes` by reading `pr-test.yml`.
-    Stages without an explicit `run_timeout_minutes:` fall back to
-    `_RUN_TIMEOUT_MIN_DEFAULT`. Stage-a-test-cpu lives inline (not via
-    the reusable workflow) and is skipped here -- it goes through
-    `_STAGE_A_OVERRIDES` and never consults `run_timeouts`."""
+    Every stage that uses `_pr-test-stage.yml` must specify
+    `run_timeout_minutes:` (it's a required reusable-workflow input);
+    KeyError surfaces a missing one. Stage-a-test-cpu lives inline and
+    is skipped here -- it goes through `_STAGE_A_OVERRIDES` and never
+    consults `run_timeouts`."""
     with open(pr_test_yml_path) as f:
         wf = yaml.safe_load(f)
     timeouts = {}
@@ -62,9 +59,7 @@ def load_run_timeouts(pr_test_yml_path: str) -> dict:
             continue
         with_ = job.get("with") or {}
         suite = with_.get("self_name", job_id)
-        timeouts[suite] = int(
-            with_.get("run_timeout_minutes", _RUN_TIMEOUT_MIN_DEFAULT)
-        )
+        timeouts[suite] = int(with_["run_timeout_minutes"])
     if not timeouts:
         raise RuntimeError(
             f"load_run_timeouts: no jobs matched uses={_REUSABLE_STAGE_USES!r} "

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -41,19 +41,39 @@ _STAGE_A_OVERRIDES = {
     "stage-a-test-1-gpu-small": 1,
 }
 
-# Default Run-test step timeout (minutes); mirrors `_pr-test-stage.yml`
-# `inputs.run_timeout_minutes.default`. Used when pr-test.yml doesn't
-# explicitly override for a given stage.
-_RUN_TIMEOUT_MIN_DEFAULT = 30
 _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
+_REUSABLE_STAGE_YML = os.path.join(
+    REPO_ROOT, ".github", "workflows", "_pr-test-stage.yml"
+)
+
+
+def load_run_timeout_default(stage_yml_path: str = _REUSABLE_STAGE_YML) -> int:
+    """Read `inputs.run_timeout_minutes.default` from `_pr-test-stage.yml`.
+    Source of truth for the default applied to stages that don't override
+    in pr-test.yml."""
+    with open(stage_yml_path) as f:
+        wf = yaml.safe_load(f)
+    # PyYAML (YAML 1.1) parses the `on:` key as boolean True.
+    on_block = wf.get(True) or wf.get("on") or {}
+    inputs = (on_block.get("workflow_call") or {}).get("inputs") or {}
+    spec = inputs.get("run_timeout_minutes") or {}
+    default = spec.get("default")
+    if default is None:
+        raise RuntimeError(
+            f"run_timeout_minutes.default missing in {stage_yml_path}; "
+            "schema changed?"
+        )
+    return int(default)
 
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
     """Map `self_name -> run_timeout_minutes` by reading `pr-test.yml`.
-    Source of truth is the workflow file; missing entries default to
-    `_RUN_TIMEOUT_MIN_DEFAULT`. Stage-a-test-cpu lives inline (not via
-    the reusable workflow) and is skipped here -- it goes through
-    `_STAGE_A_OVERRIDES` and never consults `run_timeouts`."""
+    Source of truth is the workflow file; per-stage missing values
+    fall back to the reusable workflow's `inputs.run_timeout_minutes.default`.
+    Stage-a-test-cpu lives inline (not via the reusable workflow) and is
+    skipped here -- it goes through `_STAGE_A_OVERRIDES` and never
+    consults `run_timeouts`."""
+    default_min = load_run_timeout_default()
     with open(pr_test_yml_path) as f:
         wf = yaml.safe_load(f)
     timeouts = {}
@@ -62,9 +82,7 @@ def load_run_timeouts(pr_test_yml_path: str) -> dict:
             continue
         with_ = job.get("with") or {}
         suite = with_.get("self_name", job_id)
-        timeouts[suite] = int(
-            with_.get("run_timeout_minutes", _RUN_TIMEOUT_MIN_DEFAULT)
-        )
+        timeouts[suite] = int(with_.get("run_timeout_minutes", default_min))
     if not timeouts:
         raise RuntimeError(
             f"load_run_timeouts: no jobs matched uses={_REUSABLE_STAGE_USES!r} "
@@ -78,8 +96,7 @@ def per_shard_target_seconds(suite: str, run_timeouts: dict) -> float:
     """Per-shard wall budget = 0.75 * stage timeout. 0.75 is the inverse
     of LPT's 4/3 worst-case approximation ratio, so the most imbalanced
     LPT shard fills exactly the timeout."""
-    timeout_min = run_timeouts.get(suite, _RUN_TIMEOUT_MIN_DEFAULT)
-    return 0.75 * timeout_min * 60
+    return 0.75 * run_timeouts[suite] * 60
 
 
 def discover_files(repo_root: str) -> list[str]:

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -13,6 +13,8 @@ import math
 import os
 from collections import defaultdict
 
+import yaml  # PyYAML; preinstalled on ubuntu-latest GHA runners.
+
 REPO_ROOT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
@@ -39,10 +41,39 @@ _STAGE_A_OVERRIDES = {
     "stage-a-test-1-gpu-small": 1,
 }
 
-# Per-partition wall-clock target. ~20 min avg naive; worst-case LPT 4/3
-# imbalance is ~27 min, still below the 30-min GHA job-level timeout that
-# acts as the real safety net.
-TARGET_SECONDS = 20 * 60
+# Default Run-test step timeout (minutes); mirrors `_pr-test-stage.yml`
+# `inputs.run_timeout_minutes.default`. Used when pr-test.yml doesn't
+# explicitly override for a given stage.
+_RUN_TIMEOUT_MIN_DEFAULT = 30
+_REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
+
+
+def load_run_timeouts(pr_test_yml_path: str) -> dict:
+    """Map `self_name -> run_timeout_minutes` by reading `pr-test.yml`.
+    Source of truth is the workflow file; missing entries default to
+    `_RUN_TIMEOUT_MIN_DEFAULT`. Stage-a-test-cpu lives inline (not via
+    the reusable workflow) and is skipped here -- it goes through
+    `_STAGE_A_OVERRIDES` and never consults `run_timeouts`."""
+    with open(pr_test_yml_path) as f:
+        wf = yaml.safe_load(f)
+    timeouts = {}
+    for job_id, job in (wf.get("jobs") or {}).items():
+        if not isinstance(job, dict) or job.get("uses") != _REUSABLE_STAGE_USES:
+            continue
+        with_ = job.get("with") or {}
+        suite = with_.get("self_name", job_id)
+        timeouts[suite] = int(
+            with_.get("run_timeout_minutes", _RUN_TIMEOUT_MIN_DEFAULT)
+        )
+    return timeouts
+
+
+def per_shard_target_seconds(suite: str, run_timeouts: dict) -> float:
+    """Per-shard wall budget = 0.75 * stage timeout. 0.75 is the inverse
+    of LPT's 4/3 worst-case approximation ratio, so the most imbalanced
+    LPT shard fills exactly the timeout."""
+    timeout_min = run_timeouts.get(suite, _RUN_TIMEOUT_MIN_DEFAULT)
+    return 0.75 * timeout_min * 60
 
 
 def discover_files(repo_root: str) -> list[str]:
@@ -79,8 +110,13 @@ def compute_max_parallel(size: int) -> int:
     return max(size // 4, 1)
 
 
-def compute_partitions(tests, repo_root, partition_model=None, full_parallel=False):
+def compute_partitions(
+    tests, repo_root, run_timeouts, partition_model=None, full_parallel=False
+):
     """Group per-commit tests by suite and emit partition metadata.
+
+    `run_timeouts`: `suite -> run_timeout_minutes`, parsed from pr-test.yml
+    via `load_run_timeouts`. Drives per-shard wall budget.
 
     `partition_model` (optional): sglang-ci-stats `model.json`. Per-file
     `est` and per-suite `(coeff, bias)` fit; either may be missing and
@@ -112,17 +148,17 @@ def compute_partitions(tests, repo_root, partition_model=None, full_parallel=Fal
         coeff = fit["coeff"] if fit else 1.0
         bias = fit["bias"] if fit else 0.0
 
-        # Each shard pays `bias` once, so size >= coeff*total / (TARGET-bias).
+        # Each shard pays `bias` once, so size >= coeff*total / (target-bias).
         if suite in _STAGE_A_OVERRIDES:
             size = _STAGE_A_OVERRIDES[suite]
             max_parallel = size
         else:
-            budget = TARGET_SECONDS - bias
+            target = per_shard_target_seconds(suite, run_timeouts)
+            budget = target - bias
             if budget <= 0:
                 raise RuntimeError(
-                    f"Suite {suite!r}: fit bias={bias}s >= TARGET={TARGET_SECONDS}s. "
-                    "Raise TARGET_SECONDS or investigate why this suite's overhead "
-                    "alone exceeds the per-shard budget."
+                    f"Suite {suite!r}: fit bias={bias}s >= target={target}s. "
+                    "Investigate the fit or raise the stage's run_timeout_minutes."
                 )
             size = max(1, math.ceil(coeff * total / budget))
             max_parallel = size if full_parallel else compute_max_parallel(size)
@@ -154,6 +190,11 @@ def main():
         default=None,
         help="Path to sglang-ci-stats model.json (omit/missing -> static fallback)",
     )
+    parser.add_argument(
+        "--pr-test-yml",
+        default=os.path.join(REPO_ROOT, ".github", "workflows", "pr-test.yml"),
+        help="Path to pr-test.yml; per-stage `run_timeout_minutes` is read from here.",
+    )
     args = parser.parse_args()
 
     files = discover_files(args.repo_root)
@@ -161,10 +202,12 @@ def main():
     # test-execution time with sanity_check=True; dispatch should keep going.
     all_tests = collect_tests(files, sanity_check=False)
     partition_model = load_partition_model(args.partition_model_file)
+    run_timeouts = load_run_timeouts(args.pr_test_yml)
 
     result = compute_partitions(
         all_tests,
         repo_root=args.repo_root,
+        run_timeouts=run_timeouts,
         partition_model=partition_model,
         full_parallel=(args.full_parallel == "true"),
     )

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -42,38 +42,18 @@ _STAGE_A_OVERRIDES = {
 }
 
 _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
-_REUSABLE_STAGE_YML = os.path.join(
-    REPO_ROOT, ".github", "workflows", "_pr-test-stage.yml"
-)
 
-
-def load_run_timeout_default(stage_yml_path: str = _REUSABLE_STAGE_YML) -> int:
-    """Read `inputs.run_timeout_minutes.default` from `_pr-test-stage.yml`.
-    Source of truth for the default applied to stages that don't override
-    in pr-test.yml."""
-    with open(stage_yml_path) as f:
-        wf = yaml.safe_load(f)
-    # PyYAML (YAML 1.1) parses the `on:` key as boolean True.
-    on_block = wf.get(True) or wf.get("on") or {}
-    inputs = (on_block.get("workflow_call") or {}).get("inputs") or {}
-    spec = inputs.get("run_timeout_minutes") or {}
-    default = spec.get("default")
-    if default is None:
-        raise RuntimeError(
-            f"run_timeout_minutes.default missing in {stage_yml_path}; "
-            "schema changed?"
-        )
-    return int(default)
+# Mirror `_pr-test-stage.yml` `inputs.run_timeout_minutes.default`. Keep
+# in sync if that default ever changes (last touched 2026-05-13).
+_RUN_TIMEOUT_MIN_DEFAULT = 30
 
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
     """Map `self_name -> run_timeout_minutes` by reading `pr-test.yml`.
-    Source of truth is the workflow file; per-stage missing values
-    fall back to the reusable workflow's `inputs.run_timeout_minutes.default`.
-    Stage-a-test-cpu lives inline (not via the reusable workflow) and is
-    skipped here -- it goes through `_STAGE_A_OVERRIDES` and never
-    consults `run_timeouts`."""
-    default_min = load_run_timeout_default()
+    Stages without an explicit `run_timeout_minutes:` fall back to
+    `_RUN_TIMEOUT_MIN_DEFAULT`. Stage-a-test-cpu lives inline (not via
+    the reusable workflow) and is skipped here -- it goes through
+    `_STAGE_A_OVERRIDES` and never consults `run_timeouts`."""
     with open(pr_test_yml_path) as f:
         wf = yaml.safe_load(f)
     timeouts = {}
@@ -82,7 +62,9 @@ def load_run_timeouts(pr_test_yml_path: str) -> dict:
             continue
         with_ = job.get("with") or {}
         suite = with_.get("self_name", job_id)
-        timeouts[suite] = int(with_.get("run_timeout_minutes", default_min))
+        timeouts[suite] = int(
+            with_.get("run_timeout_minutes", _RUN_TIMEOUT_MIN_DEFAULT)
+        )
     if not timeouts:
         raise RuntimeError(
             f"load_run_timeouts: no jobs matched uses={_REUSABLE_STAGE_USES!r} "

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -96,14 +96,16 @@ def discover_files(repo_root: str) -> list[str]:
 
 
 def load_partition_model(path):
-    """Read sglang-ci-stats' model.json; None on missing/unparsable."""
+    """Read sglang-ci-stats' model.json; None on missing/unparsable.
+    Cross-repo schema -- guard against non-dict top-level."""
     if not path or not os.path.exists(path):
         return None
     try:
         with open(path) as f:
-            return json.load(f)
+            data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None
+    return data if isinstance(data, dict) else None
 
 
 def compute_max_parallel(size: int) -> int:
@@ -151,9 +153,9 @@ def compute_partitions(
             relpath = os.path.relpath(t.filename, repo_root)
             total += live_est.get(relpath, t.est_time)
 
-        fit = fit_table.get(suite)
-        coeff = fit["coeff"] if fit else 1.0
-        bias = fit["bias"] if fit else 0.0
+        fit = fit_table.get(suite) or {}
+        coeff = fit.get("coeff", 1.0)
+        bias = fit.get("bias", 0.0)
 
         # Each shard pays `bias` once, so size >= coeff*total / (target-bias).
         if suite in _STAGE_A_OVERRIDES:

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -125,11 +125,18 @@ def compute_partitions(
     `full_parallel=True` (scheduled cron or `high priority` PR) sets
     max_parallel = size, lifting the matrix-fanout throttle.
     """
+    # Only emit partitions for suites pr-test.yml actually dispatches.
+    # `run_timeouts` covers reusable stages; `_STAGE_A_OVERRIDES` covers
+    # the inline stage-a jobs. Stress / weekly / nightly-* suites have
+    # tests in test/registered/ but aren't run by pr-test.yml.
+    dispatched_suites = set(run_timeouts) | set(_STAGE_A_OVERRIDES)
     suite_tests = defaultdict(list)
     for t in tests:
         if t.backend not in _TARGET_BACKENDS:
             continue
         if t.nightly or t.disabled is not None:
+            continue
+        if t.effective_suite not in dispatched_suites:
             continue
         suite_tests[t.effective_suite].append(t)
 
@@ -160,7 +167,19 @@ def compute_partitions(
                     f"Suite {suite!r}: fit bias={bias}s >= target={target}s. "
                     "Investigate the fit or raise the stage's run_timeout_minutes."
                 )
-            size = max(1, math.ceil(coeff * total / budget))
+            ideal_size = math.ceil(coeff * total / budget)
+            # size > len(group) means at least one shard would be empty --
+            # the slowest single file alone is bigger than the per-shard
+            # budget. Either split that file, raise the stage's
+            # run_timeout_minutes, or update its in-source est_time if
+            # the live model already shows a smaller value.
+            if ideal_size > len(group):
+                raise RuntimeError(
+                    f"Suite {suite!r}: needs {ideal_size} shards but has only "
+                    f"{len(group)} test file(s). target={target:.0f}s, "
+                    f"coeff={coeff}, bias={bias}s, total_est={total:.0f}s."
+                )
+            size = max(1, ideal_size)
             max_parallel = size if full_parallel else compute_max_parallel(size)
         result[suite] = {
             "size": size,

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -40,15 +40,9 @@ _STAGE_A_OVERRIDES = {
 }
 
 # Per-partition wall-clock target. ~20 min avg naive; worst-case LPT 4/3
-# imbalance is ~27 min, still below the 30-min job-level timeout that acts
-# as the real safety net. No LPT slop applied -- we lean on the runtime
-# timeout + the explicit MAX_PARTITION_SECONDS sanity check rather than
-# padding partition count.
+# imbalance is ~27 min, still below the 30-min GHA job-level timeout that
+# acts as the real safety net.
 TARGET_SECONDS = 20 * 60
-
-# Hard ceiling. Exceeded -> raise, forcing the maintainer to split a slow file
-# or bump TARGET_SECONDS deliberately.
-MAX_PARTITION_SECONDS = 30 * 60
 
 
 def discover_files(repo_root: str) -> list[str]:
@@ -132,18 +126,6 @@ def compute_partitions(tests, repo_root, partition_model=None, full_parallel=Fal
                 )
             size = max(1, math.ceil(coeff * total / budget))
             max_parallel = size if full_parallel else compute_max_parallel(size)
-        # Predicted per-shard wall on naive average (total/size). LPT can
-        # be ~4/3 of that in worst case; the 30-min job timeout enforces
-        # the real ceiling at runtime. This build-time check fails fast
-        # on egregious misconfigs.
-        pred_per_shard = coeff * (total / size) + bias
-        if pred_per_shard > MAX_PARTITION_SECONDS:
-            raise RuntimeError(
-                f"Suite {suite!r}: predicted shard wall {pred_per_shard:.0f}s "
-                f"(coeff={coeff} * total={total:.0f}/size={size} + bias={bias}) "
-                f"exceeds MAX_PARTITION_SECONDS ({MAX_PARTITION_SECONDS}s). "
-                f"Split a slow file or raise TARGET_SECONDS deliberately."
-            )
         result[suite] = {
             "size": size,
             "arr": list(range(size)),

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -45,12 +45,9 @@ _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
 
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
-    """Map `self_name -> run_timeout_minutes` by reading `pr-test.yml`.
-    Every stage that uses `_pr-test-stage.yml` must specify
-    `run_timeout_minutes:` (it's a required reusable-workflow input);
-    KeyError surfaces a missing one. Stage-a-test-cpu lives inline and
-    is skipped here -- it goes through `_STAGE_A_OVERRIDES` and never
-    consults `run_timeouts`."""
+    """Map `self_name -> run_timeout_minutes` from pr-test.yml. The input
+    is required in `_pr-test-stage.yml` -- KeyError surfaces missing.
+    Inline stage-a-test-cpu is skipped (uses `_STAGE_A_OVERRIDES`)."""
     with open(pr_test_yml_path) as f:
         wf = yaml.safe_load(f)
     timeouts = {}
@@ -117,20 +114,14 @@ def compute_partitions(
 ):
     """Group per-commit tests by suite and emit partition metadata.
 
-    `run_timeouts`: `suite -> run_timeout_minutes`, parsed from pr-test.yml
-    via `load_run_timeouts`. Drives per-shard wall budget.
-
-    `partition_model` (optional): sglang-ci-stats `model.json`. Per-file
-    `est` and per-suite `(coeff, bias)` fit; either may be missing and
-    falls back to (in-source `est_time`, `(1.0, 0.0)`) independently.
-
-    `full_parallel=True` (scheduled cron or `high priority` PR) sets
-    max_parallel = size, lifting the matrix-fanout throttle.
+    `run_timeouts`: `suite -> minutes` from `load_run_timeouts`.
+    `partition_model`: optional sglang-ci-stats `model.json`; per-file
+    `est` and per-suite `(coeff, bias)` each fall back independently to
+    in-source `est_time` / `(1.0, 0.0)`.
+    `full_parallel=True` lifts the matrix-fanout throttle.
     """
-    # Only emit partitions for suites pr-test.yml actually dispatches.
-    # `run_timeouts` covers reusable stages; `_STAGE_A_OVERRIDES` covers
-    # the inline stage-a jobs. Stress / weekly / nightly-* suites have
-    # tests in test/registered/ but aren't run by pr-test.yml.
+    # Allowlist: stages pr-test.yml dispatches. Stress / weekly /
+    # nightly-* live in test/registered/ but pr-test doesn't run them.
     dispatched_suites = set(run_timeouts) | set(_STAGE_A_OVERRIDES)
     suite_tests = defaultdict(list)
     for t in tests:
@@ -170,11 +161,8 @@ def compute_partitions(
                     "Investigate the fit or raise the stage's run_timeout_minutes."
                 )
             ideal_size = math.ceil(coeff * total / budget)
-            # size > len(group) means at least one shard would be empty --
-            # the slowest single file alone is bigger than the per-shard
-            # budget. Either split that file, raise the stage's
-            # run_timeout_minutes, or update its in-source est_time if
-            # the live model already shows a smaller value.
+            # ideal_size > len(group) -> slowest single file alone exceeds
+            # the per-shard budget; surface via raise instead of empty shard.
             if ideal_size > len(group):
                 raise RuntimeError(
                     f"Suite {suite!r}: needs {ideal_size} shards but has only "

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -65,6 +65,12 @@ def load_run_timeouts(pr_test_yml_path: str) -> dict:
         timeouts[suite] = int(
             with_.get("run_timeout_minutes", _RUN_TIMEOUT_MIN_DEFAULT)
         )
+    if not timeouts:
+        raise RuntimeError(
+            f"load_run_timeouts: no jobs matched uses={_REUSABLE_STAGE_USES!r} "
+            f"in {pr_test_yml_path}. The reusable workflow path likely "
+            "changed -- update _REUSABLE_STAGE_USES."
+        )
     return timeouts
 
 

--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_megamoe_b200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_megamoe_b200.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=1800, suite="stage-c-test-dsv4-4-gpu-b200")
+register_cuda_ci(est_time=900, suite="stage-c-test-dsv4-4-gpu-b200")
 
 MODEL = "deepseek-ai/DeepSeek-V4-Flash"
 SERVER_LAUNCH_TIMEOUT = 3600

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -1,8 +1,9 @@
 import argparse
 import glob
+import json
 import os
 import sys
-from typing import List
+from typing import Dict, List, Optional
 
 import tabulate
 
@@ -222,6 +223,31 @@ def pretty_print_tests(
     print(msg, flush=True)
 
 
+def load_live_est(
+    partition_model_file: Optional[str], suite: str, repo_root: str
+) -> Optional[Dict[str, float]]:
+    """Build a `CIRegistry.filename -> live est seconds` map from
+    sglang-ci-stats' partition model.json so `auto_partition` LPT uses the
+    same `est` snapshot the dispatcher (compute_partitions.py) used to
+    size this stage. Returns None when the file is missing / unparsable,
+    or when the requested suite has no live entries -- callers fall back
+    to in-source est_time."""
+    if not partition_model_file or not os.path.exists(partition_model_file):
+        return None
+    try:
+        with open(partition_model_file) as f:
+            partition_model = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    suite_est = partition_model.get("est", {}).get(suite)
+    if not suite_est:
+        return None
+    return {
+        os.path.join(repo_root, relpath): float(elapsed)
+        for relpath, elapsed in suite_est.items()
+    }
+
+
 def run_a_suite(args):
     hw = HW_MAPPING[args.hw]
     suite = args.suite
@@ -261,7 +287,23 @@ def run_a_suite(args):
     ci_tests, skipped_tests = filter_tests(all_tests, hw, suite, nightly)
 
     if auto_partition_size:
-        ci_tests = auto_partition(ci_tests, auto_partition_id, auto_partition_size)
+        live_est = load_live_est(args.partition_model_file, suite, repo_root)
+        if live_est is not None:
+            print(
+                f"Loaded {len(live_est)} live est entries from "
+                f"{args.partition_model_file} for suite={suite}",
+                flush=True,
+            )
+        else:
+            print(
+                f"No live est available "
+                f"(partition_model_file={args.partition_model_file!r}); "
+                f"LPT falling back to in-source est_time",
+                flush=True,
+            )
+        ci_tests = auto_partition(
+            ci_tests, auto_partition_id, auto_partition_size, live_est=live_est
+        )
 
     pretty_print_tests(args, ci_tests, skipped_tests)
 
@@ -342,6 +384,18 @@ def main():
         type=int,
         default=600,
         help="Additional timeout in seconds when retry is enabled (default: 600)",
+    )
+    parser.add_argument(
+        "--partition-model-file",
+        type=str,
+        default=None,
+        help=(
+            "Path to sglang-ci-stats partition model.json. When provided, "
+            "auto_partition uses live `est` (p90 of recent CI elapsed) for "
+            "LPT bucketing so the partition decision matches what "
+            "compute_partitions.py used to size this stage. Missing / "
+            "malformed -> falls back to in-source est_time."
+        ),
     )
     args = parser.parse_args()
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -236,8 +236,10 @@ def load_live_est(
             partition_model = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(partition_model, dict):
+        return None
     suite_est = partition_model.get("est", {}).get(suite)
-    if not suite_est:
+    if not isinstance(suite_est, dict) or not suite_est:
         return None
     return {
         os.path.join(repo_root, relpath): float(elapsed)

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -226,9 +226,8 @@ def pretty_print_tests(
 def load_live_est(
     partition_model_file: Optional[str], suite: str, repo_root: str
 ) -> Optional[Dict[str, float]]:
-    """Build a `CIRegistry.filename -> est seconds` map from
-    sglang-ci-stats' `model.json est[suite]`; None on missing file /
-    parse error / suite absent (caller falls back to in-source est)."""
+    """`CIRegistry.filename -> est seconds` from `model.json est[suite]`;
+    None on any miss (caller falls back to in-source `est_time`)."""
     if not partition_model_file or not os.path.exists(partition_model_file):
         return None
     try:

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -226,12 +226,9 @@ def pretty_print_tests(
 def load_live_est(
     partition_model_file: Optional[str], suite: str, repo_root: str
 ) -> Optional[Dict[str, float]]:
-    """Build a `CIRegistry.filename -> live est seconds` map from
-    sglang-ci-stats' partition model.json so `auto_partition` LPT uses the
-    same `est` snapshot the dispatcher (compute_partitions.py) used to
-    size this stage. Returns None when the file is missing / unparsable,
-    or when the requested suite has no live entries -- callers fall back
-    to in-source est_time."""
+    """Build a `CIRegistry.filename -> est seconds` map from
+    sglang-ci-stats' `model.json est[suite]`; None on missing file /
+    parse error / suite absent (caller falls back to in-source est)."""
     if not partition_model_file or not os.path.exists(partition_model_file):
         return None
     try:
@@ -290,15 +287,12 @@ def run_a_suite(args):
         live_est = load_live_est(args.partition_model_file, suite, repo_root)
         if live_est is not None:
             print(
-                f"Loaded {len(live_est)} live est entries from "
-                f"{args.partition_model_file} for suite={suite}",
+                f"LPT: {len(live_est)} live est entries from {args.partition_model_file}",
                 flush=True,
             )
         else:
             print(
-                f"No live est available "
-                f"(partition_model_file={args.partition_model_file!r}); "
-                f"LPT falling back to in-source est_time",
+                f"LPT: no live est ({args.partition_model_file!r}); using in-source est_time",
                 flush=True,
             )
         ci_tests = auto_partition(
@@ -389,13 +383,7 @@ def main():
         "--partition-model-file",
         type=str,
         default=None,
-        help=(
-            "Path to sglang-ci-stats partition model.json. When provided, "
-            "auto_partition uses live `est` (p90 of recent CI elapsed) for "
-            "LPT bucketing so the partition decision matches what "
-            "compute_partitions.py used to size this stage. Missing / "
-            "malformed -> falls back to in-source est_time."
-        ),
+        help="Path to sglang-ci-stats model.json for live LPT est; missing/malformed -> in-source est_time fallback.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Dispatch sizing and runtime LPT bucketing read live `est` (per-file p90) and `(coeff, bias)` OLS fit from [`sgl-project/sglang-ci-stats`](https://github.com/sgl-project/sglang-ci-stats)'s `model.json` instead of the static in-source `est_time` literals.

- per-shard `target = 0.75 × stage timeout` (inverse of LPT 4/3 worst-case bound); `size = ceil(coeff × total / (target − bias))`
- SHA-pinned across all shards; raise on transient curl failure instead of soft fallback
- in-source `est_time` remains the static fallback when sglang-ci-stats is unreachable
- raises at dispatch when a single file's est exceeds the per-shard budget