### PR TITLE
[Feature] enable DeepSeek V4 CSA indexCache reuse

### DIFF
--- a/python/sglang/srt/configs/deepseek_v4.py
+++ b/python/sglang/srt/configs/deepseek_v4.py
@@ -58,6 +58,8 @@ class DeepSeekV4Config(PretrainedConfig):
     index_head_dim: int = 128
     index_n_heads: int = 64
     index_topk: int = 512
+    index_topk_freq: int = 1
+    index_topk_pattern: Optional[List[str]] = None
     initializer_range: float = 0.02
     intermediate_size: int = 2048
     kv_lora_rank: int = 512

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -20,7 +20,10 @@ from sglang.srt.layers.attention.dsv4.metadata import PagedIndexerMetadata
 from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
 from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 from sglang.srt.layers.linear import ReplicatedLinear
-from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
+from sglang.srt.state_capturer.indexer_topk import (
+    get_global_indexer_capturer,
+    maybe_capture_indexer_topk,
+)
 from sglang.srt.utils import add_prefix, is_hip
 
 if TYPE_CHECKING:
@@ -62,7 +65,7 @@ def fp8_paged_mqa_logits_torch(
     assert weight.shape == (batch_size, num_heads)
     assert seq_lens.shape == (batch_size,)
     assert page_table.shape[0] == batch_size
-    assert clean_logits == False
+    assert not clean_logits
 
     logits = page_table.new_empty((batch_size, max_seq_len), dtype=torch.float32)
     for i in range(batch_size):
@@ -184,6 +187,36 @@ def topk_transform_512_pytorch_vectorized(
             valid_topk, raw_indices, torch.tensor(-1, device=device, dtype=torch.int32)
         )
         out_raw_indices.copy_(raw_indices)
+
+
+def transform_raw_c4_indices_to_page_indices(
+    raw_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+) -> None:
+    assert raw_indices.shape == out_page_indices.shape
+    assert page_size > 0 and (page_size & (page_size - 1)) == 0
+
+    if seq_lens.dim() == 2:
+        seq_lens = seq_lens.squeeze(-1)
+    assert seq_lens.dim() == 1
+    assert raw_indices.shape[0] == seq_lens.shape[0] == page_table.shape[0]
+
+    page_bits = (page_size - 1).bit_length()
+    page_mask = page_size - 1
+
+    page_idx = raw_indices >> page_bits
+    offset_in_page = raw_indices & page_mask
+    page_idx_clamped = page_idx.clamp(min=0, max=page_table.shape[1] - 1)
+    physical_pages = torch.gather(page_table, dim=1, index=page_idx_clamped.long())
+    page_indices = (physical_pages << page_bits) | offset_in_page
+
+    valid = (raw_indices >= 0) & (raw_indices < seq_lens.unsqueeze(1))
+    valid &= physical_pages >= 0
+    page_indices.masked_fill_(~valid, -1)
+    out_page_indices.copy_(page_indices.to(torch.int32))
 
 
 @triton.jit
@@ -320,9 +353,12 @@ class C4IndexerBackendMixin:
         alt_streams: Optional[List[torch.cuda.Stream]] = None,
         enable_multi_stream: bool = False,
         q_lora_ready: Optional[torch.cuda.Event] = None,
-    ) -> None:
+        prev_topk_indices: Optional[torch.Tensor] = None,
+        skip_topk: bool = False,
+        return_topk_indices: bool = False,
+    ) -> Optional[torch.Tensor]:
         if forward_batch.forward_mode.is_idle():
-            return
+            return None
         # PREP_IN_CG lazy upgrade: this runs from MQALayer._forward_prepare,
         # before attn_backend.forward() would trigger the upgrade.
         self._maybe_upgrade_forward_metadata()
@@ -342,6 +378,46 @@ class C4IndexerBackendMixin:
 
         assert isinstance(core_metadata, DSV4AttnMetadata)
         assert isinstance(indexer_metadata, PagedIndexerMetadata)
