### PR TITLE
Fix EPLB mapping for TopK paths

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1174,7 +1174,7 @@ def _remap_topk_for_deepep(
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     num_fused_shared_experts: int,
-    num_physical_routed_experts: int,
+    n_routed_experts: int,
     topk_config: TopKConfig,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Remap TopK output to DeepEP interleaved expert layout.
@@ -1192,7 +1192,7 @@ def _remap_topk_for_deepep(
 
     ep_size = get_moe_expert_parallel_world_size()
     ep_rank = get_moe_expert_parallel_rank()
-    num_local_routed = num_physical_routed_experts // ep_size
+    num_local_routed = n_routed_experts // ep_size
     num_local_experts = num_local_routed + num_fused_shared_experts
 
     # Remap routed IDs: insert gaps for shared expert slots (single fused op)
@@ -1273,16 +1273,11 @@ def _post_process_topk_ids(
     # DeepEP: remap to interleaved expert layout where each rank's shared
     # expert has a unique ID for dispatch routing.
     if num_fused_shared_experts > 0 and is_deepep_class_backend():
-        num_physical_routed_experts = (
-            expert_location_dispatch_info.num_physical_experts
-            if expert_location_dispatch_info is not None
-            else router_logits.shape[1]
-        )
         topk_ids, topk_weights = _remap_topk_for_deepep(
             topk_ids,
             topk_weights,
             num_fused_shared_experts,
-            num_physical_routed_experts,
+            router_logits.shape[1],
             topk_config,
         )
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -817,8 +817,6 @@ def biased_topk_impl(
             topk_weights *= routed_scaling_factor
 
     topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
-    topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
-    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
     return topk_weights, topk_ids
 
 
@@ -850,8 +848,6 @@ def biased_topk_jit_kernel_impl(
         apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
     )
     topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
-    topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
-    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
     return topk_weights, topk_ids
 
 
@@ -1178,7 +1174,7 @@ def _remap_topk_for_deepep(
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     num_fused_shared_experts: int,
-    n_routed_experts: int,
+    num_physical_routed_experts: int,
     topk_config: TopKConfig,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Remap TopK output to DeepEP interleaved expert layout.
@@ -1196,7 +1192,7 @@ def _remap_topk_for_deepep(
 
     ep_size = get_moe_expert_parallel_world_size()
     ep_rank = get_moe_expert_parallel_rank()
-    num_local_routed = n_routed_experts // ep_size
+    num_local_routed = num_physical_routed_experts // ep_size
     num_local_experts = num_local_routed + num_fused_shared_experts
 
     # Remap routed IDs: insert gaps for shared expert slots (single fused op)
@@ -1277,11 +1273,16 @@ def _post_process_topk_ids(
     # DeepEP: remap to interleaved expert layout where each rank's shared
     # expert has a unique ID for dispatch routing.
     if num_fused_shared_experts > 0 and is_deepep_class_backend():
+        num_physical_routed_experts = (
+            expert_location_dispatch_info.num_physical_experts
+            if expert_location_dispatch_info is not None
+            else router_logits.shape[1]
+        )
         topk_ids, topk_weights = _remap_topk_for_deepep(
             topk_ids,
             topk_weights,
             num_fused_shared_experts,
-            router_logits.shape[1],
+            num_physical_routed_experts,
             topk_config,
         )
 

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -1,10 +1,18 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
+import sglang.srt.layers.moe.topk as topk_module
+from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+from sglang.srt.layers.moe.topk import (
+    TopKConfig,
+    _post_process_topk_ids,
+)
 from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
 )
+from sglang.srt.layers.moe.topk import biased_topk_impl as native_biased_topk
 from sglang.srt.layers.moe.topk import fused_topk_torch_native as native_fused_topk
 from sglang.srt.layers.moe.topk import grouped_topk_gpu as native_grouped_topk
 from sglang.srt.models.llama4 import Llama4MoE
@@ -136,6 +144,83 @@ class TestBiasedGroupedTopK(CustomTestCase):
                                 bias_dtype,
                                 routed_scaling_factor,
                             )
+
+
+class TestBiasedTopK(CustomTestCase):
+    def test_biased_topk_returns_logical_ids_with_eplb_info(self):
+        hidden_states = torch.ones(1, 4)
+        gating_output = torch.tensor([[10.0, 9.0, 1.0, 0.0]])
+        correction_bias = torch.zeros(4)
+        dispatch_info = ExpertLocationDispatchInfo(
+            ep_dispatch_algorithm="static",
+            partial_logical_to_rank_dispatch_physical_map=torch.tensor(
+                [2, 3, 0, 1], dtype=torch.int64
+            ),
+            partial_logical_to_all_physical_map=torch.tensor(
+                [[2], [3], [0], [1]], dtype=torch.int64
+            ),
+            partial_logical_to_all_physical_map_num_valid=torch.ones(
+                4, dtype=torch.int64
+            ),
+            num_physical_experts=4,
+        )
+
+        _, topk_ids = native_biased_topk(
+            hidden_states=hidden_states,
+            gating_output=gating_output,
+            correction_bias=correction_bias,
+            topk=2,
+            renormalize=False,
+            scoring_func="sqrtsoftplus",
+            expert_location_dispatch_info=dispatch_info,
+        )
+
+        torch.testing.assert_close(topk_ids, torch.tensor([[0, 1]], dtype=torch.int32))
+
+    def test_deepep_shared_remap_uses_physical_expert_count_with_eplb(self):
+        topk_ids = torch.tensor([[0, 1, 4]], dtype=torch.int32)
+        topk_weights = torch.ones(1, 3, dtype=torch.float32)
+        topk_config = TopKConfig(
+            top_k=3,
+            num_fused_shared_experts=1,
+            routed_scaling_factor=1.0,
+        )
+        router_logits = torch.zeros(1, 4, dtype=torch.float32)
+        dispatch_info = ExpertLocationDispatchInfo(
+            ep_dispatch_algorithm="static",
+            partial_logical_to_rank_dispatch_physical_map=torch.tensor(
+                [0, 4, 2, 5], dtype=torch.int64
+            ),
+            partial_logical_to_all_physical_map=torch.tensor(
+                [[0], [4], [2], [5]], dtype=torch.int64
+            ),
+            partial_logical_to_all_physical_map_num_valid=torch.ones(
+                4, dtype=torch.int64
+            ),
+            num_physical_experts=6,
+        )
+
+        with (
+            patch.object(topk_module, "_is_cuda", True),
+            patch.object(topk_module, "is_deepep_class_backend", return_value=True),
+            patch.object(
+                topk_module, "get_moe_expert_parallel_world_size", return_value=2
+            ),
+            patch.object(topk_module, "get_moe_expert_parallel_rank", return_value=0),
+        ):
+            remapped_ids, remapped_weights = _post_process_topk_ids(
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+                topk_config=topk_config,
+                router_logits=router_logits,
+                layer_id=0,
+                expert_location_dispatch_info=dispatch_info,
+            )
+
+        torch.testing.assert_close(
+            remapped_ids, torch.tensor([[0, 5, 3]], dtype=remapped_ids.dtype)
+        )
+        torch.testing.assert_close(remapped_weights, torch.ones_like(topk_weights))
 
 
 class TestTopK(CustomTestCase):

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -1,14 +1,8 @@
 import unittest
-from unittest.mock import patch
 
 import torch
 
-import sglang.srt.layers.moe.topk as topk_module
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
-from sglang.srt.layers.moe.topk import (
-    TopKConfig,
-    _post_process_topk_ids,
-)
 from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
 )
@@ -176,51 +170,6 @@ class TestBiasedTopK(CustomTestCase):
         )
 
         torch.testing.assert_close(topk_ids, torch.tensor([[0, 1]], dtype=torch.int32))
-
-    def test_deepep_shared_remap_uses_physical_expert_count_with_eplb(self):
-        topk_ids = torch.tensor([[0, 1, 4]], dtype=torch.int32)
-        topk_weights = torch.ones(1, 3, dtype=torch.float32)
-        topk_config = TopKConfig(
-            top_k=3,
-            num_fused_shared_experts=1,
-            routed_scaling_factor=1.0,
-        )
-        router_logits = torch.zeros(1, 4, dtype=torch.float32)
-        dispatch_info = ExpertLocationDispatchInfo(
-            ep_dispatch_algorithm="static",
-            partial_logical_to_rank_dispatch_physical_map=torch.tensor(
-                [0, 4, 2, 5], dtype=torch.int64
-            ),
-            partial_logical_to_all_physical_map=torch.tensor(
-                [[0], [4], [2], [5]], dtype=torch.int64
-            ),
-            partial_logical_to_all_physical_map_num_valid=torch.ones(
-                4, dtype=torch.int64
-            ),
-            num_physical_experts=6,
-        )
-
-        with (
-            patch.object(topk_module, "_is_cuda", True),
-            patch.object(topk_module, "is_deepep_class_backend", return_value=True),
-            patch.object(
-                topk_module, "get_moe_expert_parallel_world_size", return_value=2
-            ),
-            patch.object(topk_module, "get_moe_expert_parallel_rank", return_value=0),
-        ):
-            remapped_ids, remapped_weights = _post_process_topk_ids(
-                topk_ids=topk_ids,
-                topk_weights=topk_weights,
-                topk_config=topk_config,
-                router_logits=router_logits,
-                layer_id=0,
-                expert_location_dispatch_info=dispatch_info,
-            )
-
-        torch.testing.assert_close(
-            remapped_ids, torch.tensor([[0, 5, 3]], dtype=remapped_ids.dtype)
-        )
-        torch.testing.assert_close(remapped_weights, torch.ones_like(topk_weights))
 
 
 class TestTopK(CustomTestCase):


### PR DESCRIPTION
## Summary

Fix two EPLB logical/physical expert mapping issues in TopK paths:

- keep `biased_topk_impl` and `biased_topk_jit_kernel_impl` returning logical expert ids, then let `_post_process_topk_ids()` apply EPLB mapping exactly once
- when DeepEP shared-expert fusion runs with EPLB dispatch info, use `ExpertLocationDispatchInfo.num_physical_experts` for the DeepEP interleaved shared-expert remap instead of `router_logits.shape[1]`

The second fix matters when EPLB/redundant experts make routed `topk_ids` physical ids before DeepEP inserts per-rank shared expert slots.

This PR intentionally stays in `topk.py` and CPU TopK tests only. HashTopK / DeepSeek V4 Waterfill wiring is kept for the separate V4 Waterfill PR.

## Testing

- `pre-commit run --files python/sglang/srt/layers/moe/topk.py test/registered/cpu/test_topk.py`
- `docker exec sglang_mergecheck bash -lc 'cd /lustre/raplab/client/xutingz/workspace/gitsrc/sglang_main_v4_eplb_fix && PYTHONPATH=$PWD/python python -m pytest test/registered/cpu/test_topk.py::TestBiasedTopK -q'`

Earlier two-node serving validation for the first EPLB mapping fix:

- no-EPLB baseline: 45,103 tok/s
- V4 static EPLB red0 baseline: 48,918 tok/s
- static EPLB gain: +8.46%













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25965869239](https://github.com/sgl-project/sglang/actions/runs/25965869239)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->