### PR TITLE
[codex] Fix SWA disagg cache pressure debugging

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -629,7 +629,11 @@ class SchedulerDisaggregationPrefillMixin:
             if poll in [KVPoll.WaitingForInput, KVPoll.Transferring]:
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
-                release_kv_cache(req, self.tree_cache)  # unlock the tree
+                release_kv_cache(
+                    req,
+                    self.tree_cache,
+                    debug_context="disagg_prefill_transfer_success",
+                )  # unlock the tree
                 req.finished_reason = FINISH_LENGTH(length=0)
                 # FIXME: clean up req's data in transfer engine
                 if hasattr(req.disagg_kv_sender, "clear"):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -201,6 +201,7 @@ class Envs:
     SGLANG_RECORD_STEP_TIME = EnvBool(False)
     SGLANG_FORCE_SHUTDOWN = EnvBool(False)
     SGLANG_DEBUG_MEMORY_POOL = EnvBool(False)
+    SGLANG_DEBUG_KV_ALLOC = EnvBool(False)
     SGLANG_TEST_REQUEST_TIME_STATS = EnvBool(False)
     SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK = EnvBool(False)
     SGLANG_SIMULATE_ACC_LEN = EnvFloat(-1)
@@ -244,6 +245,7 @@ class Envs:
     SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS = EnvStr("{}")
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
+    SGLANG_DEBUG_DISAGG_PREFILL_CACHE = EnvBool(False)
     # Extra slots in req_to_token_pool for decode workers (only effective when
     # max_num_reqs > 32). Increases pool capacity so more KV cache transfers
     # can overlap with decode execution without raising max_running_requests.

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
@@ -25,6 +26,124 @@ MAMBA_STATE_PER_REQ_PREFIX_CACHE = 3
 MAMBA_STATE_PER_REQ_NO_CACHE = 1
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_cache_stat(tree_cache: BasePrefixCache | None, stat_name: str):
+    if tree_cache is None:
+        return None
+    stat_fn = getattr(tree_cache, stat_name, None)
+    if stat_fn is None:
+        return None
+    try:
+        return stat_fn()
+    except Exception as e:
+        return f"<{type(e).__name__}: {e}>"
+
+
+def _short_repr(value, limit: int = 256) -> str:
+    text = repr(value)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _safe_call(obj, method_name: str):
+    fn = getattr(obj, method_name, None)
+    if fn is None:
+        return None
+    try:
+        return fn()
+    except Exception as e:
+        return f"<{type(e).__name__}: {e}>"
+
+
+def _safe_sub(*values):
+    if all(isinstance(v, (int, float, np.integer, np.floating)) for v in values):
+        return int(values[0] - sum(values[1:]))
+    return None
+
+
+def _tensor_sum_int(value):
+    try:
+        return int(value.sum().item())
+    except Exception:
+        return None
+
+
+def _kv_pressure_snapshot(tree_cache: BasePrefixCache | None) -> dict[str, object]:
+    if tree_cache is None:
+        return {}
+
+    allocator = tree_cache.token_to_kv_pool_allocator
+    total_size = _safe_call(tree_cache, "total_size")
+    if isinstance(total_size, tuple) and len(total_size) == 2:
+        full_tree_total, swa_tree_total = total_size
+    else:
+        full_tree_total, swa_tree_total = total_size, None
+
+    fields: dict[str, object] = {
+        "allocator": type(allocator).__name__,
+        "tree_total": total_size,
+        "full_tree_evictable": _safe_cache_stat(tree_cache, "full_evictable_size"),
+        "swa_tree_evictable": _safe_cache_stat(tree_cache, "swa_evictable_size"),
+        "full_tree_protected": _safe_cache_stat(tree_cache, "full_protected_size"),
+        "swa_tree_protected": _safe_cache_stat(tree_cache, "swa_protected_size"),
+    }
+
+    if isinstance(allocator, SWATokenToKVPoolAllocator):
+        full_capacity = getattr(allocator, "size_full", None)
+        full_capacity = full_capacity() if callable(full_capacity) else full_capacity
+        swa_capacity = getattr(allocator, "size_swa", None)
+        swa_capacity = swa_capacity() if callable(swa_capacity) else swa_capacity
+        full_available = _safe_call(allocator, "full_available_size")
+        swa_available = _safe_call(allocator, "swa_available_size")
+
+        fields.update(
+            {
+                "full_capacity": full_capacity,
+                "full_available": full_available,
+                "full_used": _safe_sub(full_capacity, full_available),
+                "full_tree_total": full_tree_total,
+                "full_non_tree_live": _safe_sub(
+                    full_capacity, full_available, full_tree_total
+                ),
+                "swa_capacity": swa_capacity,
+                "swa_available": swa_available,
+                "swa_used": _safe_sub(swa_capacity, swa_available),
+                "swa_tree_total": swa_tree_total,
+                "swa_non_tree_live": _safe_sub(
+                    swa_capacity, swa_available, swa_tree_total
+                ),
+            }
+        )
+    else:
+        capacity = getattr(allocator, "size", None)
+        capacity = capacity() if callable(capacity) else capacity
+        available = _safe_call(allocator, "available_size")
+        fields.update(
+            {
+                "capacity": capacity,
+                "available": available,
+                "used": _safe_sub(capacity, available),
+                "non_tree_live": _safe_sub(capacity, available, full_tree_total),
+            }
+        )
+
+    return fields
+
+
+def _log_kv_alloc_debug(
+    event: str,
+    tree_cache: BasePrefixCache | None,
+    **fields,
+) -> None:
+    if not envs.SGLANG_DEBUG_KV_ALLOC.get():
+        return
+    merged = {"event": event, **fields, **_kv_pressure_snapshot(tree_cache)}
+    logger.info(
+        "KV_ALLOC_DEBUG %s",
+        " ".join(f"{key}={_short_repr(value)}" for key, value in merged.items()),
+    )
 
 
 def kv_to_page_indices(kv_indices: np.ndarray, page_size: int):