+
+        indexer_capturer = get_global_indexer_capturer()
+        capture_enabled = indexer_capturer is not None
+
+        hisparse_coordinator = forward_batch.hisparse_coordinator
+        hisparse_decode = (
+            hisparse_coordinator is not None and forward_batch.forward_mode.is_decode()
+        )
+
+        if skip_topk and prev_topk_indices is not None:
+            compress_layer_id = token_to_kv_pool.layer_mapping[
+                c4_indexer.layer_id
+            ].compress_layer_id
+            raw_indices = maybe_capture_indexer_topk(
+                compress_layer_id, prev_topk_indices
+            )
+            transform_raw_c4_indices_to_page_indices(
+                raw_indices,
+                indexer_metadata.c4_seq_lens,
+                core_metadata.page_table,
+                core_metadata.c4_sparse_page_indices,
+                indexer_metadata.c4_page_size,
+            )
+            if hisparse_coordinator is not None:
+                if hisparse_decode:
+                    core_metadata.c4_sparse_page_indices = (
+                        hisparse_coordinator.swap_in_selected_pages(
+                            req_pool_indices=forward_batch.req_pool_indices,
+                            compressed_seq_lens=indexer_metadata.c4_seq_lens,
+                            top_k_result=raw_indices,
+                            layer_id=compress_layer_id,
+                        )
+                    )
+                else:
+                    core_metadata.c4_sparse_page_indices = (
+                        token_to_kv_pool.c4_kv_pool.translate_loc_to_hisparse_device(
+                            core_metadata.c4_sparse_page_indices
+                        )
+                    )
+            return raw_indices if return_topk_indices else None
 
         if enable_multi_stream:
             q_fp8, weights, c4_indexer_kv_cache = self._forward_prepare_multi_stream(
@@ -402,18 +478,10 @@ class C4IndexerBackendMixin:
 
         assert indexer_metadata.page_table is core_metadata.page_table
         if self.debug_use_external_c4_sparse_indices:
-            return
-
-        indexer_capturer = get_global_indexer_capturer()
-        capture_enabled = indexer_capturer is not None
-
-        hisparse_coordinator = forward_batch.hisparse_coordinator
-        hisparse_decode = (
-            hisparse_coordinator is not None and forward_batch.forward_mode.is_decode()
-        )
+            return None
 
         raw_indices = None
-        if capture_enabled:
+        if capture_enabled or return_topk_indices:
             raw_indices = torch.empty_like(core_metadata.c4_sparse_page_indices)
         elif hisparse_decode:
             raw_indices = hisparse_coordinator.raw_indices_buffer[
@@ -472,6 +540,8 @@ class C4IndexerBackendMixin:
                 c4_indexer.layer_id
             ].compress_layer_id
             indexer_capturer.capture(compress_layer_id, raw_indices)
+
+        return raw_indices if return_topk_indices else None
 
 
 class C4Indexer(nn.Module):
@@ -548,7 +618,10 @@ class C4Indexer(nn.Module):
         forward_batch: ForwardBatch,
         enable_multi_stream: bool = False,
         q_lora_ready: Optional[torch.cuda.Event] = None,
-    ) -> None:
+        prev_topk_indices: Optional[torch.Tensor] = None,
+        skip_topk: bool = False,
+        return_topk_indices: bool = False,
+    ) -> Optional[torch.Tensor]:
         if TYPE_CHECKING:
             assert isinstance(forward_batch.attn_backend, DeepseekV4AttnBackend)
         return forward_batch.attn_backend.forward_c4_indexer(
@@ -559,4 +632,7 @@ class C4Indexer(nn.Module):
             alt_streams=self.alt_streams,
             enable_multi_stream=enable_multi_stream,
             q_lora_ready=q_lora_ready,
+            prev_topk_indices=prev_topk_indices,
+            skip_topk=skip_topk,
+            return_topk_indices=return_topk_indices,
         )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -222,6 +222,8 @@ class MQALayer(nn.Module):
 
         self.compressor = None
         self.indexer = None
+        self.skip_topk = None
+        self.next_skip_topk = None
         if self.compress_ratio:
             self.compressor = Compressor(
                 config,
@@ -242,6 +244,20 @@ class MQALayer(nn.Module):
                     prefix=add_prefix("indexer", prefix),
                     alt_streams=self.alt_streams_indexer,
                 )
+                self.index_topk_freq = getattr(config, "index_topk_freq", 1)
+                self.index_topk_pattern = getattr(config, "index_topk_pattern", None)
+                if self.index_topk_pattern is None:
+                    assert self.index_topk_freq > 0
+                    self.skip_topk = max(layer_id - 1, 0) % self.index_topk_freq != 0
+                    self.next_skip_topk = layer_id % self.index_topk_freq != 0
+                else:
+                    self.skip_topk = self.index_topk_pattern[layer_id] == "S"
+                    if layer_id < len(self.index_topk_pattern) - 1:
+                        self.next_skip_topk = (
+                            self.index_topk_pattern[layer_id + 1] == "S"
+                        )
+                    else:
+                        self.next_skip_topk = False
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
         self.fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
