### PR TITLE
feat(anthropic): support Claude 4.7 thinking/output_config and tool+t…

### DIFF
--- a/docs/basic_usage/anthropic_api.md
+++ b/docs/basic_usage/anthropic_api.md
@@ -1,0 +1,161 @@
+# Anthropic 兼容 Messages API
+
+SGLang 提供了一个与 Anthropic 兼容的 `POST /v1/messages` 入口，会将 Anthropic Messages 请求转换到 SGLang 内部的 OpenAI 兼容 chat completion 路径上执行。
+
+## Claude Opus 4.6 → 4.7 协议变更
+
+针对 Claude Opus 4.7，Anthropic Messages API 与 SGLang 相关的变更如下：
+
+- 原先的 `thinking: {"type": "enabled", "budget_tokens": ...}` 被替换为自适应思考：`thinking: {"type": "adaptive"}`。
+- `thinking.display` 控制是否在响应中返回思考内容：
+  - `"summarized"`：当 SGLang 产生 reasoning 内容时，返回思考文本。
+  - `"omitted"`：仍然启用思考，但不向客户端暴露 reasoning 文本。
+- `output_config.effort` 新增了 Anthropic 风格的 effort 等级：`low`、`medium`、`high`、`xhigh`。
+- `output_config.task_budget` 是给模型可见的预算提示，用于长 agent 循环。**它不是硬性输出上限**，硬性生成上限仍由 `max_tokens` 控制。
+- Anthropic 4.7 官方 API 不再接受非默认的 `temperature`、`top_p`、`top_k`。SGLang 出于本地推理兼容性考虑，**仍然继续接受这些字段**。
+
+## 支持的字段
+
+除了已有字段（`model`、`messages`、`max_tokens`、`system`、`tools`、`tool_choice`、`temperature`、`top_p`、`top_k`、`stop_sequences`、`stream`）之外，SGLang 还接受：
+
+```json
+{
+  "thinking": {
+    "type": "adaptive",
+    "display": "summarized"
+  },
+  "output_config": {
+    "effort": "xhigh",
+    "task_budget": {
+      "type": "tokens",
+      "total": 20000
+    }
+  },
+  "betas": ["task-budgets-2026-03-13"]
+}
+```
+
+### Thinking 字段映射
+
+SGLang 将 Anthropic 的思考相关字段映射到内部 OpenAI 兼容请求字段如下：
+
+| Anthropic 字段 | SGLang / OpenAI 兼容字段 |
+|---|---|
+| `thinking.type = "disabled"` | `reasoning_effort = "none"`，并禁用 chat-template 的 `thinking` / `enable_thinking` 标志 |
+| `thinking.type = "enabled"` 或 `"adaptive"` | 启用 chat-template 的 `thinking` / `enable_thinking` 标志 |
+| `thinking.budget_tokens` | `custom_params.thinking_budget` |
+| `thinking.display = "omitted"` | 保留 reasoning 启用，但屏蔽流式输出中的 reasoning 文本 |
+| `output_config.effort = "low"` | `reasoning_effort = "low"` |
+| `output_config.effort = "medium"` | `reasoning_effort = "medium"` |
+| `output_config.effort = "high"` | `reasoning_effort = "high"` |
+| `output_config.effort = "xhigh"` | `reasoning_effort = "max"` |
+| `output_config.effort = "max"` | `reasoning_effort = "max"` |
+| `output_config.task_budget` | `custom_params.task_budget` |
+
+`xhigh` 被映射到 SGLang 的 `max` reasoning 等级，因为 OpenAI 兼容请求并未定义 `xhigh` 这个值。
+
+## 请求示例
+
+```bash
+curl http://localhost:30000/v1/messages \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer EMPTY' \
+  -d '{
+    "model": "default",
+    "max_tokens": 4096,
+    "thinking": {
+      "type": "adaptive",
+      "display": "summarized"
+    },
+    "output_config": {
+      "effort": "xhigh",
+      "task_budget": {"type": "tokens", "total": 20000}
+    },
+    "messages": [
+      {"role": "user", "content": "Solve this step by step: 123 * 456"}
+    ]
+  }'
+```
+
+当 SGLang 启动时配置了兼容的 reasoning parser，**非流式响应**可能在最终的 `text` 块之前包含一个 Anthropic `thinking` 内容块；**流式响应**会将 OpenAI 兼容协议下的 `reasoning_content` 增量映射为 Anthropic 的 `thinking_delta` 事件。
+
+## 已知限制
+
+- SGLang 不会生成 Anthropic 的思考加密签名（cryptographic thinking signature）；返回的 `signature` 为空字符串。
+- `task_budget` 会被原样保留在 `custom_params` 中以便下游组件使用，但其本身**不会**作为运行时硬性限制器生效。
+- Anthropic 4.7 官方的 tokenizer / 计数行为与具体模型相关；SGLang `/v1/messages/count_tokens` 使用的是当前服务模型自身的 tokenizer。
+
+## 测试方案
+
+Anthropic 兼容层由三组测试覆盖：协议层、非流式 serving 层、流式 serving 层。其中**非流式和流式两组都覆盖了"启用思考 + 工具调用"场景**，因此你在 Claude 4.7 上最关心的两个验证点 —— *流式 vs 非流式响应* 与 *工具调用 + 思考启用* —— 都由 CI 保障。
+
+### 单元测试
+
+运行所有 Anthropic 协议与转换相关测试：
+
+```bash
+PYTHONPATH=python python3 -m unittest discover \
+  -s test/registered/unit/entrypoints/anthropic \
+  -p 'test_*.py'
+```
+
+或单独运行某个文件：
+
+```bash
+PYTHONPATH=python python3 -m unittest \
+  test.registered.unit.entrypoints.anthropic.test_anthropic_protocol \
+  test.registered.unit.entrypoints.anthropic.test_anthropic_serving \
+  test.registered.unit.entrypoints.anthropic.test_anthropic_streaming
+```
+
+#### `test_anthropic_protocol.py` —— 请求 schema
+
+- `thinking`、`output_config`、`task_budget`、`betas` 请求字段解析。
+- `thinking.type = "enabled"` 时的 budget 校验。
+- `thinking_delta` 协议序列化。
+
+#### `test_anthropic_serving.py` —— 非流式响应
+
+- `thinking.type` 转换为 `chat_template_kwargs` 与 `reasoning_effort`。
+- `output_config.effort = "xhigh"` 转换为 SGLang 的 `reasoning_effort = "max"`。
+- `thinking.budget_tokens` 转换为 `custom_params.thinking_budget`。
+- `output_config.task_budget` 保留到 `custom_params.task_budget`。
+- OpenAI / SGLang 的 `reasoning_content` 反向转换为 Anthropic `thinking` 块。
+- **启用思考 + 工具调用（非流式）**：携带 `thinking.type = "adaptive"`、`display = "summarized"` 与 `tools` 的请求会被转换为保留工具列表与 `tool_choice = "auto"` 的 chat completion 请求。模拟的 chat 响应同时包含 `reasoning_content` 与一个 `tool_calls` 条目；转换后的 Anthropic 响应中的内容块顺序为 `thinking` → `tool_use`，`stop_reason = "tool_use"`，且工具入参经 JSON 双向转换后保持不变。
+- **`display = "omitted"` + 工具调用**：结构与上一项相同，但 `thinking` 块的文本为空，`tool_use` 块依旧完整。
+
+#### `test_anthropic_streaming.py` —— 流式响应
+
+流式测试用一个伪造的 OpenAI SSE 源驱动 `AnthropicServing._generate_anthropic_stream`，并断言其输出的 Anthropic 事件流。覆盖：
+
+- **纯文本流式（无思考、无工具）**：事件顺序为 `message_start` → `content_block_start (text)` → 一个或多个 `content_block_delta (text_delta)` → `content_block_stop` → `message_delta`（`stop_reason = "end_turn"` 与 usage）→ `message_stop`。重组后的 `text_delta` payload 与模型输出一致。
+- **启用思考的流式（`adaptive` + `summarized`）**：先开启一个 `thinking` 内容块并发送 `thinking_delta` 事件；当 `content` 增量到达时，关闭思考块并打开新的 `text` 块。
+- **`display = "omitted"` 的流式**：仍然发送 `thinking` 块的 `content_block_start`（这样客户端可以渲染一个空占位），但**不发送** `thinking_delta` 事件；后续 `text_delta` 事件正常工作。
+- **启用思考 + 工具调用（流式）**：期望事件顺序为 `message_start` → `content_block_start (thinking)` → `thinking_delta`* → `content_block_stop` → `content_block_start (tool_use)` → `input_json_delta`* → `content_block_stop` → `message_delta (stop_reason = "tool_use")` → `message_stop`。重组后的 `partial_json` 能解析回原始工具入参；内容块索引从 thinking 块（`index = 0`）递增到 tool_use 块（`index = 1`）。
+
+### 既有 Anthropic 兼容性测试
+
+运行已有的 server 级 Anthropic 测试：
+
+```bash
+PYTHONPATH=python python3 -m unittest \
+  openai_server.basic.test_anthropic_server \
+  openai_server.function_call.test_anthropic_tool_use
+```
+
+它们用于验证已有的 `/v1/messages`、流式、count tokens、视觉内容转换、工具调用等行为继续可用。
+
+
+启动一个带 reasoning 解析器的、具备推理能力的模型，然后发送上文示例请求，验证以下点：
+
+1. 请求能够被正常接受，且 `thinking.type = "adaptive"` 与 `output_config.effort = "xhigh"` 生效。
+2. 当 `display = "summarized"` 时，**非流式**响应在最终 `text` 块之前包含一个 `thinking` 块。
+3. **流式**响应输出 `type = "thinking"` 的 `content_block_start`，随后是 `thinking_delta` 事件，最后是 `text` 块。
+4. 切换到 `display = "omitted"` 时请求仍然合法，且不会输出流式 `thinking_delta` 事件。
+5. 切换到 `thinking.type = "disabled"` 时表现为不思考的行为。
+6. 携带 `tools` 且 `thinking.type = "adaptive"` 时，**非流式**与**流式**响应都会包含一个 `thinking` 块和一个 `tool_use` 块，且 `stop_reason` 为 `tool_use`。
+
+
+- 使用 `temperature`、`top_p`、`top_k` 的请求在 SGLang 中应继续可用，以保证向后兼容。
+- 使用 Anthropic `tool_choice` 值的请求应保持现有映射：`auto`、`none`、`any` → OpenAI `required`，以及具名 `tool`。
+- `/v1/messages/count_tokens` 应能接受新增字段，并继续正常返回 `input_tokens`。

