### PR TITLE
[dLLM] Add FDFO scheduling to eliminate head-of-line blocking in dLLM batching

### DIFF
--- a/python/sglang/srt/dllm/algorithm/__init__.py
+++ b/python/sglang/srt/dllm/algorithm/__init__.py
@@ -36,4 +36,10 @@ def get_algorithm(config: DllmConfig):
         raise RuntimeError(f"Unknown diffusion LLM algorithm: {name}")
 
 
+def get_algorithm_fdfo_requirement(algorithm_name: str) -> bool:
+    if algorithm_name in algo_name_to_cls:
+        return getattr(algo_name_to_cls[algorithm_name], "requires_fdfo_mode", False)
+    return False
+
+
 algo_name_to_cls = import_algorithms()

--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -4,6 +4,7 @@ from sglang.srt.server_args import ServerArgs
 
 
 class DllmAlgorithm:
+    requires_fdfo_mode: bool = False
 
     def __init__(
         self,

--- a/python/sglang/srt/dllm/algorithm/low_confidence.py
+++ b/python/sglang/srt/dllm/algorithm/low_confidence.py
@@ -24,7 +24,9 @@ class LowConfidence(DllmAlgorithm):
         self,
         model_runner: ModelRunner,
         forward_batch: ForwardBatch,
-    ) -> Tuple[Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], bool]:
+    ) -> Tuple[
+        Union[LogitsProcessorOutput, torch.Tensor], List[torch.Tensor], None, bool
+    ]:
         batch_size = forward_batch.batch_size
         # Here, the forward_batch full logits contains all the blocks
         # such as [dllm_block_size * batch_size, hidden_size]
@@ -37,7 +39,7 @@ class LowConfidence(DllmAlgorithm):
             logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
 
             next_token_ids = []
-            return logits_output, next_token_ids, can_run_cuda_graph
+            return logits_output, next_token_ids, None, can_run_cuda_graph
 
         # Calculate start positions for each block
         for block_id in range(batch_size):
@@ -98,7 +100,7 @@ class LowConfidence(DllmAlgorithm):
             next_token_ids[i, start_list[i] :] for i in range(batch_size)
         ]
 
-        return logits_output, next_token_ids_list, can_run_cuda_graph
+        return logits_output, next_token_ids_list, None, can_run_cuda_graph
 
 
 Algorithm = LowConfidence

--- a/python/sglang/srt/dllm/algorithm/low_confidence_fdfo.py
+++ b/python/sglang/srt/dllm/algorithm/low_confidence_fdfo.py
@@ -1,0 +1,109 @@
+from typing import List, Tuple, Union
+
+import torch
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class LowConfidenceFDFO(DllmAlgorithm):
+    """Low Confidence algorithm for DLLM requiring first-done-first-out mode."""
+
+    requires_fdfo_mode: bool = True
+
+    def __init__(self, config: DllmConfig) -> None:
+        super().__init__(config)
+        self.threshold = config.algorithm_config.get("threshold", 0.95)
+
+    def _pick_tokens(
+        self, forward_batch: ForwardBatch, full_logits: torch.Tensor
+    ) -> None:
+        batch_size = forward_batch.batch_size
+        vocab_size = full_logits.shape[-1]
+        full_logits = full_logits.view(batch_size, self.block_size, vocab_size)
+        input_ids = forward_batch.input_ids.view(batch_size, self.block_size)
+        block_mask_index = input_ids == self.mask_id
+        x = torch.argmax(full_logits, dim=-1)
+        probs = torch.nn.functional.softmax(full_logits, dim=-1)
+        confidence = torch.gather(probs, dim=-1, index=x.unsqueeze(-1)).squeeze(-1)
+        confidence = torch.where(
+            block_mask_index,
+            confidence,
+            torch.tensor(-float("inf"), device=confidence.device),
+        )
+        transfer_index = confidence > self.threshold
+        has_transfer = transfer_index.sum(dim=1) > 0
+        _, top1_indices = torch.topk(confidence, k=1, dim=1)
+        top1_indices = top1_indices.squeeze(-1)
+        batch_indices = torch.arange(batch_size, device=top1_indices.device)
+        top1_mask = torch.zeros_like(transfer_index, dtype=torch.bool)
+        top1_mask[batch_indices, top1_indices] = True
+        transfer_index = torch.where(
+            has_transfer.unsqueeze(-1), transfer_index, top1_mask
+        )
+        x = torch.where(block_mask_index, x, input_ids)
+        input_ids = torch.where(transfer_index, x, input_ids)
+
+        forward_batch.input_ids = input_ids.view(-1)
+
+    def _post_forward_process(
+        self, forward_batch: ForwardBatch, full_logits: torch.Tensor
+    ) -> Tuple[List[List[int]], List[int]]:
+        batch_size = forward_batch.batch_size
+        expected_batch_size = forward_batch.input_ids.shape[0] // self.block_size
+        if batch_size != expected_batch_size:
+            raise RuntimeError(
+                f"Batch size mismatch: forward_batch.batch_size={batch_size}, "
+                f"but input_ids shape {forward_batch.input_ids.shape[0]} / "
+                f"block_size {self.block_size} = {expected_batch_size}"
+            )
+
+        mask_counts_cpu = (
+            (forward_batch.input_ids == self.mask_id)
+            .view(batch_size, self.block_size)
+            .sum(dim=1)
+            .tolist()
+        )
+
+        self._pick_tokens(forward_batch, full_logits)
+
+        next_token_ids = forward_batch.input_ids.view(
+            batch_size, self.block_size
+        ).tolist()
+
+        next_token_ids_list = []
+        accept_length_per_req_cpu = []
+        for i in range(batch_size):
+            next_token_ids_list.append(next_token_ids[i])
+            accept_length_per_req_cpu.append(
+                self.block_size if mask_counts_cpu[i] == 0 else 0
+            )
+
+        return next_token_ids_list, accept_length_per_req_cpu
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[
+        Union[LogitsProcessorOutput, torch.Tensor], List[List[int]], List[int], bool
+    ]:
+        out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+        logits_output, can_run_cuda_graph = out.logits_output, out.can_run_graph
+
+        next_token_ids_list, accept_length_per_req_cpu = self._post_forward_process(
+            forward_batch, logits_output.full_logits
+        )
+
+        return (
+            logits_output,
+            next_token_ids_list,
+            accept_length_per_req_cpu,
+            can_run_cuda_graph,
+        )
+
+
+Algorithm = LowConfidenceFDFO

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -12,12 +12,14 @@ class DllmConfig:
         block_size: int,
         mask_id: int,
         max_running_requests: int,