@@ -366,7 +485,25 @@ def alloc_paged_token_slots_extend(
     # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
     num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
+    _log_kv_alloc_debug(
+        "extend_before_evict",
+        tree_cache,
+        extend_num_tokens=extend_num_tokens,
+        padded_num_tokens=num_tokens,
+        batch_size=len(seq_lens_cpu),
+        page_size=allocator.page_size,
+        prefix_tokens=_tensor_sum_int(prefix_lens_cpu),
+        seq_tokens=_tensor_sum_int(seq_lens_cpu),
+    )
     evict_from_tree_cache(tree_cache, num_tokens)
+    _log_kv_alloc_debug(
+        "extend_after_evict",
+        tree_cache,
+        extend_num_tokens=extend_num_tokens,
+        padded_num_tokens=num_tokens,
+        batch_size=len(seq_lens_cpu),
+        page_size=allocator.page_size,
+    )
 
     state = None
     if backup_state:
@@ -382,6 +519,14 @@ def alloc_paged_token_slots_extend(
     )
 
     if out_cache_loc is None:
+        _log_kv_alloc_debug(
+            "extend_oom",
+            tree_cache,
+            extend_num_tokens=extend_num_tokens,
+            padded_num_tokens=num_tokens,
+            batch_size=len(seq_lens_cpu),
+            page_size=allocator.page_size,
+        )
         error_msg = (
             f"Prefill out of memory. Try to lower your batch size.\n"
             f"Try to allocate {extend_num_tokens} tokens.\n"
@@ -392,6 +537,14 @@ def alloc_paged_token_slots_extend(
             tree_cache.pretty_print()
         raise RuntimeError(error_msg)
 
+    _log_kv_alloc_debug(
+        "extend_after_alloc",
+        tree_cache,
+        extend_num_tokens=extend_num_tokens,
+        padded_num_tokens=num_tokens,
+        batch_size=len(seq_lens_cpu),
+        page_size=allocator.page_size,
+    )
     return (out_cache_loc, state) if backup_state else out_cache_loc
 
 
@@ -439,6 +592,14 @@ def alloc_for_extend(
     """
     # free out-of-window swa tokens
     batch.maybe_evict_swa()
+    _log_kv_alloc_debug(
+        "alloc_for_extend_batch",
+        batch.tree_cache,
+        batch_size=len(batch.reqs),
+        extend_num_tokens=batch.extend_num_tokens,
+        prefix_tokens=sum(batch.prefix_lens),
+        seq_tokens=_tensor_sum_int(batch.seq_lens_cpu),
+    )
 
     prefix_tensors = [r.prefix_indices for r in batch.reqs]
 
@@ -563,9 +724,56 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     return out_cache_loc
 
 
-def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = True):
+def release_kv_cache(
+    req: Req,
+    tree_cache: BasePrefixCache,
+    is_insert: bool = True,
+    debug_context: Optional[str] = None,
+):
+    log_cache_debug = (
+        debug_context is not None and envs.SGLANG_DEBUG_DISAGG_PREFILL_CACHE.get()
+    )
+    if log_cache_debug:
+        req_pool_idx_before = req.req_pool_idx
+        kv_committed_len_before = req.kv_committed_len
+        kv_allocated_len_before = req.kv_allocated_len
+        skip_radix_cache_insert = getattr(req, "skip_radix_cache_insert", False)
+        effective_is_insert = is_insert and not skip_radix_cache_insert
+        cache_disable = getattr(tree_cache, "disable", None)
+        cache_disable_finished_insert = getattr(
+            tree_cache, "disable_finished_insert", None
+        )
+        cache_total_before = _safe_cache_stat(tree_cache, "total_size")
+        cache_evictable_before = _safe_cache_stat(tree_cache, "evictable_size")
+        cache_protected_before = _safe_cache_stat(tree_cache, "protected_size")
+
     # MambaRadixCache may alloc mamba state before alloc KV cache
     if req.req_pool_idx is None:
+        if log_cache_debug:
+            logger.info(
+                "release_kv_cache_debug context=%s rid=%s req_pool_idx=None "
+                "kv_committed_len=%s kv_allocated_len=%s is_insert=%s "
+                "effective_is_insert=%s skip_radix_cache_insert=%s "
+                "cache_disable=%s cache_disable_finished_insert=%s "
+                "bootstrap_host=%s bootstrap_room=%s extra_key=%s "
+                "tree_total_before=%s tree_evictable_before=%s "
+                "tree_protected_before=%s",
+                debug_context,
+                getattr(req, "rid", None),
+                kv_committed_len_before,
+                kv_allocated_len_before,
+                is_insert,
+                effective_is_insert,
+                skip_radix_cache_insert,
+                cache_disable,
+                cache_disable_finished_insert,
+                getattr(req, "bootstrap_host", None),
+                getattr(req, "bootstrap_room", None),
+                _short_repr(getattr(req, "extra_key", None)),
+                cache_total_before,
+                cache_evictable_before,
+                cache_protected_before,
+            )
         assert (
             tree_cache.supports_mamba()
         ), "Only MambaRadixCache allow freeing before alloc"
@@ -581,6 +789,56 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
         req,
         is_insert=is_insert and not getattr(req, "skip_radix_cache_insert", False),
     )
+
+    if log_cache_debug:
+        cache_total_after = _safe_cache_stat(tree_cache, "total_size")
+        cache_evictable_after = _safe_cache_stat(tree_cache, "evictable_size")
+        cache_protected_after = _safe_cache_stat(tree_cache, "protected_size")
+        logger.info(
+            "release_kv_cache_debug context=%s rid=%s req_pool_idx_before=%s "
+            "req_pool_idx_after=%s kv_committed_len_before=%s "
+            "kv_committed_len_after=%s kv_allocated_len_before=%s "
+            "kv_allocated_len_after=%s is_insert=%s effective_is_insert=%s "
+            "skip_radix_cache_insert=%s cache_disable=%s "
+            "cache_disable_finished_insert=%s bootstrap_host=%s bootstrap_port=%s "
+            "bootstrap_room=%s routed_dp_rank=%s disagg_prefill_dp_rank=%s "
+            "origin_input_len=%s output_len=%s fill_len=%s cached_tokens=%s "
+            "cache_protected_len=%s prefix_indices_len=%s extra_key=%s "
+            "tree_total_before=%s tree_total_after=%s "
+            "tree_evictable_before=%s tree_evictable_after=%s "
+            "tree_protected_before=%s tree_protected_after=%s",
+            debug_context,
+            getattr(req, "rid", None),
+            req_pool_idx_before,
+            req.req_pool_idx,
+            kv_committed_len_before,
+            req.kv_committed_len,
+            kv_allocated_len_before,
+            req.kv_allocated_len,
+            is_insert,
+            effective_is_insert,
+            skip_radix_cache_insert,
+            cache_disable,
+            cache_disable_finished_insert,
+            getattr(req, "bootstrap_host", None),
+            getattr(req, "bootstrap_port", None),
+            getattr(req, "bootstrap_room", None),
+            getattr(req, "routed_dp_rank", None),
+            getattr(req, "disagg_prefill_dp_rank", None),
+            len(getattr(req, "origin_input_ids", [])),
+            len(getattr(req, "output_ids", [])),
+            len(getattr(req, "fill_ids", [])),
+            getattr(req, "cached_tokens", None),
+            getattr(req, "cache_protected_len", None),
+            len(getattr(req, "prefix_indices", [])),
+            _short_repr(getattr(req, "extra_key", None)),
+            cache_total_before,
+            cache_total_after,
+            cache_evictable_before,
+            cache_evictable_after,
+            cache_protected_before,
+            cache_protected_after,
+        )
 
     # StreamingSession.cache_finished_req handles speculative tail trim
     # and bookkeeping flag sync internally, then sets req_pool_idx = None.

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -365,6 +365,11 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 torch.tensor([-1], dtype=torch.int64, device=device),
             ]
         )
+        self.swa_to_full_index_mapping = torch.zeros(
+            size_swa + self.page_size,
+            dtype=torch.int64,
+            device=device,
+        )
 
         self.need_sort = need_sort
         self.free_pages = None
@@ -415,6 +420,48 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert self._kvcache.full_to_swa_index_mapping is not None
         return self._kvcache.translate_loc_from_full_to_swa(kv_indices)
 
+    def _set_full_to_swa_mapping(
+        self, full_indices: torch.Tensor, swa_indices: torch.Tensor
+    ) -> None:
+        """Map full KV slots to SWA slots and invalidate stale SWA owners.
+
+        SWA slots can be reused by the sliding window before the owning request
+        finishes. Without reverse ownership, old full slots keep stale mappings
+        and can free an SWA page that now belongs to a newer full slot.
+        """
+        if full_indices.numel() == 0:
+            return
+        assert full_indices.numel() == swa_indices.numel()
+
+        full_indices = full_indices.to(dtype=torch.int64)
+        swa_indices = swa_indices.to(dtype=torch.int64)
+        valid = (full_indices > 0) & (swa_indices > 0)
+        if not torch.any(valid):
+            return
+
+        full_indices = full_indices[valid]
+        swa_indices = swa_indices[valid]
+
+        previous_swa_indices = self.full_to_swa_index_mapping[full_indices]
+        previous_valid = previous_swa_indices > 0
+        if torch.any(previous_valid):
+            previous_swa_indices = previous_swa_indices[previous_valid]
+            previous_full_indices = full_indices[previous_valid]
+            previous_owners = self.swa_to_full_index_mapping[previous_swa_indices]
+            previous_same_owner = previous_owners == previous_full_indices
+            if torch.any(previous_same_owner):
+                self.swa_to_full_index_mapping[
+                    previous_swa_indices[previous_same_owner]
+                ] = 0
+
+        old_full_indices = self.swa_to_full_index_mapping[swa_indices]
+        old_full_indices = old_full_indices[old_full_indices > 0]
+        if old_full_indices.numel() > 0:
+            self.full_to_swa_index_mapping[old_full_indices] = 0
+
+        self.full_to_swa_index_mapping[full_indices] = swa_indices
+        self.swa_to_full_index_mapping[swa_indices] = full_indices
+
     def alloc(self, need_size: int):
         assert self.page_size == 1
         if need_size > self.full_attn_allocator.available_size():
@@ -427,12 +474,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert alloc_full_indices is not None
         assert alloc_swa_indices is not None
 
-        if _is_npu:
-            self.full_to_swa_index_mapping[alloc_full_indices.to(torch.int64)] = (
-                alloc_swa_indices.to(torch.int64)
-            )
-        else:
-            self.full_to_swa_index_mapping[alloc_full_indices] = alloc_swa_indices
+        self._set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
         return alloc_full_indices
 
     def alloc_extend(
@@ -477,12 +519,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert alloc_full_indices is not None
         assert alloc_swa_indices is not None
 
-        if _is_npu:
-            self.full_to_swa_index_mapping[alloc_full_indices.to(torch.int64)] = (
-                alloc_swa_indices.to(torch.int64)
-            )
-        else:
-            self.full_to_swa_index_mapping[alloc_full_indices] = alloc_swa_indices
+        self._set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
 
         return alloc_full_indices
 
@@ -546,8 +583,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         assert alloc_swa_indices is not None
 
-        self.full_to_swa_index_mapping[alloc_full_indices[-swa_tail_len:]] = (
-            alloc_swa_indices
+        self._set_full_to_swa_mapping(
+            alloc_full_indices[-swa_tail_len:], alloc_swa_indices
         )
         return alloc_full_indices
 
@@ -570,12 +607,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if alloc_full_indices is None or alloc_swa_indices is None:
             return None
 
-        if _is_npu:
-            self.full_to_swa_index_mapping[alloc_full_indices.to(torch.int64)] = (
-                alloc_swa_indices.to(torch.int64)
-            )
-        else:
-            self.full_to_swa_index_mapping[alloc_full_indices] = alloc_swa_indices
+        self._set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
 
         return alloc_full_indices
 
@@ -603,36 +635,112 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         """
         if full_indices.numel() == 0:
             return
-        assert full_indices.numel() == swa_indices.numel()
-        if _is_npu:
-            self.full_to_swa_index_mapping[full_indices.to(torch.int64)] = (
-                swa_indices.to(torch.int64)
-            )
-        else:
-            self.full_to_swa_index_mapping[full_indices] = swa_indices
+        self._set_full_to_swa_mapping(full_indices, swa_indices)
+
+    def _expand_indices_to_pages(
+        self, indices: torch.Tensor, limit: int
+    ) -> torch.Tensor:
+        indices = indices.to(dtype=torch.int64)
+        indices = indices[(indices > 0) & (indices < limit)]
+        if indices.numel() == 0 or self.page_size == 1:
+            return indices
+
+        pages = torch.unique(indices // self.page_size)
+        pages = pages[pages > 0]
+        if pages.numel() == 0:
+            return indices[:0]
+
+        offsets = torch.arange(
+            self.page_size, dtype=torch.int64, device=indices.device
+        )
+        expanded = (pages[:, None] * self.page_size + offsets[None, :]).reshape(-1)
+        return expanded[(expanded > 0) & (expanded < limit)]
+
+    def _free_unowned_swa_pages_for_indices(self, swa_indices: torch.Tensor) -> None:
+        if swa_indices.numel() == 0:
+            return
+
+        swa_indices = swa_indices.to(dtype=torch.int64)
+        if self.page_size == 1:
+            self.swa_attn_allocator.free(swa_indices)
+            return
+
+        swa_indices = swa_indices[
+            (swa_indices > 0) & (swa_indices < self.swa_to_full_index_mapping.numel())
+        ]
+        if swa_indices.numel() == 0:
+            return
+
+        pages = torch.unique(swa_indices // self.page_size)
+        pages = pages[pages > 0]
+        if pages.numel() == 0:
+            return
+
+        offsets = torch.arange(
+            self.page_size, dtype=torch.int64, device=swa_indices.device
+        )
+        page_indices = (
+            pages[:, None] * self.page_size + offsets[None, :]
+        ).reshape(pages.numel(), self.page_size)
+        has_owner = torch.any(self.swa_to_full_index_mapping[page_indices] > 0, dim=1)
+        free_pages = pages[~has_owner]
+        if free_pages.numel() > 0:
+            self.swa_attn_allocator.free(free_pages * self.page_size)
 
     def free_swa(self, free_index: torch.Tensor):
+        free_index = self._expand_indices_to_pages(
+            free_index, self.full_to_swa_index_mapping.numel() - 1
+        )
+        if free_index.numel() == 0:
+            return
+
         swa_indices = self.full_to_swa_index_mapping[free_index]
-        swa_indices = swa_indices[swa_indices > 0]
-        self.swa_attn_allocator.free(swa_indices)
-        self.full_to_swa_index_mapping[free_index] = 0
+        valid = swa_indices > 0
+        if not torch.any(valid):
+            return
+
+        full_indices = free_index[valid]
+        swa_indices = swa_indices[valid]
+
+        # Only the current full owner may free an SWA slot. Stale full slots are
+        # possible when the sliding window reuses SWA slots before request finish.
+        current_full_indices = self.swa_to_full_index_mapping[swa_indices]
+        current_owner = current_full_indices == full_indices
+        stale_full_indices = full_indices[~current_owner]
+        if stale_full_indices.numel() > 0:
+            self.full_to_swa_index_mapping[stale_full_indices] = 0
+
+        full_indices = full_indices[current_owner]
+        swa_indices = swa_indices[current_owner]
+        if swa_indices.numel() == 0:
+            return
+
+        self.swa_to_full_index_mapping[swa_indices] = 0
+        self.full_to_swa_index_mapping[full_indices] = 0
+        self._free_unowned_swa_pages_for_indices(swa_indices)
 
     def backup_state(self):
         return [
             self.full_attn_allocator.backup_state(),
             self.swa_attn_allocator.backup_state(),
+            self.full_to_swa_index_mapping.clone(),
+            self.swa_to_full_index_mapping.clone(),
         ]
 
     def restore_state(self, state):
-        assert len(state) == 2
+        assert len(state) in (2, 4)
         self.full_attn_allocator.restore_state(state[0])
         self.swa_attn_allocator.restore_state(state[1])
+        if len(state) == 4:
+            self.full_to_swa_index_mapping.copy_(state[2])
+            self.swa_to_full_index_mapping.copy_(state[3])
 
     def clear(self):
         self.swa_attn_allocator.clear()
         self.full_attn_allocator.clear()
         # Note: the last item is -1, we don't clear it, see the comment in __init__
         self.full_to_swa_index_mapping[:-1].fill_(0)
+        self.swa_to_full_index_mapping.fill_(0)
         self.is_not_in_free_group = True
         self.free_group = []
 

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -436,28 +436,22 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         full_indices = full_indices.to(dtype=torch.int64)
         swa_indices = swa_indices.to(dtype=torch.int64)
         valid = (full_indices > 0) & (swa_indices > 0)
-        if not torch.any(valid):
-            return
-
         full_indices = full_indices[valid]
         swa_indices = swa_indices[valid]
 
         previous_swa_indices = self.full_to_swa_index_mapping[full_indices]
         previous_valid = previous_swa_indices > 0
-        if torch.any(previous_valid):
-            previous_swa_indices = previous_swa_indices[previous_valid]
-            previous_full_indices = full_indices[previous_valid]
-            previous_owners = self.swa_to_full_index_mapping[previous_swa_indices]
-            previous_same_owner = previous_owners == previous_full_indices
-            if torch.any(previous_same_owner):
-                self.swa_to_full_index_mapping[
-                    previous_swa_indices[previous_same_owner]
-                ] = 0
+        previous_swa_indices = previous_swa_indices[previous_valid]
+        previous_full_indices = full_indices[previous_valid]
+        previous_owners = self.swa_to_full_index_mapping[previous_swa_indices]
+        previous_same_owner = previous_owners == previous_full_indices
+        self.swa_to_full_index_mapping[
+            previous_swa_indices[previous_same_owner]
+        ] = 0
 
         old_full_indices = self.swa_to_full_index_mapping[swa_indices]
         old_full_indices = old_full_indices[old_full_indices > 0]
-        if old_full_indices.numel() > 0:
-            self.full_to_swa_index_mapping[old_full_indices] = 0
+        self.full_to_swa_index_mapping[old_full_indices] = 0
 
         self.full_to_swa_index_mapping[full_indices] = swa_indices
         self.swa_to_full_index_mapping[swa_indices] = full_indices
@@ -682,7 +676,15 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         page_indices = (
             pages[:, None] * self.page_size + offsets[None, :]
         ).reshape(pages.numel(), self.page_size)
-        has_owner = torch.any(self.swa_to_full_index_mapping[page_indices] > 0, dim=1)
+        valid_page_indices = page_indices < self.swa_to_full_index_mapping.numel()
+        safe_page_indices = torch.where(
+            valid_page_indices, page_indices, torch.zeros_like(page_indices)
+        )
+        has_owner = torch.any(
+            (self.swa_to_full_index_mapping[safe_page_indices] > 0)
+            & valid_page_indices,
+            dim=1,
+        )
         free_pages = pages[~has_owner]
         if free_pages.numel() > 0:
             self.swa_attn_allocator.free(free_pages * self.page_size)
@@ -696,8 +698,6 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         swa_indices = self.full_to_swa_index_mapping[free_index]
         valid = swa_indices > 0
-        if not torch.any(valid):
-            return
 
         full_indices = free_index[valid]
         swa_indices = swa_indices[valid]
@@ -707,13 +707,10 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         current_full_indices = self.swa_to_full_index_mapping[swa_indices]
         current_owner = current_full_indices == full_indices
         stale_full_indices = full_indices[~current_owner]
-        if stale_full_indices.numel() > 0:
-            self.full_to_swa_index_mapping[stale_full_indices] = 0
+        self.full_to_swa_index_mapping[stale_full_indices] = 0
 
         full_indices = full_indices[current_owner]
         swa_indices = swa_indices[current_owner]
-        if swa_indices.numel() == 0:
-            return
 
         self.swa_to_full_index_mapping[swa_indices] = 0
         self.full_to_swa_index_mapping[full_indices] = 0

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -557,12 +557,50 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
     def total_size(self) -> Tuple[int, int]:
         return self._total_size_helper()
 
+    @staticmethod
+    def _debug_sub(*values):
+        if all(isinstance(v, (int, float)) for v in values):
+            return int(values[0] - sum(values[1:]))
+        return None
+
+    def _debug_allocator_snapshot(self) -> dict[str, int | Tuple[int, int] | None]:
+        allocator = self.token_to_kv_pool_allocator
+        full_total, swa_total = self.total_size()
+        full_capacity = getattr(allocator, "size_full", None)
+        full_capacity = full_capacity() if callable(full_capacity) else full_capacity
+        swa_capacity = getattr(allocator, "size_swa", None)
+        swa_capacity = swa_capacity() if callable(swa_capacity) else swa_capacity
+        full_available = allocator.full_available_size()
+        swa_available = allocator.swa_available_size()
+        return {
+            "full_capacity": full_capacity,
+            "full_available": full_available,
+            "full_used": self._debug_sub(full_capacity, full_available),
+            "full_tree_total": full_total,
+            "full_tree_evictable": self.full_evictable_size_,
+            "full_tree_protected": self.full_protected_size_,
+            "full_non_tree_live": self._debug_sub(
+                full_capacity, full_available, full_total
+            ),
+            "swa_capacity": swa_capacity,
+            "swa_available": swa_available,
+            "swa_used": self._debug_sub(swa_capacity, swa_available),
+            "swa_tree_total": swa_total,
+            "swa_tree_evictable": self.swa_evictable_size_,
+            "swa_tree_protected": self.swa_protected_size_,
+            "swa_non_tree_live": self._debug_sub(
+                swa_capacity, swa_available, swa_total
+            ),
+        }
+
     def evict(self, params: EvictParams) -> EvictResult:
         if self.disable:
             return EvictResult()
         start_time = time.perf_counter()
         full_num_tokens = params.num_tokens
         swa_num_tokens = params.swa_num_tokens
+        debug_enabled = envs.SGLANG_DEBUG_KV_ALLOC.get()
+        debug_before = self._debug_allocator_snapshot() if debug_enabled else None
         full_num_evicted = 0
         swa_num_evicted = 0
         if full_num_tokens > 0:
@@ -660,6 +698,17 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 x = x_next
 
         self.update_eviction_metrics(full_num_evicted + swa_num_evicted, start_time)
+        if debug_enabled:
+            logger.info(
+                "SWA_EVICT_PRESSURE request_full=%s request_swa=%s "
+                "evicted_full=%s evicted_swa=%s before=%s after=%s",
+                full_num_tokens,
+                swa_num_tokens,
+                full_num_evicted,
+                swa_num_evicted,
+                debug_before,
+                self._debug_allocator_snapshot(),
+            )
         return EvictResult(
             num_tokens_evicted=full_num_evicted, swa_num_tokens_evicted=swa_num_evicted
         )


### PR DESCRIPTION
## Summary

This draft layers the disaggregated SWA cache fixes and diagnostics we validated on top of PR #24691.

- Track reverse SWA ownership so stale full-token mappings cannot free SWA slots/pages that have been reused by newer owners.
- Make SWA tail allocation, HiCache mapping restore, grouped frees, and paged frees go through ownership-aware mapping helpers.
- Add opt-in KV allocator/radix cache pressure logging behind `SGLANG_DEBUG_KV_ALLOC`.
- Add opt-in disaggregated prefill cache-release logging behind `SGLANG_DEBUG_DISAGG_PREFILL_CACHE`.

## Why

The failing disagg runs showed SWA allocator pressure and occasional stale mapping/free behavior that did not reproduce in IFB. The ownership map prevents old full slots from freeing reused SWA slots, and the page-aware free path avoids double-freeing paged SWA allocations. The debug logs preserve the allocator/radix snapshots needed to confirm whether future regressions are real pressure, fallback LRU behavior, or transfer/scheduling latency.

## Validation

- `python3 -m py_compile python/sglang/srt/mem_cache/swa_memory_pool.py python/sglang/srt/mem_cache/swa_radix_cache.py python/sglang/srt/mem_cache/common.py python/sglang/srt/disaggregation/prefill.py python/sglang/srt/environ.py`
- `git diff --check`
- Cluster run sanity from `1767362-rwlt_disagg-20260514-014435-3ee618`: final concurrency 10 results showed 96.0% cache hit rate, p50 TTFT 0.716s, p95 TTFT 1.843s, and SSE p25 output speed 86.4 tok/s. Remaining request errors appeared concentrated in an early router health-check window, so this stays draft pending re-verification.
