### PR TITLE
Port DSV4 CPU path onto main

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -590,19 +590,22 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         """Allocate non-paged DeepSeekV4CompressState buffers used by the
         old-compressor fallback.
 
-        Layout per layer: ``(max_num_reqs, ratio*coff, 2*head_dim*coff)``.
+        Layout per layer: ``(max_num_reqs + 1, ratio*coff, 2*head_dim*coff)``.
+        ReqToTokenPool reserves row 0 as a dummy slot and assigns real request
+        pool indices in the inclusive range [1, max_num_reqs].
         The buffers are small relative to the paged ring pools and only
         materialised when the radix path is off.
         """
         self.compress_states: List[Optional[DeepSeekV4CompressState]] = []
         self.indexer_compress_states: List[Optional[DeepSeekV4CompressState]] = []
         attn_kv_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        req_state_size = self.max_num_reqs + 1
         for ratio in self.compression_ratios:
             overlap = ratio == 4
             compress_state = indexer_compress_state = None
             if ratio != 0:
                 compress_state = DeepSeekV4CompressState(
-                    max_num_reqs=self.max_num_reqs,
+                    max_num_reqs=req_state_size,
                     ratio=ratio,
                     overlap=overlap,
                     head_dim=attn_kv_head_dim,
@@ -612,7 +615,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 )
             if ratio == 4:
                 indexer_compress_state = DeepSeekV4CompressState(
-                    max_num_reqs=self.max_num_reqs,
+                    max_num_reqs=req_state_size,
                     ratio=ratio,
                     overlap=overlap,
                     head_dim=self.indexer_head_dim,

--- a/test/srt/cpu/test_compressor.py
+++ b/test/srt/cpu/test_compressor.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 
+from sglang.srt.mem_cache.deepseek_v4_compress_state import DeepSeekV4CompressState
 from sglang.test.test_utils import CustomTestCase
 
 torch.manual_seed(42)
@@ -351,6 +352,26 @@ class TestCompressDecodeKernel(CustomTestCase):
         )
 
         torch.testing.assert_close(ref, out, atol=1e-3, rtol=1e-3)
+
+
+class TestDeepSeekV4CompressState(CustomTestCase):
+    def test_state_includes_dummy_req_pool_row(self):
+        max_running_requests = 2
+        state = DeepSeekV4CompressState(
+            max_num_reqs=max_running_requests + 1,
+            ratio=4,
+            overlap=True,
+            head_dim=8,
+            device="cpu",
+            dtype=torch.float32,
+            enable_memory_saver=False,
+        ).get_state()
+
+        # ReqToTokenPool reserves row 0 as padding, so real request slots can
+        # reach max_running_requests.
+        state[max_running_requests].clear()
+        state_shape = state.shape if hasattr(state, "shape") else state.kv_score.shape
+        self.assertEqual(state_shape[0], max_running_requests + 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Rewrite the DSV4 CPU support branch directly on top of `main` instead of rebasing through the divergent `intel_dev` history.

This keeps the current `main` baseline and replays the DeepSeek V4 CPU path files, including the request-state indexing fix for the non-paged DSV4 compressor state.

## Root Cause Fixed

`ReqToTokenPool` reserves row 0 as a dummy/padding row and allocates real request slots from `1..max_running_requests`. The DSV4 CPU non-paged compressor state must therefore allocate `max_num_reqs + 1` rows. Without the extra row, a request using the last valid pool slot can fail with:

```text
IndexError: index 2 is out of bounds for dimension 0 with size 2
```

## Rebase Strategy

`origin/master` does not exist; `origin/main` is the mainline branch. The earlier `intel_dev` history diverged heavily from `main`, so this PR now uses `main` directly and rewrites the DSV4 CPU changes onto it instead of resolving broad historical rebase/revert conflicts.

## Validation

- `PYTHONPATH=python:. .venv-mps312/bin/python -m unittest discover -s test/srt/cpu -p test_compressor.py -k state_includes_dummy`
- `py_compile` on DSV4 memory pool, compress state, compressor, and compressor test.

Remote AMX validation is being rerun on the rewritten main-based branch.