### PR TITLE
[perf] fix kimi tokenizer to improve ttft

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -689,9 +689,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
         else:
             logger.debug(f"Using regular tokenizer for {len(tokenizer_input)} inputs")
-            encoded = self.tokenizer(tokenizer_input, **tokenizer_kwargs)
-            input_ids = encoded["input_ids"]
-            token_type_ids = encoded.get("token_type_ids") if is_cross_encoder else None
+
+            if not is_cross_encoder:
+                input_ids = [self.tokenizer.encode(t) for t in tokenizer_input]
+                token_type_ids = None
+            else:
+                encoded = self.tokenizer(tokenizer_input, **tokenizer_kwargs)
+                input_ids = encoded["input_ids"]
+                token_type_ids = encoded.get("token_type_ids")
 
         # Step 4: Extract results based on input format
         return self._extract_tokenizer_results(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -690,13 +690,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             logger.debug(f"Using regular tokenizer for {len(tokenizer_input)} inputs")
 
-            if not is_cross_encoder:
+            if not is_cross_encoder and (not getattr(self.tokenizer, "is_fast", False)):
                 input_ids = [self.tokenizer.encode(t) for t in tokenizer_input]
                 token_type_ids = None
             else:
                 encoded = self.tokenizer(tokenizer_input, **tokenizer_kwargs)
                 input_ids = encoded["input_ids"]
-                token_type_ids = encoded.get("token_type_ids")
+                token_type_ids = (
+                    encoded.get("token_type_ids") if is_cross_encoder else None
+                )
 
         # Step 4: Extract results based on input format
         return self._extract_tokenizer_results(


### PR DESCRIPTION
## Problem

https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/tokenization_kimi.py

warning in server log
<img width="1432" height="104" alt="image" src="https://github.com/user-attachments/assets/94524ab8-6ee6-4c55-bc48-49c222f82f01" />

`TokenizerManager._tokenize_texts` calls the tokenizer via `__call__`, which forces tiktoken-derived tokenizers (Kimi-K2.5) through `PreTrainedTokenizer`'s slow Python pipeline. Its native tiktoken fast path is only reachable via `.encode()` with no kwargs.

Microbench on Kimi-K2.5, 80k tokens, single text:

| Call | Time |
|---|---:|
| `tok.encode(text)` (tiktoken native) | **47 ms** |
| `tok([text])` (`__call__`, what SGLang did) | 308 ms |

That's a fixed **~260 ms / request** overhead for any tiktoken-derived tokenizer on long inputs.


| Tokenizer | bs=1 | bs≥2 |
|---|---|---|
| Slow (Kimi / tiktoken-derived) | `.encode()` ← fix | `.encode()` loop ← fix |
| Fast (Llama / Qwen / BERT) | `.encode()` (equivalent) | `tokenizer(...)` (keep `tokenizers`-crate rayon batch) |
| Cross-encoder (BGE-reranker, …) | `tokenizer(...)` | `tokenizer(...)` (needs `token_type_ids`) |

Microbench (`.encode()` loop / `tokenizer(...)` batch ratio — >1 means loop wins, <1 means batch wins):

| Tokenizer | bs=1 | bs=2 | bs=16 | bs=100 |
|---|---:|---:|---:|---:|
| Kimi-K2.5 | 6.6× | 7.6× | 6.7× | 7.1× |
| Llama-3.1-8B | 1.0× | 0.43× | 0.14× | 0.08× |
| Qwen2.5-7B | 1.0× | 0.38× | 0.13× | ~0.08× |

For Kimi `.encode()` always wins; for fast tokenizers rayon batch wins from bs≥2. The branch condition lands exactly on this boundary.

## E2E

`bench_serving --random-input-len 80000 --random-output-len 1 --num-prompts 10 --max-concurrency 1` on Kimi-K2.5-NVFP4 (B200×4, TP=4, EAGLE3):

| | Mean TTFT | Median TTFT |
|---|---:|---:|
| Baseline | 2948 ms | 3151 ms |
| Patched | **2791 ms** | **2932 ms** |

**~157 ms** / request saving (~5–7%).