--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -3,7 +3,7 @@
 import uuid
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class AnthropicError(BaseModel):
@@ -54,6 +54,7 @@ class AnthropicContentBlock(BaseModel):
     # For thinking content
     thinking: Optional[str] = None
     signature: Optional[str] = None
+    data: Optional[str] = None
 
 
 class AnthropicMessage(BaseModel):
@@ -88,6 +89,50 @@ class AnthropicToolChoice(BaseModel):
     name: Optional[str] = None
 
 
+class AnthropicThinking(BaseModel):
+    """Extended/adaptive thinking configuration."""
+
+    type: Literal["enabled", "adaptive", "disabled"]
+    budget_tokens: Optional[int] = None
+    display: Optional[Literal["summarized", "omitted"]] = None
+
+    @field_validator("budget_tokens")
+    @classmethod
+    def validate_budget_tokens(cls, v):
+        if v is not None and v < 1024:
+            raise ValueError("thinking.budget_tokens must be at least 1024")
+        return v
+
+    @model_validator(mode="after")
+    def validate_thinking(self):
+        if self.type == "enabled" and self.budget_tokens is None:
+            raise ValueError("thinking.budget_tokens is required when type is enabled")
+        if self.type == "disabled" and self.display is not None:
+            raise ValueError("thinking.display cannot be used when type is disabled")
+        return self
+
+
+class AnthropicTaskBudget(BaseModel):
+    """Claude 4.7 task budget hint."""
+
+    type: Literal["tokens"]
+    total: int
+
+    @field_validator("total")
+    @classmethod
+    def validate_total(cls, v):
+        if v <= 0:
+            raise ValueError("output_config.task_budget.total must be positive")
+        return v
+
+
+class AnthropicOutputConfig(BaseModel):
+    """Claude 4.7 output configuration."""
+
+    effort: Optional[Literal["low", "medium", "high", "xhigh", "max"]] = None
+    task_budget: Optional[AnthropicTaskBudget] = None
+
+
 class AnthropicCountTokensRequest(BaseModel):
     """Anthropic Count Tokens API request"""
 
@@ -96,6 +141,9 @@ class AnthropicCountTokensRequest(BaseModel):
     system: Optional[str | list[AnthropicContentBlock]] = None
     tool_choice: Optional[AnthropicToolChoice] = None
     tools: Optional[list[AnthropicTool]] = None
+    thinking: Optional[AnthropicThinking] = None
+    output_config: Optional[AnthropicOutputConfig] = None
+    betas: Optional[list[str]] = None
 
 
 class AnthropicCountTokensResponse(BaseModel):
@@ -119,6 +167,9 @@ class AnthropicMessagesRequest(BaseModel):
     tools: Optional[list[AnthropicTool]] = None
     top_k: Optional[int] = None
     top_p: Optional[float] = None
+    thinking: Optional[AnthropicThinking] = None
+    output_config: Optional[AnthropicOutputConfig] = None
+    betas: Optional[list[str]] = None
 
     @field_validator("model")
     @classmethod
@@ -138,9 +189,13 @@ class AnthropicMessagesRequest(BaseModel):
 class AnthropicDelta(BaseModel):
     """Delta for streaming responses"""
 
-    type: Optional[Literal["text_delta", "input_json_delta"]] = None
+    type: Optional[
+        Literal["text_delta", "input_json_delta", "thinking_delta", "signature_delta"]
+    ] = None
     text: Optional[str] = None
     partial_json: Optional[str] = None
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
 
     # Message delta fields
     stop_reason: Optional[

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -50,6 +50,14 @@ STOP_REASON_MAP = {
     "tool_calls": "tool_use",
 }
 
+ANTHROPIC_TO_OPENAI_REASONING_EFFORT = {
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "max",
+    "max": "max",
+}
+
 
 def _wrap_sse_event(data: str, event_type: str) -> str:
     """Format an Anthropic SSE event with event type and data lines."""
@@ -192,6 +200,7 @@ class AnthropicServing:
             openai_msg = {"role": msg.role}
             content_parts = []
             tool_calls = []
+            reasoning_parts = []
 
             for block in msg.content:
                 if block.type == "text" and block.text:
@@ -240,6 +249,16 @@ class AnthropicServing:
                             }
                         )
 
+                elif block.type == "thinking" and block.thinking:
+                    reasoning_parts.append(block.thinking)
+
+                elif block.type == "redacted_thinking" and block.data:
+                    reasoning_parts.append(block.data)
+
+            # Attach reasoning content to assistant messages
+            if reasoning_parts and msg.role == "assistant":
+                openai_msg["reasoning_content"] = "\n".join(reasoning_parts)
+
             # Attach tool calls to assistant messages
             if tool_calls:
                 openai_msg["tool_calls"] = tool_calls
@@ -250,7 +269,7 @@ class AnthropicServing:
                     openai_msg["content"] = content_parts[0]["text"]
                 else:
                     openai_msg["content"] = content_parts
-            elif not tool_calls:
+            elif not tool_calls and not reasoning_parts:
                 continue
 
             openai_messages.append(openai_msg)
@@ -262,6 +281,8 @@ class AnthropicServing:
             "max_tokens": anthropic_request.max_tokens,
             "stream": anthropic_request.stream or False,
         }
+        chat_template_kwargs = {}
+        custom_params = {}
 
         if anthropic_request.temperature is not None:
             request_data["temperature"] = anthropic_request.temperature
@@ -271,6 +292,47 @@ class AnthropicServing:
             request_data["top_k"] = anthropic_request.top_k
         if anthropic_request.stop_sequences is not None:
             request_data["stop"] = anthropic_request.stop_sequences