+        first_done_first_out_mode: bool,
     ):
         self.algorithm = algorithm
         self.algorithm_config = algorithm_config
         self.block_size = block_size
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
+        self.first_done_first_out_mode = first_done_first_out_mode
 
     @staticmethod
     def from_server_args(
@@ -66,10 +68,17 @@ class DllmConfig:
             # Parse common algorithm configurations
             block_size = algorithm_config.get("block_size", block_size)
 
+        from sglang.srt.dllm.algorithm import get_algorithm_fdfo_requirement
+
+        first_done_first_out_mode = get_algorithm_fdfo_requirement(
+            server_args.dllm_algorithm
+        )
+
         return DllmConfig(
             algorithm=server_args.dllm_algorithm,
             algorithm_config=algorithm_config,
             block_size=block_size,
             mask_id=mask_id,
             max_running_requests=max_running_requests,
+            first_done_first_out_mode=first_done_first_out_mode,
         )

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -19,6 +19,7 @@ class DllmReqPhase(str, enum.Enum):
 class ReqDllmMixin:
     def init_diffusion_llm(self: Req, dllm_config: DllmConfig):
         self.dllm_phase: Optional[DllmReqPhase] = None
+        self.dllm_incomplete_ids = []
         self.dllm_block_offset = 0
         self.dllm_config = dllm_config
 
@@ -38,6 +39,10 @@ class ReqDllmMixin:
         ]
 
     def determine_dllm_phase(self: Req):
+        if self.dllm_incomplete_ids:
+            self.dllm_phase = DllmReqPhase.STAGING_DECODE
+            return
+
         prefix_length = len(self.prefix_indices)
         min_required_length = prefix_length + self.dllm_config.block_size
 
@@ -54,6 +59,12 @@ class ReqDllmMixin:
             self.dllm_phase = DllmReqPhase.STAGING_DECODE
 
     def _init_fill_ids_for_dllm(self: Req):
+        if self.dllm_incomplete_ids:
+            prefix_len = len(self.prefix_indices)
+            assert len(self.dllm_incomplete_ids) == self.dllm_config.block_size
+            self.fill_ids = self.fill_ids[:prefix_len] + self.dllm_incomplete_ids
+            return
+
         self.dllm_block_offset = (
             0
             if not self.fill_ids

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -100,6 +100,72 @@ class SchedulerDllmMixin:
             dp_cooperation_info=batch.dp_cooperation_info,
         )
 