@@ -382,7 +398,8 @@ class MQALayer(nn.Module):
         forward_batch: ForwardBatch,
         attn_backend: DeepseekV4AttnBackend,
         q_out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        prev_topk_indices: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         assert self.alt_streams is not None
         assert len(self.alt_streams) >= 3
 
@@ -406,13 +423,18 @@ class MQALayer(nn.Module):
 
         if self.indexer is not None:
             with torch.cuda.stream(stream_indexer):
-                self.indexer(
+                topk_indices = self.indexer(
                     x=x,
                     q_lora=q_lora,
                     forward_batch=forward_batch,
                     enable_multi_stream=True,
                     q_lora_ready=q_lora_ready,
+                    prev_topk_indices=prev_topk_indices,
+                    skip_topk=self.skip_topk,
+                    return_topk_indices=bool(self.next_skip_topk),
                 )
+        else:
+            topk_indices = None
 
         with torch.cuda.stream(stream_kv):
             if qkv_a_ready is not None:
@@ -441,7 +463,7 @@ class MQALayer(nn.Module):
         current_stream.wait_stream(stream_compressor)
         current_stream.wait_stream(stream_indexer)
 
-        return q, kv
+        return q, kv, topk_indices
 
     def _forward_prepare(
         self,
@@ -450,7 +472,8 @@ class MQALayer(nn.Module):
         forward_batch: ForwardBatch,
         attn_backend: DeepseekV4AttnBackend,
         q_out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        prev_topk_indices: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         if self.fuse_wqa_wkv:
             qkv_a, _ = self.wqkv_a(x)
             q = qkv_a[..., : self.q_lora_rank]
@@ -493,7 +516,16 @@ class MQALayer(nn.Module):
             )
 
         if self.indexer is not None:
-            self.indexer(x=x, q_lora=q_lora, forward_batch=forward_batch)
+            topk_indices = self.indexer(
+                x=x,
+                q_lora=q_lora,
+                forward_batch=forward_batch,
+                prev_topk_indices=prev_topk_indices,
+                skip_topk=self.skip_topk,
+                return_topk_indices=bool(self.next_skip_topk),
+            )
+        else:
+            topk_indices = None
         if self.compressor is not None:
             attn_backend.forward_core_compressor(
                 x,
@@ -504,13 +536,14 @@ class MQALayer(nn.Module):
 
         if q_out is not None:
             q_out.copy_(q)
-        return q, kv
+        return q, kv, topk_indices
 
     def forward(
         self,
         x: torch.Tensor,
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
+        prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if not get_attn_tp_context().input_scattered and x.shape[0] == 0:
             assert (
@@ -538,12 +571,12 @@ class MQALayer(nn.Module):
             q_out = q_padded[:, tp_slice, :]
 
         if enable_multi_stream:
-            q, kv = self._forward_prepare_multi_stream(
-                x, positions, forward_batch, attn_backend, q_out
+            q, kv, topk_indices = self._forward_prepare_multi_stream(
+                x, positions, forward_batch, attn_backend, q_out, prev_topk_indices
             )
         else:
-            q, kv = self._forward_prepare(
-                x, positions, forward_batch, attn_backend, q_out
+            q, kv, topk_indices = self._forward_prepare(
+                x, positions, forward_batch, attn_backend, q_out, prev_topk_indices
             )
 
         o = attn_backend.forward(
@@ -591,6 +624,8 @@ class MQALayer(nn.Module):
 
         o, _ = self.wo_b(o.flatten(1))
 
+        if self.next_skip_topk is not None:
+            return o, topk_indices if self.next_skip_topk else None
         return o
 
 
@@ -767,6 +802,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         input_ids: torch.Tensor,
         forward_batch: ForwardBatch,
         input_ids_global: torch.Tensor,
+        prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states, post, comb, norm_fused = self.hc_pre(
@@ -783,7 +819,12 @@ class DeepseekV4DecoderLayer(nn.Module):
             x=hidden_states,
             positions=positions,
             forward_batch=forward_batch,
+            prev_topk_indices=prev_topk_indices,
         )
+        if isinstance(hidden_states, tuple):
+            hidden_states, topk_indices = hidden_states
+        else:
+            topk_indices = None
 
         hidden_states = self.hc_post(hidden_states, residual, post, comb)
         residual = hidden_states
@@ -845,6 +886,8 @@ class DeepseekV4DecoderLayer(nn.Module):
 
         hidden_states = self.hc_post(hidden_states, residual, post, comb)
 
+        if self.self_attn.next_skip_topk is not None:
+            return hidden_states, topk_indices
         return hidden_states
 
 
@@ -948,6 +991,7 @@ class DeepseekV4Model(nn.Module):
             hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
 
+        topk_indices = None
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
             hidden_states = layer(
@@ -956,7 +1000,12 @@ class DeepseekV4Model(nn.Module):
                 forward_batch=forward_batch,
                 input_ids=input_ids,
                 input_ids_global=input_ids_global,
+                prev_topk_indices=topk_indices,
             )
+            if isinstance(hidden_states, tuple):
+                hidden_states, topk_indices = hidden_states
+            else:
+                topk_indices = None
 
         if nsa_use_prefill_cp(forward_batch):
             hidden_states = cp_all_gather_rerange_output(

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -152,6 +152,8 @@ class DeepseekV4ModelNextN(nn.Module):
             input_ids=input_ids,
             input_ids_global=input_ids_global,
         )
+        if isinstance(hidden_states, tuple):
+            hidden_states = hidden_states[0]
 
         pre_hc_head = hidden_states.flatten(1)
 


### PR DESCRIPTION
## Motivation

This PR adds DeepSeek V4 support for indexcache-style C4/CSA indexer topk reuse, following the same optimization direction used by DeepSeek V3.2.

DeepSeek V4 contains CSA/C4 layers that compute sparse topk indices through the C4 indexer. For selected layers, these topk indices can be reused from the previous C4 layer instead of recomputing the indexer topk path. This is intended to reduce indexer overhead while preserving the existing attention/page-table flow.

## Modifications

- Add `index_topk_freq` and `index_topk_pattern` support to DeepSeek V4 config.
- Wire `index_topk_freq` / `index_topk_pattern` into DeepSeek V4 C4/CSA attention layers.
- Propagate optional topk tensors through the DeepSeek V4 decoder stack so later selected C4 layers can reuse the previous layer's raw topk indices.
- Teach the DSV4 C4 indexer to accept reused raw topk indices and remap them through the current page table into `c4_sparse_page_indices`.
- Preserve existing HiSparse behavior when reused topk indices are used.
- Preserve indexer-topk capture behavior for both freshly computed and reused topk indices.
- Tolerate tuple returns in the DeepSeek V4 NextN path for speculative decoding compatibility.

The optimization only applies to C4/CSA layers (`compress_ratio == 4`). HCA/C128 layers are not changed because they do not use the C4 indexer/topk sparse-index path.

## Accuracy Tests

Pending.

I will run DeepSeek V4 / DeepSeek V4 Flash accuracy validation and update this section with the results shortly.

Planned tests:

- [ ] DeepSeek-V4-Flash sanity / generation correctness
- [ ] DeepSeek-V4-Flash accuracy eval
- [ ] DeepSeek-V4 accuracy eval, if resources are available
- [ ] Compare `index_topk_freq=1` baseline against reuse settings such as `index_topk_freq=2` / `4`

## Speed Tests and Profiling

Pending.

I will run performance benchmarks and profiling soon, primarily starting from DeepSeek-V4-Flash.

Planned measurements:

- [ ] Baseline throughput/latency with `index_topk_freq=1`
- [ ] Throughput/latency with `index_topk_freq=2`
- [ ] Throughput/latency with `index_topk_freq=4`
- [ ] Decode performance comparison
- [ ] Prefill/decode mixed workload comparison
- [ ] Optional profiling to confirm reduced C4 indexer/topk overhead

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## TODO

- [ ] Run DeepSeek-V4-Flash accuracy tests.
- [ ] Run DeepSeek-V4-Flash performance benchmarks.
- [ ] Add benchmark table comparing baseline and indexcache reuse settings.
- [ ] Add accuracy numbers after validation completes.
- [ ] Add or adapt an indexcache regression test if suitable for CI.