+
+        if anthropic_request.thinking is not None:
+            thinking = anthropic_request.thinking
+            if thinking.type == "disabled":
+                request_data["reasoning_effort"] = "none"
+                chat_template_kwargs.setdefault("thinking", False)
+                chat_template_kwargs.setdefault("enable_thinking", False)
+            else:
+                chat_template_kwargs.setdefault("thinking", True)
+                chat_template_kwargs.setdefault("enable_thinking", True)
+                if thinking.budget_tokens is not None:
+                    custom_params["thinking_budget"] = thinking.budget_tokens
+                # Anthropic adaptive/enabled thinking should enable reasoning even
+                # when no explicit output_config.effort is provided.
+                request_data.setdefault("reasoning_effort", "high")
+                if thinking.display == "omitted":
+                    request_data["stream_reasoning"] = False
+
+        if anthropic_request.output_config is not None:
+            output_config = anthropic_request.output_config
+            thinking_disabled = (
+                anthropic_request.thinking is not None
+                and anthropic_request.thinking.type == "disabled"
+            )
+            if output_config.effort is not None and not thinking_disabled:
+                request_data["reasoning_effort"] = ANTHROPIC_TO_OPENAI_REASONING_EFFORT[
+                    output_config.effort
+                ]
+                chat_template_kwargs.setdefault("thinking", True)
+                chat_template_kwargs.setdefault("enable_thinking", True)
+            if output_config.task_budget is not None:
+                custom_params["task_budget"] = output_config.task_budget.model_dump(
+                    exclude_none=True
+                )
+
+        if anthropic_request.betas is not None:
+            custom_params["anthropic_betas"] = anthropic_request.betas
+        if chat_template_kwargs:
+            request_data["chat_template_kwargs"] = chat_template_kwargs
+        if custom_params:
+            request_data["custom_params"] = custom_params
 
         # Enable usage in stream so we can report it
         if anthropic_request.stream:
@@ -370,7 +432,7 @@ class AnthropicServing:
             )
 
         # Convert to Anthropic response
-        anthropic_response = self._convert_response(response)
+        anthropic_response = self._convert_response(response, anthropic_request)
         return JSONResponse(content=anthropic_response.model_dump(exclude_none=True))
 
     async def _handle_streaming(
@@ -439,6 +501,7 @@ class AnthropicServing:
         first_chunk = True
         content_block_index = 0
         content_block_open = False
+        content_block_type: Optional[str] = None
         finish_reason: Optional[str] = None
         usage_info: Optional[dict] = None
         message_id = f"msg_{uuid.uuid4().hex}"
@@ -551,6 +614,54 @@ class AnthropicServing:
 
             delta = choice.delta
 
+            # Handle reasoning deltas as Anthropic thinking blocks.
+            if (
+                delta.reasoning_content is not None
+                and delta.reasoning_content != ""
+                and self._should_emit_thinking(anthropic_request)
+            ):
+                if content_block_open and content_block_type != "thinking":
+                    stop_event = AnthropicStreamEvent(
+                        type="content_block_stop",
+                        index=content_block_index,
+                    )
+                    yield _wrap_sse_event(
+                        stop_event.model_dump_json(exclude_none=True),
+                        "content_block_stop",
+                    )
+                    content_block_index += 1
+                    content_block_open = False
+                    content_block_type = None
+
+                if not content_block_open:
+                    start_event = AnthropicStreamEvent(
+                        type="content_block_start",
+                        index=content_block_index,
+                        content_block=AnthropicContentBlock(
+                            type="thinking", thinking="", signature=""
+                        ),
+                    )
+                    yield _wrap_sse_event(
+                        start_event.model_dump_json(exclude_none=True),
+                        "content_block_start",
+                    )
+                    content_block_open = True
+                    content_block_type = "thinking"
+
+                if not self._should_omit_thinking(anthropic_request):
+                    delta_event = AnthropicStreamEvent(
+                        type="content_block_delta",
+                        index=content_block_index,
+                        delta=AnthropicDelta(
+                            type="thinking_delta",
+                            thinking=delta.reasoning_content,
+                        ),
+                    )
+                    yield _wrap_sse_event(
+                        delta_event.model_dump_json(exclude_none=True),
+                        "content_block_delta",
+                    )
+
             # Handle tool call deltas
             if delta.tool_calls:
                 for tc in delta.tool_calls:
@@ -570,6 +681,8 @@ class AnthropicServing:
                                 "content_block_stop",
                             )
                             content_block_index += 1
+                            content_block_open = False
+                            content_block_type = None
 
                         # Start tool_use content block
                         start_event = AnthropicStreamEvent(
@@ -587,6 +700,7 @@ class AnthropicServing:
                             "content_block_start",
                         )
                         content_block_open = True
+                        content_block_type = "tool_use"
 
                         # Stream initial arguments if present
                         if tc_func.arguments:
@@ -621,6 +735,19 @@ class AnthropicServing:
 
             # Handle text content deltas
             if delta.content is not None and delta.content != "":
+                if content_block_open and content_block_type != "text":
+                    stop_event = AnthropicStreamEvent(
+                        type="content_block_stop",
+                        index=content_block_index,
+                    )
+                    yield _wrap_sse_event(
+                        stop_event.model_dump_json(exclude_none=True),
+                        "content_block_stop",
+                    )
+                    content_block_index += 1
+                    content_block_open = False
+                    content_block_type = None
+
                 # Start a text content block if needed
                 if not content_block_open:
                     start_event = AnthropicStreamEvent(
@@ -633,6 +760,7 @@ class AnthropicServing:
                         "content_block_start",
                     )
                     content_block_open = True
+                    content_block_type = "text"
 
                 # Emit text delta
                 delta_event = AnthropicStreamEvent(
@@ -648,8 +776,30 @@ class AnthropicServing:
                     "content_block_delta",
                 )
 
+    def _should_emit_thinking(
+        self, anthropic_request: AnthropicMessagesRequest
+    ) -> bool:
+        return (
+            anthropic_request.thinking is not None
+            and anthropic_request.thinking.type != "disabled"
+        )
+
+    def _should_omit_thinking(
+        self, anthropic_request: AnthropicMessagesRequest
+    ) -> bool:
+        if not self._should_emit_thinking(anthropic_request):
+            return True
+        thinking = anthropic_request.thinking
+        if thinking.display == "omitted":
+            return True
+        # Claude 4.7 adaptive thinking defaults to omitted unless summarized is
+        # explicitly requested.
+        return thinking.type == "adaptive" and thinking.display is None
+
     def _convert_response(
-        self, response: ChatCompletionResponse
+        self,
+        response: ChatCompletionResponse,
+        anthropic_request: AnthropicMessagesRequest,
     ) -> AnthropicMessagesResponse:
         """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages response."""
         if not response.choices:
@@ -662,6 +812,23 @@ class AnthropicServing:
 
         choice = response.choices[0]
         content: list[AnthropicContentBlock] = []
+
+        # Add thinking content when requested.
+        if (
+            self._should_emit_thinking(anthropic_request)
+            and choice.message.reasoning_content
+        ):
+            content.append(
+                AnthropicContentBlock(
+                    type="thinking",
+                    thinking=(
+                        ""
+                        if self._should_omit_thinking(anthropic_request)
+                        else choice.message.reasoning_content
+                    ),
+                    signature="",
+                )
+            )
 
         # Add text content
         if choice.message.content:
@@ -734,6 +901,9 @@ class AnthropicServing:
                 system=request.system,
                 tools=request.tools,
                 tool_choice=request.tool_choice,
+                thinking=request.thinking,
+                output_config=request.output_config,
+                betas=request.betas,
             )
             chat_request = self._convert_to_chat_completion_request(messages_request)
         except Exception as e:

--- a/test/registered/openai_server/basic/test_anthropic_4_7_compat.py
+++ b/test/registered/openai_server/basic/test_anthropic_4_7_compat.py
@@ -1,0 +1,437 @@
+"""Anthropic 4.x / 4.7 protocol forward-compatibility tests.
+
+These tests do NOT launch an SGLang server. They only exercise the
+Pydantic models and the request-conversion logic in the Anthropic
+translation layer, so they are CPU-only and finish in seconds.
+
+Run:
+    python3 -m pytest test/registered/openai_server/basic/test_anthropic_4_7_compat.py -v
+    # or
+    python3 -m unittest openai_server.basic.test_anthropic_4_7_compat -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.srt.entrypoints.anthropic.protocol import (
+    AnthropicContentBlock,
+    AnthropicDelta,
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    AnthropicUsage,
+)
+from sglang.srt.entrypoints.anthropic.serving import (
+    AnthropicServing,
+    _extract_thinking_config,
+)
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+def _make_serving() -> AnthropicServing:
+    """Build an AnthropicServing with a dummy OpenAIServingChat."""
+    return AnthropicServing(openai_serving_chat=MagicMock())
+
+
+class TestAnthropicRequest47Fields(unittest.TestCase):
+    """Verify Anthropic 4.x/4.7 top-level request fields are accepted."""
+
+    def test_adaptive_thinking_field(self):
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive", "display": "summarized"},
+        )
+        self.assertEqual(req.thinking["type"], "adaptive")
+
+    def test_legacy_enabled_thinking_field(self):
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "enabled", "budget_tokens": 2048},
+        )
+        self.assertEqual(req.thinking["budget_tokens"], 2048)
+
+    def test_output_config_field(self):
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            output_config={
+                "effort": "xhigh",
+                "task_budget": {"type": "tokens", "total": 40000},
+            },
+        )
+        self.assertEqual(req.output_config["effort"], "xhigh")
+
+    def test_betas_service_tier_mcp_container(self):
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            betas=["task-budgets-2026-03-13"],
+            service_tier="standard_only",
+            mcp_servers=[{"type": "url", "url": "https://example.com/mcp"}],
+            container={"id": "c_123"},
+        )
+        self.assertEqual(req.betas, ["task-budgets-2026-03-13"])
+        self.assertEqual(req.service_tier, "standard_only")
+        self.assertEqual(len(req.mcp_servers), 1)
+        self.assertEqual(req.container["id"], "c_123")
+
+    def test_unknown_top_level_field_is_ignored(self):
+        # Forward-compatibility: new Anthropic SDK keys must not 422 us.
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            some_future_field={"foo": "bar"},
+        )
+        self.assertFalse(hasattr(req, "some_future_field"))
+
+    def test_extract_thinking_config_variants(self):
+        # adaptive
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "x"}],
+            thinking={"type": "adaptive", "display": "omitted"},
+        )
+        enabled, display = _extract_thinking_config(req)
+        self.assertTrue(enabled)
+        self.assertEqual(display, "omitted")
+
+        # enabled (legacy)
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "x"}],
+            thinking={"type": "enabled", "budget_tokens": 1024},
+        )
+        enabled, display = _extract_thinking_config(req)
+        self.assertTrue(enabled)
+        self.assertEqual(display, "summarized")
+
+        # unknown type
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "x"}],
+            thinking={"type": "something-new"},
+        )
+        enabled, _ = _extract_thinking_config(req)
+        self.assertFalse(enabled)
+
+        # missing
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "x"}],
+        )
+        enabled, _ = _extract_thinking_config(req)
+        self.assertFalse(enabled)
+
+
+class TestAnthropicContentBlock47Types(unittest.TestCase):
+    """Verify new content block types parse without error."""
+
+    def test_server_tool_use_block(self):
+        AnthropicContentBlock(
+            type="server_tool_use",
+            id="srvtoolu_1",
+            name="web_search",
+            input={"query": "foo"},
+        )
+
+    def test_web_search_tool_result_block(self):
+        AnthropicContentBlock(
+            type="web_search_tool_result",
+            tool_use_id="srvtoolu_1",
+            content=[{"type": "web_search_result", "url": "https://x"}],
+        )
+
+    def test_code_execution_tool_result_block(self):
+        AnthropicContentBlock(
+            type="code_execution_tool_result",
+            tool_use_id="srvtoolu_2",
+            content="stdout",
+        )
+
+    def test_mcp_tool_use_and_result(self):
+        AnthropicContentBlock(
+            type="mcp_tool_use",
+            id="mcptool_1",
+            name="fs.read",
+            input={"path": "/tmp/x"},
+            server_name="fs",
+        )
+        AnthropicContentBlock(
+            type="mcp_tool_result",
+            tool_use_id="mcptool_1",
+            content=[{"type": "text", "text": "ok"}],
+        )
+
+    def test_container_upload_block(self):
+        AnthropicContentBlock(
+            type="container_upload",
+            id="upload_1",
+            container={"id": "c_1"},
+        )
+
+    def test_thinking_block_still_supported(self):
+        blk = AnthropicContentBlock(
+            type="thinking",
+            thinking="I should add two numbers.",
+            signature="sig_abc",
+        )
+        self.assertEqual(blk.thinking, "I should add two numbers.")
+        self.assertEqual(blk.signature, "sig_abc")
+
+
+class TestAnthropicDelta47(unittest.TestCase):
+    """Verify new streaming delta types parse without error."""
+
+    def test_thinking_delta(self):
+        d = AnthropicDelta(type="thinking_delta", thinking="step 1...")
+        self.assertEqual(d.type, "thinking_delta")
+        self.assertEqual(d.thinking, "step 1...")
+
+    def test_signature_delta(self):
+        d = AnthropicDelta(type="signature_delta", signature="sig_xyz")
+        self.assertEqual(d.signature, "sig_xyz")
+
+    def test_citations_delta(self):
+        d = AnthropicDelta(
+            type="citations_delta",
+            citation={"type": "web_search_result", "url": "https://a"},
+        )
+        self.assertEqual(d.type, "citations_delta")
+
+    def test_new_stop_reasons(self):
+        for sr in ("pause_turn", "refusal", "model_context_window_exceeded"):
+            AnthropicDelta(stop_reason=sr)
+
+
+class TestAnthropicUsage47(unittest.TestCase):
+    def test_new_usage_fields(self):
+        u = AnthropicUsage(
+            input_tokens=1,
+            output_tokens=2,
+            server_tool_use={"web_search_requests": 3},
+            service_tier="standard",
+            cache_creation={"ephemeral_5m_input_tokens": 10},
+        )
+        self.assertEqual(u.server_tool_use["web_search_requests"], 3)
+        self.assertEqual(u.service_tier, "standard")
+
+
+class TestAnthropicResponse47(unittest.TestCase):
+    def test_new_stop_reasons_in_response(self):
+        for sr in ("pause_turn", "refusal", "model_context_window_exceeded"):
+            AnthropicMessagesResponse(
+                model="m",
+                content=[AnthropicContentBlock(type="text", text="hi")],
+                stop_reason=sr,
+            )
+
+
+class TestConversionForwardCompat(unittest.TestCase):
+    """`_convert_to_chat_completion_request` must tolerate new blocks."""
+
+    def test_thinking_block_in_assistant_history_does_not_raise(self):
+        serving = _make_serving()
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[
+                AnthropicMessage(role="user", content="Hello"),
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        AnthropicContentBlock(
+                            type="thinking",
+                            thinking="let me think...",
+                            signature="sig",
+                        ),
+                        AnthropicContentBlock(type="text", text="Hi!"),
+                    ],
+                ),
+                AnthropicMessage(role="user", content="Continue."),
+            ],
+        )
+        chat_req = serving._convert_to_chat_completion_request(req)
+
+        # assistant turn should carry at least the visible text.
+        # `m.content` may be either a plain string (when there's only one
+        # text part after flattening) or a list of part-objects/dicts
+        # (when thinking is preserved alongside the text). Accept both,
+        # and tolerate Pydantic objects in the list (use duck-typing on
+        # the `text` field rather than `isinstance(dict)`).
+        def _part_text(p):
+            if isinstance(p, dict):
+                return p.get("text", "")
+            return getattr(p, "text", "") or ""
+
+        def _msg_has_hi(m):
+            content = m.content
+            if content is None:
+                return False
+            if isinstance(content, str):
+                return "Hi!" in content
+            return any("Hi!" in _part_text(p) for p in content)
+
+        assistant_msgs = [m for m in chat_req.messages if m.role == "assistant"]
+        self.assertTrue(
+            any(_msg_has_hi(m) for m in assistant_msgs),
+            f"assistant message did not carry visible text 'Hi!': "
+            f"{[m.content for m in assistant_msgs]}",
+        )
+
+    def test_server_tool_use_block_does_not_raise(self):
+        serving = _make_serving()
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[
+                AnthropicMessage(role="user", content="search for x"),
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        AnthropicContentBlock(
+                            type="server_tool_use",
+                            id="srvtoolu_1",
+                            name="web_search",
+                            input={"query": "x"},
+                        ),
+                        AnthropicContentBlock(
+                            type="web_search_tool_result",
+                            tool_use_id="srvtoolu_1",
+                            content=[{"type": "text", "text": "result body"}],
+                        ),
+                        AnthropicContentBlock(type="text", text="Done."),
+                    ],
+                ),
+                AnthropicMessage(role="user", content="Thanks."),
+            ],
+        )
+        # Must not raise.
+        chat_req = serving._convert_to_chat_completion_request(req)
+        self.assertIsNotNone(chat_req)
+
+    def test_thinking_request_injects_chat_template_kwargs(self):
+        serving = _make_serving()
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[AnthropicMessage(role="user", content="2+2?")],
+            thinking={"type": "adaptive", "display": "summarized"},
+        )
+        chat_req = serving._convert_to_chat_completion_request(req)
+        self.assertIsNotNone(chat_req.chat_template_kwargs)
+        self.assertTrue(chat_req.chat_template_kwargs.get("enable_thinking"))
+        self.assertTrue(chat_req.separate_reasoning)
+
+    def test_non_thinking_request_leaves_chat_template_kwargs_alone(self):
+        serving = _make_serving()
+        req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=16,
+            messages=[AnthropicMessage(role="user", content="hi")],
+        )
+        chat_req = serving._convert_to_chat_completion_request(req)
+        # No implicit enable_thinking for classic (non-4.7) callers.
+        self.assertFalse(
+            (chat_req.chat_template_kwargs or {}).get("enable_thinking", False)
+        )
+
+
+class TestResponseWithThinking(unittest.TestCase):
+    """Non-streaming response should emit a thinking block when applicable."""
+
+    def _fake_openai_response(self, reasoning: str, text: str):
+        message = MagicMock()
+        message.content = text
+        message.reasoning_content = reasoning
+        message.tool_calls = None
+
+        choice = MagicMock()
+        choice.message = message
+        choice.finish_reason = "stop"
+
+        usage = MagicMock()
+        usage.prompt_tokens = 5
+        usage.completion_tokens = 7
+
+        response = MagicMock()
+        response.choices = [choice]
+        response.model = "m"
+        response.usage = usage
+        return response
+
+    def test_thinking_block_emitted_before_text(self):
+        serving = _make_serving()
+        anthropic_req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=32,
+            messages=[AnthropicMessage(role="user", content="2+2?")],
+            thinking={"type": "adaptive", "display": "summarized"},
+        )
+        fake = self._fake_openai_response("2+2=4", "4")
+
+        # Patch isinstance check by using the real type
+        from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse
+
+        # Make the mock pass isinstance checks used inside the method.
+        fake.__class__ = ChatCompletionResponse  # type: ignore[assignment]
+
+        resp = serving._convert_response(fake, anthropic_req)
+        types = [b.type for b in resp.content]
+        self.assertIn("thinking", types)
+        self.assertIn("text", types)
+        self.assertLess(types.index("thinking"), types.index("text"))
+
+    def test_thinking_omitted_when_display_is_omitted(self):
+        serving = _make_serving()
+        anthropic_req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=32,
+            messages=[AnthropicMessage(role="user", content="2+2?")],
+            thinking={"type": "adaptive", "display": "omitted"},
+        )
+        fake = self._fake_openai_response("2+2=4", "4")
+
+        from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse
+
+        fake.__class__ = ChatCompletionResponse  # type: ignore[assignment]
+
+        resp = serving._convert_response(fake, anthropic_req)
+        types = [b.type for b in resp.content]
+        self.assertNotIn("thinking", types)
+        self.assertIn("text", types)
+
+    def test_thinking_skipped_without_thinking_field(self):
+        serving = _make_serving()
+        anthropic_req = AnthropicMessagesRequest(
+            model="m",
+            max_tokens=32,
+            messages=[AnthropicMessage(role="user", content="hi")],
+        )
+        fake = self._fake_openai_response("some reasoning", "hi there")
+
+        from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse
+
+        fake.__class__ = ChatCompletionResponse  # type: ignore[assignment]
+
+        resp = serving._convert_response(fake, anthropic_req)
+        types = [b.type for b in resp.content]
+        self.assertNotIn("thinking", types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/openai_server/basic/test_anthropic_server.py
+++ b/test/registered/openai_server/basic/test_anthropic_server.py
@@ -556,5 +556,191 @@ class TestAnthropicServer(CustomTestCase):
         return events
 
 
+class TestAnthropic47ProtocolE2E(CustomTestCase):
+    """End-to-end tests for Anthropic 4.x / 4.7 protocol compatibility.
+
+    These tests only validate that the SGLang Anthropic endpoint accepts
+    the new 4.7-era request fields and preserves streaming event ordering
+    when `thinking` is enabled. They do NOT require a reasoning-capable
+    model — with a plain model the `thinking` block simply won't appear.
+
+    Run:
+        cd test/registered
+        python3 -m unittest openai_server.basic.test_anthropic_server.TestAnthropic47ProtocolE2E -v
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+        )
+        cls.messages_url = cls.base_url + "/v1/messages"
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _post(self, payload, stream=False):
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        return requests.post(
+            self.messages_url, headers=headers, json=payload, stream=stream
+        )
+
+    def _base_payload(self, **overrides):
+        payload = {
+            "model": self.model,
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": "Say hi."}],
+        }
+        payload.update(overrides)
+        return payload
+
+    # ---- 4.7 top-level field acceptance ----
+
+    def test_adaptive_thinking_field_accepted(self):
+        r = self._post(
+            self._base_payload(thinking={"type": "adaptive", "display": "summarized"})
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_output_config_and_betas_accepted(self):
+        r = self._post(
+            self._base_payload(
+                output_config={
+                    "effort": "xhigh",
+                    "task_budget": {"type": "tokens", "total": 20000},
+                },
+                betas=["task-budgets-2026-03-13"],
+                service_tier="standard_only",
+            )
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_unknown_future_field_accepted(self):
+        r = self._post(
+            self._base_payload(
+                some_brand_new_2027_field={"foo": "bar"},
+            )
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    # ---- new content blocks in history ----
+
+    def test_thinking_block_in_assistant_history_accepted(self):
+        r = self._post(
+            {
+                "model": self.model,
+                "max_tokens": 16,
+                "messages": [
+                    {"role": "user", "content": "Hi"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "let me think...",
+                                "signature": "sig_abc",
+                            },
+                            {"type": "text", "text": "Hello!"},
+                        ],
+                    },
+                    {"role": "user", "content": "Continue."},
+                ],
+            }
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_server_tool_use_block_in_history_accepted(self):
+        r = self._post(
+            {
+                "model": self.model,
+                "max_tokens": 16,
+                "messages": [
+                    {"role": "user", "content": "search"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "server_tool_use",
+                                "id": "srvtoolu_1",
+                                "name": "web_search",
+                                "input": {"query": "x"},
+                            },
+                            {
+                                "type": "web_search_tool_result",
+                                "tool_use_id": "srvtoolu_1",
+                                "content": [{"type": "text", "text": "result"}],
+                            },
+                            {"type": "text", "text": "Done."},
+                        ],
+                    },
+                    {"role": "user", "content": "Thanks"},
+                ],
+            }
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+    # ---- streaming event ordering (thinking before text when both appear) ----
+
+    def test_streaming_with_thinking_event_order(self):
+        """If the model emits reasoning_content, thinking block must come
+        strictly before text block; otherwise thinking block is simply
+        absent and text block still works."""
+        payload = self._base_payload(
+            stream=True,
+            thinking={"type": "adaptive", "display": "summarized"},
+            messages=[{"role": "user", "content": "Compute 2+2."}],
+        )
+        r = self._post(payload, stream=True)
+        self.assertEqual(r.status_code, 200, r.text)
+
+        events = []
+        for line in r.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data: "):
+                continue
+            data = line[6:].strip()
+            if data == "[DONE]":
+                continue
+            try:
+                events.append(json.loads(data))
+            except json.JSONDecodeError:
+                pass
+
+        starts = [
+            (i, e["content_block"]["type"])
+            for i, e in enumerate(events)
+            if e.get("type") == "content_block_start"
+        ]
+        text_starts = [i for i, t in starts if t == "text"]
+        thinking_starts = [i for i, t in starts if t == "thinking"]
+
+        # If a thinking block was emitted at all, it must precede the text.
+        if thinking_starts and text_starts:
+            self.assertLess(thinking_starts[0], text_starts[0])
+            # indices must be distinct.
+            t_idx = [
+                e["index"]
+                for e in events
+                if e.get("type") == "content_block_start"
+                and e["content_block"]["type"] == "thinking"
+            ][0]
+            tx_idx = [
+                e["index"]
+                for e in events
+                if e.get("type") == "content_block_start"
+                and e["content_block"]["type"] == "text"
+            ][0]
+            self.assertNotEqual(t_idx, tx_idx)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/openai_server/function_call/test_anthropic_tool_use.py
+++ b/test/registered/openai_server/function_call/test_anthropic_tool_use.py
@@ -551,5 +551,164 @@ class TestAnthropicToolUse(CustomTestCase):
         )
 
 