+    def process_batch_result_dllm_fdfo(
+        self: Scheduler,
+        batch: ScheduleBatch,
+        result: GenerationBatchResult,
+    ):
+        if result.copy_done is not None:
+            result.copy_done.synchronize()
+
+        if result.accept_length_per_req_cpu is None:
+            raise RuntimeError("FDFO DLLM result is missing accept lengths.")
+
+        self.token_to_kv_pool_allocator.free_group_begin()
+        block_size = batch.dllm_config.block_size
+
+        for idx in range(batch.batch_size()):
+            req = batch.reqs[idx]
+            next_token_ids = result.next_token_ids[idx]
+            len_cur_tokens = len(next_token_ids)
+
+            assert len_cur_tokens == block_size
+            if result.accept_length_per_req_cpu[idx] == 0:
+                req.dllm_incomplete_ids = next_token_ids
+                old_prefix_len = len(req.prefix_indices)
+                new_fill_len = len(req.fill_ids)
+                if new_fill_len > old_prefix_len:
+                    kv_indices_to_free = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, old_prefix_len:new_fill_len
+                    ]
+                    self.token_to_kv_pool_allocator.free(kv_indices_to_free)
+                continue
+
+            req.dllm_incomplete_ids = []
+            len_input = len(req.origin_input_ids)
+            len_fill = len(req.fill_ids)
+            if len_fill <= len_input:
+                continue
+
+            if len_fill - len_cur_tokens < len_input:
+                next_token_ids = next_token_ids[len_input - len_fill :]
+
+            self.num_generated_tokens += len(next_token_ids)
+
+            finished = False
+            for next_token_id in next_token_ids:
+                req.output_ids.append(next_token_id)
+                req.check_finished()
+                if req.finished():
+                    release_kv_cache(req, self.tree_cache)
+                    req.time_stats.set_completion_time()
+                    finished = True
+                    break
+
+            if finished:
+                req.dllm_incomplete_ids = []
+
+        self.stream_output(batch.reqs, batch.return_logprob)
+        self.token_to_kv_pool_allocator.free_group_end()
+
+        can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+        self.report_prefill_stats(
+            batch=batch,
+            prefill_stats=batch.prefill_stats,
+            can_run_cuda_graph=can_run_cuda_graph,
+            dp_cooperation_info=batch.dp_cooperation_info,
+        )
+
     def _fetch_waiting_reqs(self: Scheduler):
         # Calculate how many requests can be added to DLLM manager
         max_dllm_capacity = self.dllm_config.max_running_requests - len(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2472,7 +2472,13 @@ class Scheduler(
         if self.dllm_config is not None and self.dllm_manager.any_staging_reqs():
             chunked_req_to_exclude.update(self.dllm_manager.staging_queue)
             for req in self.dllm_manager.staging_queue:
-                self.stash_chunked_request(req)
+                if self.dllm_config.first_done_first_out_mode:
+                    if not getattr(req, "dllm_incomplete_ids", None):
+                        self.stash_chunked_request(req)
+
+                    self.req_to_token_pool.free(req)
+                else:
+                    self.stash_chunked_request(req)
 
         if self.chunked_req is not None:
             # Move the chunked request out of the batch so that we can merge
@@ -3146,7 +3152,10 @@ class Scheduler(
             self.process_batch_result_decode(batch, result)
         elif batch.forward_mode.is_extend():
             if batch.is_dllm():
-                self.process_batch_result_dllm(batch, result)
+                if self.dllm_config.first_done_first_out_mode:
+                    self.process_batch_result_dllm_fdfo(batch, result)
+                else:
+                    self.process_batch_result_dllm(batch, result)
             elif self.disaggregation_mode == DisaggregationMode.PREFILL:
                 self.process_batch_result_disagg_prefill(batch, result)
             else:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -435,12 +435,13 @@ class TpModelWorker(BaseTpWorker):
     def _forward_batch_generation_dllm(
         self, forward_batch: ForwardBatch
     ) -> GenerationBatchResult:
-        logits_output, next_token_ids, can_run_cuda_graph = self.dllm_algorithm.run(
-            self.model_runner, forward_batch
+        logits_output, next_token_ids, accept_length_per_req_cpu, can_run_cuda_graph = (
+            self.dllm_algorithm.run(self.model_runner, forward_batch)
         )
         return GenerationBatchResult(
             logits_output=logits_output,
             next_token_ids=next_token_ids,
+            accept_length_per_req_cpu=accept_length_per_req_cpu,
             can_run_cuda_graph=can_run_cuda_graph,
         )
 

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -26,9 +26,12 @@ logger = logging.getLogger(__name__)
 class GenerationBatchResult:
     logits_output: Optional[LogitsProcessorOutput] = None
     pp_hidden_states_proxy_tensors: Optional[PPProxyTensors] = None
-    next_token_ids: Optional[Union[torch.Tensor, List[torch.Tensor]]] = None
+    next_token_ids: Optional[
+        Union[torch.Tensor, List[torch.Tensor], List[List[int]]]
+    ] = None
     num_correct_drafts: int = 0  # no bonus included
     num_correct_drafts_per_req_cpu: Optional[List[int]] = None
+    accept_length_per_req_cpu: Optional[List[int]] = None
     can_run_cuda_graph: bool = False
 
     # For output processing

--- a/test/registered/dllm/test_dllm_batching_fdfo.py
+++ b/test/registered/dllm/test_dllm_batching_fdfo.py
@@ -1,0 +1,64 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=500, suite="stage-b-test-large-1-gpu")
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestBatchingFDFO(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "inclusionAI/LLaDA2.0-mini"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        other_args = [
+            "--trust-remote-code",
+            "--mem-fraction-static",
+            "0.9",
+            "--max-running-requests",
+            "4",
+            "--attention-backend",
+            "flashinfer",
+            "--dllm-algorithm",
+            "LowConfidenceFDFO",
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+
+        self.assertGreater(metrics["score"], 0.88)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

We introduce **FDFO (First-Done-First-Out)** scheduling for diffusion-based LLM (dLLM) inference to address a critical head-of-line blocking bottleneck in the existing `LowConfidence` algorithm (and other similar algorithms).

### Problem

In the current implementation, all requests in a batch are processed synchronously. Requests with high confidence scores — which converge quickly and require fewer decode steps — are forced to wait for low-confidence, long-tail requests to complete. This synchronization barrier leads to significant GPU idle time and degrades overall throughput.

### Goal

This PR decouples request lifecycles at the **scheduler level** by implementing FDFO semantics: fast-converging requests are freed and returned immediately upon completion, without waiting for slower requests in the same batch. This maximizes GPU utilization and end-to-end inference throughput.

**Contributors:**  Engine Architecture Group 5, Engine Infrastructure Department, Xiaohongshu (RedNote). 
Jin Huayi, Luo Zhaokai, Wu Junxiang, Zhang Bing

## Modifications

### 1. Refactored `LowConfidence` Algorithm

- Decoupled **token selection** from **scheduling logic**.
- `LowConfidence` now focuses solely on token selection and post-processing; the selection strategy is pluggable and user-configurable.

### 2. Scheduler-Level FDFO Support

- Enabled **mixed prefill-decode batching** within a single forward pass.
- All requests are **refreshed and returned to the scheduler** after every forward pass, allowing completed requests to exit the batch immediately.

### 3. Enhanced Request State Management

The scheduler now categorizes each request into one of four distinct states per scheduling round, enabling fine-grained lifecycle management:

| State                          | Description                          | Action                          |
|--------------------------------|--------------------------------------|---------------------------------|
| **Complete Prefill**           | Prefill phase finished               | Update `fill_id` via `origin_ids` |
| **Incomplete Decode**          | Decoding still in progress           | Update `dllm_incomplete_ids`    |
| **Complete Decode (KV Pending)** | Decode done, KV cache not yet updated | Update `dllm_incomplete_ids`  |
| **Complete Decode (KV Updated)** | Decode done, KV cache updated       | Update `fill_id` via `mask_id`  |

This state machine completely eliminates head-of-line blocking caused by slower requests stalling faster ones.


## Performance Results

**Test Environment:**
- Hardware: 1x H800, TP=1
- Model: LLaDA2.0-Mini
- Benchmark: GSM8K
- CUDA Graph: Enabled
- Metric: End-to-end latency & output throughput vs. baseline `LowConfidence`

### Batch Size = 4 -- 1.35x Speedup

|                  | Score | Latency (s) | Throughput (tokens/s) |
|------------------|-------|-------------|-----------------------|
| **Baseline**     | 0.915 | 55.993      | 450.928               |
| **FDFO (Ours)**  | 0.915 | 41.204      | 615.545               |

Raw Output - Baseline:
{'score': 0.915, 'score:std': 0.2789, 'latency': 55.993, 'output_throughput': 450.928}

Raw Output - FDFO:
{'score': 0.915, 'score:std': 0.2789, 'latency': 41.204, 'output_throughput': 615.545}

---

### Batch Size = 16 -- 1.62x Speedup

|                  | Score | Latency (s) | Throughput (tokens/s) |
|------------------|-------|-------------|-----------------------|
| **Baseline**     | 0.905 | 30.219      | 796.411               |
| **FDFO (Ours)**  | 0.930 | 18.614      | 1332.298              |

Raw Output - Baseline:
{'score': 0.905, 'score:std': 0.2932, 'latency': 30.219, 'output_throughput': 796.411}

Raw Output - FDFO:
{'score': 0.930, 'score:std': 0.2551, 'latency': 18.614, 'output_throughput': 1332.298}

NOTE: The score improvement at batch size 16 (0.905 -> 0.930) is likely due to statistical variance across runs and does not indicate a change in model outputs. The core algorithm is functionally equivalent to the baseline in terms of generation quality.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
