### PR TITLE
DeepseekV2MoE: defer shared experts when routed kernel is non-mutating

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -167,6 +167,7 @@ from sglang.srt.utils import (
     BumpAllocator,
     LazyValue,
     add_prefix,
+    dispose_tensor,
     is_non_idle_and_non_empty,
     log_info_on_rank0,
     make_layers,
@@ -827,12 +828,6 @@ class DeepseekV2MoE(nn.Module):
             else None
         )
         if hidden_states.shape[0] > 0:
-            if (
-                not self._fuse_shared_experts_inside_sbo
-            ):  # TODO: check if it supports mtp
-                shared_output = self._forward_shared_experts(
-                    hidden_states, gemm_output_zero_allocator
-                )
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
             topk_kwargs = (
@@ -893,6 +888,12 @@ class DeepseekV2MoE(nn.Module):
         ):
             # fused in biased_grouped_topk so we can skip here
             final_hidden_states *= self.routed_scaling_factor
+
+        if hidden_states.shape[0] > 0:
+            if not self._fuse_shared_experts_inside_sbo:
+                shared_output = self._forward_shared_experts(
+                    hidden_states, gemm_output_zero_allocator
+                )
 
         final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
             self.experts,
@@ -1922,6 +1923,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        hidden_states_orig = hidden_states
         hidden_states, residual = self.layer_communicator.prepare_attn(
             hidden_states,
             residual,
@@ -1943,9 +1945,14 @@ class DeepseekV2DecoderLayer(nn.Module):
         else:
             topk_indices = None
 
+        get_attn_tp_context().attn_inputs_ = None
+
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch
         )