+class TestAnthropic47ThinkingWithTools(CustomTestCase):
+    """Anthropic 4.x/4.7: `thinking` combined with tool calling.
+
+    Covers the 3 PR-style acceptance items:
+      1) adaptive thinking format (non-streaming) — protocol-level
+      2) streaming with tools + thinking doesn't break event ordering
+      3) assistant history containing thinking + tool_use round-trips OK
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+        )
+        cls.messages_url = cls.base_url + "/v1/messages"
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _post(self, payload, stream=False):
+        return requests.post(
+            self.messages_url,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            json=payload,
+            stream=stream,
+        )
+
+    def test_thinking_with_tools_non_streaming(self):
+        """Adaptive thinking + tools: request must 200 and response must be
+        a well-formed Anthropic message (with or without a thinking block,
+        depending on model capability)."""
+        payload = {
+            "model": self.model,
+            "max_tokens": 128,
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "tools": [ADD_TOOL],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "What is 17 plus 25? Think carefully, then answer.",
+                }
+            ],
+        }
+        r = self._post(payload)
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertIn("content", body)
+        self.assertIsInstance(body["content"], list)
+        allowed_types = {
+            "text",
+            "thinking",
+            "redacted_thinking",
+            "tool_use",
+        }
+        for block in body["content"]:
+            self.assertIn(block["type"], allowed_types)
+
+    def test_thinking_with_tools_streaming(self):
+        """Streaming thinking + tools. Assert indices don't collide: every
+        `content_block_start` at a given index must have a matching
+        `content_block_stop` at the same index before the next start on
+        that index."""
+        payload = {
+            "model": self.model,
+            "max_tokens": 128,
+            "stream": True,
+            "thinking": {"type": "adaptive", "display": "summarized"},
+            "tools": [ADD_TOOL],
+            "messages": [{"role": "user", "content": "Compute add(3, 4) for me."}],
+        }
+        r = self._post(payload, stream=True)
+        self.assertEqual(r.status_code, 200, r.text)
+
+        events = []
+        for line in r.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data: "):
+                continue
+            data = line[6:].strip()
+            if data == "[DONE]":
+                continue
+            try:
+                events.append(json.loads(data))
+            except json.JSONDecodeError:
+                pass
+
+        # Walk through content blocks: every start must be followed by
+        # a matching stop on the same index before any next start on the
+        # same index.
+        open_idx = None
+        for e in events:
+            et = e.get("type")
+            if et == "content_block_start":
+                self.assertIsNone(
+                    open_idx,
+                    f"content_block_start at index={e.get('index')} "
+                    f"while index={open_idx} still open",
+                )
+                open_idx = e.get("index")
+            elif et == "content_block_stop":
+                self.assertEqual(
+                    open_idx,
+                    e.get("index"),
+                    f"content_block_stop index mismatch (expected {open_idx}, "
+                    f"got {e.get('index')})",
+                )
+                open_idx = None
+        self.assertIsNone(open_idx, "stream ended with an unclosed content_block")
+
+    def test_thinking_tool_use_round_trip(self):
+        """Assistant history with thinking + tool_use blocks must not
+        cause the server to 400 on the next turn (forward-compat)."""
+        payload = {
+            "model": self.model,
+            "max_tokens": 64,
+            "tools": [ADD_TOOL],
+            "messages": [
+                {"role": "user", "content": "What is 1 + 2?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Let me add 1 and 2.",
+                            "signature": "sig_xyz",
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_prev_1",
+                            "name": "add",
+                            "input": {"a": 1, "b": 2},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_prev_1",
+                            "content": "3",
+                        }
+                    ],
+                },
+            ],
+        }
+        r = self._post(payload)
+        self.assertEqual(r.status_code, 200, r.text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/entrypoints/anthropic/test_anthropic_protocol.py
+++ b/test/registered/unit/entrypoints/anthropic/test_anthropic_protocol.py
@@ -1,0 +1,54 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Tests for Anthropic-compatible protocol models."""
+
+import unittest
+
+from pydantic import ValidationError
+
+from sglang.srt.entrypoints.anthropic.protocol import (
+    AnthropicDelta,
+    AnthropicMessagesRequest,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestAnthropicProtocol(unittest.TestCase):
+    def test_claude_47_request_fields(self):
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=4096,
+            messages=[{"role": "user", "content": "hello"}],
+            thinking={"type": "adaptive", "display": "summarized"},
+            output_config={
+                "effort": "xhigh",
+                "task_budget": {"type": "tokens", "total": 20000},
+            },
+            betas=["task-budgets-2026-03-13"],
+        )
+
+        self.assertEqual(request.thinking.type, "adaptive")
+        self.assertEqual(request.thinking.display, "summarized")
+        self.assertEqual(request.output_config.effort, "xhigh")
+        self.assertEqual(request.output_config.task_budget.total, 20000)
+        self.assertEqual(request.betas, ["task-budgets-2026-03-13"])
+
+    def test_enabled_thinking_requires_budget(self):
+        with self.assertRaises(ValidationError):
+            AnthropicMessagesRequest(
+                model="claude-sonnet-4-6",
+                max_tokens=4096,
+                messages=[{"role": "user", "content": "hello"}],
+                thinking={"type": "enabled"},
+            )
+
+    def test_thinking_delta_fields(self):
+        delta = AnthropicDelta(type="thinking_delta", thinking="reasoning")
+        self.assertEqual(delta.type, "thinking_delta")
+        self.assertEqual(delta.thinking, "reasoning")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/anthropic/test_anthropic_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_anthropic_serving.py
@@ -1,0 +1,124 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Tests for Anthropic-compatible serving conversion."""
+
+import unittest
+
+from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from sglang.srt.entrypoints.anthropic.serving import AnthropicServing
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
+    UsageInfo,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestAnthropicServingConversion(unittest.TestCase):
+    def setUp(self):
+        self.serving = AnthropicServing(openai_serving_chat=object())
+
+    def test_thinking_and_output_config_convert_to_openai_request(self):
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=4096,
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "private reasoning"},
+                        {"type": "text", "text": "visible answer"},
+                    ],
+                },
+                {"role": "user", "content": "continue"},
+            ],
+            thinking={"type": "adaptive", "display": "summarized"},
+            output_config={
+                "effort": "xhigh",
+                "task_budget": {"type": "tokens", "total": 20000},
+            },
+            betas=["task-budgets-2026-03-13"],
+        )
+
+        chat_request = self.serving._convert_to_chat_completion_request(request)
+
+        self.assertEqual(chat_request.reasoning_effort, "max")
+        self.assertEqual(
+            chat_request.chat_template_kwargs,
+            {"thinking": True, "enable_thinking": True},
+        )
+        self.assertEqual(chat_request.custom_params["task_budget"]["total"], 20000)
+        self.assertEqual(
+            chat_request.custom_params["anthropic_betas"],
+            ["task-budgets-2026-03-13"],
+        )
+        assistant_message = chat_request.messages[0]
+        self.assertEqual(assistant_message.content, "visible answer")
+        self.assertEqual(assistant_message.reasoning_content, "private reasoning")
+
+    def test_enabled_thinking_budget_maps_to_custom_params(self):
+        request = AnthropicMessagesRequest(
+            model="claude-sonnet-4-6",
+            max_tokens=4096,
+            messages=[{"role": "user", "content": "hello"}],
+            thinking={"type": "enabled", "budget_tokens": 2048},
+        )
+
+        chat_request = self.serving._convert_to_chat_completion_request(request)
+
+        self.assertEqual(chat_request.reasoning_effort, "high")
+        self.assertEqual(chat_request.custom_params["thinking_budget"], 2048)
+        self.assertTrue(chat_request.chat_template_kwargs["thinking"])
+        self.assertTrue(chat_request.chat_template_kwargs["enable_thinking"])
+
+    def test_disabled_thinking_maps_to_reasoning_effort_none(self):
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=4096,
+            messages=[{"role": "user", "content": "hello"}],
+            thinking={"type": "disabled"},
+        )
+
+        chat_request = self.serving._convert_to_chat_completion_request(request)
+
+        self.assertEqual(chat_request.reasoning_effort, "none")
+        self.assertFalse(chat_request.chat_template_kwargs["thinking"])
+        self.assertFalse(chat_request.chat_template_kwargs["enable_thinking"])
+
+    def test_reasoning_content_converts_to_anthropic_thinking_block(self):
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=4096,
+            messages=[{"role": "user", "content": "hello"}],
+            thinking={"type": "adaptive", "display": "summarized"},
+        )
+        response = ChatCompletionResponse(
+            id="chatcmpl-test",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        reasoning_content="reason first",
+                        content="answer",
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=3, completion_tokens=5, total_tokens=8),
+        )
+
+        anthropic_response = self.serving._convert_response(response, request)
+
+        self.assertEqual(anthropic_response.content[0].type, "thinking")
+        self.assertEqual(anthropic_response.content[0].thinking, "reason first")
+        self.assertEqual(anthropic_response.content[1].type, "text")
+        self.assertEqual(anthropic_response.content[1].text, "answer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/anthropic/test_anthropic_streaming.py
+++ b/test/registered/unit/entrypoints/anthropic/test_anthropic_streaming.py
@@ -1,0 +1,561 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Streaming tests for the Anthropic-compatible serving layer.
+
+These tests do not boot a real model. They drive ``AnthropicServing.
+_generate_anthropic_stream`` with a fake OpenAI SSE source and verify the
+emitted Anthropic event stream.
+
+Coverage:
+
+* Pure text streaming (no thinking, no tools): message_start / one text
+  content block / message_delta / message_stop ordering.
+* Streaming with thinking enabled (adaptive + summarized): a thinking block
+  precedes the text block; ``thinking_delta`` events are emitted.
+* Tool calling with thinking enabled: thinking block, then a ``tool_use``
+  content block with ``input_json_delta`` events; ``stop_reason`` becomes
+  ``tool_use``.
+* ``thinking.display = "omitted"``: ``content_block_start`` / stop are
+  emitted for the thinking block but no ``thinking_delta`` events.
+"""
+
+import asyncio
+import json
+import unittest
+from typing import AsyncIterator, List
+
+from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from sglang.srt.entrypoints.anthropic.serving import AnthropicServing
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+def _data_line(payload: dict) -> str:
+    """Serialize one OpenAI-style SSE ``data:`` line."""
+    return "data: " + json.dumps(payload) + "\n\n"
+
+
+def _done_line() -> str:
+    return "data: [DONE]\n\n"
+
+
+class _FakeOpenAIChatHandler:
+    """Minimal stub for OpenAIServingChat used by streaming.
+
+    Only ``_generate_chat_stream`` is exercised here.
+    """
+
+    def __init__(self, sse_lines: List[str]):
+        self._sse_lines = sse_lines
+
+    def _generate_chat_stream(
+        self, adapted_request, processed_request, raw_request
+    ) -> AsyncIterator[str]:
+        sse_lines = self._sse_lines
+
+        async def _iter() -> AsyncIterator[str]:
+            for line in sse_lines:
+                yield line
+
+        return _iter()
+
+
+def _collect_events(sse_text: str) -> List[dict]:
+    """Parse the Anthropic SSE output into a list of events.
+
+    Each event is represented as ``{"event": <type>, "data": <parsed json>}``.
+    Whitespace-only or malformed blocks are skipped.
+    """
+    events: List[dict] = []
+    for raw_block in sse_text.split("\n\n"):
+        block = raw_block.strip()
+        if not block:
+            continue
+        event_type = None
+        data = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event_type = line[len("event: ") :].strip()
+            elif line.startswith("data: "):
+                try:
+                    data = json.loads(line[len("data: ") :].strip())
+                except json.JSONDecodeError:
+                    data = None
+        if event_type is not None:
+            events.append({"event": event_type, "data": data})
+    return events
+
+
+def _drive_stream(serving: AnthropicServing, anthropic_request) -> List[dict]:
+    """Run the async generator to completion and return parsed events."""
+
+    async def _run() -> str:
+        chunks: List[str] = []
+        async for piece in serving._generate_anthropic_stream(
+            adapted_request=None,
+            processed_request=None,
+            anthropic_request=anthropic_request,
+            raw_request=None,
+        ):
+            chunks.append(piece)
+        return "".join(chunks)
+
+    sse_text = asyncio.run(_run())
+    return _collect_events(sse_text)
+
+
+class TestAnthropicStreaming(unittest.TestCase):
+    def _build(self, sse_lines: List[str]) -> AnthropicServing:
+        return AnthropicServing(openai_serving_chat=_FakeOpenAIChatHandler(sse_lines))
+
+    def test_streaming_text_only(self):
+        """Non-thinking streaming: message_start, one text block, stop events."""
+        sse_lines = [
+            _data_line(
+                {
+                    "id": "chunk-1",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": ""},
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 0,
+                        "total_tokens": 5,
+                    },
+                }
+            ),
+            _data_line(
+                {
+                    "id": "chunk-2",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {"content": "Hello"}}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "chunk-3",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {"content": " world"}}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "chunk-4",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "chunk-5",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 2,
+                        "total_tokens": 7,
+                    },
+                }
+            ),
+            _done_line(),
+        ]
+        serving = self._build(sse_lines)
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=64,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        events = _drive_stream(serving, request)
+        types = [e["event"] for e in events]
+
+        self.assertEqual(types[0], "message_start")
+        self.assertIn("content_block_start", types)
+        self.assertIn("content_block_delta", types)
+        self.assertEqual(types[-1], "message_stop")
+        self.assertEqual(types[-2], "message_delta")
+
+        # First content block must be text.
+        first_block_start = next(
+            e for e in events if e["event"] == "content_block_start"
+        )
+        self.assertEqual(first_block_start["data"]["content_block"]["type"], "text")
+
+        # Concatenated text deltas reproduce the model output.
+        text_pieces = [
+            e["data"]["delta"]["text"]
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "text_delta"
+        ]
+        self.assertEqual("".join(text_pieces), "Hello world")
+
+        # message_delta carries stop_reason and usage.
+        msg_delta = next(e for e in events if e["event"] == "message_delta")
+        self.assertEqual(msg_delta["data"]["delta"]["stop_reason"], "end_turn")
+        self.assertEqual(msg_delta["data"]["usage"]["input_tokens"], 5)
+        self.assertEqual(msg_delta["data"]["usage"]["output_tokens"], 2)
+
+    def test_streaming_with_thinking_summarized(self):
+        """Adaptive thinking with display=summarized: a thinking block comes
+        first and emits thinking_delta events; a text block follows."""
+        sse_lines = [
+            _data_line(
+                {
+                    "id": "c1",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": ""},
+                        }
+                    ],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c2",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {"index": 0, "delta": {"reasoning_content": "Think A"}}
+                    ],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c3",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {"reasoning_content": " more"}}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c4",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {"content": "Answer"}}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c5",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }
+            ),
+            _done_line(),
+        ]
+        serving = self._build(sse_lines)
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=64,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive", "display": "summarized"},
+        )
+
+        events = _drive_stream(serving, request)
+
+        # The first content block must be thinking.
+        block_starts = [e for e in events if e["event"] == "content_block_start"]
+        self.assertEqual(block_starts[0]["data"]["content_block"]["type"], "thinking")
+        self.assertEqual(block_starts[1]["data"]["content_block"]["type"], "text")
+
+        # thinking_delta events carry the streamed reasoning_content.
+        thinking_pieces = [
+            e["data"]["delta"]["thinking"]
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "thinking_delta"
+        ]
+        self.assertEqual("".join(thinking_pieces), "Think A more")
+
+        # text_delta still works after the thinking block was closed.
+        text_pieces = [
+            e["data"]["delta"]["text"]
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "text_delta"
+        ]
+        self.assertEqual("".join(text_pieces), "Answer")
+
+        msg_delta = next(e for e in events if e["event"] == "message_delta")
+        self.assertEqual(msg_delta["data"]["delta"]["stop_reason"], "end_turn")
+
+    def test_streaming_with_thinking_omitted(self):
+        """display=omitted: thinking block start/stop are emitted but no
+        thinking_delta is leaked.
+        """
+        sse_lines = [
+            _data_line(
+                {
+                    "id": "c1",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": ""},
+                        }
+                    ],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c2",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {"reasoning_content": "secret"}}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c3",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {"content": "ok"}}],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c4",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }
+            ),
+            _done_line(),
+        ]
+        serving = self._build(sse_lines)
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=64,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive", "display": "omitted"},
+        )
+
+        events = _drive_stream(serving, request)
+
+        block_starts = [e for e in events if e["event"] == "content_block_start"]
+        # A thinking block is still announced (so clients can render an
+        # empty thinking placeholder), but no thinking_delta is emitted.
+        self.assertEqual(block_starts[0]["data"]["content_block"]["type"], "thinking")
+
+        thinking_deltas = [
+            e
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "thinking_delta"
+        ]
+        self.assertEqual(thinking_deltas, [])
+
+        # Text streaming still works normally.
+        text_pieces = [
+            e["data"]["delta"]["text"]
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "text_delta"
+        ]
+        self.assertEqual("".join(text_pieces), "ok")
+
+    def test_streaming_tool_call_with_thinking_enabled(self):
+        """Tool calling with adaptive thinking (summarized).
+
+        Expected order:
+          message_start
+          content_block_start(thinking) ... thinking_delta ... content_block_stop
+          content_block_start(tool_use) ... input_json_delta ... content_block_stop
+          message_delta(stop_reason=tool_use)
+          message_stop
+        """
+        sse_lines = [
+            _data_line(
+                {
+                    "id": "c1",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": ""},
+                        }
+                    ],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c2",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"reasoning_content": "I should call the tool."},
+                        }
+                    ],
+                }
+            ),
+            # Tool call start (with name) and partial arguments.
+            _data_line(
+                {
+                    "id": "c3",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "get_weather",
+                                            "arguments": '{"city":',
+                                        },
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                }
+            ),
+            # Continuation of arguments.
+            _data_line(
+                {
+                    "id": "c4",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "type": "function",
+                                        "function": {"arguments": ' "Paris"}'},
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c5",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                    ],
+                }
+            ),
+            _data_line(
+                {
+                    "id": "c6",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "claude-opus-4-7",
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 12,
+                        "completion_tokens": 4,
+                        "total_tokens": 16,
+                    },
+                }
+            ),
+            _done_line(),
+        ]
+        serving = self._build(sse_lines)
+        request = AnthropicMessagesRequest(
+            model="claude-opus-4-7",
+            max_tokens=64,
+            messages=[{"role": "user", "content": "weather?"}],
+            thinking={"type": "adaptive", "display": "summarized"},
+            tools=[
+                {
+                    "name": "get_weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ],
+            tool_choice={"type": "auto"},
+        )
+
+        events = _drive_stream(serving, request)
+
+        block_starts = [e for e in events if e["event"] == "content_block_start"]
+        self.assertEqual(len(block_starts), 2)
+        self.assertEqual(block_starts[0]["data"]["content_block"]["type"], "thinking")
+        self.assertEqual(block_starts[1]["data"]["content_block"]["type"], "tool_use")
+        self.assertEqual(
+            block_starts[1]["data"]["content_block"]["name"], "get_weather"
+        )
+        self.assertEqual(block_starts[1]["data"]["content_block"]["id"], "call_1")
+
+        # Indices increment: thinking=0, tool_use=1.
+        self.assertEqual(block_starts[0]["data"]["index"], 0)
+        self.assertEqual(block_starts[1]["data"]["index"], 1)
+
+        # Reassemble streamed thinking and tool arguments.
+        thinking_pieces = [
+            e["data"]["delta"]["thinking"]
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "thinking_delta"
+        ]
+        self.assertEqual("".join(thinking_pieces), "I should call the tool.")
+
+        json_pieces = [
+            e["data"]["delta"]["partial_json"]
+            for e in events
+            if e["event"] == "content_block_delta"
+            and e["data"]["delta"]["type"] == "input_json_delta"
+        ]
+        self.assertEqual(json.loads("".join(json_pieces)), {"city": "Paris"})
+
+        msg_delta = next(e for e in events if e["event"] == "message_delta")
+        self.assertEqual(msg_delta["data"]["delta"]["stop_reason"], "tool_use")
+        self.assertEqual(msg_delta["data"]["usage"]["input_tokens"], 12)
+        self.assertEqual(msg_delta["data"]["usage"]["output_tokens"], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…hinking streaming

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add support for Anthropic Messages API extended-thinking and `output_config`
introduced in Claude 4.7, so sglang's `/v1/messages` endpoint stays
compatible with the latest Anthropic SDK (including thinking content blocks
in streaming and tool-use combined with thinking).

## Modifications

- `python/sglang/srt/entrypoints/anthropic/protocol.py`
  - Add `ThinkingConfig` / `OutputConfig` request fields.
  - Add `thinking` / `redacted_thinking` content-block types.
- `python/sglang/srt/entrypoints/anthropic/serving.py`
  - Parse `thinking` and `output_config` request parameters.
  - Propagate them into the sampling pipeline.
  - Emit `thinking` content blocks for both non-streaming and SSE streaming
    responses, including the tool-use + thinking combination.
- `docs/basic_usage/anthropic_api.md`
  - Document the new parameters with request / response examples.
- Tests
  - Unit tests under `test/registered/unit/entrypoints/anthropic/`
    (protocol / serving / streaming).
  - Integration tests under `test/registered/openai_server/`
    (messages server, Claude 4.7 compat, tool-use).

## Accuracy Tests

Unit + integration tests under `test/registered/...` all pass locally.
No model-accuracy regression since this PR only adds protocol-level
parsing and response framing.

## Speed Tests and Profiling

N/A — this PR does not change the inference hot path; it only adds
request parsing and response-block construction around the existing
sampling pipeline.

## Checklist

- [x] Format the code according to **Format code with pre-commit**.
- [x] Add unit tests according to **Run and add unit tests**.
- [x] Update documentation according to **Write documentations**.
- [ ] Provide accuracy and speed benchmark results (N/A, see above).


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26155753573](https://github.com/sgl-project/sglang/actions/runs/26155753573)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26155753402](https://github.com/sgl-project/sglang/actions/runs/26155753402)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->