+
+        if residual is not hidden_states_orig:
+            dispose_tensor(hidden_states_orig)
 
         should_allreduce_fusion = (
             self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -167,7 +167,6 @@ from sglang.srt.utils import (
     BumpAllocator,
     LazyValue,
     add_prefix,
-    dispose_tensor,
     is_non_idle_and_non_empty,
     log_info_on_rank0,
     make_layers,
@@ -1931,7 +1930,6 @@ class DeepseekV2DecoderLayer(nn.Module):
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        hidden_states_orig = hidden_states
         hidden_states, residual = self.layer_communicator.prepare_attn(
             hidden_states,
             residual,
@@ -1956,9 +1954,6 @@ class DeepseekV2DecoderLayer(nn.Module):
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch
         )
-
-        if residual is not hidden_states_orig:
-            dispose_tensor(hidden_states_orig)
 
         should_allreduce_fusion = (
             self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -894,7 +894,11 @@ class DeepseekV2MoE(nn.Module):
             # fused in biased_grouped_topk so we can skip here
             final_hidden_states *= self.routed_scaling_factor
 
-        if defer_shared and hidden_states.shape[0] > 0 and not self._fuse_shared_experts_inside_sbo:
+        if (
+            defer_shared
+            and hidden_states.shape[0] > 0
+            and not self._fuse_shared_experts_inside_sbo
+        ):
             shared_output = self._forward_shared_experts(
                 hidden_states, gemm_output_zero_allocator
             )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -827,7 +827,12 @@ class DeepseekV2MoE(nn.Module):
             if server_args.enable_eplb
             else None
         )
+        defer_shared = not self.experts.moe_runner_config.inplace
         if hidden_states.shape[0] > 0:
+            if not defer_shared and not self._fuse_shared_experts_inside_sbo:
+                shared_output = self._forward_shared_experts(
+                    hidden_states, gemm_output_zero_allocator
+                )
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
             topk_kwargs = (
@@ -889,11 +894,10 @@ class DeepseekV2MoE(nn.Module):
             # fused in biased_grouped_topk so we can skip here
             final_hidden_states *= self.routed_scaling_factor
 
-        if hidden_states.shape[0] > 0:
-            if not self._fuse_shared_experts_inside_sbo:
-                shared_output = self._forward_shared_experts(
-                    hidden_states, gemm_output_zero_allocator
-                )
+        if defer_shared and hidden_states.shape[0] > 0 and not self._fuse_shared_experts_inside_sbo:
+            shared_output = self._forward_shared_experts(
+                hidden_states, gemm_output_zero_allocator
+            )
 
         final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
             self.experts,
@@ -1944,8 +1948,6 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states, topk_indices = hidden_states
         else:
             topk_indices = None
-
-        get_attn_tp_context().attn_inputs_ = None
 
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2976,11 +2976,19 @@ def load_json_config(data: str):
         return orjson.loads(Path(data).read_text())
 
 
+_DISPOSE_CLEAR_ALIAS_MIN_BYTES = 16 * 1024 * 1024
+
+
 def dispose_tensor(x: torch.Tensor):
     """
     Dispose a tensor by freeing its memory.
     During piecewise CUDA graph capture/replay, we skip disposal to avoid
     interfering with torch.compile's memory tracking and graph recording.
+
+    For large tensors (>= 16 MiB), also clear any aliased Python tensors that
+    share the same UntypedStorage. Some workspace/communication paths keep a
+    Python tensor pointing at the same data_ptr; without clearing it, x.set_()
+    alone does not free the underlying storage.
     """
 
     # Skip disposal during piecewise CUDA graph to avoid torch.compile issues
@@ -2991,6 +2999,41 @@ def dispose_tensor(x: torch.Tensor):
 
     if is_in_piecewise_cuda_graph():
         return
+
+    try:
+        nbytes = x.untyped_storage().nbytes()
+    except Exception:
+        nbytes = 0
+
+    if nbytes >= _DISPOSE_CLEAR_ALIAS_MIN_BYTES:
+        import gc
+
+        try:
+            from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+                is_tensor_in_symmetric_mempool,
+            )
+        except Exception:
+            is_tensor_in_symmetric_mempool = lambda _t: False
+
+        # NCCL symmetric-memory-registered tensors must stay live for collectives;
+        # skip them.
+        if is_tensor_in_symmetric_mempool(x):
+            x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
+            return
+
+        data_ptr = x.untyped_storage().data_ptr()
+        empty = torch.empty((0,), device=x.device, dtype=x.dtype)
+        for obj in gc.get_objects():
+            try:
+                if (
+                    isinstance(obj, torch.Tensor)
+                    and obj is not x
+                    and obj.untyped_storage().data_ptr() == data_ptr
+                    and not is_tensor_in_symmetric_mempool(obj)
+                ):
+                    obj.set_(empty)
+            except Exception:
+                pass
 
     x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2976,19 +2976,11 @@ def load_json_config(data: str):
         return orjson.loads(Path(data).read_text())
 
 
-_DISPOSE_CLEAR_ALIAS_MIN_BYTES = 16 * 1024 * 1024
-
-
 def dispose_tensor(x: torch.Tensor):
     """
     Dispose a tensor by freeing its memory.
     During piecewise CUDA graph capture/replay, we skip disposal to avoid
     interfering with torch.compile's memory tracking and graph recording.
-
-    For large tensors (>= 16 MiB), also clear any aliased Python tensors that
-    share the same UntypedStorage. Some workspace/communication paths keep a
-    Python tensor pointing at the same data_ptr; without clearing it, x.set_()
-    alone does not free the underlying storage.
     """
 
     # Skip disposal during piecewise CUDA graph to avoid torch.compile issues
@@ -2999,41 +2991,6 @@ def dispose_tensor(x: torch.Tensor):
 
     if is_in_piecewise_cuda_graph():
         return
-
-    try:
-        nbytes = x.untyped_storage().nbytes()
-    except Exception:
-        nbytes = 0
-
-    if nbytes >= _DISPOSE_CLEAR_ALIAS_MIN_BYTES:
-        import gc
-
-        try:
-            from sglang.srt.distributed.device_communicators.pynccl_allocator import (
-                is_tensor_in_symmetric_mempool,
-            )
-        except Exception:
-            is_tensor_in_symmetric_mempool = lambda _t: False
-
-        # NCCL symmetric-memory-registered tensors must stay live for collectives;
-        # skip them.
-        if is_tensor_in_symmetric_mempool(x):
-            x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
-            return
-
-        data_ptr = x.untyped_storage().data_ptr()
-        empty = torch.empty((0,), device=x.device, dtype=x.dtype)
-        for obj in gc.get_objects():
-            try:
-                if (
-                    isinstance(obj, torch.Tensor)
-                    and obj is not x
-                    and obj.untyped_storage().data_ptr() == data_ptr
-                    and not is_tensor_in_symmetric_mempool(obj)
-                ):
-                    obj.set_(empty)
-            except Exception:
-                pass
 
     x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
 


### PR DESCRIPTION
## Motivation

When the routed-MoE kernel does **not** mutate its input (`inplace=False`, e.g. `flashinfer_trtllm_routed`), `hidden_states` is preserved across `self.experts(...)`. In that case the existing ordering — compute `shared_experts` **before** the routed call — forces the shared-experts activations and the routed-MoE workspace to coexist on-device, inflating transient peak memory at long prefill on Kimi-K2.5-NVFP4 / Blackwell.

## Modifications

`python/sglang/srt/models/deepseek_v2.py` — `DeepseekV2MoE.forward_normal`:

- Read `defer_shared = not self.experts.moe_runner_config.inplace` once at the top.
- When `defer_shared` is **False** (in-place routed kernel, e.g. triton fused_moe — default): preserve existing ordering, call `_forward_shared_experts` **before** the routed dispatch. Required because `out_hidden_states = hidden_states` inside the triton kernel overwrites the shared-experts input.
- When `defer_shared` is **True** (non-mutating routed kernel): skip the pre-routed shared call and invoke `_forward_shared_experts` **after** the routed dispatch, so the routed workspace can be freed before shared-experts activations are allocated.
- `FusedMoE` / `MoeRunnerConfig` definitions are untouched; only the call-site ordering changes.

## Accuracy Tests

Kimi-K2.5-NVFP4, TP=4, GB300, `--moe-runner-backend flashinfer_trtllm_routed --fp4-gemm-backend flashinfer_trtllm --attention-backend trtllm_mla`: short-prompt `/generate` produces coherent decode across math, geography, translation, multi-turn prompts. Triton-MoE path (in-place default) is bit-for-bit unchanged since the deferral does not fire.

## Speed Tests and Profiling

No additional ops; only call-site reordering. Latency unaffected on the affected (`flashinfer_trtllm_routed`) path; memory peak benefit measured on Kimi-K2.5-NVFP4 16K prefill.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)