### PR TITLE
Port DSV4 CPU path onto main

### DIFF
--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -68,6 +68,7 @@ dependencies = [
   "uvloop",
   "xgrammar==0.2.0",
   "smg-grpc-servicer>=0.5.0",
+  "tilelang==0.1.8",
 ]
 
 [project.optional-dependencies]

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -13,7 +13,10 @@ from sglang.jit_kernel.utils import (
     make_cpp_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
@@ -192,52 +195,6 @@ def _jit_fused_store_module(
         *args,
         cuda_files=["deepseek_v4/store.cuh"],
         cuda_wrappers=[("run", f"{kernel_class}::run")],
-    )
-
-
-@cache_once
-def _jit_main_q_norm_rope_module(
-    dtype: torch.dtype, head_dim: int, rope_dim: int
-) -> Module:
-    """Main MLA path Q kernel: rmsnorm-self + RoPE, warp per (token, head)."""
-    args = make_cpp_args(dtype, head_dim, rope_dim, is_arch_support_pdl())
-    return load_jit(
-        make_name("main_q_norm_rope"),
-        *args,
-        cuda_files=["deepseek_v4/main_norm_rope.cuh"],
-        cuda_wrappers=[
-            ("forward", f"FusedQNormRopeKernel<{args}>::forward"),
-        ],
-    )
-
-
-@cache_once
-def _jit_main_k_norm_rope_flashmla_module(
-    dtype: torch.dtype, head_dim: int, rope_dim: int, page_size: int
-) -> Module:
-    """Main MLA path K kernel: rmsnorm + RoPE + write to FlashMLA paged cache."""
-    args = make_cpp_args(dtype, head_dim, rope_dim, page_size, is_arch_support_pdl())
-    return load_jit(
-        make_name("main_k_norm_rope_flashmla"),
-        *args,
-        cuda_files=["deepseek_v4/main_norm_rope.cuh"],
-        cuda_wrappers=[
-            ("forward", f"FusedKNormRopeFlashMLAKernel<{args}>::forward"),
-        ],
-    )
-
-
-@cache_once
-def _jit_main_q_indexer_rope_hadamard_quant_module(dtype: torch.dtype) -> Module:
-    """C4 indexer Q kernel: RoPE + 128-pt Hadamard + fp8 act-quant (no norm)."""
-    args = make_cpp_args(dtype, is_arch_support_pdl())
-    return load_jit(
-        make_name("main_q_indexer_rope_hadamard_quant"),
-        *args,
-        cuda_files=["deepseek_v4/main_norm_rope.cuh"],
-        cuda_wrappers=[
-            ("forward", f"FusedQIndexerRopeHadamardQuantKernel<{args}>::forward"),
-        ],
     )
 
 
@@ -462,19 +419,31 @@ class CompressorPrefillPlan(NamedTuple):
             (2, num_q_tokens, 16),
             dtype=torch.uint8,
             device=seq_lens.device,
-            pin_memory=seq_lens.is_cpu,
+            pin_memory=seq_lens.is_cpu if not _is_cpu else False,
         )
-        module = _jit_common_module()
+
         is_overlap = compress_ratio == 4
-        plan_lens = module.plan_compress_prefill(
-            extend_lens,
-            seq_lens,
-            plan_tensor[0],
-            plan_tensor[1],
-            compress_ratio,
-            is_overlap,
-            use_cuda_graph,
-        )
+        if _is_cpu:
+            plan_lens = _plan_compress_prefill_torch(
+                extend_lens,
+                seq_lens,
+                plan_tensor[0],
+                plan_tensor[1],
+                compress_ratio,
+                is_overlap,
+                use_cuda_graph,
+            )
+        else:
+            module = _jit_common_module()
+            plan_lens = module.plan_compress_prefill(
+                extend_lens,
+                seq_lens,
+                plan_tensor[0],
+                plan_tensor[1],
+                compress_ratio,
+                is_overlap,
+                use_cuda_graph,
+            )
         return CompressorPrefillPlan(
             compress_ratio,
             plan_tensor[0, : plan_lens[0]].to(device, non_blocking=True),
@@ -497,7 +466,7 @@ class CompressorPrefillPlan(NamedTuple):
             (2, num_q_tokens, 16),
             dtype=torch.uint8,
             device="cpu",
-            pin_memory=True,
+            pin_memory=True if not _is_cpu else False,
         )
         module = _jit_compress_128_online_plan_module()
         plan_lens = module.plan_compress_online_prefill(
@@ -617,26 +586,6 @@ def compress_fused_norm_rope_inplace(
     )
 
 
-def fused_norm_rope_inplace(
-    kv: torch.Tensor,
-    weight: torch.Tensor,
-    eps: float,
-    freq_cis: torch.Tensor,
-    positions: torch.Tensor,
-) -> None:
-    freq_cis = torch.view_as_real(freq_cis).flatten(-2)
-    module = _jit_norm_rope_module(kv.dtype, kv.shape[-1], freq_cis.shape[-1])
-    module.forward(
-        kv,
-        weight,
-        positions,
-        freq_cis,
-        2,
-        eps,
-        0,
-    )
-
-
 def fused_rope(
     q: torch.Tensor,
     k: Optional[torch.Tensor],
@@ -644,65 +593,14 @@ def fused_rope(
     positions: torch.Tensor,
     inverse: bool = False,
 ) -> None:
-    freqs_real = torch.view_as_real(freqs_cis).flatten(-2).contiguous()
-    module = _jit_fused_rope_module()
-    module.forward(q, k, freqs_real, positions, inverse)
-
-
-# Alias for V2 code paths
-fused_rope_inplace = fused_rope
-
-
-def fused_q_norm_rope(
-    q_input: torch.Tensor,
-    q_output: torch.Tensor,
-    eps: float,
-    freqs_cis: torch.Tensor,
-    positions: torch.Tensor,
-) -> None:
-    freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
-    head_dim = q_input.shape[-1]
-    rope_dim = freqs_real.shape[-1]
-    module = _jit_main_q_norm_rope_module(q_input.dtype, head_dim, rope_dim)
-    module.forward(q_input, q_output, freqs_real, positions, eps)
-
-
-def fused_q_indexer_rope_hadamard_quant(
-    q_input: torch.Tensor,
-    weight: torch.Tensor,
-    weight_scale: float,
-    freqs_cis: torch.Tensor,
-    positions: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
-    q_fp8 = torch.empty(q_input.shape, dtype=torch.float8_e4m3fn, device=q_input.device)
-    weights_out = torch.empty(
-        (*q_input.shape[:-1], 1), dtype=torch.float32, device=q_input.device
-    )
-    module = _jit_main_q_indexer_rope_hadamard_quant_module(q_input.dtype)
-    module.forward(
-        q_input, q_fp8, weight, weights_out, float(weight_scale), freqs_real, positions
-    )
-    return q_fp8, weights_out
-
-
-def fused_k_norm_rope_flashmla(
-    kv: torch.Tensor,
-    kv_weight: torch.Tensor,
-    eps: float,
-    freqs_cis: torch.Tensor,
-    positions: torch.Tensor,
-    out_loc: torch.Tensor,
-    kvcache: torch.Tensor,
-    page_size: int,
-) -> None:
-    freqs_real = torch.view_as_real(freqs_cis).flatten(-2)
-    head_dim = kv.shape[-1]
-    rope_dim = freqs_real.shape[-1]
-    module = _jit_main_k_norm_rope_flashmla_module(
-        kv.dtype, head_dim, rope_dim, page_size
-    )
-    module.forward(kv, kv_weight, freqs_real, positions, out_loc, kvcache, eps)
+    if _is_cpu and _cpu_amx:
+        torch.ops.sgl_kernel.apply_rotary_emb_interleaved_cpu(
+            q, freqs_cis, inverse, positions, k
+        )
+    else:
+        freqs_real = torch.view_as_real(freqs_cis).flatten(-2).contiguous()
+        module = _jit_fused_rope_module()
+        module.forward(q, k, freqs_real, positions, inverse)
 
 
 @triton.jit
@@ -833,6 +731,56 @@ def triton_create_paged_compress_data(
     return out_0, out_1
 
 
+def torch_create_paged_compress_data(
+    *,
+    compress_ratio: int,
+    is_overlap: bool,
+    swa_page_size: int,
+    ring_size: int,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    extend_seq_lens: torch.Tensor,
+    req_to_token: torch.Tensor,
+    full_to_swa_index_mapping: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    batch_size = req_pool_indices.shape[0]
+    device = req_pool_indices.device
+
+    rid = req_pool_indices.to(torch.int32)
+    seq_len = seq_lens[:batch_size].to(torch.int32)
+    extend_len = extend_seq_lens[:batch_size].to(torch.int32)
+    prefix_len = seq_len - extend_len
+
+    cr = compress_ratio
+    write_pos = ((seq_len - 1) // cr) * cr
+    load_pos = ((prefix_len - 1) // cr) * cr
+    write_overlap_pos = write_pos - cr
+    load_overlap_pos = load_pos - cr
+
+    def compute_state_loc(pos: torch.Tensor) -> torch.Tensor:
+        pos = pos.clamp(min=0)
+        loc = req_to_token[rid, pos].to(torch.int32)
+        swa_loc = full_to_swa_index_mapping[loc].to(torch.int32)
+        swa_page = swa_loc // swa_page_size
+        state_loc = swa_page * ring_size + (swa_loc % ring_size)
+        state_loc = state_loc // cr
+        return state_loc
+
+    v0 = compute_state_loc(load_pos)  # i == 0
+    v1 = compute_state_loc(write_pos)  # i == 1
+    v2 = compute_state_loc(load_overlap_pos)  # i == 2
+    v3 = compute_state_loc(write_overlap_pos)  # i == 3
+
+    out_0 = v1.clone()
+
+    if is_overlap:
+        out_1 = torch.stack([v2, v0, v3, write_pos.to(torch.int32)], dim=1)
+    else:
+        out_1 = v0.clone()
+
+    return out_0, out_1
+
+
 def fused_store_cache(
     input: torch.Tensor,
     cache: torch.Tensor,
@@ -940,12 +888,9 @@ def get_paged_mqa_logits_metadata(seq_lens: torch.Tensor, page_size: int, num_sm
     return metadata
 
 
-def rmsnorm_self(
-    q: torch.Tensor, eps: float, out: Optional[torch.Tensor] = None
-) -> torch.Tensor:
+def rmsnorm_self(q: torch.Tensor, eps: float) -> torch.Tensor:
     module = _jit_rmsnorm_head_module(q.shape[-1], q.dtype)
-    if out is None:
-        out = q.new_empty(q.shape)
+    out = q.new_empty(q.shape)
     module.run_self(q, out, eps)
     return out
 
@@ -1014,6 +959,8 @@ def linear_bf16_fp32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     from sglang.srt.environ import envs
 
     algo = envs.SGLANG_OPT_BF16_FP32_GEMM_ALGO.get()
+    if _is_cpu and _cpu_amx:
+        algo = "cpu_amx"
     return _dispatch_bf16_fp32_backend(x, y, algo=algo)
 
 
@@ -1029,5 +976,81 @@ def _dispatch_bf16_fp32_backend(
         z = x.new_empty(x.size(0), y.size(0), dtype=torch.float32)
         deep_gemm.bf16_gemm_nt(x, y, z)
         return z
+    elif algo == "cpu_amx":
+        return torch.ops.sgl_kernel.weight_packed_linear(
+            x, y, None, True, torch.float32
+        )
     else:
         return torch.nn.functional.linear(x.float(), y.float())
+
+
+def _plan_compress_prefill_torch(
+    extend_lens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    compress_plan: torch.Tensor,
+    write_plan: torch.Tensor,
+    compress_ratio: int,
+    is_overlap: bool,
+    use_cuda_graph: bool,
+) -> Tuple[int, int]:
+    """Pure-torch fallback for ``plan_compress_prefill``."""
+    import struct
+
+    assert compress_plan.dtype == torch.uint8
+    assert write_plan.dtype == torch.uint8
+    num_tokens = compress_plan.shape[0]
+    assert write_plan.shape[0] == num_tokens
+    assert compress_plan.shape[1] == 16 and write_plan.shape[1] == 16
+
+    extend_lens_cpu = extend_lens.detach().to("cpu", dtype=torch.int64).tolist()
+    seq_lens_cpu = seq_lens.detach().to("cpu", dtype=torch.int64).tolist()
+    batch_size = len(extend_lens_cpu)
+    assert len(seq_lens_cpu) == batch_size
+
+    ratio = compress_ratio * (2 if is_overlap else 1)
+    counter = 0
+    compress_entries: list = []
+    write_entries: list = []
+
+    for i in range(batch_size):
+        seq_len = int(seq_lens_cpu[i])
+        extend_len = int(extend_lens_cpu[i])
+        assert 0 < extend_len <= seq_len
+        prefix_len = seq_len - extend_len
+        pos = (seq_len // compress_ratio) * compress_ratio
+        if is_overlap:
+            start_write_pos = pos - compress_ratio if pos >= compress_ratio else 0
+        else:
+            start_write_pos = pos
+        for j in range(extend_len):
+            position = prefix_len + j
+            window_len = ratio - min(j + 1, ratio)
+            plan = (counter + j, i, position, window_len)
+            if (position + 1) % compress_ratio == 0:
+                compress_entries.append(plan)
+            if position >= start_write_pos:
+                write_entries.append(plan)
+        counter += extend_len
+    assert counter == num_tokens, f"input size {counter} != num_q_tokens {num_tokens}"
+
+    kInvalid = 0xFFFFFFFF
+    invalid_row = struct.pack("<IIII", kInvalid, kInvalid, kInvalid, kInvalid)
+
+    def _fill(buf: torch.Tensor, entries: list) -> int:
+        n_entries = len(entries)
+        n_rows = num_tokens if use_cuda_graph else n_entries
+        if n_rows == 0:
+            return num_tokens if use_cuda_graph else 0
+        payload = bytearray()
+        for e in entries:
+            payload.extend(struct.pack("<IIII", *e))
+        if use_cuda_graph and n_entries < num_tokens:
+            for _ in range(num_tokens - n_entries):
+                payload.extend(invalid_row)
+        cpu_view = torch.frombuffer(payload, dtype=torch.uint8).view(n_rows, 16)
+        buf[:n_rows].copy_(cpu_view)
+        return num_tokens if use_cuda_graph else n_entries
+
+    compress_count = _fill(compress_plan, compress_entries)
+    write_count = _fill(write_plan, write_entries)
+    return compress_count, write_count

--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -137,6 +137,13 @@ def adjust_tp_num_heads_if_necessary(model_config, tp_size, is_post_update):
                 )
 
 
+def _set_padded_attr(model_config, attr_name, value):
+    if hasattr(model_config, attr_name):
+        update_config(model_config, attr_name, value)
+    update_config(model_config.hf_config, attr_name, value)
+    update_config(model_config.hf_text_config, attr_name, value)
+
+
 def update_intermediate_size(model_config, attr_name, intermediate_padding_size):
     attr_value = intermediate_padding_size
     if (
@@ -188,22 +195,44 @@ def adjust_config_with_unaligned_cpu_tp(
     # Support the case where the num_attention_heads is not divisible by the TP size.
     weight_block_size = may_get_weight_block_size(model_config, load_config)
 
-    for config in [model_config.hf_config, model_config.hf_text_config]:
-        update_config(
-            config,
-            "original_num_attention_heads",
-            model_config.num_attention_heads,
-        )
-        update_config(
-            config,
-            "original_total_num_kv_heads",
-            model_config.get_total_num_kv_heads(),
-        )
+    _set_padded_attr(
+        model_config, "original_num_attention_heads", model_config.num_attention_heads
+    )
+    _set_padded_attr(
+        model_config,
+        "original_total_num_kv_heads",
+        model_config.get_total_num_kv_heads(),
+    )
 
+    total_kv_heads = model_config.get_total_num_kv_heads()
+    # MQA models (num_kv_heads == 1) replicate the single KV head across TP ranks,
+    # so kv-head padding is not applicable — only attention-head padding is.
+    is_mqa = total_kv_heads == 1
+
+    # Grouped-MQA models (e.g. DeepSeek-V4) carry an additional `o_groups` dim
+    # that must also divide tp_size; the heads-per-group ratio must remain
+    # integer, so pad `o_groups` and `num_attention_heads` together.
+    o_groups = getattr(model_config.hf_config, "o_groups", None)
     if (
-        model_config.num_attention_heads % tp_size != 0
-        or model_config.get_total_num_kv_heads() % tp_size != 0
+        is_mqa
+        and isinstance(o_groups, int)
+        and o_groups > 0
+        and model_config.num_attention_heads % o_groups == 0
+        and (o_groups % tp_size != 0 or model_config.num_attention_heads % tp_size != 0)
     ):
+        _set_padded_attr(model_config, "original_o_groups", o_groups)
+
+        heads_per_group = model_config.num_attention_heads // o_groups
+        new_o_groups = ((o_groups + tp_size - 1) // tp_size) * tp_size
+        new_num_attention_heads = heads_per_group * new_o_groups
+
+        _set_padded_attr(model_config, "o_groups", new_o_groups)
+        _set_padded_attr(model_config, "num_attention_heads", new_num_attention_heads)
+
+    needs_attn_pad = model_config.num_attention_heads % tp_size != 0
+    needs_kv_pad = not is_mqa and total_kv_heads % tp_size != 0
+
+    if needs_attn_pad or needs_kv_pad:
 
         if hasattr(model_config.hf_config, "qk_nope_head_dim") and hasattr(
             model_config.hf_config, "qk_rope_head_dim"
@@ -215,10 +244,6 @@ def adjust_config_with_unaligned_cpu_tp(
                 + model_config.hf_config.qk_rope_head_dim,
             )
 
-        query_heads_per_kv = (
-            model_config.num_attention_heads // model_config.get_total_num_kv_heads()
-        )
-        total_kv_heads = model_config.get_total_num_kv_heads()
         from sglang.srt.layers.vocab_parallel_embedding import pad_vocab_size
 
         head_dim = resolve_head_dim(
@@ -226,16 +251,21 @@ def adjust_config_with_unaligned_cpu_tp(
         )
 
         pad_size = get_num_heads_padding_size(tp_size, weight_block_size, head_dim)
-        num_key_value_heads = pad_vocab_size(total_kv_heads, pad_size)
 
-        num_attention_heads = num_key_value_heads * query_heads_per_kv
-        for config in [
-            model_config,
-            model_config.hf_config,
-            model_config.hf_text_config,
-        ]:
-            update_config(config, "num_key_value_heads", num_key_value_heads)
-            update_config(config, "num_attention_heads", num_attention_heads)
+        if is_mqa:
+            # Plain MQA path; grouped-MQA models (with `o_groups`) were already
+            # aligned by the pre-pad above, so they won't reach here.
+            # Keep num_key_value_heads == 1 (replicated). Pad attention heads only.
+            num_attention_heads = pad_vocab_size(
+                model_config.num_attention_heads, pad_size
+            )
+        else:
+            query_heads_per_kv = model_config.num_attention_heads // total_kv_heads
+            num_key_value_heads = pad_vocab_size(total_kv_heads, pad_size)
+            _set_padded_attr(model_config, "num_key_value_heads", num_key_value_heads)
+            num_attention_heads = num_key_value_heads * query_heads_per_kv
+
+        _set_padded_attr(model_config, "num_attention_heads", num_attention_heads)
 
     adjust_tp_num_heads_if_necessary(model_config.hf_config, tp_size, True)
     if hasattr(model_config.hf_config, "text_config"):

--- a/python/sglang/srt/layers/amx_utils.py
+++ b/python/sglang/srt/layers/amx_utils.py
@@ -14,6 +14,7 @@ class CPUQuantMethod(IntEnum):
     INT8_W8A8 = 1
     FP8_W8A16 = 2
     INT4_W4A8 = 3
+    MXFP4 = 4
 
 
 class CPUQuantAlgo(IntEnum):
@@ -171,3 +172,96 @@ class PackWeightMethod:
         _amx_process_weight_after_loading(
             module, self.weight_names, self.transpose_dims
         )
+
+
+class PackWeightMethodBMM:
+    """Pack weight for batched matrix multiplication (bmm_cpu).
+
+    Replaces the default UnquantizedLinearMethod on a linear layer so that
+    the 2D weight [G*R, D] is reshaped to 3D [G, R, D] and then VNNI-packed.
+    """
+
+    def __init__(self, n_groups, group_size):
+        self.n_groups = n_groups
+        self.group_size = group_size
+
+    def process_weights_after_loading(self, module) -> None:
+        weight = module.weight
+        device = weight.device
+
+        # Reshape [G*R, D] → [G, R, D] for batched GEMM
+        weight_3d = weight.data.view(self.n_groups, self.group_size, -1).contiguous()
+
+        if not dim_is_supported(weight_3d):
+            logger.warning(
+                f"Unsupported dimension for prepacking for weight "
+                f"'weight' with shape {weight_3d.shape} in {module}. "
+                f"The derived (OC, IC) dimensions must be divisible by (16, 32). "
+            )
+            module.use_intel_amx_backend = False
+            return
+
+        packed_weight = torch.nn.Parameter(
+            amx_process_weight_after_loading(weight_3d),
+            requires_grad=False,
+        )
+        module.weight = packed_weight
+        module.use_intel_amx_backend = (
+            device == torch.device("cpu") and cpu_has_amx_support()
+        )
+
+
+def amx_fused_experts_mxfp4(
+    layer,
+    dispatch_output,
+    moe_runner_config,
+    *,
+    scale_attrs=("w13_weight_scale", "w2_weight_scale"),
+):
+    """Run the CPU AMX fused_experts kernel for MxFP4 MoE.
+
+    Returns a StandardCombineInput wrapping the output tensor.
+    """
+    from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+    from sglang.srt.layers.moe.topk import apply_topk_weights_cpu
+
+    hidden_states = dispatch_output.hidden_states
+    topk_weights, topk_ids, _ = dispatch_output.topk_output
+    x, topk_weights = apply_topk_weights_cpu(
+        moe_runner_config.apply_router_weight_on_input,
+        topk_weights,
+        hidden_states,
+    )
+
+    # Two checkpoint conventions expose the gate/up clamp differently
+    # (gemm1_clamp_limit on GPT-OSS/Step3.5, swiglu_limit on DSv4). No model
+    # sets both today. Add an assertion that they can't be both set to avoid
+    # silent bug in the future
+    assert not (
+        moe_runner_config.gemm1_clamp_limit is not None
+        and moe_runner_config.swiglu_limit is not None
+    ), "gemm1_clamp_limit and swiglu_limit must not both be set"
+    clamp = moe_runner_config.gemm1_clamp_limit
+    if clamp is None and moe_runner_config.swiglu_limit is not None:
+        clamp = float(moe_runner_config.swiglu_limit)
+
+    output = torch.ops.sgl_kernel.fused_experts_cpu(
+        x,
+        layer.w13_weight,
+        layer.w2_weight,
+        topk_weights,
+        topk_ids.to(torch.int32),
+        False,  # inplace See [Note] inplace should be False in fused_experts.
+        CPUQuantMethod.MXFP4,
+        getattr(layer, scale_attrs[0]),
+        getattr(layer, scale_attrs[1]),
+        None,  # w1_zp
+        None,  # w2_zp
+        None,  # block_size
+        getattr(layer, "w13_weight_bias", None),
+        getattr(layer, "w2_weight_bias", None),
+        moe_runner_config.gemm1_alpha,
+        clamp,
+        True,  # is_vnni
+    )
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -20,21 +20,11 @@ import torch.nn.functional as F
 
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-
-if envs.SGLANG_OPT_USE_COMPRESSOR_V2.get():
-    # NOTE: should eventually be the only compressor backend
-    from sglang.srt.layers.attention.dsv4.compressor_v2 import (
-        CompressorBackendMixin,
-        FusedCompressMetadata,
-        create_paged_compressor_data,
-    )
-else:
-    from sglang.srt.layers.attention.dsv4.compressor import (
-        CompressorBackendMixin,
-        FusedCompressMetadata,
-        create_paged_compressor_data,
-    )
-
+from sglang.srt.layers.attention.dsv4.compressor import (
+    CompressorBackendMixin,
+    FusedCompressMetadata,
+    create_paged_compressor_data,
+)
 from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
 from sglang.srt.layers.attention.dsv4.metadata import (
     PagedIndexerMetadata,
@@ -54,8 +44,17 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.spec_info import SpecInput
-from sglang.srt.utils import ceil_align
+from sglang.srt.utils import ceil_align, cpu_has_amx_support, is_cpu
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
+
+if _is_cpu and _cpu_amx:
+    from sglang.srt.layers.attention.dsv4.metadata_kernel import (
+        init_compression_metadata_torch,
+    )
+
+    _init_compression_metadata_triton = init_compression_metadata_torch
 if TYPE_CHECKING:
     from flash_mla.flash_mla_interface import FlashMLASchedMeta
 
@@ -81,9 +80,12 @@ def _pad_last_dim(x: T, multiples_of: int = PAGE_INDEX_ALIGNED_SIZE) -> T:
 
 
 def _create_flashmla_metadata():
-    import flash_mla
+    try:
+        import flash_mla
 
-    return flash_mla.get_mla_metadata()[0]
+        return flash_mla.get_mla_metadata()[0]
+    except:
+        return None
 
 
 def _create_dummy_paged_compress_data(compress_ratio: int):
@@ -905,7 +907,21 @@ class DeepseekV4AttnBackend(
         self, layer_id: int, swa_k: torch.Tensor, forward_batch: ForwardBatch
     ) -> None:
         raw_loc = forward_batch.out_cache_loc
-        if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
+
+        if _is_cpu and _cpu_amx:
+            from sglang.srt.layers.attention.dsv4.index_buf_accessor import (
+                NopeFp8RopeBf16Pack,
+            )
+
+            swa_k_pack = NopeFp8RopeBf16Pack(
+                *torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(swa_k)
+            )
+            self.token_to_kv_pool.set_swa_key_buffer_radix(
+                layer_id=layer_id,
+                raw_loc=raw_loc,
+                cache_nope_fp8_rope_bf16_pack=swa_k_pack,
+            )
+        elif envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             self.token_to_kv_pool.set_swa_key_buffer_radix_fused(
                 layer_id=layer_id,
                 raw_loc=raw_loc,
@@ -1030,25 +1046,45 @@ class DeepseekV4AttnBackend(
                 assert (
                     extra_indices.shape[-1] % 64 == 0
                 ), f"{extra_indices.shape=}'s last dimension is not aligned to 64"
+            if _is_cpu and _cpu_amx:
+                from sgl_kernel.flash_mla import flash_mla_with_kvcache_cpu
 
-            import flash_mla
+                o = flash_mla_with_kvcache_cpu(
+                    q=q,
+                    k_cache=swa_k_cache,
+                    block_table=None,
+                    cache_seqlens=None,
+                    head_dim_v=self.head_dim_v,
+                    tile_scheduler_metadata=flashmla_metadata,
+                    softmax_scale=self.softmax_scale,
+                    is_fp8_kvcache=True,
+                    indices=swa_page_indices,
+                    topk_length=swa_topk_lengths,
+                    attn_sink=attn_sink,
+                    extra_k_cache=extra_k_cache,
+                    extra_indices_in_kvcache=extra_indices,
+                    extra_topk_length=extra_topk_lengths,
+                )[0]
+            else:
 
-            o = flash_mla.flash_mla_with_kvcache(
-                q=q,
-                k_cache=swa_k_cache,
-                head_dim_v=self.head_dim_v,
-                block_table=None,
-                cache_seqlens=None,
-                tile_scheduler_metadata=flashmla_metadata,
-                softmax_scale=self.softmax_scale,
-                is_fp8_kvcache=True,
-                indices=swa_page_indices,
-                topk_length=swa_topk_lengths,
-                attn_sink=attn_sink,
-                extra_k_cache=extra_k_cache,
-                extra_indices_in_kvcache=extra_indices,
-                extra_topk_length=extra_topk_lengths,
-            )[0]
+                import flash_mla
+
+                o = flash_mla.flash_mla_with_kvcache(
+                    q=q,
+                    k_cache=swa_k_cache,
+                    head_dim_v=self.head_dim_v,
+                    block_table=None,
+                    cache_seqlens=None,
+                    tile_scheduler_metadata=flashmla_metadata,
+                    softmax_scale=self.softmax_scale,
+                    is_fp8_kvcache=True,
+                    indices=swa_page_indices,
+                    topk_length=swa_topk_lengths,
+                    attn_sink=attn_sink,
+                    extra_k_cache=extra_k_cache,
+                    extra_indices_in_kvcache=extra_indices,
+                    extra_topk_length=extra_topk_lengths,
+                )[0]
 
             o = o.squeeze(1)
             return o

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Literal, NamedTuple, Optional, Union
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, List, Literal, NamedTuple, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -11,6 +12,7 @@ from sglang.jit_kernel.deepseek_v4 import (
     compress_forward,
     compress_fused_norm_rope_inplace,
     linear_bf16_fp32,
+    torch_create_paged_compress_data,
     triton_create_paged_compress_data,
 )
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
@@ -24,13 +26,33 @@ from sglang.srt.layers.dp_attention import get_attention_cp_size
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_output
-from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
+from sglang.srt.mem_cache.deepseek_v4_compress_state import (
+    CompressStatePool,
+    KVAndScore,
+    KVAndScoreSeparate,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, cpu_has_amx_support, is_cpu
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+if _is_cpu and _cpu_amx:
+
+    def apply_rotary_emb_cpu(
+        x: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        positions: Optional[torch.Tensor] = None,
+        inverse: bool = False,
+    ) -> torch.Tensor:
+        return torch.ops.sgl_kernel.apply_rotary_emb_interleaved_cpu(
+            x, freqs_cis, inverse, positions
+        )
+
+    apply_rotary_emb_triton = apply_rotary_emb_cpu
 
 
 class FusedCompressMetadata(NamedTuple):
@@ -131,7 +153,18 @@ class CompressorBackendMixin:
             if compressor.ratio == 4
             else core_metadata.c128_out_loc
         )
-        if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
+        if _is_cpu and _cpu_amx:
+            from sglang.srt.layers.attention.dsv4.index_buf_accessor import (
+                NopeFp8RopeBf16Pack,
+            )
+
+            pack = NopeFp8RopeBf16Pack(
+                *torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(
+                    new_compressed_kv.bfloat16()
+                )
+            )
+            token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
+        elif envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             token_to_kv_pool.set_extra_key_buffer_fused(
                 layer_id=layer_id,
                 loc=out_loc,
@@ -156,7 +189,18 @@ class CompressorBackendMixin:
             assert isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
 
         new_compressed_kv = compressor(x, forward_batch)
-        if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
+
+        if _is_cpu and _cpu_amx:
+            new_compressed_kv_fp8, new_compressed_kv_scale = (
+                torch.ops.sgl_kernel.act_quant_cpu(new_compressed_kv)
+            )
+            token_to_kv_pool.set_index_k_scale_buffer(
+                layer_id=layer_id,
+                loc=self.forward_metadata.core_metadata.c4_out_loc,
+                index_k=new_compressed_kv_fp8,
+                index_k_scale=new_compressed_kv_scale,
+            )
+        elif envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             token_to_kv_pool.set_index_k_fused(
                 layer_id=layer_id,
                 loc=self.forward_metadata.core_metadata.c4_out_loc,
@@ -236,7 +280,12 @@ def create_paged_compressor_data(
 
     if is_prefill:
         assert extend_lens is not None
-        write_loc, extra_data = triton_create_paged_compress_data(
+        create_paged_compress_data_func = (
+            triton_create_paged_compress_data
+            if not _is_cpu
+            else torch_create_paged_compress_data
+        )
+        write_loc, extra_data = create_paged_compress_data_func(
             compress_ratio=compress_ratio,
             is_overlap=is_overlap,
             swa_page_size=swa_page_size,
@@ -305,6 +354,7 @@ class Compressor(nn.Module):
         self.overlap = self.ratio == 4
         self.rotate = rotate
         coff = 1 + self.overlap
+        self.coff = coff
 
         self.ape = nn.Parameter(
             torch.empty(self.ratio, coff * self.head_dim, dtype=torch.float32)
@@ -334,21 +384,58 @@ class Compressor(nn.Module):
             ape = torch.cat([ape[0], ape[1]], dim=0)
             self.ape.data.copy_(ape.view(self.ratio, -1))
 
-    # NOTE: used by v2 compressor backend
-    def get_state_pool(self, forward_batch: ForwardBatch) -> CompressStatePool:
+    @cached_property
+    def use_fused_compress(self) -> bool:
+        if _is_cpu and _cpu_amx:
+            return False
+        return True
+
+    def _get_states(
+        self, forward_batch: ForwardBatch
+    ) -> "KVAndScore | KVAndScoreSeparate | CompressStatePool":
+        """Return the per-layer compress-state for this Compressor.
+
+        When the radix path is on this is a paged ``CompressStatePool``;
+        otherwise it is a ``KVAndScore`` / ``KVAndScoreSeparate`` view of the
+        per-request non-paged buffer (used by the old-compressor fallback).
+        """
         token_to_kv_pool = forward_batch.token_to_kv_pool
         assert isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
         if self.is_in_indexer:
-            ret = token_to_kv_pool.get_indexer_compress_states(self.layer_id)
-        else:
-            ret = token_to_kv_pool.get_attention_compress_states(self.layer_id)
+            return token_to_kv_pool.get_indexer_compress_states(self.layer_id)
+        return token_to_kv_pool.get_attention_compress_states(self.layer_id)
 
+    def _get_state_pool(self, forward_batch: ForwardBatch) -> CompressStatePool:
+        ret = self._get_states(forward_batch)
         assert isinstance(ret, CompressStatePool)
-
         return ret
 
-    # NOTE: used by v2 compressor backend
-    def compute_kv_score(self, x: torch.Tensor, forward_batch: ForwardBatch):
+    def overlap_transform(self, tensor: torch.Tensor, fill_value: Any) -> torch.Tensor:
+        assert tensor.dim() == 3
+        assert tensor.shape[1:] == (self.ratio, 2 * self.head_dim)
+
+        s, r, d = tensor.size(0), self.ratio, self.head_dim
+        new_tensor = tensor.new_full((s, 2 * r, d), fill_value)
+        new_tensor[:, r:] = tensor[:, :, d:]
+        new_tensor[1:, :r] = tensor[:-1, :, :d]
+        return new_tensor
+
+    def overlap_transform_decode(self, tensor: torch.Tensor) -> torch.Tensor:
+        assert tensor.dim() == 3
+        assert tensor.shape[1:] == (2 * self.ratio, 2 * self.head_dim)
+        r, d = self.ratio, self.head_dim
+        ret = torch.cat((tensor[:, :r, :d], tensor[:, r:, d:]), dim=1)
+        return ret
+
+    @staticmethod
+    def compute_state_len(seq_len: int, ratio: int):
+        return seq_len % ratio + (ratio == 4) * ratio
+
+    def forward(self, x: torch.Tensor, forward_batch: ForwardBatch) -> torch.Tensor:
+        if forward_batch.forward_mode.is_idle():
+            assert x.shape[0] == 0
+            return x.new_empty(0, self.head_dim)
+
         kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
         if nsa_use_prefill_cp(forward_batch):
             kv_score = cp_all_gather_rerange_output(
@@ -357,19 +444,17 @@ class Compressor(nn.Module):
                 forward_batch,
                 torch.cuda.current_stream(),
             )
-        return kv_score
+        return self.compress_dispatch(kv_score, forward_batch)
 
-    def forward(self, x: torch.Tensor, forward_batch: ForwardBatch) -> torch.Tensor:
-        if forward_batch.forward_mode.is_idle():
-            assert x.shape[0] == 0
-            return x.new_empty(0, self.head_dim)
-
-        kv_score = self.compute_kv_score(x, forward_batch)
-
+    def compress_fused(
+        self,
+        kv_score: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
         backend = forward_batch.attn_backend
         if TYPE_CHECKING:
             assert isinstance(backend, DeepseekV4AttnBackend)
-        kv_score_buffer = self.get_state_pool(forward_batch)
+        kv_score_buffer = self._get_state_pool(forward_batch)
         kv_score_buffer = kv_score_buffer.kv_score_buffer.kv_score
         return backend.forward_compress(
             kv_score_buffer=kv_score_buffer,
@@ -382,4 +467,253 @@ class Compressor(nn.Module):
             compress_ratio=self.ratio,
             forward_batch=forward_batch,
             is_paged=True,
+        )
+
+    def compress_decode_separate(
+        self,
+        kv_and_scores: "KVAndScoreSeparate",
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
+
+        """
+        Reads from non-paged ``DeepSeekV4CompressState`` buffers.
+        """
+
+        assert self.ape_converted
+        seq_lens = forward_batch.seq_lens
+        pool = self._get_states(forward_batch)
+        assert isinstance(pool, KVAndScoreSeparate)
+        req_pool_indices = forward_batch.req_pool_indices
+
+        bs = kv_and_scores.kv.size(0)
+        write_pos = (seq_lens - 1) % self.ratio + self.overlap * self.ratio
+        pool[req_pool_indices, write_pos] = kv_and_scores
+
+        # NOTE: copy out before modifying overlap states
+        kv_and_score_to_compress = pool[req_pool_indices]
+
+        if self.overlap:
+            should_shift = (seq_lens % self.ratio == 0)[:, None, None]
+            pool[req_pool_indices, : self.ratio] = KVAndScoreSeparate(
+                kv=torch.where(
+                    should_shift,
+                    kv_and_score_to_compress.kv[:, self.ratio :],
+                    kv_and_score_to_compress.kv[:, : self.ratio],
+                ),
+                score=torch.where(
+                    should_shift,
+                    kv_and_score_to_compress.score[:, self.ratio :],
+                    kv_and_score_to_compress.score[:, : self.ratio],
+                ),
+            )
+
+        # shape: [bs * coff, ratio, coff * head_dim]
+        kv_and_score_to_compress = kv_and_score_to_compress.view(
+            -1, self.ratio, self.coff * self.head_dim
+        )
+        kv_and_score_to_compress.score = (
+            kv_and_score_to_compress.score + self.ape.unsqueeze(0)
+        )
+
+        if self.overlap:
+            # shape: [bs, coff * ratio, coff * head_dim]
+            kv_and_score_to_compress = kv_and_score_to_compress.view(
+                bs, self.coff * self.ratio, self.coff * self.head_dim
+            )
+            kv_and_score_to_compress.kv = self.overlap_transform_decode(
+                kv_and_score_to_compress.kv
+            )
+            kv_and_score_to_compress.score = self.overlap_transform_decode(
+                kv_and_score_to_compress.score
+            )
+
+        # kv_to_compress: [bs, ratio * coff, head_dim]
+        kv_and_score_to_compress = kv_and_score_to_compress.view(
+            bs, self.ratio * self.coff, self.head_dim
+        )
+        kv_compressed = (
+            kv_and_score_to_compress.kv * kv_and_score_to_compress.score.softmax(dim=1)
+        ).sum(dim=1)
+        kv_compressed = self.norm(kv_compressed)
+        freqs_cis = self.freqs_cis[(seq_lens - 1) // self.ratio * self.ratio]
+        apply_rotary_emb_triton(kv_compressed[..., -self.rope_head_dim :], freqs_cis)
+        if self.rotate:
+            kv_compressed = rotate_activation(kv_compressed)
+        return kv_compressed
+
+    def compress_extend_separate(
+        self,
+        kv_and_scores: "KVAndScoreSeparate",
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
+
+        """
+        Reads from non-paged ``DeepSeekV4CompressState`` buffers.
+        """
+        assert self.ape_converted
+
+        kv_and_score_states = self._get_states(forward_batch)
+        assert isinstance(kv_and_score_states, KVAndScoreSeparate)
+        _, _, head_dim_times_coff = kv_and_score_states.kv.shape
+
+        prefix_lens = forward_batch.extend_prefix_lens_cpu
+        extend_lens = forward_batch.extend_seq_lens_cpu
+        req_pool_indices = forward_batch.req_pool_indices
+        assert extend_lens is not None and prefix_lens is not None
+
+        max_buffer_size = 2 * kv_and_score_states.shape[1] + kv_and_scores.shape[0]
+        temp_buffer_shape = [max_buffer_size, head_dim_times_coff]
+        temp_buffer = KVAndScoreSeparate.empty_like(
+            temp_buffer_shape, sep=kv_and_scores
+        )
+
+        assert kv_and_scores.kv.shape[-1] == self.head_dim * self.coff
+        compressed_kv_output = torch.full(
+            (kv_and_scores.kv.size(0), self.head_dim),
+            fill_value=10000.0,
+            dtype=kv_and_scores.kv.dtype,
+            device=kv_and_scores.kv.device,
+        )
+
+        bs = forward_batch.batch_size
+        pt = 0
+        for i in range(bs):
+            kv_and_score = kv_and_scores[pt : pt + extend_lens[i]]
+            kv_and_score_state = kv_and_score_states[req_pool_indices[i]]
+            if prefix_lens[i] == 0:
+                # Pad with default values for overlap.
+                kv_and_score_state.clear()
+
+            pre_state_len = self.compute_state_len(
+                seq_len=prefix_lens[i], ratio=self.ratio
+            )
+            valid_kv_len = pre_state_len + extend_lens[i]
+            kv_and_score_buffer = temp_buffer[:valid_kv_len]
+            kv_and_score_buffer[:pre_state_len] = kv_and_score_state[:pre_state_len]
+            kv_and_score_buffer[pre_state_len:valid_kv_len] = kv_and_score
+
+            post_state_len = self.compute_state_len(
+                seq_len=valid_kv_len, ratio=self.ratio
+            )
+            kv_and_score_state[:post_state_len] = kv_and_score_buffer[
+                valid_kv_len - post_state_len : valid_kv_len
+            ]
+
+            compress_len = valid_kv_len // self.ratio * self.ratio
+            if compress_len == 0:
+                pt += extend_lens[i]
+                continue
+
+            kv_and_score_to_compress = kv_and_score_buffer[:compress_len].view(
+                compress_len // self.ratio, self.ratio, -1
+            )
+            kv_and_score_to_compress.score = (
+                kv_and_score_to_compress.score + self.ape.unsqueeze(0)
+            )
+
+            if self.overlap:
+                kv_and_score_to_compress.kv = self.overlap_transform(
+                    kv_and_score_to_compress.kv, 0
+                )
+                kv_and_score_to_compress.score = self.overlap_transform(
+                    kv_and_score_to_compress.score, float("-inf")
+                )
+                # Drop the leading window before compression.
+                kv_and_score_to_compress = kv_and_score_to_compress[1:]
+                if kv_and_score_to_compress.kv.size(0) == 0:
+                    pt += extend_lens[i]
+                    continue
+
+            kv_compressed = (
+                kv_and_score_to_compress.kv
+                * kv_and_score_to_compress.score.softmax(dim=1)
+            ).sum(dim=1)
+            assert kv_compressed.dtype == torch.float32
+            kv_compressed = self.norm(kv_compressed)
+
+            beg_idx = prefix_lens[i] // self.ratio * self.ratio
+            end_idx = (prefix_lens[i] + extend_lens[i]) // self.ratio * self.ratio
+            freqs_cis = self.freqs_cis[beg_idx : end_idx : self.ratio]
+            assert freqs_cis.size(0) == kv_compressed.size(
+                0
+            ), f"{freqs_cis.shape=} {kv_compressed.shape=}"
+            apply_rotary_emb_triton(
+                kv_compressed[..., -self.rope_head_dim :], freqs_cis
+            )
+
+            if self.rotate:
+                kv_compressed = rotate_activation(kv_compressed)
+
+            start = prefix_lens[i]
+            start = start + self.ratio - 1 - start % self.ratio
+            indices_in_seq = torch.arange(
+                start,
+                prefix_lens[i] + extend_lens[i],
+                self.ratio,
+                device=kv_and_scores.kv.device,
+            )
+            assert indices_in_seq.size(0) == kv_compressed.size(0)
+            compressed_kv_output[indices_in_seq - prefix_lens[i] + pt] = kv_compressed
+
+            pt += extend_lens[i]
+
+        return compressed_kv_output
+
+    def _get_freqs_cis_real(self):
+        """Return freqs_cis as real float32 [N, rope_dim] for CPU kernel."""
+        if not hasattr(self, "_freqs_cis_real"):
+            fc = self.freqs_cis
+            if fc.is_complex():
+                self._freqs_cis_real = (
+                    torch.view_as_real(fc).contiguous().reshape(fc.size(0), -1)
+                )
+            else:
+                self._freqs_cis_real = fc.contiguous()
+        return self._freqs_cis_real
+
+    def compress_dispatch(
+        self,
+        kv_score: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if self.use_fused_compress:
+            return self.compress_fused(kv_score, forward_batch)
+        self.compress_decode = self.compress_decode_separate
+        self.compress_extend = self.compress_extend_separate
+        kv = kv_score[:, : self.coff * self.head_dim]
+        score = kv_score[:, self.coff * self.head_dim :]
+        kv_and_scores = KVAndScoreSeparate(kv=kv, score=score)
+        forward_mode = forward_batch.forward_mode
+        if forward_mode.is_decode() or forward_mode.is_target_verify():
+            if _cpu_amx:
+                pool = self._get_states(forward_batch)
+                assert isinstance(pool, KVAndScoreSeparate)
+                freqs_real = self._get_freqs_cis_real()
+                norm_weight = self.norm.weight.float()
+
+                forward_mode = forward_batch.forward_mode
+                return torch.ops.sgl_kernel.compress_decode_cpu(
+                    pool.kv,
+                    pool.score,
+                    kv,
+                    score,
+                    forward_batch.seq_lens.to(torch.int64),
+                    forward_batch.req_pool_indices.to(torch.int64),
+                    self.ape,
+                    norm_weight,
+                    freqs_real,
+                    self.ratio,
+                    self.head_dim,
+                    self.rope_head_dim,
+                    self.overlap,
+                    self.rotate,
+                    self.norm.variance_epsilon,
+                )
+            return self.compress_decode(kv_and_scores, forward_batch)
+        if forward_mode.is_extend():
+            return self.compress_extend(kv_and_scores, forward_batch)
+        raise NotImplementedError(
+            f"Forward mode {forward_mode} not supported in KVAndScoreSeparate compressor."
         )

--- a/python/sglang/srt/layers/attention/dsv4/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/dsv4/index_buf_accessor.py
@@ -10,6 +10,10 @@ import triton.language as tl
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
 
 fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
+
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 
 
 @dataclass
@@ -34,11 +38,24 @@ class NopeFp8RopeBf16Pack:
 class SetKAndS:
     @classmethod
     def execute(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        cls.triton(pool, buf, loc, nope_fp8_rope_bf16_pack)
+        if _is_cpu:
+            cls.torch(pool, buf, loc, nope_fp8_rope_bf16_pack)
+        else:
+            cls.triton(pool, buf, loc, nope_fp8_rope_bf16_pack)
 
     @classmethod
     def torch(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        _set_k_and_s_torch(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
+        if _is_cpu and _cpu_amx:
+            torch.ops.sgl_kernel.set_k_and_s_cpu(
+                buf,
+                loc,
+                nope_fp8_rope_bf16_pack.k_nope_fp8,
+                nope_fp8_rope_bf16_pack.k_rope_bf16,
+                nope_fp8_rope_bf16_pack.scale_k_nope_ue8m0,
+                pool.page_size,
+            )
+        else:
+            _set_k_and_s_torch(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
 
     @classmethod
     def triton(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -9,7 +9,7 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.deepseek_v4 import (
-    fused_q_indexer_rope_hadamard_quant,
+    fused_rope,
     topk_transform_512,
     topk_transform_512_v2,
 )
@@ -17,10 +17,14 @@ from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4.compressor import Compressor
 from sglang.srt.layers.attention.dsv4.metadata import PagedIndexerMetadata
+from sglang.srt.layers.attention.nsa.nsa_indexer import rotate_activation
+from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
-from sglang.srt.utils import add_prefix, is_hip
+from sglang.srt.utils import add_prefix, cpu_has_amx_support, is_cpu, is_hip
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import DeepseekV4AttnBackend
     from sglang.srt.layers.attention.dsv4.compressor import (
@@ -37,6 +41,15 @@ if is_hip():
 else:
     FP8_DTYPE = torch.float8_e4m3fn
     FP8_MAX = torch.finfo(FP8_DTYPE).max
+
+if _is_cpu and _cpu_amx:
+
+    def act_quant_cpu(
+        x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return torch.ops.sgl_kernel.act_quant_cpu(x, block_size, scale_fmt)
+
+    act_quant = act_quant_cpu
 
 
 def fp8_paged_mqa_logits_torch(
@@ -227,6 +240,53 @@ def fused_scale(
     return out
 
 
+def fp8_paged_mqa_logits_cpu(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata: Any,
+    max_seq_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.fp8_paged_mqa_logits_cpu(
+        q_fp8,
+        kvcache_fp8,
+        weight,
+        seq_lens,
+        page_table,
+        max_seq_len,
+        clean_logits,
+    )
+
+
+def topk_transform_512_cpu(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    torch.ops.sgl_kernel.topk_transform_512_cpu(
+        scores,
+        seq_lens,
+        page_tables,
+        out_page_indices,
+        page_size,
+        out_raw_indices,
+    )
+
+
+def fused_scale_cpu(
+    weight: torch.Tensor,
+    out_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.fused_scale_cpu(weight, out_scale, q_scale)
+
+
 class C4IndexerBackendMixin:
     def __init__(self):
         super().__init__()
@@ -265,21 +325,21 @@ class C4IndexerBackendMixin:
             layer_id=c4_indexer.layer_id,
         )
 
-        # The weight projection is small and fast; compute it on its own
-        # stream, then have the Q stream wait on it before launching the big
-        # fused Q kernel (which folds rope + hadamard + fp8 quant + the
-        # weight*weight_scale*q_scale step into one pass).
-        with torch.cuda.stream(stream_weights):
-            weights = c4_indexer.compute_weights(x, skip_scale=True)
-            weights_ready = stream_weights.record_event()
-
         with torch.cuda.stream(stream_q):
             if q_lora_ready is not None:
                 stream_q.wait_event(q_lora_ready)
-            stream_q.wait_event(weights_ready)
-            q_fp8, weights = c4_indexer.compute_q(q_lora, positions, weights)
+            q = c4_indexer.compute_q(q_lora, positions=positions)
+            q_fp8, q_scale = act_quant(q)
+            q_scale_ready = stream_q.record_event()
+
+        with torch.cuda.stream(stream_weights):
+            weights = c4_indexer.compute_weights(x, skip_scale=True)
+            stream_weights.wait_event(q_scale_ready)
+            weights = fused_scale(weights, c4_indexer.weight_scale, q_scale)
 
         current_stream.wait_stream(stream_q)
+        current_stream.wait_stream(stream_weights)
+
         return q_fp8, weights, c4_indexer_kv_cache
 
     def _forward_prepare_normal(
@@ -294,8 +354,13 @@ class C4IndexerBackendMixin:
         if TYPE_CHECKING:
             assert isinstance(self, CompressorBackendMixin)
 
+        q = c4_indexer.compute_q(q_lora, positions=positions)
+        q_fp8, q_scale = act_quant(q)
         weights = c4_indexer.compute_weights(x, skip_scale=True)
-        q_fp8, weights = c4_indexer.compute_q(q_lora, positions, weights)
+        if _is_cpu and _cpu_amx:
+            weights = fused_scale_cpu(weights, c4_indexer.weight_scale, q_scale)
+        else:
+            weights = fused_scale(weights, c4_indexer.weight_scale, q_scale)
         self.forward_indexer_compressor(
             x=x,
             forward_batch=forward_batch,
@@ -379,11 +444,13 @@ class C4IndexerBackendMixin:
             )
         elif envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
             fn = fp8_paged_mqa_logits_torch
+        elif _is_cpu and _cpu_amx:
+            fn = fp8_paged_mqa_logits_cpu
         else:
             from deep_gemm import fp8_paged_mqa_logits as fn
 
         _c4sl = indexer_metadata.c4_seq_lens
-        if _c4sl.dim() == 1:
+        if _c4sl.dim() == 1 and not (_is_cpu and _cpu_amx):
             _c4sl = _c4sl.unsqueeze(-1)
         logits = fn(
             q_fp8,
@@ -433,6 +500,15 @@ class C4IndexerBackendMixin:
                 core_metadata.c4_sparse_page_indices,
                 indexer_metadata.c4_page_size,
                 indexer_metadata.topk_metadata,
+            )
+        elif _is_cpu and _cpu_amx:
+            topk_transform_512_cpu(
+                logits,
+                indexer_metadata.c4_seq_lens,
+                core_metadata.page_table,
+                core_metadata.c4_sparse_page_indices,
+                indexer_metadata.c4_page_size,
+                raw_indices,
             )
         else:
             topk_transform_512(
@@ -519,17 +595,17 @@ class C4Indexer(nn.Module):
         self.weight_scale: float = self.softmax_scale * self.n_heads**-0.5
         self.alt_streams = alt_streams
 
-    def compute_q(
-        self,
-        q_lora: torch.Tensor,
-        positions: torch.Tensor,
-        weight: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    def compute_q(self, q_lora: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
         q, _ = self.wq_b(q_lora)
         q = q.view(-1, self.n_local_heads, self.head_dim)
-        return fused_q_indexer_rope_hadamard_quant(
-            q, weight, self.weight_scale, self.freqs_cis, positions
+        fused_rope(
+            q[..., -self.rope_head_dim :],
+            None,
+            self.freqs_cis,
+            positions=positions,
         )
+        q = rotate_activation(q)
+        return q
 
     def compute_weights(self, x: torch.Tensor, skip_scale=False) -> torch.Tensor:
         out, _ = self.weights_proj(x)

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 if TYPE_CHECKING:
     pass
@@ -103,7 +103,9 @@ class PagedIndexerMetadata:
     topk_metadata: torch.Tensor = field(init=False, repr=False)
 
     def __post_init__(self):
-        if envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
+        if envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get() or (
+            is_cpu() and cpu_has_amx_support()
+        ):
             self.deep_gemm_metadata = None
         else:
             import deep_gemm

--- a/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata_kernel.py
@@ -198,3 +198,151 @@ def init_compression_metadata(
         page_size,
         compute_page_indices,
     )
+
+
+def _init_compression_attn_metadata_pytorch(
+    seq_lens: torch.Tensor,
+    positions: torch.Tensor,
+    raw_out_loc: torch.Tensor,
+    page_table: Optional[torch.Tensor] = None,
+    page_size: int = 0,
+    compute_page_indices: bool = True,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    Optional[torch.Tensor],
+]:
+    bs = seq_lens.shape[0]
+    device = seq_lens.device
+
+    # --- c4 (compress-by-4) metadata ---
+    c4_should_compress = (seq_lens % 4) == 0
+    c4_out_loc = torch.where(
+        c4_should_compress, raw_out_loc // 4, torch.zeros_like(raw_out_loc)
+    )
+    c4_positions = (positions & (~3)).to(torch.int32)
+    c4_seq_lens_raw = (seq_lens // 4).to(torch.int32)
+    c4_seq_lens_clamp1 = torch.clamp(c4_seq_lens_raw, min=1)
+
+    # --- c128 (compress-by-128) metadata ---
+    c128_should_compress = (seq_lens % 128) == 0
+    c128_out_loc = torch.where(
+        c128_should_compress, raw_out_loc // 128, torch.zeros_like(raw_out_loc)
+    )
+    c128_positions = (positions & (~127)).to(torch.int32)
+    c128_seq_lens_raw = (seq_lens // 128).to(torch.int32)
+    c128_seq_lens_clamp1 = torch.clamp(c128_seq_lens_raw, min=1)
+
+    # --- page indices for c128 ---
+    c128_page_indices: Optional[torch.Tensor] = None
+    if compute_page_indices:
+        assert (
+            page_table is not None
+        ), "page_table required when compute_page_indices=True"
+        assert page_size > 0, "page_size required when compute_page_indices=True"
+
+        max_pages = page_table.shape[1]
+        c128_page_size = page_size // 128
+        c128_max_seq_len = c128_page_size * max_pages
+
+        # offsets: [c128_max_seq_len]
+        offsets = torch.arange(c128_max_seq_len, device=device, dtype=torch.int32)
+
+        # page_idx and offset_in_page for every position
+        page_idx = offsets // c128_page_size  # [c128_max_seq_len]
+        offset_in_page = offsets % c128_page_size  # [c128_max_seq_len]
+
+        # Clamp page_idx for safe gather (values beyond max_pages will be masked later)
+        page_idx_clamped = torch.clamp(page_idx, max=max_pages - 1)
+
+        # Gather page table values for all batches: page_table is [bs, max_pages]
+        # page_idx_clamped is [c128_max_seq_len], expand to [bs, c128_max_seq_len]
+        page_idx_expanded = page_idx_clamped.unsqueeze(0).expand(bs, -1)
+        page_table_vals = torch.gather(
+            page_table, dim=1, index=page_idx_expanded.to(torch.int64)
+        ).to(
+            torch.int32
+        )  # [bs, c128_max_seq_len]
+
+        # c_page_indices_vals = page_table_vals * c128_page_size + offset_in_page
+        c128_page_indices_vals = (
+            page_table_vals * c128_page_size + offset_in_page.unsqueeze(0)
+        )
+
+        # Mask: set to -1 where offsets >= c128_seq_lens_raw per batch
+        # c128_seq_lens_raw: [bs], offsets: [c128_max_seq_len]
+        valid_mask = offsets.unsqueeze(0) < c128_seq_lens_raw.unsqueeze(
+            1
+        )  # [bs, c128_max_seq_len]
+        c128_page_indices = torch.where(
+            valid_mask,
+            c128_page_indices_vals,
+            torch.tensor(-1, dtype=torch.int32, device=device),
+        )
+
+    return (
+        c4_out_loc.to(torch.int32),
+        c4_positions,
+        c4_seq_lens_raw,
+        c4_seq_lens_clamp1,
+        c128_out_loc.to(torch.int32),
+        c128_positions,
+        c128_seq_lens_clamp1,
+        c128_page_indices,
+    )
+
+
+def init_compression_metadata_torch(
+    seq_lens: torch.Tensor,
+    positions: torch.Tensor,
+    raw_out_loc: torch.Tensor,
+    page_table: Optional[torch.Tensor] = None,
+    page_size: int = 0,
+    compute_page_indices: bool = True,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    Optional[torch.Tensor],
+]:
+    """Initialize compressed attention metadata using pure PyTorch operations.
+    Computes compress-by-4 and compress-by-128 metadata for attention,
+    and optionally computes page indices for paged KV cache.
+    Args:
+        seq_lens: Sequence lengths per batch element, shape [bs].
+        positions: Current token positions per batch element, shape [bs].
+        raw_out_loc: Raw output locations per batch element, shape [bs].
+        page_table: Page table mapping for paged KV cache, shape [bs, max_pages].
+            Required when compute_page_indices is True.
+        page_size: Size of each page in the KV cache. Required when
+            compute_page_indices is True.
+        compute_page_indices: Whether to compute c128 page indices.
+    Returns:
+        A tuple of:
+        - c4_out_loc: Compressed-by-4 output locations, shape [bs].
+        - c4_positions: Compressed-by-4 positions (aligned to 4), shape [bs].
+        - c4_seq_lens_raw: Raw compressed-by-4 sequence lengths, shape [bs].
+        - c4_seq_lens_clamp1: Compressed-by-4 sequence lengths clamped to min 1, shape [bs].
+        - c128_out_loc: Compressed-by-128 output locations, shape [bs].
+        - c128_positions: Compressed-by-128 positions (aligned to 128), shape [bs].
+        - c128_seq_lens_clamp1: Compressed-by-128 sequence lengths clamped to min 1, shape [bs].
+        - c128_page_indices: Page indices for c128 compression, shape [bs, c128_max_seq_len],
+            or None if compute_page_indices is False.
+    """
+    return _init_compression_attn_metadata_pytorch(
+        seq_lens,
+        positions,
+        raw_out_loc,
+        page_table,
+        page_size,
+        compute_page_indices,
+    )

--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor.py
@@ -4,21 +4,13 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.layers.attention.nsa.utils import aiter_can_use_preshuffle_paged_mqa
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-from sglang.srt.utils import get_bool_env_var, is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 _is_hip = is_hip()
 _is_fp8_fnuz = is_fp8_fnuz()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
-# aiter cp_gather kernel with preshuffle=True is only valid when the indexer
-# uses the page_size=64 preshuffle layout (i.e. when the matching MQA gluon path
-# is also enabled).
-_use_aiter_preshuffle = aiter_can_use_preshuffle_paged_mqa()
-
-if _use_aiter_preshuffle:
-    from aiter.ops.cache import cp_gather_indexer_k_quant_cache
-
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import NSATokenToKVPool
 
@@ -172,55 +164,7 @@ class GetS:
 class GetKAndS:
     @classmethod
     def execute(cls, *args, **kwargs):
-        # The aiter path uses cp_gather_indexer_k_quant_cache(preshuffle=True),
-        # which only matches the layout produced when the rest of the indexer
-        # is on the page_size=64 preshuffle path. Otherwise fall back to the
-        # triton implementation (which works on the page_size=1 legacy layout).
-        if _use_aiter_preshuffle:
-            return cls.aiter(*args, **kwargs)
         return cls.triton(*args, **kwargs)
-
-    @classmethod
-    def aiter(
-        cls,
-        pool: "NSATokenToKVPool",
-        buf: torch.Tensor,
-        page_indices: torch.Tensor,
-        seq_len_tensor: torch.Tensor,
-        seq_len_sum: int,
-        max_seq_len: int,
-    ):
-        from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
-
-        page_size = pool.page_size
-        index_head_dim = pool.index_head_dim
-        quant_block_size = pool.quant_block_size
-        scale_elems = index_head_dim // quant_block_size
-
-        kv_cache = buf.view(-1, page_size, index_head_dim + scale_elems * 4).view(
-            fp8_dtype
-        )
-        dst_k = torch.empty(
-            (seq_len_sum, index_head_dim), dtype=torch.uint8, device=buf.device
-        )
-        dst_scale = torch.empty(
-            (seq_len_sum, scale_elems * 4), dtype=torch.uint8, device=buf.device
-        )
-
-        cu_seq_lens = torch.zeros(
-            seq_len_tensor.shape[0] + 1, dtype=torch.int32, device=buf.device
-        )
-        torch.cumsum(seq_len_tensor.to(torch.int32), dim=0, out=cu_seq_lens[1:])
-
-        cp_gather_indexer_k_quant_cache(
-            kv_cache,
-            dst_k.view(fp8_dtype),
-            dst_scale,
-            page_indices.to(torch.int32),
-            cu_seq_lens,
-            preshuffle=True,
-        )
-        return dst_k, dst_scale
 
     @classmethod
     def triton(
@@ -256,7 +200,15 @@ class GetKAndS:
 class SetK:
     @classmethod
     def execute(cls, *args, buf, **kwargs):
-        return cls.torch_fast(*args, **kwargs, buf=buf)
+        if _is_cpu and _cpu_amx:
+            pool = args[0] if args else kwargs["pool"]
+            loc = args[1] if len(args) > 1 else kwargs["loc"]
+            index_k = args[2] if len(args) > 2 else kwargs["index_k"]
+            torch.ops.sgl_kernel.set_k_cpu(
+                buf, loc, index_k, pool.page_size, pool.index_head_dim
+            )
+        else:
+            return cls.torch_fast(*args, **kwargs, buf=buf)
 
     @classmethod
     def slow(
@@ -306,7 +258,15 @@ class SetK:
 class SetS:
     @classmethod
     def execute(cls, *args, buf, **kwargs):
-        return cls.torch_fast(*args, **kwargs, buf=buf)
+        if _is_cpu and _cpu_amx:
+            pool = args[0] if args else kwargs["pool"]
+            loc = args[1] if len(args) > 1 else kwargs["loc"]
+            index_k_scale = args[2] if len(args) > 2 else kwargs["index_k_scale"]
+            torch.ops.sgl_kernel.set_s_cpu(
+                buf, loc, index_k_scale, pool.page_size, pool.index_head_dim
+            )
+        else:
+            return cls.torch_fast(*args, **kwargs, buf=buf)
 
     @classmethod
     def slow(
@@ -374,8 +334,10 @@ class SetKAndS:
                 buf == buf_cloned
             ), f"{buf=} {buf_cloned=} {kwargs['loc'].to_list()=}"
             return
-
-        cls.triton(*args, **kwargs, buf=buf)
+        if _is_cpu and _cpu_amx:
+            cls.vanilla(*args, **kwargs, buf=buf)
+        else:
+            cls.triton(*args, **kwargs, buf=buf)
 
     @classmethod
     def vanilla(cls, pool, buf, loc, index_k, index_k_scale):
@@ -423,19 +385,15 @@ def _set_k_and_s_triton(
         raise ValueError(
             f"index_k_scale must be 1D or 2D, got shape {index_k_scale.shape}"
         )
-    assert buf_numel_per_page == page_size * (128 + 4)
+    if _is_hip:
+        assert buf_numel_per_page == 1 * (128 + 4)
+    else:
+        assert buf_numel_per_page == 64 * (128 + 4)
     assert num_tokens_to_write == num_tokens_to_write_ == num_tokens_to_write__
     assert index_head_dim == 128
     assert scale_dim == 1
     if _is_hip:
-        if _use_aiter_preshuffle:
-            assert (
-                page_size % 16 == 0
-            ), f"HIP preshuffle requires page_size to be a multiple of 16, got {page_size}"
-        else:
-            assert (
-                page_size == 1
-            ), f"HIP legacy NSA path requires page_size == 1, got {page_size}"
+        assert page_size == 1
     else:
         assert page_size == 64
 

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
@@ -13,11 +12,6 @@ from sglang.jit_kernel.fused_store_index_cache import (
     fused_store_index_k_cache,
 )
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.nsa.utils import (
-    aiter_can_use_preshuffle_paged_mqa,
-    is_nsa_enable_prefill_cp,
-    is_nsa_prefill_cp_in_seq_split,
-)
 from sglang.srt.layers.dp_attention import attn_tp_all_gather_into_tensor
 from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
@@ -28,14 +22,14 @@ from sglang.srt.state_capturer.indexer_topk import (
 from sglang.srt.utils import (
     add_prefix,
     ceil_align,
+    cpu_has_amx_support,
     get_bool_env_var,
+    is_cpu,
     is_cuda,
     is_gfx95_supported,
     is_hip,
     is_npu,
 )
-
-logger = logging.getLogger(__name__)
 
 global _use_multi_stream
 _is_cuda = is_cuda()
@@ -44,16 +38,10 @@ _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_gfx95_supported = is_gfx95_supported()
-# Whether the aiter preshuffle paged-MQA path (page_size=64 + Preshuffle=True +
-# KVBlockSize=64) can be used. Falls back to the legacy page_size=1 / KVBlockSize=1
-# path when the gluon kernel is unavailable (Triton<3.5 and no AOT bundle).
-_use_aiter_preshuffle = aiter_can_use_preshuffle_paged_mqa()
-if _use_aiter and not _use_aiter_preshuffle:
-    logger.warning(
-        "ROCm NSA indexer: aiter preshuffle paged-MQA path is unavailable "
-        "(needs Triton>=3.5.0 or AITER_ENABLE_AOT_GLUON_PA_MQA_LOGITS=1); "
-        "falling back to legacy page_size=1 / KVBlockSize=1 path."
-    )
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
+
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 if _is_cuda:
     try:
         import deep_gemm
@@ -73,6 +61,10 @@ from sglang.srt.distributed import (
 )
 from sglang.srt.distributed.parallel_state import get_pp_group
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.attention.nsa.utils import (
+    is_nsa_enable_prefill_cp,
+    is_nsa_prefill_cp_in_seq_split,
+)
 from sglang.srt.layers.communicator import ScatterMode
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -165,6 +157,8 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     # from sgl_kernel import hadamard_transform
     if _is_hip:
         from fast_hadamard_transform import hadamard_transform
+    elif _is_cpu and _cpu_amx:
+        hadamard_transform = torch.ops.sgl_kernel.fast_hadamard_transform_cpu
     else:
         from sglang.jit_kernel.hadamard import hadamard_transform
 
@@ -445,20 +439,11 @@ class Indexer(MultiPlatformOp):
         page_size = forward_batch.token_to_kv_pool.page_size
         # NOTE(dark): blocksize = 64 is hardcoded in deep_gemm
         if _is_hip:
-            if _use_aiter_preshuffle:
-                assert (
-                    page_size % 16 == 0
-                ), f"HIP preshuffle requires page_size to be a multiple of 16, got {page_size}"
-            else:
-                assert (
-                    page_size == 1
-                ), f"HIP legacy NSA path requires page_size == 1, got {page_size}"
-        else:
-            assert page_size == 64, "only support page size 64"
-        # NOTE(dark): this support extend/decode/decode+graph
-        if _is_hip and not _use_aiter_preshuffle:
+            assert page_size == 1, "only support page size 1"
             block_tables = metadata.get_page_table_1()
         else:
+            assert page_size == 64, "only support page size 64"
+            # NOTE(dark): this support extend/decode/decode+graph
             block_tables = metadata.get_page_table_64()
 
         max_seq_len = block_tables.shape[1] * page_size
@@ -494,12 +479,17 @@ class Indexer(MultiPlatformOp):
         assert len(q_fp8.shape) == 3
         q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
         assert len(kv_cache_fp8.shape) == 2
-        block_kv = page_size
+        block_kv = 1 if _is_hip else 64
         num_heads_kv = 1
         head_dim_with_sf = 132
-        kv_cache_fp8 = kv_cache_fp8.view(
-            kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
-        )
+        if _is_hip:
+            kv_cache_fp8 = kv_cache_fp8.view(
+                -1, block_kv, num_heads_kv, head_dim_with_sf
+            )
+        else:
+            kv_cache_fp8 = kv_cache_fp8.view(
+                kv_cache_fp8.shape[0], block_kv, num_heads_kv, head_dim_with_sf
+            )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
 
@@ -510,8 +500,9 @@ class Indexer(MultiPlatformOp):
             from aiter.ops.triton.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
 
             batch_size, next_n, heads, _ = q_fp8.shape
-            logits = torch.empty(
+            logits = torch.full(
                 (batch_size * next_n, max_seq_len),
+                float("-inf"),
                 device=q_fp8.device,
                 dtype=torch.float32,
             )
@@ -523,7 +514,7 @@ class Indexer(MultiPlatformOp):
                 seqlens_32,
                 block_tables,
                 max_seq_len,
-                Preshuffle=_use_aiter_preshuffle,
+                Preshuffle=False,
                 KVBlockSize=block_kv,
             )
         else:
@@ -587,14 +578,7 @@ class Indexer(MultiPlatformOp):
 
         page_size = forward_batch.token_to_kv_pool.page_size
         if _is_hip:
-            if _use_aiter_preshuffle:
-                assert (
-                    page_size % 16 == 0
-                ), f"HIP preshuffle requires page_size to be a multiple of 16, got {page_size}"
-            else:
-                assert (
-                    page_size == 1
-                ), f"HIP legacy NSA path requires page_size == 1, got {page_size}"
+            assert page_size == 1, "only support page size 1"
         else:
             assert page_size == 64, "only support page size 64"
 
@@ -605,7 +589,7 @@ class Indexer(MultiPlatformOp):
         )
         weights = weights.squeeze(-1)
 
-        if _is_hip and not _use_aiter_preshuffle:
+        if _is_hip:
             block_tables = metadata.get_page_table_1()
         else:
             block_tables = metadata.get_page_table_64()
@@ -1064,27 +1048,19 @@ class Indexer(MultiPlatformOp):
             )
             return
 
-        # Fast path: AITER fused quant + cache store
-        # When _use_aiter_preshuffle is True we use the new MFMA 16x16 preshuffle
-        # layout (page_size>=16). Otherwise we fall back to the legacy row-major
-        # layout with page_size=1; the same kv_cache.view works for both cases
-        # because page_size is 1 there.
+        # Fast path: AITER fused quant + cache store (HIP, page_size=1)
         if _use_aiter:
-            page_size = forward_batch.token_to_kv_pool.page_size
             buf = forward_batch.token_to_kv_pool.get_index_k_with_scale_buffer(
                 layer_id=layer_id
             )
-            kv_cache = buf.view(-1, page_size, 132).view(fp8_dtype)
+            # Reshape from (num_pages, 132) uint8 to (num_pages, 1, 132) fp8
+            # to match kernel's (num_blocks, block_size, head_dim + scale_bytes) layout
+            kv_cache = buf.unsqueeze(1).view(fp8_dtype)
             out_loc = forward_batch.out_cache_loc
             if not out_loc.is_contiguous():
                 out_loc = out_loc.contiguous()
             indexer_k_quant_and_cache(
-                key,
-                kv_cache,
-                out_loc,
-                self.block_size,
-                self.scale_fmt,
-                preshuffle=_use_aiter_preshuffle,
+                key, kv_cache, out_loc, self.block_size, self.scale_fmt
             )
             return
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://github.com/vllm-project/vllm/blob/a6221a144af772fd1a68fe7e627935dc53e81738/vllm/model_executor/layers/fused_moe/layer.py
 
 import logging
@@ -222,12 +220,12 @@ class FusedMoE(torch.nn.Module):
         self.reduce_results = reduce_results
         self.use_presharded_weights = use_presharded_weights
 
-        self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
-        self.use_flashinfer_trtllm_moe = (
-            get_moe_runner_backend().is_flashinfer_trtllm()
-            or get_moe_runner_backend().is_flashinfer_trtllm_routed()
+        self.use_triton_kernels = (
+            get_moe_runner_backend().is_triton_kernels()
+            if not (_is_cpu and _is_cpu_amx_available)
+            else False
         )
-        self.use_deep_gemm = get_moe_runner_backend().is_deep_gemm()
+        self.use_flashinfer_trtllm_moe = get_moe_runner_backend().is_flashinfer_trtllm()
 
         # flashinfer_trtllm kernel requires intermediate_size to be a multiple of 128
         # Pad the intermediate_size_per_partition if necessary
@@ -285,9 +283,7 @@ class FusedMoE(torch.nn.Module):
                 self.quant_method = quant_config.get_quant_method(self, prefix)
             if self.quant_method is None:
                 self.quant_method = UnquantizedFusedMoEMethod(
-                    self.use_triton_kernels,
-                    self.use_flashinfer_trtllm_moe,
-                    self.use_deep_gemm,
+                    self.use_triton_kernels, self.use_flashinfer_trtllm_moe
                 )
 
         self.quant_method.create_weights(

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -15,9 +15,12 @@ from sglang.srt.layers.moe.topk import (
     StandardTopKOutput,
     _mask_topk_ids_padded_region,
 )
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 logger = logging.getLogger(__name__)
+
+_is_cpu = is_cpu()
+_is_cpu_amx_available = cpu_has_amx_support()
 
 
 class HashTopK(nn.Module):
@@ -109,16 +112,31 @@ class HashTopK(nn.Module):
         ), f"{input_ids.shape=} {hidden_states.shape=} {router_logits.shape=}"
 
         if envs.SGLANG_OPT_USE_FUSED_HASH_TOPK.get():
-            from sglang.jit_kernel.deepseek_v4 import hash_topk
+            if _is_cpu and _is_cpu_amx_available:
+                # CPU SGL kernel path: tid2eid lookup done in Python, kernel does scoring + gather
+                tid2eid_for_tokens = self.tid2eid[
+                    input_ids
+                ]  # [num_tokens, routed_topk]
+                topk_weights, topk_ids = torch.ops.sgl_kernel.hash_topk_cpu(
+                    router_logits,
+                    tid2eid_for_tokens,
+                    self.topk,
+                    self.score_func,
+                    self.num_fused_shared_experts,
+                    self.num_experts,
+                    self.routed_scaling_factor,
+                )
+            else:
+                from sglang.jit_kernel.deepseek_v4 import hash_topk
 
-            topk_weights, topk_ids = hash_topk(
-                router_logits=router_logits,
-                input_ids=input_ids,
-                tid2eid=self.tid2eid,
-                num_fused_shared_experts=self.num_fused_shared_experts,
-                routed_scaling_factor=self.routed_scaling_factor,
-                scoring_func=self.score_func,
-            )
+                topk_weights, topk_ids = hash_topk(
+                    router_logits=router_logits,
+                    input_ids=input_ids,
+                    tid2eid=self.tid2eid,
+                    num_fused_shared_experts=self.num_fused_shared_experts,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                    scoring_func=self.score_func,
+                )
         else:
             topk_weights, topk_ids = self._forward_torch(router_logits, input_ids)
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -243,18 +243,6 @@ class BypassedTopKOutput(NamedTuple):
     def format(self) -> TopKOutputFormat:
         return TopKOutputFormat.BYPASSED
 
-    def to_standard(self, layer_id: Optional[int] = None) -> "StandardTopKOutput":
-        """Materialize routing tensors. Used by MoE kernels that need explicit
-        topk_ids / topk_weights rather than doing routing internally."""
-        return select_experts(
-            hidden_states=self.hidden_states,
-            router_logits=self.router_logits,
-            topk_config=self.topk_config,
-            layer_id=layer_id,
-            num_token_non_padded=self.num_token_non_padded,
-            expert_location_dispatch_info=self.expert_location_dispatch_info,
-        )
-
 
 # -------------------------------- TopK ---------------------------------------
 
@@ -296,25 +284,6 @@ class TopK(MultiPlatformOp):
             assert num_expert_group is not None and topk_group is not None
 
         self.layer_id = layer_id
-        if num_fused_shared_experts > 0:
-            from sglang.srt.server_args import get_global_server_args
-
-            try:
-                self.enable_deepep_waterfill = (
-                    get_global_server_args().enable_deepep_waterfill
-                )
-            except ValueError:
-                self.enable_deepep_waterfill = False
-        else:
-            self.enable_deepep_waterfill = False
-
-        self.deepep_waterfill_balancer = None
-        if self.enable_deepep_waterfill:
-            # TODO(ch-wan): Refactor shared-expert fusion and routed TopK fusion.
-            top_k -= num_fused_shared_experts
-            num_fused_shared_experts = 0
-            output_format = TopKOutputFormat.STANDARD
-
         # flashinfer_mxfp4 backend only: True -> STANDARD (Mxfp4FlashinferTrtllmMoEMethod
         # consumes), False -> BYPASSED (flashinfer's own mxfp4 kernel). No-op otherwise.
         self.is_fp4_experts = is_fp4_experts
@@ -334,18 +303,6 @@ class TopK(MultiPlatformOp):
             scoring_func=scoring_func,
         )
 
-    def _apply_deepep_waterfill(
-        self, topk_output: TopKOutput, num_tokens: int
-    ) -> TopKOutput:
-        if self.enable_deepep_waterfill and self.deepep_waterfill_balancer is None:
-            raise RuntimeError(
-                "DeepEP waterfill TopK must be prepared by ModelRunner before forward."
-            )
-        if self.deepep_waterfill_balancer is None:
-            return topk_output
-        assert TopKOutputChecker.format_is_standard(topk_output)
-        return self.deepep_waterfill_balancer.expand_topk(topk_output, num_tokens)
-
     def forward_native(
         self,
         hidden_states: torch.Tensor,
@@ -355,7 +312,7 @@ class TopK(MultiPlatformOp):
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     ) -> TopKOutput:
         self.topk_config.torch_native = True
-        topk_output = select_experts(
+        return select_experts(
             hidden_states=hidden_states,
             layer_id=self.layer_id,
             router_logits=router_logits,
@@ -363,7 +320,6 @@ class TopK(MultiPlatformOp):
             num_token_non_padded=num_token_non_padded,
             expert_location_dispatch_info=expert_location_dispatch_info,
         )
-        return self._apply_deepep_waterfill(topk_output, hidden_states.shape[0])
 
     def forward_cuda(
         self,
@@ -413,7 +369,7 @@ class TopK(MultiPlatformOp):
                     num_token_non_padded=num_token_non_padded,
                     expert_location_dispatch_info=expert_location_dispatch_info,
                 )
-        return self._apply_deepep_waterfill(topk_output, hidden_states.shape[0])
+            return topk_output
 
     def forward_cpu(
         self,
@@ -423,7 +379,7 @@ class TopK(MultiPlatformOp):
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     ) -> TopKOutput:
-        topk_output = select_experts(
+        return select_experts(
             hidden_states=hidden_states,
             layer_id=self.layer_id,
             router_logits=router_logits,
@@ -431,7 +387,6 @@ class TopK(MultiPlatformOp):
             num_token_non_padded=num_token_non_padded,
             expert_location_dispatch_info=expert_location_dispatch_info,
         )
-        return self._apply_deepep_waterfill(topk_output, hidden_states.shape[0])
 
     def forward_npu(
         self,
@@ -462,18 +417,7 @@ class TopK(MultiPlatformOp):
             topk_ids = torch.full((0, topk), -1, dtype=torch.int32, device=device)
         # FIXME: router_logits should be of size (0, num_experts)
         router_logits = torch.empty((0, topk), dtype=torch.float32, device=device)
-        topk_output = StandardTopKOutput(topk_weights, topk_ids, router_logits)
-        if self.topk_config.num_fused_shared_experts > 0 and is_deepep_class_backend():
-            n = self.topk_config.num_fused_shared_experts
-            topk_output = topk_output._replace(
-                topk_ids=topk_output.topk_ids.new_empty(
-                    (0, topk_output.topk_ids.shape[-1] + n)
-                ),
-                topk_weights=topk_output.topk_weights.new_empty(
-                    (0, topk_output.topk_weights.shape[-1] + n)
-                ),
-            )
-        return self._apply_deepep_waterfill(topk_output, 0)
+        return StandardTopKOutput(topk_weights, topk_ids, router_logits)
 
 
 # ------------------------------- TopK implementation -------------------------------------
@@ -1163,6 +1107,35 @@ def biased_grouped_topk_cpu(
     )
 
 
+def biased_topk_cpu(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    scoring_func: str = "sigmoid",
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: Optional[float] = None,
+    num_token_non_padded: Optional[torch.Tensor] = None,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    apply_routed_scaling_factor_on_output: Optional[bool] = False,
+):
+    topk_weights, topk_ids = torch.ops.sgl_kernel.biased_topk_cpu(
+        hidden_states,
+        gating_output,
+        correction_bias,
+        topk,
+        renormalize,
+        scoring_func,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output or False,
+    )
+    topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
+    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    return topk_weights, topk_ids
+
+
 if _is_cpu and _is_cpu_amx_available:
     biased_grouped_topk = biased_grouped_topk_cpu
     grouped_topk = grouped_topk_cpu
@@ -1370,25 +1343,40 @@ def select_experts(
     elif custom_routing_function is None:
         assert not apply_routed_scaling_factor_on_output, "Not implemented"
         if scoring_func == "sqrtsoftplus":
-            _biased_topk = (
-                biased_topk_jit_kernel_impl
-                if envs.SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK.get()
-                else biased_topk_impl
-            )
+            if _is_cpu and _is_cpu_amx_available:
+                topk_weights, topk_ids = biased_topk_cpu(
+                    hidden_states=hidden_states,
+                    gating_output=router_logits,
+                    correction_bias=correction_bias,
+                    topk=top_k,
+                    renormalize=renormalize,
+                    scoring_func=scoring_func,
+                    num_fused_shared_experts=num_fused_shared_experts,
+                    routed_scaling_factor=routed_scaling_factor,
+                    num_token_non_padded=num_token_non_padded,
+                    expert_location_dispatch_info=expert_location_dispatch_info,
+                    apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                )
+            else:
+                _biased_topk = (
+                    biased_topk_jit_kernel_impl
+                    if envs.SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK.get()
+                    else biased_topk_impl
+                )
 
-            topk_weights, topk_ids = _biased_topk(
-                hidden_states=hidden_states,
-                gating_output=router_logits,
-                correction_bias=correction_bias,
-                topk=num_routed_topk if _use_aiter else top_k,
-                renormalize=renormalize,
-                scoring_func=scoring_func,
-                num_fused_shared_experts=num_fused_shared_experts,
-                routed_scaling_factor=routed_scaling_factor,
-                num_token_non_padded=num_token_non_padded,
-                expert_location_dispatch_info=expert_location_dispatch_info,
-                apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
-            )
+                topk_weights, topk_ids = _biased_topk(
+                    hidden_states=hidden_states,
+                    gating_output=router_logits,
+                    correction_bias=correction_bias,
+                    topk=num_routed_topk if _use_aiter else top_k,
+                    renormalize=renormalize,
+                    scoring_func=scoring_func,
+                    num_fused_shared_experts=num_fused_shared_experts,
+                    routed_scaling_factor=routed_scaling_factor,
+                    num_token_non_padded=num_token_non_padded,
+                    expert_location_dispatch_info=expert_location_dispatch_info,
+                    apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+                )
         elif (
             get_moe_runner_backend().is_flashinfer_trtllm_routed()
             and scoring_func == "softmax"

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://raw.githubusercontent.com/vllm-project/vllm/v0.5.5/vllm/model_executor/layers/quantization/__init__.py
 from __future__ import annotations
 
@@ -31,7 +29,6 @@ from sglang.srt.layers.quantization.fpgemm_fp8 import FBGEMMFp8Config
 from sglang.srt.layers.quantization.gguf import GGUFConfig
 from sglang.srt.layers.quantization.gptq import GPTQConfig, GPTQMarlinConfig
 from sglang.srt.layers.quantization.gptq_cpu import CPUGPTQConfig
-from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp8Config,
@@ -49,9 +46,9 @@ from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
 from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
 from sglang.srt.utils import (
     cpu_has_amx_support,
+    is_cpu,
     is_cuda,
     is_hip,
-    is_mps,
     is_npu,
     mxfp_supported,
 )
@@ -91,19 +88,10 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
 }
 
 
-if is_cuda() or (_is_mxfp_supported and is_hip()):
+if is_cpu() or is_cuda() or (_is_mxfp_supported and is_hip()):
     BASE_QUANTIZATION_METHODS.update(
         {
             "mxfp4": Mxfp4Config,
-        }
-    )
-
-
-if is_mps():
-    BASE_QUANTIZATION_METHODS.update(
-        {
-            "mlx_q4": MlxQuantizationConfig,
-            "mlx_q8": MlxQuantizationConfig,
         }
     )
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/model_executor/layers/quantization/fp8.py
 
 from __future__ import annotations
@@ -264,20 +262,18 @@ class Fp8Config(QuantizationConfig):
                 return Mxfp4MarlinMoEMethod(fp8_method, prefix=prefix)
 
             if self.is_fp4_experts and get_moe_runner_backend().is_flashinfer_mxfp4():
-                # SM100 (Blackwell) -> trtllm-gen path.
-                # SM90  (Hopper)    -> cutlass mixed-input path (FlashInfer #3084).
-                if is_sm90_supported() and not is_sm100_supported():
-                    from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
-                        Mxfp4FlashinferCutlassMoEMethod,
-                    )
-
-                    return Mxfp4FlashinferCutlassMoEMethod(fp8_method, prefix=prefix)
-
                 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
                     Mxfp4FlashinferTrtllmMoEMethod,
                 )
 
                 return Mxfp4FlashinferTrtllmMoEMethod(fp8_method, prefix=prefix)
+
+            if self.is_fp4_experts and _is_cpu and _is_cpu_amx_available:
+                from sglang.srt.layers.quantization.mxfp4_fp8config_cpu_moe import (
+                    Mxfp4Fp8ConfigCpuMoEMethod,
+                )
+
+                return Mxfp4Fp8ConfigCpuMoEMethod()
             return fp8_method
         elif isinstance(layer, RadixAttention):
             return Fp8KVCacheMethod(self)
@@ -1712,6 +1708,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 None,  # w1_zp
                 None,  # w2_zp
                 self.quant_config.weight_block_size,  # block_size
+                None,  # w1 bias
+                None,  # w3 bias
+                None,  # alpha
+                None,  # limi
                 True,  # is_vnni
             )
             return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,25 +16,21 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import replace
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
 from torch.nn.parameter import Parameter
 
-# Silence the TRT-LLM cutlass autotune trace embedded inside FlashInfer's
-# cutlass_fused_moe. Its C++ logger reads TLLM_LOG_LEVEL on first kernel launch;
-# setdefault preserves any explicit user override.
-os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
-
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
+from sglang.srt.layers.amx_utils import (
+    _amx_process_weight_after_loading,
+)
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 from sglang.srt.layers.quantization.base_config import (
@@ -46,6 +41,8 @@ from sglang.srt.layers.quantization.base_config import (
 from sglang.srt.layers.quantization.utils import is_layer_skipped
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
+    cpu_has_amx_support,
+    is_cpu,
     is_flashinfer_available,
     is_gfx95_supported,
     is_hip,
@@ -57,6 +54,7 @@ from sglang.srt.utils import (
     next_power_of_2,
     round_up,
     set_weight_attrs,
+    use_intel_amx_backend,
 )
 from sglang.srt.utils.common import get_bool_env_var
 from sglang.srt.utils.custom_op import register_custom_op
@@ -70,27 +68,7 @@ if is_flashinfer_available():
         nvfp4_block_scale_interleave,
         trtllm_fp4_block_scale_moe,
     )
-    from flashinfer.fused_moe import cutlass_fused_moe as flashinfer_cutlass_fused_moe
-    from flashinfer.fused_moe.core import (
-        ActivationType,
-        get_w2_permute_indices_with_cache,
-    )
-
-    # SM90 mixed-input helpers landed in FlashInfer #3084 (post-0.6.10). Older
-    # versions don't ship them; gate at import so unrelated code paths still load.
-    try:
-        from flashinfer.fused_moe import (
-            interleave_moe_scales_for_sm90_mixed_gemm,
-            interleave_moe_weights_for_sm90_mixed_gemm,
-        )
-
-        _FI_HAS_SM90_CUTLASS_MXFP4 = True
-    except ImportError:
-        interleave_moe_scales_for_sm90_mixed_gemm = None
-        interleave_moe_weights_for_sm90_mixed_gemm = None
-        _FI_HAS_SM90_CUTLASS_MXFP4 = False
-else:
-    _FI_HAS_SM90_CUTLASS_MXFP4 = False
+    from flashinfer.fused_moe.core import get_w2_permute_indices_with_cache
 
 _flashinfer_mxfp4_permute_indices_cache: dict[torch.Size, torch.Tensor] = {}
 _flashinfer_mxfp4_permute_indices_device_cache: dict[
@@ -138,8 +116,10 @@ if TYPE_CHECKING:
         StandardDispatchOutput,
     )
 
+_is_cpu = is_cpu()
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
+_is_cpu_amx_available = cpu_has_amx_support()
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 
 if _is_hip:
@@ -343,32 +323,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
-        self.use_marlin = get_moe_runner_backend().is_marlin()
         self.flashinfer_mxfp4_moe_precision = (
             get_global_server_args().flashinfer_mxfp4_moe_precision
         )
-        # When `flashinfer_mxfp4` is enabled, dispatch to one of two FlashInfer
-        # entry points depending on the GPU:
-        #   - SM100 (Blackwell)  -> trtllm_fp4_block_scale_moe (existing)
-        #   - SM90  (Hopper)     -> cutlass_fused_moe(use_w4_group_scaling=True)
-        #                           (FlashInfer PR #3084, post-0.6.10)
-        self._fi_kernel: Optional[str] = None
-        if self.use_flashinfer:
-            if is_sm100_supported():
-                self._fi_kernel = "trtllm_sm100"
-            elif is_sm90_supported():
-                if not _FI_HAS_SM90_CUTLASS_MXFP4:
-                    raise RuntimeError(
-                        "moe_runner_backend=flashinfer_mxfp4 on SM90 requires the "
-                        "interleave_moe_{weights,scales}_for_sm90_mixed_gemm helpers "
-                        "from FlashInfer PR #3084 (>= 0.6.11). Upgrade flashinfer-python "
-                        "or pick a different backend (e.g. marlin / triton_kernel)."
-                    )
-                self._fi_kernel = "cutlass_sm90"
-            else:
-                raise NotImplementedError(
-                    "moe_runner_backend=flashinfer_mxfp4 requires SM90 or SM100."
-                )
 
     def create_weights(
         self,
@@ -400,26 +357,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 intermediate_size_per_partition_after_pad = round_up(
                     intermediate_size_per_partition, triton_kernels_padding_alignment
                 )
-        elif self._fi_kernel == "cutlass_sm90":
-            # cutlass mixed-input GEMM contraction dim K must be % 128 == 0
-            # (interleave factor for MXFP4 group_size=32 is 4). The kernel
-            # also expects ``fc1_expert_weights`` in halved ``[up; gate]``
-            # layout, which means the padding boundary must fall on the
-            # gate / up split.
-            #
-            # The mxfp4 weight loader (FusedMoE.weight_loader fast path) does
-            # a NAIVE copy of HF's ``[2*intermediate_size, hidden_packed]``
-            # tensor into the buffer's ``[:dim1, :dim2]`` slice. Padding the
-            # buffer here would push the gate/up boundary, so HF's "up"
-            # rows would land in the buffer's "gate" half and vice versa.
-            # Marlin sidesteps this by not padding; we do the same and
-            # rebuild a properly-padded buffer in
-            # ``_process_weights_for_sm90_cutlass`` after the load completes.
-            self._padded_intermediate = round_up(intermediate_size_per_partition, 128)
-            self._padded_hidden = round_up(hidden_size, 128)
-            # create_weights below uses the *unpadded* sizes so the loader's
-            # naive-copy fast path is correct.
-            intermediate_size_per_partition_after_pad = intermediate_size_per_partition
         elif _use_aiter:
 
             intermediate_size_per_partition_after_pad = round_up(
@@ -509,28 +446,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
-        if self.use_marlin:
-            from sglang.srt.layers.quantization.marlin_utils import (
-                check_moe_marlin_supports_layer,
-            )
-            from sglang.srt.layers.quantization.marlin_utils_fp4 import (
-                prepare_moe_mxfp4_layer_for_marlin,
-            )
-
-            if not is_sm90_supported():
-                raise RuntimeError("MXFP4 Marlin requires Hopper/SM90 or above.")
-            if not check_moe_marlin_supports_layer(layer, 32):
-                raise RuntimeError(
-                    "Current MXFP4 MoE layer is not supported by Marlin."
-                )
-
-            prepare_moe_mxfp4_layer_for_marlin(layer)
-            layer._mxfp4_backend = "marlin"
-            return
-
-        if self._fi_kernel == "cutlass_sm90":
-            self._process_weights_for_sm90_cutlass(layer)
-            return
         if self.use_flashinfer:
             # TODO: these values are hardcoded for now, we need to get them from the model
             layer.gemm1_alpha = Parameter(
@@ -806,6 +721,30 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.w2_weight_triton_tensor = w2_weight
             del layer.w13_weight
             del layer.w2_weight
+        elif _is_cpu and _is_cpu_amx_available:
+            _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+            if use_intel_amx_backend(layer):
+                packed_w13_weight_scale = torch.ops.sgl_kernel.convert_scale_packed(
+                    layer.w13_weight_scale
+                )
+                packed_w2_weight_scale = torch.ops.sgl_kernel.convert_scale_packed(
+                    layer.w2_weight_scale
+                )
+                layer.w13_weight_scale = Parameter(
+                    packed_w13_weight_scale, requires_grad=False
+                )
+                layer.w2_weight_scale = Parameter(
+                    packed_w2_weight_scale, requires_grad=False
+                )
+                if hasattr(layer, "w13_weight_bias"):
+                    layer.w13_weight_bias = Parameter(
+                        layer.w13_weight_bias.float(), requires_grad=False
+                    )
+                if hasattr(layer, "w2_weight_bias"):
+                    layer.w2_weight_bias = Parameter(
+                        layer.w2_weight_bias.float(), requires_grad=False
+                    )
+            return
         else:
             from triton_kernels.numerics_details.mxfp import upcast_from_mxfp
 
@@ -829,133 +768,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight = Parameter(w2_weight.data, requires_grad=False)
         torch.cuda.empty_cache()
 
-    def _process_weights_for_sm90_cutlass(self, layer):
-        """De-interleave + pad + halving-swap + byte-interleave MXFP4 weights
-        for FlashInfer's SM90 ``cutlass_fused_moe(use_w4_group_scaling=True)``
-        path (PR #3084).
-
-        The cutlass kernel needs (a) K (contraction dim) % 128 == 0, and (b)
-        ``fc1_expert_weights`` in halved ``[up; gate]`` order -- the
-        ``compute_with_experts`` reference in FlashInfer's
-        ``test_trtllm_cutlass_fused_moe.py`` splits
-        ``w3, w1 = chunk(W, 2, dim=0)`` and uses w3 as up, w1 as gate.
-
-        GPT-OSS's HF layout is *interleaved* ``[g_0, u_0, g_1, u_1, ..., g_{N-1}, u_{N-1}]``
-        (each pair occupies two adjacent rows). The mxfp4 weight loader does
-        a naive copy, so our unpadded buffer is interleaved post-load. We
-        de-interleave (even rows -> gate, odd rows -> up), pad each half from
-        N_un to N_pad, concatenate as halved ``[up; gate]``, and then run
-        FlashInfer's byte / scale interleave helpers.
-        """
-        sf_block_size = 32  # MXFP4 group size
-
-        # Sizes from the unpadded loaded buffers.
-        N_un = layer.w13_weight.shape[1] // 2  # intermediate (unpadded)
-        K_un = (
-            layer.w13_weight.shape[2] * 2
-        )  # hidden (unpadded, *2 because packed 4-bit)
-        N_pad = self._padded_intermediate
-        K_pad = self._padded_hidden
-        # Use the local expert count (matches the existing buffer allocation in
-        # create_weights) so the SM90 cutlass path remains correct under
-        # Expert Parallelism. `self.num_experts` is the *global* count.
-        E = layer.num_local_experts
-        device = layer.w13_weight.device
-        bias_dtype = layer.w13_weight_bias.dtype
-
-        # ---- De-interleave + pad w13 weight/scale/bias to halved [up; gate]
-        # Even rows of HF = gate, odd rows = up. After splitting we pad each
-        # half along its row dim (N) from N_un to N_pad with zeros, and along
-        # its last dim (K) from K_un (or K_un / sf_block_size) to K_pad.
-
-        def _stack_up_gate_w13(unpadded_w13, last_pad, last_un):
-            # unpadded_w13: [E, 2*N_un, last_un]
-            # Returns: [E, 2*N_pad, last_pad] in [up_padded; gate_padded] order.
-            gate_rows = unpadded_w13[:, 0::2, :]  # [E, N_un, last_un]
-            up_rows = unpadded_w13[:, 1::2, :]  # [E, N_un, last_un]
-            out = torch.zeros(
-                E, 2 * N_pad, last_pad, dtype=unpadded_w13.dtype, device=device
-            )
-            # First half: up (with row + col padding zeros).
-            out[:, :N_un, :last_un] = up_rows
-            # Second half: gate.
-            out[:, N_pad : N_pad + N_un, :last_un] = gate_rows
-            return out
-
-        w13_padded = _stack_up_gate_w13(
-            layer.w13_weight.data.view(torch.uint8), K_pad // 2, K_un // 2
-        )
-        w13_scale_padded = _stack_up_gate_w13(
-            layer.w13_weight_scale.data,
-            K_pad // sf_block_size,
-            K_un // sf_block_size,
-        )
-        # Bias: same de-interleave on dim=-1.
-        w13_bias_gate = layer.w13_weight_bias.data[:, 0::2]  # [E, N_un]
-        w13_bias_up = layer.w13_weight_bias.data[:, 1::2]  # [E, N_un]
-        w13_bias_padded = torch.zeros(E, 2 * N_pad, dtype=bias_dtype, device=device)
-        w13_bias_padded[:, :N_un] = w13_bias_up
-        w13_bias_padded[:, N_pad : N_pad + N_un] = w13_bias_gate
-
-        def _pad_w2_3d(unpadded, last_pad, last_un):
-            out = torch.zeros(E, K_pad, last_pad, dtype=unpadded.dtype, device=device)
-            out[:, :K_un, :last_un] = unpadded[:, :K_un, :]
-            return out
-
-        # ---- w2 (no halving, just pad to [E, K_pad, N_pad/2]) ----------------
-        w2_padded = _pad_w2_3d(
-            layer.w2_weight.data.view(torch.uint8), N_pad // 2, N_un // 2
-        )
-        w2_scale_padded = _pad_w2_3d(
-            layer.w2_weight_scale.data,
-            N_pad // sf_block_size,
-            N_un // sf_block_size,
-        )
-        w2_bias_padded = torch.zeros(E, K_pad, dtype=bias_dtype, device=device)
-        w2_bias_padded[:, :K_un] = layer.w2_weight_bias.data
-
-        # ---- Per-expert SwiGLU scalars (GPT-OSS defaults) ------------------
-        layer.swiglu_alpha = Parameter(
-            torch.full((E,), 1.702, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-        layer.swiglu_beta = Parameter(
-            torch.full((E,), 1.0, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-        layer.swiglu_limit = Parameter(
-            torch.full((E,), 7.0, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-
-        # ---- FlashInfer SM90 byte / scale interleave -----------------------
-        # The padded buffers above are contiguous by construction (allocated
-        # via torch.zeros + slice assignment), so we feed them straight in.
-        layer.w13_weight = Parameter(
-            interleave_moe_weights_for_sm90_mixed_gemm(w13_padded, "fp4"),
-            requires_grad=False,
-        )
-        layer.w2_weight = Parameter(
-            interleave_moe_weights_for_sm90_mixed_gemm(w2_padded, "fp4"),
-            requires_grad=False,
-        )
-        layer.w13_weight_scale = Parameter(
-            interleave_moe_scales_for_sm90_mixed_gemm(
-                w13_scale_padded, group_size=sf_block_size
-            ),
-            requires_grad=False,
-        )
-        layer.w2_weight_scale = Parameter(
-            interleave_moe_scales_for_sm90_mixed_gemm(
-                w2_scale_padded, group_size=sf_block_size
-            ),
-            requires_grad=False,
-        )
-        layer.w13_weight_bias = Parameter(w13_bias_padded, requires_grad=False)
-        layer.w2_weight_bias = Parameter(w2_bias_padded, requires_grad=False)
-
-        torch.cuda.empty_cache()
-
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
@@ -975,83 +787,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.runner = MoeRunner(
                 moe_runner_backend, replace(moe_runner_config, activation="swiglu")
             )
-        elif (
-            moe_runner_backend.is_triton_kernels()
-            or moe_runner_backend.is_triton()
-            or moe_runner_backend.is_marlin()
-        ):
+        elif moe_runner_backend.is_triton_kernels() or moe_runner_backend.is_triton():
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         else:
             # TODO(cwan): refactor other backends
             pass
-
-    def _apply_sm90_cutlass(self, layer, x, topk_output):
-        """SM90 (Hopper) MXFP4 x BF16 MoE via FlashInfer's cutlass mixed-input
-        path (PR #3084). The fused kernel does GEMM1 + SwiGLU + GEMM2 in one
-        call; weights/scales were pre-interleaved at load time."""
-        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
-        from sglang.srt.layers.moe.topk import TopKOutputChecker
-
-        # Under ``--moe-runner-backend flashinfer_mxfp4`` the SGLang TopK layer
-        # emits BypassedTopKOutput by default (the SM100 trtllm-gen kernel does
-        # routing internally). The cutlass kernel needs explicit topk_ids /
-        # topk_weights, so materialize them here when bypassed.
-        if TopKOutputChecker.format_is_bypassed(topk_output):
-            topk_output = topk_output.to_standard()
-        topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
-
-        # Pad input hidden dim to the (already-padded) loaded weight width.
-        origin_hidden = x.shape[-1]
-        padded_hidden = self._padded_hidden
-        if padded_hidden != origin_hidden:
-            x = torch.nn.functional.pad(
-                x,
-                (0, padded_hidden - origin_hidden),
-                mode="constant",
-                value=0.0,
-            )
-
-        output_dtype = torch.bfloat16
-        # Output is allocated at padded width (kernel writes padded_hidden
-        # columns), then trimmed back to origin_hidden before returning.
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            out_padded = torch.empty(
-                x.shape[0], padded_hidden, dtype=output_dtype, device=x.device
-            )
-
-        flashinfer_cutlass_fused_moe(
-            input=x,
-            token_selected_experts=topk_ids.to(torch.int),
-            token_final_scales=topk_weights,
-            fc1_expert_weights=layer.w13_weight,  # uint8 [E, 2*N, K/2] interleaved
-            fc2_expert_weights=layer.w2_weight,  # uint8 [E, K, N/2] interleaved
-            output_dtype=output_dtype,
-            quant_scales=[
-                layer.w13_weight_scale.view(torch.int32),
-                layer.w2_weight_scale.view(torch.int32),
-            ],
-            fc1_expert_biases=layer.w13_weight_bias,  # bf16 [E, 2*N]
-            fc2_expert_biases=layer.w2_weight_bias,  # bf16 [E, K]
-            swiglu_alpha=layer.swiglu_alpha,
-            swiglu_beta=layer.swiglu_beta,
-            swiglu_limit=layer.swiglu_limit,
-            tp_size=layer.moe_tp_size,
-            tp_rank=layer.moe_tp_rank,
-            ep_size=layer.moe_ep_size,
-            ep_rank=layer.moe_ep_rank,
-            use_w4_group_scaling=True,
-            activation_type=ActivationType.Swiglu,
-            tune_max_num_tokens=next_power_of_2(x.shape[0]),
-            output=out_padded,
-        )
-
-        if padded_hidden != origin_hidden:
-            out = out_padded[:, :origin_hidden].contiguous()
-        else:
-            out = out_padded
-        return StandardCombineInput(hidden_states=out)
 
     def apply(
         self,
@@ -1065,22 +805,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         x = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
 
-        if self.use_marlin:
-            assert TopKOutputChecker.format_is_standard(topk_output)
-            quant_info = MarlinMoeQuantInfo(
-                w13_qweight=layer.w13_weight,
-                w2_qweight=layer.w2_weight,
-                w13_scales=layer.w13_weight_scale,
-                w2_scales=layer.w2_weight_scale,
-                w13_g_idx_sort_indices=None,
-                w2_g_idx_sort_indices=None,
-                weight_bits=4,
-                is_k_full=True,
-            )
-            return self.runner.run(dispatch_output, quant_info)
+        if use_intel_amx_backend(layer):
+            from sglang.srt.layers.amx_utils import amx_fused_experts_mxfp4
 
-        if self._fi_kernel == "cutlass_sm90":
-            return self._apply_sm90_cutlass(layer, x, topk_output)
+            return amx_fused_experts_mxfp4(
+                layer, dispatch_output, self.moe_runner_config
+            )
+
         if self.use_flashinfer:
             # When bf16 mode is enabled, we don't need to quantize the input,
             # TRT-LLM automatically handles quantization in the kernel implementation and pipelines it with GEMM operations,

--- a/python/sglang/srt/layers/quantization/mxfp4_fp8config_cpu_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_fp8config_cpu_moe.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
+from sglang.srt.layers.amx_utils import amx_fused_experts_mxfp4
+from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
+    Mxfp4FlashinferTrtllmMoEMethod,
+)
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
+
+
+class Mxfp4Fp8ConfigCpuMoEMethod(Mxfp4FlashinferTrtllmMoEMethod):
+    # MxFP4 MoE method for the `Fp8Config + is_fp4_experts=True` dispatch on CPU AMX.
+
+    def __init__(self):
+        # Skip parent's __init__: it reads a GPU-only server arg and stores
+        # fp8_method/prefix used only by the GPU path.
+        pass
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        kernel = torch.ops.sgl_kernel
+
+        w13 = layer.w13_weight.data
+        w2 = layer.w2_weight.data
+        w13_scale = layer.w13_weight_scale_inv.data
+        w2_scale = layer.w2_weight_scale_inv.data
+
+        # Weights are int8-storage of packed FP4 (two values/byte). The CPU
+        # kernel checks w scalar_type == uint8, so view as uint8 (bit-equivalent).
+        w13 = w13.view(torch.uint8)
+        w2 = w2.view(torch.uint8)
+
+        if w13_scale.dtype == torch.float32:
+            w13_scale = w13_scale.to(torch.float8_e8m0fnu)
+            w2_scale = w2_scale.to(torch.float8_e8m0fnu)
+        w13_scale = w13_scale.view(torch.uint8)
+        w2_scale = w2_scale.view(torch.uint8)
+
+        w13 = kernel.convert_weight_packed(w13)
+        w2 = kernel.convert_weight_packed(w2)
+        w13_scale = kernel.convert_scale_packed(w13_scale)
+        w2_scale = kernel.convert_scale_packed(w2_scale)
+
+        layer.w13_weight = Parameter(w13, requires_grad=False)
+        layer.w2_weight = Parameter(w2, requires_grad=False)
+        layer.w13_weight_scale_inv = Parameter(w13_scale, requires_grad=False)
+        layer.w2_weight_scale_inv = Parameter(w2_scale, requires_grad=False)
+
+        layer.use_intel_amx_backend = True
+
+    def apply(
+        self,
+        layer: Module,
+        dispatch_output: DispatchOutput,
+    ) -> CombineInput:
+        return amx_fused_experts_mxfp4(
+            layer,
+            dispatch_output,
+            self.moe_runner_config,
+            scale_attrs=("w13_weight_scale_inv", "w2_weight_scale_inv"),
+        )

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -9,7 +9,6 @@ import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
-from sglang.srt.environ import envs
 from sglang.srt.layers.amx_utils import (
     CPUQuantMethod,
     _amx_process_weight_after_loading,
@@ -164,17 +163,13 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
     """MoE method without quantization."""
 
     def __init__(
-        self,
-        use_triton_kernels: bool = False,
-        use_flashinfer_trtllm_moe: bool = False,
-        use_deep_gemm: bool = False,
+        self, use_triton_kernels: bool = False, use_flashinfer_trtllm_moe: bool = False
     ):
         super().__init__()
         self.use_flashinfer_cutlass = get_moe_runner_backend().is_flashinfer_cutlass()
         self.use_triton_kernels = use_triton_kernels
         self.with_bias = False
         self.use_flashinfer_trtllm_moe = use_flashinfer_trtllm_moe
-        self.use_deep_gemm = use_deep_gemm
         self._cache_permute_indices = dict({})
 
     def create_weights(
@@ -252,6 +247,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         # Pack weight for get better performance on CPU
         if _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+            if hasattr(layer, "w13_weight_bias"):
+                layer.w13_weight_bias = Parameter(
+                    layer.w13_weight_bias.float(), requires_grad=False
+                )
+            if hasattr(layer, "w2_weight_bias"):
+                layer.w2_weight_bias = Parameter(
+                    layer.w2_weight_bias.float(), requires_grad=False
+                )
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
@@ -380,8 +383,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 if get_moe_runner_backend().is_flashinfer_trtllm_routed()
                 else MoeRunnerBackend.FLASHINFER_TRTLLM
             )
-        elif self.use_deep_gemm:
-            backend = MoeRunnerBackend.DEEP_GEMM
         elif self.use_triton_kernels:
             backend = MoeRunnerBackend.TRITON_KERNELS
         else:
@@ -423,6 +424,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
 
         x = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
 
         moe_runner_config = self.moe_runner_config
 
@@ -439,22 +441,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 w2_bias=getattr(layer, "w2_weight_bias", None),
             )
             return self.runner.run(dispatch_output, quant_info)
-        elif self.runner.runner_backend.is_deep_gemm():
-            w13_weight = layer.w13_weight
-            w2_weight = layer.w2_weight
-            from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
-
-            # Only use_fp8=False when SGLANG_DEEPEP_BF16_DISPATCH is true,
-            # otherwise use_fp8=True for FP8 dispatch path
-            use_fp8 = not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
-            quant_info = DeepGemmMoeQuantInfo(
-                w13_weight=w13_weight,
-                w2_weight=w2_weight,
-                use_fp8=use_fp8,
-            )
-            return self.runner.run(dispatch_output, quant_info)
         elif self.use_flashinfer_cutlass:
-            topk_output = dispatch_output.topk_output
             output = flashinfer_cutlass_fused_moe(
                 input=x,
                 token_selected_experts=topk_output.topk_ids,
@@ -550,6 +537,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 None,  # w1_zp
                 None,  # w2_zp
                 None,  # block_size
+                getattr(layer, "w13_weight_bias", None),
+                getattr(layer, "w2_weight_bias", None),
+                layer.moe_runner_config.gemm1_alpha,
+                layer.moe_runner_config.gemm1_clamp_limit,
                 True,  # is_vnni
             )
             return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -375,6 +375,10 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
                 None,  # w1_zp
                 None,  # w2_zp
                 None,  # block_size
+                None,  # w1 bias
+                None,  # w3 bias
+                None,  # alpha
+                None,  # limit
                 True,  # is_vnni
             )
             return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -26,7 +26,16 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_2
+from sglang.srt.utils import (
+    cpu_has_amx_support,
+    get_bool_env_var,
+    get_num_new_pages,
+    is_cpu,
+    next_power_of_2,
+)
+
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
@@ -430,16 +439,25 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
-
-        alloc_extend_kernel[(bs,)](
-            prefix_lens,
-            seq_lens,
-            last_loc,
-            self.free_pages,
-            out_indices,
-            next_power_of_2(bs),
-            self.page_size,
-        )
+        if _is_cpu and _cpu_amx:
+            torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                self.free_pages,
+                out_indices,
+                self.page_size,
+            )
+        else:
+            alloc_extend_kernel[(bs,)](
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                self.free_pages,
+                out_indices,
+                next_power_of_2(bs),
+                self.page_size,
+            )
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
@@ -472,14 +490,23 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.merge_and_sort_free()
 
         out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
-        alloc_decode_kernel[(bs,)](
-            seq_lens,
-            last_loc,
-            self.free_pages,
-            out_indices,
-            next_power_of_2(bs),
-            self.page_size,
-        )
+        if _is_cpu and _cpu_amx:
+            torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+                seq_lens,
+                last_loc,
+                self.free_pages,
+                out_indices,
+                self.page_size,
+            )
+        else:
+            alloc_decode_kernel[(bs,)](
+                seq_lens,
+                last_loc,
+                self.free_pages,
+                out_indices,
+                next_power_of_2(bs),
+                self.page_size,
+            )
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -12,10 +12,11 @@ from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import is_hip, support_triton
+from sglang.srt.utils import is_cpu, is_hip, support_triton
 from sglang.srt.utils.common import ceil_align
 
 _is_hip = is_hip()
+_is_cpu = is_cpu()
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
@@ -114,7 +115,7 @@ def write_cache_indices(
     prefix_tensors: list[torch.Tensor],
     req_to_token_pool: ReqToTokenPool,
 ):
-    if support_triton(get_global_server_args().attention_backend):
+    if support_triton(get_global_server_args().attention_backend) and not _is_cpu:
         prefix_pointers = torch.tensor(
             [t.data_ptr() for t in prefix_tensors],
             device=req_to_token_pool.device,

--- a/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_compress_state.py
@@ -7,7 +7,11 @@ import torch
 
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 
 
 @dataclasses.dataclass
@@ -31,6 +35,84 @@ class KVAndScore:
     def clear(self):
         self.kv.zero_()
         self.score.fill_(float("-inf"))
+
+
+@dataclasses.dataclass
+class KVAndScoreSeparate:
+    """Legacy layout: kv and score stored as separate tensors of equal shape."""
+
+    kv: torch.Tensor
+    score: torch.Tensor
+
+    def __post_init__(self):
+        assert self.kv.shape == self.score.shape
+
+    @property
+    def shape(self):
+        return self.kv.shape
+
+    @staticmethod
+    def empty_like(new_shape, sep: "KVAndScoreSeparate") -> "KVAndScoreSeparate":
+        return KVAndScoreSeparate(
+            kv=sep.kv.new_empty(new_shape),
+            score=sep.score.new_empty(new_shape),
+        )
+
+    def new_empty(self, new_shape) -> "KVAndScoreSeparate":
+        return KVAndScoreSeparate.empty_like(new_shape, self)
+
+    def __getitem__(self, index) -> "KVAndScoreSeparate":
+        return KVAndScoreSeparate(kv=self.kv[index], score=self.score[index])
+
+    def __setitem__(self, index, value: "KVAndScoreSeparate"):
+        self.kv[index] = value.kv
+        self.score[index] = value.score
+
+    def view(self, *args) -> "KVAndScoreSeparate":
+        return KVAndScoreSeparate(kv=self.kv.view(*args), score=self.score.view(*args))
+
+    def clone(self) -> "KVAndScoreSeparate":
+        return KVAndScoreSeparate(kv=self.kv.clone(), score=self.score.clone())
+
+    def clear(self):
+        self.kv.zero_()
+        self.score.fill_(float("-inf"))
+
+
+class DeepSeekV4CompressState:
+    def __init__(
+        self,
+        max_num_reqs: int,
+        ratio: int,
+        overlap: bool,
+        head_dim: int,
+        device: str,
+        dtype: torch.dtype,
+        enable_memory_saver: bool = True,
+    ):
+        self.max_num_reqs = max_num_reqs
+        self.ratio = ratio
+        self.overlap = overlap
+        self.head_dim = head_dim
+        self.device = device
+        self.dtype = dtype
+        coff = 1 + self.overlap
+
+        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=enable_memory_saver
+        )
+        state_shape = (max_num_reqs, ratio * coff, 2 * head_dim * coff)
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.kv_score_state = torch.empty(state_shape, dtype=dtype, device=device)
+
+    def get_state(self):
+        if _is_cpu and _cpu_amx:
+            half_dim = self.head_dim * (1 + self.overlap)
+            return KVAndScoreSeparate(
+                kv=self.kv_score_state[..., :half_dim],
+                score=self.kv_score_state[..., half_dim:],
+            )
+        return KVAndScore(self.kv_score_state)
 
 
 class CompressStatePool:
@@ -79,3 +161,18 @@ class CompressStatePool:
                 )
                 if not online:
                     self.kv_score_buffer[-1].clear()
+
+    def translate_from_swa_loc_to_state_loc(
+        self, swa_loc: torch.Tensor
+    ) -> torch.Tensor:
+        swa_pages = swa_loc // self.swa_page_size
+        state_loc = swa_pages * self.ring_size + (swa_loc % self.ring_size)
+        state_loc = torch.where(swa_loc < 0, -1, state_loc)
+        return state_loc
+
+    def get_state_by_state_loc(self, state_loc: torch.Tensor) -> KVAndScore:
+        return self.kv_score_buffer[state_loc]
+
+    def set_state_by_state_loc(self, state_loc: torch.Tensor, value: KVAndScore):
+        self.kv_score_buffer[state_loc] = value
+        self.kv_score_buffer[-1].clear()

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 from contextlib import nullcontext
-from typing import List, Literal, NamedTuple, Optional, Tuple
+from typing import List, Literal, NamedTuple, Optional, Tuple, Union
 
 import torch
 
-from sglang.jit_kernel.deepseek_v4 import fused_k_norm_rope_flashmla, fused_store_cache
+from sglang.jit_kernel.deepseek_v4 import fused_store_cache
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4 import (
@@ -15,13 +15,20 @@ from sglang.srt.layers.attention.dsv4 import (
 from sglang.srt.layers.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16Pack
 from sglang.srt.layers.attention.nsa import index_buf_accessor
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
-from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
+from sglang.srt.mem_cache.deepseek_v4_compress_state import (
+    CompressStatePool,
+    DeepSeekV4CompressState,
+    KVAndScore,
+    KVAndScoreSeparate,
+)
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import ceil_div
+from sglang.srt.utils import ceil_div, cpu_has_amx_support, is_cpu
 
 logger = logging.getLogger(__name__)
 
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
 ONLINE_C128 = envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
 
 
@@ -464,7 +471,15 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
         self._init_compressed_layer_mapping()
 
-        self._init_paged_compress_states(enable_memory_saver)
+        # Mutually exclusive: paged ring pools (radix path) vs. non-paged
+        if not (_is_cpu and _cpu_amx):
+            self._init_paged_compress_states(enable_memory_saver)
+            self.compress_states: List[Optional[DeepSeekV4CompressState]] = []
+            self.indexer_compress_states: List[Optional[DeepSeekV4CompressState]] = []
+        else:
+            self.compress_state_pools: List[CompressStatePool] = []
+            self.indexer_compress_state_pools: List[CompressStatePool] = []
+            self._init_compress_states(enable_memory_saver)
 
         self._should_cache_swa = envs.SGLANG_OPT_CACHE_SWA_TRANSLATION.get()
 
@@ -571,6 +586,46 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             self.compress_state_pools.append(compress_state_pool)
             self.indexer_compress_state_pools.append(indexer_compress_state_pool)
 
+    def _init_compress_states(self, enable_memory_saver: bool):
+        """Allocate non-paged DeepSeekV4CompressState buffers used by the
+        old-compressor fallback.
+
+        Layout per layer: ``(max_num_reqs + 1, ratio*coff, 2*head_dim*coff)``.
+        The buffers are small relative to the paged ring pools and only
+        materialised when the radix path is off.
+        """
+        self.compress_states: List[Optional[DeepSeekV4CompressState]] = []
+        self.indexer_compress_states: List[Optional[DeepSeekV4CompressState]] = []
+        attn_kv_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        # ReqToTokenPool reserves row 0 as a dummy slot and assigns real
+        # request pool indices in the inclusive range [1, max_num_reqs].
+        req_state_size = self.max_num_reqs + 1
+        for ratio in self.compression_ratios:
+            overlap = ratio == 4
+            compress_state = indexer_compress_state = None
+            if ratio != 0:
+                compress_state = DeepSeekV4CompressState(
+                    max_num_reqs=req_state_size,
+                    ratio=ratio,
+                    overlap=overlap,
+                    head_dim=attn_kv_head_dim,
+                    device=self.device,
+                    dtype=self.state_dtype,
+                    enable_memory_saver=enable_memory_saver,
+                )
+            if ratio == 4:
+                indexer_compress_state = DeepSeekV4CompressState(
+                    max_num_reqs=req_state_size,
+                    ratio=ratio,
+                    overlap=overlap,
+                    head_dim=self.indexer_head_dim,
+                    device=self.device,
+                    dtype=self.state_dtype,
+                    enable_memory_saver=enable_memory_saver,
+                )
+            self.compress_states.append(compress_state)
+            self.indexer_compress_states.append(indexer_compress_state)
+
     def _init_compressed_layer_mapping(self):
         c1_cnt, c4_cnt, c128_cnt = 0, 0, 0
         self.layer_mapping: List[DeepSeekV4LayerItem] = []
@@ -605,19 +660,31 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             else:
                 raise ValueError(f"Unsupported compression ratio: {ratio}")
 
-    def get_attention_compress_states(self, layer_id: int) -> CompressStatePool:
-        compress_state_pool = self.compress_state_pools[layer_id]
-        assert (
-            compress_state_pool is not None
-        ), "Only c4/c128 layers have attention states."
-        return compress_state_pool
+    def get_attention_compress_states(
+        self, layer_id: int
+    ) -> Union[CompressStatePool, KVAndScore, KVAndScoreSeparate]:
+        if not (_is_cpu and _cpu_amx):
+            compress_state_pool = self.compress_state_pools[layer_id]
+            assert (
+                compress_state_pool is not None
+            ), "Only c4/c128 layers have attention states."
+            return compress_state_pool
+        compress_state = self.compress_states[layer_id]
+        assert compress_state is not None, "Only c4/c128 layers have attention states."
+        return compress_state.get_state()
 
-    def get_indexer_compress_states(self, layer_id: int) -> CompressStatePool:
-        indexer_compress_state_pool = self.indexer_compress_state_pools[layer_id]
-        assert (
-            indexer_compress_state_pool is not None
-        ), "Only c4 layers have indexer states."
-        return indexer_compress_state_pool
+    def get_indexer_compress_states(
+        self, layer_id: int
+    ) -> Union[CompressStatePool, KVAndScore, KVAndScoreSeparate]:
+        if not (_is_cpu and _cpu_amx):
+            indexer_compress_state_pool = self.indexer_compress_state_pools[layer_id]
+            assert (
+                indexer_compress_state_pool is not None
+            ), "Only c4 layers have indexer states."
+            return indexer_compress_state_pool
+        compress_state = self.indexer_compress_states[layer_id]
+        assert compress_state is not None, "Only c4 layers have indexer states."
+        return compress_state.get_state()
 
     def get_swa_key_buffer(self, layer_id: int) -> torch.Tensor:
         return self.swa_kv_pool.get_key_buffer(layer_id)
@@ -630,12 +697,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     ) -> None:
         self.swa_kv_pool.set_key_buffer(layer_id, loc, cache_nope_fp8_rope_bf16_pack)
 
-    def get_extra_key_page_size(self, layer_id: int) -> int:
-        _, _, compress_kv_pool = self.layer_mapping[layer_id]
-        assert compress_kv_pool is not None
-        return compress_kv_pool.page_size
-
-    def get_extra_key_buffer(self, layer_id: int) -> torch.Tensor:
+    def get_extra_key_buffer(self, layer_id: int) -> torch.Tensor | None:
         _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
         assert compress_kv_pool is not None
         return compress_kv_pool.get_key_buffer(compress_layer_id)
@@ -651,9 +713,6 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         compress_kv_pool.set_key_buffer(
             compress_layer_id, loc, cache_nope_fp8_rope_bf16_pack
         )
-
-    def get_index_k_page_size(self) -> int:
-        return self.c4_indexer_kv_pool.page_size
 
     def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
@@ -724,33 +783,6 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         else:
             swa_loc = self.translate_loc_from_full_to_swa(raw_loc)
         return self.swa_kv_pool.set_key_buffer_fused(layer_id, swa_loc, cache_k)
-
-    def set_swa_key_buffer_radix_fused_norm_rope(
-        self,
-        layer_id: int,
-        raw_loc: torch.Tensor,
-        kv: torch.Tensor,
-        kv_weight: torch.Tensor,
-        eps: float,
-        freqs_cis: torch.Tensor,
-        positions: torch.Tensor,
-    ) -> None:
-        if self._should_cache_swa:
-            if layer_id == self.start_layer or self.cached_loc is None:
-                self.cached_loc = self.translate_loc_from_full_to_swa(raw_loc)
-            swa_loc = self.cached_loc
-        else:
-            swa_loc = self.translate_loc_from_full_to_swa(raw_loc)
-        fused_k_norm_rope_flashmla(
-            kv=kv,
-            kv_weight=kv_weight,
-            eps=eps,
-            freqs_cis=freqs_cis,
-            positions=positions,
-            out_loc=swa_loc,
-            kvcache=self.swa_kv_pool.kv_buffer[layer_id],
-            page_size=self.swa_kv_pool.page_size,
-        )
 
     def set_extra_key_buffer_fused(
         self,

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -263,10 +263,11 @@ def register_fake_ops():
         return mat2.shape[0]
 
     @torch.library.register_fake("sgl_kernel::weight_packed_linear")
-    def _(mat1, mat2, bias, is_vnni):
+    def _(mat1, mat2, bias, is_vnni, out_dtype=None):
         M = mat1.shape[0]
         N = get_n_size(mat2, is_vnni)
-        return mat1.new_empty(M, N)
+        dtype = out_dtype if out_dtype is not None else mat1.dtype
+        return mat1.new_empty(M, N, dtype=dtype)
 
     @torch.library.register_fake("sgl_kernel::per_token_quant_int8_cpu")
     def _(input):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -57,6 +57,7 @@ from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
 )
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
+    is_cpu,
     is_cuda,
     is_hip,
     is_npu,
@@ -75,6 +76,7 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 
 _is_npu = is_npu()
+_is_cpu = is_cpu()
 
 
 class ForwardMode(IntEnum):
@@ -1125,7 +1127,7 @@ def compute_position(
     extend_seq_lens: torch.Tensor,
     extend_seq_lens_sum: int,
 ):
-    if support_triton(attn_backend):
+    if support_triton(attn_backend) and not _is_cpu:
         positions, extend_start_loc = compute_position_triton(
             extend_prefix_lens,
             extend_seq_lens,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -122,7 +122,6 @@ from sglang.srt.layers.dp_attention import (
     set_is_extend_in_batch,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.pooler import EmbeddingPoolerOutput
 from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.layers.sampler import create_sampler
@@ -193,6 +192,7 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_cpu_ids_by_node,
     init_custom_process_group,
+    is_cpu,
     is_hip,
     is_host_cpu_arm64,
     is_npu,
@@ -223,6 +223,7 @@ from sglang.srt.weight_sync.tensor_bucket import (
     FlattenedTensorMetadata,
 )
 
+_is_cpu = is_cpu()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu_amx_available = cpu_has_amx_support()
@@ -245,7 +246,6 @@ MLA_ATTENTION_BACKENDS = [
     "flashmla",
     "cutlass_mla",
     "trtllm_mla",
-    "tokenspeed_mla",
     "ascend",
     "nsa",
     "intel_xpu",
@@ -258,7 +258,6 @@ CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = [
     "flashmla",
     "cutlass_mla",
     "trtllm_mla",
-    "tokenspeed_mla",
 ]
 
 TORCH_DTYPE_TO_KV_CACHE_STR = {
@@ -653,7 +652,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Load the model
         self.sampler = create_sampler()
         self.load_model()
-        self._prepare_moe_topk()
 
         # Load the expert backup client
         self.expert_backup_client = (
@@ -789,22 +787,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 )
             self._pre_initialize_flashinfer_allreduce_workspace()
             self.init_device_graphs()
-        elif self.device == "cpu":
+        elif self.device in ["npu", "cpu"]:
             self.init_attention_backend()
-            self.init_device_graphs()
-        elif self.device == "npu":
-            self.init_attention_backend()
-            # lazy init for zbal with mix mode(before graph capture when enable_cuda_graph)
-            if envs.SGLANG_ZBAL_LOCAL_MEM_SIZE.get() > 0 and not self.is_draft_worker:
-                from sglang.srt.hardware_backend.npu.utils import lazy_init_zbal_gva_mem
-
-                lazy_init_zbal_gva_mem(
-                    self.device,
-                    self.gpu_id,
-                    get_world_group().rank_in_group,
-                    get_world_group().world_size,
-                    get_world_group().cpu_group,
-                )
             self.init_device_graphs()
         elif current_platform.is_out_of_tree():
             self.init_attention_backend()
@@ -1601,49 +1585,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 raise ValueError(
                     f"TP rank {self.tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
                 ) from None
-
-    def _prepare_moe_topk(self):
-        balancer_cls = None
-        num_prepared = 0
-        num_routed_experts = None
-        for module in self.model.modules():
-            if not isinstance(module, TopK):
-                continue
-            if (
-                not module.enable_deepep_waterfill
-                or module.deepep_waterfill_balancer is not None
-            ):
-                continue
-            if num_routed_experts is None:
-                num_routed_experts = getattr(
-                    self.model_config.hf_config, "n_routed_experts", None
-                )
-                if num_routed_experts is None:
-                    raise ValueError(
-                        "DeepEP waterfill requires model config n_routed_experts."
-                    )
-            if balancer_cls is None:
-                from sglang.srt.layers.moe.deepep_waterfill import (
-                    DeepEPWaterfillBalancer,
-                )
-
-                balancer_cls = DeepEPWaterfillBalancer
-            module.deepep_waterfill_balancer = balancer_cls(
-                num_routed_experts=num_routed_experts,
-                world_size=self.moe_ep_size,
-                rank=self.moe_ep_rank,
-                layer_id=module.layer_id,
-                routed_scaling_factor=(
-                    module.topk_config.routed_scaling_factor
-                    if module.topk_config.routed_scaling_factor is not None
-                    else 1.0
-                ),
-            )
-            num_prepared += 1
-        if num_prepared:
-            log_info_on_rank0(
-                logger, f"Prepared {num_prepared} DeepEP waterfill TopK modules."
-            )
 
     def update_expert_location(
         self,
@@ -3311,6 +3252,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         step_span_ctx = (
             torch.profiler.record_function(_build_step_span_name(forward_batch))
             if torch.autograd._profiler_enabled()
+            and not (_is_cpu and _is_cpu_amx_available)
             else contextlib.nullcontext()
         )
         with (

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,10 +27,6 @@ import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
 
-from sglang.jit_kernel.deepseek_v4 import (
-    silu_and_mul_clamp,
-    silu_and_mul_contig_post_quant,
-)
 from sglang.srt.batch_overlap.single_batch_overlap import SboFlags, compute_overlap_args
 from sglang.srt.batch_overlap.two_batch_overlap import (
     MaybeTboDeepEPDispatcher,
@@ -113,9 +107,6 @@ from sglang.srt.layers.moe.utils import (
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8 import Fp8Config
-from sglang.srt.layers.quantization.fp8_kernel import (
-    create_per_token_group_quant_fp8_output_scale,
-)
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
@@ -278,51 +269,13 @@ class DeepseekV2MLP(nn.Module):
             x = (x, None, y)
 
         gate_up, _ = self.gate_up_proj(x)
-        # Fast path: fused silu+clamp+fp8_quant+deepgemm when conditions met.
-        # Only valid when down_proj does NOT need an all-reduce and its weights
-        # are fp8 (uint8 storage with weight_scale_inv).
-        if (
-            self.swiglu_limit is not None
-            and not self.down_proj.reduce_results
-            and self.down_proj.weight.dtype == torch.uint8
-            and hasattr(self.down_proj, "weight_scale_inv")
-        ):
-            M, N = gate_up.shape
-            down_input_fp8 = gate_up.new_empty((M, N // 2), dtype=torch.float8_e4m3fn)
-            scale_block_size = 128
-            down_input_scale = create_per_token_group_quant_fp8_output_scale(
-                x_shape=(M, N // 2),
-                device=gate_up.device,
-                group_size=scale_block_size,
-                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-            )
-            silu_and_mul_contig_post_quant(
-                input=gate_up,
-                output=down_input_fp8,
-                output_scale=down_input_scale,
-                quant_group_size=scale_block_size,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                transposed=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                swiglu_limit=float(self.swiglu_limit),
-            )
-            down_output = gate_up.new_empty(
-                (M, self.down_proj.output_size), dtype=torch.bfloat16
-            )
-            deep_gemm_wrapper.gemm_nt_f8f8bf16(
-                (down_input_fp8, down_input_scale),
-                (self.down_proj.weight, self.down_proj.weight_scale_inv),
-                down_output,
-            )
-            return down_output
-        # Fallback: fused silu+clamp kernel (still faster than unfused)
         if self.swiglu_limit is not None:
-            M, N = gate_up.shape
-            x = gate_up.new_empty((M, N // 2))
-            silu_and_mul_clamp(gate_up, x, float(self.swiglu_limit))
-        else:
-            x = self.act_fn(gate_up)
+            _g, _u = gate_up.chunk(2, dim=-1)
+            _lim = float(self.swiglu_limit)
+            gate_up = torch.cat(
+                [_g.clamp(max=_lim), _u.clamp(min=-_lim, max=_lim)], dim=-1
+            )
+        x = self.act_fn(gate_up)
         x, _ = self.down_proj(
             x,
             skip_all_reduce=should_allreduce_fusion or use_reduce_scatter,
@@ -580,6 +533,7 @@ class DeepseekV2MoE(nn.Module):
 
         self.shared_experts_is_int8 = False
         self.shared_experts_is_fp8 = False
+        self.shared_experts_is_mxfp4 = False
         self.shared_experts_weight_block_size = None
         self._shared_expert_tp1 = False
         # Shared experts: skip when fused into MoE kernel (self.num_fused_shared_experts > 0)
@@ -625,6 +579,10 @@ class DeepseekV2MoE(nn.Module):
             self.shared_experts_is_int8 = (
                 not is_packed_weight
                 and self.shared_experts.gate_up_proj.weight.dtype == torch.int8
+            )
+            self.shared_experts_is_mxfp4 = (
+                not is_packed_weight
+                and self.shared_experts.gate_up_proj.weight.dtype == torch.uint8
             )
             self.shared_experts_is_fp8 = (
                 not is_packed_weight
@@ -819,7 +777,9 @@ class DeepseekV2MoE(nn.Module):
         if hasattr(self, "shared_experts") and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
         ):
-            return self.forward_cpu(hidden_states, should_allreduce_fusion)
+            return self.forward_cpu(
+                hidden_states, should_allreduce_fusion, input_ids_global
+            )
         server_args = get_global_server_args()
         dispatch_info = (
             ExpertLocationDispatchInfo.init_new(layer_id=self.layer_id)
@@ -917,10 +877,12 @@ class DeepseekV2MoE(nn.Module):
         self,
         hidden_states: torch.Tensor,
         should_allreduce_fusion: bool = False,
+        input_ids_global: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # router_logits: (num_tokens, n_experts)
         router_logits = self.gate(hidden_states)
-        topk_output = self.topk(hidden_states, router_logits)
+        topk_kwargs = {"input_ids": input_ids_global} if self.is_hash else {}
+        topk_output = self.topk(hidden_states, router_logits, **topk_kwargs)
         fused_experts_out = self.experts(
             hidden_states=hidden_states, topk_output=topk_output
         )
@@ -940,6 +902,7 @@ class DeepseekV2MoE(nn.Module):
             True,  # inplace
             self.shared_experts_is_int8,  # use_int8_w8a8
             self.shared_experts_is_fp8,  # use_fp8_w8a16
+            self.shared_experts_is_mxfp4,  # use_mxfp4
             (
                 self.shared_experts.gate_up_proj.weight_scale
                 if self.shared_experts_is_int8
@@ -963,6 +926,8 @@ class DeepseekV2MoE(nn.Module):
                 if self.shared_experts_is_fp8
                 else None
             ),  # block_size
+            None,  # alpha
+            self.shared_experts.swiglu_limit,  # swiglu_limit
             True,  # is_vnni
         )
         if self.tp_size > 1 and not should_allreduce_fusion:
@@ -1012,6 +977,16 @@ class DeepseekV2MoE(nn.Module):
             )
         else:
             topk_output = self.topk.empty_topk_output(hidden_states.device)
+            if is_deepep_class_backend() and self.num_fused_shared_experts > 0:
+                n = self.num_fused_shared_experts
+                topk_output = topk_output._replace(
+                    topk_ids=topk_output.topk_ids.new_empty(
+                        (0, topk_output.topk_ids.shape[-1] + n)
+                    ),
+                    topk_weights=topk_output.topk_weights.new_empty(
+                        (0, topk_output.topk_weights.shape[-1] + n)
+                    ),
+                )
 
         if sbo_overlap_dispatch_flag:
             shared_output = None
@@ -1724,15 +1699,11 @@ class DeepseekV2AttentionMLA(
         self, hidden_states: torch.Tensor, forward_batch: ForwardBatch
     ):
         assert self.q_lora_rank is not None
-        # When the module is wrapped with LoRA, the fused GEMM fast-path would
-        # bypass the adapter because it reads weight.T directly.
-        lora_active = getattr(self.fused_qkv_a_proj_with_mqa, "set_lora", False)
         if (
             (not isinstance(hidden_states, tuple))
             and hidden_states.shape[0] >= 1
             and hidden_states.shape[0] <= 16
             and self.use_min_latency_fused_a_gemm
-            and not lora_active
         ):
             qkv_latent = dsv3_fused_a_gemm(
                 hidden_states, self.fused_qkv_a_proj_with_mqa.weight.T
@@ -2405,10 +2376,19 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         if server_args.disable_shared_experts_fusion:
             return
 
+        # DeepEP + enforce: the only path that enables fusion under DeepEP.
+        if is_deepep_class_backend() and server_args.enforce_shared_experts_fusion:
+            log_info_on_rank0(
+                logger,
+                "DeepEP shared expert fusion: fusing shared expert into MoE kernel "
+                "at home EP rank local slot (--enforce-shared-experts-fusion).",
+            )
+            self.num_fused_shared_experts = self.config.n_shared_experts
+            return
+
+        # Check all conditions that disable fusion.
         disable_reason = None
-        if server_args.enforce_shared_experts_fusion:
-            pass
-        elif is_sbo_enabled() or is_tbo_enabled():
+        if is_sbo_enabled() or is_tbo_enabled():
             disable_reason = "SBO/TBO enabled: incompatible with fusing shared expert into MoE kernel."
         elif is_deepep_class_backend():
             disable_reason = "DeepEP: fusion off by default (use --enforce-shared-experts-fusion to enable)."

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -11,11 +11,7 @@ import triton
 import triton.language as tl
 
 import sglang.srt.models.deepseek_v2 as deepseek_v2
-from sglang.jit_kernel.deepseek_v4 import (
-    fused_norm_rope_inplace,
-    fused_q_norm_rope,
-    fused_rope_inplace,
-)
+from sglang.jit_kernel.deepseek_v4 import fused_rope, rmsnorm_self
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from sglang.srt.environ import envs
@@ -29,6 +25,7 @@ from sglang.srt.layers.attention.nsa.utils import (
     nsa_use_prefill_cp,
 )
 from sglang.srt.layers.communicator import get_attn_tp_context
+from sglang.srt.layers.deepseek_v4_rope import apply_rotary_emb_triton
 from sglang.srt.layers.dp_attention import (
     _DpGatheredBufferWrapper,
     attn_tp_all_gather,
@@ -65,15 +62,71 @@ from sglang.srt.model_executor.cuda_graph_runner import (
 from sglang.srt.model_loader.utils import maybe_executor_submit, should_async_load
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dbrx import ReplicatedLinear
-from sglang.srt.models.deepseek_v2 import ParallelLMHead, _is_cuda, _is_hip, _is_npu
+from sglang.srt.models.deepseek_v2 import (
+    ParallelLMHead,
+    _is_cuda,
+    _is_hip,
+    _is_npu,
+)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
+    cpu_has_amx_support,
+    is_cpu,
     log_info_on_rank0,
     make_layers,
+    use_intel_amx_backend,
 )
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+_is_cpu = is_cpu()
+_cpu_amx = cpu_has_amx_support()
+
+
+def apply_rotary_emb_cpu(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    positions: Optional[torch.Tensor] = None,
+    inverse: bool = False,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.apply_rotary_emb_interleaved_cpu(
+        x, freqs_cis, inverse, positions
+    )
+
+
+if _is_cpu and _cpu_amx:
+    apply_rotary_emb_triton = apply_rotary_emb_cpu
+
+
+def rms_normalize_cpu(
+    x: torch.Tensor, eps: float, weight: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    if weight is None:
+        shape = x.shape
+        x_2d = x.reshape(-1, shape[-1])
+        if not x_2d.is_contiguous():
+            x_2d = x_2d.contiguous()
+        return torch.ops.sgl_kernel.l2norm_cpu(x_2d, eps).view(shape)
+    else:
+        shape = x.shape
+        x_2d = x.reshape(-1, shape[-1])
+        if x_2d.stride(-1) != 1:
+            x_2d = x_2d.contiguous()
+
+        w = weight.reshape(-1)
+        if w.dtype != x.dtype:
+            w = w.to(dtype=x.dtype)
+        if not w.is_contiguous():
+            w = w.contiguous()
+
+        out = torch.ops.sgl_kernel.rmsnorm_cpu(
+            x_2d,
+            w,
+            eps,
+        ).view(shape)
+        return out
+
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +138,6 @@ if TYPE_CHECKING:
         DeepseekV4AttnBackend,
     )
     from sglang.srt.layers.quantization import QuantizationConfig
-    from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import (
         ForwardBatch,
         PPProxyTensors,
@@ -248,6 +300,31 @@ class MQALayer(nn.Module):
                 )
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
+
+        # Reuse the CPU-TP padding-aware helper to copy the checkpoint's
+        # (original_n_heads,) into the (possibly padded) param and zero any
+        # tail entries from CPU-TP head padding. shard_size = full param length
+        # since attn_sink is replicated, not sharded.
+        def _attn_sink_weight_loader(
+            param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> None:
+            from sglang.srt.model_loader.weight_utils import (
+                narrow_padded_param_and_loaded_weight,
+            )
+
+            # for attn_sink, we can set padded place to any finite value. just leverage
+            # the pad to zero path for simplicity
+            param_view, loaded_view = narrow_padded_param_and_loaded_weight(
+                param.data,
+                loaded_weight,
+                param_data_start=0,
+                weight_start=0,
+                dim=0,
+                shard_size=param.data.shape[0],
+            )
+            param_view.copy_(loaded_view)
+
+        self.attn_sink.weight_loader = _attn_sink_weight_loader
         self.fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
         if self.fuse_wqa_wkv:
             self.wqkv_a = ReplicatedLinear(
@@ -298,6 +375,13 @@ class MQALayer(nn.Module):
                 self.wo_a, "weight_scale_inv"
             ), "FP8 quant_config must create weight_scale_inv"
             self.wo_a.weight_scale_inv.format_ue8m0 = True
+        elif _is_cpu and _cpu_amx:
+            from sglang.srt.layers.amx_utils import PackWeightMethodBMM
+
+            self.wo_a.quant_method = PackWeightMethodBMM(
+                n_groups=self.n_local_groups,
+                group_size=self.o_lora_rank,
+            )
         self.wo_b = RowParallelLinear(
             self.n_groups * self.o_lora_rank,
             self.hidden_size,
@@ -319,9 +403,10 @@ class MQALayer(nn.Module):
             prefix=add_prefix("attn_mqa", prefix),
         )
 
-        # KV cache write is always fused into the K kernel
-        # (`_compute_kv_to_cache`), so the legacy "overlap store cache" flag
-        # has no effect here -- the fused path is on by default.
+        self.overlap_store_cache = envs.SGLANG_OPT_USE_OVERLAP_STORE_CACHE.get()
+        if _is_cpu and _cpu_amx:
+            self.overlap_store_cache = False
+        self.use_jit_norm = envs.SGLANG_OPT_USE_JIT_NORM.get()
 
     def _compute_q_a(
         self,
@@ -332,69 +417,56 @@ class MQALayer(nn.Module):
             q = qkv_a[..., : self.q_lora_rank]
         else:
             q, _ = self.wq_a(x)
-        return self.q_norm(q)
+        q = self.q_norm(q)
+        q_lora = q
+        return q_lora
 
     def _compute_q_b(
         self,
         q: torch.Tensor,
-        positions: torch.Tensor,
-        q_out: Optional[torch.Tensor] = None,
+        positions: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         q, _ = self.wq_b(q)
         q = q.view(-1, self.n_local_heads, self.head_dim)
-        if q_out is None:
-            q_out = torch.empty_like(q)
-        # Fused warp-per-(token, head) rmsnorm-self + RoPE + write to q_out.
-        fused_q_norm_rope(q, q_out, self.eps, self.freqs_cis, positions)
-        return q_out
-
-    def _compute_kv_to_cache(
-        self,
-        x: torch.Tensor,
-        positions: torch.Tensor,
-        forward_batch: ForwardBatch,
-        qkv_a: Optional[torch.Tensor] = None,
-    ) -> None:
-        """Fused: rmsnorm + RoPE + write directly to FlashMLA paged cache.
-
-        Replaces the bf16-kv-intermediate path. Used everywhere except the NSA
-        prefill-CP case (which needs bf16 kv for the cross-rank all-gather).
-        """
-        if qkv_a is not None:
-            kv = qkv_a[..., self.q_lora_rank :]
+        if self.use_jit_norm:
+            q = rmsnorm_self(q, self.eps)
         else:
-            kv, _ = self.wkv(x)
-        token_to_kv_pool = forward_batch.token_to_kv_pool
-        if TYPE_CHECKING:
-            assert isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
-        token_to_kv_pool.set_swa_key_buffer_radix_fused_norm_rope(
-            layer_id=self.layer_id,
-            raw_loc=forward_batch.out_cache_loc,
-            kv=kv,
-            kv_weight=self.kv_norm.weight.data,
-            eps=self.eps,
-            freqs_cis=self.freqs_cis,
-            positions=positions,
-        )
+            q = (
+                rms_normalize_triton(q, self.eps)
+                if not (_is_cpu and _cpu_amx)
+                else rms_normalize_cpu(q, self.eps)
+            )
+        if positions is not None:
+            fused_rope(
+                q[..., -self.qk_rope_head_dim :],
+                None,
+                self.freqs_cis,
+                positions=positions,
+            )
+        else:
+            apply_rotary_emb_triton(q[..., -self.qk_rope_head_dim :], self.freqs_cis)
+        return q
 
-    def _compute_kv_bf16(
+    def _compute_kv(
         self,
         x: torch.Tensor,
-        positions: torch.Tensor,
+        positions: Optional[torch.Tensor] = None,
         qkv_a: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Bf16-kv path used by the NSA prefill-CP case (needs all-gather)."""
         if qkv_a is not None:
             kv = qkv_a[..., self.q_lora_rank :]
         else:
             kv, _ = self.wkv(x)
-        fused_norm_rope_inplace(
-            kv,
-            self.kv_norm.weight.data,
-            self.eps,
-            self.freqs_cis,
-            positions,
-        )
+        kv = self.kv_norm(kv)
+        if positions is not None:
+            fused_rope(
+                kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
+                None,
+                self.freqs_cis,
+                positions=positions,
+            )
+        else:
+            apply_rotary_emb_triton(kv[..., -self.qk_rope_head_dim :], self.freqs_cis)
         return kv
 
     def _forward_prepare_multi_stream(
@@ -404,7 +476,7 @@ class MQALayer(nn.Module):
         forward_batch: ForwardBatch,
         attn_backend: DeepseekV4AttnBackend,
         q_out: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         assert self.alt_streams is not None
         assert len(self.alt_streams) >= 3
 
@@ -439,8 +511,13 @@ class MQALayer(nn.Module):
         with torch.cuda.stream(stream_kv):
             if qkv_a_ready is not None:
                 stream_kv.wait_event(qkv_a_ready)
-            # Fused norm + rope + cache write -- no bf16 KV intermediate.
-            self._compute_kv_to_cache(x, positions, forward_batch, qkv_a=qkv_a)
+            kv = self._compute_kv(x, positions, qkv_a=qkv_a)
+            if self.overlap_store_cache:
+                attn_backend.store_cache(
+                    layer_id=self.layer_id,
+                    swa_k=kv,
+                    forward_batch=forward_batch,
+                )
 
         del qkv_a
 
@@ -450,12 +527,15 @@ class MQALayer(nn.Module):
                     x, forward_batch, self.layer_id, self.compressor
                 )
 
-        q = self._compute_q_b(q_lora, positions, q_out)
+        q = self._compute_q_b(q_lora, positions)
+        if q_out is not None:
+            q_out.copy_(q)
+
         current_stream.wait_stream(stream_kv)
         current_stream.wait_stream(stream_compressor)
         current_stream.wait_stream(stream_indexer)
 
-        return q
+        return q, kv
 
     def _forward_prepare(
         self,
@@ -464,38 +544,51 @@ class MQALayer(nn.Module):
         forward_batch: ForwardBatch,
         attn_backend: DeepseekV4AttnBackend,
         q_out: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.fuse_wqa_wkv:
             qkv_a, _ = self.wqkv_a(x)
-            q_lora = qkv_a[..., : self.q_lora_rank]
+            q = qkv_a[..., : self.q_lora_rank]
+            kv = qkv_a[..., self.q_lora_rank :]
+            del qkv_a
         else:
-            q_lora, _ = self.wq_a(x)
-            qkv_a = None
-        q_lora = self.q_norm(q_lora)
-        q = self._compute_q_b(q_lora, positions, q_out)
+            kv, _ = self.wkv(x)
+            q, _ = self.wq_a(x)
+        q = self.q_norm(q)
+        q_lora = q
+        q, _ = self.wq_b(q)
+        q = q.view(-1, self.n_local_heads, self.head_dim)
+        if self.use_jit_norm:
+            q = rmsnorm_self(q, self.eps)
+        else:
+            q = (
+                rms_normalize_triton(q, self.eps)
+                if not (_is_cpu and _cpu_amx)
+                else rms_normalize_cpu(q, self.eps)
+            )
 
-        use_cp = self.nsa_enable_prefill_cp and nsa_use_prefill_cp(forward_batch)
-        kv: Optional[torch.Tensor]
-        if use_cp:
-            # NSA CP: keep bf16 kv around for the cross-rank all-gather, then
-            # write to the FlashMLA cache after gather.
-            kv = self._compute_kv_bf16(x, positions, qkv_a=qkv_a)
+        kv = self.kv_norm(kv)
+
+        fused_rope(
+            q[..., -self.qk_rope_head_dim :],
+            kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
+            self.freqs_cis,
+            positions=positions,
+        )
+
+        if self.nsa_enable_prefill_cp and nsa_use_prefill_cp(forward_batch):
             kv = cp_all_gather_rerange_output(
                 kv.contiguous(),
                 self.cp_size,
                 forward_batch,
                 torch.cuda.current_stream(),
             )
+
+        if self.overlap_store_cache:
             attn_backend.store_cache(
                 layer_id=self.layer_id,
                 swa_k=kv,
                 forward_batch=forward_batch,
             )
-        else:
-            self._compute_kv_to_cache(x, positions, forward_batch, qkv_a=qkv_a)
-            kv = None
-
-        del qkv_a
 
         if self.indexer is not None:
             self.indexer(x=x, q_lora=q_lora, forward_batch=forward_batch)
@@ -507,6 +600,8 @@ class MQALayer(nn.Module):
                 self.compressor,
             )
 
+        if q_out is not None:
+            q_out.copy_(q)
         return q, kv
 
     def forward(
@@ -541,34 +636,26 @@ class MQALayer(nn.Module):
             q_out = q_padded[:, tp_slice, :]
 
         if enable_multi_stream:
-            # Multi-stream path always fuses cache write into the K kernel,
-            # so the bf16 KV intermediate is gone.
-            q = self._forward_prepare_multi_stream(
+            q, kv = self._forward_prepare_multi_stream(
                 x, positions, forward_batch, attn_backend, q_out
             )
-            kv = None
         else:
             q, kv = self._forward_prepare(
                 x, positions, forward_batch, attn_backend, q_out
             )
 
-        # The cache write is always fused / already done by _forward_prepare* --
-        # tell the backend to skip its own store_cache. When `kv is None`
-        # (no NSA-CP), pass `q` as a sentinel for the `k is v` assert; the
-        # attention path doesn't read it once `save_kv_cache=False`.
-        attn_k = kv if kv is not None else q
         o = attn_backend.forward(
             q=q_padded if q_padded is not None else q,
-            k=attn_k,
-            v=attn_k,
+            k=kv,
+            v=kv,
             layer=self.attn_mqa,
             forward_batch=forward_batch,
             compress_ratio=self.compress_ratio,
             attn_sink=self.attn_sink,
-            save_kv_cache=False,
+            save_kv_cache=not self.overlap_store_cache,
         )
         o = o[:, tp_slice, :]
-        fused_rope_inplace(
+        fused_rope(
             o[..., -self.qk_rope_head_dim :],
             None,
             self.freqs_cis,
@@ -594,6 +681,18 @@ class MQALayer(nn.Module):
                 (self.wo_a.weight.view(G, R, D), self.wo_a.weight_scale_inv.data),
                 output,
                 recipe=(1, 1, 128),
+            )
+            o = output
+        elif use_intel_amx_backend(self.wo_a):
+            T, G, D = o.shape
+            R = self.o_lora_rank
+            output = torch.empty([T, G, R], dtype=o.dtype, device=o.device)
+            torch.ops.sgl_kernel.bmm_cpu(
+                output.transpose(0, 1),  # [G, T, R]
+                o.transpose(0, 1),  # [G, T, D]
+                self.wo_a.weight,  # [G, R, D] packed in VNNI
+                True,  # is_vnni
+                None,  # scale
             )
             o = output
         else:
@@ -688,6 +787,19 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             return y, post, comb, False
 
+        if _is_cpu and _cpu_amx:
+            y, post, comb = torch.ops.sgl_kernel.hc_pre_fused_cpu(
+                x,
+                hc_fn,
+                hc_scale,
+                hc_base,
+                self.hc_mult,
+                self.hc_sinkhorn_iters,
+                self.rms_norm_eps,
+                self.hc_eps,
+            )
+            return y, post, comb, False
+
         if envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
             from sglang.srt.layers.mhc import mhc_pre
 
@@ -751,6 +863,14 @@ class DeepseekV4DecoderLayer(nn.Module):
         if x.shape[0] == 0:
             return torch.empty(
                 (0, self.hc_mult, x.shape[-1]), dtype=x.dtype, device=x.device
+            )
+
+        if _is_cpu and _cpu_amx:
+            return torch.ops.sgl_kernel.hc_post_fused_cpu(
+                x,
+                residual,
+                post,
+                comb,
             )
 
         if envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get():
@@ -916,6 +1036,10 @@ class DeepseekV4Model(nn.Module):
         hc_base: torch.Tensor,
     ):
         if x.numel() > 0:
+            if _is_cpu and _cpu_amx:
+                return torch.ops.sgl_kernel.hc_head_fused_cpu(
+                    x, hc_fn, hc_scale, hc_base, self.hc_eps, self.norm_eps
+                )
             from sglang.srt.layers.mhc_head import fused_hc_head
 
             return fused_hc_head(

--- a/sgl-kernel/csrc/cpu/act_quant.cpp
+++ b/sgl-kernel/csrc/cpu/act_quant.cpp
@@ -1,0 +1,198 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <ATen/record_function.h>
+#include <c10/util/Float8_e4m3fn.h>
+#include <torch/all.h>
+
+#include <cmath>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+constexpr float kFP8Max = 448.0f;
+constexpr float kFP8Min = -448.0f;
+constexpr float kMinScaleAmax = 1.0e-4f;
+
+template <bool round_scale, typename scalar_t>
+void act_quant_cpu_impl(
+    at::Float8_e4m3fn* __restrict__ y_ptr,
+    float* __restrict__ scale_ptr,
+    const scalar_t* __restrict__ x_ptr,
+    int64_t block_size,
+    int64_t M,
+    int64_t N,
+    int64_t num_groups) {
+  const int64_t total_blocks = M * num_groups;
+  at::parallel_for(0, total_blocks, 0, [&](int64_t begin, int64_t end) {
+    int64_t m = 0;
+    int64_t group = 0;
+    data_index_init(begin, m, M, group, num_groups);
+
+    for (int64_t offset = begin; offset < end; ++offset) {
+      const int64_t base = m * N + group * block_size;
+
+      float amax = 0.0f;
+      for (int64_t d = 0; d < block_size; ++d) {
+        amax = std::max(amax, std::abs(static_cast<float>(x_ptr[base + d])));
+      }
+      amax = std::max(amax, kMinScaleAmax);
+
+      float scale_value;
+      if constexpr (round_scale) {
+        scale_value = std::exp2(std::ceil(std::log2(amax / kFP8Max)));
+      } else {
+        scale_value = amax / kFP8Max;
+      }
+      scale_ptr[offset] = scale_value;
+
+      const float inv_scale = 1.0f / scale_value;
+      for (int64_t d = 0; d < block_size; ++d) {
+        float value = static_cast<float>(x_ptr[base + d]) * inv_scale;
+        value = std::min(std::max(value, kFP8Min), kFP8Max);
+        y_ptr[base + d] = at::Float8_e4m3fn(value);
+      }
+
+      data_index_step(m, M, group, num_groups);
+    }
+  });
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+template <bool round_scale>
+void act_quant_cpu_impl(
+    at::Float8_e4m3fn* __restrict__ y_ptr,
+    float* __restrict__ scale_ptr,
+    const at::BFloat16* __restrict__ x_ptr,
+    int64_t block_size,
+    int64_t M,
+    int64_t N,
+    int64_t num_groups) {
+  const int64_t total_blocks = M * num_groups;
+  at::parallel_for(0, total_blocks, 0, [&](int64_t begin, int64_t end) {
+    const __m512 signBit = _mm512_set1_ps(-0.0f);
+    const __m512 vfp8_min = _mm512_set1_ps(kFP8Min);
+    const __m512 vfp8_max = _mm512_set1_ps(kFP8Max);
+
+    int64_t m = 0;
+    int64_t group = 0;
+    data_index_init(begin, m, M, group, num_groups);
+
+    for (int64_t offset = begin; offset < end; ++offset) {
+      const int64_t base = m * N + group * block_size;
+      const at::BFloat16* __restrict__ x_block = x_ptr + base;
+      auto* __restrict__ y_block = y_ptr + base;
+
+      // Phase 1: vectorized absolute max reduction
+      __m512 vamax0 = _mm512_setzero_ps();
+      __m512 vamax1 = _mm512_setzero_ps();
+      int64_t d = 0;
+      for (; d + 32 <= block_size; d += 32) {
+        __m512i raw = _mm512_loadu_si512(reinterpret_cast<const void*>(x_block + d));
+        __m512 v0 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 0));
+        __m512 v1 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 1));
+        vamax0 = _mm512_max_ps(vamax0, _mm512_andnot_ps(signBit, v0));
+        vamax1 = _mm512_max_ps(vamax1, _mm512_andnot_ps(signBit, v1));
+      }
+      float amax = _mm512_reduce_max_ps(_mm512_max_ps(vamax0, vamax1));
+      for (; d < block_size; ++d) {
+        amax = std::max(amax, std::abs(static_cast<float>(x_block[d])));
+      }
+      amax = std::max(amax, kMinScaleAmax);
+
+      // Phase 2: compute scale
+      float scale_value;
+      if constexpr (round_scale) {
+        scale_value = std::exp2(std::ceil(std::log2(amax / kFP8Max)));
+      } else {
+        scale_value = amax / kFP8Max;
+      }
+      scale_ptr[offset] = scale_value;
+
+      // Phase 3: vectorized scale + scalar FP8 conversion
+      const float inv_scale = 1.0f / scale_value;
+      const __m512 vinv_scale = _mm512_set1_ps(inv_scale);
+      const __m512 vfp8_min_local = vfp8_min;
+      const __m512 vfp8_max_local = vfp8_max;
+      d = 0;
+      // Use vectorized scaling, then scalar FP8 cast to match reference exactly
+      alignas(64) float scaled_buf[32];
+      for (; d + 32 <= block_size; d += 32) {
+        __m512i raw = _mm512_loadu_si512(reinterpret_cast<const void*>(x_block + d));
+        __m512 v0 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 0));
+        __m512 v1 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 1));
+
+        v0 = _mm512_min_ps(_mm512_max_ps(_mm512_mul_ps(v0, vinv_scale), vfp8_min_local), vfp8_max_local);
+        v1 = _mm512_min_ps(_mm512_max_ps(_mm512_mul_ps(v1, vinv_scale), vfp8_min_local), vfp8_max_local);
+
+        _mm512_store_ps(scaled_buf, v0);
+        _mm512_store_ps(scaled_buf + 16, v1);
+
+        for (int64_t i = 0; i < 32; ++i) {
+          y_block[d + i] = at::Float8_e4m3fn(scaled_buf[i]);
+        }
+      }
+      // Scalar remainder
+      for (; d < block_size; ++d) {
+        float value = static_cast<float>(x_block[d]) * inv_scale;
+        value = std::min(std::max(value, kFP8Min), kFP8Max);
+        y_block[d] = at::Float8_e4m3fn(value);
+      }
+
+      data_index_step(m, M, group, num_groups);
+    }
+  });
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+}  // namespace
+
+std::tuple<at::Tensor, at::Tensor>
+act_quant_cpu(at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt) {
+  CHECK_INPUT(x);
+  TORCH_CHECK(x.dim() >= 1, "x must have at least 1 dimension");
+  TORCH_CHECK(block_size > 0, "block_size must be positive");
+
+  const int64_t N = x.size(-1);
+  TORCH_CHECK(N % block_size == 0, "Last dimension size must be divisible by block_size");
+
+  const int64_t M = x.numel() / N;
+  const int64_t num_groups = N / block_size;
+
+  at::Tensor y = at::empty_like(x, x.options().dtype(at::kFloat8_e4m3fn));
+
+  std::vector<int64_t> scale_sizes = x.sizes().vec();
+  scale_sizes.back() = num_groups;
+  at::Tensor scale = at::empty(scale_sizes, x.options().dtype(at::kFloat));
+
+  const bool round_scale = scale_fmt.has_value();
+  CPU_DISPATCH_FLOATING_TYPES(x.scalar_type(), "act_quant_cpu", [&] {
+    if (round_scale) {
+      act_quant_cpu_impl<true>(
+          y.data_ptr<at::Float8_e4m3fn>(),
+          scale.data_ptr<float>(),
+          x.data_ptr<scalar_t>(),
+          block_size,
+          M,
+          N,
+          num_groups);
+    } else {
+      act_quant_cpu_impl<false>(
+          y.data_ptr<at::Float8_e4m3fn>(),
+          scale.data_ptr<float>(),
+          x.data_ptr<scalar_t>(),
+          block_size,
+          M,
+          N,
+          num_groups);
+    }
+  });
+
+  return {y, scale};
+}

--- a/sgl-kernel/csrc/cpu/allocator.cpp
+++ b/sgl-kernel/csrc/cpu/allocator.cpp
@@ -1,0 +1,231 @@
+#include "common.h"
+
+namespace {
+
+inline int64_t ceil_div(int64_t a, int64_t b) {
+  return (a + b - 1) / b;
+}
+
+// Ensure tensor is of the given dtype and contiguous, avoiding copy when already matching.
+inline at::Tensor as_dtype(at::Tensor& t, at::ScalarType dtype) {
+  if (t.scalar_type() == dtype && t.is_contiguous()) return t;
+  return t.to(dtype).contiguous();
+}
+
+// Check if tensor is of given dtype and contiguous
+inline bool is_dtype_contig(const at::Tensor& t, at::ScalarType dtype) {
+  return t.scalar_type() == dtype && t.is_contiguous();
+}
+
+// ---------------------------------------------------------------------------
+// alloc_extend_kernel_impl: templated on input type, always writes int64 output
+// ---------------------------------------------------------------------------
+template <typename in_t>
+void alloc_extend_kernel_impl(
+    const in_t* pre_lens_ptr,
+    const in_t* seq_lens_ptr,
+    const in_t* last_loc_ptr,
+    const in_t* free_pages_ptr,
+    int64_t* out_ptr,
+    int64_t bs,
+    int64_t page_size) {
+  std::vector<int64_t> extend_lens(bs);
+  std::vector<int64_t> output_start(bs);
+  std::vector<int64_t> num_new_pages_vec(bs);
+  std::vector<int64_t> new_page_start(bs);
+
+  int64_t extend_cumsum = 0;
+  int64_t page_cumsum = 0;
+  for (int64_t i = 0; i < bs; ++i) {
+    int64_t pre_len = static_cast<int64_t>(pre_lens_ptr[i]);
+    int64_t seq_len = static_cast<int64_t>(seq_lens_ptr[i]);
+    int64_t ext_len = seq_len - pre_len;
+    extend_lens[i] = ext_len;
+
+    output_start[i] = extend_cumsum;
+    extend_cumsum += ext_len;
+
+    int64_t pages_after = ceil_div(seq_len, page_size);
+    int64_t pages_before = ceil_div(pre_len, page_size);
+    int64_t new_pages = pages_after - pages_before;
+    num_new_pages_vec[i] = new_pages;
+
+    new_page_start[i] = page_cumsum;
+    page_cumsum += new_pages;
+  }
+
+  at::parallel_for(0, bs, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t pre_len = static_cast<int64_t>(pre_lens_ptr[i]);
+      const int64_t seq_len = static_cast<int64_t>(seq_lens_ptr[i]);
+      const int64_t ext_len = extend_lens[i];
+      if (ext_len == 0) continue;
+
+      const int64_t out_start = output_start[i];
+      const int64_t pg_start = new_page_start[i];
+      const int64_t num_new_pages_self = num_new_pages_vec[i];
+      const int64_t last_loc_i = static_cast<int64_t>(last_loc_ptr[i]);
+      int64_t* out = out_ptr + out_start;
+
+      // Part 1: fill the old partial page
+      const int64_t page_boundary = ceil_div(pre_len, page_size) * page_size;
+      const int64_t num_part1 = std::min(seq_len, page_boundary) - pre_len;
+      for (int64_t j = 0; j < num_part1; ++j) {
+        out[j] = last_loc_i + 1 + j;
+      }
+
+      if (pre_len + num_part1 == seq_len) continue;
+
+      // Part 2: fill new full pages
+      const int64_t full_page_start = ceil_div(pre_len, page_size) * page_size;
+      const int64_t full_page_end = (seq_len / page_size) * page_size;
+      const int64_t num_part2 = full_page_end - full_page_start;
+      if (num_part2 > 0) {
+        int64_t* out2 = out + num_part1;
+        for (int64_t j = 0; j < num_part2; ++j) {
+          int64_t page_idx = j / page_size;
+          int64_t in_page_off = j % page_size;
+          out2[j] = static_cast<int64_t>(free_pages_ptr[pg_start + page_idx]) * page_size + in_page_off;
+        }
+      }
+
+      if (pre_len + num_part1 + num_part2 == seq_len) continue;
+
+      // Part 3: fill the new partial page at the end
+      const int64_t num_part3 = seq_len - (seq_len / page_size) * page_size;
+      if (num_part3 > 0) {
+        int64_t start_page = static_cast<int64_t>(free_pages_ptr[pg_start + num_new_pages_self - 1]);
+        int64_t* out3 = out + num_part1 + num_part2;
+        for (int64_t j = 0; j < num_part3; ++j) {
+          out3[j] = start_page * page_size + j;
+        }
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// alloc_decode_kernel_impl: templated on input type, always writes int64 output
+// ---------------------------------------------------------------------------
+template <typename in_t>
+void alloc_decode_kernel_impl(
+    const in_t* seq_lens_ptr,
+    const in_t* last_loc_ptr,
+    const in_t* free_pages_ptr,
+    int64_t* out_ptr,
+    int64_t bs,
+    int64_t page_size) {
+  std::vector<int64_t> num_new_pages_vec(bs);
+  std::vector<int64_t> new_page_start(bs);
+
+  int64_t page_cumsum = 0;
+  for (int64_t i = 0; i < bs; ++i) {
+    int64_t seq_len = static_cast<int64_t>(seq_lens_ptr[i]);
+    int64_t pre_len = seq_len - 1;
+    int64_t pages_after = ceil_div(seq_len, page_size);
+    int64_t pages_before = ceil_div(pre_len, page_size);
+    int64_t new_pages = pages_after - pages_before;
+    num_new_pages_vec[i] = new_pages;
+    new_page_start[i] = page_cumsum;
+    page_cumsum += new_pages;
+  }
+
+  at::parallel_for(0, bs, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      if (num_new_pages_vec[i] == 0) {
+        out_ptr[i] = static_cast<int64_t>(last_loc_ptr[i]) + 1;
+      } else {
+        int64_t page = static_cast<int64_t>(free_pages_ptr[new_page_start[i]]);
+        out_ptr[i] = page * page_size;
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Prepare output buffer: always int64, reuse tensor if already int64+contiguous
+// ---------------------------------------------------------------------------
+inline std::pair<int64_t*, at::Tensor> prepare_out_i64(at::Tensor& out_indices) {
+  if (out_indices.scalar_type() == at::kLong && out_indices.is_contiguous()) {
+    return {out_indices.data_ptr<int64_t>(), at::Tensor()};
+  }
+  auto buf = at::empty({out_indices.numel()}, out_indices.options().dtype(at::kLong));
+  return {buf.data_ptr<int64_t>(), buf};
+}
+
+inline void copy_back_if_needed(at::Tensor& out_indices, const at::Tensor& buf) {
+  if (buf.defined()) {
+    out_indices.copy_(buf);
+  }
+}
+
+}  // anonymous namespace
+
+// ============================================================================
+// alloc_extend_kernel_cpu
+// ============================================================================
+void alloc_extend_kernel_cpu(
+    at::Tensor& pre_lens,
+    at::Tensor& seq_lens,
+    at::Tensor& last_loc,
+    at::Tensor& free_pages,
+    at::Tensor& out_indices,
+    int64_t page_size) {
+  const int64_t bs = pre_lens.size(0);
+  auto [out_ptr, out_buf] = prepare_out_i64(out_indices);
+
+  if (pre_lens.scalar_type() == at::kInt) {
+    auto pl = as_dtype(pre_lens, at::kInt);
+    auto sl = as_dtype(seq_lens, at::kInt);
+    auto ll = as_dtype(last_loc, at::kInt);
+    auto fp = as_dtype(free_pages, at::kInt);
+    alloc_extend_kernel_impl<int32_t>(
+        pl.data_ptr<int32_t>(),
+        sl.data_ptr<int32_t>(),
+        ll.data_ptr<int32_t>(),
+        fp.data_ptr<int32_t>(),
+        out_ptr,
+        bs,
+        page_size);
+  } else {
+    auto pl = as_dtype(pre_lens, at::kLong);
+    auto sl = as_dtype(seq_lens, at::kLong);
+    auto ll = as_dtype(last_loc, at::kLong);
+    auto fp = as_dtype(free_pages, at::kLong);
+    alloc_extend_kernel_impl<int64_t>(
+        pl.data_ptr<int64_t>(),
+        sl.data_ptr<int64_t>(),
+        ll.data_ptr<int64_t>(),
+        fp.data_ptr<int64_t>(),
+        out_ptr,
+        bs,
+        page_size);
+  }
+
+  copy_back_if_needed(out_indices, out_buf);
+}
+
+// ============================================================================
+// alloc_decode_kernel_cpu
+// ============================================================================
+void alloc_decode_kernel_cpu(
+    at::Tensor& seq_lens, at::Tensor& last_loc, at::Tensor& free_pages, at::Tensor& out_indices, int64_t page_size) {
+  const int64_t bs = seq_lens.size(0);
+  auto [out_ptr, out_buf] = prepare_out_i64(out_indices);
+
+  if (seq_lens.scalar_type() == at::kInt) {
+    auto sl = as_dtype(seq_lens, at::kInt);
+    auto ll = as_dtype(last_loc, at::kInt);
+    auto fp = as_dtype(free_pages, at::kInt);
+    alloc_decode_kernel_impl<int32_t>(
+        sl.data_ptr<int32_t>(), ll.data_ptr<int32_t>(), fp.data_ptr<int32_t>(), out_ptr, bs, page_size);
+  } else {
+    auto sl = as_dtype(seq_lens, at::kLong);
+    auto ll = as_dtype(last_loc, at::kLong);
+    auto fp = as_dtype(free_pages, at::kLong);
+    alloc_decode_kernel_impl<int64_t>(
+        sl.data_ptr<int64_t>(), ll.data_ptr<int64_t>(), fp.data_ptr<int64_t>(), out_ptr, bs, page_size);
+  }
+
+  copy_back_if_needed(out_indices, out_buf);
+}

--- a/sgl-kernel/csrc/cpu/common.h
+++ b/sgl-kernel/csrc/cpu/common.h
@@ -73,6 +73,27 @@ namespace {
     }                                                            \
   }()
 
+// dispatch: float, bfloat16, float16
+#define CPU_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)                      \
+  [&] {                                                                   \
+    switch (TYPE) {                                                       \
+      case at::ScalarType::Float: {                                       \
+        using scalar_t = float;                                           \
+        return __VA_ARGS__();                                             \
+      }                                                                   \
+      case at::ScalarType::BFloat16: {                                    \
+        using scalar_t = at::BFloat16;                                    \
+        return __VA_ARGS__();                                             \
+      }                                                                   \
+      case at::ScalarType::Half: {                                        \
+        using scalar_t = at::Half;                                        \
+        return __VA_ARGS__();                                             \
+      }                                                                   \
+      default:                                                            \
+        TORCH_CHECK(false, NAME, ": unsupported dtype ", toString(TYPE)); \
+    }                                                                     \
+  }()
+
 // Helper MICRO for CPU_DISPATCH_FLOATING_TYPES_EXT:
 //   TYPE1: the primary dtype (input, output, weight);
 //   TYPE2: defined as PARAM_T input
@@ -276,6 +297,33 @@ int inline adjust_num_threads(int m) {
   return std::max(1, (actual_nth >> 1) * 2);
 }
 
+// Like parallel_2d but with explicit nth_m × nth_n decomposition.
+// Caller is responsible for choosing nth_m and nth_n.
+template <typename func_t>
+inline void parallel_2d_tiled(int m, int n, int nth_m, int nth_n, const func_t& f) {
+  const int nth = nth_m * nth_n;
+#if defined(_OPENMP)
+#pragma omp parallel num_threads(nth)
+  {
+    int ith = omp_get_thread_num();
+    int ith_m = ith / nth_n;
+    int ith_n = ith % nth_n;
+
+    int thread_block_m = div_up(m, nth_m);
+    int thread_block_n = div_up(n, nth_n);
+
+    int begin_m = std::min(ith_m * thread_block_m, m);
+    int end_m = std::min(begin_m + thread_block_m, m);
+    int begin_n = std::min(ith_n * thread_block_n, n);
+    int end_n = std::min(begin_n + thread_block_n, n);
+
+    f(begin_m, end_m, begin_n, end_n);
+  }
+#else
+  f(0, m, 0, n);
+#endif
+}
+
 template <typename func_t>
 inline void parallel_2d(int m, int n, const func_t& f) {
   // make sure we have even num_threads
@@ -339,6 +387,13 @@ inline int get_cache_blocks(int chunk_size) {
 template <>
 inline int get_cache_blocks<at::Float8_e4m3fn>(int chunk_size) {
   // fp8 uses bf16 as accumulate type
+  int cache_block_size = get_cache_blocks<at::BFloat16>(chunk_size);
+  return std::min(MAX_CACHE_BLOCK_SIZE, cache_block_size);
+}
+
+template <>
+inline int get_cache_blocks<uint8_t>(int chunk_size) {
+  // mxfp4 uses bf16 as accumulate type
   int cache_block_size = get_cache_blocks<at::BFloat16>(chunk_size);
   return std::min(MAX_CACHE_BLOCK_SIZE, cache_block_size);
 }

--- a/sgl-kernel/csrc/cpu/compressor.cpp
+++ b/sgl-kernel/csrc/cpu/compressor.cpp
@@ -1,0 +1,478 @@
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+using fVec = at::vec::Vectorized<float>;
+
+// ──────────────────────────── helpers ────────────────────────────
+
+static inline int64_t compute_state_len(int64_t seq_len, int64_t ratio) {
+  return seq_len % ratio + (ratio == 4 ? ratio : 0);
+}
+
+// In-place RMS norm on a single row of float data with weight.
+static inline void rmsnorm_row(
+    float* __restrict__ out,
+    const float* __restrict__ input,
+    const float* __restrict__ weight,
+    int64_t dim,
+    float eps) {
+  float sum_sq = 0.0f;
+  int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+  fVec sum_v(0.0f);
+  for (; d <= dim - fVec::size(); d += fVec::size()) {
+    fVec x = fVec::loadu(input + d);
+    sum_v = sum_v + x * x;
+  }
+  sum_sq = vec_reduce_sum(sum_v);
+#endif
+  for (; d < dim; ++d) {
+    sum_sq += input[d] * input[d];
+  }
+  float rsqrt_var = 1.0f / std::sqrt(sum_sq / dim + eps);
+
+  d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+  fVec scale_v(rsqrt_var);
+  for (; d <= dim - fVec::size(); d += fVec::size()) {
+    fVec x = fVec::loadu(input + d);
+    fVec w = fVec::loadu(weight + d);
+    (x * scale_v * w).store(out + d);
+  }
+#endif
+  for (; d < dim; ++d) {
+    out[d] = input[d] * rsqrt_var * weight[d];
+  }
+}
+
+// In-place interleaved rotary embedding on a single row.
+// freqs is [rope_dim] float, x is [rope_dim] float.
+static inline void
+apply_rotary_emb_row_f32(float* __restrict__ x, const float* __restrict__ freqs, int64_t rope_dim, bool inverse) {
+  int64_t k = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+  // Build sign mask for complex multiply
+  __m512 sign_mask;
+  if (inverse) {
+    sign_mask = _mm512_castsi512_ps(_mm512_set_epi32(
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0));
+  } else {
+    sign_mask = _mm512_castsi512_ps(_mm512_set_epi32(
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000,
+        0,
+        (int)0x80000000));
+  }
+  for (; k <= rope_dim - 16; k += 16) {
+    __m512 xv = _mm512_loadu_ps(x + k);
+    __m512 fv = _mm512_loadu_ps(freqs + k);
+    __m512 out = _mm512_fmadd_ps(
+        xv,
+        _mm512_permute_ps(fv, 0xA0),
+        _mm512_mul_ps(_mm512_permute_ps(xv, 0xB1), _mm512_xor_ps(_mm512_permute_ps(fv, 0xF5), sign_mask)));
+    _mm512_storeu_ps(x + k, out);
+  }
+#endif
+  for (; k < rope_dim; k += 2) {
+    float xr = x[k], xi = x[k + 1];
+    float cr = freqs[k], ci = freqs[k + 1];
+    if (inverse) {
+      x[k] = xr * cr + xi * ci;
+      x[k + 1] = xi * cr - xr * ci;
+    } else {
+      x[k] = xr * cr - xi * ci;
+      x[k + 1] = xr * ci + xi * cr;
+    }
+  }
+}
+
+// Hadamard transform for rotate_activation.
+// Operates on float buffer of power-of-2 size.
+static void hadamard_transform_row(float* __restrict__ data, int64_t n, float scale) {
+  if (n == 1) {
+    data[0] *= scale;
+    return;
+  }
+#if defined(CPU_CAPABILITY_AVX512)
+  if (n >= 16) {
+    // Phase 1: fused butterflies for h=1,2,4,8
+    for (int64_t j = 0; j < n; j += 16) {
+      __m512 v = _mm512_loadu_ps(data + j);
+      __m512 p, s, d;
+      // h=1
+      p = _mm512_permute_ps(v, 0b10'11'00'01);
+      s = _mm512_add_ps(v, p);
+      d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xAAAA, s, d);
+      // h=2
+      p = _mm512_permute_ps(v, 0b01'00'11'10);
+      s = _mm512_add_ps(v, p);
+      d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xCCCC, s, d);
+      // h=4
+      p = _mm512_permutexvar_ps(_mm512_set_epi32(11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4), v);
+      s = _mm512_add_ps(v, p);
+      d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xF0F0, s, d);
+      // h=8
+      p = _mm512_permutexvar_ps(_mm512_set_epi32(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8), v);
+      s = _mm512_add_ps(v, p);
+      d = _mm512_sub_ps(p, v);
+      v = _mm512_mask_blend_ps((__mmask16)0xFF00, s, d);
+      _mm512_storeu_ps(data + j, v);
+    }
+    // Phase 2: larger butterflies
+    for (int64_t h = 16; h < n; h <<= 1) {
+      for (int64_t j = 0; j < n; j += 2 * h) {
+        for (int64_t k = 0; k < h; k += 16) {
+          __m512 a = _mm512_loadu_ps(data + j + k);
+          __m512 b = _mm512_loadu_ps(data + j + k + h);
+          _mm512_storeu_ps(data + j + k, _mm512_add_ps(a, b));
+          _mm512_storeu_ps(data + j + k + h, _mm512_sub_ps(a, b));
+        }
+      }
+    }
+    // Apply scale
+    __m512 sv = _mm512_set1_ps(scale);
+    for (int64_t j = 0; j < n; j += 16) {
+      __m512 v = _mm512_loadu_ps(data + j);
+      _mm512_storeu_ps(data + j, _mm512_mul_ps(v, sv));
+    }
+    return;
+  }
+#endif
+  // Scalar fallback
+  int64_t h = 1;
+  while (h < n) {
+    for (int64_t j = 0; j < n; j += 2 * h) {
+      for (int64_t k = 0; k < h; ++k) {
+        float a = data[j + k], b = data[j + k + h];
+        data[j + k] = a + b;
+        data[j + k + h] = a - b;
+      }
+    }
+    h <<= 1;
+  }
+  for (int64_t j = 0; j < n; ++j) {
+    data[j] *= scale;
+  }
+}
+
+// overlap_transform_decode: tensor [bs, 2*ratio, 2*head_dim] -> [bs, 2*ratio, head_dim]
+// ret[:, :r, :] = tensor[:, :r, :d]
+// ret[:, r:, :] = tensor[:, r:, d:]
+// where r = ratio, d = head_dim
+static void overlap_transform_decode_inplace(
+    float* __restrict__ out,       // [n_items, head_dim]
+    const float* __restrict__ in,  // [n_items, 2*head_dim]
+    int64_t ratio,
+    int64_t head_dim) {
+  // First half: copy in[:ratio, :head_dim]
+  for (int64_t i = 0; i < ratio; ++i) {
+    const float* src = in + i * 2 * head_dim;
+    float* dst = out + i * head_dim;
+    std::memcpy(dst, src, head_dim * sizeof(float));
+  }
+  // Second half: copy in[ratio:2*ratio, head_dim:2*head_dim]
+  for (int64_t i = ratio; i < 2 * ratio; ++i) {
+    const float* src = in + i * 2 * head_dim + head_dim;
+    float* dst = out + i * head_dim;
+    std::memcpy(dst, src, head_dim * sizeof(float));
+  }
+}
+
+// ──────────────────── compress_decode_cpu ────────────────────
+
+// Equivalent to compress_decode_old in Python.
+// pool_kv/pool_score: [max_reqs, state_len, coff*head_dim]
+// kv/score: [bs, coff*head_dim]
+// seq_lens: [bs] int64
+// req_pool_indices: [bs] int64
+// ape: [ratio, coff*head_dim] float32
+// norm_weight: [head_dim] float32
+// freqs_cis: [max_seq, rope_dim] float32 (real-valued interleaved cos/sin)
+void compress_decode_cpu_impl(
+    float* __restrict__ pool_kv,
+    float* __restrict__ pool_score,
+    const float* __restrict__ kv,
+    const float* __restrict__ score,
+    const int64_t* __restrict__ seq_lens,
+    const int64_t* __restrict__ req_pool_indices,
+    const float* __restrict__ ape,
+    const float* __restrict__ norm_weight,
+    const float* __restrict__ freqs_cis,
+    float* __restrict__ output,  // [bs, head_dim]
+    int64_t bs,
+    int64_t pool_state_len,
+    int64_t pool_row_stride,  // stride between rows in pool (may be > coff_hd for interleaved storage)
+    int64_t kv_row_stride,    // stride between rows in kv/score input
+    int64_t ratio,
+    int64_t head_dim,
+    int64_t rope_head_dim,
+    int64_t coff,
+    bool overlap,
+    bool rotate,
+    float norm_eps,
+    int64_t freqs_stride) {
+  int64_t coff_hd = coff * head_dim;
+
+  at::parallel_for(0, bs, 1, [&](int64_t begin, int64_t end) {
+    // Scratch buffers per thread
+    std::vector<float> kv_buf(ratio * coff * coff_hd);
+    std::vector<float> score_buf(ratio * coff * coff_hd);
+    std::vector<float> kv_work(ratio * coff * head_dim);
+    std::vector<float> score_work(ratio * coff * head_dim);
+    std::vector<float> compressed(head_dim);
+
+    for (int64_t b = begin; b < end; ++b) {
+      int64_t seq_len = seq_lens[b];
+      int64_t req_idx = req_pool_indices[b];
+      int64_t write_pos = (seq_len - 1) % ratio + (overlap ? ratio : 0);
+
+      float* pool_kv_req = pool_kv + req_idx * pool_state_len * pool_row_stride;
+      float* pool_score_req = pool_score + req_idx * pool_state_len * pool_row_stride;
+
+      // Write new kv and score to pool at write_pos
+      std::memcpy(pool_kv_req + write_pos * pool_row_stride, kv + b * kv_row_stride, coff_hd * sizeof(float));
+      std::memcpy(pool_score_req + write_pos * pool_row_stride, score + b * kv_row_stride, coff_hd * sizeof(float));
+
+      // Copy out entire pool state for this request (strided -> contiguous)
+      int64_t total_state = ratio * coff;
+      for (int64_t r = 0; r < total_state; ++r) {
+        std::memcpy(kv_buf.data() + r * coff_hd, pool_kv_req + r * pool_row_stride, coff_hd * sizeof(float));
+        std::memcpy(score_buf.data() + r * coff_hd, pool_score_req + r * pool_row_stride, coff_hd * sizeof(float));
+      }
+
+      // Handle overlap shift
+      if (overlap && (seq_len % ratio == 0)) {
+        // Shift: pool[:ratio] = pool[ratio:2*ratio]
+        for (int64_t r = 0; r < ratio; ++r) {
+          std::memcpy(
+              pool_kv_req + r * pool_row_stride, pool_kv_req + (ratio + r) * pool_row_stride, coff_hd * sizeof(float));
+          std::memcpy(
+              pool_score_req + r * pool_row_stride,
+              pool_score_req + (ratio + r) * pool_row_stride,
+              coff_hd * sizeof(float));
+        }
+      }
+
+      // Add APE to score
+      // kv_buf/score_buf shape: [coff, ratio, coff_hd] (after reshape from [total_state, coff_hd])
+      // APE shape: [ratio, coff_hd]
+      for (int64_t c = 0; c < coff; ++c) {
+        for (int64_t r = 0; r < ratio; ++r) {
+          float* sp = score_buf.data() + (c * ratio + r) * coff_hd;
+          const float* ap = ape + r * coff_hd;
+          int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+          for (; d <= coff_hd - 16; d += 16) {
+            __m512 sv = _mm512_loadu_ps(sp + d);
+            __m512 av = _mm512_loadu_ps(ap + d);
+            _mm512_storeu_ps(sp + d, _mm512_add_ps(sv, av));
+          }
+#endif
+          for (; d < coff_hd; ++d) {
+            sp[d] += ap[d];
+          }
+        }
+      }
+
+      if (overlap) {
+        // overlap_transform_decode on kv and score
+        // Input: [bs=1, coff*ratio=2*ratio, coff*head_dim=2*head_dim]
+        // Output: [bs=1, 2*ratio, head_dim]
+        overlap_transform_decode_inplace(kv_work.data(), kv_buf.data(), ratio, head_dim);
+        overlap_transform_decode_inplace(score_work.data(), score_buf.data(), ratio, head_dim);
+      } else {
+        // Just copy, treating as [ratio, head_dim]
+        for (int64_t r = 0; r < ratio; ++r) {
+          std::memcpy(kv_work.data() + r * head_dim, kv_buf.data() + r * coff_hd, head_dim * sizeof(float));
+          std::memcpy(score_work.data() + r * head_dim, score_buf.data() + r * coff_hd, head_dim * sizeof(float));
+        }
+      }
+
+      // Now: kv_work, score_work are [ratio*coff, head_dim]
+      int64_t compress_rows = ratio * coff;
+
+      // Row-major vectorized softmax + weighted sum
+      // 1) Find per-column max across rows
+      std::memcpy(compressed.data(), score_work.data(), head_dim * sizeof(float));
+      for (int64_t r = 1; r < compress_rows; ++r) {
+        const float* sr = score_work.data() + r * head_dim;
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          __m512 mx = _mm512_loadu_ps(compressed.data() + d);
+          __m512 sv = _mm512_loadu_ps(sr + d);
+          _mm512_storeu_ps(compressed.data() + d, _mm512_max_ps(mx, sv));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          compressed[d] = std::max(compressed[d], sr[d]);
+        }
+      }
+      // 2) Compute exp(score - max) in-place in score_work, accumulate sum
+      // Use kv_buf as sum accumulator (reuse buffer, head_dim <= kv_buf size)
+      float* sum_buf = kv_buf.data();  // reuse, only need head_dim floats
+      std::memset(sum_buf, 0, head_dim * sizeof(float));
+      for (int64_t r = 0; r < compress_rows; ++r) {
+        float* sr = score_work.data() + r * head_dim;
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          fVec diff_v = fVec::loadu(sr + d) - fVec::loadu(compressed.data() + d);
+          fVec exp_v = diff_v.exp();
+          exp_v.store(sr + d);
+          __m512 sm = _mm512_loadu_ps(sum_buf + d);
+          _mm512_storeu_ps(sum_buf + d, _mm512_add_ps(sm, (__m512)exp_v));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          sr[d] = std::exp(sr[d] - compressed[d]);
+          sum_buf[d] += sr[d];
+        }
+      }
+      // 3) Pre-compute inv_sum, then weighted sum with division fused
+      // Compute inv_sum = 1/sum in-place in sum_buf
+      {
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          __m512 sm = _mm512_loadu_ps(sum_buf + d);
+          _mm512_storeu_ps(sum_buf + d, _mm512_rcp14_ps(sm));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          sum_buf[d] = 1.0f / sum_buf[d];
+        }
+      }
+      std::memset(compressed.data(), 0, head_dim * sizeof(float));
+      for (int64_t r = 0; r < compress_rows; ++r) {
+        const float* kr = kv_work.data() + r * head_dim;
+        const float* sr = score_work.data() + r * head_dim;
+        int64_t d = 0;
+#if defined(CPU_CAPABILITY_AVX512)
+        for (; d <= head_dim - 16; d += 16) {
+          __m512 kv = _mm512_loadu_ps(kr + d);
+          __m512 sw = _mm512_mul_ps(_mm512_loadu_ps(sr + d), _mm512_loadu_ps(sum_buf + d));
+          __m512 acc = _mm512_loadu_ps(compressed.data() + d);
+          _mm512_storeu_ps(compressed.data() + d, _mm512_fmadd_ps(kv, sw, acc));
+        }
+#endif
+        for (; d < head_dim; ++d) {
+          compressed[d] += kr[d] * sr[d] * sum_buf[d];
+        }
+      }
+
+      // RMS norm with weight
+      rmsnorm_row(output + b * head_dim, compressed.data(), norm_weight, head_dim, norm_eps);
+
+      // Apply rotary embedding to last rope_head_dim elements
+      int64_t freq_pos = (seq_len - 1) / ratio * ratio;
+      const float* freq_ptr = freqs_cis + freq_pos * freqs_stride;
+      apply_rotary_emb_row_f32(output + b * head_dim + (head_dim - rope_head_dim), freq_ptr, rope_head_dim, false);
+
+      // Optional rotate (Hadamard transform)
+      if (rotate) {
+        float scale = 1.0f / std::sqrt((float)head_dim);
+        hadamard_transform_row(output + b * head_dim, head_dim, scale);
+      }
+    }
+  });
+}
+
+}  // anonymous namespace
+
+at::Tensor compress_decode_cpu(
+    at::Tensor& pool_kv,
+    at::Tensor& pool_score,
+    at::Tensor& kv,
+    at::Tensor& score,
+    at::Tensor& seq_lens,
+    at::Tensor& req_pool_indices,
+    at::Tensor& ape,
+    at::Tensor& norm_weight,
+    at::Tensor& freqs_cis,
+    int64_t ratio,
+    int64_t head_dim,
+    int64_t rope_head_dim,
+    bool overlap,
+    bool rotate,
+    double norm_eps) {
+  int64_t bs = kv.size(0);
+  int64_t coff = 1 + (overlap ? 1 : 0);
+  int64_t pool_state_len = pool_kv.size(1);
+
+  // Ensure float32
+  TORCH_CHECK(kv.scalar_type() == at::kFloat, "compress_decode_cpu: kv must be float32");
+  TORCH_CHECK(score.scalar_type() == at::kFloat, "compress_decode_cpu: score must be float32");
+  TORCH_CHECK(pool_kv.scalar_type() == at::kFloat, "compress_decode_cpu: pool_kv must be float32");
+
+  at::Tensor output = at::empty({bs, head_dim}, kv.options());
+
+  // freqs_cis stride: number of elements per position
+  int64_t freqs_stride = freqs_cis.size(-1);
+  // Pool row stride (may be > coff_hd if pool is a non-contiguous view)
+  int64_t pool_row_stride = pool_kv.stride(-2);
+  // kv/score row stride
+  int64_t kv_row_stride = kv.stride(0);
+
+  compress_decode_cpu_impl(
+      pool_kv.data_ptr<float>(),
+      pool_score.data_ptr<float>(),
+      kv.data_ptr<float>(),
+      score.data_ptr<float>(),
+      seq_lens.data_ptr<int64_t>(),
+      req_pool_indices.data_ptr<int64_t>(),
+      ape.data_ptr<float>(),
+      norm_weight.data_ptr<float>(),
+      freqs_cis.data_ptr<float>(),
+      output.data_ptr<float>(),
+      bs,
+      pool_state_len,
+      pool_row_stride,
+      kv_row_stride,
+      ratio,
+      head_dim,
+      rope_head_dim,
+      coff,
+      overlap,
+      rotate,
+      static_cast<float>(norm_eps),
+      freqs_stride);
+
+  return output;
+}

--- a/sgl-kernel/csrc/cpu/flash_mla.cpp
+++ b/sgl-kernel/csrc/cpu/flash_mla.cpp
@@ -1,0 +1,993 @@
+#include <algorithm>
+#include <vector>
+
+#include "common.h"
+#include "gemm.h"
+#include "vec.h"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// FP8 layouts
+// ---------------------------------------------------------------------------
+//
+// V32_FP8Sparse:    (d=576, d_nope=512, d_rope=64, tile=128, num_tiles=4)
+//   per-token storage = d_nope FP8(e4m3) | num_tiles * 4 (fp32 scales) | d_rope * 2 (bf16 RoPE)
+//   = 512 + 16 + 128 = 656 bytes
+//   tokens are tightly packed:  [num_blocks, block_size, 656]
+//
+// V4_FP8Sparse: (d=512, d_nope=448, d_rope=64, tile=64,  num_tiles=7)
+//   per block:
+//     [block_size * (d_nope + 2*d_rope) bytes  ; FP8 NoPE + bf16 RoPE interleaved per token]
+//     [block_size * 8 bytes                    ; 7 e8m0 scales per token + 1 byte pad]
+//   block stride is padded up to a multiple of 576 bytes.
+//
+enum FP8KVCacheLayout : int64_t {
+  kV32FP8Sparse = 1,  // FP8KVCacheLayout.V32_FP8Sparse
+  kV4FP8Sparse = 2    // FP8KVCacheLayout.V4_FP8Sparse
+};
+
+struct FP8LayoutMeta {
+  int64_t d;
+  int64_t d_nope;
+  int64_t d_rope;
+  int64_t tile_size;
+  int64_t num_tiles;
+};
+
+inline FP8LayoutMeta get_fp8_meta(int64_t layout) {
+  switch (layout) {
+    case kV32FP8Sparse:
+      return {576, 512, 64, 128, 4};
+    case kV4FP8Sparse:
+      return {512, 448, 64, 64, 7};
+    default:
+      TORCH_CHECK(false, "flash_mla_with_kvcache_cpu: unsupported FP8 layout ", layout);
+  }
+}
+
+// Convert a single fp8_e4m3 byte to float using ATen's helper to keep
+// behaviour aligned with the rest of the codebase.
+inline float fp8_e4m3_to_float(uint8_t v) {
+  c10::Float8_e4m3fn x;
+  x.x = v;
+  return static_cast<float>(x);
+}
+
+// Convert one fp8_e8m0 byte (= unsigned 8-bit exponent) to float.
+// e8m0 only stores an exponent (bias 127); value = 2^(e - 127), with 0xFF
+// reserved for NaN.
+inline float fp8_e8m0_to_float(uint8_t v) {
+  if (v == 0xFF) return std::numeric_limits<float>::quiet_NaN();
+  // exponent of 0 maps to +-0 according to e8m0fnu spec.
+  if (v == 0) return 0.f;
+  union {
+    uint32_t u;
+    float f;
+  } u;
+  u.u = static_cast<uint32_t>(v) << 23;
+  return u.f;
+}
+
+struct FP8KVCacheInfo {
+  const uint8_t* data;
+  int64_t block_size;
+  int64_t block_stride_bytes;
+};
+
+FP8KVCacheInfo get_fp8_kvcache_info(at::Tensor k_cache, int64_t layout) {
+  get_fp8_meta(layout);
+
+  TORCH_CHECK(k_cache.dim() == 4, "k_cache must be 4D [num_blocks, block_size, 1, packed_bytes]");
+  TORCH_CHECK(k_cache.size(2) == 1, "h_k must be 1 for FlashMLA sparse FP8 path");
+  TORCH_CHECK(
+      k_cache.dtype() == at::kFloat8_e4m3fn || k_cache.scalar_type() == at::kByte,
+      "flash_mla_with_kvcache_cpu: expect FP8 k_cache to be float8_e4m3fn or uint8, got ",
+      k_cache.dtype());
+
+  return {
+      static_cast<const uint8_t*>(k_cache.data_ptr()),
+      k_cache.size(1),
+      k_cache.stride(0) * static_cast<int64_t>(k_cache.element_size())};
+}
+
+template <typename index_t>
+int64_t infer_active_total_tokens(
+    const index_t* __restrict__ indices,
+    int64_t batches,
+    int64_t s_q,
+    int64_t topk,
+    int64_t capacity,
+    const int32_t* __restrict__ topk_length) {
+  if (indices == nullptr || topk == 0 || capacity == 0) {
+    return 0;
+  }
+
+  const int num_threads = at::get_num_threads();
+  std::vector<int64_t> thread_max(num_threads, -1);
+  at::parallel_for(0, batches * s_q, 0, [&](int64_t begin, int64_t end) {
+    const int tid = at::get_thread_num();
+    int64_t local_max = -1;
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t b = i / s_q;
+      const int64_t limit =
+          topk_length != nullptr ? std::max<int64_t>(0, std::min<int64_t>(topk_length[b], topk)) : topk;
+      const index_t* row = indices + i * topk;
+      for (int64_t k = 0; k < limit; ++k) {
+        const int64_t v = static_cast<int64_t>(row[k]);
+        if (v >= 0 && v < capacity) {
+          local_max = std::max(local_max, v);
+        }
+      }
+    }
+    thread_max[tid] = std::max(thread_max[tid], local_max);
+  });
+
+  int64_t max_seen = -1;
+  for (int64_t v : thread_max) {
+    max_seen = std::max(max_seen, v);
+  }
+  return max_seen + 1;
+}
+
+template <typename index_t>
+inline bool is_valid_sparse_index(index_t idx, int64_t pos, int64_t topk_limit, int64_t total_tokens) {
+  const int64_t v = static_cast<int64_t>(idx);
+  return pos < topk_limit && v >= 0 && v < total_tokens;
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+inline __attribute__((always_inline)) __m512i cvt_fp8_32_to_scaled_bf16(__m256i fp8, float scale) {
+  const __m512bh bf16_ext = CVT_FP8_TO_BF16_EXT(fp8);
+  const __m512 scale_vec = _mm512_mul_ps(_mm512_set1_ps(scale), _mm512_castsi512_ps(_mm512_set1_epi32(kFP8_BIAS)));
+  const __m512 f0 = _mm512_mul_ps(CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32((__m512i)bf16_ext, 0)), scale_vec);
+  const __m512 f1 = _mm512_mul_ps(CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32((__m512i)bf16_ext, 1)), scale_vec);
+  return (__m512i)_mm512_cvtne2ps_pbh(f1, f0);
+}
+
+template <int64_t LAYOUT>
+inline __attribute__((always_inline)) __m512i load_fp8_kvcache_32_from_row(
+    const uint8_t* __restrict__ row_base, const uint8_t* __restrict__ scale_base, int dim_offset) {
+  static_assert(LAYOUT == kV32FP8Sparse || LAYOUT == kV4FP8Sparse, "bad layout");
+  constexpr FP8LayoutMeta meta =
+      (LAYOUT == kV32FP8Sparse) ? FP8LayoutMeta{576, 512, 64, 128, 4} : FP8LayoutMeta{512, 448, 64, 64, 7};
+
+  if constexpr (LAYOUT == kV32FP8Sparse) {
+    if (dim_offset < meta.d_nope) {
+      const auto* scale_ptr = reinterpret_cast<const float*>(scale_base);
+      const float scale = scale_ptr[dim_offset / meta.tile_size];
+      return cvt_fp8_32_to_scaled_bf16(
+          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(row_base + dim_offset)), scale);
+    }
+    const auto* rope_ptr = reinterpret_cast<const at::BFloat16*>(row_base + meta.d_nope + meta.num_tiles * 4);
+    return _mm512_loadu_si512(rope_ptr + dim_offset - meta.d_nope);
+  } else {
+    if (dim_offset < meta.d_nope) {
+      const float scale = fp8_e8m0_to_float(scale_base[dim_offset / meta.tile_size]);
+      return cvt_fp8_32_to_scaled_bf16(
+          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(row_base + dim_offset)), scale);
+    }
+    const auto* rope_ptr = reinterpret_cast<const at::BFloat16*>(row_base + meta.d_nope);
+    return _mm512_loadu_si512(rope_ptr + dim_offset - meta.d_nope);
+  }
+}
+
+template <int64_t LAYOUT>
+inline __attribute__((always_inline)) void init_fp8_kvcache_tile_rows(
+    const uint8_t* __restrict__ fp8_storage,
+    const int64_t block_size,
+    const int64_t storage_block_stride_bytes,
+    const int64_t token_idx,
+    const uint8_t*& row_base,
+    const uint8_t*& scale_base) {
+  static_assert(LAYOUT == kV32FP8Sparse || LAYOUT == kV4FP8Sparse, "bad layout");
+  constexpr FP8LayoutMeta meta =
+      (LAYOUT == kV32FP8Sparse) ? FP8LayoutMeta{576, 512, 64, 128, 4} : FP8LayoutMeta{512, 448, 64, 64, 7};
+  const int64_t block_idx = token_idx / block_size;
+  const int64_t block_off = token_idx - block_idx * block_size;
+  const uint8_t* block_base = fp8_storage + block_idx * storage_block_stride_bytes;
+  if constexpr (LAYOUT == kV32FP8Sparse) {
+    constexpr int64_t bytes_per_token = meta.d_nope + meta.num_tiles * 4 + meta.d_rope * 2;
+    row_base = block_base + block_off * bytes_per_token;
+    scale_base = row_base + meta.d_nope;
+  } else {
+    constexpr int64_t nope_rope_per_token = meta.d_nope + 2 * meta.d_rope;
+    constexpr int64_t scale_stride = 8;
+    row_base = block_base + block_off * nope_rope_per_token;
+    scale_base = block_base + block_size * nope_rope_per_token + block_off * scale_stride;
+  }
+}
+
+template <bool convert_v, typename scalar_t, typename index_t, typename load_vec_t>
+inline __attribute__((always_inline)) void sparse_pack_vnni_Nx32(
+    scalar_t* __restrict__ dst0,
+    scalar_t* __restrict__ dst1,
+    const index_t* __restrict__ ind,
+    const bool* __restrict__ valid_mask,
+    int N,
+    int dim_offset,
+    int ld_dst0,
+    int ld_dst1,
+    const load_vec_t& load_vec) {
+  __m512i vinputs[16];
+  int n = 0;
+  for (; n < N; ++n) {
+    if (!valid_mask[n]) {
+      vinputs[n] = _mm512_set1_epi32(0);
+    } else {
+      vinputs[n] = load_vec(n, static_cast<int64_t>(ind[n]), dim_offset);
+    }
+  }
+  for (; n < 16; ++n) {
+    vinputs[n] = _mm512_set1_epi32(0);
+  }
+
+  if constexpr (convert_v) {
+    for (int nn = 0; nn < 16; nn += 2) {
+      __m512i d0, d1;
+      std::tie(d0, d1) = transpose_2x32_16bit(vinputs[nn], vinputs[nn + 1]);
+      _mm512_storeu_si512(dst1 + (nn >> 1) * ld_dst1 * 2, d0);
+      _mm512_storeu_si512(dst1 + (nn >> 1) * ld_dst1 * 2 + 32, d1);
+    }
+  }
+
+  transpose_16x16_32bit(vinputs);
+  const __mmask16 vmask = (1 << N) - 1;
+  for (int k = 0; k < 16; ++k) {
+    _mm512_mask_storeu_epi32(dst0 + k * ld_dst0 * 2, vmask, vinputs[k]);
+  }
+}
+#endif
+
+template <typename scalar_t, typename index_t>
+void sparse_pack_vnni(
+    scalar_t* __restrict__ dst0,
+    scalar_t* __restrict__ dst1,
+    const scalar_t* __restrict__ src,
+    const index_t* __restrict__ ind,
+    const bool* __restrict__ valid_mask,
+    int N,
+    int K,
+    int Kv,
+    int ld_src,
+    int ld_dst0,
+    int ld_dst1) {
+#if defined(CPU_CAPABILITY_AVX512)
+  const int NB = div_up(N, 16);
+  const int KB = K / 32;
+  const int KBv = std::min(Kv / 32, KB);
+  auto load_vec = [src, ld_src](int n, int64_t idx, int dim_offset) {
+    UNUSED(n);
+    return _mm512_loadu_si512(src + idx * ld_src + dim_offset);
+  };
+  for (int nb = 0; nb < NB; ++nb) {
+    for (int kb = 0; kb < KBv; ++kb) {
+      int nb_size = std::min(N - nb * 16, 16);
+      sparse_pack_vnni_Nx32<true, scalar_t, index_t>(
+          /*    dst0 */ dst0 + ((kb * 32) >> 1) * ld_dst0 * 2 + nb * 16 * 2,
+          /*    dst1 */ dst1 + ((nb * 16) >> 1) * ld_dst1 * 2 + kb * 32 * 2,
+          /*     ind */ ind + nb * 16,
+          /*   valid */ valid_mask + nb * 16,
+          /*       N */ nb_size,
+          /* dim_off */ kb * 32,
+          /* ld_dst0 */ ld_dst0,
+          /* ld_dst1 */ ld_dst1,
+          /* load_vec */ load_vec);
+    }
+    for (int kb = KBv; kb < KB; ++kb) {
+      int nb_size = std::min(N - nb * 16, 16);
+      sparse_pack_vnni_Nx32<false, scalar_t, index_t>(
+          /*    dst0 */ dst0 + ((kb * 32) >> 1) * ld_dst0 * 2 + nb * 16 * 2,
+          /*    dst1 */ dst1 + ((nb * 16) >> 1) * ld_dst1 * 2 + kb * 32 * 2,
+          /*     ind */ ind + nb * 16,
+          /*   valid */ valid_mask + nb * 16,
+          /*       N */ nb_size,
+          /* dim_off */ kb * 32,
+          /* ld_dst0 */ ld_dst0,
+          /* ld_dst1 */ ld_dst1,
+          /* load_vec */ load_vec);
+    }
+  }
+#else
+  // Reference scalar fallback (NO-AVX512 build).
+  for (int n = 0; n < N; ++n) {
+    index_t idx = ind[n];
+    const bool valid = valid_mask[n];
+    for (int k = 0; k < K / 2; ++k) {
+      for (int d = 0; d < 2; ++d) {
+        scalar_t v = !valid ? scalar_t(0) : src[idx * ld_src + k * 2 + d];
+        dst0[k * ld_dst0 * 2 + n * 2 + d] = v;
+      }
+    }
+  }
+  for (int n = 0; n < (N >> 1) * 2; n += 2) {
+    index_t i0 = ind[n + 0];
+    index_t i1 = ind[n + 1];
+    const bool valid0 = valid_mask[n + 0];
+    const bool valid1 = valid_mask[n + 1];
+    for (int k = 0; k < Kv; ++k) {
+      dst1[(n >> 1) * ld_dst1 * 2 + k * 2 + 0] = !valid0 ? scalar_t(0) : src[i0 * ld_src + k];
+      dst1[(n >> 1) * ld_dst1 * 2 + k * 2 + 1] = !valid1 ? scalar_t(0) : src[i1 * ld_src + k];
+    }
+  }
+  if (N % 2 != 0) {
+    index_t idx = ind[N - 1];
+    const bool valid = valid_mask[N - 1];
+    for (int k = 0; k < Kv; ++k) {
+      dst1[(N >> 1) * ld_dst1 * 2 + k * 2 + 0] = !valid ? scalar_t(0) : src[idx * ld_src + k];
+      dst1[(N >> 1) * ld_dst1 * 2 + k * 2 + 1] = 0;
+    }
+  }
+#endif
+}
+
+template <int64_t LAYOUT, typename scalar_t, typename index_t>
+void sparse_pack_vnni_fp8(
+    scalar_t* __restrict__ dst0,
+    scalar_t* __restrict__ dst1,
+    const uint8_t* __restrict__ fp8_storage,
+    const index_t* __restrict__ ind,
+    const bool* __restrict__ valid_mask,
+    int N,
+    int K,
+    int Kv,
+    int64_t block_size,
+    int64_t storage_block_stride_bytes,
+    int ld_dst0,
+    int ld_dst1) {
+#if defined(CPU_CAPABILITY_AVX512)
+  const int NB = div_up(N, 16);
+  const int KB = K / 32;
+  const int KBv = std::min(Kv / 32, KB);
+  for (int nb = 0; nb < NB; ++nb) {
+    const uint8_t* row_base[16];
+    const uint8_t* scale_base[16];
+    const int nb_size = std::min(N - nb * 16, 16);
+    for (int n = 0; n < nb_size; ++n) {
+      if (!valid_mask[nb * 16 + n]) {
+        row_base[n] = nullptr;
+        scale_base[n] = nullptr;
+        continue;
+      }
+      init_fp8_kvcache_tile_rows<LAYOUT>(
+          fp8_storage,
+          block_size,
+          storage_block_stride_bytes,
+          static_cast<int64_t>(ind[nb * 16 + n]),
+          row_base[n],
+          scale_base[n]);
+    }
+    auto load_vec = [&row_base, &scale_base](int n, int64_t idx, int dim_offset) {
+      UNUSED(idx);
+      return load_fp8_kvcache_32_from_row<LAYOUT>(row_base[n], scale_base[n], dim_offset);
+    };
+    for (int kb = 0; kb < KBv; ++kb) {
+      sparse_pack_vnni_Nx32<true, scalar_t, index_t>(
+          /*    dst0 */ dst0 + ((kb * 32) >> 1) * ld_dst0 * 2 + nb * 16 * 2,
+          /*    dst1 */ dst1 + ((nb * 16) >> 1) * ld_dst1 * 2 + kb * 32 * 2,
+          /*     ind */ ind + nb * 16,
+          /*   valid */ valid_mask + nb * 16,
+          /*       N */ nb_size,
+          /* dim_off */ kb * 32,
+          /* ld_dst0 */ ld_dst0,
+          /* ld_dst1 */ ld_dst1,
+          /* load_vec */ load_vec);
+    }
+    for (int kb = KBv; kb < KB; ++kb) {
+      sparse_pack_vnni_Nx32<false, scalar_t, index_t>(
+          /*    dst0 */ dst0 + ((kb * 32) >> 1) * ld_dst0 * 2 + nb * 16 * 2,
+          /*    dst1 */ dst1 + ((nb * 16) >> 1) * ld_dst1 * 2 + kb * 32 * 2,
+          /*     ind */ ind + nb * 16,
+          /*   valid */ valid_mask + nb * 16,
+          /*       N */ nb_size,
+          /* dim_off */ kb * 32,
+          /* ld_dst0 */ ld_dst0,
+          /* ld_dst1 */ ld_dst1,
+          /* load_vec */ load_vec);
+    }
+  }
+#else
+  constexpr FP8LayoutMeta meta =
+      (LAYOUT == kV32FP8Sparse) ? FP8LayoutMeta{576, 512, 64, 128, 4} : FP8LayoutMeta{512, 448, 64, 64, 7};
+  auto load_scalar = [&](int64_t token_idx, int dim) -> scalar_t {
+    const int64_t block_idx = token_idx / block_size;
+    const int64_t block_off = token_idx - block_idx * block_size;
+    const uint8_t* block_base = fp8_storage + block_idx * storage_block_stride_bytes;
+    if constexpr (LAYOUT == kV32FP8Sparse) {
+      constexpr int64_t bytes_per_token = meta.d_nope + meta.num_tiles * 4 + meta.d_rope * 2;
+      const uint8_t* token_base = block_base + block_off * bytes_per_token;
+      if (dim < meta.d_nope) {
+        const auto* scale_ptr = reinterpret_cast<const float*>(token_base + meta.d_nope);
+        return static_cast<scalar_t>(fp8_e4m3_to_float(token_base[dim]) * scale_ptr[dim / meta.tile_size]);
+      }
+      const auto* rope_ptr = reinterpret_cast<const at::BFloat16*>(token_base + meta.d_nope + meta.num_tiles * 4);
+      return rope_ptr[dim - meta.d_nope];
+    } else {
+      constexpr int64_t nope_rope_per_token = meta.d_nope + 2 * meta.d_rope;
+      constexpr int64_t scale_stride = 8;
+      const uint8_t* nope_rope = block_base + block_off * nope_rope_per_token;
+      if (dim < meta.d_nope) {
+        const uint8_t* scale_base = block_base + block_size * nope_rope_per_token + block_off * scale_stride;
+        return static_cast<scalar_t>(
+            fp8_e4m3_to_float(nope_rope[dim]) * fp8_e8m0_to_float(scale_base[dim / meta.tile_size]));
+      }
+      const auto* rope_ptr = reinterpret_cast<const at::BFloat16*>(nope_rope + meta.d_nope);
+      return rope_ptr[dim - meta.d_nope];
+    }
+  };
+
+  for (int n = 0; n < N; ++n) {
+    index_t idx = ind[n];
+    const bool valid = valid_mask[n];
+    for (int k = 0; k < K / 2; ++k) {
+      for (int d = 0; d < 2; ++d) {
+        scalar_t v = !valid ? scalar_t(0) : load_scalar(static_cast<int64_t>(idx), k * 2 + d);
+        dst0[k * ld_dst0 * 2 + n * 2 + d] = v;
+      }
+    }
+  }
+  for (int n = 0; n < (N >> 1) * 2; n += 2) {
+    index_t i0 = ind[n + 0];
+    index_t i1 = ind[n + 1];
+    const bool valid0 = valid_mask[n + 0];
+    const bool valid1 = valid_mask[n + 1];
+    for (int k = 0; k < Kv; ++k) {
+      dst1[(n >> 1) * ld_dst1 * 2 + k * 2 + 0] = !valid0 ? scalar_t(0) : load_scalar(static_cast<int64_t>(i0), k);
+      dst1[(n >> 1) * ld_dst1 * 2 + k * 2 + 1] = !valid1 ? scalar_t(0) : load_scalar(static_cast<int64_t>(i1), k);
+    }
+  }
+  if (N % 2 != 0) {
+    index_t idx = ind[N - 1];
+    const bool valid = valid_mask[N - 1];
+    for (int k = 0; k < Kv; ++k) {
+      dst1[(N >> 1) * ld_dst1 * 2 + k * 2 + 0] = !valid ? scalar_t(0) : load_scalar(static_cast<int64_t>(idx), k);
+      dst1[(N >> 1) * ld_dst1 * 2 + k * 2 + 1] = 0;
+    }
+  }
+#endif
+}
+
+template <typename scalar_t>
+inline void fmla_fill_stub(scalar_t* __restrict__ out, float val, int64_t size) {
+  using Vec = at::vec::Vectorized<scalar_t>;
+  constexpr int kVecSize = Vec::size();
+  const Vec data_vec = Vec(static_cast<scalar_t>(val));
+  int64_t d = 0;
+#pragma GCC unroll 4
+  for (; d <= size - kVecSize; d += kVecSize) {
+    data_vec.store(out + d);
+  }
+  if (size - d > 0) {
+    data_vec.store(out + d, size - d);
+  }
+}
+
+template <typename scalar_t, int BLOCK_N>
+inline void fmla_copy_stub(scalar_t* __restrict__ out, const float* __restrict__ input) {
+  static_assert(BLOCK_N % 32 == 0);
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int COLS = BLOCK_N / 16;
+  auto store = [&](auto i) {
+    constexpr int col = i % COLS;
+    if constexpr (col % 2 == 0) {
+      fVec a0 = fVec::loadu(input + col * 16);
+      fVec a1 = fVec::loadu(input + col * 16 + 16);
+      bVec out_bvec = convert_from_float_ext<scalar_t>(a0, a1);
+      out_bvec.store(out + col * 16);
+    }
+  };
+  Unroll<COLS>{}(store);
+}
+
+template <typename scalar_t>
+inline void fmla_finalize_out(scalar_t* __restrict__ out, const float* __restrict__ acc, float inv_s, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec s_fvec = fVec(inv_s);
+  int64_t d = 0;
+#pragma GCC unroll 4
+  for (; d <= size - kVecSize; d += kVecSize) {
+    fVec a0 = fVec::loadu(acc + d) * s_fvec;
+    fVec a1 = fVec::loadu(acc + d + fVec::size()) * s_fvec;
+    bVec out_bvec = convert_from_float_ext<scalar_t>(a0, a1);
+    out_bvec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(acc[d] * inv_s);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// query    : [B, S_q, H_q, D_qk]   bf16
+// k_main   : [active_main_tokens, D_qk] bf16 or original fp8 cache storage
+// indices  : [B, S_q, topk_main]        int32
+// k_extra  : optional extra KV source with its own indices
+// topk_len : [B]                   int32 or null
+// attn_sink: [H_q]                 float32 or null
+// output   : [B, S_q, H_q, D_v]    bf16
+// lse      : [B, H_q, S_q]         float32
+// ---------------------------------------------------------------------------
+
+template <typename scalar_t, typename index_t, int64_t BLOCK_N>
+void sparse_mla_decode_kernel_impl(
+    scalar_t* __restrict__ output,
+    float* __restrict__ lse_out,
+    const scalar_t* __restrict__ query,
+    const scalar_t* __restrict__ k_main,
+    const scalar_t* __restrict__ k_extra,
+    const uint8_t* __restrict__ k_main_fp8,
+    const uint8_t* __restrict__ k_extra_fp8,
+    const index_t* __restrict__ indices,
+    const index_t* __restrict__ extra_indices,
+    const int32_t* __restrict__ topk_length,
+    const int32_t* __restrict__ extra_topk_length,
+    const float* __restrict__ attn_sink,
+    scalar_t* __restrict__ buffer,
+    int64_t batches,
+    int64_t s_q,
+    int64_t num_heads,
+    int64_t head_size,
+    int64_t head_size_v,
+    bool is_fp8_kvcache,
+    int64_t fp8_layout,
+    int64_t topk_main,
+    int64_t topk_extra,
+    int64_t total_tokens_main,
+    int64_t total_tokens_extra,
+    int64_t q_strideB,
+    int64_t q_strideS,
+    int64_t q_strideH,
+    int64_t k_main_strideN,
+    int64_t k_extra_strideN,
+    int64_t k_main_block_size,
+    int64_t k_extra_block_size,
+    int64_t k_main_block_stride_bytes,
+    int64_t k_extra_block_stride_bytes,
+    int64_t idx_strideB,
+    int64_t idx_strideS,
+    int64_t extra_idx_strideB,
+    int64_t extra_idx_strideS,
+    float scaling,
+    int64_t buffer_size_per_thread) {
+  using Vec = at::vec::Vectorized<float>;
+
+  // partition heads
+  constexpr int64_t kBLOCK_H_MAX = 16;
+  const int64_t BLOCK_H = (batches * s_q) >= 16 ? kBLOCK_H_MAX : 8;
+  const int64_t num_h_blocks = div_up(num_heads, BLOCK_H);
+
+  // parallel on [B, S_q, head_block]
+  at::parallel_for(0, batches * s_q * num_h_blocks, 0, [&](int64_t begin, int64_t end) {
+    int64_t bs{0}, sq{0}, hb{0};
+    data_index_init(begin, bs, batches, sq, s_q, hb, num_h_blocks);
+
+    int tid = at::get_thread_num();
+    scalar_t* __restrict__ Btmp0 = buffer + tid * buffer_size_per_thread;  // K  packed
+    scalar_t* __restrict__ Btmp1 = Btmp0 + BLOCK_N * head_size;            // V  packed
+    // f32 V accumulator follows the bf16 packing region (reinterpret cast).
+    float* __restrict__ v_acc_local = reinterpret_cast<float*>(Btmp1 + BLOCK_N * head_size_v);
+    fmla_fill_stub(Btmp1, 0.f, BLOCK_N * head_size_v);  // initialize V padding
+
+    alignas(64) float s_i[kBLOCK_H_MAX * BLOCK_N];
+    float* __restrict__ s_delta = s_i;
+    alignas(64) scalar_t s_delta2[kBLOCK_H_MAX * BLOCK_N];
+
+    alignas(64) float s_prime[kBLOCK_H_MAX];
+    alignas(64) float m_prime[kBLOCK_H_MAX];
+
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t h_start = hb * BLOCK_H;
+      const int64_t h_end = std::min(h_start + BLOCK_H, num_heads);
+      const int64_t h_size = h_end - h_start;
+
+      const scalar_t* __restrict__ q_ptr = query + bs * q_strideB + sq * q_strideS + h_start * q_strideH;
+      const index_t* __restrict__ idx_ptr = indices + bs * idx_strideB + sq * idx_strideS;
+      const index_t* __restrict__ extra_idx_ptr =
+          extra_indices == nullptr ? nullptr : extra_indices + bs * extra_idx_strideB + sq * extra_idx_strideS;
+
+      fmla_fill_stub(s_prime, 0.f, BLOCK_H);
+      fmla_fill_stub(m_prime, -std::numeric_limits<float>::infinity(), BLOCK_H);
+      for (int64_t h = 0; h < h_size; ++h) {
+        fmla_fill_stub(v_acc_local + h * head_size_v, 0.f, head_size_v);
+      }
+
+      auto process_cache = [&](const scalar_t* __restrict__ k_ptr,
+                               const uint8_t* __restrict__ fp8_ptr,
+                               const index_t* __restrict__ cur_idx_ptr,
+                               const int32_t* __restrict__ cur_topk_length,
+                               int64_t topk_count,
+                               int64_t total_tokens,
+                               int64_t k_strideN,
+                               int64_t fp8_block_size,
+                               int64_t fp8_block_stride_bytes) {
+        if (((!is_fp8_kvcache && k_ptr == nullptr) || (is_fp8_kvcache && fp8_ptr == nullptr)) ||
+            cur_idx_ptr == nullptr || topk_count == 0) {
+          return;
+        }
+        const int64_t topk_limit = cur_topk_length != nullptr
+                                       ? std::max<int64_t>(0, std::min<int64_t>(cur_topk_length[bs], topk_count))
+                                       : topk_count;
+        if (topk_limit == 0) {
+          return;
+        }
+
+        for (int64_t n = 0; n < topk_limit; n += BLOCK_N) {
+          int64_t n_size = std::min<int64_t>(BLOCK_N, topk_limit - n);
+          const int64_t padded_n_size = div_up(int(n_size), TILE_K) * TILE_K;
+          bool valid_mask[BLOCK_N];
+          bool has_valid = false;
+          for (int64_t k = 0; k < n_size; ++k) {
+            const bool valid = is_valid_sparse_index(cur_idx_ptr[n + k], n + k, topk_limit, total_tokens);
+            valid_mask[k] = valid;
+            has_valid |= valid;
+          }
+          if (!has_valid) {
+            continue;
+          }
+
+          // Pack K (BLOCK_N rows via gather) into Btmp0 (key, vnni) and Btmp1
+          // (value, vnni). FP8 cache entries are dequantized here while packing.
+          if (is_fp8_kvcache) {
+            if (fp8_layout == kV32FP8Sparse) {
+              sparse_pack_vnni_fp8<kV32FP8Sparse, scalar_t, index_t>(
+                  /*    dst0 */ Btmp0,
+                  /*    dst1 */ Btmp1,
+                  /*     src */ fp8_ptr,
+                  /*     ind */ cur_idx_ptr + n,
+                  /*   valid */ valid_mask,
+                  /*       N */ static_cast<int>(n_size),
+                  /*       K */ static_cast<int>(head_size),
+                  /*      Kv */ static_cast<int>(head_size_v),
+                  /* blk_sz */ fp8_block_size,
+                  /* stride */ fp8_block_stride_bytes,
+                  /* ld_dst0 */ static_cast<int>(BLOCK_N),
+                  /* ld_dst1 */ static_cast<int>(head_size_v));
+            } else {
+              sparse_pack_vnni_fp8<kV4FP8Sparse, scalar_t, index_t>(
+                  /*    dst0 */ Btmp0,
+                  /*    dst1 */ Btmp1,
+                  /*     src */ fp8_ptr,
+                  /*     ind */ cur_idx_ptr + n,
+                  /*   valid */ valid_mask,
+                  /*       N */ static_cast<int>(n_size),
+                  /*       K */ static_cast<int>(head_size),
+                  /*      Kv */ static_cast<int>(head_size_v),
+                  /* blk_sz */ fp8_block_size,
+                  /* stride */ fp8_block_stride_bytes,
+                  /* ld_dst0 */ static_cast<int>(BLOCK_N),
+                  /* ld_dst1 */ static_cast<int>(head_size_v));
+            }
+          } else {
+            sparse_pack_vnni<scalar_t, index_t>(
+                /*    dst0 */ Btmp0,
+                /*    dst1 */ Btmp1,
+                /*     src */ k_ptr,
+                /*     ind */ cur_idx_ptr + n,
+                /*   valid */ valid_mask,
+                /*       N */ static_cast<int>(n_size),
+                /*       K */ static_cast<int>(head_size),
+                /*      Kv */ static_cast<int>(head_size_v),
+                /*  ld_src */ static_cast<int>(k_strideN),
+                /* ld_dst0 */ static_cast<int>(BLOCK_N),
+                /* ld_dst1 */ static_cast<int>(head_size_v));
+          }
+
+          // Q @ K
+          at::native::cpublas::brgemm(
+              /* M     */ h_size,
+              /* N     */ n_size,
+              /* K     */ head_size,
+              /* lda   */ q_strideH,
+              /* ldb   */ BLOCK_N,
+              /* ldc   */ BLOCK_N,
+              /* add_C */ false,
+              /* A     */ q_ptr,
+              /* B     */ Btmp0,
+              /* C     */ s_i);
+
+          const Vec scale_vec = Vec(scaling);
+          for (int64_t h = 0; h < h_size; ++h) {
+            float* row = s_i + h * BLOCK_N;
+            // s_i <- s_i * scale, with masking for invalid indices and tail
+            at::vec::map<float>([scale_vec](Vec x) { return x * scale_vec; }, row, row, n_size);
+
+            for (int64_t k = 0; k < n_size; ++k) {
+              if (!valid_mask[k]) {
+                row[k] = -std::numeric_limits<float>::infinity();
+              }
+            }
+
+            // online softmax update
+            float m_i = at::vec::reduce_all<float>([](Vec& x, Vec& y) { return at::vec::maximum(x, y); }, row, n_size);
+            m_i = std::max(m_i, m_prime[h]);
+
+            // Guard against the all-masked tile (m_i == -inf): keep state unchanged.
+            if (!std::isfinite(m_i)) {
+              // Still need to produce zeros for s_delta on this tile.
+              fmla_fill_stub(s_delta + h * BLOCK_N, 0.f, padded_n_size);
+              fmla_copy_stub<scalar_t, BLOCK_N>(s_delta2 + h * BLOCK_N, s_delta + h * BLOCK_N);
+              continue;
+            }
+
+            const float m_delta = std::exp(m_prime[h] - m_i);
+            at::vec::map<float>([m_i](Vec x) { return (x - Vec(m_i)).exp_u20(); }, s_delta + h * BLOCK_N, row, n_size);
+
+            s_prime[h] *= m_delta;
+            s_prime[h] +=
+                at::vec::reduce_all<float>([](Vec& x, Vec& y) { return x + y; }, s_delta + h * BLOCK_N, n_size);
+
+            m_prime[h] = m_i;
+
+            // Rescale the running V accumulator for this head.
+            float scale_m = m_delta;
+            at::vec::map<float>(
+                [scale_m](Vec x) { return x * Vec(scale_m); },
+                v_acc_local + h * head_size_v,
+                v_acc_local + h * head_size_v,
+                head_size_v);
+
+            // Pad s_delta with 0 then convert to bf16 (s_delta2)
+            fmla_fill_stub(s_delta + h * BLOCK_N + n_size, 0.f, padded_n_size - n_size);
+            fmla_copy_stub<scalar_t, BLOCK_N>(s_delta2 + h * BLOCK_N, s_delta + h * BLOCK_N);
+          }
+
+          // V' <- s_delta @ V + V'   (accumulate into v_acc_local at f32)
+          at::native::cpublas::brgemm(
+              /* M     */ h_size,
+              /* N     */ head_size_v,
+              /* K     */ padded_n_size,
+              /* lda   */ BLOCK_N,
+              /* ldb   */ head_size_v,
+              /* ldc   */ head_size_v,
+              /* add_C */ true,
+              /* A     */ s_delta2,
+              /* B     */ Btmp1,
+              /* C     */ v_acc_local);
+        }
+      };
+
+      process_cache(
+          k_main,
+          k_main_fp8,
+          idx_ptr,
+          topk_length,
+          topk_main,
+          total_tokens_main,
+          k_main_strideN,
+          k_main_block_size,
+          k_main_block_stride_bytes);
+      process_cache(
+          k_extra,
+          k_extra_fp8,
+          extra_idx_ptr,
+          extra_topk_length,
+          topk_extra,
+          total_tokens_extra,
+          k_extra_strideN,
+          k_extra_block_size,
+          k_extra_block_stride_bytes);
+
+      // Apply attention sink correction directly on the output and lse.
+      //   out *= exp(lse_no_sink) / (exp(lse_no_sink) + exp(attn_sink))
+      //        = 1 / (1 + exp(attn_sink - lse_no_sink))
+      for (int64_t h = 0; h < h_size; ++h) {
+        const int64_t hh = h_start + h;
+        const bool lonely = !std::isfinite(m_prime[h]) || s_prime[h] == 0.f;
+        float lse_val = lonely ? std::numeric_limits<float>::infinity() : (m_prime[h] + std::log(s_prime[h]));
+        float inv_s = lonely ? 0.f : (1.f / s_prime[h]);
+
+        if (!lonely && attn_sink != nullptr) {
+          const float sink = attn_sink[hh];
+          // sink scaling on output:  out *= 1 / (1 + exp(sink - lse))
+          // (lse here is the un-sinked lse).
+          const float corr = 1.f / (1.f + std::exp(sink - lse_val));
+          inv_s *= corr;
+        }
+
+        // Write final bf16 output row.
+        scalar_t* out_row =
+            output + bs * (s_q * num_heads * head_size_v) + sq * (num_heads * head_size_v) + hh * head_size_v;
+        if (lonely) {
+          fmla_fill_stub(out_row, 0.f, head_size_v);
+        } else {
+          fmla_finalize_out<scalar_t>(out_row, v_acc_local + h * head_size_v, inv_s, head_size_v);
+        }
+
+        // lse layout: (B, H_q, S_q)
+        lse_out[bs * num_heads * s_q + hh * s_q + sq] = lse_val;
+      }
+
+      data_index_step(bs, batches, sq, s_q, hb, num_h_blocks);
+    }
+    at::native::cpublas::brgemm_release();
+  });
+}
+
+}  // namespace
+
+std::tuple<at::Tensor, at::Tensor> flash_mla_with_kvcache_cpu(
+    at::Tensor& q,
+    at::Tensor& k_cache,
+    int64_t head_dim_v,
+    double softmax_scale,
+    at::Tensor& indices,                    // [B, S_q, topk]
+    std::optional<at::Tensor> topk_length,  // [B]
+    std::optional<at::Tensor> attn_sink,    // [H_q]
+    std::optional<at::Tensor> extra_k_cache,
+    std::optional<at::Tensor> extra_indices,
+    std::optional<at::Tensor> extra_topk_length,
+    bool is_fp8_kvcache,
+    int64_t fp8_layout) {
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q);
+  CHECK_DIM(4, q);  // [B, S_q, H_q, D_qk]
+  CHECK_DIM(4, k_cache);
+
+  TORCH_CHECK(
+      q.scalar_type() == at::kBFloat16,
+      "flash_mla_with_kvcache_cpu: only bfloat16 query is supported, got ",
+      q.scalar_type());
+  TORCH_CHECK(
+      indices.scalar_type() == at::kInt,
+      "flash_mla_with_kvcache_cpu: indices must be int32, got ",
+      indices.scalar_type());
+
+  const int64_t B = q.size(0);
+  const int64_t S_q = q.size(1);
+  const int64_t H_q = q.size(2);
+  const int64_t D_qk = q.size(3);
+  const int64_t D_v = head_dim_v;
+
+  TORCH_CHECK(D_qk >= D_v, "head_dim must be >= head_dim_v");
+  CHECK_EQ(indices.size(0), B);
+  CHECK_EQ(indices.size(1), S_q);
+  const int64_t topk_main = indices.size(2);
+
+  TORCH_CHECK(
+      extra_k_cache.has_value() == extra_indices.has_value(),
+      "extra_k_cache and extra_indices must be both provided or both omitted");
+  bool has_extra = extra_k_cache.has_value();
+  int64_t topk_extra = has_extra ? extra_indices.value().size(2) : 0;
+  if (has_extra) {
+    CHECK_EQ(extra_indices.value().size(0), B);
+    CHECK_EQ(extra_indices.value().size(1), S_q);
+    TORCH_CHECK(extra_indices.value().scalar_type() == at::kInt, "extra_indices must be int32");
+  }
+
+  if (topk_length.has_value()) {
+    TORCH_CHECK(topk_length.value().scalar_type() == at::kInt, "topk_length must be int32");
+    CHECK_EQ(topk_length.value().size(0), B);
+  }
+  if (extra_topk_length.has_value()) {
+    TORCH_CHECK(extra_topk_length.value().scalar_type() == at::kInt, "extra_topk_length must be int32");
+    CHECK_EQ(extra_topk_length.value().size(0), B);
+  }
+  const int32_t* tl_main_ptr = topk_length.has_value() ? topk_length.value().data_ptr<int32_t>() : nullptr;
+  const int32_t* tl_extra_ptr = extra_topk_length.has_value() ? extra_topk_length.value().data_ptr<int32_t>() : nullptr;
+
+  const int64_t capacity_main = k_cache.size(0) * k_cache.size(1);
+  int64_t capacity_extra = 0;
+  if (has_extra) {
+    capacity_extra = extra_k_cache.value().size(0) * extra_k_cache.value().size(1);
+  }
+
+  int64_t total_tokens_main = 0;
+  int64_t total_tokens_extra = 0;
+
+  total_tokens_main =
+      infer_active_total_tokens<int32_t>(indices.data_ptr<int32_t>(), B, S_q, topk_main, capacity_main, tl_main_ptr);
+  if (has_extra) {
+    total_tokens_extra = infer_active_total_tokens<int32_t>(
+        extra_indices.value().data_ptr<int32_t>(), B, S_q, topk_extra, capacity_extra, tl_extra_ptr);
+  }
+
+  const at::BFloat16* k_main_ptr = nullptr;
+  const at::BFloat16* k_extra_ptr = nullptr;
+  FP8KVCacheInfo k_main_fp8_info{nullptr, 0, 0};
+  FP8KVCacheInfo k_extra_fp8_info{nullptr, 0, 0};
+  int64_t k_main_strideN = D_qk;
+  int64_t k_extra_strideN = D_qk;
+
+  if (is_fp8_kvcache) {
+    const FP8LayoutMeta meta = get_fp8_meta(fp8_layout);
+    TORCH_CHECK(meta.d == D_qk, "FP8 layout D_qk (", meta.d, ") does not match q's last dim (", D_qk, ")");
+    TORCH_CHECK(D_v <= meta.d, "head_dim_v (", D_v, ") exceeds FP8 layout D_v capacity (", meta.d, ")");
+    k_main_fp8_info = get_fp8_kvcache_info(k_cache, fp8_layout);
+    if (has_extra) {
+      k_extra_fp8_info = get_fp8_kvcache_info(extra_k_cache.value(), fp8_layout);
+    }
+  } else {
+    TORCH_CHECK(
+        k_cache.scalar_type() == at::kBFloat16,
+        "flash_mla_with_kvcache_cpu: non-FP8 k_cache must be bfloat16, got ",
+        k_cache.scalar_type());
+    TORCH_CHECK(k_cache.is_contiguous(), "non-FP8 k_cache must be contiguous");
+    CHECK_EQ(k_cache.size(2), 1);
+    CHECK_EQ(k_cache.size(3), D_qk);
+    k_main_ptr = k_cache.data_ptr<at::BFloat16>();
+    k_main_strideN = k_cache.stride(1);
+
+    if (has_extra) {
+      TORCH_CHECK(
+          extra_k_cache.value().scalar_type() == at::kBFloat16,
+          "flash_mla_with_kvcache_cpu: non-FP8 extra_k_cache must be bfloat16, got ",
+          extra_k_cache.value().scalar_type());
+      TORCH_CHECK(extra_k_cache.value().is_contiguous(), "non-FP8 extra_k_cache must be contiguous");
+      CHECK_EQ(extra_k_cache.value().size(2), 1);
+      CHECK_EQ(extra_k_cache.value().size(3), D_qk);
+      k_extra_ptr = extra_k_cache.value().data_ptr<at::BFloat16>();
+      k_extra_strideN = extra_k_cache.value().stride(1);
+    }
+  }
+
+  // 2) allocate outputs
+  auto out = at::empty({B, S_q, H_q, D_v}, q.options());
+  auto lse = at::empty({B, H_q, S_q}, q.options().dtype(at::kFloat));
+
+  // 3) per-thread B buffer for K (head_size) + V (head_size_v) packing,
+  //    plus an f32 V accumulator of size kBLOCK_H_MAX * head_size_v.
+  constexpr int64_t BLOCK_N = 128;  // multiple of 32 for AMX brgemm
+  constexpr int64_t kBLOCK_H_MAX = 16;
+  TORCH_CHECK(D_qk % 32 == 0, "head_dim_qk must be a multiple of 32");
+  TORCH_CHECK(D_v % 32 == 0, "head_dim_v must be a multiple of 32");
+
+  const int num_threads = at::get_num_threads();
+  // Layout per thread (in bf16 elements):
+  //   [Btmp0 : BLOCK_N * D_qk] [Btmp1 : BLOCK_N * D_v] [v_acc_local : kBLOCK_H_MAX * D_v floats]
+  // f32 takes 2 bf16 elements -> multiply by 2.
+  const int64_t buffer_size_per_thread = BLOCK_N * D_qk + BLOCK_N * D_v + 2 * kBLOCK_H_MAX * D_v;
+  auto buffer = at::empty({num_threads, buffer_size_per_thread}, q.options());
+
+  // 4) strides
+  const int64_t q_strideB = q.stride(0);
+  const int64_t q_strideS = q.stride(1);
+  const int64_t q_strideH = q.stride(2);
+  const int64_t idx_strideB = indices.stride(0);
+  const int64_t idx_strideS = indices.stride(1);
+  const int64_t extra_idx_strideB = has_extra ? extra_indices.value().stride(0) : 0;
+  const int64_t extra_idx_strideS = has_extra ? extra_indices.value().stride(1) : 0;
+
+  sparse_mla_decode_kernel_impl<at::BFloat16, int32_t, BLOCK_N>(
+      out.data_ptr<at::BFloat16>(),
+      lse.data_ptr<float>(),
+      q.data_ptr<at::BFloat16>(),
+      k_main_ptr,
+      k_extra_ptr,
+      k_main_fp8_info.data,
+      k_extra_fp8_info.data,
+      indices.data_ptr<int32_t>(),
+      has_extra ? extra_indices.value().data_ptr<int32_t>() : nullptr,
+      tl_main_ptr,
+      tl_extra_ptr,
+      attn_sink.has_value() ? attn_sink.value().data_ptr<float>() : nullptr,
+      buffer.data_ptr<at::BFloat16>(),
+      B,
+      S_q,
+      H_q,
+      D_qk,
+      D_v,
+      is_fp8_kvcache,
+      fp8_layout,
+      topk_main,
+      topk_extra,
+      total_tokens_main,
+      total_tokens_extra,
+      q_strideB,
+      q_strideS,
+      q_strideH,
+      k_main_strideN,
+      k_extra_strideN,
+      k_main_fp8_info.block_size,
+      k_extra_fp8_info.block_size,
+      k_main_fp8_info.block_stride_bytes,
+      k_extra_fp8_info.block_stride_bytes,
+      idx_strideB,
+      idx_strideS,
+      extra_idx_strideB,
+      extra_idx_strideS,
+      static_cast<float>(softmax_scale),
+      buffer_size_per_thread);
+
+  return std::make_tuple(out, lse);
+}

--- a/sgl-kernel/csrc/cpu/fused_scale.cpp
+++ b/sgl-kernel/csrc/cpu/fused_scale.cpp
@@ -1,0 +1,52 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <ATen/record_function.h>
+#include <torch/all.h>
+
+#include <vector>
+
+#include "common.h"
+
+namespace {
+
+template <typename out_t, typename weight_t, typename scale_t>
+void fused_scale_cpu_impl(
+    at::Tensor& out, const at::Tensor& weight, const at::Tensor& q_scale, double out_scale, int64_t numel) {
+  const weight_t* __restrict__ weight_ptr = weight.const_data_ptr<weight_t>();
+  const scale_t* __restrict__ q_scale_ptr = q_scale.const_data_ptr<scale_t>();
+  out_t* __restrict__ out_ptr = out.mutable_data_ptr<out_t>();
+  const float out_scale_f = static_cast<float>(out_scale);
+
+  at::parallel_for(0, numel, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const float value = static_cast<float>(weight_ptr[i]) * out_scale_f * static_cast<float>(q_scale_ptr[i]);
+      out_ptr[i] = static_cast<out_t>(value);
+    }
+  });
+}
+
+}  // namespace
+
+at::Tensor fused_scale_cpu(at::Tensor& weight, double out_scale, at::Tensor& q_scale) {
+  RECORD_FUNCTION("sgl-kernel::fused_scale_cpu", std::vector<c10::IValue>({weight, q_scale}));
+
+  CHECK_INPUT(weight);
+  CHECK_INPUT(q_scale);
+  CHECK_DIM(2, weight);
+  TORCH_CHECK(q_scale.numel() == weight.numel(), "q_scale must have the same number of elements as weight");
+  TORCH_CHECK(
+      weight.scalar_type() == at::kFloat || weight.scalar_type() == at::kHalf || weight.scalar_type() == at::kBFloat16,
+      "weight must be float32, float16, or bfloat16");
+  TORCH_CHECK(q_scale.scalar_type() == at::kFloat, "q_scale must be float32");
+
+  const int64_t B = weight.size(0);
+  const int64_t H = weight.size(1);
+  const int64_t numel = B * H;
+  at::Tensor out = at::empty({B, H, 1}, weight.options().dtype(at::kFloat));
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, weight.scalar_type(), "fused_scale_cpu_weight", [&] {
+    fused_scale_cpu_impl<float, scalar_t, float>(out, weight, q_scale, out_scale, numel);
+  });
+
+  return out;
+}

--- a/sgl-kernel/csrc/cpu/gemm.cpp
+++ b/sgl-kernel/csrc/cpu/gemm.cpp
@@ -161,6 +161,21 @@ inline void copy_add_stub(
   }
 }
 
+inline void
+copy_add_stub(float* __restrict__ out, const float* __restrict__ input, const float* __restrict__ bias, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - fVec::size(); d += fVec::size()) {
+    fVec data = fVec::loadu(input + d) + fVec::loadu(bias + d);
+    data.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = input[d] + bias[d];
+  }
+}
+
 template <typename scalar_t, bool has_bias>
 inline void scalar_sigmoid_and_mul(
     scalar_t* __restrict__ out,
@@ -581,6 +596,66 @@ void weight_packed_linear_kernel_impl(
   });
 }
 
+// bf16/fp16 input, bf16/fp16 weight (vnni packed) -> fp32 output
+template <typename scalar_t>
+void weight_packed_linear_fp32_out_kernel_impl(
+    float* __restrict__ out,
+    const scalar_t* __restrict__ mat1,
+    const scalar_t* __restrict__ mat2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t mat1_strideM,
+    int64_t out_strideM) {
+  constexpr int64_t BLOCK_M = block_size_m();
+  constexpr int64_t BLOCK_N = block_size_n();
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
+    parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+      alignas(64) float Ctmp[BLOCK_M * BLOCK_N];
+
+      loop_2d<scalar_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+        int64_t mb_start = mb * BLOCK_M;
+        int64_t mb_size = std::min(M - mb_start, BLOCK_M);
+        int64_t nb_start = nb * BLOCK_N;
+        int64_t nb_size = std::min(N - nb_start, BLOCK_N);
+
+        // bf16 * bf16 -> fp32 accumulation via brgemm
+        at::native::cpublas::brgemm(
+            mb_size,
+            nb_size,
+            K,
+            mat1_strideM,
+            nb_size,
+            BLOCK_N,
+            /* add_C */ false,
+            mat1 + mb_start * mat1_strideM,
+            mat2 + nb_start * K,
+            Ctmp);
+
+        // copy Ctmp (fp32) directly to fp32 output
+        for (int64_t m = 0; m < mb_size; ++m) {
+          if constexpr (has_bias) {
+            copy_add_stub(
+                out + mb_start * out_strideM + nb_start + m * out_strideM,
+                Ctmp + m * BLOCK_N,
+                bias + nb_start,
+                nb_size);
+          } else {
+            std::memcpy(
+                out + mb_start * out_strideM + nb_start + m * out_strideM, Ctmp + m * BLOCK_N, nb_size * sizeof(float));
+          }
+        }
+      });
+
+      at::native::cpublas::brgemm_release();
+    });
+  });
+}
+
 }  // anonymous namespace
 
 // tinygemm interface
@@ -727,8 +802,12 @@ at::Tensor convert_scale_packed(at::Tensor& scale) {
 // bias : [N]
 // out  : [M, N]
 //
-at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni) {
+at::Tensor weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype) {
   auto packed_w = is_vnni ? mat2 : convert_weight_packed(mat2);
   bool use_fma_gemm = false;
   if (packed_w.scalar_type() == at::kFloat) {
@@ -748,7 +827,10 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
   }
 
   auto dispatch_type = mat1.scalar_type();
-  auto out = at::empty({M, N}, mat1.options());
+  auto out_scalar_type = out_dtype.value_or(dispatch_type);
+  bool fp32_out = (out_scalar_type == at::kFloat) && (dispatch_type != at::kFloat);
+
+  auto out = at::empty({M, N}, mat1.options().dtype(out_scalar_type));
   // strides
   int64_t out_strideM = out.stride(0);
   int64_t mat1_strideM = mat1.stride(0);
@@ -760,22 +842,10 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
     bias_data = bias.value().data_ptr<float>();
   }
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
-    if (use_fma_gemm) {
-      weight_packed_linear_kernel_impl<scalar_t>(
-          out.data_ptr<scalar_t>(),
-          mat1.data_ptr<scalar_t>(),
-          packed_w.data_ptr<float>(),
-          bias_data,
-          nullptr,
-          M,
-          N,
-          K,
-          mat1_strideM,
-          out_strideM);
-    } else {
-      weight_packed_linear_kernel_impl<scalar_t>(
-          out.data_ptr<scalar_t>(),
+  if (fp32_out && !use_fma_gemm) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_fp32_out", [&] {
+      weight_packed_linear_fp32_out_kernel_impl<scalar_t>(
+          out.data_ptr<float>(),
           mat1.data_ptr<scalar_t>(),
           packed_w.data_ptr<scalar_t>(),
           bias_data,
@@ -784,8 +854,35 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
           K,
           mat1_strideM,
           out_strideM);
-    }
-  });
+    });
+  } else {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
+      if (use_fma_gemm) {
+        weight_packed_linear_kernel_impl<scalar_t>(
+            out.data_ptr<scalar_t>(),
+            mat1.data_ptr<scalar_t>(),
+            packed_w.data_ptr<float>(),
+            bias_data,
+            nullptr,
+            M,
+            N,
+            K,
+            mat1_strideM,
+            out_strideM);
+      } else {
+        weight_packed_linear_kernel_impl<scalar_t>(
+            out.data_ptr<scalar_t>(),
+            mat1.data_ptr<scalar_t>(),
+            packed_w.data_ptr<scalar_t>(),
+            bias_data,
+            M,
+            N,
+            K,
+            mat1_strideM,
+            out_strideM);
+      }
+    });
+  }
 
   return out;
 }

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -67,7 +67,28 @@ inline int64_t get_row_size(int64_t K, bool use_int8_w8a8) {
   return use_int8_w8a8 ? K + sizeof(int32_t) : K;
 }
 
-enum class CPUQuantMethod : int64_t { BF16 = 0, INT8_W8A8 = 1, FP8_W8A16 = 2, INT4_W4A8 = 3 };
+enum class CPUAcTMethod : int { silu_and_mul = 0, swiglu = 1, clamped_silu_and_mul = 2 };
+
+// Select activation based on which clamp/scale parameters the caller provided:
+//   limit + alpha ⇒ gpt-oss swiglu.
+//   limit only    ⇒ DSV4-2604B clamped silu_and_mul.
+//   neither       ⇒ plain silu_and_mul.
+inline CPUAcTMethod select_act_func(const std::optional<double>& alpha, const std::optional<double>& limit) {
+  if (!limit.has_value()) {
+    return CPUAcTMethod::silu_and_mul;
+  }
+  return alpha.has_value() ? CPUAcTMethod::swiglu : CPUAcTMethod::clamped_silu_and_mul;
+}
+
+constexpr bool operator==(CPUAcTMethod a, int b) {
+  return static_cast<int>(a) == b;
+}
+
+constexpr bool operator==(int a, CPUAcTMethod b) {
+  return a == static_cast<int>(b);
+}
+
+enum class CPUQuantMethod : int64_t { BF16 = 0, INT8_W8A8 = 1, FP8_W8A16 = 2, INT4_W4A8 = 3, MXFP4 = 4 };
 
 constexpr bool operator==(CPUQuantMethod a, int64_t b) {
   return static_cast<int64_t>(a) == b;
@@ -124,9 +145,9 @@ void fused_experts_int8_kernel_impl(
     int64_t topk,
     int64_t num_tokens_post_pad);
 
-// moe implementations for fp8 w8a16
-template <typename scalar_t>
-void fused_experts_fp8_kernel_impl(
+// moe implementations for fp8 w8a16 and mxfp4
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void fused_experts_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
@@ -135,10 +156,12 @@ void fused_experts_fp8_kernel_impl(
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const float* __restrict__ w1_bias,
+    const float* __restrict__ w2_bias,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const float* __restrict__ topk_weights,
@@ -150,7 +173,11 @@ void fused_experts_fp8_kernel_impl(
     int64_t K,
     int64_t E,
     int64_t topk,
-    int64_t num_tokens_post_pad);
+    int64_t num_tokens_post_pad,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func,
+    bool with_bias);
 
 // shared expert implementation for int8 w8a8
 template <typename scalar_t>
@@ -202,25 +229,29 @@ void fused_experts_int4_w4a8_kernel_impl(
     int64_t topk,
     int64_t num_tokens_post_pad);
 
-template <typename scalar_t>
-void shared_expert_fp8_kernel_impl(
+// moe implementations for fp8 w8a16 and mxfp4
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void shared_expert_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const scalar_t* __restrict__ fused_experts_out,
     float routed_scaling_factor,
     int64_t M,
     int64_t N,
-    int64_t K);
+    int64_t K,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func);
 
 // tinygemm interface
 template <typename scalar_t>
@@ -261,6 +292,7 @@ void tinygemm_kernel(
     scalar_t* __restrict__ C,
     scalar_t* __restrict__ Btmp,
     float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
     const float* __restrict__ scale,
     int64_t M,
     int64_t N,
@@ -288,6 +320,26 @@ void tinygemm_kernel(
     int64_t ldb,
     int64_t ldc,
     bool brg);
+
+// mxfp4
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    scalar_t* __restrict__ Btmp,
+    float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
+    const uint8_t* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg,
+    int64_t block_size_K,
+    bool do_unpack = true);
 
 template <typename scalar_t>
 void tinygemm_kernel(

--- a/sgl-kernel/csrc/cpu/gemm_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8.cpp
@@ -62,6 +62,23 @@ inline void copy_mul_stub(scalar_t* __restrict__ out, const float* __restrict__ 
   }
 }
 
+template <>
+inline void
+copy_add_stub(float* __restrict__ out, const float* __restrict__ input, const float* __restrict__ bias, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = fVec::size();
+
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    fVec data = fVec::loadu(input + d) + fVec::loadu(bias + d);
+    data.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = input[d] + bias[d];
+  }
+}
+
 inline void unpack_B(
     at::BFloat16* __restrict__ Btmp,
     const at::Float8_e4m3fn* __restrict__ packed_B,
@@ -913,6 +930,7 @@ void tinygemm_kernel(
     scalar_t* __restrict__ C,
     scalar_t* __restrict__ Btmp,
     float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
     const float* __restrict__ scale,
     int64_t M,
     int64_t N,
@@ -923,6 +941,11 @@ void tinygemm_kernel(
     bool brg,
     int64_t block_size_K,
     bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
   tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
       A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
@@ -952,6 +975,7 @@ void tinygemm_kernel(
     scalar_t* __restrict__ C,
     scalar_t* __restrict__ Btmp,
     float* __restrict__ Ctmp,
+    const float* __restrict__ Bbias,
     const uint8_t* __restrict__ scale,
     int64_t M,
     int64_t N,
@@ -962,8 +986,66 @@ void tinygemm_kernel(
     bool brg,
     int64_t block_size_K,
     bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
   tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
       A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+}
+
+// tinygemm interface
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const at::Float8_e4m3fn* __restrict__ B,
+    float* __restrict__ C,
+    scalar_t* __restrict__ Btmp,
+    const float* __restrict__ Bbias,
+    const float* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg,
+    int64_t block_size_K,
+    bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
+  tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+}
+
+template <typename scalar_t>
+void tinygemm_kernel(
+    const scalar_t* __restrict__ A,
+    const uint8_t* __restrict__ B,
+    float* __restrict__ C,
+    scalar_t* __restrict__ Btmp,
+    const float* __restrict__ Bbias,
+    const uint8_t* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    bool brg,
+    int64_t block_size_K,
+    bool do_unpack) {
+  if (Bbias != nullptr) {
+    tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+    return;
+  }
+  tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
 
 #define INSTANTIATE_TINYGEMM_TEMPLATE(TYPE_A, TYPE_B, TYPE_S) \
@@ -973,6 +1055,7 @@ void tinygemm_kernel(
       TYPE_A* __restrict__ C,                                 \
       TYPE_A* __restrict__ Btmp,                              \
       float* __restrict__ Ctmp,                               \
+      const float* __restrict__ Bbias,                        \
       const TYPE_S* __restrict__ scale,                       \
       int64_t M,                                              \
       int64_t N,                                              \

--- a/sgl-kernel/csrc/cpu/hadamard.cpp
+++ b/sgl-kernel/csrc/cpu/hadamard.cpp
@@ -1,0 +1,205 @@
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+using fVec = at::vec::Vectorized<float>;
+
+// ── Unified scalar FWHT ──
+// For float: buf unused, work=out; casts are no-ops.
+// For bf16/f16: work=buf as scratch; casts do dtype conversion.
+template <typename scalar_t>
+inline void fwht_row_scalar(
+    scalar_t* __restrict__ out, const scalar_t* __restrict__ in, float* __restrict__ buf, int64_t n, float scale) {
+  if (n == 1) {
+    out[0] = static_cast<scalar_t>(static_cast<float>(in[0]) * scale);
+    return;
+  }
+  if (n == 2) {
+    float a = static_cast<float>(in[0]), b = static_cast<float>(in[1]);
+    out[0] = static_cast<scalar_t>((a + b) * scale);
+    out[1] = static_cast<scalar_t>((a - b) * scale);
+    return;
+  }
+  float* work;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    work = out;
+  } else {
+    work = buf;
+  }
+  // h=1: read from in → work
+  for (int64_t j = 0; j < n; j += 2) {
+    float a = static_cast<float>(in[j]), b = static_cast<float>(in[j + 1]);
+    work[j] = a + b;
+    work[j + 1] = a - b;
+  }
+  // h=2..n/4: in-place on work
+  const int64_t last_h = n >> 1;
+  for (int64_t h = 2; h < last_h; h <<= 1)
+    for (int64_t j = 0; j < n; j += 2 * h)
+      for (int64_t k = 0; k < h; ++k) {
+        float a = work[j + k], b = work[j + k + h];
+        work[j + k] = a + b;
+        work[j + k + h] = a - b;
+      }
+  // h=n/2: butterfly + scale → out
+  for (int64_t k = 0; k < last_h; ++k) {
+    float a = work[k], b = work[k + last_h];
+    out[k] = static_cast<scalar_t>((a + b) * scale);
+    out[k + last_h] = static_cast<scalar_t>((a - b) * scale);
+  }
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+// Phase-1: in-register butterflies h=1,2,4,8.
+// Requires permute/blend intrinsics with no Vectorized equivalent.
+static inline __m512 fwht_phase1_fused(__m512 v) {
+  __m512 p, s, d;
+  p = _mm512_permute_ps(v, 0b10'11'00'01);  // h=1
+  s = _mm512_add_ps(v, p);
+  d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xAAAA, s, d);
+  p = _mm512_permute_ps(v, 0b01'00'11'10);  // h=2
+  s = _mm512_add_ps(v, p);
+  d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xCCCC, s, d);
+  p = _mm512_permutexvar_ps(                                         // h=4
+      _mm512_set_epi32(11,10,9,8, 15,14,13,12, 3,2,1,0, 7,6,5,4), v);
+  s = _mm512_add_ps(v, p);
+  d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xF0F0, s, d);
+  p = _mm512_permutexvar_ps(                                         // h=8
+      _mm512_set_epi32(7,6,5,4, 3,2,1,0, 15,14,13,12, 11,10,9,8), v);
+  s = _mm512_add_ps(v, p);
+  d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xFF00, s, d);
+  return v;
+}
+
+// fVec wrapper for fwht_phase1_fused
+static inline fVec fwht_phase1(fVec v) {
+  return fVec(fwht_phase1_fused(__m512(v)));
+}
+
+// ── Vectorized dtype conversion (16 elements) ──
+// For float: identity load/store. For bf16/f16: intrinsic conversion.
+template <typename scalar_t>
+static inline fVec load_cvt(const scalar_t*);
+template <typename scalar_t>
+static inline void store_cvt(scalar_t*, fVec);
+
+template <>
+inline fVec load_cvt<float>(const float* p) {
+  return fVec::loadu(p);
+}
+template <>
+inline fVec load_cvt<at::BFloat16>(const at::BFloat16* p) {
+  return fVec(CVT_BF16_TO_FP32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(p))));
+}
+template <>
+inline fVec load_cvt<at::Half>(const at::Half* p) {
+  return fVec(CVT_FP16_TO_FP32(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(p))));
+}
+template <>
+inline void store_cvt<float>(float* p, fVec v) {
+  v.store(p);
+}
+template <>
+inline void store_cvt<at::BFloat16>(at::BFloat16* p, fVec v) {
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(p), (__m256i)_mm512_cvtneps_pbh(__m512(v)));
+}
+template <>
+inline void store_cvt<at::Half>(at::Half* p, fVec v) {
+  _mm256_storeu_si256(
+      reinterpret_cast<__m256i*>(p), _mm512_cvtps_ph(__m512(v), _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+}
+
+// Phase-2: h=16..last_h-1 vectorized butterflies on float buffer.
+static inline void fwht_phase2(float* __restrict__ buf, int64_t n, int64_t last_h) {
+  for (int64_t h = 16; h < last_h; h <<= 1)
+    for (int64_t j = 0; j < n; j += 2 * h)
+      for (int64_t k = 0; k < h; k += fVec::size()) {
+        fVec a = fVec::loadu(buf + j + k);
+        fVec b = fVec::loadu(buf + j + k + h);
+        (a + b).store(buf + j + k);
+        (a - b).store(buf + j + k + h);
+      }
+}
+
+// Unified AVX-512 FWHT with optional dtype conversion.
+// For float: load_cvt/store_cvt are identity, work=out.
+// For bf16/f16: load_cvt/store_cvt handle conversion, work=buf.
+template <typename scalar_t>
+inline void fwht_row_avx512(
+    scalar_t* __restrict__ out, const scalar_t* __restrict__ in, float* __restrict__ buf, int64_t n, float scale) {
+  fVec sv(scale);
+  if (n == 16) {
+    store_cvt(out, fwht_phase1(load_cvt(in)) * sv);
+    return;
+  }
+
+  float* work;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    work = out;
+  } else {
+    work = buf;
+  }
+
+  // Phase 1: load (+ convert) → fused butterflies → work
+  for (int64_t j = 0; j < n; j += fVec::size())
+    fwht_phase1(load_cvt(in + j)).store(work + j);
+
+  // Phase 2: h=16..n/4 butterflies on work
+  const int64_t last_h = n >> 1;
+  fwht_phase2(work, n, last_h);
+
+  // Last stage: butterfly + scale (+ convert) → out
+  for (int64_t k = 0; k < last_h; k += fVec::size()) {
+    fVec a = fVec::loadu(work + k);
+    fVec b = fVec::loadu(work + k + last_h);
+    store_cvt(out + k, (a + b) * sv);
+    store_cvt(out + k + last_h, (a - b) * sv);
+  }
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+template <typename scalar_t>
+void fast_hadamard_transform_kernel_impl(
+    scalar_t* __restrict__ output, const scalar_t* __restrict__ input, int64_t rows, int64_t n, float scale) {
+  at::parallel_for(0, rows, 0, [&](int64_t begin, int64_t end) {
+    float* buf = nullptr;
+    std::vector<float> scratch;
+    if constexpr (!std::is_same_v<scalar_t, float>) {
+      scratch.resize(n);
+      buf = scratch.data();
+    }
+    for (int64_t r = begin; r < end; ++r) {
+#if defined(CPU_CAPABILITY_AVX512)
+      if (n >= 16)
+        fwht_row_avx512(output + r * n, input + r * n, buf, n, scale);
+      else
+#endif
+        fwht_row_scalar(output + r * n, input + r * n, buf, n, scale);
+    }
+  });
+}
+
+}  // anonymous namespace
+
+at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale) {
+  CHECK_INPUT(x);
+  const int64_t n = x.size(-1);
+  TORCH_CHECK(n > 0 && (n & (n - 1)) == 0, "fast_hadamard_transform: last dim must be a power of 2, got ", n);
+
+  const int64_t rows = x.numel() / n;
+  auto out = at::empty_like(x);
+  const float s = static_cast<float>(scale);
+
+  CPU_DISPATCH_FLOATING_TYPES(x.scalar_type(), "fast_hadamard_transform_cpu", [&] {
+    fast_hadamard_transform_kernel_impl<scalar_t>(out.data_ptr<scalar_t>(), x.data_ptr<scalar_t>(), rows, n, s);
+  });
+
+  return out;
+}

--- a/sgl-kernel/csrc/cpu/mhc.cpp
+++ b/sgl-kernel/csrc/cpu/mhc.cpp
@@ -1,0 +1,1034 @@
+// MHC (Multi-Head Channel) fused kernels for Xeon CPU.
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+// Loop tiling heuristics.
+constexpr int64_t kMhcTileCacheBudgetBytes = 36 * 1024;
+constexpr int64_t kMhcDefaultTokenBlock = 32;
+
+inline int64_t round_to_nearest_multiple(int64_t value, int64_t multiple) {
+  return ((value + multiple / 2) / multiple) * multiple;
+}
+
+inline int64_t choose_t_block(int64_t /*T*/) {
+  return kMhcDefaultTokenBlock;
+}
+
+inline int64_t choose_k_block(int64_t weight_rows, int64_t vec_size, int64_t max_block) {
+  const int64_t bytes_per_k = (weight_rows + 1) * static_cast<int64_t>(sizeof(float));
+  const int64_t raw = std::max(vec_size, kMhcTileCacheBudgetBytes / bytes_per_k);
+  const int64_t rounded = round_to_nearest_multiple(raw, vec_size);
+  return std::max(vec_size, std::min(max_block, rounded));
+}
+
+template <typename func_t>
+inline void parallel_mhc_phase1(int64_t n_t_blocks, int64_t n_k_blocks, const func_t& f) {
+  const int64_t nth = static_cast<int64_t>(at::get_num_threads());
+  if (n_t_blocks >= nth) {
+    // Large prefill: enough token blocks exist to fill all workers.
+    parallel_2d_tiled(static_cast<int>(n_t_blocks), static_cast<int>(n_k_blocks), static_cast<int>(nth), 1, f);
+  } else {
+    // Decode / small T: split both T and K to expose enough parallel tasks.
+    parallel_2d(static_cast<int>(n_t_blocks), static_cast<int>(n_k_blocks), f);
+  }
+}
+
+// In-place Sinkhorn on a row-major [hc, hc] matrix.
+inline void
+sinkhorn_inplace(float* __restrict__ comb_matrix, int hc, int sinkhorn_iters, float eps, float* __restrict__ scratch) {
+  float* const row_sum = scratch;
+  float* const col_sum = scratch + hc;
+
+  // First iteration.
+  for (int r = 0; r < hc; ++r) {
+    const float* row = comb_matrix + r * hc;
+    float row_acc = 0.f;
+#pragma GCC unroll 4
+    for (int c = 0; c < hc; ++c)
+      row_acc += row[c];
+    row_sum[r] = row_acc;
+  }
+  for (int r = 0; r < hc; ++r) {
+    const float row_inv = 1.0f / row_sum[r];
+    float* row = comb_matrix + r * hc;
+#pragma GCC unroll 4
+    for (int c = 0; c < hc; ++c)
+      row[c] = row[c] * row_inv + eps;
+  }
+  for (int c = 0; c < hc; ++c) {
+    float col_acc = 0.f;
+#pragma GCC unroll 4
+    for (int r = 0; r < hc; ++r)
+      col_acc += comb_matrix[r * hc + c];
+    col_sum[c] = col_acc;
+  }
+  for (int r = 0; r < hc; ++r)
+#pragma GCC unroll 4
+    for (int c = 0; c < hc; ++c)
+      comb_matrix[r * hc + c] /= (col_sum[c] + eps);
+
+  // Remaining iterations.
+  for (int iter = 1; iter < sinkhorn_iters; ++iter) {
+    for (int r = 0; r < hc; ++r) {
+      const float* row = comb_matrix + r * hc;
+      float row_acc = 0.f;
+#pragma GCC unroll 4
+      for (int c = 0; c < hc; ++c)
+        row_acc += row[c];
+      row_sum[r] = row_acc;
+    }
+    for (int r = 0; r < hc; ++r) {
+      const float row_inv = 1.0f / (row_sum[r] + eps);
+      float* row = comb_matrix + r * hc;
+#pragma GCC unroll 4
+      for (int c = 0; c < hc; ++c)
+        row[c] *= row_inv;
+    }
+    for (int c = 0; c < hc; ++c) {
+      float col_acc = 0.f;
+#pragma GCC unroll 4
+      for (int r = 0; r < hc; ++r)
+        col_acc += comb_matrix[r * hc + c];
+      col_sum[c] = col_acc;
+    }
+    for (int r = 0; r < hc; ++r)
+#pragma GCC unroll 4
+      for (int c = 0; c < hc; ++c)
+        comb_matrix[r * hc + c] /= (col_sum[c] + eps);
+  }
+}
+
+// Parse mixes -> pre/post/comb and run sinkhorn on comb.
+inline void parse_mixes_and_sinkhorn(
+    float* __restrict__ pre_gate,     // [hc] output
+    float* __restrict__ post_gate,    // [hc] output
+    float* __restrict__ comb_matrix,  // [hc*hc] output (row-major)
+    const float* __restrict__ mixes,  // [mix_hc] input
+    float s0,
+    float s1,
+    float s2,
+    const float* __restrict__ hc_base,
+    int sinkhorn_iters,
+    float eps,
+    int hc,
+    float* __restrict__ scratch) {
+#pragma GCC unroll 4
+  for (int h = 0; h < hc; ++h) {
+    const float v = mixes[h] * s0 + hc_base[h];
+    pre_gate[h] = 1.f / (1.f + std::exp(-v)) + eps;
+  }
+#pragma GCC unroll 4
+  for (int h = 0; h < hc; ++h) {
+    const float v = mixes[hc + h] * s1 + hc_base[hc + h];
+    post_gate[h] = 2.f / (1.f + std::exp(-v));
+  }
+  float* const row_max = scratch;
+  for (int r = 0; r < hc; ++r)
+    row_max[r] = -std::numeric_limits<float>::infinity();
+  for (int r = 0; r < hc; ++r) {
+    float* row = comb_matrix + r * hc;
+    for (int c = 0; c < hc; ++c) {
+      const int idx = r * hc + c;
+      const float v = mixes[2 * hc + idx] * s2 + hc_base[2 * hc + idx];
+      row[c] = v;
+      if (v > row_max[r]) row_max[r] = v;
+    }
+  }
+  for (int r = 0; r < hc; ++r) {
+    float* row = comb_matrix + r * hc;
+#pragma GCC unroll 4
+    for (int c = 0; c < hc; ++c)
+      row[c] = std::exp(row[c] - row_max[r]);
+  }
+
+  sinkhorn_inplace(comb_matrix, hc, sinkhorn_iters, eps, scratch + hc);
+}
+
+template <typename scalar_t>
+static void hc_post_fuse_impl(
+    scalar_t* __restrict__ out,             // [T, hc, d]  output
+    const scalar_t* __restrict__ x,         // [T, d]      input
+    const scalar_t* __restrict__ residual,  // [T, hc, d]  input
+    const float* __restrict__ post,         // [T, hc]     float32
+    const float* __restrict__ comb,         // [T, hc, hc] float32 row-major
+    int64_t T,
+    int64_t d,
+    int hc) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int64_t kVecSize = bVec::size();
+
+  const int64_t nthreads = at::get_num_threads();
+  const int64_t max_splits = std::max(int64_t(1), d / kVecSize);
+  const int64_t token_head_tasks = T * hc;
+  const int64_t k_splits = (token_head_tasks >= nthreads) ? int64_t(1) : std::min(nthreads, max_splits);
+  const int64_t k_chunk = (d + k_splits - 1) / k_splits;
+
+  const int64_t fvec_floats = static_cast<int64_t>(sizeof(fVec) / sizeof(float));
+  auto comb_fvec_storage = at::empty({nthreads * hc * fvec_floats}, at::kFloat);
+  fVec* const comb_fvec_base = reinterpret_cast<fVec*>(comb_fvec_storage.data_ptr<float>());
+
+  at::parallel_for(0, T * hc * k_splits, 0, [&](int64_t begin, int64_t end) {
+    const int tid = static_cast<int>(at::get_thread_num());
+    fVec* const comb_fvec = comb_fvec_base + tid * hc;
+
+    for (int64_t idx = begin; idx < end; ++idx) {
+      const int64_t task = idx / k_splits;
+      const int64_t split_id = idx % k_splits;
+      const int64_t t = task / hc;
+      const int h = static_cast<int>(task % hc);
+      const int64_t k0 = split_id * k_chunk;
+      const int64_t k1 = std::min(k0 + k_chunk, d);
+
+      const float post_val = post[t * hc + h];
+      const float* comb_t = comb + t * hc * hc;
+      const scalar_t* x_t = x + t * d;
+      const scalar_t* res_t = residual + t * hc * d;
+      scalar_t* out_th = out + (t * hc + h) * d;
+
+      const fVec post_fvec(post_val);
+#pragma GCC unroll 4
+      for (int i = 0; i < hc; ++i)
+        comb_fvec[i] = fVec(comb_t[i * hc + h]);
+
+      int64_t k;
+      // bf16: convert and accumulate
+      for (k = k0; k <= k1 - kVecSize; k += kVecSize) {
+        fVec acc0, acc1;
+        std::tie(acc0, acc1) = at::vec::convert_to_float(bVec::loadu(x_t + k));
+        acc0 = post_fvec * acc0;
+        acc1 = post_fvec * acc1;
+#pragma GCC unroll 4
+        for (int i = 0; i < hc; ++i) {
+          fVec r0, r1;
+          std::tie(r0, r1) = at::vec::convert_to_float(bVec::loadu(res_t + i * d + k));
+          acc0 += comb_fvec[i] * r0;
+          acc1 += comb_fvec[i] * r1;
+        }
+        at::vec::convert_from_float<scalar_t>(acc0, acc1).store(out_th + k);
+      }
+      if (k < k1) {
+        const int64_t rem = k1 - k;
+        fVec acc0, acc1;
+        std::tie(acc0, acc1) = at::vec::convert_to_float(bVec::loadu(x_t + k, rem));
+        acc0 = post_fvec * acc0;
+        acc1 = post_fvec * acc1;
+#pragma GCC unroll 4
+        for (int i = 0; i < hc; ++i) {
+          fVec r0, r1;
+          std::tie(r0, r1) = at::vec::convert_to_float(bVec::loadu(res_t + i * d + k, rem));
+          acc0 += comb_fvec[i] * r0;
+          acc1 += comb_fvec[i] * r1;
+        }
+        at::vec::convert_from_float<scalar_t>(acc0, acc1).store(out_th + k, rem);
+      }
+    }
+  });
+}
+
+// Fused hc_pre path.
+template <typename scalar_t>
+static void hc_pre_fuse_impl(
+    scalar_t* __restrict__ y,            // [T, d]      bf16 output
+    float* __restrict__ post_out,        // [T, hc]     float32 output
+    float* __restrict__ comb_out,        // [T, hc*hc]  float32 output
+    const scalar_t* __restrict__ x,      // [T, hc, d]  bf16 input
+    const float* __restrict__ hc_fn,     // [mix_hc, hc_d] float32 row-major
+    const float* __restrict__ hc_scale,  // [3]
+    const float* __restrict__ hc_base,   // [mix_hc]
+    int64_t T,
+    int64_t d,
+    int hc,
+    int sinkhorn_iters,
+    float hc_eps,
+    float norm_eps) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int64_t kVecSize = bVec::size();   // 32 bf16
+  constexpr int64_t kFVecSize = fVec::size();  // 16 fp32
+  constexpr int64_t kSmallTKBlockCap = 128;
+  constexpr int64_t kLargeTKBlockCap = 256;
+  constexpr int64_t kDVecsPerBlock = 16;
+  constexpr int64_t kCacheKBlockCap = kLargeTKBlockCap;
+  constexpr int64_t MAX_K_VECS = kCacheKBlockCap / kVecSize;
+  const int mix_hc = (2 + hc) * hc;
+  const int64_t hc_d = hc * d;
+  const float s0 = hc_scale[0], s1 = hc_scale[1], s2 = hc_scale[2];
+
+  const int64_t T_BLOCK = choose_t_block(T);
+  const int64_t num_threads = static_cast<int64_t>(at::get_num_threads());
+  const int64_t K_BLOCK_CAP = (T >= num_threads) ? kLargeTKBlockCap : kSmallTKBlockCap;
+  const int64_t K_BLOCK = choose_k_block(mix_hc, kVecSize, K_BLOCK_CAP);
+  TORCH_CHECK(
+      K_BLOCK <= K_BLOCK_CAP && K_BLOCK_CAP <= kCacheKBlockCap && K_BLOCK % kVecSize == 0,
+      "hc_pre_fuse_impl: K_BLOCK must be within capacity and a multiple of vector size");
+  const int64_t D_BLOCK = kDVecsPerBlock * kVecSize;
+
+  const int64_t n_t_blocks = div_up(T, T_BLOCK);
+  const int64_t n_k_blocks = div_up(hc_d, K_BLOCK);
+
+  // Partial buffer: [n_t_blocks, n_k_blocks, T_BLOCK, 1+mix_hc]
+  const int64_t partial_stride = 1 + mix_hc;
+  auto partials_tensor = at::empty({n_t_blocks * n_k_blocks * T_BLOCK * partial_stride}, at::kFloat);
+  float* const partials = partials_tensor.data_ptr<float>();
+
+  // Per-thread scratch: [mix_buffer[mix_hc] | pre_gate[hc] |
+  //                      post_gate[hc] | comb_matrix[hc*hc] | sinkhorn_scratch[3*hc]]
+  const int64_t per_thread_scratch = mix_hc + hc + hc + hc * hc + 3 * hc;
+  auto scratch_tensor = at::empty({num_threads * per_thread_scratch}, at::kFloat);
+  float* const scratch_base = scratch_tensor.data_ptr<float>();
+
+  // Phase 1.
+  parallel_mhc_phase1(n_t_blocks, n_k_blocks, [&](int64_t tb0, int64_t tb1, int64_t kb0, int64_t kb1) {
+    for (int64_t kb = kb0; kb < kb1; ++kb) {
+      const int64_t k0 = kb * K_BLOCK;
+      const int64_t klen = std::min(K_BLOCK, hc_d - k0);
+
+      for (int64_t tb = tb0; tb < tb1; ++tb) {
+        const int64_t t0 = tb * T_BLOCK;
+        const int64_t tlen = std::min(T_BLOCK, T - t0);
+        float* partial_block = partials + (tb * n_k_blocks + kb) * T_BLOCK * partial_stride;
+
+        const float* w_ptr[mix_hc];
+        for (int h = 0; h < mix_hc; ++h)
+          w_ptr[h] = hc_fn + h * hc_d + k0;
+
+        // Stack cache is sized for the largest selected K block, but only the first
+        // n_full entries are touched for the current K_BLOCK.
+        fVec x_cache_lo[MAX_K_VECS], x_cache_hi[MAX_K_VECS];
+
+        for (int64_t tl = 0; tl < tlen; ++tl) {
+          const scalar_t* x_t = x + (t0 + tl) * hc_d + k0;
+          float* partial_row = partial_block + tl * partial_stride;
+
+          const int64_t n_full = klen / kVecSize;
+          const int64_t k_tail = n_full * kVecSize;
+          const int64_t rem = klen - k_tail;
+          const int64_t rem0 = std::min(rem, kFVecSize);
+          const int64_t rem1 = rem - rem0;
+
+          // Prefetch next token.
+          if (tl + 1 < tlen) {
+            const scalar_t* xn = x + (t0 + tl + 1) * hc_d + k0;
+            __builtin_prefetch(xn, 0, 0);
+            if (klen > kVecSize * 4) __builtin_prefetch(xn + kVecSize * 4, 0, 0);
+          }
+
+          // h=0..3: convert/cache x and accumulate sq + four dots.
+          if (tl == 0) {
+            for (int pw = 1; pw < mix_hc; ++pw)
+              __builtin_prefetch(w_ptr[pw], 0, 3);
+          }
+          {
+            const float* w0 = w_ptr[0];
+            const float* w1 = w_ptr[1];
+            const float* w2 = w_ptr[2];
+            const float* w3 = w_ptr[3];
+            fVec sq_lo(0.f), sq_hi(0.f);
+            fVec d0_lo(0.f), d0_hi(0.f);
+            fVec d1_lo(0.f), d1_hi(0.f);
+            fVec d2_lo(0.f), d2_hi(0.f);
+            fVec d3_lo(0.f), d3_hi(0.f);
+            for (int64_t ki = 0; ki < n_full; ++ki) {
+              const int64_t k = ki * kVecSize;
+              std::tie(x_cache_lo[ki], x_cache_hi[ki]) = at::vec::convert_to_float(bVec::loadu(x_t + k));
+              sq_lo += x_cache_lo[ki] * x_cache_lo[ki];
+              sq_hi += x_cache_hi[ki] * x_cache_hi[ki];
+              d0_lo += x_cache_lo[ki] * fVec::loadu(w0 + k);
+              d0_hi += x_cache_hi[ki] * fVec::loadu(w0 + k + kFVecSize);
+              d1_lo += x_cache_lo[ki] * fVec::loadu(w1 + k);
+              d1_hi += x_cache_hi[ki] * fVec::loadu(w1 + k + kFVecSize);
+              d2_lo += x_cache_lo[ki] * fVec::loadu(w2 + k);
+              d2_hi += x_cache_hi[ki] * fVec::loadu(w2 + k + kFVecSize);
+              d3_lo += x_cache_lo[ki] * fVec::loadu(w3 + k);
+              d3_hi += x_cache_hi[ki] * fVec::loadu(w3 + k + kFVecSize);
+            }
+
+            fVec x_tail_lo(0.f), x_tail_hi(0.f);
+            if (rem > 0) {
+              std::tie(x_tail_lo, x_tail_hi) = at::vec::convert_to_float(bVec::loadu(x_t + k_tail, rem));
+              sq_lo += x_tail_lo * x_tail_lo;
+              if (rem1 > 0) sq_hi += x_tail_hi * x_tail_hi;
+              d0_lo += x_tail_lo * fVec::loadu(w0 + k_tail, rem0);
+              d1_lo += x_tail_lo * fVec::loadu(w1 + k_tail, rem0);
+              d2_lo += x_tail_lo * fVec::loadu(w2 + k_tail, rem0);
+              d3_lo += x_tail_lo * fVec::loadu(w3 + k_tail, rem0);
+              if (rem1 > 0) {
+                d0_hi += x_tail_hi * fVec::loadu(w0 + k_tail + kFVecSize, rem1);
+                d1_hi += x_tail_hi * fVec::loadu(w1 + k_tail + kFVecSize, rem1);
+                d2_hi += x_tail_hi * fVec::loadu(w2 + k_tail + kFVecSize, rem1);
+                d3_hi += x_tail_hi * fVec::loadu(w3 + k_tail + kFVecSize, rem1);
+              }
+            }
+
+            partial_row[0] = vec_reduce_sum(sq_lo + sq_hi);
+            partial_row[1 + 0] = vec_reduce_sum(d0_lo + d0_hi);
+            partial_row[1 + 1] = vec_reduce_sum(d1_lo + d1_hi);
+            partial_row[1 + 2] = vec_reduce_sum(d2_lo + d2_hi);
+            partial_row[1 + 3] = vec_reduce_sum(d3_lo + d3_hi);
+
+            // h=4..mix_hc-1: reuse cached x, four dots per pass.
+            int h = 4;
+            for (; h + 3 < mix_hc; h += 4) {
+              const float* wa = w_ptr[h];
+              const float* wb = w_ptr[h + 1];
+              const float* wc = w_ptr[h + 2];
+              const float* wd = w_ptr[h + 3];
+              fVec a0(0.f), a1(0.f), b0(0.f), b1(0.f);
+              fVec c0(0.f), c1(0.f), d0(0.f), d1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                a0 += x_cache_lo[ki] * fVec::loadu(wa + k);
+                b0 += x_cache_lo[ki] * fVec::loadu(wb + k);
+                c0 += x_cache_lo[ki] * fVec::loadu(wc + k);
+                d0 += x_cache_lo[ki] * fVec::loadu(wd + k);
+                a1 += x_cache_hi[ki] * fVec::loadu(wa + k + kFVecSize);
+                b1 += x_cache_hi[ki] * fVec::loadu(wb + k + kFVecSize);
+                c1 += x_cache_hi[ki] * fVec::loadu(wc + k + kFVecSize);
+                d1 += x_cache_hi[ki] * fVec::loadu(wd + k + kFVecSize);
+              }
+              if (rem > 0) {
+                a0 += x_tail_lo * fVec::loadu(wa + k_tail, rem0);
+                b0 += x_tail_lo * fVec::loadu(wb + k_tail, rem0);
+                c0 += x_tail_lo * fVec::loadu(wc + k_tail, rem0);
+                d0 += x_tail_lo * fVec::loadu(wd + k_tail, rem0);
+                if (rem1 > 0) {
+                  a1 += x_tail_hi * fVec::loadu(wa + k_tail + kFVecSize, rem1);
+                  b1 += x_tail_hi * fVec::loadu(wb + k_tail + kFVecSize, rem1);
+                  c1 += x_tail_hi * fVec::loadu(wc + k_tail + kFVecSize, rem1);
+                  d1 += x_tail_hi * fVec::loadu(wd + k_tail + kFVecSize, rem1);
+                }
+              }
+              partial_row[1 + h] = vec_reduce_sum(a0 + a1);
+              partial_row[1 + h + 1] = vec_reduce_sum(b0 + b1);
+              partial_row[1 + h + 2] = vec_reduce_sum(c0 + c1);
+              partial_row[1 + h + 3] = vec_reduce_sum(d0 + d1);
+            }
+            for (; h + 1 < mix_hc; h += 2) {
+              const float* wa = w_ptr[h];
+              const float* wb = w_ptr[h + 1];
+              fVec a0(0.f), a1(0.f), b0(0.f), b1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                a0 += x_cache_lo[ki] * fVec::loadu(wa + k);
+                b0 += x_cache_lo[ki] * fVec::loadu(wb + k);
+                a1 += x_cache_hi[ki] * fVec::loadu(wa + k + kFVecSize);
+                b1 += x_cache_hi[ki] * fVec::loadu(wb + k + kFVecSize);
+              }
+              if (rem > 0) {
+                a0 += x_tail_lo * fVec::loadu(wa + k_tail, rem0);
+                b0 += x_tail_lo * fVec::loadu(wb + k_tail, rem0);
+                if (rem1 > 0) {
+                  a1 += x_tail_hi * fVec::loadu(wa + k_tail + kFVecSize, rem1);
+                  b1 += x_tail_hi * fVec::loadu(wb + k_tail + kFVecSize, rem1);
+                }
+              }
+              partial_row[1 + h] = vec_reduce_sum(a0 + a1);
+              partial_row[1 + h + 1] = vec_reduce_sum(b0 + b1);
+            }
+            // odd leftover
+            if (h < mix_hc) {
+              const float* w = w_ptr[h];
+              fVec hd0(0.f), hd1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                hd0 += x_cache_lo[ki] * fVec::loadu(w + k);
+                hd1 += x_cache_hi[ki] * fVec::loadu(w + k + kFVecSize);
+              }
+              if (rem > 0) {
+                hd0 += x_tail_lo * fVec::loadu(w + k_tail, rem0);
+                if (rem1 > 0) hd1 += x_tail_hi * fVec::loadu(w + k_tail + kFVecSize, rem1);
+              }
+              partial_row[1 + h] = vec_reduce_sum(hd0 + hd1);
+            }
+          }
+        }  // tl
+
+        // Prefetch next t-block head.
+        if (tb + 1 < tb1) {
+          const scalar_t* x_next_tb = x + ((tb + 1) * T_BLOCK) * hc_d + k0;
+          __builtin_prefetch(x_next_tb, 0, 0);
+          if (klen > kVecSize * 4) __builtin_prefetch(x_next_tb + kVecSize * 4, 0, 0);
+        }
+      }  // tb
+    }  // kb
+  });  // Phase 1
+
+  // Phase 2+3: reduce partials, sinkhorn, and combine.
+  at::parallel_for(0, T, 1, [&](int64_t begin, int64_t end) {
+    const int64_t tid = at::get_thread_num();
+    fVec v0, v1, pre_fvec;
+    float* const thread_scratch = scratch_base + tid * per_thread_scratch;
+    float* const mix_buffer = thread_scratch;
+    float* const pre_gate = thread_scratch + mix_hc;
+    float* const post_gate = pre_gate + hc;
+    float* const comb_matrix = post_gate + hc;
+    float* const sinkhorn_scratch = comb_matrix + hc * hc;
+
+    for (int64_t t = begin; t < end; ++t) {
+      const int64_t tb = t / T_BLOCK;
+      const int64_t tl = t % T_BLOCK;
+
+      std::fill(mix_buffer, mix_buffer + mix_hc, 0.f);
+      double sq_total = 0.0;
+      for (int64_t kb = 0; kb < n_k_blocks; ++kb) {
+        const float* partial_row = partials + (tb * n_k_blocks + kb) * T_BLOCK * partial_stride + tl * partial_stride;
+        sq_total += static_cast<double>(partial_row[0]);
+#pragma GCC unroll 4
+        for (int i = 0; i < mix_hc; ++i)
+          mix_buffer[i] += partial_row[1 + i];
+      }
+      const float inv_rms =
+          static_cast<float>(1.0 / std::sqrt(sq_total / static_cast<double>(hc_d) + static_cast<double>(norm_eps)));
+#pragma GCC unroll 4
+      for (int i = 0; i < mix_hc; ++i)
+        mix_buffer[i] *= inv_rms;
+
+      parse_mixes_and_sinkhorn(
+          pre_gate,
+          post_gate,
+          comb_matrix,
+          mix_buffer,
+          s0,
+          s1,
+          s2,
+          hc_base,
+          sinkhorn_iters,
+          hc_eps,
+          hc,
+          sinkhorn_scratch);
+
+      std::copy_n(post_gate, hc, post_out + t * hc);
+      std::copy_n(comb_matrix, hc * hc, comb_out + t * hc * hc);
+
+      // Phase 3: d-tiled combine.
+      const scalar_t* x_t = x + t * hc_d;
+      scalar_t* y_t = y + t * d;
+      for (int64_t j0 = 0; j0 < d; j0 += D_BLOCK) {
+        const int64_t jlen = std::min(D_BLOCK, d - j0);
+
+        int64_t kk = 0;
+        for (; kk <= jlen - kVecSize; kk += kVecSize) {
+          pre_fvec = fVec(pre_gate[0]);
+          std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_t + j0 + kk));
+          fVec acc0 = pre_fvec * v0;
+          fVec acc1 = pre_fvec * v1;
+#pragma GCC unroll 4
+          for (int h = 1; h < hc; ++h) {
+            pre_fvec = fVec(pre_gate[h]);
+            const scalar_t* x_th = x_t + (int64_t)h * d + j0 + kk;
+            std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_th));
+            acc0 += pre_fvec * v0;
+            acc1 += pre_fvec * v1;
+          }
+          at::vec::convert_from_float<scalar_t>(acc0, acc1).store(y_t + j0 + kk);
+        }
+        if (kk < jlen) {
+          const int64_t rem = jlen - kk, rem1 = rem - std::min(rem, kFVecSize);
+          pre_fvec = fVec(pre_gate[0]);
+          std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_t + j0 + kk, rem));
+          fVec acc0 = pre_fvec * v0;
+          fVec acc1 = pre_fvec * v1;
+#pragma GCC unroll 4
+          for (int h = 1; h < hc; ++h) {
+            pre_fvec = fVec(pre_gate[h]);
+            const scalar_t* x_th = x_t + (int64_t)h * d + j0 + kk;
+            std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_th, rem));
+            acc0 += pre_fvec * v0;
+            acc1 += pre_fvec * v1;
+          }
+          at::vec::convert_from_float<scalar_t>(acc0, rem1 > 0 ? acc1 : fVec(0.f)).store(y_t + j0 + kk, rem);
+        }
+      }  // d-tile
+    }  // t
+  });  // Phase 2+3
+}
+
+// Fused hc_head path.
+template <typename scalar_t>
+static void hc_head_fuse_impl(
+    scalar_t* __restrict__ y,
+    const scalar_t* __restrict__ x,
+    const float* __restrict__ hc_fn,  // [hc, hc*d] row-major
+    float hc_scale_val,
+    const float* __restrict__ hc_base,
+    int64_t T,
+    int64_t d,
+    int hc,
+    float hc_eps,
+    float norm_eps) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int64_t kVecSize = bVec::size();   // 32 bf16
+  constexpr int64_t kFVecSize = fVec::size();  // 16 fp32
+  constexpr int64_t kDVecsPerBlock = 16;
+  const int64_t hc_d = hc * d;
+
+  constexpr int64_t K_BLOCK_CAP = 1024;
+  constexpr int64_t MAX_K_VECS = K_BLOCK_CAP / kVecSize;
+
+  const int64_t T_BLOCK = choose_t_block(T);
+  const int64_t num_threads = static_cast<int64_t>(at::get_num_threads());
+  const int64_t K_BLOCK = choose_k_block(hc, kVecSize, K_BLOCK_CAP);
+  TORCH_CHECK(
+      K_BLOCK <= K_BLOCK_CAP && K_BLOCK % kVecSize == 0,
+      "hc_head_fuse_impl: K_BLOCK must be <= K_BLOCK_CAP and a multiple of vector size");
+  const int64_t D_BLOCK = kDVecsPerBlock * kVecSize;
+
+  const int64_t n_t_blocks = div_up(T, T_BLOCK);
+  const int64_t n_k_blocks = div_up(hc_d, K_BLOCK);
+
+  // Partial buffer: [n_t_blocks, n_k_blocks, T_BLOCK, 1+hc]
+  //   p[0] = partial sq,  p[1..hc] = partial dots
+  const int64_t partial_stride = 1 + hc;
+  auto partials_tensor = at::empty({n_t_blocks * n_k_blocks * T_BLOCK * partial_stride}, at::kFloat);
+  float* const partials = partials_tensor.data_ptr<float>();
+
+  // Per-thread scratch: [pre_gate[hc]]
+  const int64_t per_thread_head = hc;
+  auto scratch_tensor = at::empty({num_threads * per_thread_head}, at::kFloat);
+  float* const scratch_base = scratch_tensor.data_ptr<float>();
+
+  // Phase 1.
+  parallel_mhc_phase1(n_t_blocks, n_k_blocks, [&](int64_t tb0, int64_t tb1, int64_t kb0, int64_t kb1) {
+    for (int64_t kb = kb0; kb < kb1; ++kb) {
+      const int64_t k0 = kb * K_BLOCK;
+      const int64_t klen = std::min(K_BLOCK, hc_d - k0);
+
+      for (int64_t tb = tb0; tb < tb1; ++tb) {
+        const int64_t t0 = tb * T_BLOCK;
+        const int64_t tlen = std::min(T_BLOCK, T - t0);
+        float* partial_block = partials + (tb * n_k_blocks + kb) * T_BLOCK * partial_stride;
+
+        const float* w_ptr[hc];
+        for (int h = 0; h < hc; ++h)
+          w_ptr[h] = hc_fn + h * hc_d + k0;
+
+        // Stack cache is sized for the largest selected K block, but only the first
+        // n_full entries are touched for the current K_BLOCK.
+        fVec x_cache_lo[MAX_K_VECS], x_cache_hi[MAX_K_VECS];
+
+        for (int64_t tl = 0; tl < tlen; ++tl) {
+          const scalar_t* x_t = x + (t0 + tl) * hc_d + k0;
+          float* partial_row = partial_block + tl * partial_stride;
+
+          const int64_t n_full = klen / kVecSize;
+          const int64_t k_tail = n_full * kVecSize;
+          const int64_t rem = klen - k_tail;
+          const int64_t rem0 = std::min(rem, kFVecSize);
+          const int64_t rem1 = rem - rem0;
+
+          // Prefetch next token.
+          if (tl + 1 < tlen) {
+            const scalar_t* xn = x + (t0 + tl + 1) * hc_d + k0;
+            __builtin_prefetch(xn, 0, 0);
+            if (klen > kVecSize * 4) __builtin_prefetch(xn + kVecSize * 4, 0, 0);
+          }
+
+          // Convert/cache x and accumulate sq + multiple dots.
+          if (tl == 0) {
+            for (int pw = 1; pw < hc; ++pw)
+              __builtin_prefetch(w_ptr[pw], 0, 3);
+          }
+          {
+            fVec x_tail_lo(0.f), x_tail_hi(0.f);
+            int h = 0;
+
+            if (hc >= 4) {
+              const float* w0 = w_ptr[0];
+              const float* w1 = w_ptr[1];
+              const float* w2 = w_ptr[2];
+              const float* w3 = w_ptr[3];
+              fVec sq_lo(0.f), sq_hi(0.f);
+              fVec d0_lo(0.f), d0_hi(0.f);
+              fVec d1_lo(0.f), d1_hi(0.f);
+              fVec d2_lo(0.f), d2_hi(0.f);
+              fVec d3_lo(0.f), d3_hi(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                std::tie(x_cache_lo[ki], x_cache_hi[ki]) = at::vec::convert_to_float(bVec::loadu(x_t + k));
+                sq_lo += x_cache_lo[ki] * x_cache_lo[ki];
+                sq_hi += x_cache_hi[ki] * x_cache_hi[ki];
+                d0_lo += x_cache_lo[ki] * fVec::loadu(w0 + k);
+                d0_hi += x_cache_hi[ki] * fVec::loadu(w0 + k + kFVecSize);
+                d1_lo += x_cache_lo[ki] * fVec::loadu(w1 + k);
+                d1_hi += x_cache_hi[ki] * fVec::loadu(w1 + k + kFVecSize);
+                d2_lo += x_cache_lo[ki] * fVec::loadu(w2 + k);
+                d2_hi += x_cache_hi[ki] * fVec::loadu(w2 + k + kFVecSize);
+                d3_lo += x_cache_lo[ki] * fVec::loadu(w3 + k);
+                d3_hi += x_cache_hi[ki] * fVec::loadu(w3 + k + kFVecSize);
+              }
+              if (rem > 0) {
+                std::tie(x_tail_lo, x_tail_hi) = at::vec::convert_to_float(bVec::loadu(x_t + k_tail, rem));
+                sq_lo += x_tail_lo * x_tail_lo;
+                if (rem1 > 0) sq_hi += x_tail_hi * x_tail_hi;
+                d0_lo += x_tail_lo * fVec::loadu(w0 + k_tail, rem0);
+                d1_lo += x_tail_lo * fVec::loadu(w1 + k_tail, rem0);
+                d2_lo += x_tail_lo * fVec::loadu(w2 + k_tail, rem0);
+                d3_lo += x_tail_lo * fVec::loadu(w3 + k_tail, rem0);
+                if (rem1 > 0) {
+                  d0_hi += x_tail_hi * fVec::loadu(w0 + k_tail + kFVecSize, rem1);
+                  d1_hi += x_tail_hi * fVec::loadu(w1 + k_tail + kFVecSize, rem1);
+                  d2_hi += x_tail_hi * fVec::loadu(w2 + k_tail + kFVecSize, rem1);
+                  d3_hi += x_tail_hi * fVec::loadu(w3 + k_tail + kFVecSize, rem1);
+                }
+              }
+              partial_row[0] = vec_reduce_sum(sq_lo + sq_hi);
+              partial_row[1 + 0] = vec_reduce_sum(d0_lo + d0_hi);
+              partial_row[1 + 1] = vec_reduce_sum(d1_lo + d1_hi);
+              partial_row[1 + 2] = vec_reduce_sum(d2_lo + d2_hi);
+              partial_row[1 + 3] = vec_reduce_sum(d3_lo + d3_hi);
+              h = 4;
+            } else {
+              const float* w0 = w_ptr[0];
+              fVec sq_lo(0.f), sq_hi(0.f);
+              fVec d0(0.f), d1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                std::tie(x_cache_lo[ki], x_cache_hi[ki]) = at::vec::convert_to_float(bVec::loadu(x_t + k));
+                sq_lo += x_cache_lo[ki] * x_cache_lo[ki];
+                sq_hi += x_cache_hi[ki] * x_cache_hi[ki];
+                d0 += x_cache_lo[ki] * fVec::loadu(w0 + k);
+                d1 += x_cache_hi[ki] * fVec::loadu(w0 + k + kFVecSize);
+              }
+              if (rem > 0) {
+                std::tie(x_tail_lo, x_tail_hi) = at::vec::convert_to_float(bVec::loadu(x_t + k_tail, rem));
+                sq_lo += x_tail_lo * x_tail_lo;
+                if (rem1 > 0) sq_hi += x_tail_hi * x_tail_hi;
+                d0 += x_tail_lo * fVec::loadu(w0 + k_tail, rem0);
+                if (rem1 > 0) d1 += x_tail_hi * fVec::loadu(w0 + k_tail + kFVecSize, rem1);
+              }
+              partial_row[0] = vec_reduce_sum(sq_lo + sq_hi);
+              partial_row[1 + 0] = vec_reduce_sum(d0 + d1);
+              h = 1;
+            }
+
+            // h: reuse cached x, four dots per pass.
+            for (; h + 3 < hc; h += 4) {
+              const float* wa = w_ptr[h];
+              const float* wb = w_ptr[h + 1];
+              const float* wc = w_ptr[h + 2];
+              const float* wd = w_ptr[h + 3];
+              fVec a0(0.f), a1(0.f), b0(0.f), b1(0.f);
+              fVec c0(0.f), c1(0.f), d0(0.f), d1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                a0 += x_cache_lo[ki] * fVec::loadu(wa + k);
+                b0 += x_cache_lo[ki] * fVec::loadu(wb + k);
+                c0 += x_cache_lo[ki] * fVec::loadu(wc + k);
+                d0 += x_cache_lo[ki] * fVec::loadu(wd + k);
+                a1 += x_cache_hi[ki] * fVec::loadu(wa + k + kFVecSize);
+                b1 += x_cache_hi[ki] * fVec::loadu(wb + k + kFVecSize);
+                c1 += x_cache_hi[ki] * fVec::loadu(wc + k + kFVecSize);
+                d1 += x_cache_hi[ki] * fVec::loadu(wd + k + kFVecSize);
+              }
+              if (rem > 0) {
+                a0 += x_tail_lo * fVec::loadu(wa + k_tail, rem0);
+                b0 += x_tail_lo * fVec::loadu(wb + k_tail, rem0);
+                c0 += x_tail_lo * fVec::loadu(wc + k_tail, rem0);
+                d0 += x_tail_lo * fVec::loadu(wd + k_tail, rem0);
+                if (rem1 > 0) {
+                  a1 += x_tail_hi * fVec::loadu(wa + k_tail + kFVecSize, rem1);
+                  b1 += x_tail_hi * fVec::loadu(wb + k_tail + kFVecSize, rem1);
+                  c1 += x_tail_hi * fVec::loadu(wc + k_tail + kFVecSize, rem1);
+                  d1 += x_tail_hi * fVec::loadu(wd + k_tail + kFVecSize, rem1);
+                }
+              }
+              partial_row[1 + h] = vec_reduce_sum(a0 + a1);
+              partial_row[1 + h + 1] = vec_reduce_sum(b0 + b1);
+              partial_row[1 + h + 2] = vec_reduce_sum(c0 + c1);
+              partial_row[1 + h + 3] = vec_reduce_sum(d0 + d1);
+            }
+            for (; h + 1 < hc; h += 2) {
+              const float* wa = w_ptr[h];
+              const float* wb = w_ptr[h + 1];
+              fVec a0(0.f), a1(0.f), b0(0.f), b1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                a0 += x_cache_lo[ki] * fVec::loadu(wa + k);
+                b0 += x_cache_lo[ki] * fVec::loadu(wb + k);
+                a1 += x_cache_hi[ki] * fVec::loadu(wa + k + kFVecSize);
+                b1 += x_cache_hi[ki] * fVec::loadu(wb + k + kFVecSize);
+              }
+              if (rem > 0) {
+                a0 += x_tail_lo * fVec::loadu(wa + k_tail, rem0);
+                b0 += x_tail_lo * fVec::loadu(wb + k_tail, rem0);
+                if (rem1 > 0) {
+                  a1 += x_tail_hi * fVec::loadu(wa + k_tail + kFVecSize, rem1);
+                  b1 += x_tail_hi * fVec::loadu(wb + k_tail + kFVecSize, rem1);
+                }
+              }
+              partial_row[1 + h] = vec_reduce_sum(a0 + a1);
+              partial_row[1 + h + 1] = vec_reduce_sum(b0 + b1);
+            }
+            // odd leftover
+            if (h < hc) {
+              const float* w = w_ptr[h];
+              fVec hd0(0.f), hd1(0.f);
+              for (int64_t ki = 0; ki < n_full; ++ki) {
+                const int64_t k = ki * kVecSize;
+                hd0 += x_cache_lo[ki] * fVec::loadu(w + k);
+                hd1 += x_cache_hi[ki] * fVec::loadu(w + k + kFVecSize);
+              }
+              if (rem > 0) {
+                hd0 += x_tail_lo * fVec::loadu(w + k_tail, rem0);
+                if (rem1 > 0) hd1 += x_tail_hi * fVec::loadu(w + k_tail + kFVecSize, rem1);
+              }
+              partial_row[1 + h] = vec_reduce_sum(hd0 + hd1);
+            }
+          }
+        }  // tl
+
+        // Prefetch next t-block head.
+        if (tb + 1 < tb1) {
+          const scalar_t* x_next_tb = x + ((tb + 1) * T_BLOCK) * hc_d + k0;
+          __builtin_prefetch(x_next_tb, 0, 0);
+          if (klen > kVecSize * 2) __builtin_prefetch(x_next_tb + kVecSize * 2, 0, 0);
+        }
+      }  // tb
+    }  // kb
+  });  // Phase 1
+
+  // Phase 2+3.
+  at::parallel_for(0, T, 1, [&](int64_t begin, int64_t end) {
+    const int64_t tid = at::get_thread_num();
+    float* const pre_gate = scratch_base + tid * per_thread_head;
+    fVec v0, v1, pre_fvec;
+
+    for (int64_t t = begin; t < end; ++t) {
+      const int64_t tb = t / T_BLOCK;
+      const int64_t tl = t % T_BLOCK;
+
+      // Phase 2: reduce partials + sigmoid gate.
+      double sq_total = 0.0;
+      std::fill(pre_gate, pre_gate + hc, 0.f);
+      for (int64_t kb = 0; kb < n_k_blocks; ++kb) {
+        const float* partial_row = partials + (tb * n_k_blocks + kb) * T_BLOCK * partial_stride + tl * partial_stride;
+        sq_total += static_cast<double>(partial_row[0]);
+#pragma GCC unroll 4
+        for (int h = 0; h < hc; ++h)
+          pre_gate[h] += partial_row[1 + h];
+      }
+      const float inv_rms =
+          static_cast<float>(1.0 / std::sqrt(sq_total / static_cast<double>(hc_d) + static_cast<double>(norm_eps)));
+#pragma GCC unroll 4
+      for (int h = 0; h < hc; ++h) {
+        const float gate = pre_gate[h] * inv_rms * hc_scale_val + hc_base[h];
+        pre_gate[h] = 1.f / (1.f + std::exp(-gate)) + hc_eps;
+      }
+
+      // Phase 3: d-tiled combine.
+      const scalar_t* x_t = x + t * hc_d;
+      scalar_t* y_t = y + t * d;
+      for (int64_t j0 = 0; j0 < d; j0 += D_BLOCK) {
+        const int64_t jlen = std::min(D_BLOCK, d - j0);
+
+        int64_t kk = 0;
+        for (; kk <= jlen - kVecSize; kk += kVecSize) {
+          pre_fvec = fVec(pre_gate[0]);
+          std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_t + j0 + kk));
+          fVec acc0 = pre_fvec * v0;
+          fVec acc1 = pre_fvec * v1;
+#pragma GCC unroll 4
+          for (int h = 1; h < hc; ++h) {
+            pre_fvec = fVec(pre_gate[h]);
+            const scalar_t* x_th = x_t + (int64_t)h * d + j0 + kk;
+            std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_th));
+            acc0 += pre_fvec * v0;
+            acc1 += pre_fvec * v1;
+          }
+          at::vec::convert_from_float<scalar_t>(acc0, acc1).store(y_t + j0 + kk);
+        }
+        if (kk < jlen) {
+          const int64_t rem = jlen - kk, rem1 = rem - std::min(rem, kFVecSize);
+          pre_fvec = fVec(pre_gate[0]);
+          std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_t + j0 + kk, rem));
+          fVec acc0 = pre_fvec * v0;
+          fVec acc1 = pre_fvec * v1;
+#pragma GCC unroll 4
+          for (int h = 1; h < hc; ++h) {
+            pre_fvec = fVec(pre_gate[h]);
+            const scalar_t* x_th = x_t + (int64_t)h * d + j0 + kk;
+            std::tie(v0, v1) = at::vec::convert_to_float(bVec::loadu(x_th, rem));
+            acc0 += pre_fvec * v0;
+            acc1 += pre_fvec * v1;
+          }
+          at::vec::convert_from_float<scalar_t>(acc0, rem1 > 0 ? acc1 : fVec(0.f)).store(y_t + j0 + kk, rem);
+        }
+      }  // d-tile
+    }  // t
+  });  // Phase 2+3
+}
+
+}  // anonymous namespace
+
+// Fused hc_pre entry.
+std::tuple<at::Tensor, at::Tensor, at::Tensor> hc_pre_fused_cpu(
+    at::Tensor& x,
+    at::Tensor& hc_fn,
+    at::Tensor& hc_scale,
+    at::Tensor& hc_base,
+    int64_t hc_mult,
+    int64_t sinkhorn_iters,
+    double rms_eps,
+    double hc_eps) {
+  TORCH_CHECK(hc_mult >= 2, "hc_pre_fused_cpu: hc_mult must be >= 2");
+  TORCH_CHECK(
+      x.dim() == 3 && (x.scalar_type() == at::kBFloat16 || x.scalar_type() == at::kHalf),
+      "hc_pre_fused_cpu: x must be bf16/fp16 [T, hc, d]");
+  TORCH_CHECK(hc_fn.scalar_type() == at::kFloat, "hc_pre_fused_cpu: hc_fn must be float32");
+  TORCH_CHECK(
+      hc_scale.scalar_type() == at::kFloat && hc_scale.numel() == 3, "hc_pre_fused_cpu: hc_scale must be float32 [3]");
+  TORCH_CHECK(hc_base.scalar_type() == at::kFloat, "hc_pre_fused_cpu: hc_base must be float32");
+  TORCH_CHECK(
+      x.device().is_cpu() && hc_fn.device().is_cpu() && hc_scale.device().is_cpu() && hc_base.device().is_cpu(),
+      "hc_pre_fused_cpu: all inputs must be CPU tensors");
+
+  const int64_t T = x.size(0);
+  const int64_t d = x.size(2);
+  const int64_t hc_d = hc_mult * d;
+  const int64_t mix_hc = (2 + hc_mult) * hc_mult;
+
+  TORCH_CHECK(T > 0 && d > 0, "hc_pre_fused_cpu: T and d must be positive");
+  TORCH_CHECK(x.size(1) == hc_mult, "hc_pre_fused_cpu: x shape must be [T, hc_mult, d]");
+  TORCH_CHECK(
+      hc_fn.dim() == 2 && hc_fn.size(0) == mix_hc && hc_fn.size(1) == hc_d,
+      "hc_pre_fused_cpu: hc_fn must be [mix_hc, hc_mult*d]");
+  TORCH_CHECK(hc_base.numel() == mix_hc, "hc_pre_fused_cpu: hc_base.numel() must equal mix_hc");
+
+  // Accept non-contiguous inputs and use contiguous copies/views internally.
+  const at::Tensor x_contig = x.is_contiguous() ? x : x.contiguous();
+  const at::Tensor hc_fn_contig = hc_fn.is_contiguous() ? hc_fn : hc_fn.contiguous();
+  const at::Tensor hc_scale_contig = hc_scale.is_contiguous() ? hc_scale : hc_scale.contiguous();
+  const at::Tensor hc_base_contig = hc_base.is_contiguous() ? hc_base : hc_base.contiguous();
+
+  auto f32_opts = at::TensorOptions().dtype(at::kFloat).device(x.device());
+  auto post = at::empty({T, hc_mult}, f32_opts);
+  auto comb = at::empty({T, hc_mult, hc_mult}, f32_opts);
+  auto y = at::empty({T, d}, x.options());
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(x.scalar_type(), "hc_pre_fused_cpu", [&] {
+    hc_pre_fuse_impl<scalar_t>(
+        y.data_ptr<scalar_t>(),
+        post.data_ptr<float>(),
+        comb.data_ptr<float>(),
+        x_contig.data_ptr<scalar_t>(),
+        hc_fn_contig.data_ptr<float>(),
+        hc_scale_contig.data_ptr<float>(),
+        hc_base_contig.data_ptr<float>(),
+        T,
+        d,
+        static_cast<int>(hc_mult),
+        static_cast<int>(sinkhorn_iters),
+        static_cast<float>(hc_eps),
+        static_cast<float>(rms_eps));
+  });
+  return {y, post, comb};
+}
+
+// Fused hc_post entry.
+at::Tensor hc_post_fused_cpu(at::Tensor& x, at::Tensor& residual, at::Tensor& post, at::Tensor& comb) {
+  TORCH_CHECK(
+      x.dim() == 2 && (x.scalar_type() == at::kBFloat16 || x.scalar_type() == at::kHalf),
+      "hc_post_fused_cpu: x must be bf16/fp16 [T, d]");
+  TORCH_CHECK(
+      residual.dim() == 3 && residual.scalar_type() == x.scalar_type(),
+      "hc_post_fused_cpu: residual must be same dtype as x [T, hc, d]");
+  TORCH_CHECK(post.scalar_type() == at::kFloat, "hc_post_fused_cpu: post must be float32");
+  TORCH_CHECK(comb.scalar_type() == at::kFloat, "hc_post_fused_cpu: comb must be float32");
+  TORCH_CHECK(
+      x.device().is_cpu() && residual.device().is_cpu() && post.device().is_cpu() && comb.device().is_cpu(),
+      "hc_post_fused_cpu: all inputs must be CPU tensors");
+
+  const int64_t T = x.size(0);
+  const int64_t d = x.size(1);
+  const int64_t hc = residual.size(1);
+  TORCH_CHECK(hc >= 2, "hc_post_fused_cpu: hc_mult must be >= 2");
+  TORCH_CHECK(T > 0 && d > 0, "hc_post_fused_cpu: T and d must be positive");
+  TORCH_CHECK(residual.size(0) == T && residual.size(2) == d, "hc_post_fused_cpu: residual shape must be [T, hc, d]");
+  TORCH_CHECK(
+      post.dim() == 2 && post.size(0) == T && post.size(1) == hc, "hc_post_fused_cpu: post shape must be [T, hc]");
+  TORCH_CHECK(
+      comb.dim() == 3 && comb.size(0) == T && comb.size(1) == hc && comb.size(2) == hc,
+      "hc_post_fused_cpu: comb shape must be [T, hc, hc]");
+
+  // Accept non-contiguous inputs and use contiguous copies/views internally.
+  const at::Tensor x_contig = x.is_contiguous() ? x : x.contiguous();
+  const at::Tensor residual_contig = residual.is_contiguous() ? residual : residual.contiguous();
+  const at::Tensor post_contig = post.is_contiguous() ? post : post.contiguous();
+  const at::Tensor comb_contig = comb.is_contiguous() ? comb : comb.contiguous();
+
+  auto out = at::empty({T, hc, d}, x.options());  // same dtype as x
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(x.scalar_type(), "hc_post_fused_cpu", [&] {
+    hc_post_fuse_impl<scalar_t>(
+        out.data_ptr<scalar_t>(),
+        x_contig.data_ptr<scalar_t>(),
+        residual_contig.data_ptr<scalar_t>(),
+        post_contig.data_ptr<float>(),
+        comb_contig.data_ptr<float>(),
+        T,
+        d,
+        static_cast<int>(hc));
+  });
+
+  return out;
+}
+
+// Fused hc_head entry.
+at::Tensor hc_head_fused_cpu(
+    at::Tensor& x, at::Tensor& hc_fn, at::Tensor& hc_scale, at::Tensor& hc_base, double hc_eps, double norm_eps) {
+  TORCH_CHECK(
+      x.dim() == 3 && (x.scalar_type() == at::kBFloat16 || x.scalar_type() == at::kHalf),
+      "hc_head_fused_cpu: x must be bf16/fp16 [T, hc, d]");
+  const int64_t hc_mult = x.size(1);
+  TORCH_CHECK(hc_mult >= 2, "hc_head_fused_cpu: hc_mult must be >= 2");
+  TORCH_CHECK(hc_fn.scalar_type() == at::kFloat, "hc_head_fused_cpu: hc_fn must be float32");
+  TORCH_CHECK(
+      hc_scale.scalar_type() == at::kFloat && hc_scale.numel() == 1,
+      "hc_head_fused_cpu: hc_scale must be a scalar float32");
+  TORCH_CHECK(hc_base.scalar_type() == at::kFloat, "hc_head_fused_cpu: hc_base must be float32");
+  TORCH_CHECK(hc_base.numel() == hc_mult, "hc_head_fused_cpu: hc_base.numel() must equal hc_mult");
+  TORCH_CHECK(
+      x.device().is_cpu() && hc_fn.device().is_cpu() && hc_scale.device().is_cpu() && hc_base.device().is_cpu(),
+      "hc_head_fused_cpu: all inputs must be CPU tensors");
+
+  const int64_t T = x.size(0);
+  const int64_t d = x.size(2);
+  TORCH_CHECK(T > 0 && d > 0, "hc_head_fused_cpu: T and d must be positive");
+  TORCH_CHECK(
+      hc_fn.dim() == 2 && hc_fn.size(0) == hc_mult && hc_fn.size(1) == hc_mult * d,
+      "hc_head_fused_cpu: hc_fn must be [hc_mult, hc_mult*d]");
+
+  // Accept non-contiguous inputs; make contiguous copies if needed.
+  const at::Tensor x_contig = x.is_contiguous() ? x : x.contiguous();
+  const at::Tensor hc_fn_contig = hc_fn.is_contiguous() ? hc_fn : hc_fn.contiguous();
+  const at::Tensor hc_scale_contig = hc_scale.is_contiguous() ? hc_scale : hc_scale.contiguous();
+  const at::Tensor hc_base_contig = hc_base.is_contiguous() ? hc_base : hc_base.contiguous();
+  const float hc_scale_val = hc_scale_contig.data_ptr<float>()[0];
+
+  auto y = at::empty({T, d}, x.options());
+
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(x.scalar_type(), "hc_head_fused_cpu", [&] {
+    hc_head_fuse_impl<scalar_t>(
+        y.data_ptr<scalar_t>(),
+        x_contig.data_ptr<scalar_t>(),
+        hc_fn_contig.data_ptr<float>(),
+        hc_scale_val,
+        hc_base_contig.data_ptr<float>(),
+        T,
+        d,
+        static_cast<int>(hc_mult),
+        static_cast<float>(hc_eps),
+        static_cast<float>(norm_eps));
+  });
+
+  return y;
+}

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -158,6 +158,99 @@ inline void silu_and_mul(
   }
 }
 
+template <typename scalar_t, int BLOCK_N>
+inline void clamped_silu_and_mul(
+    scalar_t* __restrict__ output,
+    const float* __restrict__ input0,  // gate (x)
+    const float* __restrict__ input1,  // up (y)
+    int64_t m_size,
+    int64_t N,
+    const float limit) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  const fVec one = fVec(1.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+
+  // no remainder
+  for (int64_t m = 0; m < m_size; ++m) {
+    scalar_t* __restrict__ out = output + m * N;
+    const float* __restrict__ x = input0 + m * BLOCK_N;
+    const float* __restrict__ y = input1 + m * BLOCK_N;
+
+    for (int64_t d = 0; d < BLOCK_N; d += bVec::size()) {
+      fVec x0 = fVec::loadu(x + d);
+      fVec x1 = fVec::loadu(x + d + fVec::size());
+      fVec y0 = fVec::loadu(y + d);
+      fVec y1 = fVec::loadu(y + d + fVec::size());
+      // gate clamped at upper bound; up clamped symmetrically
+      x0 = at::vec::minimum(x0, limit_v);
+      x1 = at::vec::minimum(x1, limit_v);
+      y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+      y1 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y1));
+      // silu(gate) * up
+      x0 = x0 / (one + x0.neg().exp_u20());
+      x1 = x1 / (one + x1.neg().exp_u20());
+      x0 = x0 * y0;
+      x1 = x1 * y1;
+      // convert
+      bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+      out_vec.store(out + d);
+    }
+  }
+}
+
+template <typename scalar_t, int BLOCK_N>
+inline void clamp_sigmoid_and_mul(
+    scalar_t* __restrict__ output,
+    const float* __restrict__ input0,
+    int64_t m_size,
+    int64_t N,
+    const float alpha,
+    const float limit,
+    int64_t offset) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  const fVec one = fVec(1.f);
+  const fVec zero = fVec(0.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+  const fVec alpha_v = fVec(alpha);
+
+  // no remainder
+  for (int64_t m = 0; m < m_size; ++m) {
+    scalar_t* __restrict__ out = output + m * N;
+    const float* __restrict__ cur_ptr = input0 + m * BLOCK_N;
+    for (int64_t d = 0; d < BLOCK_N; d += bVec::size()) {
+      float tmp_glu0[fVec::size()];     // 16
+      float tmp_linear0[fVec::size()];  // 16
+
+      // interleaved: x[2i] = glu, x[2i+1] = linear
+      for (int j = 0; j < fVec::size(); ++j) {
+        // x0 [0,2,..30]
+        tmp_glu0[j] = cur_ptr[d + j * 2];
+        // y0 [1,3,...31]
+        tmp_linear0[j] = cur_ptr[d + j * 2 + 1];
+      }
+      fVec x0 = fVec::loadu(tmp_glu0);
+      fVec y0 = fVec::loadu(tmp_linear0);
+
+      // clamp
+      x0 = at::vec::minimum(x0, limit_v);
+      y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+      // x * sigmoid(x * alpha)
+      x0 = x0 / (one + (x0 * alpha_v).neg().exp_u20());
+      // (y + 1) * x
+      y0 = y0 + one;
+      x0 = x0 * y0;
+      // // convert
+      convert_from_float_and_store<scalar_t>(out + d / 2 + offset, x0);
+    }
+  }
+}
+
 template <typename scalar_t, int BLOCK_M, int BLOCK_N>
 struct tinygemm_kernel_nn2 {
   static inline void apply(
@@ -450,6 +543,8 @@ void fused_experts_kernel_impl(
     const scalar_t* __restrict__ input,
     const scalar_t* __restrict__ packed_w1,
     const scalar_t* __restrict__ packed_w2,
+    const float* __restrict__ w1_bias,
+    const float* __restrict__ w2_bias,
     const float* __restrict__ topk_weights,
     const int32_t* __restrict__ sorted_ids,
     const int32_t* __restrict__ expert_ids,
@@ -459,7 +554,11 @@ void fused_experts_kernel_impl(
     int64_t K,
     int64_t E,
     int64_t topk,
-    int64_t num_tokens_post_pad) {
+    int64_t num_tokens_post_pad,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func,
+    bool with_bias) {
   // handle 2 tiles per block
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
@@ -494,6 +593,8 @@ void fused_experts_kernel_impl(
       int32_t expert_id = expert_ids[mb];
       const scalar_t* __restrict__ B0 = packed_w1 + expert_id * stride_e + nb_upper * BLOCK_N * stride_n;
       const scalar_t* __restrict__ B1 = packed_w1 + expert_id * stride_e + nb_lower * BLOCK_N * stride_n;
+      const float* __restrict__ B0_bias = w1_bias + expert_id * 2 * N + nb_upper * BLOCK_N;
+      const float* __restrict__ B1_bias = w1_bias + expert_id * 2 * N + nb_lower * BLOCK_N;
 
       int64_t m_size = offsets[mb + 1] - offsets[mb];
 
@@ -533,23 +634,60 @@ void fused_experts_kernel_impl(
             /* B     */ B1,
             /* C     */ C1);
 
-        // 1.d silu and mul
-        const int64_t offset = offsets[mb];
-        silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N);
       } else {
-        // fused 1.bcd: silu_and_mul(A @ B0, A @ B1)
         const int64_t offset = offsets[mb];
-        tinygemm_kernel(
-            /* A     */ A,
-            /* B0    */ B0,
-            /* B1    */ B1,
-            /* C     */ ic1 + offset * N + nb * BLOCK_N,
-            /* M     */ m_size,
-            /* N     */ n_size,
-            /* K     */ K,
-            /* lda   */ K,
-            /* ldb   */ n_size,
-            /* ldc   */ N);
+        if (act_func == CPUAcTMethod::swiglu) {
+          tinygemm_kernel(
+              /* A     */ A,
+              /* B     */ B0,
+              /* C     */ C0,
+              /* M     */ m_size,
+              /* N     */ n_size,
+              /* K     */ K,
+              /* lda   */ K,
+              /* ldb   */ n_size,
+              /* ldc   */ BLOCK_N);
+          tinygemm_kernel(
+              /* A     */ A,
+              /* B     */ B1,
+              /* C     */ C1,
+              /* M     */ m_size,
+              /* N     */ n_size,
+              /* K     */ K,
+              /* lda   */ K,
+              /* ldb   */ n_size,
+              /* ldc   */ BLOCK_N);
+        } else {
+          // fused 1.bcd: silu_and_mul(A @ B0, A @ B1)
+          tinygemm_kernel(
+              /* A     */ A,
+              /* B0    */ B0,
+              /* B1    */ B1,
+              /* C     */ ic1 + offset * N + nb * BLOCK_N,
+              /* M     */ m_size,
+              /* N     */ n_size,
+              /* K     */ K,
+              /* lda   */ K,
+              /* ldb   */ n_size,
+              /* ldc   */ N);
+        }
+      }
+      if (with_bias) {
+        for (int64_t m = 0; m < m_size; ++m) {
+          add_bias_stub(C0 + m * BLOCK_N, B0_bias, n_size);
+          add_bias_stub(C1 + m * BLOCK_N, B1_bias, n_size);
+        }
+      }
+      // 1.d silu and mul
+      const int64_t offset = offsets[mb];
+      if (act_func == CPUAcTMethod::silu_and_mul && use_brgemm) {
+        silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N);
+      } else if (act_func == CPUAcTMethod::clamped_silu_and_mul && use_brgemm) {
+        clamped_silu_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N + nb * BLOCK_N, C0, C1, m_size, N, limit);
+      } else if (act_func == CPUAcTMethod::swiglu) {
+        clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(ic1 + offset * N, C0, m_size, N, alpha, limit, 0 + nb * BLOCK_N / 2);
+        clamp_sigmoid_and_mul<scalar_t, BLOCK_N>(
+            ic1 + offset * N, C1, m_size, N, alpha, limit, N / 2 + nb * BLOCK_N / 2);
       }
     });
 
@@ -586,6 +724,7 @@ void fused_experts_kernel_impl(
       // B shape [IC, n_size] in vnni format
       int32_t expert_id = expert_ids[mb];
       const scalar_t* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
+      const float* __restrict__ B_bias = w2_bias + expert_id * OC + nb * BLOCK_N;
 
       // 2.a gemm: C = A @ B
       if (use_brgemm) {
@@ -611,6 +750,11 @@ void fused_experts_kernel_impl(
             /* lda   */ IC,
             /* ldb   */ n_size,
             /* ldc   */ BLOCK_N);
+      }
+      if (with_bias) {
+        for (int64_t m = 0; m < m_size; ++m) {
+          add_bias_stub(C + m * BLOCK_N, B_bias, n_size);
+        }
       }
 
       // 2.b copy from C to ic2 in original order
@@ -807,6 +951,7 @@ void shared_expert_kernel_impl(
 static inline void check_moe_scales(
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_mxfp4,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size) {
@@ -819,6 +964,12 @@ static inline void check_moe_scales(
     TORCH_CHECK(w2_scale.has_value(), "missing w2_scale for fp8 w8a16.");
     TORCH_CHECK(block_size.has_value(), "missing block_size for fp8 w8a16.");
     TORCH_CHECK(block_size.value().size() == 2, "expect block_size.size() to be 2.");
+  }
+  if (use_mxfp4) {
+    TORCH_CHECK(w1_scale.has_value(), "missing w1_scale for mxfp4.");
+    TORCH_CHECK(w2_scale.has_value(), "missing w2_scale for mxfp4.");
+    TORCH_CHECK(w1_scale.value().scalar_type() == at::kByte, "expect w1_scale to be uint8.");
+    TORCH_CHECK(w2_scale.value().scalar_type() == at::kByte, "expect w2_scale to be uint8.");
   }
 }
 
@@ -834,8 +985,8 @@ static inline void check_moe_scales(
   TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
 
 // hidden_states: [M, K]
-// w1: [E, 2N, K]
-// w2: [E, K, N]
+// w1: [E, 2N, K] or [E, 2N, K / 2] for uint8
+// w2: [E, K, N] or [E, K, N / 2] for uint8
 // topk_weights: [M, topk]
 // topk_ids: [M, topk] (int32_t)
 //
@@ -853,6 +1004,10 @@ at::Tensor fused_experts_cpu(
     const std::optional<at::Tensor>& w1_zero,
     const std::optional<at::Tensor>& w2_zero,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w2_bias,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni) {
   auto packed_w1 = is_vnni ? w1 : convert_weight_packed(w1);
   auto packed_w2 = is_vnni ? w2 : convert_weight_packed(w2);
@@ -892,8 +1047,12 @@ at::Tensor fused_experts_cpu(
   int64_t topk = topk_weights_.size(1);
 
   // we use int32_t compensation for int8 w8a8
-  int64_t packed_K = get_row_size(K, moe_comp_method == CPUQuantMethod::INT8_W8A8);
-  int64_t packed_N = get_row_size(N, moe_comp_method == CPUQuantMethod::INT8_W8A8);
+  int64_t packed_K = moe_comp_method == CPUQuantMethod::MXFP4
+                         ? get_row_size<uint8_t>(K)
+                         : get_row_size(K, moe_comp_method == CPUQuantMethod::INT8_W8A8);
+  int64_t packed_N = moe_comp_method == CPUQuantMethod::MXFP4
+                         ? get_row_size<uint8_t>(N)
+                         : get_row_size(N, moe_comp_method == CPUQuantMethod::INT8_W8A8);
 
   // check weight shapes
   CHECK_EQ(w2.size(0), E);
@@ -906,6 +1065,7 @@ at::Tensor fused_experts_cpu(
   check_moe_scales(
       moe_comp_method == CPUQuantMethod::INT8_W8A8,
       moe_comp_method == CPUQuantMethod::FP8_W8A16,
+      moe_comp_method == CPUQuantMethod::MXFP4,
       w1_scale,
       w2_scale,
       block_size);
@@ -960,7 +1120,7 @@ at::Tensor fused_experts_cpu(
   //   5. Aq_tmp : [M, K] or [M * topk, N]
   //   6. As_tmp : [M * topk]
   //
-  // for fp8 w8a16:
+  // for fp8 w8a16 and mxfp4:
   //   7. intermediate_cache0 : [M * topk, 2N]
   //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
   //
@@ -973,7 +1133,7 @@ at::Tensor fused_experts_cpu(
   if (moe_comp_method == CPUQuantMethod::INT8_W8A8) {
     buffer_size_nbytes += std::max(M * K, M * topk * N) + M * topk * sizeof(float);
   }
-  if (moe_comp_method == CPUQuantMethod::FP8_W8A16) {
+  if (moe_comp_method == CPUQuantMethod::FP8_W8A16 || moe_comp_method == CPUQuantMethod::MXFP4) {
     buffer_size_nbytes += M * topk * 2 * N * 2 + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N) * 2;
   }
   if (moe_comp_method == CPUQuantMethod::INT4_W4A8) {
@@ -1026,9 +1186,11 @@ at::Tensor fused_experts_cpu(
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
+      bool with_bias = w1_bias.has_value();
+      auto act_func = select_act_func(alpha, limit);
 
       CHECK_MOE_SCALES_FP8(1, 2);
-      fused_experts_fp8_kernel_impl(
+      fused_experts_fp_kernel_impl<scalar_t, at::Float8_e4m3fn, float, false>(
           out_hidden_states.data_ptr<scalar_t>(),
           intermediate_cache0,
           intermediate_cache1,
@@ -1039,6 +1201,8 @@ at::Tensor fused_experts_cpu(
           hidden_states.data_ptr<scalar_t>(),
           packed_w1.data_ptr<at::Float8_e4m3fn>(),
           packed_w2.data_ptr<at::Float8_e4m3fn>(),
+          with_bias ? w1_bias.value().data_ptr<float>() : nullptr,
+          with_bias ? w2_bias.value().data_ptr<float>() : nullptr,
           w1s.data_ptr<float>(),
           w2s.data_ptr<float>(),
           block_size_N,
@@ -1052,7 +1216,56 @@ at::Tensor fused_experts_cpu(
           K,
           E,
           topk,
-          num_tokens_post_pad);
+          num_tokens_post_pad,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func,
+          with_bias);
+    } else if (moe_comp_method == CPUQuantMethod::MXFP4) {
+      scalar_t* __restrict__ A_tmp = (scalar_t*)((void*)(intermediate_cache2 + M * topk * K));
+      float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
+      scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
+      scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
+      bool with_bias = w1_bias.has_value();
+      auto act_func = select_act_func(alpha, limit);
+
+      // mxfp4 supports only group size of 32 (2^5)
+      constexpr int64_t group_size = 32;
+      auto w1s = w1_scale.value();
+      auto w2s = w2_scale.value();
+      TORCH_CHECK(w1s.numel(), E * 2 * N * K >> 5);
+      TORCH_CHECK(w2s.numel(), E * K * N >> 5);
+      fused_experts_fp_kernel_impl<scalar_t, uint8_t, uint8_t, true>(
+          out_hidden_states.data_ptr<scalar_t>(),
+          intermediate_cache0,
+          intermediate_cache1,
+          intermediate_cache2,
+          A_tmp,
+          B_tmp,
+          C_tmp,
+          hidden_states.data_ptr<scalar_t>(),
+          packed_w1.data_ptr<uint8_t>(),
+          packed_w2.data_ptr<uint8_t>(),
+          with_bias ? w1_bias.value().data_ptr<float>() : nullptr,
+          with_bias ? w2_bias.value().data_ptr<float>() : nullptr,
+          w1s.data_ptr<uint8_t>(),
+          w2s.data_ptr<uint8_t>(),
+          /*block_size_N*/ 1,
+          /*block_size_K*/ group_size,
+          topk_weights_.data_ptr<float>(),
+          sorted_ids,
+          expert_ids,
+          offsets,
+          M,
+          N,
+          K,
+          E,
+          topk,
+          num_tokens_post_pad,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func,
+          with_bias);
     } else if (moe_comp_method == CPUQuantMethod::INT4_W4A8) {
       uint8_t* __restrict__ A_tmp = (uint8_t*)((void*)(intermediate_cache2 + M * topk * K));
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
@@ -1098,6 +1311,8 @@ at::Tensor fused_experts_cpu(
     } else {
       scalar_t* __restrict__ A_tmp = intermediate_cache2 + M * topk * K;
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
+      bool with_bias = w1_bias.has_value();
+      auto act_func = select_act_func(alpha, limit);
 
       fused_experts_kernel_impl<scalar_t>(
           out_hidden_states.data_ptr<scalar_t>(),
@@ -1108,6 +1323,8 @@ at::Tensor fused_experts_cpu(
           hidden_states.data_ptr<scalar_t>(),
           packed_w1.data_ptr<scalar_t>(),
           packed_w2.data_ptr<scalar_t>(),
+          with_bias ? w1_bias.value().data_ptr<float>() : nullptr,
+          with_bias ? w2_bias.value().data_ptr<float>() : nullptr,
           topk_weights_.data_ptr<float>(),
           sorted_ids,
           expert_ids,
@@ -1117,7 +1334,11 @@ at::Tensor fused_experts_cpu(
           K,
           E,
           topk,
-          num_tokens_post_pad);
+          num_tokens_post_pad,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func,
+          with_bias);
     }
   });
   return out_hidden_states;
@@ -1138,9 +1359,12 @@ at::Tensor shared_expert_cpu(
     bool inplace,
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_mxfp4,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni) {
   auto packed_w1 = is_vnni ? w1 : convert_weight_packed(w1);
   auto packed_w2 = is_vnni ? w2 : convert_weight_packed(w2);
@@ -1171,8 +1395,8 @@ at::Tensor shared_expert_cpu(
   int64_t N = w1.size(0) / 2;
 
   // we use int32_t compensation for int8 w8a8
-  int64_t packed_K = get_row_size(K, use_int8_w8a8);
-  int64_t packed_N = get_row_size(N, use_int8_w8a8);
+  int64_t packed_K = use_mxfp4 ? get_row_size<uint8_t>(K) : get_row_size(K, use_int8_w8a8);
+  int64_t packed_N = use_mxfp4 ? get_row_size<uint8_t>(N) : get_row_size(N, use_int8_w8a8);
 
   // check weight shapes
   CHECK_EQ(w2.size(0), K);
@@ -1180,7 +1404,7 @@ at::Tensor shared_expert_cpu(
   CHECK_EQ(packed_w2.size(1), packed_N);
 
   // check scales
-  check_moe_scales(use_int8_w8a8, use_fp8_w8a16, w1_scale, w2_scale, block_size);
+  check_moe_scales(use_int8_w8a8, use_fp8_w8a16, use_mxfp4, w1_scale, w2_scale, block_size);
 
   at::Tensor out_hidden_states = inplace ? hidden_states : at::empty_like(hidden_states);
 
@@ -1192,7 +1416,7 @@ at::Tensor shared_expert_cpu(
   //   3. Aq_tmp : [M, K] or [M, N]
   //   4. As_tmp : [M]
   //
-  // for fp8 w8a16:
+  // for fp8 w8a16 and mxfp4:
   //   5. intermediate_cache0 : [M, 2N]
   //   6. B_tmp: [T, MAX_CACHE_BLOCK_SIZE, BLOCK_M, max(K, N)]
   //
@@ -1202,7 +1426,7 @@ at::Tensor shared_expert_cpu(
   if (use_int8_w8a8) {
     buffer_size_nbytes += std::max(M * K, M * N) + M * sizeof(float);
   }
-  if (use_fp8_w8a16) {
+  if (use_fp8_w8a16 || use_mxfp4) {
     buffer_size_nbytes += M * 2 * N * 2 + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_M * std::max(K, N) * 2;
   }
 
@@ -1239,9 +1463,10 @@ at::Tensor shared_expert_cpu(
     } else if (use_fp8_w8a16) {
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * 2 * N));
+      auto act_func = select_act_func(alpha, limit);
 
       CHECK_MOE_SCALES_FP8(0, 1);
-      shared_expert_fp8_kernel_impl<scalar_t>(
+      shared_expert_fp_kernel_impl<scalar_t, at::Float8_e4m3fn, float, false>(
           out_hidden_states.data_ptr<scalar_t>(),
           intermediate_cache0,
           intermediate_cache1,
@@ -1258,7 +1483,42 @@ at::Tensor shared_expert_cpu(
           routed_scaling_factor_value,
           M,
           N,
-          K);
+          K,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func);
+    } else if (use_mxfp4) {
+      scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
+      scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * 2 * N));
+      auto act_func = select_act_func(alpha, limit);
+
+      // mxfp4 supports only group size of 32 (2^5)
+      constexpr int64_t group_size = 32;
+      auto w1s = w1_scale.value();
+      auto w2s = w2_scale.value();
+      TORCH_CHECK(w1s.numel(), 2 * N * K >> 5);
+      TORCH_CHECK(w2s.numel(), K * N >> 5);
+      shared_expert_fp_kernel_impl<scalar_t, uint8_t, uint8_t, true>(
+          out_hidden_states.data_ptr<scalar_t>(),
+          intermediate_cache0,
+          intermediate_cache1,
+          B_tmp,
+          C_tmp,
+          hidden_states.data_ptr<scalar_t>(),
+          packed_w1.data_ptr<uint8_t>(),
+          packed_w2.data_ptr<uint8_t>(),
+          w1s.data_ptr<uint8_t>(),
+          w2s.data_ptr<uint8_t>(),
+          /*block_size_N*/ 1,
+          /*block_size_K*/ group_size,
+          conditional_data_ptr<scalar_t>(fused_experts_out),
+          routed_scaling_factor_value,
+          M,
+          N,
+          K,
+          alpha.has_value() ? float(alpha.value()) : 0,
+          limit.has_value() ? float(limit.value()) : 0,
+          act_func);
     } else {
       shared_expert_kernel_impl<scalar_t>(
           out_hidden_states.data_ptr<scalar_t>(),

--- a/sgl-kernel/csrc/cpu/moe.h
+++ b/sgl-kernel/csrc/cpu/moe.h
@@ -171,3 +171,146 @@ inline void silu_and_mul_stub(
     out_vec.store(out + d);
   }
 }
+
+template <typename scalar_t>
+inline void clamped_silu_and_mul_stub(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,   // gate buffer
+    const scalar_t* __restrict__ input2,  // up buffer
+    int64_t size,
+    const float limit) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+
+  // no remainder
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d += bVec::size()) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x);
+    bVec y = bVec::loadu(input2 + d);
+    fVec y0, y1;
+    std::tie(y0, y1) = at::vec::convert_to_float(y);
+    // gate: clamp at upper bound only; up: clamp symmetrically
+    x0 = at::vec::minimum(x0, limit_v);
+    x1 = at::vec::minimum(x1, limit_v);
+    y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+    y1 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y1));
+    // silu(gate) * up
+    x0 = x0 / (one + x0.neg().exp_u20());
+    x1 = x1 / (one + x1.neg().exp_u20());
+    x0 = x0 * y0;
+    x1 = x1 * y1;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+}
+
+template <typename scalar_t>
+inline void copy_mul_stub(scalar_t* __restrict__ out, const float* __restrict__ input, float weight, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec weight_vec = fVec(weight);
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    fVec data0 = fVec::loadu(input + d) * weight_vec;
+    fVec data1 = fVec::loadu(input + d + fVec::size()) * weight_vec;
+    bVec out_vec = convert_from_float_ext<scalar_t>(data0, data1);
+    out_vec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(input[d] * weight);
+  }
+}
+
+// input = input + input2
+inline void add_bias_stub(float* __restrict__ input, const float* __restrict__ input2, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = fVec::size();
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    fVec x_fvec = fVec::loadu(input + d);
+    fVec y_fvec = fVec::loadu(input2 + d);
+    x_fvec = x_fvec + y_fvec;
+    x_fvec.store(input + d);
+  }
+  for (; d < size; ++d) {
+    input[d] = input[d] + input2[d];
+  }
+}
+
+template <typename scalar_t>
+inline void copy_mul_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, float weight, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec weight_vec = fVec(weight);
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x);
+    x0 = x0 * weight_vec;
+    x1 = x1 * weight_vec;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(input[d] * weight);
+  }
+}
+
+template <typename scalar_t>
+inline void clamp_sigmoid_and_mul_stub(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    int64_t size,
+    const float alpha,
+    const float limit) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+  const fVec zero = fVec(0.f);
+  const fVec limit_v = fVec(limit);
+  const fVec nlimit_v = fVec(-limit);
+  const fVec alpha_v = fVec(alpha);
+
+  // no remainder
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d += bVec::size()) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0_, y0_;
+    std::tie(x0_, y0_) = at::vec::convert_to_float(x);
+    float tmp_buffer[fVec::size() * 2];  // 32
+    float tmp_glu[fVec::size()];         // 16
+    float tmp_linear[fVec::size()];      // 16
+    x0_.store(tmp_buffer);
+    y0_.store(tmp_buffer + fVec::size());
+    // interleaved: x[2i] = glu, x[2i+1] = linear
+    for (int j = 0; j < fVec::size(); ++j) {
+      // x0 [0,2,..30]
+      tmp_glu[j] = tmp_buffer[j * 2];
+      // y0 [1,3,...31]
+      tmp_linear[j] = tmp_buffer[j * 2 + 1];
+    }
+    fVec x0 = fVec::loadu(tmp_glu);
+    fVec y0 = fVec::loadu(tmp_linear);
+
+    // clamp
+    x0 = at::vec::minimum(x0, limit_v);
+    y0 = at::vec::minimum(limit_v, at::vec::maximum(nlimit_v, y0));
+    // x * sigmoid(x * alpha)
+    x0 = x0 / (one + (x0 * alpha_v).neg().exp_u20());
+    // (y + 1) * x
+    y0 = y0 + one;
+    x0 = x0 * y0;
+    convert_from_float_and_store<scalar_t>(out + d / 2, x0);
+  }
+}

--- a/sgl-kernel/csrc/cpu/moe_fp8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8.cpp
@@ -2,8 +2,8 @@
 #include "gemm.h"
 #include "moe.h"
 
-template <typename scalar_t>
-void fused_experts_fp8_kernel_impl(
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void fused_experts_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
@@ -12,10 +12,12 @@ void fused_experts_fp8_kernel_impl(
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const float* __restrict__ w1_bias,
+    const float* __restrict__ w2_bias,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const float* __restrict__ topk_weights,
@@ -27,7 +29,11 @@ void fused_experts_fp8_kernel_impl(
     int64_t K,
     int64_t E,
     int64_t topk,
-    int64_t num_tokens_post_pad) {
+    int64_t num_tokens_post_pad,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func,
+    bool with_bias) {
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
 
@@ -38,11 +44,20 @@ void fused_experts_fp8_kernel_impl(
   int64_t scale_size_K = div_up(K, block_size_K);
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
 
-  const int64_t stride_e = 2 * N * K;
-  const int64_t stride_n = K;
+  std::function<int64_t(int64_t)> scale_offset_per_block;
+  if constexpr (is_mxfp4) {
+    scale_offset_per_block = [&](int64_t a) { return a * BLOCK_N; };
+  } else {
+    scale_offset_per_block = [&](int64_t a) { return a / blocks_n_per_group; };
+  }
+
+  const int64_t packed_K = get_row_size<packed_t>(K);
+
+  const int64_t stride_e = 2 * N * packed_K;
+  const int64_t stride_n = packed_K;
 
   int64_t avg_M = std::max(int64_t(1), M * topk / E);
-  const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(avg_M);
+  const bool use_brgemm = can_use_brgemm<packed_t>(avg_M);
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
 
@@ -52,14 +67,15 @@ void fused_experts_fp8_kernel_impl(
     int tid = get_thread_num();
     scalar_t* __restrict__ A = A_tmp + tid * BLOCK_M * K;
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t n_size = std::min(2 * N - nb * BLOCK_N, BLOCK_N);
 
       // B shape [K, n_size] in vnni format
       int32_t expert_id = expert_ids[mb];
-      const at::Float8_e4m3fn* __restrict__ B = packed_w1 + expert_id * stride_e + nb * BLOCK_N * stride_n;
-      const float* __restrict__ Bs =
-          w1s + expert_id * scale_size_N * scale_size_K + (nb / blocks_n_per_group) * scale_size_K;
+      const packed_t* __restrict__ B = packed_w1 + expert_id * stride_e + nb * BLOCK_N * stride_n;
+      const param_t* __restrict__ Bs =
+          w1s + expert_id * scale_size_N * scale_size_K + scale_offset_per_block(nb) * scale_size_K;
+      const float* __restrict__ B_bias = with_bias ? w1_bias + expert_id * 2 * N + nb * BLOCK_N : nullptr;
 
       // do unpacking for the first row or a new expert
       int32_t pre_expert_id = mb == 0 ? -1 : expert_ids[mb - 1];
@@ -83,6 +99,7 @@ void fused_experts_fp8_kernel_impl(
           /*   C            */ ic0 + offset * 2 * N + nb * BLOCK_N,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * K,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   Bbias        */ B_bias,
           /*   scale        */ Bs,
           /*   M            */ m_size,
           /*   N            */ n_size,
@@ -101,11 +118,26 @@ void fused_experts_fp8_kernel_impl(
   });
 
   // stage 1.5: intermediate_cache1 = silu(intermediate_cache0)
-  at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t m = begin; m < end; ++m) {
-      silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
-    }
-  });
+  if (act_func == CPUAcTMethod::silu_and_mul) {
+    at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::clamped_silu_and_mul) {
+    at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamped_silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N, limit);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::swiglu) {
+    at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamp_sigmoid_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, N, alpha, limit);
+        clamp_sigmoid_and_mul_stub(ic1 + m * N + N / 2, ic0 + m * 2 * N + N, N, alpha, limit);
+      }
+    });
+  }
 
   // stage 2: intermediate_cache2 = intermediate_cache1 @ w2
   //   w2 : [E, K, N] as [E, OC, IC]
@@ -115,15 +147,16 @@ void fused_experts_fp8_kernel_impl(
   const int64_t NB2 = div_up(OC, BLOCK_N);
   scale_size_N = div_up(K, block_size_N);
   scale_size_K = div_up(N, block_size_K);
-  const int64_t stride_e2 = OC * IC;
-  const int64_t stride_oc = IC;
+  const int64_t packed_IC = get_row_size<packed_t>(IC);
+  const int64_t stride_e2 = OC * packed_IC;
+  const int64_t stride_oc = packed_IC;
 
   // parallel on [MB2, NB2]
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = offsets[mb + 1] - offsets[mb];
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
 
@@ -134,9 +167,10 @@ void fused_experts_fp8_kernel_impl(
 
       // B shape [IC, n_size] in vnni format
       int32_t expert_id = expert_ids[mb];
-      const at::Float8_e4m3fn* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
-      const float* __restrict__ Bs =
-          w2s + expert_id * scale_size_N * scale_size_K + (nb / blocks_n_per_group) * scale_size_K;
+      const packed_t* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
+      const param_t* __restrict__ Bs =
+          w2s + expert_id * scale_size_N * scale_size_K + scale_offset_per_block(nb) * scale_size_K;
+      const float* __restrict__ B_bias = with_bias ? w2_bias + expert_id * OC + nb * BLOCK_N : nullptr;
 
       // do unpacking for the first row or a new expert
       int32_t pre_expert_id = mb == 0 ? -1 : expert_ids[mb - 1];
@@ -148,6 +182,7 @@ void fused_experts_fp8_kernel_impl(
           /*   C            */ C,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * IC,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   Bbias        */ B_bias,
           /*   scale        */ Bs,
           /*   M            */ m_size,
           /*   N            */ n_size,
@@ -182,55 +217,66 @@ void fused_experts_fp8_kernel_impl(
   });
 }
 
-#define INSTANTIATE_MOE_FP8_TEMPLATE(TYPE)             \
-  template void fused_experts_fp8_kernel_impl<TYPE>(   \
-      TYPE* __restrict__ output,                       \
-      TYPE* __restrict__ ic0,                          \
-      TYPE* __restrict__ ic1,                          \
-      TYPE* __restrict__ ic2,                          \
-      TYPE* __restrict__ A_tmp,                        \
-      TYPE* __restrict__ B_tmp,                        \
-      float* __restrict__ C_tmp,                       \
-      const TYPE* __restrict__ input,                  \
-      const at::Float8_e4m3fn* __restrict__ packed_w1, \
-      const at::Float8_e4m3fn* __restrict__ packed_w2, \
-      const float* __restrict__ w1s,                   \
-      const float* __restrict__ w2s,                   \
-      int64_t block_size_N,                            \
-      int64_t block_size_K,                            \
-      const float* __restrict__ topk_weights,          \
-      const int32_t* __restrict__ sorted_ids,          \
-      const int32_t* __restrict__ expert_ids,          \
-      const int32_t* __restrict__ offsets,             \
-      int64_t M,                                       \
-      int64_t N,                                       \
-      int64_t K,                                       \
-      int64_t E,                                       \
-      int64_t topk,                                    \
-      int64_t num_tokens_post_pad)
+#define INSTANTIATE_MOE_FP_TEMPLATE(TYPE1, TYPE2, TYPE3, IS_MXFP4)           \
+  template void fused_experts_fp_kernel_impl<TYPE1, TYPE2, TYPE3, IS_MXFP4>( \
+      TYPE1* __restrict__ output,                                            \
+      TYPE1* __restrict__ ic0,                                               \
+      TYPE1* __restrict__ ic1,                                               \
+      TYPE1* __restrict__ ic2,                                               \
+      TYPE1* __restrict__ A_tmp,                                             \
+      TYPE1* __restrict__ B_tmp,                                             \
+      float* __restrict__ C_tmp,                                             \
+      const TYPE1* __restrict__ input,                                       \
+      const TYPE2* __restrict__ packed_w1,                                   \
+      const TYPE2* __restrict__ packed_w2,                                   \
+      const float* __restrict__ w1_bias,                                     \
+      const float* __restrict__ w2_bias,                                     \
+      const TYPE3* __restrict__ w1s,                                         \
+      const TYPE3* __restrict__ w2s,                                         \
+      int64_t block_size_N,                                                  \
+      int64_t block_size_K,                                                  \
+      const float* __restrict__ topk_weights,                                \
+      const int32_t* __restrict__ sorted_ids,                                \
+      const int32_t* __restrict__ expert_ids,                                \
+      const int32_t* __restrict__ offsets,                                   \
+      int64_t M,                                                             \
+      int64_t N,                                                             \
+      int64_t K,                                                             \
+      int64_t E,                                                             \
+      int64_t topk,                                                          \
+      int64_t num_tokens_post_pad,                                           \
+      float alpha,                                                           \
+      float limit,                                                           \
+      CPUAcTMethod act_func,                                                 \
+      bool with_bias)
 
-INSTANTIATE_MOE_FP8_TEMPLATE(at::BFloat16);
-INSTANTIATE_MOE_FP8_TEMPLATE(at::Half);
+INSTANTIATE_MOE_FP_TEMPLATE(at::BFloat16, at::Float8_e4m3fn, float, false);
+INSTANTIATE_MOE_FP_TEMPLATE(at::Half, at::Float8_e4m3fn, float, false);
+INSTANTIATE_MOE_FP_TEMPLATE(at::BFloat16, uint8_t, uint8_t, true);
+INSTANTIATE_MOE_FP_TEMPLATE(at::Half, uint8_t, uint8_t, true);
 
-template <typename scalar_t>
-void shared_expert_fp8_kernel_impl(
+template <typename scalar_t, typename packed_t, typename param_t, bool is_mxfp4>
+void shared_expert_fp_kernel_impl(
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ ic0,
     scalar_t* __restrict__ ic1,
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
     const scalar_t* __restrict__ input,
-    const at::Float8_e4m3fn* __restrict__ packed_w1,
-    const at::Float8_e4m3fn* __restrict__ packed_w2,
-    const float* __restrict__ w1s,
-    const float* __restrict__ w2s,
+    const packed_t* __restrict__ packed_w1,
+    const packed_t* __restrict__ packed_w2,
+    const param_t* __restrict__ w1s,
+    const param_t* __restrict__ w2s,
     int64_t block_size_N,
     int64_t block_size_K,
     const scalar_t* __restrict__ fused_experts_out,
     float routed_scaling_factor,
     int64_t M,
     int64_t N,
-    int64_t K) {
+    int64_t K,
+    float alpha,
+    float limit,
+    CPUAcTMethod act_func) {
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
 
@@ -239,8 +285,15 @@ void shared_expert_fp8_kernel_impl(
   const int64_t NB = div_up(2 * N, BLOCK_N);
   int64_t scale_size_K = div_up(K, block_size_K);
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
+  std::function<int64_t(int64_t)> scale_offset_per_block;
+  if constexpr (is_mxfp4) {
+    scale_offset_per_block = [&](int64_t a) { return a * BLOCK_N; };
+  } else {
+    scale_offset_per_block = [&](int64_t a) { return a / blocks_n_per_group; };
+  }
 
-  const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(M);
+  const int64_t packed_K = get_row_size<packed_t>(K);
+  const bool use_brgemm = can_use_brgemm<packed_t>(M);
   const bool apply_scaling_factor = fused_experts_out != nullptr;
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
@@ -248,7 +301,7 @@ void shared_expert_fp8_kernel_impl(
   parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = std::min(M - mb * BLOCK_M, BLOCK_M);
       int64_t n_size = std::min(2 * N - nb * BLOCK_N, BLOCK_N);
 
@@ -257,11 +310,12 @@ void shared_expert_fp8_kernel_impl(
 
       tinygemm_kernel<scalar_t>(
           /*   A            */ input + mb * BLOCK_M * K,
-          /*   B            */ packed_w1 + nb * BLOCK_N * K,
+          /*   B            */ packed_w1 + nb * BLOCK_N * packed_K,
           /*   C            */ ic0 + mb * BLOCK_M * 2 * N + nb * BLOCK_N,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * K,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
-          /*   scale        */ w1s + (nb / blocks_n_per_group) * scale_size_K,
+          /*   Bbias        */ nullptr,
+          /*   scale        */ w1s + scale_offset_per_block(nb) * scale_size_K,
           /*   M            */ m_size,
           /*   N            */ n_size,
           /*   K            */ K,
@@ -279,11 +333,26 @@ void shared_expert_fp8_kernel_impl(
   });
 
   // stage 1.5: intermediate_cache1 = silu(intermediate_cache0)
-  at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
-    for (int64_t m = begin; m < end; ++m) {
-      silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
-    }
-  });
+  if (act_func == CPUAcTMethod::silu_and_mul) {
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::clamped_silu_and_mul) {
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamped_silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N, limit);
+      }
+    });
+  } else if (act_func == CPUAcTMethod::swiglu) {
+    at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+      for (int64_t m = begin; m < end; ++m) {
+        clamp_sigmoid_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, N, alpha, limit);
+        clamp_sigmoid_and_mul_stub(ic1 + m * N + N / 2, ic0 + m * 2 * N + N, N, alpha, limit);
+      }
+    });
+  }
 
   // stage 2: intermediate_cache2 = intermediate_cache1 @ w2
   //   w2 : [K, N] as [OC, IC]
@@ -292,13 +361,14 @@ void shared_expert_fp8_kernel_impl(
   const int64_t MB2 = MB;
   const int64_t NB2 = div_up(K, BLOCK_N);
   scale_size_K = div_up(N, block_size_K);
+  const int64_t packed_IC = get_row_size<packed_t>(IC);
 
   // parallel on [MB2, NB2]
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
 
-    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+    loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = std::min(M - mb * BLOCK_M, BLOCK_M);
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
 
@@ -308,11 +378,12 @@ void shared_expert_fp8_kernel_impl(
       // 2.a gemm: C = A @ B
       tinygemm_kernel<scalar_t>(
           /*   A            */ ic1 + mb * BLOCK_M * N,
-          /*   B            */ packed_w2 + nb * BLOCK_N * N,
+          /*   B            */ packed_w2 + nb * BLOCK_N * packed_IC,
           /*   C            */ C,
           /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * IC,
           /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
-          /*   scale        */ w2s + (nb / blocks_n_per_group) * scale_size_K,
+          /*   Bbias        */ nullptr,
+          /*   scale        */ w2s + scale_offset_per_block(nb) * scale_size_K,
           /*   M            */ m_size,
           /*   N            */ n_size,
           /*   K            */ IC,
@@ -339,25 +410,30 @@ void shared_expert_fp8_kernel_impl(
   }
 }
 
-#define INSTANTIATE_SHARED_EXPERT_FP8_TEMPLATE(TYPE)   \
-  template void shared_expert_fp8_kernel_impl<TYPE>(   \
-      TYPE* __restrict__ output,                       \
-      TYPE* __restrict__ ic0,                          \
-      TYPE* __restrict__ ic1,                          \
-      TYPE* __restrict__ B_tmp,                        \
-      float* __restrict__ C_tmp,                       \
-      const TYPE* __restrict__ input,                  \
-      const at::Float8_e4m3fn* __restrict__ packed_w1, \
-      const at::Float8_e4m3fn* __restrict__ packed_w2, \
-      const float* __restrict__ w1s,                   \
-      const float* __restrict__ w2s,                   \
-      int64_t block_size_N,                            \
-      int64_t block_size_K,                            \
-      const TYPE* __restrict__ fused_experts_out,      \
-      float routed_scaling_factor,                     \
-      int64_t M,                                       \
-      int64_t N,                                       \
-      int64_t K)
+#define INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(TYPE1, TYPE2, TYPE3, IS_MXFP4) \
+  template void shared_expert_fp_kernel_impl<TYPE1, TYPE2, TYPE3, IS_MXFP4>( \
+      TYPE1* __restrict__ output,                                            \
+      TYPE1* __restrict__ ic0,                                               \
+      TYPE1* __restrict__ ic1,                                               \
+      TYPE1* __restrict__ B_tmp,                                             \
+      float* __restrict__ C_tmp,                                             \
+      const TYPE1* __restrict__ input,                                       \
+      const TYPE2* __restrict__ packed_w1,                                   \
+      const TYPE2* __restrict__ packed_w2,                                   \
+      const TYPE3* __restrict__ w1s,                                         \
+      const TYPE3* __restrict__ w2s,                                         \
+      int64_t block_size_N,                                                  \
+      int64_t block_size_K,                                                  \
+      const TYPE1* __restrict__ fused_experts_out,                           \
+      float routed_scaling_factor,                                           \
+      int64_t M,                                                             \
+      int64_t N,                                                             \
+      int64_t K,                                                             \
+      float alpha,                                                           \
+      float limit,                                                           \
+      CPUAcTMethod act_func)
 
-INSTANTIATE_SHARED_EXPERT_FP8_TEMPLATE(at::BFloat16);
-INSTANTIATE_SHARED_EXPERT_FP8_TEMPLATE(at::Half);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::BFloat16, at::Float8_e4m3fn, float, false);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::Half, at::Float8_e4m3fn, float, false);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::BFloat16, uint8_t, uint8_t, true);
+INSTANTIATE_SHARED_EXPERT_FP_TEMPLATE(at::Half, uint8_t, uint8_t, true);

--- a/sgl-kernel/csrc/cpu/norm.cpp
+++ b/sgl-kernel/csrc/cpu/norm.cpp
@@ -1,6 +1,13 @@
 #include "common.h"
 #include "vec.h"
 
+#define SGL_DISPATCH_FP16_BF16_F32_TYPES(TYPE, NAME, ...)                                                         \
+  AT_DISPATCH_SWITCH(                                                                                             \
+      TYPE,                                                                                                       \
+      NAME,                                                                                                       \
+      AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__) AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__) \
+          AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__))
+
 namespace {
 
 // NB: avoid using `at::vec::map<>` on bfloat16 or half
@@ -35,12 +42,17 @@ void l2norm_kernel_impl(
       int64_t d;
 #pragma GCC unroll 4
       for (d = 0; d <= hidden_size - kVecSize; d += kVecSize) {
-        bVec x_bvec = bVec::loadu(input_ptr + d);
-        fVec x_fvec0, x_fvec1;
-        std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          fVec x_fvec = fVec::loadu(input_ptr + d);
+          sum_fvec += x_fvec * x_fvec;
+        } else {
+          bVec x_bvec = bVec::loadu(input_ptr + d);
+          fVec x_fvec0, x_fvec1;
+          std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-        sum_fvec += x_fvec0 * x_fvec0;
-        sum_fvec += x_fvec1 * x_fvec1;
+          sum_fvec += x_fvec0 * x_fvec0;
+          sum_fvec += x_fvec1 * x_fvec1;
+        }
       }
 #pragma GCC unroll 4
       for (; d < hidden_size; ++d) {
@@ -54,15 +66,21 @@ void l2norm_kernel_impl(
 
 #pragma GCC unroll 4
       for (d = 0; d <= hidden_size - kVecSize; d += kVecSize) {
-        bVec x_bvec = bVec::loadu(input_ptr + d);
-        fVec x_fvec0, x_fvec1;
-        std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          fVec x_fvec = fVec::loadu(input_ptr + d);
+          x_fvec = x_fvec * scale_fvec;
+          x_fvec.store(out_ptr + d);
+        } else {
+          bVec x_bvec = bVec::loadu(input_ptr + d);
+          fVec x_fvec0, x_fvec1;
+          std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-        x_fvec0 = x_fvec0 * scale_fvec;
-        x_fvec1 = x_fvec1 * scale_fvec;
+          x_fvec0 = x_fvec0 * scale_fvec;
+          x_fvec1 = x_fvec1 * scale_fvec;
 
-        bVec out_bvec = convert_from_float_ext<scalar_t>(x_fvec0, x_fvec1);
-        out_bvec.store(out_ptr + d);
+          bVec out_bvec = convert_from_float_ext<scalar_t>(x_fvec0, x_fvec1);
+          out_bvec.store(out_ptr + d);
+        }
       }
 #pragma GCC unroll 4
       for (; d < hidden_size; ++d) {
@@ -108,12 +126,17 @@ void rmsnorm_kernel_impl(
       int64_t d;
 #pragma GCC unroll 4
       for (d = 0; d <= hidden_size - kVecSize; d += kVecSize) {
-        bVec x_bvec = bVec::loadu(input_ptr + d);
-        fVec x_fvec0, x_fvec1;
-        std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          fVec x_fvec = fVec::loadu(input_ptr + d);
+          sum_fvec += x_fvec * x_fvec;
+        } else {
+          bVec x_bvec = bVec::loadu(input_ptr + d);
+          fVec x_fvec0, x_fvec1;
+          std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-        sum_fvec += x_fvec0 * x_fvec0;
-        sum_fvec += x_fvec1 * x_fvec1;
+          sum_fvec += x_fvec0 * x_fvec0;
+          sum_fvec += x_fvec1 * x_fvec1;
+        }
       }
 #pragma GCC unroll 4
       for (; d < hidden_size; ++d) {
@@ -127,19 +150,26 @@ void rmsnorm_kernel_impl(
 
 #pragma GCC unroll 4
       for (d = 0; d <= hidden_size - kVecSize; d += kVecSize) {
-        bVec x_bvec = bVec::loadu(input_ptr + d);
-        fVec x_fvec0, x_fvec1;
-        std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          fVec x_fvec = fVec::loadu(input_ptr + d);
+          fVec w_fvec = fVec::loadu(weight + d);
+          x_fvec = x_fvec * scale_fvec * vf(w_fvec);
+          x_fvec.store(out_ptr + d);
+        } else {
+          bVec x_bvec = bVec::loadu(input_ptr + d);
+          fVec x_fvec0, x_fvec1;
+          std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-        bVec w_bvec = bVec::loadu(weight + d);
-        fVec w_fvec0, w_fvec1;
-        std::tie(w_fvec0, w_fvec1) = at::vec::convert_to_float(w_bvec);
+          bVec w_bvec = bVec::loadu(weight + d);
+          fVec w_fvec0, w_fvec1;
+          std::tie(w_fvec0, w_fvec1) = at::vec::convert_to_float(w_bvec);
 
-        x_fvec0 = x_fvec0 * scale_fvec * vf(w_fvec0);
-        x_fvec1 = x_fvec1 * scale_fvec * vf(w_fvec1);
+          x_fvec0 = x_fvec0 * scale_fvec * vf(w_fvec0);
+          x_fvec1 = x_fvec1 * scale_fvec * vf(w_fvec1);
 
-        bVec out_bvec = convert_from_float_ext<scalar_t>(x_fvec0, x_fvec1);
-        out_bvec.store(out_ptr + d);
+          bVec out_bvec = convert_from_float_ext<scalar_t>(x_fvec0, x_fvec1);
+          out_bvec.store(out_ptr + d);
+        }
       }
 #pragma GCC unroll 4
       for (; d < hidden_size; ++d) {
@@ -188,12 +218,17 @@ void gemma3_rmsnorm_kernel_4d_impl(
       int64_t d;
 #pragma GCC unroll 4
       for (d = 0; d <= hidden_size - kVecSize; d += kVecSize) {
-        bVec x_bvec = bVec::loadu(input_ptr + d);
-        fVec x_fvec0, x_fvec1;
-        std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          fVec x_fvec = fVec::loadu(input_ptr + d);
+          sum_fvec += x_fvec * x_fvec;
+        } else {
+          bVec x_bvec = bVec::loadu(input_ptr + d);
+          fVec x_fvec0, x_fvec1;
+          std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
 
-        sum_fvec += x_fvec0 * x_fvec0;
-        sum_fvec += x_fvec1 * x_fvec1;
+          sum_fvec += x_fvec0 * x_fvec0;
+          sum_fvec += x_fvec1 * x_fvec1;
+        }
       }
 #pragma GCC unroll 4
       for (; d < hidden_size; ++d) {
@@ -544,7 +579,7 @@ at::Tensor l2norm_cpu(at::Tensor& input, double eps) {
   int64_t hidden_size = input.size(1);
   at::Tensor output = at::empty_like(input);
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "l2norm_kernel", [&] {
+  SGL_DISPATCH_FP16_BF16_F32_TYPES(input.scalar_type(), "l2norm_kernel", [&] {
     l2norm_kernel_impl<scalar_t>(
         output.data_ptr<scalar_t>(),
         input.data_ptr<scalar_t>(),
@@ -584,7 +619,7 @@ at::Tensor rmsnorm_cpu(at::Tensor& input, at::Tensor& weight, double eps) {
     output_strideS = output.stride(1);
   }
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(input.scalar_type(), "rmsnorm_kernel", [&] {
+  SGL_DISPATCH_FP16_BF16_F32_TYPES(input.scalar_type(), "rmsnorm_kernel", [&] {
     using Vec = at::vec::Vectorized<float>;
     rmsnorm_kernel_impl<scalar_t>(
         output.data_ptr<scalar_t>(),
@@ -992,3 +1027,5 @@ at::Tensor fused_add_layernorm_cpu(
   });
   return output;
 }
+
+#undef SGL_DISPATCH_FP16_BF16_F32_TYPES

--- a/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
+++ b/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
@@ -1,0 +1,202 @@
+#include <c10/util/Float8_e4m3fn.h>
+
+#include <algorithm>
+#include <cstdint>
+
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+constexpr int64_t kBlockSize = 64;
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kHeadDimWithScaleBytes = 132;
+constexpr int64_t kScaleOffsetBytes = kBlockSize * kHeadDim;
+constexpr int64_t kBlockBytes = kBlockSize * kHeadDimWithScaleBytes;
+
+inline float fp8_e4m3_to_float(uint8_t v) {
+  c10::Float8_e4m3fn x;
+  x.x = v;
+  return static_cast<float>(x);
+}
+
+inline float dot_fp8_128_scalar(const uint8_t* k, const uint8_t* q) {
+  float dot = 0.0f;
+  for (int64_t d = 0; d < kHeadDim; ++d) {
+    dot += fp8_e4m3_to_float(k[d]) * fp8_e4m3_to_float(q[d]);
+  }
+  return dot;
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+inline float dot_fp8_128(const uint8_t* k, const uint8_t* q) {
+  __m512 acc = _mm512_setzero_ps();
+  for (int64_t d = 0; d < kHeadDim; d += 32) {
+    const __m256i k8 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(k + d));
+    const __m256i q8 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(q + d));
+    acc = _mm512_dpbf16_ps(acc, CVT_FP8_TO_BF16(k8), CVT_FP8_TO_BF16(q8));
+  }
+  return _mm512_reduce_add_ps(acc);
+}
+#else
+inline float dot_fp8_128(const uint8_t* k, const uint8_t* q) {
+  return dot_fp8_128_scalar(k, q);
+}
+#endif
+
+template <typename T>
+inline int64_t load_int(const T* ptr, int64_t idx) {
+  return static_cast<int64_t>(ptr[idx]);
+}
+
+template <typename T>
+inline float load_weight(const T* ptr, int64_t idx) {
+  return static_cast<float>(ptr[idx]);
+}
+
+template <typename seq_t, typename page_t, typename weight_t>
+void fp8_paged_mqa_logits_cpu_impl(
+    const at::Tensor& q_fp8,
+    const at::Tensor& kvcache_fp8,
+    const at::Tensor& weight,
+    const at::Tensor& seq_lens,
+    const at::Tensor& page_table,
+    at::Tensor& logits,
+    int64_t max_seq_len) {
+  const int64_t batch_size = q_fp8.size(0);
+  const int64_t num_heads = q_fp8.size(2);
+  const int64_t num_blocks = kvcache_fp8.size(0);
+  const int64_t pages_per_batch = page_table.size(1);
+
+  const auto* q_ptr = reinterpret_cast<const uint8_t*>(q_fp8.const_data_ptr());
+  const auto* cache_ptr = reinterpret_cast<const uint8_t*>(kvcache_fp8.const_data_ptr());
+  const auto* weight_ptr = weight.const_data_ptr<weight_t>();
+  const auto* seq_ptr = seq_lens.const_data_ptr<seq_t>();
+  const auto* page_ptr = page_table.const_data_ptr<page_t>();
+  auto* out_ptr = logits.data_ptr<float>();
+
+  at::parallel_for(0, batch_size * max_seq_len, GRAIN_SIZE / kHeadDim, [&](int64_t begin, int64_t end) {
+    int64_t b{0}, token{0};
+    data_index_init(begin, b, batch_size, token, max_seq_len);
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t seq_len = load_int(seq_ptr, b);
+      TORCH_CHECK(seq_len >= 0 && seq_len <= max_seq_len, "seq_lens must be in [0, max_seq_len]");
+
+      if (token >= seq_len) {
+        data_index_step(b, batch_size, token, max_seq_len);
+        continue;
+      }
+
+      const int64_t q_batch_offset = ((b * 1 * num_heads) * kHeadDim);
+      const int64_t weight_batch_offset = b * num_heads;
+      const int64_t page_batch_offset = b * pages_per_batch;
+      float* out_row = out_ptr + b * max_seq_len;
+
+      const int64_t logical_page = token / kBlockSize;
+      const int64_t token_in_page = token % kBlockSize;
+      TORCH_CHECK(logical_page < pages_per_batch, "page_table does not cover seq_len");
+
+      const int64_t physical_page = load_int(page_ptr, page_batch_offset + logical_page);
+      TORCH_CHECK(physical_page >= 0 && physical_page < num_blocks, "page_table contains an invalid page index");
+
+      const uint8_t* block = cache_ptr + physical_page * kBlockBytes;
+      const uint8_t* k_token = block + token_in_page * kHeadDim;
+      const float* scale_ptr = reinterpret_cast<const float*>(block + kScaleOffsetBytes);
+      const float k_scale = scale_ptr[token_in_page];
+
+      float score_sum = 0.0f;
+      for (int64_t h = 0; h < num_heads; ++h) {
+        const uint8_t* q_head = q_ptr + q_batch_offset + h * kHeadDim;
+        float dot = dot_fp8_128(k_token, q_head);
+        dot = std::max(dot, 0.0f);
+        score_sum += dot * load_weight(weight_ptr, weight_batch_offset + h);
+      }
+
+      out_row[token] = score_sum * k_scale;
+
+      data_index_step(b, batch_size, token, max_seq_len);
+    }
+  });
+}
+
+template <typename seq_t, typename page_t>
+void dispatch_weight_type(
+    const at::Tensor& q_fp8,
+    const at::Tensor& kvcache_fp8,
+    const at::Tensor& weight,
+    const at::Tensor& seq_lens,
+    const at::Tensor& page_table,
+    at::Tensor& logits,
+    int64_t max_seq_len) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, weight.scalar_type(), "fp8_paged_mqa_logits_cpu_weight", [&] {
+        fp8_paged_mqa_logits_cpu_impl<seq_t, page_t, scalar_t>(
+            q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+      });
+}
+
+template <typename seq_t>
+void dispatch_page_type(
+    const at::Tensor& q_fp8,
+    const at::Tensor& kvcache_fp8,
+    const at::Tensor& weight,
+    const at::Tensor& seq_lens,
+    const at::Tensor& page_table,
+    at::Tensor& logits,
+    int64_t max_seq_len) {
+  if (page_table.scalar_type() == at::kInt) {
+    dispatch_weight_type<seq_t, int32_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else if (page_table.scalar_type() == at::kLong) {
+    dispatch_weight_type<seq_t, int64_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else {
+    TORCH_CHECK(false, "page_table must be int32 or int64");
+  }
+}
+
+}  // namespace
+
+at::Tensor fp8_paged_mqa_logits_cpu(
+    at::Tensor& q_fp8,
+    at::Tensor& kvcache_fp8,
+    at::Tensor& weight,
+    at::Tensor& seq_lens,
+    at::Tensor& page_table,
+    int64_t max_seq_len,
+    bool clean_logits) {
+  TORCH_CHECK(!clean_logits, "fp8_paged_mqa_logits_cpu only supports clean_logits == false");
+  CHECK_INPUT(q_fp8);
+  CHECK_INPUT(kvcache_fp8);
+  CHECK_INPUT(weight);
+  CHECK_INPUT(seq_lens);
+  CHECK_INPUT(page_table);
+  TORCH_CHECK(q_fp8.scalar_type() == at::ScalarType::Float8_e4m3fn, "q_fp8 must be torch.float8_e4m3fn");
+  TORCH_CHECK(kvcache_fp8.scalar_type() == at::kByte, "kvcache_fp8 must be torch.uint8 storage");
+
+  // The checks are aligned with fp8_paged_mqa_logits_torch in indexer.py.
+  TORCH_CHECK(q_fp8.dim() == 4, "q_fp8 must have shape [batch, 1, heads, 128]");
+  TORCH_CHECK(q_fp8.size(1) == 1, "q_fp8 second dimension must be 1");
+  TORCH_CHECK(q_fp8.size(3) == kHeadDim, "q_fp8 head_dim must be 128");
+  TORCH_CHECK(kvcache_fp8.dim() == 4, "kvcache_fp8 must have shape [blocks, 64, 1, 132]");
+  TORCH_CHECK(kvcache_fp8.size(1) == kBlockSize, "kvcache_fp8 block size must be 64");
+  TORCH_CHECK(kvcache_fp8.size(2) == 1, "kvcache_fp8 num kv heads must be 1");
+  TORCH_CHECK(kvcache_fp8.size(3) == kHeadDimWithScaleBytes, "kvcache_fp8 last dimension must be 132 bytes");
+
+  const int64_t batch_size = q_fp8.size(0);
+  const int64_t num_heads = q_fp8.size(2);
+  TORCH_CHECK(weight.sizes() == at::IntArrayRef({batch_size, num_heads}), "weight must have shape [batch, heads]");
+  TORCH_CHECK(seq_lens.sizes() == at::IntArrayRef({batch_size}), "seq_lens must have shape [batch]");
+  TORCH_CHECK(page_table.dim() == 2 && page_table.size(0) == batch_size, "page_table must have shape [batch, pages]");
+  TORCH_CHECK(max_seq_len >= 0, "max_seq_len must be non-negative");
+
+  auto logits = at::empty({batch_size, max_seq_len}, q_fp8.options().dtype(at::kFloat));
+
+  if (seq_lens.scalar_type() == at::kInt) {
+    dispatch_page_type<int32_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else if (seq_lens.scalar_type() == at::kLong) {
+    dispatch_page_type<int64_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else {
+    TORCH_CHECK(false, "seq_lens must be int32 or int64");
+  }
+
+  return logits;
+}

--- a/sgl-kernel/csrc/cpu/qkv_proj.cpp
+++ b/sgl-kernel/csrc/cpu/qkv_proj.cpp
@@ -210,6 +210,7 @@ void segment_gemm_kernel_impl(
           /*   C */ C + mb_start * ldc + local_nb_start,
           /* Btmp*/ Btmp + tid * BLOCK_N * K,
           /* Ctmp*/ Ctmp,
+          /*Bbias*/ nullptr,
           /*  Bs */ Bs + (new_nb / blocks_n_per_group) * scale_size_K,
           /*   M */ mb_size,
           /*   N */ nb_size,
@@ -385,8 +386,12 @@ void rotary_emb_kernel_impl(
 
 }  // anonymous namespace
 
-extern at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni);
+extern at::Tensor weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype = c10::nullopt);
 
 extern at::Tensor int8_scaled_mm_with_quant(
     at::Tensor& mat1,

--- a/sgl-kernel/csrc/cpu/rope.cpp
+++ b/sgl-kernel/csrc/cpu/rope.cpp
@@ -1,3 +1,5 @@
+#include <type_traits>
+
 #include "common.h"
 #include "vec.h"
 
@@ -953,4 +955,335 @@ std::tuple<at::Tensor, at::Tensor> multimodal_rotary_embedding_cpu(
     });
   }
   return std::make_tuple(query, key);
+}
+
+// In-place rotary embedding on interleaved real/imag pairs.
+// Supports [T, rope_dim] and [T, nh, rope_dim] with explicit outer strides.
+namespace {
+
+#ifdef CPU_CAPABILITY_AVX512
+static inline __m512 rotary_emb_sign_mask(bool inverse) {
+  // Forward negates even lanes of the sin broadcast; inverse negates odd lanes.
+  return _mm512_castsi512_ps(
+      inverse ? _mm512_set_epi32(
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0)
+              : _mm512_set_epi32(
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000,
+                    0,
+                    (int)0x80000000));
+}
+#endif
+
+template <typename scalar_t>
+static inline void apply_rotary_emb_row(
+    scalar_t* __restrict__ xp,
+    const float* __restrict__ fp,
+    int64_t rope_dim,
+    bool inverse
+#ifdef CPU_CAPABILITY_AVX512
+    ,
+    const __m512 avx_sign
+#endif
+) {
+#ifdef CPU_CAPABILITY_AVX512
+  {
+    using bVec = at::vec::Vectorized<scalar_t>;
+    using fVec = at::vec::Vectorized<float>;
+    constexpr int64_t kVecSize = bVec::size();
+    constexpr int64_t kFVecSize = fVec::size();
+
+    int64_t k = 0;
+    // double is dispatched but handled by the scalar path below.
+    if constexpr (!std::is_same_v<scalar_t, double>) {
+      for (; k <= rope_dim - kVecSize; k += kVecSize) {
+        if constexpr (std::is_same_v<scalar_t, float>) {
+          const __m512 xv0 = _mm512_loadu_ps(xp + k);
+          const __m512 fv0 = _mm512_loadu_ps(fp + k);
+          // 0xA0 broadcasts even lanes within each complex pair, 0xF5 broadcasts
+          // odd lanes, and 0xB1 swaps real/imag lanes within each pair.
+          const __m512 out0 = _mm512_fmadd_ps(
+              xv0,
+              _mm512_permute_ps(fv0, 0xA0),
+              _mm512_mul_ps(_mm512_permute_ps(xv0, 0xB1), _mm512_xor_ps(_mm512_permute_ps(fv0, 0xF5), avx_sign)));
+          _mm512_storeu_ps(xp + k, out0);
+        } else {
+          fVec x0_v, x1_v;
+          std::tie(x0_v, x1_v) = at::vec::convert_to_float(bVec::loadu(xp + k));
+          const __m512 xv0 = x0_v;
+          const __m512 xv1 = x1_v;
+
+          const __m512 fv0 = _mm512_loadu_ps(fp + k);
+          const __m512 fv1 = _mm512_loadu_ps(fp + k + kFVecSize);
+
+          const __m512 out0 = _mm512_fmadd_ps(
+              xv0,
+              _mm512_permute_ps(fv0, 0xA0),
+              _mm512_mul_ps(_mm512_permute_ps(xv0, 0xB1), _mm512_xor_ps(_mm512_permute_ps(fv0, 0xF5), avx_sign)));
+          const __m512 out1 = _mm512_fmadd_ps(
+              xv1,
+              _mm512_permute_ps(fv1, 0xA0),
+              _mm512_mul_ps(_mm512_permute_ps(xv1, 0xB1), _mm512_xor_ps(_mm512_permute_ps(fv1, 0xF5), avx_sign)));
+
+          at::vec::convert_from_float<scalar_t>(fVec(out0), fVec(out1)).store(xp + k);
+        }
+      }
+    }  // if constexpr (!double)
+
+    // Scalar tail.
+    for (; k < rope_dim; k += 2) {
+      const float xr = static_cast<float>(xp[k]);
+      const float xi = static_cast<float>(xp[k + 1]);
+      const float cr = fp[k], ci = fp[k + 1];
+      if (inverse) {
+        xp[k] = static_cast<scalar_t>(xr * cr + xi * ci);
+        xp[k + 1] = static_cast<scalar_t>(xi * cr - xr * ci);
+      } else {
+        xp[k] = static_cast<scalar_t>(xr * cr - xi * ci);
+        xp[k + 1] = static_cast<scalar_t>(xr * ci + xi * cr);
+      }
+    }
+  }
+#else
+  // Scalar fallback.
+  for (int64_t k = 0; k < rope_dim; k += 2) {
+    const float xr = static_cast<float>(xp[k]);
+    const float xi = static_cast<float>(xp[k + 1]);
+    const float cr = fp[k], ci = fp[k + 1];
+    if (inverse) {
+      xp[k] = static_cast<scalar_t>(xr * cr + xi * ci);
+      xp[k + 1] = static_cast<scalar_t>(xi * cr - xr * ci);
+    } else {
+      xp[k] = static_cast<scalar_t>(xr * cr - xi * ci);
+      xp[k + 1] = static_cast<scalar_t>(xr * ci + xi * cr);
+    }
+  }
+#endif
+}
+
+template <typename scalar_t, typename index_t>
+static void apply_rotary_emb_impl(
+    scalar_t* __restrict__ q,
+    scalar_t* __restrict__ k,
+    const float* __restrict__ freqs,
+    const index_t* __restrict__ positions,
+    int64_t T,
+    int64_t q_nh,
+    int64_t k_nh,
+    int64_t rope_dim,
+    int64_t q_stride_t,
+    int64_t q_stride_h,
+    int64_t k_stride_t,
+    int64_t k_stride_h,
+    int64_t freqs_stride_t,
+    int64_t positions_stride,
+    bool inverse) {
+  // Interleaved complex rotation:
+  //   x = [xr0, xi0, xr1, xi1, ...]
+  //   f = [c0,  s0,  c1,  s1,  ...]
+  // AVX-512 uses permutes to broadcast cos/sin within each pair and a sign mask
+  // to switch between forward and inverse rotation without branching.
+
+#ifdef CPU_CAPABILITY_AVX512
+  const __m512 avx_sign = rotary_emb_sign_mask(inverse);
+#endif
+
+  constexpr int64_t kRopeBlock = 256;
+  const int64_t max_nh = std::max<int64_t>(q_nh, k == nullptr ? 0 : k_nh);
+  const int64_t outer_rows = T * max_nh;
+  const int64_t grain = std::max<int64_t>(1, GRAIN_SIZE / rope_dim);
+
+  at::parallel_for(0, outer_rows, grain, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t t = i / max_nh;
+      const int64_t h = i % max_nh;
+      const int64_t freq_t = positions == nullptr ? t : static_cast<int64_t>(positions[t * positions_stride]);
+      const float* fp = freqs + freq_t * freqs_stride_t;
+      const bool do_q = h < q_nh;
+      const bool do_k = k != nullptr && h < k_nh;
+
+      if (!do_q && !do_k) {
+        continue;
+      }
+
+      scalar_t* qx = do_q ? q + t * q_stride_t + h * q_stride_h : nullptr;
+      scalar_t* kx = do_k ? k + t * k_stride_t + h * k_stride_h : nullptr;
+
+      for (int64_t d0 = 0; d0 < rope_dim; d0 += kRopeBlock) {
+        const int64_t dlen = std::min<int64_t>(kRopeBlock, rope_dim - d0);
+
+        if (do_q) {
+          apply_rotary_emb_row<scalar_t>(
+              qx + d0,
+              fp + d0,
+              dlen,
+              inverse
+#ifdef CPU_CAPABILITY_AVX512
+              ,
+              avx_sign
+#endif
+          );
+        }
+
+        if (do_k) {
+          apply_rotary_emb_row<scalar_t>(
+              kx + d0,
+              fp + d0,
+              dlen,
+              inverse
+#ifdef CPU_CAPABILITY_AVX512
+              ,
+              avx_sign
+#endif
+          );
+        }
+      }
+    }
+  });
+}
+
+}  // namespace
+
+at::Tensor apply_rotary_emb_interleaved_cpu(
+    at::Tensor& x,
+    at::Tensor& freqs,
+    bool inverse,
+    const std::optional<at::Tensor>& positions,
+    const std::optional<at::Tensor>& k_opt) {
+  TORCH_CHECK(
+      x.dim() == 2 || x.dim() == 3,
+      "apply_rotary_emb_interleaved_cpu: x must be 2D [T,rope_dim] or 3D [T,nh,rope_dim]");
+  TORCH_CHECK(
+      x.device().is_cpu() && freqs.device().is_cpu(), "apply_rotary_emb_interleaved_cpu: all tensors must be on CPU");
+
+  const int64_t T = x.size(0);
+  const int64_t rope_dim = x.size(-1);
+  const int64_t nh = x.dim() == 3 ? x.size(1) : 1;
+  const bool has_k = k_opt.has_value();
+
+  at::Tensor freqs_real;
+  if (freqs.is_complex()) {
+    TORCH_CHECK(freqs.dim() == 2, "apply_rotary_emb_interleaved_cpu: freqs_cis must be 2D [N, rope_dim/2]");
+    TORCH_CHECK(
+        freqs.scalar_type() == at::kComplexFloat, "apply_rotary_emb_interleaved_cpu: complex freqs must be complex64");
+    freqs_real = at::view_as_real(freqs).flatten(-2);
+  } else {
+    TORCH_CHECK(
+        freqs.dim() == 2 && freqs.scalar_type() == at::kFloat,
+        "apply_rotary_emb_interleaved_cpu: freqs must be float32 [N, rope_dim] or complex64 [N, rope_dim/2]");
+    freqs_real = freqs;
+  }
+
+  TORCH_CHECK(rope_dim % 2 == 0, "apply_rotary_emb_interleaved_cpu: rope_dim must be even");
+
+  TORCH_CHECK(
+      freqs_real.size(1) == rope_dim, "apply_rotary_emb_interleaved_cpu: frequency rope dim must match x last dim");
+
+  const bool has_positions = positions.has_value();
+  if (has_positions) {
+    const at::Tensor& pos = positions.value();
+    TORCH_CHECK(pos.device().is_cpu(), "apply_rotary_emb_interleaved_cpu: positions must be on CPU");
+    TORCH_CHECK(pos.dim() == 1, "apply_rotary_emb_interleaved_cpu: positions must be 1D [T]");
+    TORCH_CHECK(pos.size(0) == T, "apply_rotary_emb_interleaved_cpu: positions must have shape [T]");
+    TORCH_CHECK(
+        pos.scalar_type() == at::kLong || pos.scalar_type() == at::kInt,
+        "apply_rotary_emb_interleaved_cpu: positions must be int64 or int32");
+  } else {
+    TORCH_CHECK(freqs_real.size(0) == T, "apply_rotary_emb_interleaved_cpu: freqs must have shape [T, rope_dim]");
+  }
+
+  if (freqs_real.stride(-1) != 1) {
+    freqs_real = freqs_real.contiguous();
+  }
+
+  // The rope dimension must be contiguous. Outer strides are handled explicitly,
+  // so non-contiguous [T] or [head] slices are still supported.
+  TORCH_CHECK(
+      x.stride(-1) == 1,
+      "apply_rotary_emb_interleaved_cpu: x inner (rope) dim must be contiguous (stride[-1]==1); "
+      "got stride[-1]=",
+      x.stride(-1));
+
+  int64_t k_nh = 0;
+  int64_t k_stride_t = 0;
+  int64_t k_stride_h = 0;
+  if (has_k) {
+    const at::Tensor& k = k_opt.value();
+    TORCH_CHECK(k.device().is_cpu(), "apply_rotary_emb_interleaved_cpu: k must be on CPU");
+    TORCH_CHECK(k.dim() == 2 || k.dim() == 3, "apply_rotary_emb_interleaved_cpu: k must be 2D or 3D");
+    TORCH_CHECK(k.scalar_type() == x.scalar_type(), "apply_rotary_emb_interleaved_cpu: x and k must have same dtype");
+    TORCH_CHECK(k.size(0) == T, "apply_rotary_emb_interleaved_cpu: k must have same T as x");
+    TORCH_CHECK(k.size(-1) == rope_dim, "apply_rotary_emb_interleaved_cpu: k rope dim must match x");
+    TORCH_CHECK(k.stride(-1) == 1, "apply_rotary_emb_interleaved_cpu: k inner (rope) dim must be contiguous");
+    k_nh = k.dim() == 3 ? k.size(1) : 1;
+    k_stride_t = k.stride(0);
+    k_stride_h = k.dim() == 3 ? k.stride(1) : 0;
+  }
+
+  const int64_t x_stride_t = x.stride(0);
+  const int64_t x_stride_h = x.dim() == 3 ? x.stride(1) : 0;
+  const int64_t freqs_stride_t = freqs_real.stride(0);
+  const int64_t positions_stride = has_positions ? positions.value().stride(0) : 0;
+  const bool pos_i64 = has_positions && positions.value().scalar_type() == at::kLong;
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kBFloat16, at::kHalf, x.scalar_type(), "apply_rotary_emb_interleaved_cpu", [&] {
+    scalar_t* k_ptr = nullptr;
+    if (has_k) {
+      k_ptr = k_opt.value().data_ptr<scalar_t>();
+    }
+
+    auto run_with_positions = [&](const auto* positions_ptr) {
+      using index_t = typename std::remove_cv<typename std::remove_pointer<decltype(positions_ptr)>::type>::type;
+      apply_rotary_emb_impl<scalar_t, index_t>(
+          x.data_ptr<scalar_t>(),
+          k_ptr,
+          freqs_real.data_ptr<float>(),
+          positions_ptr,
+          T,
+          nh,
+          k_nh,
+          rope_dim,
+          x_stride_t,
+          x_stride_h,
+          k_stride_t,
+          k_stride_h,
+          freqs_stride_t,
+          positions_stride,
+          inverse);
+    };
+
+    if (!has_positions || pos_i64) {
+      run_with_positions(has_positions ? positions.value().data_ptr<int64_t>() : nullptr);
+    } else {
+      run_with_positions(positions.value().data_ptr<int32_t>());
+    }
+  });
+  return x;
 }

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -1,0 +1,428 @@
+#include <immintrin.h>
+
+#include <cmath>
+#include <cstring>
+
+#include "common.h"
+
+// ============================================================================
+// quant_to_nope_fp8_rope_bf16_pack_cpu
+//
+// Equivalent to Python:
+//   k_nope_bf16, k_rope_bf16 = k_bf16.split([448, 64], dim=-1)
+//   x = k_nope_bf16.view(-1, 7, 64)
+//   scale = x.abs().amax(dim=-1).float() / 448.0
+//   scale_pow2 = 2^ceil(log2(max(scale, 1e-4)))
+//   k_nope_fp8 = (x.float() / scale_pow2.unsqueeze(-1)).to(fp8_e4m3fn)
+//   scale_uint8 = e8m0_encode(scale_pow2) -> (ceil_log2 + 127)
+// ============================================================================
+
+namespace {
+
+constexpr int64_t QUANT_DIM_NOPE = 448;
+constexpr int64_t QUANT_DIM_ROPE = 64;
+constexpr int64_t QUANT_TILE_SIZE = 64;
+constexpr int64_t QUANT_NUM_TILES = QUANT_DIM_NOPE / QUANT_TILE_SIZE;  // 7
+constexpr float QUANT_FP8_MAX = 448.0f;
+constexpr float QUANT_FP8_MIN = -448.0f;
+constexpr float QUANT_EPS = 1e-4f;
+
+// Float to fp8_e4m3fn using PyTorch's conversion (scalar fallback)
+inline uint8_t float_to_fp8_e4m3fn(float val) {
+  return at::Float8_e4m3fn(val).x;
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+// Vectorized float32x16 -> fp8_e4m3fn x16 using AVX512 bit manipulation.
+// Implements RNE (round-to-nearest-even). Flushes subnormal fp8 to zero
+// (safe because SGLANG_CPU_FP8_CVT_FTZ flushes them on decode too).
+// fp8_e4m3fn: sign(1), exp(4, bias=7), mant(3), no inf/nan special values.
+// Normal: exp_field in [1..15], value = 2^(exp-7) * (1 + mant/8)
+// Input assumed clamped to [-448, 448].
+inline __m128i cvt_fp32x16_to_fp8x16(__m512 input) {
+  __m512i bits = _mm512_castps_si512(input);
+
+  // Extract sign -> bit 7 of fp8 byte
+  __m512i signs = _mm512_srli_epi32(_mm512_and_si512(bits, _mm512_set1_epi32(0x80000000)), 24);
+
+  // Absolute value bits
+  __m512i abs_bits = _mm512_and_si512(bits, _mm512_set1_epi32(0x7FFFFFFF));
+
+  // Float32 biased exponent
+  __m512i f32_exp = _mm512_srli_epi32(abs_bits, 23);
+
+  // Float32 mantissa (23 bits)
+  __m512i f32_mant = _mm512_and_si512(abs_bits, _mm512_set1_epi32(0x7FFFFF));
+
+  // fp8_exp = f32_exp - 120 (rebias from 127 to 7)
+  __m512i fp8_exp = _mm512_sub_epi32(f32_exp, _mm512_set1_epi32(120));
+
+  // Top 3 mantissa bits
+  __m512i mant3 = _mm512_srli_epi32(f32_mant, 20);
+
+  // RNE rounding: round_bit = bit 19, sticky = bits[18:0]
+  __m512i round_bit = _mm512_and_si512(_mm512_srli_epi32(f32_mant, 19), _mm512_set1_epi32(1));
+  __m512i sticky_bits = _mm512_and_si512(f32_mant, _mm512_set1_epi32(0x7FFFF));
+  __mmask16 has_sticky = _mm512_cmpneq_epi32_mask(sticky_bits, _mm512_setzero_si512());
+
+  // Round up if round_bit AND (sticky OR lsb_of_mant3)
+  __m512i lsb = _mm512_and_si512(mant3, _mm512_set1_epi32(1));
+  __m512i sticky_or_lsb = _mm512_or_si512(_mm512_maskz_mov_epi32(has_sticky, _mm512_set1_epi32(1)), lsb);
+  __m512i do_round = _mm512_and_si512(round_bit, sticky_or_lsb);
+  mant3 = _mm512_add_epi32(mant3, do_round);
+
+  // Mantissa overflow (mant3 == 8) -> increment exponent, zero mantissa
+  __mmask16 mant_ovf = _mm512_cmpeq_epi32_mask(mant3, _mm512_set1_epi32(8));
+  mant3 = _mm512_mask_mov_epi32(mant3, mant_ovf, _mm512_setzero_si512());
+  fp8_exp = _mm512_mask_add_epi32(fp8_exp, mant_ovf, fp8_exp, _mm512_set1_epi32(1));
+
+  // Clamp exponent: max 15
+  fp8_exp = _mm512_min_epi32(fp8_exp, _mm512_set1_epi32(15));
+
+  // Result: (fp8_exp << 3) | mant3
+  __m512i result = _mm512_or_si512(_mm512_slli_epi32(fp8_exp, 3), mant3);
+
+  // Flush to zero: if f32_exp < 121 (would be subnormal in fp8), output 0
+  __mmask16 is_subnormal_or_zero = _mm512_cmplt_epi32_mask(f32_exp, _mm512_set1_epi32(121));
+  result = _mm512_mask_mov_epi32(result, is_subnormal_or_zero, _mm512_setzero_si512());
+
+  // Add sign
+  result = _mm512_or_si512(result, signs);
+
+  // Pack 16 x i32 -> 16 x i8
+  return _mm512_cvtepi32_epi8(result);
+}
+
+// Process one tile (64 bf16 values): find amax, compute scale, quantize to fp8
+inline uint8_t quantize_tile_avx512(const at::BFloat16* __restrict__ src, uint8_t* __restrict__ dst) {
+  // Load 64 bf16 -> 4 x 16 floats
+  __m256i bf16_0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+  __m256i bf16_1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 16));
+  __m256i bf16_2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+  __m256i bf16_3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 48));
+
+  __m512 f0 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_0), 16));
+  __m512 f1 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_1), 16));
+  __m512 f2 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_2), 16));
+  __m512 f3 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_3), 16));
+
+  // Absolute values
+  const __m512i abs_mask_i = _mm512_set1_epi32(0x7FFFFFFF);
+  __m512 abs0 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f0), abs_mask_i));
+  __m512 abs1 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f1), abs_mask_i));
+  __m512 abs2 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f2), abs_mask_i));
+  __m512 abs3 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f3), abs_mask_i));
+
+  // Horizontal max
+  __m512 max01 = _mm512_max_ps(abs0, abs1);
+  __m512 max23 = _mm512_max_ps(abs2, abs3);
+  __m512 max0123 = _mm512_max_ps(max01, max23);
+  float amax = _mm512_reduce_max_ps(max0123);
+
+  // Scale computation
+  float scale = std::max(amax / QUANT_FP8_MAX, QUANT_EPS);
+  float ceil_log2 = std::ceil(std::log2(scale));
+  float scale_pow2 = std::exp2(ceil_log2);
+  float scale_inv = 1.0f / scale_pow2;
+
+  int exponent = static_cast<int>(ceil_log2);
+  uint8_t scale_uint8 = static_cast<uint8_t>(exponent + 127);
+
+  // Scale all values
+  __m512 vinv = _mm512_set1_ps(scale_inv);
+  __m512 s0 = _mm512_mul_ps(f0, vinv);
+  __m512 s1 = _mm512_mul_ps(f1, vinv);
+  __m512 s2 = _mm512_mul_ps(f2, vinv);
+  __m512 s3 = _mm512_mul_ps(f3, vinv);
+
+  // Clamp
+  __m512 vmax = _mm512_set1_ps(QUANT_FP8_MAX);
+  __m512 vmin = _mm512_set1_ps(QUANT_FP8_MIN);
+  s0 = _mm512_max_ps(_mm512_min_ps(s0, vmax), vmin);
+  s1 = _mm512_max_ps(_mm512_min_ps(s1, vmax), vmin);
+  s2 = _mm512_max_ps(_mm512_min_ps(s2, vmax), vmin);
+  s3 = _mm512_max_ps(_mm512_min_ps(s3, vmax), vmin);
+
+  // Vectorized float -> fp8 conversion (16 values at a time)
+  __m128i fp8_0 = cvt_fp32x16_to_fp8x16(s0);
+  __m128i fp8_1 = cvt_fp32x16_to_fp8x16(s1);
+  __m128i fp8_2 = cvt_fp32x16_to_fp8x16(s2);
+  __m128i fp8_3 = cvt_fp32x16_to_fp8x16(s3);
+
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), fp8_0);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 16), fp8_1);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 32), fp8_2);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 48), fp8_3);
+
+  return scale_uint8;
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+inline uint8_t quantize_tile_scalar(const at::BFloat16* __restrict__ src, uint8_t* __restrict__ dst) {
+  float amax = 0.0f;
+  for (int j = 0; j < QUANT_TILE_SIZE; ++j) {
+    float v = std::abs(static_cast<float>(src[j]));
+    if (v > amax) amax = v;
+  }
+
+  float scale = std::max(amax / QUANT_FP8_MAX, QUANT_EPS);
+  float ceil_log2 = std::ceil(std::log2(scale));
+  float scale_pow2 = std::exp2(ceil_log2);
+  float scale_inv = 1.0f / scale_pow2;
+
+  int exponent = static_cast<int>(ceil_log2);
+  uint8_t scale_uint8 = static_cast<uint8_t>(exponent + 127);
+
+  for (int j = 0; j < QUANT_TILE_SIZE; ++j) {
+    float val = static_cast<float>(src[j]) * scale_inv;
+    val = std::max(std::min(val, QUANT_FP8_MAX), QUANT_FP8_MIN);
+    dst[j] = float_to_fp8_e4m3fn(val);
+  }
+
+  return scale_uint8;
+}
+
+}  // anonymous namespace
+
+// set_k_and_s_cpu: scatter-copy k_nope (fp8), k_rope (bf16), and
+// scale_k_nope (uint8) into a paged KV-cache buffer.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   Token data region: page_size * (nope_dim + rope_dim*2) bytes
+//     Per token: [nope_dim bytes fp8 | rope_dim*2 bytes bf16]
+//   Scale region: page_size * (scale_dim + 1) bytes
+//     Per token: [scale_dim bytes | 1 byte padding]
+//
+void set_k_and_s_cpu(
+    at::Tensor& buf,           // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,           // [num_tokens], int32 or int64
+    at::Tensor& k_nope,        // [num_tokens, nope_dim], fp8 (viewed as uint8)
+    at::Tensor& k_rope,        // [num_tokens, rope_dim], bf16 (viewed as uint8, rope_dim*2 bytes)
+    at::Tensor& scale_k_nope,  // [num_tokens, scale_dim], uint8
+    int64_t page_size) {
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t nope_dim = k_nope.size(1);         // 448 (bytes, fp8 elements)
+  const int64_t rope_dim = k_rope.size(1);         // 64 (bf16 elements, 128 bytes)
+  const int64_t scale_dim = scale_k_nope.size(1);  // 7
+
+  const int64_t nope_rope_bytes = nope_dim + rope_dim * 2;
+  const int64_t s_offset_nbytes_in_page = page_size * nope_rope_bytes;
+  const int64_t padded_scale_per_token = scale_dim + 1;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* k_nope_ptr = reinterpret_cast<const uint8_t*>(k_nope.data_ptr());
+  const uint8_t* k_rope_ptr = reinterpret_cast<const uint8_t*>(k_rope.data_ptr());
+  const uint8_t* scale_ptr = scale_k_nope.data_ptr<uint8_t>();
+
+  // We handle both int32 and int64 loc
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      // --- nope: copy nope_dim bytes (fp8) ---
+      const int64_t nope_byte_offset = page_idx * buf_numel_per_page + token_off * nope_rope_bytes;
+      uint8_t* dst_nope = buf_ptr + nope_byte_offset;
+      const uint8_t* src_nope = k_nope_ptr + i * nope_dim;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // nope_dim=448: 7 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= nope_dim; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src_nope + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst_nope + d), v);
+        }
+        // Handle remainder (nope_dim % 64 == 0 for 448, but be safe)
+        if (d < nope_dim) {
+          std::memcpy(dst_nope + d, src_nope + d, nope_dim - d);
+        }
+      }
+#else
+      std::memcpy(dst_nope, src_nope, nope_dim);
+#endif
+
+      // --- rope: copy rope_dim bf16 values = rope_dim*2 bytes ---
+      const int64_t rope_byte_offset = page_idx * buf_numel_per_page + token_off * nope_rope_bytes + nope_dim;
+      uint8_t* dst_rope = buf_ptr + rope_byte_offset;
+      const uint8_t* src_rope = k_rope_ptr + i * rope_dim * 2;
+      const int64_t rope_bytes = rope_dim * 2;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // rope_bytes=128: 2 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= rope_bytes; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src_rope + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst_rope + d), v);
+        }
+        if (d < rope_bytes) {
+          std::memcpy(dst_rope + d, src_rope + d, rope_bytes - d);
+        }
+      }
+#else
+      std::memcpy(dst_rope, src_rope, rope_bytes);
+#endif
+
+      // --- scale: copy scale_dim bytes ---
+      const int64_t s_byte_offset =
+          page_idx * buf_numel_per_page + s_offset_nbytes_in_page + token_off * padded_scale_per_token;
+      uint8_t* dst_scale = buf_ptr + s_byte_offset;
+      const uint8_t* src_scale = scale_ptr + i * scale_dim;
+      std::memcpy(dst_scale, src_scale, scale_dim);
+    }
+  });
+}
+
+// set_k_cpu: scatter-copy index key data (fp8, viewed as uint8) into
+// a paged buffer for NSA (non-sparse attention) index cache.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   K data region: page_size * index_head_dim bytes (fp8 key data)
+//   S data region: page_size * 4 bytes (fp32 scale per token)
+//
+// index_k is fp8 (index_head_dim elements per token), stored as raw bytes.
+//
+void set_k_cpu(
+    at::Tensor& buf,      // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,      // [num_tokens], int32 or int64
+    at::Tensor& index_k,  // [num_tokens, index_head_dim], fp8 (viewed as uint8)
+    int64_t page_size,
+    int64_t index_head_dim) {
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t num_k_bytes_per_token = index_head_dim;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* k_ptr = reinterpret_cast<const uint8_t*>(index_k.data_ptr());
+
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      const int64_t dst_offset = page_idx * buf_numel_per_page + token_off * num_k_bytes_per_token;
+
+      uint8_t* dst = buf_ptr + dst_offset;
+      const uint8_t* src = k_ptr + i * num_k_bytes_per_token;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // index_head_dim=128: 2 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= num_k_bytes_per_token; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst + d), v);
+        }
+        if (d < num_k_bytes_per_token) {
+          std::memcpy(dst + d, src + d, num_k_bytes_per_token - d);
+        }
+      }
+#else
+      std::memcpy(dst, src, num_k_bytes_per_token);
+#endif
+    }
+  });
+}
+
+// set_s_cpu: scatter-copy scale values (fp32, viewed as 4 bytes uint8)
+// into a paged buffer for NSA (non-sparse attention) index cache.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   K data region: page_size * index_head_dim bytes (fp8 key data)
+//   S data region: page_size * 4 bytes (fp32 scale per token)
+//
+// index_k_scale is fp32 (1 per token), stored as 4 raw bytes in the buffer.
+//
+void set_s_cpu(
+    at::Tensor& buf,            // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,            // [num_tokens], int32 or int64
+    at::Tensor& index_k_scale,  // [num_tokens] or [num_tokens, 1], fp32
+    int64_t page_size,
+    int64_t index_head_dim) {
+  // Flatten index_k_scale to 1D if needed
+  auto scale_flat = index_k_scale.dim() == 2 ? index_k_scale.squeeze(1) : index_k_scale;
+
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t num_s_bytes_per_token = 4;  // fp32 = 4 bytes
+  const int64_t s_offset_in_page = page_size * index_head_dim;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* scale_ptr = reinterpret_cast<const uint8_t*>(scale_flat.data_ptr<float>());
+
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      const int64_t dst_offset = page_idx * buf_numel_per_page + s_offset_in_page + token_off * num_s_bytes_per_token;
+
+      uint8_t* dst = buf_ptr + dst_offset;
+      const uint8_t* src = scale_ptr + i * num_s_bytes_per_token;
+
+      // 4-byte copy: use 32-bit integer copy for efficiency
+      *reinterpret_cast<uint32_t*>(dst) = *reinterpret_cast<const uint32_t*>(src);
+    }
+  });
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16) {
+  TORCH_CHECK(
+      k_bf16.dtype() == at::kBFloat16, "quant_to_nope_fp8_rope_bf16_pack_cpu: expect bf16 input, got ", k_bf16.dtype());
+  TORCH_CHECK(
+      k_bf16.dim() == 2 && k_bf16.size(1) == 512, "quant_to_nope_fp8_rope_bf16_pack_cpu: expect input shape [N, 512]");
+  TORCH_CHECK(k_bf16.is_contiguous(), "quant_to_nope_fp8_rope_bf16_pack_cpu: expect contiguous input");
+
+  const int64_t num_tokens = k_bf16.size(0);
+
+  auto k_nope_fp8 = at::empty({num_tokens, QUANT_DIM_NOPE}, k_bf16.options().dtype(at::kFloat8_e4m3fn));
+  auto k_rope_bf16 = at::empty({num_tokens, QUANT_DIM_ROPE}, k_bf16.options().dtype(at::kBFloat16));
+  auto scale_out = at::empty({num_tokens, QUANT_NUM_TILES}, k_bf16.options().dtype(at::kByte));
+
+  const at::BFloat16* input_ptr = k_bf16.data_ptr<at::BFloat16>();
+  uint8_t* nope_ptr = reinterpret_cast<uint8_t*>(k_nope_fp8.data_ptr());
+  at::BFloat16* rope_ptr = k_rope_bf16.data_ptr<at::BFloat16>();
+  uint8_t* scale_ptr = scale_out.data_ptr<uint8_t>();
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t t = begin; t < end; ++t) {
+      const at::BFloat16* src_token = input_ptr + t * 512;
+
+      // Copy rope portion (last 64 bf16 values = 128 bytes)
+      std::memcpy(rope_ptr + t * QUANT_DIM_ROPE, src_token + QUANT_DIM_NOPE, QUANT_DIM_ROPE * sizeof(at::BFloat16));
+
+      // Quantize each nope tile
+      for (int64_t tile = 0; tile < QUANT_NUM_TILES; ++tile) {
+        const at::BFloat16* tile_src = src_token + tile * QUANT_TILE_SIZE;
+        uint8_t* tile_dst = nope_ptr + t * QUANT_DIM_NOPE + tile * QUANT_TILE_SIZE;
+
+#if defined(CPU_CAPABILITY_AVX512)
+        scale_ptr[t * QUANT_NUM_TILES + tile] = quantize_tile_avx512(tile_src, tile_dst);
+#else
+        scale_ptr[t * QUANT_NUM_TILES + tile] = quantize_tile_scalar(tile_src, tile_dst);
+#endif
+      }
+    }
+  });
+
+  return std::make_tuple(k_nope_fp8, k_rope_bf16, scale_out);
+}

--- a/sgl-kernel/csrc/cpu/topk.cpp
+++ b/sgl-kernel/csrc/cpu/topk.cpp
@@ -1,9 +1,119 @@
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 #include "common.h"
 #include "vec.h"
 
 namespace {
 
-template <typename scalar_t, int SIZE>
+constexpr int C4_TOPK = 512;
+
+template <typename T>
+inline int64_t load_index_value(const T* __restrict__ ptr, int64_t idx) {
+  return static_cast<int64_t>(ptr[idx]);
+}
+
+struct TopKTransformElem {
+  float score;
+  int32_t index;
+};
+
+struct TopKTransformMinHeapCmp {
+  bool operator()(const TopKTransformElem& lhs, const TopKTransformElem& rhs) const {
+    if (lhs.score == rhs.score) {
+      return lhs.index > rhs.index;
+    }
+    return lhs.score > rhs.score;
+  }
+};
+
+template <typename seq_t, typename page_t>
+void topk_transform_512_cpu_kernel_impl(
+    const float* __restrict__ scores,
+    const seq_t* __restrict__ seq_lens,
+    const page_t* __restrict__ page_tables,
+    int32_t* __restrict__ out_page_indices,
+    int32_t* __restrict__ out_raw_indices,
+    int64_t batch_size,
+    int64_t max_seq_len,
+    int64_t page_table_stride,
+    int64_t out_stride,
+    int64_t page_size) {
+  TORCH_CHECK(page_size > 0, "page_size must be positive");
+  TORCH_CHECK((page_size & (page_size - 1)) == 0, "page_size must be a power of 2");
+  const int page_bits = page_size > 1 ? static_cast<int>(std::log2(static_cast<double>(page_size))) : 0;
+  const int64_t page_mask = page_size - 1;
+
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    std::vector<TopKTransformElem> heap;
+    heap.reserve(C4_TOPK);
+
+    for (int64_t b = begin; b < end; ++b) {
+      const float* __restrict__ scores_row = scores + b * max_seq_len;
+      const page_t* __restrict__ page_table_row = page_tables + b * page_table_stride;
+      int32_t* __restrict__ out_page_row = out_page_indices + b * out_stride;
+      int32_t* __restrict__ out_raw_row = out_raw_indices == nullptr ? nullptr : out_raw_indices + b * out_stride;
+
+      int64_t seq_len = load_index_value(seq_lens, b);
+      seq_len = std::max<int64_t>(0, std::min<int64_t>(seq_len, max_seq_len));
+      const int64_t valid_topk = std::min<int64_t>(seq_len, C4_TOPK);
+
+      auto store_slot = [&](int64_t slot, int32_t raw_index) {
+        if (raw_index < 0) {
+          out_page_row[slot] = -1;
+          if (out_raw_row != nullptr) {
+            out_raw_row[slot] = -1;
+          }
+          return;
+        }
+
+        const int64_t page_idx = static_cast<int64_t>(raw_index) >> page_bits;
+        const int64_t offset_in_page = static_cast<int64_t>(raw_index) & page_mask;
+        const int64_t physical_page = load_index_value(page_table_row, page_idx);
+        out_page_row[slot] = static_cast<int32_t>((physical_page << page_bits) | offset_in_page);
+        if (out_raw_row != nullptr) {
+          out_raw_row[slot] = raw_index;
+        }
+      };
+
+      if (seq_len <= C4_TOPK) {
+        for (int64_t i = 0; i < valid_topk; ++i) {
+          store_slot(i, static_cast<int32_t>(i));
+        }
+        for (int64_t i = valid_topk; i < C4_TOPK; ++i) {
+          store_slot(i, -1);
+        }
+        continue;
+      }
+
+      heap.clear();
+      for (int64_t i = 0; i < C4_TOPK; ++i) {
+        heap.push_back({scores_row[i], static_cast<int32_t>(i)});
+      }
+      std::make_heap(heap.begin(), heap.end(), TopKTransformMinHeapCmp());
+
+      for (int64_t i = C4_TOPK; i < seq_len; ++i) {
+        const float score = scores_row[i];
+        const TopKTransformElem& current_min = heap.front();
+        if (score > current_min.score || (score == current_min.score && static_cast<int32_t>(i) < current_min.index)) {
+          std::pop_heap(heap.begin(), heap.end(), TopKTransformMinHeapCmp());
+          heap.back() = {score, static_cast<int32_t>(i)};
+          std::push_heap(heap.begin(), heap.end(), TopKTransformMinHeapCmp());
+        }
+      }
+
+      for (int64_t i = 0; i < C4_TOPK; ++i) {
+        store_slot(i, heap[i].index);
+      }
+    }
+  });
+}
+
+template <typename scalar_t, int SIZE, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
 inline void softmax(float* __restrict__ out, const scalar_t* __restrict__ input) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
@@ -63,6 +173,39 @@ inline void softmax(float* __restrict__ out, const scalar_t* __restrict__ input)
       fVec out_fvec = fVec::loadu(out + d) * sum_fvec;
       out_fvec.store(out + d);
     }
+  }
+}
+
+template <typename scalar_t, int SIZE, std::enable_if_t<std::is_same_v<scalar_t, float>, int> = 0>
+inline void softmax(float* __restrict__ out, const float* __restrict__ input) {
+  using fVec = at::vec::Vectorized<float>;
+
+  constexpr int kVecSize = fVec::size();
+
+  // step 1: get max
+  fVec max_fvec = fVec(-std::numeric_limits<float>::infinity());
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec x_fvec = fVec::loadu(input + d);
+    max_fvec = at::vec::maximum(max_fvec, x_fvec);
+    x_fvec.store(out + d);
+  }
+  float max_val = vec_reduce_max(max_fvec);
+  max_fvec = fVec(max_val);
+
+  // step 2: sum of (x - max).exp()
+  fVec sum_fvec = fVec(float(0));
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec x_fvec = (fVec::loadu(out + d) - max_fvec).exp_u20();
+    sum_fvec += x_fvec;
+    x_fvec.store(out + d);
+  }
+  float sum_val = vec_reduce_sum(sum_fvec);
+
+  // step 3: x * (1 / sum)
+  sum_fvec = fVec(1.f / sum_val);
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec out_fvec = fVec::loadu(out + d) * sum_fvec;
+    out_fvec.store(out + d);
   }
 }
 
@@ -404,6 +547,266 @@ void biased_grouped_topk_kernel_impl(
   });
 }
 
+// sqrtsoftplus: sqrt(softplus(x)) = sqrt(log(1 + exp(x)))
+// For numerical stability: when x > threshold, softplus(x) ≈ x
+// When x < -threshold, softplus(x) ≈ exp(x), so sqrt(softplus(x)) ≈ sqrt(exp(x)) = exp(x/2)
+template <typename scalar_t, int SIZE, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
+inline void sqrtsoftplus(float* __restrict__ out, const scalar_t* __restrict__ input) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+
+  const fVec one = fVec(1.f);
+  const fVec half = fVec(0.5f);
+  const fVec threshold = fVec(20.f);
+  const fVec neg_threshold = fVec(-15.f);  // below this, 1+exp(x) loses precision in float32
+
+  constexpr int kVecSize = bVec::size();
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    bVec x_bvec = bVec::loadu(input + d);
+    fVec x_fvec0, x_fvec1;
+    std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+
+    // default: softplus(x) = log(1 + exp(x))
+    fVec sp0 = (one + x_fvec0.exp_u20()).log();
+    fVec sp1 = (one + x_fvec1.exp_u20()).log();
+    // x > 20: softplus(x) ≈ x
+    sp0 = fVec::blendv(sp0, x_fvec0, x_fvec0 > threshold);
+    sp1 = fVec::blendv(sp1, x_fvec1, x_fvec1 > threshold);
+    // x < -15: softplus(x) ≈ exp(x), sqrt(exp(x)) = exp(x/2)
+    fVec exp_half0 = (x_fvec0 * half).exp_u20();
+    fVec exp_half1 = (x_fvec1 * half).exp_u20();
+    sp0 = fVec::blendv(sp0.sqrt(), exp_half0, x_fvec0 < neg_threshold);
+    sp1 = fVec::blendv(sp1.sqrt(), exp_half1, x_fvec1 < neg_threshold);
+
+    sp0.store(out + d);
+    sp1.store(out + d + fVec::size());
+  }
+}
+
+template <typename scalar_t, int SIZE, std::enable_if_t<std::is_same_v<scalar_t, float>, int> = 0>
+inline void sqrtsoftplus(float* __restrict__ out, const float* __restrict__ input) {
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+  const fVec half = fVec(0.5f);
+  const fVec threshold = fVec(20.f);
+  const fVec neg_threshold = fVec(-15.f);
+  constexpr int kVecSize = fVec::size();
+  for (int d = 0; d < SIZE; d += kVecSize) {
+    fVec x = fVec::loadu(input + d);
+    fVec sp = (one + x.exp_u20()).log();
+    sp = fVec::blendv(sp, x, x > threshold);
+    fVec exp_half = (x * half).exp_u20();
+    sp = fVec::blendv(sp.sqrt(), exp_half, x < neg_threshold);
+    sp.store(out + d);
+  }
+}
+
+// biased_topk: flat (non-grouped) biased topk for DeepSeek V4
+// scoring_func: 0 = sigmoid, 1 = sqrtsoftplus
+template <typename scalar_t, typename param_t, int NUM_EXPERTS, int TOPK>
+void biased_topk_kernel_impl(
+    float* __restrict__ topk_weights,
+    int32_t* __restrict__ topk_ids,
+    const scalar_t* __restrict__ gating_output,
+    const param_t* __restrict__ bias,
+    int64_t num_tokens,
+    int64_t topk,
+    bool renormalize,
+    int scoring_func,
+    int64_t num_fused_shared_experts,
+    float routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  // actual number of routed experts selected (excluding fused shared experts)
+  const int64_t num_routed_topk = topk - num_fused_shared_experts;
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scores[NUM_EXPERTS];
+    alignas(64) float scores_biased[NUM_EXPERTS];
+
+    using elem_t = std::pair<float, int32_t>;
+    std::vector<elem_t> queue(NUM_EXPERTS);
+
+    // simple RNG for fused shared expert random ID
+    uint64_t rng_state = begin * 6364136223846793005ULL + 1442695040888963407ULL;
+
+    for (int64_t i = begin; i < end; ++i) {
+      // compute scores
+      if (scoring_func == 0) {
+        sigmoid<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      } else {
+        sqrtsoftplus<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      }
+
+      // add bias for selection
+      apply_bias<param_t, NUM_EXPERTS>(scores_biased, scores, bias);
+
+      // build queue and partial sort to find top-k
+      for (int64_t e = 0; e < NUM_EXPERTS; ++e) {
+        queue[e] = {scores_biased[e], static_cast<int32_t>(e)};
+      }
+
+      bool need_sorted = num_fused_shared_experts > 0;
+      if (need_sorted) {
+        std::partial_sort(
+            queue.begin(), queue.begin() + topk, queue.end(), [](const elem_t& x, const elem_t& y) -> bool {
+              return x.first > y.first;
+            });
+      } else {
+        std::partial_sort(
+            queue.begin(), queue.begin() + topk, queue.end(), [](const elem_t& x, const elem_t& y) -> bool {
+              return x.first > y.first;
+            });
+      }
+
+      // gather original scores (without bias) as weights
+      for (int64_t j = 0; j < topk; ++j) {
+        int32_t idx = queue[j].second;
+        topk_ids[i * topk + j] = idx;
+        topk_weights[i * topk + j] = scores[idx];
+      }
+
+      // handle fused shared experts
+      if (num_fused_shared_experts > 0) {
+        // replace last slot with random shared expert ID
+        rng_state = rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+        int32_t shared_id =
+            NUM_EXPERTS + static_cast<int32_t>((rng_state >> 33) % static_cast<uint64_t>(num_fused_shared_experts));
+        topk_ids[i * topk + topk - 1] = shared_id;
+
+        // shared expert weight = sum of routed weights / scaling_factor
+        if (routed_scaling_factor != 0.0f) {
+          float routed_sum = 0.f;
+          for (int64_t j = 0; j < topk - 1; ++j) {
+            routed_sum += topk_weights[i * topk + j];
+          }
+          topk_weights[i * topk + topk - 1] = routed_sum / routed_scaling_factor;
+        }
+      }
+
+      // renormalize
+      if (renormalize) {
+        float sum = 0.f;
+        int64_t norm_end = (num_fused_shared_experts == 0) ? topk : topk - 1;
+        for (int64_t j = 0; j < norm_end; ++j) {
+          sum += topk_weights[i * topk + j];
+        }
+        float scale = 1.f / sum;
+        if (apply_routed_scaling_factor_on_output) {
+          scale *= routed_scaling_factor;
+        }
+        for (int64_t j = 0; j < norm_end; ++j) {
+          topk_weights[i * topk + j] *= scale;
+        }
+        // also scale the shared expert weight if present
+        if (num_fused_shared_experts > 0) {
+          topk_weights[i * topk + topk - 1] *= scale;
+        }
+      }
+    }
+  });
+}
+
+// hash_topk: expert IDs come from a precomputed lookup table tid2eid[input_ids]
+// scoring_func: 0 = softmax, 1 = sigmoid, 2 = sqrtsoftplus
+template <typename scalar_t, int NUM_EXPERTS, int TOPK>
+void hash_topk_kernel_impl(
+    float* __restrict__ topk_weights,
+    int32_t* __restrict__ topk_ids,
+    const scalar_t* __restrict__ gating_output,
+    const int32_t* __restrict__ tid2eid,  // [num_tokens, routed_topk]
+    int64_t num_tokens,
+    int scoring_func,
+    int64_t num_fused_shared_experts,
+    int64_t num_experts,
+    float routed_scaling_factor,
+    int64_t topk) {
+  const int64_t routed_topk = topk - num_fused_shared_experts;
+  const bool need_renormalize = (scoring_func != 0);  // renormalize for non-softmax
+
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
+    alignas(64) float scores[NUM_EXPERTS];
+
+    // simple RNG for fused shared expert random ID
+    uint64_t rng_state = begin * 6364136223846793005ULL + 1442695040888963407ULL;
+
+    for (int64_t i = begin; i < end; ++i) {
+      // compute scores over all experts
+      if (scoring_func == 0) {
+        softmax<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      } else if (scoring_func == 1) {
+        sigmoid<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      } else {
+        sqrtsoftplus<scalar_t, NUM_EXPERTS>(scores, gating_output + i * NUM_EXPERTS);
+      }
+
+      // gather expert IDs from lookup table
+      const int32_t* eid_row = tid2eid + i * routed_topk;
+      for (int64_t j = 0; j < routed_topk; ++j) {
+        int32_t eid = eid_row[j];
+        topk_ids[i * topk + j] = eid;
+        topk_weights[i * topk + j] = scores[eid];
+      }
+
+      // renormalize routed weights (for non-softmax scoring)
+      if (need_renormalize) {
+        float sum = 0.f;
+        for (int64_t j = 0; j < routed_topk; ++j) {
+          sum += topk_weights[i * topk + j];
+        }
+        if (sum > 0.f) {
+          float scale = 1.f / sum;
+          for (int64_t j = 0; j < routed_topk; ++j) {
+            topk_weights[i * topk + j] *= scale;
+          }
+        }
+      }
+
+      // handle fused shared expert
+      if (num_fused_shared_experts > 0) {
+        // random shared expert ID in [num_experts, num_experts + num_fused_shared_experts)
+        rng_state = rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+        int32_t shared_id =
+            num_experts + static_cast<int32_t>((rng_state >> 33) % static_cast<uint64_t>(num_fused_shared_experts));
+        topk_ids[i * topk + topk - 1] = shared_id;
+
+        // shared expert weight = sum of routed weights / scaling_factor
+        float routed_sum = 0.f;
+        for (int64_t j = 0; j < routed_topk; ++j) {
+          routed_sum += topk_weights[i * topk + j];
+        }
+        topk_weights[i * topk + topk - 1] = routed_sum / routed_scaling_factor;
+      }
+    }
+  });
+}
+
+#define LAUNCH_HASH_TOPK_KERNEL(NE, NTOPK)    \
+  hash_topk_kernel_impl<scalar_t, NE, NTOPK>( \
+      topk_weights.data_ptr<float>(),         \
+      topk_ids.data_ptr<int32_t>(),           \
+      gating_output.data_ptr<scalar_t>(),     \
+      tid2eid_flat.data_ptr<int32_t>(),       \
+      num_tokens,                             \
+      scoring_func_id,                        \
+      num_fused_shared_experts,               \
+      num_experts,                            \
+      routed_scaling_factor_value,            \
+      topk);
+
+#define LAUNCH_BIASED_TOPK_KERNEL(NE, NTOPK)             \
+  biased_topk_kernel_impl<scalar_t, param_t, NE, NTOPK>( \
+      topk_weights.data_ptr<float>(),                    \
+      topk_ids.data_ptr<int32_t>(),                      \
+      gating_output.data_ptr<scalar_t>(),                \
+      correction_bias.data_ptr<param_t>(),               \
+      num_tokens,                                        \
+      topk,                                              \
+      renormalize,                                       \
+      scoring_func_id,                                   \
+      num_fused_shared_experts,                          \
+      routed_scaling_factor_value,                       \
+      apply_routed_scaling_factor_on_output);
+
 #define LAUNCH_GROUPED_TOPK_KERNEL(NE)    \
   grouped_topk_kernel_impl<scalar_t, NE>( \
       topk_weights.data_ptr<float>(),     \
@@ -446,6 +849,303 @@ void biased_grouped_topk_kernel_impl(
       renormalize);
 
 }  // anonymous namespace
+
+// biased topk for DeepSeek V4 (flat, non-grouped)
+std::tuple<at::Tensor, at::Tensor> biased_topk_cpu(
+    at::Tensor& hidden_states,
+    at::Tensor& gating_output,
+    at::Tensor& correction_bias,
+    int64_t topk,
+    bool renormalize,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    std::optional<double> routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  CHECK_INPUT(gating_output);
+  CHECK_INPUT(correction_bias);
+
+  const auto st = gating_output.scalar_type();
+  int64_t num_tokens = hidden_states.size(0);
+  int64_t num_experts = gating_output.size(1);
+  TORCH_CHECK(gating_output.size(0) == num_tokens, "Number of tokens mismatch");
+  TORCH_CHECK(correction_bias.numel() == num_experts, "Bias shape mismatch");
+
+  int scoring_func_id = 0;
+  if (scoring_func == "sigmoid") {
+    scoring_func_id = 0;
+  } else if (scoring_func == "sqrtsoftplus") {
+    scoring_func_id = 1;
+  } else {
+    TORCH_CHECK(false, "Unsupported scoring_func: ", scoring_func);
+  }
+
+  float routed_scaling_factor_value = routed_scaling_factor.has_value() ? routed_scaling_factor.value() : 0.0f;
+
+  at::Tensor topk_weights = at::empty({num_tokens, topk}, hidden_states.options().dtype(at::kFloat));
+  at::Tensor topk_ids = at::empty({num_tokens, topk}, hidden_states.options().dtype(at::kInt));
+
+  // The actual routed topk (excluding fused shared experts)
+  int64_t routed_topk = topk - num_fused_shared_experts;
+
+  CPU_DISPATCH_FLOATING_TYPES_EXT(st, correction_bias.scalar_type(), "biased_topk_kernel", [&] {
+    // dispatch on num_experts and routed_topk
+    // For DeepSeek V4: typically 256 experts, topk=8 or topk=9 (with 1 fused shared expert)
+    switch (num_experts) {
+      case 64:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(64, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(64, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=64");
+        }
+        break;
+      case 128:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(128, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(128, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=128");
+        }
+        break;
+      case 256:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(256, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(256, 8);
+            break;
+          case 9:
+            LAUNCH_BIASED_TOPK_KERNEL(256, 9);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=256");
+        }
+        break;
+      case 384:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_BIASED_TOPK_KERNEL(384, 6);
+            break;
+          case 8:
+            LAUNCH_BIASED_TOPK_KERNEL(384, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected topk: ", topk, " for num_experts=384");
+        }
+        break;
+      default:
+        TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
+    }
+  });
+  return std::make_tuple(topk_weights, topk_ids);
+}
+
+// hash topk for DeepSeek V4 (expert IDs from precomputed lookup table)
+std::tuple<at::Tensor, at::Tensor> hash_topk_cpu(
+    at::Tensor& gating_output,
+    at::Tensor& tid2eid,
+    int64_t topk,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    int64_t num_experts,
+    double routed_scaling_factor) {
+  CHECK_INPUT(gating_output);
+  CHECK_INPUT(tid2eid);
+
+  const auto st = gating_output.scalar_type();
+  int64_t num_tokens = gating_output.size(0);
+  int64_t num_experts_gating = gating_output.size(1);
+  int64_t routed_topk = topk - num_fused_shared_experts;
+
+  TORCH_CHECK(tid2eid.size(0) == num_tokens, "tid2eid row count must match num_tokens");
+  TORCH_CHECK(tid2eid.size(1) == routed_topk, "tid2eid column count must match routed_topk");
+  TORCH_CHECK(tid2eid.scalar_type() == at::kInt, "tid2eid must be int32");
+  TORCH_CHECK(num_experts_gating == num_experts, "num_experts mismatch");
+
+  int scoring_func_id = 0;
+  if (scoring_func == "softmax") {
+    scoring_func_id = 0;
+  } else if (scoring_func == "sigmoid") {
+    scoring_func_id = 1;
+  } else if (scoring_func == "sqrtsoftplus") {
+    scoring_func_id = 2;
+  } else {
+    TORCH_CHECK(false, "Unsupported scoring_func: ", scoring_func);
+  }
+
+  float routed_scaling_factor_value = static_cast<float>(routed_scaling_factor);
+
+  at::Tensor topk_weights = at::empty({num_tokens, topk}, gating_output.options().dtype(at::kFloat));
+  at::Tensor topk_ids = at::empty({num_tokens, topk}, gating_output.options().dtype(at::kInt));
+
+  // tid2eid is [num_tokens, routed_topk], already indexed by input_ids in Python
+  at::Tensor tid2eid_flat = tid2eid.contiguous();
+
+  // Dispatch for bf16, fp16, and float32
+  // Note: cannot use AT_DISPATCH_FLOATING_TYPES_AND2 since it includes double which lacks convert_to_float
+  auto dispatch_fn = [&]<typename scalar_t>() {
+    switch (num_experts) {
+      case 64:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(64, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(64, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(64, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=64");
+        }
+        break;
+      case 128:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(128, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(128, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(128, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=128");
+        }
+        break;
+      case 256:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(256, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(256, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(256, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=256");
+        }
+        break;
+      case 384:
+        switch (routed_topk) {
+          case 6:
+            LAUNCH_HASH_TOPK_KERNEL(384, 6);
+            break;
+          case 7:
+            LAUNCH_HASH_TOPK_KERNEL(384, 7);
+            break;
+          case 8:
+            LAUNCH_HASH_TOPK_KERNEL(384, 8);
+            break;
+          default:
+            TORCH_CHECK(false, "Unexpected routed_topk: ", routed_topk, " for num_experts=256");
+        }
+        break;
+      default:
+        TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
+    }
+  };
+
+  if (st == at::ScalarType::BFloat16) {
+    dispatch_fn.template operator()<at::BFloat16>();
+  } else if (st == at::ScalarType::Half) {
+    dispatch_fn.template operator()<at::Half>();
+  } else if (st == at::ScalarType::Float) {
+    dispatch_fn.template operator()<float>();
+  } else {
+    TORCH_CHECK(false, "Unsupported dtype for hash_topk_cpu: ", st);
+  }
+
+  return std::make_tuple(topk_weights, topk_ids);
+}
+
+void topk_transform_512_cpu(
+    at::Tensor& scores,
+    at::Tensor& seq_lens,
+    at::Tensor& page_tables,
+    at::Tensor& out_page_indices,
+    int64_t page_size,
+    const std::optional<at::Tensor>& out_raw_indices) {
+  CHECK_INPUT(scores);
+  CHECK_INPUT(seq_lens);
+  CHECK_INPUT(page_tables);
+  CHECK_INPUT(out_page_indices);
+
+  TORCH_CHECK(scores.scalar_type() == at::kFloat, "scores must be float32");
+  TORCH_CHECK(out_page_indices.scalar_type() == at::kInt, "out_page_indices must be int32");
+  TORCH_CHECK(scores.dim() == 2, "scores must be a 2D tensor");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must be a 1D tensor");
+  TORCH_CHECK(page_tables.dim() == 2, "page_tables must be a 2D tensor");
+  TORCH_CHECK(out_page_indices.dim() == 2, "out_page_indices must be a 2D tensor");
+
+  const int64_t batch_size = scores.size(0);
+  const int64_t max_seq_len = scores.size(1);
+  TORCH_CHECK(seq_lens.size(0) == batch_size, "seq_lens row count must match scores");
+  TORCH_CHECK(page_tables.size(0) == batch_size, "page_tables row count must match scores");
+  TORCH_CHECK(out_page_indices.size(0) == batch_size, "out_page_indices row count must match scores");
+  TORCH_CHECK(out_page_indices.size(1) >= C4_TOPK, "out_page_indices must have at least 512 columns");
+
+  int32_t* raw_ptr = nullptr;
+  if (out_raw_indices.has_value()) {
+    at::Tensor raw = out_raw_indices.value();
+    CHECK_INPUT(raw);
+    TORCH_CHECK(raw.scalar_type() == at::kInt, "out_raw_indices must be int32");
+    TORCH_CHECK(raw.dim() == 2, "out_raw_indices must be a 2D tensor");
+    TORCH_CHECK(raw.sizes() == out_page_indices.sizes(), "out_raw_indices shape must match out_page_indices");
+    raw_ptr = raw.data_ptr<int32_t>();
+  }
+
+  auto launch_with_page_type = [&]<typename seq_t>() {
+    if (page_tables.scalar_type() == at::kInt) {
+      topk_transform_512_cpu_kernel_impl<seq_t, int32_t>(
+          scores.data_ptr<float>(),
+          seq_lens.data_ptr<seq_t>(),
+          page_tables.data_ptr<int32_t>(),
+          out_page_indices.data_ptr<int32_t>(),
+          raw_ptr,
+          batch_size,
+          max_seq_len,
+          page_tables.stride(0),
+          out_page_indices.stride(0),
+          page_size);
+    } else if (page_tables.scalar_type() == at::kLong) {
+      topk_transform_512_cpu_kernel_impl<seq_t, int64_t>(
+          scores.data_ptr<float>(),
+          seq_lens.data_ptr<seq_t>(),
+          page_tables.data_ptr<int64_t>(),
+          out_page_indices.data_ptr<int32_t>(),
+          raw_ptr,
+          batch_size,
+          max_seq_len,
+          page_tables.stride(0),
+          out_page_indices.stride(0),
+          page_size);
+    } else {
+      TORCH_CHECK(false, "page_tables must be int32 or int64");
+    }
+  };
+
+  if (seq_lens.scalar_type() == at::kInt) {
+    launch_with_page_type.template operator()<int32_t>();
+  } else if (seq_lens.scalar_type() == at::kLong) {
+    launch_with_page_type.template operator()<int64_t>();
+  } else {
+    TORCH_CHECK(false, "seq_lens must be int32 or int64");
+  }
+}
 
 std::tuple<at::Tensor, at::Tensor>
 topk_sigmoid_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize) {

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -58,6 +58,10 @@ at::Tensor fused_add_layernorm_cpu(
 // topk
 std::tuple<at::Tensor, at::Tensor>
 topk_sigmoid_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize);
+
+// hadamard transform
+at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale);
+
 std::tuple<at::Tensor, at::Tensor>
 topk_softmax_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize);
 
@@ -83,6 +87,43 @@ std::tuple<at::Tensor, at::Tensor> biased_grouped_topk_cpu(
     int64_t num_fused_shared_experts,
     std::optional<double> routed_scaling_factor,
     std::optional<at::Tensor> num_token_non_padded);
+
+std::tuple<at::Tensor, at::Tensor> biased_topk_cpu(
+    at::Tensor& hidden_states,
+    at::Tensor& gating_output,
+    at::Tensor& correction_bias,
+    int64_t topk,
+    bool renormalize,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    std::optional<double> routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output);
+
+std::tuple<at::Tensor, at::Tensor> hash_topk_cpu(
+    at::Tensor& gating_output,
+    at::Tensor& tid2eid,
+    int64_t topk,
+    std::string scoring_func,
+    int64_t num_fused_shared_experts,
+    int64_t num_experts,
+    double routed_scaling_factor);
+
+void topk_transform_512_cpu(
+    at::Tensor& scores,
+    at::Tensor& seq_lens,
+    at::Tensor& page_tables,
+    at::Tensor& out_page_indices,
+    int64_t page_size,
+    const std::optional<at::Tensor>& out_raw_indices);
+
+at::Tensor fp8_paged_mqa_logits_cpu(
+    at::Tensor& q_fp8,
+    at::Tensor& kvcache_fp8,
+    at::Tensor& weight,
+    at::Tensor& seq_lens,
+    at::Tensor& page_table,
+    int64_t max_seq_len,
+    bool clean_logits);
 
 // attention
 void decode_attention_cpu(
@@ -127,6 +168,21 @@ at::Tensor flash_attn_varlen_func(
     int64_t max_seqlen_k,
     bool causal);
 
+// flash_mla_with_kvcache (DeepSeek FlashMLA sparse decode)
+std::tuple<at::Tensor, at::Tensor> flash_mla_with_kvcache_cpu(
+    at::Tensor& q,
+    at::Tensor& k_cache,
+    int64_t head_dim_v,
+    double softmax_scale,
+    at::Tensor& indices,
+    std::optional<at::Tensor> topk_length,
+    std::optional<at::Tensor> attn_sink,
+    std::optional<at::Tensor> extra_k_cache,
+    std::optional<at::Tensor> extra_indices,
+    std::optional<at::Tensor> extra_topk_length,
+    bool is_fp8_kvcache,
+    int64_t fp8_layout);
+
 // linear attention
 std::tuple<at::Tensor, at::Tensor> chunk_gated_delta_rule_cpu(
     const at::Tensor& query,
@@ -149,6 +205,9 @@ at::Tensor convert_scale_packed(at::Tensor& scale);
 
 // quant
 std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A);
+std::tuple<at::Tensor, at::Tensor>
+act_quant_cpu(at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt);
+at::Tensor fused_scale_cpu(at::Tensor& weight, double out_scale, at::Tensor& q_scale);
 
 // igemm
 at::Tensor int8_scaled_mm_cpu(
@@ -197,8 +256,12 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> convert_weight_packed_scale_zp(
 #endif
 
 // gemm
-at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni);
+at::Tensor weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype = c10::nullopt);
 
 // gemm fusion
 at::Tensor fused_linear_sigmoid_mul(
@@ -225,6 +288,10 @@ at::Tensor fused_experts_cpu(
     const std::optional<at::Tensor>& w1_zero,
     const std::optional<at::Tensor>& w2_zero,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<at::Tensor>& w1_bias,
+    const std::optional<at::Tensor>& w2_bias,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni);
 
 #if !defined(SGLANG_CPU_ARM64_SKIP_X86_ONLY_OPS)
@@ -237,9 +304,12 @@ at::Tensor shared_expert_cpu(
     bool inplace,
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_mxfp4,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
+    const std::optional<double>& alpha,
+    const std::optional<double>& limit,
     bool is_vnni);
 
 // weight absorption
@@ -347,8 +417,33 @@ std::tuple<at::Tensor, at::Tensor> multimodal_rotary_embedding_cpu(
     bool mrope_interleaved,
     bool is_neox);
 
+at::Tensor apply_rotary_emb_interleaved_cpu(
+    at::Tensor& x,
+    at::Tensor& freqs,
+    bool inverse,
+    const std::optional<at::Tensor>& positions,
+    const std::optional<at::Tensor>& k);
+
 // CPU and memory binding
 std::string init_cpu_threads_env(const std::string& cpu_ids);
+
+// set_k_and_s
+void set_k_and_s_cpu(
+    at::Tensor& buf,
+    at::Tensor& loc,
+    at::Tensor& k_nope,
+    at::Tensor& k_rope,
+    at::Tensor& scale_k_nope,
+    int64_t page_size);
+
+// set_k
+void set_k_cpu(at::Tensor& buf, at::Tensor& loc, at::Tensor& index_k, int64_t page_size, int64_t index_head_dim);
+
+// set_s
+void set_s_cpu(at::Tensor& buf, at::Tensor& loc, at::Tensor& index_k_scale, int64_t page_size, int64_t index_head_dim);
+
+// quant_to_nope_fp8_rope_bf16_pack
+std::tuple<at::Tensor, at::Tensor, at::Tensor> quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16);
 
 // fused_sigmoid_gating_delta_rule_update
 at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
@@ -406,6 +501,52 @@ std::tuple<at::Tensor, at::Tensor> image_preprocess_cpu(
     bool disable_grouping,
     at::ScalarType out_dtype);
 
+// compressor
+at::Tensor compress_decode_cpu(
+    at::Tensor& pool_kv,
+    at::Tensor& pool_score,
+    at::Tensor& kv,
+    at::Tensor& score,
+    at::Tensor& seq_lens,
+    at::Tensor& req_pool_indices,
+    at::Tensor& ape,
+    at::Tensor& norm_weight,
+    at::Tensor& freqs_cis,
+    int64_t ratio,
+    int64_t head_dim,
+    int64_t rope_head_dim,
+    bool overlap,
+    bool rotate,
+    double norm_eps);
+
+// scheduler: paged allocation
+void alloc_extend_kernel_cpu(
+    at::Tensor& pre_lens,
+    at::Tensor& seq_lens,
+    at::Tensor& last_loc,
+    at::Tensor& free_pages,
+    at::Tensor& out_indices,
+    int64_t page_size);
+
+void alloc_decode_kernel_cpu(
+    at::Tensor& seq_lens, at::Tensor& last_loc, at::Tensor& free_pages, at::Tensor& out_indices, int64_t page_size);
+
+// mhc kernels
+std::tuple<at::Tensor, at::Tensor, at::Tensor> hc_pre_fused_cpu(
+    at::Tensor& x,
+    at::Tensor& hc_fn,
+    at::Tensor& hc_scale,
+    at::Tensor& hc_base,
+    int64_t hc_mult,
+    int64_t sinkhorn_iters,
+    double rms_eps,
+    double hc_eps);
+
+at::Tensor hc_post_fused_cpu(at::Tensor& x, at::Tensor& residual, at::Tensor& post, at::Tensor& comb);
+
+at::Tensor hc_head_fused_cpu(
+    at::Tensor& x, at::Tensor& hc_fn, at::Tensor& hc_scale, at::Tensor& hc_base, double hc_eps, double norm_eps);
+
 // [NOTE] When registering kernels, we should accurately describe the in-place information.
 // Taking fused_add_rmsnorm_cpu as an example, add `Tensor(a!)` modifier to all tensors that
 // will be modified in-place to avoid incorrect fusing and execution order on graph mode.
@@ -460,6 +601,31 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor? num_token_non_padded) -> (Tensor, Tensor)");
   m.impl("biased_grouped_topk_cpu", torch::kCPU, &biased_grouped_topk_cpu);
 
+  // biased topk (flat, non-grouped)
+  m.def(
+      "biased_topk_cpu(Tensor hidden_states, Tensor gating_output, Tensor correction_bias, int topk, bool "
+      "renormalize, str scoring_func, int num_fused_shared_experts, float? routed_scaling_factor, "
+      "bool apply_routed_scaling_factor_on_output) -> (Tensor, Tensor)");
+  m.impl("biased_topk_cpu", torch::kCPU, &biased_topk_cpu);
+
+  // hash topk (expert IDs from lookup table)
+  m.def(
+      "hash_topk_cpu(Tensor gating_output, Tensor tid2eid, int topk, str scoring_func, "
+      "int num_fused_shared_experts, int num_experts, float routed_scaling_factor) -> (Tensor, Tensor)");
+  m.impl("hash_topk_cpu", torch::kCPU, &hash_topk_cpu);
+
+  // DeepSeek V4 compressed attention top-k transform
+  m.def(
+      "topk_transform_512_cpu(Tensor scores, Tensor seq_lens, Tensor page_tables, Tensor(a!) out_page_indices, "
+      "int page_size, Tensor(a!)? out_raw_indices) -> ()");
+  m.impl("topk_transform_512_cpu", torch::kCPU, &topk_transform_512_cpu);
+
+  // DeepSeek V4 compressed attention FP8 paged MQA logits
+  m.def(
+      "fp8_paged_mqa_logits_cpu(Tensor q_fp8, Tensor kvcache_fp8, Tensor weight, Tensor seq_lens, "
+      "Tensor page_table, int max_seq_len, bool clean_logits) -> Tensor");
+  m.impl("fp8_paged_mqa_logits_cpu", torch::kCPU, &fp8_paged_mqa_logits_cpu);
+
   // decode
   m.def(
       "decode_attention_cpu(Tensor query, Tensor k_cache, Tensor v_cahce, Tensor(a!) output, Tensor key, Tensor value, "
@@ -479,6 +645,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "flash_attn_varlen_func(Tensor q, Tensor k, Tensor v, Tensor cu_seqlens_q, Tensor cu_seqlens_k, "
       "int max_seqlen_q, int max_seqlen_k, bool causal) -> Tensor");
   m.impl("flash_attn_varlen_func", torch::kCPU, &flash_attn_varlen_func);
+  // flash mla with kvcache
+  m.def(
+      "flash_mla_with_kvcache_cpu(Tensor q, Tensor k_cache, int head_dim_v, float softmax_scale, "
+      "Tensor indices, Tensor? topk_length, Tensor? attn_sink, "
+      "Tensor? extra_k_cache, Tensor? extra_indices, Tensor? extra_topk_length, "
+      "bool is_fp8_kvcache, int fp8_layout) -> (Tensor, Tensor)");
+  m.impl("flash_mla_with_kvcache_cpu", torch::kCPU, &flash_mla_with_kvcache_cpu);
 
   // linear attn
   m.def(
@@ -498,6 +671,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // quant
   m.def("per_token_quant_int8_cpu(Tensor A) -> (Tensor, Tensor)");
   m.impl("per_token_quant_int8_cpu", torch::kCPU, &per_token_quant_int8_cpu);
+  m.def("act_quant_cpu(Tensor x, int block_size=128, str? scale_fmt=None) -> (Tensor, Tensor)");
+  m.impl("act_quant_cpu", torch::kCPU, &act_quant_cpu);
+  m.def("fused_scale_cpu(Tensor weight, float out_scale, Tensor q_scale) -> Tensor");
+  m.impl("fused_scale_cpu", torch::kCPU, &fused_scale_cpu);
 
   // igemm
   m.def(
@@ -534,7 +711,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 #endif
 
   // gemm
-  m.def("weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_vnni) -> Tensor");
+  m.def(
+      "weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_vnni, ScalarType? out_dtype=None) -> "
+      "Tensor");
   m.impl("weight_packed_linear", torch::kCPU, &weight_packed_linear);
 
   // gemm fusion
@@ -550,7 +729,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "fused_experts_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor topk_weights, Tensor topk_ids, bool "
       "inplace, int moe_comp_method, Tensor? w1_scale, Tensor? w2_scale, "
-      "Tensor? w1_zero, Tensor? w2_zero, int[]? block_size, bool is_vnni) -> Tensor");
+      "Tensor? w1_zero, Tensor? w2_zero, int[]? block_size, Tensor? w1_bias, Tensor? w2_bias, float? alpha, float? "
+      "limit, bool is_vnni) -> Tensor");
   m.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);
 
 #if !defined(SGLANG_CPU_ARM64_SKIP_X86_ONLY_OPS)
@@ -574,8 +754,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // shared expert
   m.def(
       "shared_expert_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor? fused_experts_out, float? "
-      "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, Tensor? w1_scale, Tensor? "
-      "w2_scale, int[]? block_size, bool is_vnni) -> Tensor");
+      "routed_scaling_factor, bool inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_mxfp4, Tensor? w1_scale, "
+      "Tensor? "
+      "w2_scale, int[]? block_size, float? alpha, float? limit, bool is_vnni) -> Tensor");
   m.impl("shared_expert_cpu", torch::kCPU, &shared_expert_cpu);
 
   // causal conv1d
@@ -614,6 +795,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("rotary_embedding_cpu", torch::kCPU, &rotary_embedding_cpu);
   m.def("apply_rotary_pos_emb_cpu(Tensor query, Tensor key, Tensor cos, Tensor sin) -> (Tensor, Tensor)");
   m.impl("apply_rotary_pos_emb_cpu", torch::kCPU, &apply_rotary_pos_emb_cpu);
+  m.def(
+      "apply_rotary_emb_interleaved_cpu(Tensor(a!) x, Tensor freqs, bool inverse, Tensor? positions=None, Tensor(b!)? "
+      "k=None) -> Tensor(a!)");
+  m.impl("apply_rotary_emb_interleaved_cpu", torch::kCPU, &apply_rotary_emb_interleaved_cpu);
 
   // multimodal rope
   m.def(
@@ -623,6 +808,32 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   // CPU and memory binding
   m.def("init_cpu_threads_env(str cpu_ids) -> str");
+
+  // hadamard transform
+  m.def("fast_hadamard_transform_cpu(Tensor x, float scale) -> Tensor");
+  m.impl("fast_hadamard_transform_cpu", torch::kCPU, &fast_hadamard_transform_cpu);
+
+  // set_k_and_s
+  m.def(
+      "set_k_and_s_cpu(Tensor(a!) buf, Tensor loc, Tensor k_nope, Tensor k_rope, "
+      "Tensor scale_k_nope, int page_size) -> ()");
+  m.impl("set_k_and_s_cpu", torch::kCPU, &set_k_and_s_cpu);
+
+  // set_k
+  m.def(
+      "set_k_cpu(Tensor(a!) buf, Tensor loc, Tensor index_k, "
+      "int page_size, int index_head_dim) -> ()");
+  m.impl("set_k_cpu", torch::kCPU, &set_k_cpu);
+
+  // set_s
+  m.def(
+      "set_s_cpu(Tensor(a!) buf, Tensor loc, Tensor index_k_scale, "
+      "int page_size, int index_head_dim) -> ()");
+  m.impl("set_s_cpu", torch::kCPU, &set_s_cpu);
+
+  // quant_to_nope_fp8_rope_bf16_pack
+  m.def("quant_to_nope_fp8_rope_bf16_pack_cpu(Tensor k_bf16) -> (Tensor, Tensor, Tensor)");
+  m.impl("quant_to_nope_fp8_rope_bf16_pack_cpu", torch::kCPU, &quant_to_nope_fp8_rope_bf16_pack_cpu);
 
   // fused_sigmoid_gating_delta_rule_update
   m.def(
@@ -652,6 +863,38 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "image_std, int patch_size, int temporal_patch_size, int merge_size, bool disable_grouping, ScalarType "
       "out_dtype) -> (Tensor, Tensor)");
   m.impl("image_preprocess_cpu", torch::kCPU, &image_preprocess_cpu);
+
+  // compressor
+  m.def(
+      "compress_decode_cpu(Tensor(a!) pool_kv, Tensor(b!) pool_score, Tensor kv, Tensor score, "
+      "Tensor seq_lens, Tensor req_pool_indices, Tensor ape, Tensor norm_weight, Tensor freqs_cis, "
+      "int ratio, int head_dim, int rope_head_dim, bool overlap, bool rotate, float norm_eps) -> Tensor");
+  m.impl("compress_decode_cpu", torch::kCPU, &compress_decode_cpu);
+
+  // scheduler: paged allocation
+  m.def(
+      "alloc_extend_kernel_cpu(Tensor pre_lens, Tensor seq_lens, Tensor last_loc, "
+      "Tensor free_pages, Tensor(a!) out_indices, int page_size) -> ()");
+  m.impl("alloc_extend_kernel_cpu", torch::kCPU, &alloc_extend_kernel_cpu);
+
+  m.def(
+      "alloc_decode_kernel_cpu(Tensor seq_lens, Tensor last_loc, "
+      "Tensor free_pages, Tensor(a!) out_indices, int page_size) -> ()");
+  m.impl("alloc_decode_kernel_cpu", torch::kCPU, &alloc_decode_kernel_cpu);
+
+  // mhc
+  m.def(
+      "hc_pre_fused_cpu(Tensor x, Tensor hc_fn, Tensor hc_scale, Tensor hc_base, "
+      "int hc_mult, int sinkhorn_iters, float rms_eps, float hc_eps) -> (Tensor, Tensor, Tensor)");
+  m.impl("hc_pre_fused_cpu", torch::kCPU, &hc_pre_fused_cpu);
+
+  m.def("hc_post_fused_cpu(Tensor x, Tensor residual, Tensor post, Tensor comb) -> Tensor");
+  m.impl("hc_post_fused_cpu", torch::kCPU, &hc_post_fused_cpu);
+
+  m.def(
+      "hc_head_fused_cpu(Tensor x, Tensor hc_fn, Tensor hc_scale, Tensor hc_base, "
+      "float hc_eps, float norm_eps) -> Tensor");
+  m.impl("hc_head_fused_cpu", torch::kCPU, &hc_head_fused_cpu);
 }
 
 TORCH_LIBRARY_IMPL(sgl_kernel, CatchAll, m) {

--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -6,6 +6,7 @@
 
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
+#include <immintrin.h>
 
 namespace {
 
@@ -14,6 +15,15 @@ using namespace at::vec;
 template <typename scalar_t, typename std::enable_if_t<is_reduced_floating_point_v<scalar_t>, int> = 0>
 inline Vectorized<scalar_t> convert_from_float_ext(const Vectorized<float>& a, const Vectorized<float>& b) {
   return at::vec::convert_from_float<scalar_t>(a, b);
+}
+
+template <typename scalar_t>
+inline void convert_from_float_and_store(scalar_t* out, const Vectorized<float>& a) {
+  float out_buffer[at::vec::Vectorized<float>::size()];
+  a.store(out_buffer);
+  for (int i = 0; i < 16; i++) {
+    out[i] = (scalar_t)out_buffer[i];
+  }
 }
 
 // allow f16, bf16
@@ -43,6 +53,11 @@ template <>
 inline Vectorized<at::BFloat16>
 convert_from_float_ext<at::BFloat16>(const Vectorized<float>& a, const Vectorized<float>& b) {
   return (__m512i)(_mm512_cvtne2ps_pbh(__m512(b), __m512(a)));
+}
+
+template <>
+inline void convert_from_float_and_store<at::BFloat16>(at::BFloat16* out, const Vectorized<float>& a) {
+  _mm256_storeu_si256((__m256i*)out, (__m256i)(_mm512_cvtneps_pbh(__m512(a))));
 }
 
 #define CVT_BF16_TO_FP32(a) _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(a), 16))

--- a/sgl-kernel/python/sgl_kernel/flash_mla.py
+++ b/sgl-kernel/python/sgl_kernel/flash_mla.py
@@ -162,3 +162,56 @@ def flash_mla_sparse_fwd(
         q, kv, indices, sm_scale, d_v
     )
     return results
+
+
+def flash_mla_with_kvcache_cpu(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    block_table: Optional[torch.Tensor],
+    cache_seqlens: Optional[torch.Tensor],
+    head_dim_v: int,
+    tile_scheduler_metadata=None,
+    num_splits=None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    is_fp8_kvcache: bool = False,
+    indices: Optional[torch.Tensor] = None,
+    attn_sink: Optional[torch.Tensor] = None,
+    extra_k_cache: Optional[torch.Tensor] = None,
+    extra_indices_in_kvcache: Optional[torch.Tensor] = None,
+    topk_length: Optional[torch.Tensor] = None,
+    extra_topk_length: Optional[torch.Tensor] = None,
+    fp8_layout: int = 2,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Returns:
+        out: ``(B, S_q, H_q, head_dim_v)``, ``bfloat16``.
+        softmax_lse: ``(B, H_q, S_q)``, ``float32``.
+    """
+    assert indices is not None, (
+        "flash_mla_with_kvcache_cpu currently only supports the sparse path "
+        "(indices must be provided)"
+    )
+    assert not causal, "causal must be False for sparse attention"
+    assert (
+        block_table is None and cache_seqlens is None
+    ), "block_table and cache_seqlens must be None for the sparse path"
+
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+
+    out, lse = torch.ops.sgl_kernel.flash_mla_with_kvcache_cpu.default(
+        q,
+        k_cache,
+        head_dim_v,
+        float(softmax_scale),
+        indices,
+        topk_length,
+        attn_sink,
+        extra_k_cache,
+        extra_indices_in_kvcache,
+        extra_topk_length,
+        bool(is_fp8_kvcache),
+        int(fp8_layout),
+    )
+    return out, lse

--- a/test/srt/cpu/quant_utils.py
+++ b/test/srt/cpu/quant_utils.py
@@ -1,0 +1,252 @@
+import enum
+from typing import Tuple
+
+import torch
+
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+class FP8KVCacheLayout(enum.Enum):
+    V32_FP8Sparse = 1
+    V4_FP8Sparse = 2
+
+    def get_meta(self) -> Tuple[int, int, int, int, int]:
+        # Return: (d, d_nope, d_rope, tile_size, num_tiles)
+        return {
+            FP8KVCacheLayout.V32_FP8Sparse: (576, 512, 64, 128, 4),
+            FP8KVCacheLayout.V4_FP8Sparse: (512, 448, 64, 64, 7),
+        }[self]
+
+
+def _cast_scale_inv_to_ue8m0(
+    scales_inv: torch.Tensor, out_dtype=torch.float32
+) -> torch.Tensor:
+    return torch.pow(2, torch.clamp_min(scales_inv, 1e-4).log2().ceil()).to(out_dtype)
+
+
+def quantize_k_cache(
+    input_k_cache: torch.Tensor,  # (num_blocks, block_size, h_k, d)
+    kvcache_layout: FP8KVCacheLayout,
+) -> torch.Tensor:
+    """
+    Quantize the k-cache
+    For more detail about the layout of K/V, please refer to comments in flash_mla_interface.py
+    """
+    d, d_nope, d_rope, tile_size, num_tiles = kvcache_layout.get_meta()
+    assert input_k_cache.shape[-1] == d
+    num_blocks, block_size, h_k, _ = input_k_cache.shape
+    assert h_k == 1
+    input_k_cache = input_k_cache.squeeze(2)  # [num_blocks, block_size, d]
+    input_elem_size = input_k_cache.element_size()
+
+    if kvcache_layout == FP8KVCacheLayout.V32_FP8Sparse:
+        bytes_per_token = d_nope + num_tiles * 4 + input_elem_size * d_rope
+        result = torch.empty(
+            (num_blocks, block_size + 1, bytes_per_token),
+            dtype=FP8_DTYPE,
+            device=input_k_cache.device,
+        )[:, :block_size, :]
+        result_k_nope_part = result[..., :d_nope]
+        result_k_scale_factor = result[..., d_nope : d_nope + num_tiles * 4].view(
+            torch.float32
+        )
+        result_k_rope_part = result[..., d_nope + num_tiles * 4 :].view(
+            input_k_cache.dtype
+        )
+        result_k_rope_part[:] = input_k_cache[..., d_nope:]
+
+        for tile_idx in range(0, num_tiles):
+            cur_scale_factors_inv = (
+                torch.abs(
+                    input_k_cache[
+                        ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+                    ]
+                )
+                .max(dim=-1)
+                .values.float()
+                / 448.0
+            )  # [num_blocks, block_size]
+            cur_scale_factors_inv = _cast_scale_inv_to_ue8m0(cur_scale_factors_inv)
+            result_k_scale_factor[:, :, tile_idx] = cur_scale_factors_inv
+
+            cur_scale_factors_inv.unsqueeze_(-1)  # [num_blocks, block_size, 1]
+            cur_quantized_nope = (
+                input_k_cache[
+                    ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+                ].float()
+                / cur_scale_factors_inv.float()
+            ).to(FP8_DTYPE)
+            result_k_nope_part[
+                ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+            ] = cur_quantized_nope
+
+        result = result.view(num_blocks, block_size, 1, -1)
+        return result
+
+    elif kvcache_layout == FP8KVCacheLayout.V4_FP8Sparse:
+        bytes_per_token = d_nope + 2 * d_rope + num_tiles + 1
+        size_per_block_padded = (block_size * bytes_per_token + 576 - 1) // 576 * 576
+        result = torch.empty(
+            (num_blocks, size_per_block_padded),
+            dtype=FP8_DTYPE,
+            device=input_k_cache.device,
+        )[:, : block_size * bytes_per_token]
+        result_k_nope_rope_part = result[:, : block_size * (d_nope + 2 * d_rope)].view(
+            num_blocks, block_size, d_nope + 2 * d_rope
+        )
+        result_k_nope = result_k_nope_rope_part[
+            :, :, :d_nope
+        ]  # [num_blocks, block_size, d_nope]
+        result_k_rope = result_k_nope_rope_part[:, :, d_nope:].view(
+            input_k_cache.dtype
+        )  # [num_blocks, block_size, d_rope]
+        result_k_scale_factor = (
+            result[:, block_size * (d_nope + 2 * d_rope) :]
+            .view(num_blocks, block_size, 8)[:, :, :7]
+            .view(torch.float8_e8m0fnu)
+        )  # [num_blocks, block_size, num_tiles]
+
+        result_k_rope[:] = input_k_cache[..., d_nope:]
+        for tile_idx in range(0, num_tiles):
+            cur_scale_factors_inv = (
+                torch.abs(
+                    input_k_cache[
+                        ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+                    ]
+                )
+                .max(dim=-1)
+                .values.float()
+                / 448.0
+            )  # [num_blocks, block_size]
+            cur_scale_factors_inv = _cast_scale_inv_to_ue8m0(cur_scale_factors_inv)
+            result_k_scale_factor[:, :, tile_idx] = cur_scale_factors_inv.to(
+                torch.float8_e8m0fnu
+            )
+
+            cur_scale_factors_inv = cur_scale_factors_inv.view(
+                num_blocks, block_size, 1
+            )
+            cur_quantized_nope = (
+                input_k_cache[
+                    ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+                ].float()
+                / cur_scale_factors_inv.float()
+            ).to(FP8_DTYPE)
+            result_k_nope[:, :, tile_idx * tile_size : (tile_idx + 1) * tile_size] = (
+                cur_quantized_nope
+            )
+
+        result = result.view(num_blocks, block_size, 1, -1)
+        return result
+
+    else:
+        raise NotImplementedError(f"Unsupported kvcache_layout: {kvcache_layout}")
+
+
+def dequantize_k_cache(
+    quant_k_cache: torch.Tensor,  # (num_blocks, block_size, 1, bytes_per_token)
+    kvcache_layout: FP8KVCacheLayout,
+) -> torch.Tensor:
+    """
+    De-quantize the k-cache
+    """
+    # NOTE ADD
+    assert quant_k_cache.dtype == FP8_DTYPE
+
+    d, d_nope, d_rope, tile_size, num_tiles = kvcache_layout.get_meta()
+    num_blocks, block_size, h_k, _ = quant_k_cache.shape
+    assert h_k == 1
+    result = torch.empty(
+        (num_blocks, block_size, d), dtype=torch.bfloat16, device=quant_k_cache.device
+    )
+
+    if kvcache_layout == FP8KVCacheLayout.V32_FP8Sparse:
+        quant_k_cache = quant_k_cache.view(num_blocks, block_size, -1)
+
+        input_nope = quant_k_cache[..., :d_nope]
+        input_scale = quant_k_cache[..., d_nope : d_nope + num_tiles * 4].view(
+            torch.float32
+        )
+        input_rope = quant_k_cache[..., d_nope + num_tiles * 4 :].view(torch.bfloat16)
+        result[..., d_nope:] = input_rope
+
+        for tile_idx in range(0, num_tiles):
+            cur_nope = input_nope[
+                ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+            ].to(torch.float32)
+            cur_scales = input_scale[..., tile_idx].unsqueeze(-1)
+            result[..., tile_idx * tile_size : (tile_idx + 1) * tile_size] = (
+                cur_nope * cur_scales
+            )
+
+    elif kvcache_layout == FP8KVCacheLayout.V4_FP8Sparse:
+        quant_k_cache = quant_k_cache.view(num_blocks, -1)  # [num_blocks, ...]
+        input_nope_rope = quant_k_cache[:, : block_size * (d_nope + 2 * d_rope)].view(
+            num_blocks, block_size, d_nope + 2 * d_rope
+        )
+        input_nope = input_nope_rope[:, :, :d_nope]
+        input_rope = input_nope_rope[:, :, d_nope:].view(torch.bfloat16)
+        input_scale = (
+            quant_k_cache[:, block_size * (d_nope + 2 * d_rope) :]
+            .view(num_blocks, block_size, 8)[:, :, :7]
+            .view(torch.float8_e8m0fnu)
+        )  # [num_blocks, block_size, num_tiles]
+
+        result[..., d_nope:] = input_rope
+        for tile_idx in range(0, num_tiles):
+            cur_nope = input_nope[
+                ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+            ].to(torch.bfloat16)
+            cur_scales = input_scale[:, :, tile_idx].to(torch.bfloat16).unsqueeze(-1)
+            result[..., tile_idx * tile_size : (tile_idx + 1) * tile_size] = (
+                cur_nope * cur_scales
+            )
+
+    else:
+        raise NotImplementedError(f"Unsupported kvcache_layout: {kvcache_layout}")
+
+    result = result.view(num_blocks, block_size, 1, d)
+    return result
+
+
+def abs_indices2indices_in_kvcache(
+    abs_indices: torch.Tensor,  # [b, s_q, topk]
+    block_table: torch.Tensor,  # [b, /]
+    block_size: int,
+) -> torch.Tensor:
+    """
+    Convert abs_indices (logical index, ranging from 0 to s_k-1) to index expected by the sparse attn kernel
+    Equivalent to:
+
+    b, s_q, topk = abs_indices.shape
+    indices_in_kvcache = torch.empty_like(abs_indices)
+    for i in range(b):
+        cur_abs_indices = abs_indices[i, :, :].clone()  # [s_q, topk]
+        invalid_mask = cur_abs_indices == -1
+        cur_abs_indices[invalid_mask] = 0
+        cur_indices_in_kvcache = block_table[i].index_select(0, cur_abs_indices.flatten()//block_size).view(s_q, topk)*block_size + cur_abs_indices%block_size
+        cur_indices_in_kvcache[invalid_mask] = -1
+        indices_in_kvcache[i] = cur_indices_in_kvcache
+    return indices_in_kvcache
+
+    """
+    b, s_q, topk = abs_indices.shape
+    _, max_blocks_per_seq = block_table.shape
+
+    abs_indices = abs_indices.clone()
+    invalid_mask = abs_indices == -1
+    abs_indices[invalid_mask] = 0
+
+    real_block_idxs = block_table.view(-1).index_select(
+        0,
+        (
+            abs_indices // block_size
+            + torch.arange(0, b).view(b, 1, 1) * max_blocks_per_seq
+        ).view(-1),
+    )
+    indices_in_kvcache = (
+        real_block_idxs.view(b, s_q, topk) * block_size + abs_indices % block_size
+    )
+    indices_in_kvcache[invalid_mask] = -1
+
+    return indices_in_kvcache

--- a/test/srt/cpu/test_act_quant_cpu.py
+++ b/test/srt/cpu/test_act_quant_cpu.py
@@ -1,0 +1,123 @@
+import itertools
+import unittest
+from typing import Optional, Tuple
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+
+def act_quant_pytorch(
+    x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantizes the input tensor `x` using block-wise quantization (PyTorch native).
+    This is a pure PyTorch implementation equivalent to the Triton kernel version.
+    It performs per-block FP8 quantization along the last dimension.
+    Args:
+        x (torch.Tensor): The input tensor to be quantized. Must be contiguous and
+            its last dimension size must be divisible by `block_size`.
+        block_size (int, optional): The size of the blocks used for quantization.
+            Default is 128.
+        scale_fmt (Optional[str], optional): If not None, scales are rounded to
+            powers of 2. Default is None.
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
+            - The quantized tensor with dtype `torch.float8_e4m3fn`.
+            - A tensor of scaling factors with dtype `torch.float32`.
+    """
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert (
+        x.size(-1) % block_size == 0
+    ), f"Last dimension size must be divisible by block_size (block_size={block_size})"
+
+    # FP8 e4m3fn constants
+    fp8_max = 448.0
+    fp8_min = -448.0
+
+    # Flatten all dims except last
+    orig_shape = x.shape
+    N = x.size(-1)
+    x_flat = x.view(-1, N).float()  # (M, N)
+    M = x_flat.size(0)
+    num_groups = N // block_size
+
+    # Reshape into blocks: (M, num_groups, block_size)
+    x_blocked = x_flat.view(M, num_groups, block_size)
+
+    # Compute per-block absolute max -> (M, num_groups)
+    amax = x_blocked.abs().amax(dim=2)
+
+    # Clamp to avoid division by zero
+    amax = amax.clamp(min=1e-4)
+
+    # Compute scale
+    round_scale = scale_fmt is not None
+    if round_scale:
+        # Round scale to nearest power of 2 (ceiling in log2 space)
+        scale = torch.exp2(torch.ceil(torch.log2(amax / fp8_max)))
+    else:
+        scale = amax / fp8_max
+
+    # Quantize: y = clamp(x / scale, fp8_min, fp8_max)
+    # scale shape: (M, num_groups) -> broadcast to (M, num_groups, block_size)
+    y = x_blocked / scale.unsqueeze(2)
+    y = y.clamp(fp8_min, fp8_max)
+
+    # Reshape output back to original shape and cast to fp8
+    y = y.view(orig_shape).to(torch.float8_e4m3fn)
+
+    # Reshape scale to match expected output shape: (*orig_shape[:-1], num_groups)
+    s = scale.view(*orig_shape[:-1], num_groups)
+
+    return y, s
+
+
+def _assert_fp8_equal(ref: torch.Tensor, out: torch.Tensor) -> None:
+    assert ref.dtype == torch.float8_e4m3fn
+    assert out.dtype == torch.float8_e4m3fn
+    torch.testing.assert_close(
+        ref.view(torch.uint8), out.view(torch.uint8), atol=0, rtol=0
+    )
+
+
+class TestActQuantCPU(CustomTestCase):
+    shapes = [(1, 128), (3, 256), (2, 3, 128), (2, 2, 384)]
+    dtypes = [torch.float32, torch.bfloat16, torch.float16]
+    scale_fmts = [None, "power2"]
+
+    def _run_case(self, shape, dtype, scale_fmt):
+        torch.manual_seed(1234)
+        x = (torch.randn(shape, dtype=torch.float32) * 3.0).to(dtype).contiguous()
+
+        ref_y, ref_scale = act_quant_pytorch(x, block_size=128, scale_fmt=scale_fmt)
+        out_y, out_scale = torch.ops.sgl_kernel.act_quant_cpu(x, 128, scale_fmt)
+
+        _assert_fp8_equal(ref_y, out_y)
+        torch.testing.assert_close(ref_scale, out_scale, atol=0, rtol=0)
+
+    def test_act_quant_cpu(self):
+        for shape, dtype, scale_fmt in itertools.product(
+            self.shapes, self.dtypes, self.scale_fmts
+        ):
+            with self.subTest(shape=shape, dtype=dtype, scale_fmt=scale_fmt):
+                self._run_case(shape, dtype, scale_fmt)
+
+    def test_zeros_use_min_scale(self):
+        x = torch.zeros((2, 128), dtype=torch.bfloat16)
+        ref_y, ref_scale = act_quant_pytorch(x, block_size=128)
+        out_y, out_scale = torch.ops.sgl_kernel.act_quant_cpu(x, 128, None)
+
+        _assert_fp8_equal(ref_y, out_y)
+        torch.testing.assert_close(ref_scale, out_scale, atol=0, rtol=0)
+
+    def test_invalid_block_size(self):
+        x = torch.randn((2, 129), dtype=torch.float32)
+        with self.assertRaisesRegex(
+            RuntimeError, "Last dimension size must be divisible"
+        ):
+            torch.ops.sgl_kernel.act_quant_cpu(x, 128, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_allocator.py
+++ b/test/srt/cpu/test_allocator.py
@@ -1,0 +1,446 @@
+"""
+Unit tests for alloc_extend_kernel_cpu and alloc_decode_kernel_cpu.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+
+def _ceil_div(a, b):
+    """Integer ceiling division. Works for both Python ints and torch Tensors."""
+    return (a + b - 1) // b
+
+
+def alloc_extend_kernel_pytorch(
+    pre_lens, seq_lens, last_loc, free_pages, out_indices, page_size
+):
+    """Reference PyTorch implementation."""
+    bs = pre_lens.shape[0]
+    extend_lens = seq_lens - pre_lens
+    extend_cumsum = torch.cumsum(extend_lens, dim=0)
+    output_start_locs = extend_cumsum - extend_lens
+
+    num_pages_after = _ceil_div(seq_lens, page_size)
+    num_pages_before = _ceil_div(pre_lens, page_size)
+    num_new_pages = num_pages_after - num_pages_before
+    new_pages_cumsum = torch.cumsum(num_new_pages, dim=0)
+    new_page_start_locs = new_pages_cumsum - num_new_pages
+
+    for i in range(bs):
+        pre_len = pre_lens[i].item()
+        seq_len = seq_lens[i].item()
+        extend_len = seq_len - pre_len
+        if extend_len == 0:
+            continue
+
+        output_start = output_start_locs[i].item()
+        new_page_start = new_page_start_locs[i].item()
+        num_new_pages_self = num_new_pages[i].item()
+        last_loc_i = last_loc[i].item()
+
+        page_boundary = _ceil_div(pre_len, page_size) * page_size
+        num_part1 = min(seq_len, page_boundary) - pre_len
+        if num_part1 > 0:
+            offsets = torch.arange(num_part1, device=out_indices.device)
+            out_indices[output_start : output_start + num_part1] = (
+                last_loc_i + 1 + offsets
+            )
+
+        if pre_len + num_part1 == seq_len:
+            continue
+
+        full_page_end = (seq_len // page_size) * page_size
+        full_page_start = _ceil_div(pre_len, page_size) * page_size
+        num_part2 = full_page_end - full_page_start
+        if num_part2 > 0:
+            offsets = torch.arange(num_part2, device=out_indices.device)
+            page_indices = offsets // page_size
+            in_page_offsets = offsets % page_size
+            pages = free_pages[new_page_start + page_indices]
+            out_indices[
+                output_start + num_part1 : output_start + num_part1 + num_part2
+            ] = (pages * page_size + in_page_offsets)
+
+        if pre_len + num_part1 + num_part2 == seq_len:
+            continue
+
+        num_part3 = seq_len - (seq_len // page_size) * page_size
+        if num_part3 > 0:
+            start_page = free_pages[new_page_start + num_new_pages_self - 1].item()
+            offsets = torch.arange(num_part3, device=out_indices.device)
+            out_indices[
+                output_start
+                + num_part1
+                + num_part2 : output_start
+                + num_part1
+                + num_part2
+                + num_part3
+            ] = (start_page * page_size + offsets)
+
+
+def alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_indices, page_size):
+    """Reference PyTorch implementation."""
+    pre_lens = seq_lens - 1
+    num_pages_after = _ceil_div(seq_lens, page_size)
+    num_pages_before = _ceil_div(pre_lens, page_size)
+    num_new_pages = num_pages_after - num_pages_before
+
+    new_pages_cumsum = torch.cumsum(num_new_pages, dim=0)
+    new_page_start_locs = new_pages_cumsum - num_new_pages
+
+    no_new_page_mask = num_new_pages == 0
+    out_indices[no_new_page_mask] = last_loc[no_new_page_mask].to(out_indices.dtype) + 1
+
+    new_page_mask = num_new_pages > 0
+    if new_page_mask.any():
+        new_page_offsets = new_page_start_locs[new_page_mask]
+        pages = free_pages[new_page_offsets]
+        out_indices[new_page_mask] = pages.to(out_indices.dtype) * page_size
+
+
+def _gen_extend_test_data(bs, page_size, max_pre_len=128, max_extend_len=64):
+    """Generate consistent test data for alloc_extend_kernel."""
+    pre_lens = torch.randint(0, max_pre_len + 1, (bs,), dtype=torch.int64)
+    extend_lens = torch.randint(1, max_extend_len + 1, (bs,), dtype=torch.int64)
+    seq_lens = pre_lens + extend_lens
+
+    # Compute last_loc: for each request, simulate the physical location of
+    # the last token in the prefix. last_loc must satisfy:
+    #   (last_loc + 1) % page_size == pre_len % page_size
+    # We simulate by placing prefix pages sequentially starting from some base page.
+    last_loc = torch.zeros(bs, dtype=torch.int64)
+    page_counter = 0
+    for i in range(bs):
+        pre_len = pre_lens[i].item()
+        if pre_len == 0:
+            last_loc[i] = 0
+        else:
+            num_pages = (pre_len + page_size - 1) // page_size
+            # last page of prefix
+            last_page = page_counter + num_pages - 1
+            in_page_offset = (pre_len - 1) % page_size
+            last_loc[i] = last_page * page_size + in_page_offset
+            page_counter += num_pages
+
+    # Generate free pages (enough for all requests)
+    total_new_pages = 0
+    for i in range(bs):
+        pages_after = (seq_lens[i].item() + page_size - 1) // page_size
+        pages_before = (pre_lens[i].item() + page_size - 1) // page_size
+        total_new_pages += pages_after - pages_before
+    free_pages = torch.arange(
+        page_counter, page_counter + total_new_pages + 100, dtype=torch.int64
+    )
+
+    extend_num_tokens = extend_lens.sum().item()
+    return pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens
+
+
+def _gen_decode_test_data(bs, page_size, max_seq_len=256):
+    """Generate consistent test data for alloc_decode_kernel."""
+    # seq_lens are the lengths AFTER the decode step (already incremented by 1)
+    seq_lens = torch.randint(2, max_seq_len + 1, (bs,), dtype=torch.int64)
+
+    # last_loc: simulate physical location of the last allocated token
+    last_loc = torch.zeros(bs, dtype=torch.int64)
+    page_counter = 0
+    for i in range(bs):
+        pre_len = seq_lens[i].item() - 1  # length before decode
+        if pre_len == 0:
+            last_loc[i] = 0
+        else:
+            num_pages = (pre_len + page_size - 1) // page_size
+            last_page = page_counter + num_pages - 1
+            in_page_offset = (pre_len - 1) % page_size
+            last_loc[i] = last_page * page_size + in_page_offset
+            page_counter += num_pages
+
+    # Free pages
+    total_new_pages = 0
+    for i in range(bs):
+        pages_after = (seq_lens[i].item() + page_size - 1) // page_size
+        pages_before = ((seq_lens[i].item() - 1) + page_size - 1) // page_size
+        total_new_pages += pages_after - pages_before
+    free_pages = torch.arange(
+        page_counter, page_counter + total_new_pages + 100, dtype=torch.int64
+    )
+
+    return seq_lens, last_loc, free_pages
+
+
+class TestAllocExtendKernel(CustomTestCase):
+    def _run_test(self, bs, page_size, max_pre_len=128, max_extend_len=64):
+        pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens = (
+            _gen_extend_test_data(bs, page_size, max_pre_len, max_extend_len)
+        )
+
+        # Reference
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens, seq_lens, last_loc, free_pages, out_ref, page_size
+        )
+
+        # CPU kernel
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_basic_page_size_1(self):
+        self._run_test(bs=4, page_size=1)
+
+    def test_basic_page_size_16(self):
+        self._run_test(bs=8, page_size=16)
+
+    def test_basic_page_size_128(self):
+        self._run_test(bs=8, page_size=128)
+
+    def test_single_request(self):
+        self._run_test(bs=1, page_size=16)
+
+    def test_large_batch(self):
+        self._run_test(bs=256, page_size=16, max_pre_len=512, max_extend_len=256)
+
+    def test_all_full_pages(self):
+        """All pre_lens and seq_lens are multiples of page_size."""
+        page_size = 16
+        bs = 4
+        pre_lens = torch.tensor([0, 16, 32, 48], dtype=torch.int64)
+        seq_lens = torch.tensor([16, 32, 64, 64], dtype=torch.int64)
+        extend_lens = seq_lens - pre_lens
+        extend_num_tokens = extend_lens.sum().item()
+
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = pre_lens[i].item()
+            if pre_len == 0:
+                last_loc[i] = 0
+            else:
+                num_pages = pre_len // page_size
+                last_page = page_counter + num_pages - 1
+                last_loc[i] = last_page * page_size + page_size - 1
+                page_counter += num_pages
+        total_new_pages = sum(
+            (seq_lens[i].item() + page_size - 1) // page_size
+            - (pre_lens[i].item() + page_size - 1) // page_size
+            for i in range(bs)
+        )
+        free_pages = torch.arange(
+            page_counter, page_counter + total_new_pages + 10, dtype=torch.int64
+        )
+
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens, seq_lens, last_loc, free_pages, out_ref, page_size
+        )
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_zero_extend(self):
+        """Some requests have zero extend length."""
+        page_size = 16
+        bs = 4
+        pre_lens = torch.tensor([10, 20, 30, 40], dtype=torch.int64)
+        seq_lens = torch.tensor([10, 25, 30, 50], dtype=torch.int64)
+        extend_lens = seq_lens - pre_lens
+        extend_num_tokens = extend_lens.sum().item()
+
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = pre_lens[i].item()
+            if pre_len == 0:
+                last_loc[i] = 0
+            else:
+                num_pages = (pre_len + page_size - 1) // page_size
+                last_page = page_counter + num_pages - 1
+                in_page_offset = (pre_len - 1) % page_size
+                last_loc[i] = last_page * page_size + in_page_offset
+                page_counter += num_pages
+
+        total_new_pages = sum(
+            (seq_lens[i].item() + page_size - 1) // page_size
+            - (pre_lens[i].item() + page_size - 1) // page_size
+            for i in range(bs)
+        )
+        free_pages = torch.arange(
+            page_counter, page_counter + total_new_pages + 10, dtype=torch.int64
+        )
+
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens, seq_lens, last_loc, free_pages, out_ref, page_size
+        )
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def _run_test_int32(self, bs, page_size, max_pre_len=128, max_extend_len=64):
+        pre_lens, seq_lens, last_loc, free_pages, extend_num_tokens = (
+            _gen_extend_test_data(bs, page_size, max_pre_len, max_extend_len)
+        )
+        # Convert to int32
+        pre_lens = pre_lens.to(torch.int32)
+        seq_lens = seq_lens.to(torch.int32)
+        last_loc = last_loc.to(torch.int32)
+        free_pages = free_pages.to(torch.int32)
+
+        # Reference (use int64 for reference)
+        out_ref = torch.empty(extend_num_tokens, dtype=torch.int64)
+        alloc_extend_kernel_pytorch(
+            pre_lens.to(torch.int64),
+            seq_lens.to(torch.int64),
+            last_loc.to(torch.int64),
+            free_pages.to(torch.int64),
+            out_ref,
+            page_size,
+        )
+
+        # CPU kernel with int32
+        out_cpu = torch.empty(extend_num_tokens, dtype=torch.int32)
+        torch.ops.sgl_kernel.alloc_extend_kernel_cpu(
+            pre_lens, seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu.to(torch.int64), out_ref)
+
+    def test_int32_basic(self):
+        self._run_test_int32(bs=8, page_size=16)
+
+    def test_int32_large_batch(self):
+        self._run_test_int32(bs=64, page_size=16)
+
+    def _run_test(self, bs, page_size, max_seq_len=256):
+        seq_lens, last_loc, free_pages = _gen_decode_test_data(
+            bs, page_size, max_seq_len
+        )
+
+        # Reference
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_ref, page_size)
+
+        # CPU kernel
+        out_cpu = torch.empty(bs, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_basic_page_size_1(self):
+        self._run_test(bs=4, page_size=1)
+
+    def test_basic_page_size_16(self):
+        self._run_test(bs=8, page_size=16)
+
+    def test_basic_page_size_128(self):
+        self._run_test(bs=8, page_size=128)
+
+    def test_single_request(self):
+        self._run_test(bs=1, page_size=16)
+
+    def test_large_batch(self):
+        self._run_test(bs=1024, page_size=16)
+
+    def test_all_need_new_page(self):
+        """All requests need a new page (seq_len is at page boundary)."""
+        page_size = 16
+        bs = 4
+        # seq_lens at multiples of page_size + 1 => need new page
+        seq_lens = torch.tensor([17, 33, 49, 65], dtype=torch.int64)
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = seq_lens[i].item() - 1
+            num_pages = (pre_len + page_size - 1) // page_size
+            last_page = page_counter + num_pages - 1
+            in_page_offset = (pre_len - 1) % page_size
+            last_loc[i] = last_page * page_size + in_page_offset
+            page_counter += num_pages
+
+        free_pages = torch.arange(
+            page_counter, page_counter + bs + 10, dtype=torch.int64
+        )
+
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_ref, page_size)
+        out_cpu = torch.empty(bs, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def test_none_need_new_page(self):
+        """No requests need a new page."""
+        page_size = 16
+        bs = 4
+        seq_lens = torch.tensor([2, 3, 10, 15], dtype=torch.int64)
+        last_loc = torch.zeros(bs, dtype=torch.int64)
+        page_counter = 0
+        for i in range(bs):
+            pre_len = seq_lens[i].item() - 1
+            if pre_len == 0:
+                last_loc[i] = 0
+            else:
+                num_pages = (pre_len + page_size - 1) // page_size
+                last_page = page_counter + num_pages - 1
+                in_page_offset = (pre_len - 1) % page_size
+                last_loc[i] = last_page * page_size + in_page_offset
+                page_counter += num_pages
+
+        free_pages = torch.arange(page_counter, page_counter + 10, dtype=torch.int64)
+
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(seq_lens, last_loc, free_pages, out_ref, page_size)
+        out_cpu = torch.empty(bs, dtype=torch.int64)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+        torch.testing.assert_close(out_cpu, out_ref)
+
+    def _run_test_int32(self, bs, page_size, max_seq_len=256):
+        seq_lens, last_loc, free_pages = _gen_decode_test_data(
+            bs, page_size, max_seq_len
+        )
+        seq_lens = seq_lens.to(torch.int32)
+        last_loc = last_loc.to(torch.int32)
+        free_pages = free_pages.to(torch.int32)
+
+        # Reference
+        out_ref = torch.empty(bs, dtype=torch.int64)
+        alloc_decode_kernel_pytorch(
+            seq_lens.to(torch.int64),
+            last_loc.to(torch.int64),
+            free_pages.to(torch.int64),
+            out_ref,
+            page_size,
+        )
+
+        # CPU kernel with int32
+        out_cpu = torch.empty(bs, dtype=torch.int32)
+        torch.ops.sgl_kernel.alloc_decode_kernel_cpu(
+            seq_lens, last_loc, free_pages, out_cpu, page_size
+        )
+
+        torch.testing.assert_close(out_cpu.to(torch.int64), out_ref)
+
+    def test_int32_basic(self):
+        self._run_test_int32(bs=8, page_size=16)
+
+    def test_int32_large_batch(self):
+        self._run_test_int32(bs=256, page_size=16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_compressor.py
+++ b/test/srt/cpu/test_compressor.py
@@ -1,0 +1,378 @@
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.deepseek_v4_compress_state import DeepSeekV4CompressState
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+
+# ───────────────── Reference Python implementation ─────────────────
+
+
+def compute_state_len(seq_len, ratio):
+    return seq_len % ratio + (ratio == 4) * ratio
+
+
+def overlap_transform(tensor, fill_value, ratio, head_dim):
+    """tensor: [S, ratio, 2*head_dim] -> [S, 2*ratio, head_dim]"""
+    s, r, _ = tensor.shape
+    d = head_dim
+    new_tensor = tensor.new_full((s, 2 * r, d), fill_value)
+    new_tensor[:, r:] = tensor[:, :, d:]
+    if s > 1:
+        new_tensor[1:, :r] = tensor[:-1, :, :d]
+    return new_tensor
+
+
+def overlap_transform_decode(tensor, ratio, head_dim):
+    """tensor: [bs, 2*ratio, 2*head_dim] -> [bs, 2*ratio, head_dim]"""
+    r, d = ratio, head_dim
+    return torch.cat((tensor[:, :r, :d], tensor[:, r:, d:]), dim=1)
+
+
+def rmsnorm_ref(x, weight, eps):
+    """RMS norm reference: x is [head_dim], weight is [head_dim]."""
+    x_f32 = x.float()
+    variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
+    return (x_f32 * torch.rsqrt(variance + eps) * weight.float()).float()
+
+
+def apply_rotary_emb_ref(x, freqs):
+    """Interleaved rotary embedding reference. x, freqs are 1D [rope_dim]."""
+    x = x.float().clone()
+    f = freqs.float()
+    for k in range(0, x.size(0), 2):
+        xr, xi = x[k].item(), x[k + 1].item()
+        cr, ci = f[k].item(), f[k + 1].item()
+        x[k] = xr * cr - xi * ci
+        x[k + 1] = xr * ci + xi * cr
+    return x
+
+
+def hadamard_transform_ref(x, scale):
+    n = x.size(-1)
+    out = x.float().clone()
+    h = 1
+    while h < n:
+        for j in range(0, n, 2 * h):
+            for k in range(h):
+                a, b = out[j + k].item(), out[j + k + h].item()
+                out[j + k] = a + b
+                out[j + k + h] = a - b
+        h <<= 1
+    return out * scale
+
+
+def compress_decode_ref(
+    pool_kv,
+    pool_score,
+    kv,
+    score,
+    seq_lens,
+    req_pool_indices,
+    ape,
+    norm_weight,
+    freqs_cis,
+    ratio,
+    head_dim,
+    rope_head_dim,
+    overlap,
+    rotate,
+    norm_eps,
+):
+    """Pure Python reference matching compress_decode_old."""
+    bs = kv.size(0)
+    coff = 1 + (1 if overlap else 0)
+    coff_hd = coff * head_dim
+
+    output = torch.empty(bs, head_dim, dtype=torch.float32)
+
+    for b in range(bs):
+        seq_len = seq_lens[b].item()
+        req_idx = req_pool_indices[b].item()
+        write_pos = (seq_len - 1) % ratio + (ratio if overlap else 0)
+
+        pool_kv[req_idx, write_pos] = kv[b]
+        pool_score[req_idx, write_pos] = score[b]
+
+        kv_buf = pool_kv[req_idx].clone()
+        score_buf = pool_score[req_idx].clone()
+
+        if overlap and (seq_len % ratio == 0):
+            pool_kv[req_idx, :ratio] = kv_buf[ratio:]
+            pool_score[req_idx, :ratio] = score_buf[ratio:]
+
+        # Reshape to [coff, ratio, coff_hd] then add APE
+        kv_r = kv_buf.view(coff, ratio, coff_hd)
+        score_r = score_buf.view(coff, ratio, coff_hd)
+        score_r = score_r + ape.unsqueeze(0)
+
+        if overlap:
+            kv_r2 = kv_r.view(1, coff * ratio, coff_hd)
+            score_r2 = score_r.view(1, coff * ratio, coff_hd)
+            kv_r2 = overlap_transform_decode(kv_r2, ratio, head_dim)
+            score_r2 = overlap_transform_decode(score_r2, ratio, head_dim)
+            kv_final = kv_r2.view(ratio * coff, head_dim)
+            score_final = score_r2.view(ratio * coff, head_dim)
+        else:
+            kv_final = kv_r.view(ratio, head_dim)
+            score_final = score_r.view(ratio, head_dim)
+
+        weights = score_final.softmax(dim=0)
+        compressed = (kv_final * weights).sum(dim=0)
+        normed = rmsnorm_ref(compressed, norm_weight, norm_eps)
+
+        freq_pos = (seq_len - 1) // ratio * ratio
+        freq = freqs_cis[freq_pos]
+        normed[-rope_head_dim:] = apply_rotary_emb_ref(normed[-rope_head_dim:], freq)
+
+        if rotate:
+            normed = hadamard_transform_ref(normed, head_dim**-0.5)
+
+        output[b] = normed
+
+    return output
+
+
+class TestCompressDecodeKernel(CustomTestCase):
+
+    def _make_inputs(
+        self, bs, ratio, head_dim, rope_head_dim, overlap, max_reqs=4, max_seq=256
+    ):
+        coff = 1 + (1 if overlap else 0)
+        coff_hd = coff * head_dim
+        state_len = ratio * coff
+
+        pool_kv = torch.randn(max_reqs, state_len, coff_hd, dtype=torch.float32)
+        pool_score = torch.randn(max_reqs, state_len, coff_hd, dtype=torch.float32)
+        kv = torch.randn(bs, coff_hd, dtype=torch.float32)
+        score = torch.randn(bs, coff_hd, dtype=torch.float32)
+
+        seq_lens = torch.randint(ratio, max_seq, (bs,), dtype=torch.int64)
+        req_pool_indices = torch.arange(bs, dtype=torch.int64)
+
+        ape = torch.randn(ratio, coff_hd, dtype=torch.float32)
+        norm_weight = torch.randn(head_dim, dtype=torch.float32).abs() + 0.1
+
+        # freqs_cis: [max_seq, rope_head_dim] interleaved cos/sin
+        freqs_cis = torch.randn(max_seq, rope_head_dim, dtype=torch.float32)
+
+        return (
+            pool_kv,
+            pool_score,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+        )
+
+    def test_decode_no_overlap(self):
+        bs, ratio, head_dim, rope_head_dim = 4, 128, 256, 64
+        overlap, rotate = False, False
+        norm_eps = 1e-6
+
+        inputs = self._make_inputs(bs, ratio, head_dim, rope_head_dim, overlap)
+        (
+            pool_kv,
+            pool_score,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+        ) = inputs
+
+        # Reference
+        pool_kv_ref = pool_kv.clone()
+        pool_score_ref = pool_score.clone()
+        ref = compress_decode_ref(
+            pool_kv_ref,
+            pool_score_ref,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+            ratio,
+            head_dim,
+            rope_head_dim,
+            overlap,
+            rotate,
+            norm_eps,
+        )
+
+        # Kernel
+        pool_kv_kern = pool_kv.clone()
+        pool_score_kern = pool_score.clone()
+        out = torch.ops.sgl_kernel.compress_decode_cpu(
+            pool_kv_kern,
+            pool_score_kern,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+            ratio,
+            head_dim,
+            rope_head_dim,
+            overlap,
+            rotate,
+            norm_eps,
+        )
+
+        torch.testing.assert_close(ref, out, atol=1e-4, rtol=1e-4)
+
+    def test_decode_with_overlap(self):
+        bs, ratio, head_dim, rope_head_dim = 4, 4, 256, 64
+        overlap, rotate = True, False
+        norm_eps = 1e-6
+
+        inputs = self._make_inputs(bs, ratio, head_dim, rope_head_dim, overlap)
+        (
+            pool_kv,
+            pool_score,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+        ) = inputs
+
+        pool_kv_ref = pool_kv.clone()
+        pool_score_ref = pool_score.clone()
+        ref = compress_decode_ref(
+            pool_kv_ref,
+            pool_score_ref,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+            ratio,
+            head_dim,
+            rope_head_dim,
+            overlap,
+            rotate,
+            norm_eps,
+        )
+
+        pool_kv_kern = pool_kv.clone()
+        pool_score_kern = pool_score.clone()
+        out = torch.ops.sgl_kernel.compress_decode_cpu(
+            pool_kv_kern,
+            pool_score_kern,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+            ratio,
+            head_dim,
+            rope_head_dim,
+            overlap,
+            rotate,
+            norm_eps,
+        )
+
+        torch.testing.assert_close(ref, out, atol=1e-4, rtol=1e-4)
+
+    def test_decode_with_rotate(self):
+        bs, ratio, head_dim, rope_head_dim = 2, 4, 128, 64
+        overlap, rotate = True, True
+        norm_eps = 1e-6
+
+        inputs = self._make_inputs(bs, ratio, head_dim, rope_head_dim, overlap)
+        (
+            pool_kv,
+            pool_score,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+        ) = inputs
+
+        pool_kv_ref = pool_kv.clone()
+        pool_score_ref = pool_score.clone()
+        ref = compress_decode_ref(
+            pool_kv_ref,
+            pool_score_ref,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+            ratio,
+            head_dim,
+            rope_head_dim,
+            overlap,
+            rotate,
+            norm_eps,
+        )
+
+        pool_kv_kern = pool_kv.clone()
+        pool_score_kern = pool_score.clone()
+        out = torch.ops.sgl_kernel.compress_decode_cpu(
+            pool_kv_kern,
+            pool_score_kern,
+            kv,
+            score,
+            seq_lens,
+            req_pool_indices,
+            ape,
+            norm_weight,
+            freqs_cis,
+            ratio,
+            head_dim,
+            rope_head_dim,
+            overlap,
+            rotate,
+            norm_eps,
+        )
+
+        torch.testing.assert_close(ref, out, atol=1e-3, rtol=1e-3)
+
+
+class TestDeepSeekV4CompressState(CustomTestCase):
+    def test_state_includes_dummy_req_pool_row(self):
+        max_running_requests = 2
+        state = DeepSeekV4CompressState(
+            max_num_reqs=max_running_requests + 1,
+            ratio=4,
+            overlap=True,
+            head_dim=8,
+            device="cpu",
+            dtype=torch.float32,
+            enable_memory_saver=False,
+        ).get_state()
+
+        # ReqToTokenPool reserves row 0 as padding, so real request slots can
+        # reach max_running_requests.
+        state[max_running_requests].clear()
+        state_shape = state.shape if hasattr(state, "shape") else state.kv_score.shape
+        self.assertEqual(state_shape[0], max_running_requests + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_flash_mla_with_kvcache_cpu.py
+++ b/test/srt/cpu/test_flash_mla_with_kvcache_cpu.py
@@ -1,0 +1,523 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+try:
+    import quant_utils as flashmla_quant
+    from sgl_kernel.flash_mla import flash_mla_with_kvcache_cpu
+
+    _IMPORT_ERROR = None
+except Exception as _e:  # pragma: no cover - exercised only when kernel missing
+    flash_mla_with_kvcache_cpu = None  # type: ignore[assignment]
+    flashmla_quant = None  # type: ignore[assignment]
+    _IMPORT_ERROR = _e
+
+
+_LAYOUT_DIMS = {
+    1: (576, 512),  # V32_FP8Sparse
+    2: (512, 512),  # V4_FP8Sparse
+}
+
+
+def _ref_sparse_attn_decode(
+    q: torch.Tensor,  # [B, S_q, H_q, D_qk] bf16
+    k_dequant: torch.Tensor,  # [num_blocks, page_size, 1, D_qk] bf16
+    indices: torch.Tensor,  # [B, S_q, topk] int32
+    topk_length,
+    attn_sink,
+    extra_k_dequant,
+    extra_indices,
+    extra_topk_length,
+    sm_scale: float,
+    d_v: int,
+):
+    """Pure-PyTorch reference for the sparse FP8 decode kernel."""
+    b, s_q, h_q, d_qk = q.shape
+
+    def _gather(k_dq: torch.Tensor, idxs: torch.Tensor, tl):
+        topk = idxs.size(-1)
+        idxs_fixed = torch.clamp_min(idxs, 0).to(torch.int64)
+        flat_k = k_dq.reshape(-1, d_qk)
+        gathered = flat_k.index_select(0, idxs_fixed.reshape(-1)).reshape(
+            b, s_q, topk, d_qk
+        )
+        invalid = idxs == -1
+        if tl is not None:
+            tl_mask = torch.arange(topk, device=invalid.device).view(1, 1, topk).expand(
+                b, s_q, topk
+            ) >= tl.view(b, 1, 1)
+            invalid = invalid | tl_mask
+        return gathered, invalid
+
+    gathered_kv, invalid_mask = _gather(k_dequant, indices, topk_length)
+    if extra_k_dequant is not None:
+        gathered_kv1, invalid_mask1 = _gather(
+            extra_k_dequant, extra_indices, extra_topk_length
+        )
+        gathered_kv = torch.cat([gathered_kv, gathered_kv1], dim=2)
+        invalid_mask = torch.cat([invalid_mask, invalid_mask1], dim=2)
+
+    gathered_kv_f = gathered_kv.reshape(b * s_q, -1, d_qk).float()
+    gathered_kv_f[gathered_kv_f != gathered_kv_f] = 0.0  # NaN -> 0
+
+    q_f = q.float().reshape(b * s_q, h_q, d_qk)
+    attn_weight = q_f @ gathered_kv_f.transpose(-1, -2)  # [B*S_q, H_q, T]
+    attn_weight = attn_weight * sm_scale
+    full_invalid = invalid_mask.reshape(b * s_q, 1, -1).expand(
+        b * s_q, h_q, invalid_mask.size(-1)
+    )
+    attn_weight = attn_weight.masked_fill(full_invalid, float("-inf"))
+
+    lse = attn_weight.logsumexp(dim=-1)  # [B*S_q, H_q]
+    probs = torch.exp(attn_weight - lse.unsqueeze(-1))
+    output = probs @ gathered_kv_f[..., :d_v]
+    output = output.view(b, s_q, h_q, d_v)
+    lse = lse.view(b, s_q, h_q)
+
+    if attn_sink is not None:
+        output = output * (
+            1.0 / (1.0 + torch.exp(attn_sink.view(1, 1, h_q) - lse))
+        ).unsqueeze(-1)
+
+    lonely_q_mask = lse == float("-inf")
+    output = output.masked_fill(
+        lonely_q_mask.unsqueeze(-1).expand(b, s_q, h_q, d_v), 0.0
+    )
+    lse = torch.where(lonely_q_mask, torch.full_like(lse, float("+inf")), lse)
+
+    return output.to(torch.bfloat16), lse.transpose(1, 2).contiguous()
+
+
+@unittest.skipIf(
+    _IMPORT_ERROR is not None,
+    f"flash_mla_with_kvcache_cpu : {_IMPORT_ERROR}",
+)
+class TestFlashMLAWithKVCacheCPU(CustomTestCase):
+
+    def setUp(self):
+        torch.manual_seed(1234)
+
+    def _make_quantized_kv_cache(
+        self, num_blocks, page_size, d_qk, layout_enum, *, as_uint8=False
+    ):
+
+        k_bf16 = torch.randn(num_blocks, page_size, 1, d_qk, dtype=torch.bfloat16) * 0.5
+        k_quant = flashmla_quant.quantize_k_cache(k_bf16, layout_enum)
+        k_dequant = flashmla_quant.dequantize_k_cache(k_quant, layout_enum)
+        if as_uint8:
+            k_quant = k_quant.view(torch.uint8)
+        return k_quant.contiguous(), k_dequant
+
+    def _make_bf16_kv_cache(self, num_blocks, page_size, d_qk):
+        k_bf16 = torch.randn(num_blocks, page_size, 1, d_qk, dtype=torch.bfloat16) * 0.5
+        k_bf16 = k_bf16.contiguous()
+        return k_bf16, k_bf16
+
+    def _make_indices(
+        self, b, s_q, topk, total_tokens, *, dtype=torch.int32, invalid_ratio=0.0
+    ):
+        # Unique-per-row valid token indices, optionally with some -1 entries.
+        idx = torch.empty(b, s_q, topk, dtype=dtype)
+        for bi in range(b):
+            for si in range(s_q):
+                if total_tokens >= topk:
+                    perm = torch.randperm(total_tokens)[:topk]
+                else:
+                    perm = torch.randint(0, total_tokens, (topk,))
+                idx[bi, si] = perm.to(dtype)
+        if invalid_ratio > 0.0:
+            mask = torch.rand(b, s_q, topk) < invalid_ratio
+            idx[mask] = -1
+        return idx
+
+    def _run_one(
+        self,
+        *,
+        b,
+        s_q,
+        h_q,
+        topk,
+        page_size,
+        num_blocks,
+        fp8_layout,
+        idx_dtype=torch.int32,
+        have_attn_sink=False,
+        have_topk_length=False,
+        have_extra=False,
+        have_extra_topk_length=False,
+        extra_topk=0,
+        extra_num_blocks=0,
+        valid_tokens=None,
+        extra_valid_tokens=None,
+        invalid_ratio=0.0,
+        is_fp8_kvcache=True,
+        topk_length_value=None,
+        extra_topk_length_value=None,
+        fp8_cache_as_uint8=False,
+    ):
+        d_qk, d_v = _LAYOUT_DIMS[fp8_layout]
+        layout_enum = flashmla_quant.FP8KVCacheLayout(fp8_layout)
+
+        q = torch.randn(b, s_q, h_q, d_qk, dtype=torch.bfloat16) * 0.5
+
+        if is_fp8_kvcache:
+            k_cache, k_dequant = self._make_quantized_kv_cache(
+                num_blocks,
+                page_size,
+                d_qk,
+                layout_enum,
+                as_uint8=fp8_cache_as_uint8,
+            )
+        else:
+            k_cache, k_dequant = self._make_bf16_kv_cache(num_blocks, page_size, d_qk)
+        total_tokens = (
+            valid_tokens if valid_tokens is not None else (num_blocks * page_size)
+        )
+        indices = self._make_indices(
+            b, s_q, topk, total_tokens, dtype=idx_dtype, invalid_ratio=invalid_ratio
+        )
+
+        attn_sink = torch.randn(h_q, dtype=torch.float32) if have_attn_sink else None
+        topk_length = None
+        if have_topk_length:
+            if topk_length_value is None:
+                lo = max(1, topk // 2)
+                topk_length = torch.randint(
+                    low=lo, high=topk + 1, size=(b,), dtype=torch.int32
+                )
+            else:
+                topk_length = torch.full((b,), topk_length_value, dtype=torch.int32)
+
+        extra_k_cache = None
+        extra_k_dequant = None
+        extra_indices = None
+        extra_topk_length = None
+        if have_extra:
+            if is_fp8_kvcache:
+                extra_k_cache, extra_k_dequant = self._make_quantized_kv_cache(
+                    extra_num_blocks,
+                    page_size,
+                    d_qk,
+                    layout_enum,
+                    as_uint8=fp8_cache_as_uint8,
+                )
+            else:
+                extra_k_cache, extra_k_dequant = self._make_bf16_kv_cache(
+                    extra_num_blocks, page_size, d_qk
+                )
+            extra_total_tokens = (
+                extra_valid_tokens
+                if extra_valid_tokens is not None
+                else (extra_num_blocks * page_size)
+            )
+            extra_indices = self._make_indices(
+                b, s_q, extra_topk, extra_total_tokens, dtype=idx_dtype
+            )
+            if have_extra_topk_length:
+                if extra_topk_length_value is None:
+                    lo = max(1, extra_topk // 2)
+                    extra_topk_length = torch.randint(
+                        low=lo, high=extra_topk + 1, size=(b,), dtype=torch.int32
+                    )
+                else:
+                    extra_topk_length = torch.full(
+                        (b,), extra_topk_length_value, dtype=torch.int32
+                    )
+
+        sm_scale = d_qk**-0.5
+
+        out_cpu, lse_cpu = flash_mla_with_kvcache_cpu(
+            q=q,
+            k_cache=k_cache,
+            block_table=None,
+            cache_seqlens=None,
+            head_dim_v=d_v,
+            softmax_scale=sm_scale,
+            causal=False,
+            is_fp8_kvcache=is_fp8_kvcache,
+            indices=indices,
+            attn_sink=attn_sink,
+            extra_k_cache=extra_k_cache,
+            extra_indices_in_kvcache=extra_indices,
+            topk_length=topk_length,
+            extra_topk_length=extra_topk_length,
+            fp8_layout=fp8_layout,
+        )
+
+        out_ref, lse_ref = _ref_sparse_attn_decode(
+            q=q,
+            k_dequant=k_dequant,
+            indices=indices,
+            topk_length=topk_length,
+            attn_sink=attn_sink,
+            extra_k_dequant=extra_k_dequant,
+            extra_indices=extra_indices,
+            extra_topk_length=extra_topk_length,
+            sm_scale=sm_scale,
+            d_v=d_v,
+        )
+
+        # Shape / dtype contract.
+        self.assertEqual(tuple(out_cpu.shape), (b, s_q, h_q, d_v))
+        self.assertEqual(tuple(lse_cpu.shape), (b, h_q, s_q))
+        self.assertEqual(out_cpu.dtype, torch.bfloat16)
+        self.assertEqual(lse_cpu.dtype, torch.float32)
+
+        torch.testing.assert_close(out_cpu, out_ref, atol=1e-2, rtol=1e-2)
+
+        finite = torch.isfinite(lse_ref) & torch.isfinite(lse_cpu)
+        if finite.any():
+            torch.testing.assert_close(
+                lse_cpu[finite], lse_ref[finite], atol=5e-3, rtol=1e-2
+            )
+
+    def test_basic_layouts_and_page_sizes(self):
+        configs = list(
+            itertools.product(
+                [64, 128, 256],  # page_size
+                [1, 2],  # fp8_layout (V32 / V4)
+            )
+        )
+        for page_size, fp8_layout in configs:
+            with self.subTest(
+                page_size=page_size,
+                fp8_layout=fp8_layout,
+            ):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=128,
+                    page_size=page_size,
+                    num_blocks=4,
+                    fp8_layout=fp8_layout,
+                )
+
+    def test_varying_batch_seq_and_topk(self):
+        # Cover non-trivial batch / s_q / topk combinations that are not
+        # exact multiples of the kernel's BLOCK_N (128).
+        configs = [
+            # (b, s_q, h_q, topk, page_size, num_blocks, fp8_layout)
+            (1, 1, 16, 64, 64, 4, 1),
+            (1, 2, 32, 100, 64, 4, 2),
+            (3, 1, 16, 200, 128, 3, 1),
+            (2, 2, 16, 256, 128, 4, 2),
+            (1, 1, 64, 32, 64, 2, 2),
+        ]
+        for b, s_q, h_q, topk, page_size, num_blocks, layout in configs:
+            with self.subTest(
+                b=b,
+                s_q=s_q,
+                h_q=h_q,
+                topk=topk,
+                page_size=page_size,
+                num_blocks=num_blocks,
+                fp8_layout=layout,
+            ):
+                self._run_one(
+                    b=b,
+                    s_q=s_q,
+                    h_q=h_q,
+                    topk=topk,
+                    page_size=page_size,
+                    num_blocks=num_blocks,
+                    fp8_layout=layout,
+                )
+
+    def test_with_attn_sink(self):
+        for fp8_layout in (1, 2):
+            with self.subTest(fp8_layout=fp8_layout):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=128,
+                    page_size=64,
+                    num_blocks=4,
+                    fp8_layout=fp8_layout,
+                    have_attn_sink=True,
+                )
+
+    def test_with_topk_length(self):
+        for fp8_layout in (1, 2):
+            with self.subTest(fp8_layout=fp8_layout):
+                self._run_one(
+                    b=3,
+                    s_q=1,
+                    h_q=16,
+                    topk=128,
+                    page_size=128,
+                    num_blocks=4,
+                    fp8_layout=fp8_layout,
+                    have_topk_length=True,
+                )
+
+    def test_with_short_topk_length(self):
+        # Covers the optimized path that stops processing once topk_length is
+        # reached instead of iterating over the full preallocated topk width.
+        for is_fp8_kvcache in (True, False):
+            with self.subTest(is_fp8_kvcache=is_fp8_kvcache):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=256,
+                    page_size=128,
+                    num_blocks=4,
+                    fp8_layout=2,
+                    have_topk_length=True,
+                    topk_length_value=17,
+                    have_extra=True,
+                    extra_topk=128,
+                    extra_num_blocks=2,
+                    have_extra_topk_length=True,
+                    extra_topk_length_value=9,
+                    is_fp8_kvcache=is_fp8_kvcache,
+                )
+
+    def test_with_invalid_indices(self):
+        # Some indices set to -1; the kernel must mask them out and the
+        # reference output must still match.
+        for fp8_layout in (1, 2):
+            with self.subTest(fp8_layout=fp8_layout):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=128,
+                    page_size=64,
+                    num_blocks=4,
+                    fp8_layout=fp8_layout,
+                    invalid_ratio=0.25,
+                )
+
+    def test_with_all_invalid_tile(self):
+        # A fully invalid sparse tile should be skipped without changing the
+        # online-softmax state; the query becomes lonely and returns zero/+inf.
+        for is_fp8_kvcache in (True, False):
+            with self.subTest(is_fp8_kvcache=is_fp8_kvcache):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=256,
+                    page_size=128,
+                    num_blocks=4,
+                    fp8_layout=2,
+                    invalid_ratio=1.0,
+                    is_fp8_kvcache=is_fp8_kvcache,
+                )
+
+    def test_with_extra_kv_cache(self):
+        # Exercise the "main + extra" KV-cache concatenation path
+        # (used by DSv4's chunked KV cache layout).
+        for fp8_layout in (1, 2):
+            for have_topk_length, have_extra_topk_length in (
+                (False, False),
+                (True, True),
+            ):
+                with self.subTest(
+                    fp8_layout=fp8_layout,
+                    have_topk_length=have_topk_length,
+                ):
+                    self._run_one(
+                        b=2,
+                        s_q=1,
+                        h_q=16,
+                        topk=64,
+                        page_size=64,
+                        num_blocks=4,
+                        fp8_layout=fp8_layout,
+                        have_extra=True,
+                        extra_topk=64,
+                        extra_num_blocks=2,
+                        have_topk_length=have_topk_length,
+                        have_extra_topk_length=have_extra_topk_length,
+                    )
+
+    def test_with_uint8_fp8_kv_cache(self):
+        # Production FP8 sparse caches may be passed as raw packed bytes.
+        for fp8_layout in (1, 2):
+            with self.subTest(fp8_layout=fp8_layout):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=64,
+                    page_size=64,
+                    num_blocks=4,
+                    fp8_layout=fp8_layout,
+                    have_extra=True,
+                    extra_topk=32,
+                    extra_num_blocks=2,
+                    fp8_cache_as_uint8=True,
+                )
+
+    def test_with_bf16_kv_cache(self):
+        # Non-FP8 KV cache should skip dequantization and use BF16 cache rows
+        # directly for both main and extra KV sources.
+        for have_extra in (False, True):
+            with self.subTest(have_extra=have_extra):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=64,
+                    page_size=64,
+                    num_blocks=4,
+                    fp8_layout=2,
+                    have_extra=have_extra,
+                    extra_topk=32 if have_extra else 0,
+                    extra_num_blocks=2 if have_extra else 0,
+                    have_topk_length=True,
+                    have_extra_topk_length=have_extra,
+                    is_fp8_kvcache=False,
+                )
+
+    def test_oversized_preallocated_kv_cache(self):
+        # Only the token range implied by indices should be considered active;
+        # the backing KV cache can be much larger because it is preallocated.
+        for is_fp8_kvcache in (True, False):
+            with self.subTest(is_fp8_kvcache=is_fp8_kvcache):
+                self._run_one(
+                    b=2,
+                    s_q=1,
+                    h_q=16,
+                    topk=64,
+                    page_size=64,
+                    num_blocks=8,
+                    fp8_layout=2,
+                    have_extra=True,
+                    extra_topk=32,
+                    extra_num_blocks=4,
+                    valid_tokens=96,
+                    extra_valid_tokens=48,
+                    invalid_ratio=0.1,
+                    is_fp8_kvcache=is_fp8_kvcache,
+                )
+
+    def test_with_attn_sink_and_extra(self):
+        # Combined: attn_sink + topk_length + extra K cache, both layouts.
+        for fp8_layout in (1, 2):
+            with self.subTest(fp8_layout=fp8_layout):
+                self._run_one(
+                    b=2,
+                    s_q=2,
+                    h_q=16,
+                    topk=128,
+                    page_size=128,
+                    num_blocks=3,
+                    fp8_layout=fp8_layout,
+                    have_attn_sink=True,
+                    have_topk_length=True,
+                    have_extra=True,
+                    extra_topk=64,
+                    extra_num_blocks=2,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
+++ b/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
@@ -1,0 +1,168 @@
+import unittest
+from typing import Any
+
+import sgl_kernel  # noqa: F401
+import torch
+import torch.nn.functional as F
+from utils import precision
+
+from sglang.test.test_utils import CustomTestCase
+
+BLOCK_SIZE = 64
+HEAD_DIM = 128
+HEAD_DIM_WITH_SCALE_BYTES = 132
+
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+def fp8_paged_mqa_logits_torch(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata: Any,
+    max_seq_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    _ = deep_gemm_metadata
+    batch_size, _, num_heads, head_dim = q_fp8.shape
+    block_size = kvcache_fp8.shape[1]
+
+    assert head_dim == 128, "TODO"
+    assert block_size == 64, "TODO"
+    assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)
+    assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
+    assert weight.shape == (batch_size, num_heads)
+    assert seq_lens.shape == (batch_size,)
+    assert page_table.shape[0] == batch_size
+    assert clean_logits == False
+
+    logits = page_table.new_empty((batch_size, max_seq_len), dtype=torch.float32)
+    for i in range(batch_size):
+        q = q_fp8[i, 0]
+        q = q.to(torch.float32)
+        q_scale = weight[i]
+        seq_len = int(seq_lens[i].item())
+        assert seq_len <= max_seq_len
+        num_pages = (seq_len + block_size - 1) // block_size
+        padded_seq_len = num_pages * block_size
+        pages = page_table[i, :num_pages]
+        kvcache_fp8 = kvcache_fp8.view(-1, block_size * (head_dim + 4))
+        kvcache = kvcache_fp8[pages]
+        SCALE_OFFSET = block_size * head_dim
+        kvcache_value = kvcache[..., :SCALE_OFFSET].view(dtype=FP8_DTYPE)
+        kvcache_scale = kvcache[..., SCALE_OFFSET:].view(dtype=torch.float32)
+        kvcache_value = kvcache_value.to(torch.float32)
+        kvcache_scale = kvcache_scale.contiguous()
+        kvcache_value = kvcache_value.view(padded_seq_len, head_dim)
+        kvcache_scale = kvcache_scale.view(padded_seq_len)
+        score = F.linear(kvcache_value, q)
+        score = F.relu(score)
+        score *= q_scale[None, :]
+        score = score.sum(dim=1)
+        score *= kvcache_scale
+        logits[i, :seq_len] = score[:seq_len]
+
+    return logits
+
+
+class TestFp8PagedMqaLogitsCPU(CustomTestCase):
+    def _make_inputs(
+        self,
+        *,
+        batch_size: int = 3,
+        num_heads: int = 4,
+        max_seq_len: int = 192,
+        num_blocks: int = 8,
+        index_dtype: torch.dtype = torch.int32,
+        weight_dtype: torch.dtype = torch.float32,
+        q_dtype: torch.dtype = torch.bfloat16,
+    ):
+        torch.manual_seed(2)
+
+        q = (torch.randn(batch_size, 1, num_heads, HEAD_DIM) * 0.25).to(q_dtype)
+        q_fp8 = q.to(torch.float8_e4m3fn).contiguous()
+
+        k = (torch.randn(num_blocks, BLOCK_SIZE, HEAD_DIM) * 0.25).to(q_dtype)
+        k_fp8 = k.to(torch.float8_e4m3fn).contiguous()
+        k_bytes = k_fp8.view(num_blocks, BLOCK_SIZE * HEAD_DIM).view(dtype=torch.uint8)
+
+        scales = torch.rand(num_blocks, BLOCK_SIZE, dtype=torch.float32) * 0.5 + 0.75
+        scale_bytes = (
+            scales.contiguous().view(num_blocks, BLOCK_SIZE).view(dtype=torch.uint8)
+        )
+
+        kvcache = torch.cat([k_bytes, scale_bytes], dim=1).contiguous()
+        kvcache = kvcache.view(num_blocks, BLOCK_SIZE, 1, HEAD_DIM_WITH_SCALE_BYTES)
+
+        weight = (
+            torch.randn(batch_size, num_heads, dtype=torch.float32)
+            .to(weight_dtype)
+            .contiguous()
+        )
+        seq_lens = torch.tensor([0, 65, max_seq_len - 1], dtype=index_dtype)
+
+        pages_per_batch = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+        page_table = torch.empty(batch_size, pages_per_batch, dtype=index_dtype)
+        page_table[0] = torch.tensor([0, 1, 2], dtype=index_dtype)
+        page_table[1] = torch.tensor([3, 4, 5], dtype=index_dtype)
+        page_table[2] = torch.tensor([2, 6, 7], dtype=index_dtype)
+
+        return q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len
+
+    def _assert_matches_reference(
+        self,
+        index_dtype: torch.dtype,
+        weight_dtype: torch.dtype,
+        q_dtype: torch.dtype = torch.bfloat16,
+    ):
+        q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len = self._make_inputs(
+            index_dtype=index_dtype,
+            weight_dtype=weight_dtype,
+            q_dtype=q_dtype,
+        )
+
+        actual = torch.ops.sgl_kernel.fp8_paged_mqa_logits_cpu(
+            q_fp8,
+            kvcache,
+            weight,
+            seq_lens,
+            page_table,
+            max_seq_len,
+            False,
+        )
+        expected = fp8_paged_mqa_logits_torch(
+            q_fp8,
+            kvcache,
+            weight,
+            seq_lens,
+            page_table,
+            None,
+            max_seq_len,
+            False,
+        )
+
+        self.assertEqual(actual.shape, (seq_lens.numel(), max_seq_len))
+        self.assertEqual(actual.dtype, torch.float32)
+        atol = rtol = precision[q_dtype]
+        for batch_idx, seq_len in enumerate(seq_lens.tolist()):
+            if seq_len == 0:
+                continue
+            torch.testing.assert_close(
+                actual[batch_idx, :seq_len],
+                expected[batch_idx, :seq_len],
+                atol=atol,
+                rtol=rtol,
+            )
+
+    def test_matches_torch_reference(self):
+        self._assert_matches_reference(
+            index_dtype=torch.int32,
+            weight_dtype=torch.float32,
+            q_dtype=torch.bfloat16,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_fused_scale_cpu.py
+++ b/test/srt/cpu/test_fused_scale_cpu.py
@@ -1,0 +1,57 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+
+def fused_scale_torch(
+    weight: torch.Tensor,
+    out_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    assert weight.is_contiguous() and q_scale.is_contiguous()
+    B, H = weight.shape
+    out_dtype = torch.promote_types(weight.dtype, q_scale.dtype)
+    acc = weight.reshape(-1).float() * out_scale * q_scale.reshape(-1).float()
+    out = acc.to(out_dtype).reshape(B, H, 1)
+    return out
+
+
+class TestFusedScaleCPU(CustomTestCase):
+    shapes = [(1, 1), (2, 8), (3, 128)]
+    weight_dtypes = [torch.float32, torch.bfloat16, torch.float16]
+
+    def _run_case(self, shape, weight_dtype):
+        torch.manual_seed(1234)
+        weight = torch.randn(shape, dtype=torch.float32).to(weight_dtype).contiguous()
+        # act_quant always emits fp32 scales; the kernel pins q_scale to fp32
+        # and always returns fp32 output.
+        q_scale = torch.rand(shape, dtype=torch.float32).contiguous()
+        out_scale = 0.03125
+
+        ref = fused_scale_torch(weight, out_scale, q_scale)
+        out = torch.ops.sgl_kernel.fused_scale_cpu(weight, out_scale, q_scale)
+
+        self.assertEqual(out.shape, (*shape, 1))
+        self.assertEqual(out.dtype, torch.float32)
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+    def test_fused_scale_cpu(self):
+        for shape, weight_dtype in itertools.product(self.shapes, self.weight_dtypes):
+            with self.subTest(shape=shape, weight_dtype=weight_dtype):
+                self._run_case(shape, weight_dtype)
+
+    def test_q_scale_view_shape(self):
+        weight = torch.randn((2, 4), dtype=torch.bfloat16).contiguous()
+        q_scale = torch.rand((2, 4, 1), dtype=torch.float32).contiguous()
+
+        ref = fused_scale_torch(weight, 0.5, q_scale)
+        out = torch.ops.sgl_kernel.fused_scale_cpu(weight, 0.5, q_scale)
+
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_gemm.py
+++ b/test/srt/cpu/test_gemm.py
@@ -327,6 +327,37 @@ class TestGemm(CustomTestCase):
             ):
                 self._int4_gptq_gemm(*params)
 
+    def _bf16_fp32_gemm(self, M, N, K, has_bias):
+        mat1 = torch.randn(M, K, dtype=torch.bfloat16)
+        mat2 = torch.randn(N, K, dtype=torch.bfloat16)
+        bias = torch.randn(N, dtype=torch.float32) if has_bias else None
+
+        ref = torch.nn.functional.linear(mat1.float(), mat2.float(), bias)
+
+        out = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, mat2, bias, False, torch.float32
+        )
+        self.assertEqual(out.dtype, torch.float32)
+        atol = rtol = precision[torch.float32]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+        packed_mat2 = torch.ops.sgl_kernel.convert_weight_packed(mat2)
+        out2 = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, packed_mat2, bias, True, torch.float32
+        )
+        self.assertEqual(out2.dtype, torch.float32)
+        torch.testing.assert_close(ref, out2, atol=atol, rtol=rtol)
+
+    def test_bf16_fp32_gemm(self):
+        for params in itertools.product(self.M, self.N, self.K, self.has_bias):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+            ):
+                self._bf16_fp32_gemm(*params)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/srt/cpu/test_hadamard.py
+++ b/test/srt/cpu/test_hadamard.py
@@ -1,0 +1,98 @@
+import itertools
+import unittest
+
+import torch
+from utils import precision
+
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+
+def _torch_hadamard_transform(x: torch.Tensor, scale: float) -> torch.Tensor:
+    """Reference pure-torch FWHT implementation."""
+    n = x.size(-1)
+    leading = x.shape[:-1]
+    out = x.reshape(-1, n).float().clone()
+    h = 1
+    while h < n:
+        out = out.view(-1, n // (2 * h), 2, h)
+        a = out[:, :, 0, :]
+        b = out[:, :, 1, :]
+        out = torch.stack((a + b, a - b), dim=2).view(-1, n)
+        h *= 2
+    return (out.view(*leading, n) * scale).to(x.dtype)
+
+
+class TestHadamardTransform(CustomTestCase):
+    # Last dim must be power of 2
+    N = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+    BATCH = [1, 3, 7, 16]
+    DTYPE = [torch.float32, torch.bfloat16, torch.float16]
+
+    def _test_hadamard(self, batch, n, dtype):
+        x = torch.randn([batch, n], dtype=dtype)
+        scale = n**-0.5
+
+        out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+        ref = _torch_hadamard_transform(x, scale)
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_basic(self):
+        """Test across various batch sizes, dimensions, and dtypes."""
+        for params in itertools.product(self.BATCH, self.N, self.DTYPE):
+            with self.subTest(batch=params[0], n=params[1], dtype=params[2]):
+                self._test_hadamard(*params)
+
+    def test_3d_input(self):
+        """Test with 3-D input tensor (e.g. [B, S, D])."""
+        for n in [32, 64, 128, 256]:
+            for dtype in [torch.bfloat16, torch.float32]:
+                x = torch.randn([2, 8, n], dtype=dtype)
+                scale = n**-0.5
+                out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+                ref = _torch_hadamard_transform(x, scale)
+                atol = rtol = precision[dtype]
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_4d_input(self):
+        """Test with 4-D input tensor (e.g. [B, H, S, D])."""
+        for n in [32, 128]:
+            x = torch.randn([2, 4, 8, n], dtype=torch.bfloat16)
+            scale = n**-0.5
+            out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+            ref = _torch_hadamard_transform(x, scale)
+            atol = rtol = precision[torch.bfloat16]
+            torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_scale_one(self):
+        """Test with scale=1.0 (no scaling)."""
+        x = torch.randn([4, 64], dtype=torch.float32)
+        out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, 1.0)
+        ref = _torch_hadamard_transform(x, 1.0)
+        torch.testing.assert_close(ref, out, atol=1e-5, rtol=1e-5)
+
+    def test_large_dim(self):
+        """Test with large last dimension typical of LLM hidden sizes."""
+        for n in [2048, 4096]:
+            x = torch.randn([2, n], dtype=torch.bfloat16)
+            scale = n**-0.5
+            out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+            ref = _torch_hadamard_transform(x, scale)
+            atol = rtol = precision[torch.bfloat16]
+            torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_involution(self):
+        """FWHT applied twice (with scale=1/n) should recover the original."""
+        n = 128
+        x = torch.randn([4, n], dtype=torch.float32)
+        # H * H = n * I, so applying twice with scale 1/n gives identity.
+        y = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, 1.0)
+        z = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(y, 1.0 / n)
+        torch.testing.assert_close(x, z, atol=1e-4, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_mhc.py
+++ b/test/srt/cpu/test_mhc.py
@@ -1,0 +1,175 @@
+import itertools
+import unittest
+
+import torch
+import torch.nn.functional as F
+from utils import precision
+
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(1234)
+
+
+def _ref_hc_split_sinkhorn(mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, eps):
+    hc = hc_mult
+
+    pre = torch.sigmoid(mixes[:, :hc] * hc_scale[0] + hc_base[:hc]) + eps
+    post = 2.0 * torch.sigmoid(
+        mixes[:, hc : 2 * hc] * hc_scale[1] + hc_base[hc : 2 * hc]
+    )
+
+    comb = mixes[:, 2 * hc :].view(-1, hc, hc) * hc_scale[2] + hc_base[2 * hc :].view(
+        hc, hc
+    )
+    comb = (comb - comb.amax(dim=-1, keepdim=True)).exp()
+
+    row_sum = comb.sum(dim=-1, keepdim=True)
+    comb = comb / row_sum + eps
+    col_sum = comb.sum(dim=-2, keepdim=True)
+    comb = comb / (col_sum + eps)
+
+    for _ in range(sinkhorn_iters - 1):
+        row_sum = comb.sum(dim=-1, keepdim=True)
+        comb = comb / (row_sum + eps)
+        col_sum = comb.sum(dim=-2, keepdim=True)
+        comb = comb / (col_sum + eps)
+
+    return pre, post, comb
+
+
+def _ref_hc_pre(
+    x, hc_fn, hc_scale, hc_base, hc_mult, sinkhorn_iters, rms_norm_eps, hc_eps
+):
+    dtype = x.dtype
+    x_flat = x.flatten(1).float()
+    rsqrt = torch.rsqrt(x_flat.square().mean(-1, keepdim=True) + rms_norm_eps)
+    mixes = F.linear(x_flat, hc_fn.float()) * rsqrt
+    pre, post, comb = _ref_hc_split_sinkhorn(
+        mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, hc_eps
+    )
+    y = (pre.unsqueeze(-1) * x.float()).sum(dim=1)
+    return y.to(dtype), post, comb
+
+
+def _ref_hc_post(x, residual, post, comb):
+    return (
+        post.unsqueeze(-1) * x.unsqueeze(1)
+        + (comb.unsqueeze(-1) * residual.unsqueeze(2)).sum(dim=1)
+    ).type_as(x)
+
+
+def _ref_hc_head(x, hc_fn, hc_scale, hc_base, hc_eps, norm_eps):
+    dtype = x.dtype
+    shape = x.size()
+    x_flat = x.flatten(1).float()
+    rsqrt = torch.rsqrt(x_flat.square().mean(-1, keepdim=True) + norm_eps)
+    mixes = F.linear(x_flat, hc_fn.float()) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale + hc_base) + hc_eps
+    y = torch.sum(pre.unsqueeze(-1) * x_flat.view(shape).float(), dim=1)
+    return y.to(dtype)
+
+
+def _make_inputs(T, hc, d, dtype=torch.bfloat16, seed=42):
+    gen = torch.Generator()
+    gen.manual_seed(seed)
+    mix_hc = (2 + hc) * hc
+
+    x = torch.randn(T, hc, d, dtype=dtype, generator=gen)
+    hc_fn = torch.randn(mix_hc, hc * d, dtype=torch.float32, generator=gen) * 0.02
+    hc_scale = torch.tensor([1.0, 1.0, 0.5], dtype=torch.float32)
+    hc_base = torch.zeros(mix_hc, dtype=torch.float32)
+    return x, hc_fn, hc_scale, hc_base
+
+
+def _make_post_inputs(T, hc, d, dtype=torch.bfloat16, seed=7):
+    gen = torch.Generator()
+    gen.manual_seed(seed)
+    x = torch.randn(T, d, dtype=dtype, generator=gen)
+    residual = torch.randn(T, hc, d, dtype=dtype, generator=gen)
+    post = torch.rand(T, hc, dtype=torch.float32, generator=gen)
+    comb = torch.rand(T, hc, hc, dtype=torch.float32, generator=gen)
+    comb = comb / comb.sum(dim=-1, keepdim=True)
+    comb = comb / comb.sum(dim=-2, keepdim=True)
+    return x, residual, post, comb
+
+
+class TestMhcAccuracy(CustomTestCase):
+    T = [1, 64]
+    HC = [2, 4]
+    D = [128, 141]
+    DTYPE = [torch.bfloat16, torch.float16]
+    SINKHORN_ITERS = 20
+    RMS_EPS = 1e-5
+    HC_EPS = 1e-6
+    NORM_EPS = 1e-5
+
+    def _pre_accuracy_test(self, T, hc, d, dtype):
+        x, hc_fn, hc_scale, hc_base = _make_inputs(
+            T, hc, d, dtype=dtype, seed=2000 + T + d + hc
+        )
+
+        ref_y, ref_post, ref_comb = _ref_hc_pre(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            hc,
+            self.SINKHORN_ITERS,
+            self.RMS_EPS,
+            self.HC_EPS,
+        )
+        out_y, out_post, out_comb = torch.ops.sgl_kernel.hc_pre_fused_cpu(
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            hc,
+            self.SINKHORN_ITERS,
+            self.RMS_EPS,
+            self.HC_EPS,
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref_y, out_y, atol=atol, rtol=rtol)
+        torch.testing.assert_close(ref_post, out_post, atol=atol, rtol=rtol)
+        torch.testing.assert_close(ref_comb, out_comb, atol=atol, rtol=rtol)
+
+    def _post_accuracy_test(self, T, hc, d, dtype):
+        x, residual, post, comb = _make_post_inputs(
+            T, hc, d, dtype=dtype, seed=3000 + T + d + hc
+        )
+
+        ref_out = _ref_hc_post(x, residual, post, comb)
+        out = torch.ops.sgl_kernel.hc_post_fused_cpu(x, residual, post, comb)
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
+
+    def _head_accuracy_test(self, T, hc, d, dtype):
+        gen = torch.Generator()
+        gen.manual_seed(4000 + T + d + hc)
+        x = torch.randn(T, hc, d, dtype=dtype, generator=gen)
+        hc_fn = torch.randn(hc, hc * d, dtype=torch.float32, generator=gen) * 0.02
+        hc_scale = torch.tensor(1.0, dtype=torch.float32)
+        hc_base = torch.zeros(hc, dtype=torch.float32)
+
+        ref_out = _ref_hc_head(x, hc_fn, hc_scale, hc_base, self.HC_EPS, self.NORM_EPS)
+        out = torch.ops.sgl_kernel.hc_head_fused_cpu(
+            x, hc_fn, hc_scale, hc_base, self.HC_EPS, self.NORM_EPS
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
+
+    def test_mhc_accuracy(self):
+        for T, hc, d, dtype in itertools.product(self.T, self.HC, self.D, self.DTYPE):
+            with self.subTest(op="hc_pre", T=T, hc=hc, d=d, dtype=dtype):
+                self._pre_accuracy_test(T, hc, d, dtype)
+            with self.subTest(op="hc_post", T=T, hc=hc, d=d, dtype=dtype):
+                self._post_accuracy_test(T, hc, d, dtype)
+            with self.subTest(op="hc_head", T=T, hc=hc, d=d, dtype=dtype):
+                self._head_accuracy_test(T, hc, d, dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_moe.py
+++ b/test/srt/cpu/test_moe.py
@@ -1,4 +1,3 @@
-import itertools
 import math
 import unittest
 
@@ -9,18 +8,22 @@ from sglang.srt.layers.amx_utils import CPUQuantMethod
 
 kernel = torch.ops.sgl_kernel
 
-torch.manual_seed(128)
+torch.manual_seed(1234)
 
 from utils import (
     BLOCK_K,
     BLOCK_N,
+    MXFP4QuantizeUtil,
     factor_for_scale,
     fp8_max,
     fp8_min,
+    native_clamped_silu_fused_moe,
     native_fp8_fused_moe,
+    parametrize,
     precision,
     scaled_weight,
     torch_naive_fused_moe,
+    torch_naive_fused_moe_gptoss,
     torch_w8a8_per_column_fused_moe,
     unpack_and_dequant_awq,
 )
@@ -57,37 +60,18 @@ def fused_moe(a, w1, w2, score, topk, renormalize, prepack):
         None,
         None,
         None,
+        None,
+        None,
+        None,
+        None,
         prepack,
     )
 
 
 class TestFusedExperts(CustomTestCase):
-    M = [2, 114]
-    N = [32]
-    K = [32]
-    E = [4]
-    topk = [2]
-    renormalize = [False, True]
 
-    M_int8 = [1, 39]
-    N_int8 = [128]
-    K_int8 = [256]
-    E_int8 = [8]
-    topk_int8 = [3]
-
-    M_fp8 = [2, 121]
-    N_fp8 = [352, 512]
-    K_fp8 = [256, 320]
-    E_fp8 = [8]
-    topk_fp8 = [4]
-
-    M_int4 = [1, 6]
-    N_int4 = [512]
-    K_int4 = [256]
-    E_int4 = [8]
-    topk_int4 = [4]
-
-    def _bf16_moe(self, m, n, k, e, topk, renormalize):
+    @parametrize(m=[2, 114], n=[32], k=[32], e=[4], topk=[2], renormalize=[False, True])
+    def test_bf16_moe(self, m, n, k, e, topk, renormalize):
         dtype = torch.bfloat16
         prepack = True
 
@@ -102,26 +86,51 @@ class TestFusedExperts(CustomTestCase):
         atol = rtol = precision[torch_output.dtype]
         torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
 
-    def test_bf16_moe(self):
-        for params in itertools.product(
-            self.M,
-            self.N,
-            self.K,
-            self.E,
-            self.topk,
-            self.renormalize,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                e=params[3],
-                topk=params[4],
-                renormalize=params[5],
-            ):
-                self._bf16_moe(*params)
+    @parametrize(
+        m=[1, 32], n=[128, 64], k=[128, 64], e=[4], topk=[2], renormalize=[False]
+    )
+    def test_bf16_moe_bias(self, m, n, k, e, topk, renormalize):
+        dtype = torch.bfloat16
 
-    def _int8_moe(self, M, N, K, E, topk):
+        a = torch.randn((m, k), device="cpu", dtype=dtype) / 10
+        w1 = torch.randn((e, 2 * n, k), device="cpu", dtype=dtype) / 10
+        w1_b = torch.randn((e, 2 * n), device="cpu", dtype=torch.float) / 10
+        w2 = torch.randn((e, k, n), device="cpu", dtype=dtype) / 10
+        w2_b = torch.randn((e, k), device="cpu", dtype=torch.float) / 10
+        score = torch.randn((m, e), device="cpu", dtype=dtype)
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+        alpha = 1.702
+        limit = 7.0
+        torch_output = torch_naive_fused_moe_gptoss(
+            a, w1, w2, w1_b, w2_b, topk_weight, topk_ids, renormalize, alpha, limit, e
+        )
+        packed_w1 = kernel.convert_weight_packed(w1)
+        packed_w2 = kernel.convert_weight_packed(w2)
+        fused_output = torch.ops.sgl_kernel.fused_experts_cpu(
+            a,
+            packed_w1,
+            packed_w2,
+            topk_weight,
+            topk_ids.to(torch.int),
+            False,  # inplace # See [Note] inplace should be False in fused_experts.
+            CPUQuantMethod.UNQUANT,
+            None,  # w1_scale
+            None,  # w2_scale
+            None,  # w1_zp
+            None,  # w2_zp
+            None,  # block_size
+            w1_b,
+            w2_b,
+            alpha,
+            limit,
+            True,  # is_vnni
+        )
+        atol = rtol = precision[torch_output.dtype]
+        torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
+
+    @parametrize(M=[1, 39], N=[128], K=[256], E=[8], topk=[3])
+    def test_int8_moe(self, M, N, K, E, topk):
         dtype = torch.bfloat16
         prepack = True
 
@@ -170,6 +179,10 @@ class TestFusedExperts(CustomTestCase):
             None,
             None,
             None,
+            None,
+            None,
+            None,
+            None,
             prepack,
         )
 
@@ -179,24 +192,8 @@ class TestFusedExperts(CustomTestCase):
             atol = rtol = 0.02
         torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
 
-    def test_int8_moe(self):
-        for params in itertools.product(
-            self.M_int8,
-            self.N_int8,
-            self.K_int8,
-            self.E_int8,
-            self.topk_int8,
-        ):
-            with self.subTest(
-                M=params[0],
-                N=params[1],
-                K=params[2],
-                E=params[3],
-                topk=params[4],
-            ):
-                self._int8_moe(*params)
-
-    def _fp8_moe(self, M, N, K, E, topk):
+    @parametrize(M=[2, 121], N=[352, 512], K=[256, 320], E=[8], topk=[4])
+    def test_fp8_moe(self, M, N, K, E, topk):
         dtype = torch.bfloat16
 
         a = torch.randn(M, K, dtype=dtype) / math.sqrt(K)
@@ -242,30 +239,190 @@ class TestFusedExperts(CustomTestCase):
             None,
             None,
             [BLOCK_N, BLOCK_K],
+            None,
+            None,
+            None,
+            None,
             True,
         )
 
         atol = rtol = precision[dtype]
         torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
 
-    def test_fp8_moe(self):
-        for params in itertools.product(
-            self.M_fp8,
-            self.N_fp8,
-            self.K_fp8,
-            self.E_fp8,
-            self.topk_fp8,
-        ):
-            with self.subTest(
-                M=params[0],
-                N=params[1],
-                K=params[2],
-                E=params[3],
-                topk=params[4],
-            ):
-                self._fp8_moe(*params)
+    @parametrize(M=[2, 121], N=[352, 512], K=[256, 320], E=[8], topk=[4])
+    def test_mxfp4_moe(self, M, N, K, E, topk):
+        dtype = torch.bfloat16
 
-    def _int4_moe(self, M, N, K, E, topk, group_size=128):
+        a = torch.randn(M, K, dtype=dtype) / 10
+
+        w1_bf16 = torch.randn((E, 2 * N, K), dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+        w1s = w1s.reshape(E, 2 * N, K // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+
+        w2_bf16 = torch.randn((E, K, N), dtype=dtype) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+        w2s = w2s.reshape(E, K, N // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+
+        score = torch.randn((M, E), dtype=dtype)
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+
+        ref_out = native_fp8_fused_moe(
+            a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, topk
+        )
+        out = kernel.fused_experts_cpu(
+            a,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids.to(torch.int32),
+            False,
+            CPUQuantMethod.MXFP4,
+            w1s,
+            w2s,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            True,
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
+
+    @parametrize(
+        m=[1, 32], n=[128, 64], k=[128, 64], e=[4], topk=[2], renormalize=[False]
+    )
+    def test_mxfp4_moe_bias(self, m, n, k, e, topk, renormalize):
+        dtype = torch.bfloat16
+
+        a = torch.randn((m, k), device="cpu", dtype=dtype) / 10
+        w1_bf16 = torch.randn((e, 2 * n, k), device="cpu", dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+        w1s = w1s.reshape(e, 2 * n, k // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+        w1_b = torch.randn((e, 2 * n), device="cpu", dtype=torch.float32) / 10
+        w2_bf16 = torch.randn((e, k, n), device="cpu", dtype=dtype) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+        w2s = w2s.reshape(e, k, n // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+        w2_b = torch.randn((e, k), device="cpu", dtype=torch.float32) / 10
+        score = torch.randn((m, e), device="cpu", dtype=dtype)
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+        alpha = 1.702
+        limit = 7.0
+        torch_output = torch_naive_fused_moe_gptoss(
+            a,
+            w1dq,
+            w2dq,
+            w1_b,
+            w2_b,
+            topk_weight,
+            topk_ids,
+            renormalize,
+            alpha,
+            limit,
+            e,
+        )
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+
+        fused_output = torch.ops.sgl_kernel.fused_experts_cpu(
+            a,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids.to(torch.int32),
+            False,  # inplace # See [Note] inplace should be False in fused_experts.
+            CPUQuantMethod.MXFP4,  # use_mxfp4
+            w1s,  # w1_scale
+            w2s,  # w2_scale
+            None,  # w1_zp
+            None,  # w2_zp
+            None,  # block_size
+            w1_b,
+            w2_b,
+            alpha,
+            limit,
+            True,  # is_vnni
+        )
+        atol = rtol = precision[torch_output.dtype]
+        torch.testing.assert_close(torch_output, fused_output, atol=atol, rtol=rtol)
+
+    @parametrize(M=[1, 16], N=[256], K=[512], E=[8], topk=[6], limit=[None, 10.0])
+    def test_mxfp4_moe_dsv4(self, M, N, K, E, topk, limit):
+        dtype = torch.bfloat16
+
+        a = torch.randn(M, K, dtype=dtype) / 10
+
+        w1_bf16 = torch.randn((E, 2 * N, K), dtype=dtype) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+        w1s = w1s.reshape(E, 2 * N, K // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+
+        w2_bf16 = torch.randn((E, K, N), dtype=dtype) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+        w2s = w2s.reshape(E, K, N // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+
+        score = torch.softmax(
+            torch.randn((M, E), dtype=dtype), dim=-1, dtype=torch.float32
+        )
+        topk_weight, topk_ids = torch.topk(score, topk)
+
+        if limit is None:
+            ref = native_fp8_fused_moe(
+                a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, topk
+            )
+        else:
+            ref = native_clamped_silu_fused_moe(
+                a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, topk, limit
+            )
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+
+        out = kernel.fused_experts_cpu(
+            a,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids.to(torch.int32),
+            False,  # inplace
+            CPUQuantMethod.MXFP4,
+            w1s,
+            w2s,
+            None,
+            None,
+            None,  # w1_zp, w2_zp, block_size
+            None,
+            None,  # w1_bias, w2_bias  (DSV4 has no bias)
+            None,  # gemm1_alpha       (2604B has no alpha)
+            limit,  # gemm1_clamp_limit (None for 2604; float for 2604B)
+            True,  # is_vnni
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref.bfloat16(), out, atol=atol, rtol=rtol)
+
+    @parametrize(M=[1, 6], N=[512], K=[256], E=[8], topk=[4])
+    def test_int4_moe(self, M, N, K, E, topk, group_size=128):
         dtype = torch.bfloat16
 
         a = torch.rand(M, K, dtype=dtype) / math.sqrt(K)
@@ -324,28 +481,15 @@ class TestFusedExperts(CustomTestCase):
             awq_w13_zero_pack,
             awq_w2_zero_pack,
             None,
+            None,
+            None,
+            None,
+            None,
             True,
         )
 
         atol = rtol = precision[dtype]
         torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
-
-    def test_int4_moe(self):
-        for params in itertools.product(
-            self.M_int4,
-            self.N_int4,
-            self.K_int4,
-            self.E_int4,
-            self.topk_int4,
-        ):
-            with self.subTest(
-                M=params[0],
-                N=params[1],
-                K=params[2],
-                E=params[3],
-                topk=params[4],
-            ):
-                self._int4_moe(*params)
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_norm.py
+++ b/test/srt/cpu/test_norm.py
@@ -134,7 +134,7 @@ class TestNorm(CustomTestCase):
     @parametrize(
         m=[4096, 1024],
         n=[4096, 4109],
-        dtype=[torch.float16, torch.bfloat16],
+        dtype=[torch.float16, torch.bfloat16, torch.float],
     )
     def test_l2norm(self, m, n, dtype):
 

--- a/test/srt/cpu/test_rope.py
+++ b/test/srt/cpu/test_rope.py
@@ -17,7 +17,157 @@ from sglang.test.test_utils import CustomTestCase
 torch.manual_seed(1234)
 
 
+def apply_rotary_interleaved_ref(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    positions: torch.Tensor | None = None,
+    inverse: bool = False,
+) -> torch.Tensor:
+    is_3d = x.ndim == 3
+
+    if is_3d:
+        batch_size, n_heads, rope_dim = x.shape
+    else:
+        batch_size, rope_dim = x.shape
+        n_heads = 1
+
+    # freqs_cis is complex; convert to interleaved real/imag then split
+    freqs_real = torch.view_as_real(freqs_cis).flatten(-2)  # (..., rope_dim)
+
+    # Select frequencies based on positions
+    if positions is not None:
+        assert positions.shape == (batch_size,)
+        freqs_real = freqs_real[positions]  # (batch_size, rope_dim)
+    else:
+        assert freqs_real.shape[0] == batch_size
+
+    # Split x into even (real) and odd (imag) indices along the last dim
+    x_real = x[..., 0::2].float()  # (..., rope_dim // 2)
+    x_imag = x[..., 1::2].float()  # (..., rope_dim // 2)
+
+    # Split freqs into real and imag parts the same way
+    # freqs_real shape: (batch_size, rope_dim)
+    # For 3D input, add a head dimension for broadcasting
+    freq_r = freqs_real[..., 0::2]  # (batch_size, rope_dim // 2)
+    freq_i = freqs_real[..., 1::2]  # (batch_size, rope_dim // 2)
+
+    if is_3d:
+        freq_r = freq_r.unsqueeze(1)  # (batch_size, 1, rope_dim // 2)
+        freq_i = freq_i.unsqueeze(1)
+
+    # Complex multiplication: (x_real + j*x_imag) * (freq_r + j*freq_i)
+    if inverse:
+        # Multiply by conjugate: (freq_r - j*freq_i)
+        out_real = x_real * freq_r + x_imag * freq_i
+        out_imag = x_imag * freq_r - x_real * freq_i
+    else:
+        out_real = x_real * freq_r - x_imag * freq_i
+        out_imag = x_real * freq_i + x_imag * freq_r
+
+    # Interleave real and imag back into x (in-place)
+    x[..., 0::2] = out_real.to(x.dtype)
+    x[..., 1::2] = out_imag.to(x.dtype)
+
+    return x
+
+
 class TestROPE(CustomTestCase):
+    def test_apply_rotary_emb_interleaved_cpu_entry_compat(self):
+        rope_dim = 64
+        for dtype in [torch.float32, torch.bfloat16]:
+            for shape in [(41, rope_dim), (41, 3, rope_dim)]:
+                for inverse in [False, True]:
+                    with self.subTest(dtype=dtype, shape=shape, inverse=inverse):
+                        max_pos = shape[0] + 17
+                        positions = torch.randint(
+                            0, max_pos, (shape[0],), dtype=torch.long
+                        )
+                        angles = torch.randn(
+                            max_pos, rope_dim // 2, dtype=torch.float32
+                        )
+                        freqs_cis = torch.polar(torch.ones_like(angles), angles).to(
+                            torch.complex64
+                        )
+                        x_ref = torch.randn(*shape, dtype=dtype)
+                        x_cpp = x_ref.clone()
+
+                        apply_rotary_interleaved_ref(
+                            x_ref,
+                            freqs_cis,
+                            positions=positions,
+                            inverse=inverse,
+                        )
+
+                        torch.ops.sgl_kernel.apply_rotary_emb_interleaved_cpu(
+                            x_cpp,
+                            freqs_cis,
+                            inverse,
+                            positions,
+                        )
+
+                        atol = rtol = precision[x_ref.dtype]
+                        torch.testing.assert_close(
+                            x_cpp.float(),
+                            x_ref.float(),
+                            atol=atol,
+                            rtol=rtol,
+                        )
+
+    def test_apply_rotary_emb_interleaved_cpu_with_k_entry_compat(self):
+        if not hasattr(torch.ops.sgl_kernel, "apply_rotary_emb_interleaved_cpu"):
+            self.skipTest("apply_rotary_emb_interleaved_cpu is not available")
+
+        rope_dim = 64
+        for dtype in [torch.float32, torch.bfloat16]:
+            for inverse in [False, True]:
+                with self.subTest(dtype=dtype, inverse=inverse):
+                    T = 41
+                    max_pos = T + 17
+                    positions = torch.randint(0, max_pos, (T,), dtype=torch.long)
+                    angles = torch.randn(max_pos, rope_dim // 2, dtype=torch.float32)
+                    freqs_cis = torch.polar(torch.ones_like(angles), angles).to(
+                        torch.complex64
+                    )
+                    q_ref = torch.randn(T, 3, rope_dim, dtype=dtype)
+                    k_ref = torch.randn(T, 1, rope_dim, dtype=dtype)
+                    q_cpp = q_ref.clone()
+                    k_cpp = k_ref.clone()
+
+                    apply_rotary_interleaved_ref(
+                        q_ref,
+                        freqs_cis,
+                        positions=positions,
+                        inverse=inverse,
+                    )
+                    apply_rotary_interleaved_ref(
+                        k_ref,
+                        freqs_cis,
+                        positions=positions,
+                        inverse=inverse,
+                    )
+
+                    torch.ops.sgl_kernel.apply_rotary_emb_interleaved_cpu(
+                        q_cpp,
+                        freqs_cis,
+                        inverse,
+                        positions,
+                        k_cpp,
+                    )
+
+                    atol = rtol = precision[q_ref.dtype]
+                    torch.testing.assert_close(
+                        q_cpp.float(),
+                        q_ref.float(),
+                        atol=atol,
+                        rtol=rtol,
+                    )
+                    torch.testing.assert_close(
+                        k_cpp.float(),
+                        k_ref.float(),
+                        atol=atol,
+                        rtol=rtol,
+                    )
+
     def test_mrope(self):
         torch.manual_seed(100)
         head_size = 128

--- a/test/srt/cpu/test_shared_expert.py
+++ b/test/srt/cpu/test_shared_expert.py
@@ -1,38 +1,44 @@
-import itertools
 import math
 import unittest
 
 import torch
+
+kernel = torch.ops.sgl_kernel
+
 from utils import (
     BLOCK_K,
     BLOCK_N,
+    MXFP4QuantizeUtil,
+    SiluAndMul,
     factor_for_scale,
     fp8_max,
     fp8_min,
+    parametrize,
     per_token_quant_int8,
     precision,
     scaled_weight,
+    torch_naive_clamped_silu_moe,
     torch_naive_moe,
     torch_w8a8_per_column_moe,
 )
 
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.test.test_utils import CustomTestCase
 
 torch.manual_seed(1234)
 
 
 class TestSharedExpert(CustomTestCase):
-    M = [2, 121]
-    N = [32, 32 * 4]
-    K = [32, 32 * 2]
-    routed_scaling_factor = [16]
-    apply_scaling_factor = [True, False]
-
-    M_fp8 = [2, 12]
-    N_fp8 = [512]
-    K_fp8 = [256]
-
-    def _bf16_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(
+        m=[2, 121],
+        n=[32, 32 * 4],
+        k=[32, 32 * 2],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+    )
+    def test_bf16_shared_expert(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor
+    ):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / k
@@ -64,6 +70,9 @@ class TestSharedExpert(CustomTestCase):
             True,
             False,
             False,
+            False,
+            None,
+            None,
             None,
             None,
             None,
@@ -73,24 +82,16 @@ class TestSharedExpert(CustomTestCase):
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    def test_bf16_shared_expert(self):
-        for params in itertools.product(
-            self.M,
-            self.N,
-            self.K,
-            self.routed_scaling_factor,
-            self.apply_scaling_factor,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                routed_scaling_factor=params[3],
-                apply_scaling_factor=params[4],
-            ):
-                self._bf16_shared_expert(*params)
-
-    def _int8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(
+        m=[2, 121],
+        n=[32, 32 * 4],
+        k=[32, 32 * 2],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+    )
+    def test_int8_shared_expert(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor
+    ):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / k
@@ -124,8 +125,11 @@ class TestSharedExpert(CustomTestCase):
             True,
             True,
             False,
+            False,
             w1_s,
             w2_s,
+            None,
+            None,
             None,
             False,
         )
@@ -133,24 +137,16 @@ class TestSharedExpert(CustomTestCase):
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    def test_int8_shared_expert(self):
-        for params in itertools.product(
-            self.M,
-            self.N,
-            self.K,
-            self.routed_scaling_factor,
-            self.apply_scaling_factor,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                routed_scaling_factor=params[3],
-                apply_scaling_factor=params[4],
-            ):
-                self._int8_shared_expert(*params)
-
-    def _fp8_shared_expert(self, m, n, k, routed_scaling_factor, apply_scaling_factor):
+    @parametrize(
+        m=[2, 12],
+        n=[512],
+        k=[256],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+    )
+    def test_fp8_shared_expert(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor
+    ):
         dtype = torch.bfloat16
 
         hidden_states = torch.randn(m, k, dtype=dtype) / math.sqrt(k)
@@ -201,31 +197,174 @@ class TestSharedExpert(CustomTestCase):
             True,
             False,
             True,
+            False,
             w1s,
             w2s,
             [BLOCK_N, BLOCK_K],
+            None,
+            None,
             True,
         )
 
         atol = rtol = precision[ref.dtype]
         torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
 
-    def test_fp8_shared_expert(self):
-        for params in itertools.product(
-            self.M_fp8,
-            self.N_fp8,
-            self.K_fp8,
-            self.routed_scaling_factor,
-            self.apply_scaling_factor,
-        ):
-            with self.subTest(
-                m=params[0],
-                n=params[1],
-                k=params[2],
-                routed_scaling_factor=params[3],
-                apply_scaling_factor=params[4],
-            ):
-                self._fp8_shared_expert(*params)
+    @parametrize(
+        m=[2, 12],
+        n=[512],
+        k=[256],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+        limit=[None, 10.0],
+    )
+    def test_fp8_shared_expert_dsv4(
+        self, m, n, k, routed_scaling_factor, apply_scaling_factor, limit
+    ):
+        dtype = torch.bfloat16
+
+        hidden_states = torch.randn(m, k, dtype=dtype) / math.sqrt(k)
+
+        w1_fp32 = torch.randn(1, 2 * n, k)
+        w1 = (w1_fp32 * fp8_max).clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+        w2_fp32 = torch.randn(1, k, n)
+        w2 = (w2_fp32 * fp8_max).clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+        w1s = torch.randn(1, 2 * n // BLOCK_N, k // BLOCK_K) * factor_for_scale
+        w2s = torch.randn(1, k // BLOCK_N, n // BLOCK_K) * factor_for_scale
+
+        w1_scaled = scaled_weight(w1, w1s).view(2 * n, k)
+        w2_scaled = scaled_weight(w2, w2s).view(k, n)
+
+        # change back to 2D
+        w1, w2 = w1.squeeze(0), w2.squeeze(0)
+        w1s, w2s = w1s.squeeze(0), w2s.squeeze(0)
+        w1_scaled, w2_scaled = w1_scaled.squeeze(0), w2_scaled.squeeze(0)
+
+        fused_output = (
+            torch.randn(m, k, dtype=dtype) / math.sqrt(k)
+            if apply_scaling_factor
+            else None
+        )
+        routed_scaling_factor = routed_scaling_factor if apply_scaling_factor else None
+        hidden_states2 = hidden_states.clone()
+
+        # ref with bfloat16
+        if limit is None:
+            ref = torch_naive_moe(
+                hidden_states,
+                w1_scaled,
+                w2_scaled,
+                fused_output,
+                routed_scaling_factor,
+                output_dtype=dtype,
+            )
+        else:
+            ref = torch_naive_clamped_silu_moe(
+                hidden_states,
+                w1_scaled,
+                w2_scaled,
+                fused_output,
+                routed_scaling_factor,
+                limit,
+                output_dtype=dtype,
+            )
+
+        w1 = torch.ops.sgl_kernel.convert_weight_packed(w1)  # [2N, K]
+        w2 = torch.ops.sgl_kernel.convert_weight_packed(w2)  # [K, N]
+        out = torch.ops.sgl_kernel.shared_expert_cpu(
+            hidden_states2,
+            w1,
+            w2,
+            fused_output,
+            routed_scaling_factor,
+            True,
+            False,
+            True,
+            False,
+            w1s,
+            w2s,
+            [BLOCK_N, BLOCK_K],
+            None,
+            limit,
+            True,
+        )
+
+        atol = rtol = precision[ref.dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    @parametrize(
+        M=[2, 12],
+        N=[512],
+        K=[256],
+        routed_scaling_factor=[16],
+        apply_scaling_factor=[True, False],
+    )
+    def test_mxfp4_shared_expert(
+        self, M, N, K, routed_scaling_factor, apply_scaling_factor
+    ):
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+        dtype = torch.bfloat16
+        prepack = True
+
+        a = torch.randn(M, K, dtype=dtype) / math.sqrt(K)
+
+        w1_fp32 = torch.randn(1, 2 * N, K) / 10
+        w1q, w1s = MXFP4QuantizeUtil.quantize(w1_fp32)
+        w1s = w1s.reshape(1, 2 * N, K // 32)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, torch.float32, w1s)
+
+        w2_fp32 = torch.randn(1, K, N) / 10
+        w2q, w2s = MXFP4QuantizeUtil.quantize(w2_fp32)
+        w2s = w2s.reshape(1, K, N // 32)
+        w2dq = MXFP4QuantizeUtil.dequantize(w2q, torch.float32, w2s)
+
+        fused_out = (
+            torch.randn(M, K, dtype=dtype) / math.sqrt(K)
+            if apply_scaling_factor
+            else None
+        )
+        routed_scaling_factor = routed_scaling_factor if apply_scaling_factor else None
+        a2 = a.clone()
+
+        # ref
+        ic0 = torch.matmul(a.float(), w1dq.squeeze(0).transpose(0, 1))
+        ic1 = SiluAndMul(ic0)
+        shared_out = torch.matmul(ic1, w2dq.squeeze(0).transpose(0, 1))
+        ref_out = shared_out + (
+            fused_out.float() * routed_scaling_factor if apply_scaling_factor else 0
+        )
+        ref_out = ref_out.to(dtype=dtype)
+
+        # change back to 2D
+        w1q, w2q = w1q.squeeze(0), w2q.squeeze(0)
+        w1s, w2s = w1s.squeeze(0), w2s.squeeze(0)
+
+        w1 = kernel.convert_weight_packed(w1q)
+        w2 = kernel.convert_weight_packed(w2q)
+        w1s = kernel.convert_scale_packed(w1s)
+        w2s = kernel.convert_scale_packed(w2s)
+        out = torch.ops.sgl_kernel.shared_expert_cpu(
+            a2,
+            w1,
+            w2,
+            fused_out,
+            routed_scaling_factor,
+            True,
+            False,
+            False,
+            True,
+            w1s,
+            w2s,
+            [BLOCK_N, BLOCK_K],
+            None,
+            None,
+            True,
+        )
+
+        atol = rtol = precision[ref_out.dtype]
+        torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_store_cache.py
+++ b/test/srt/cpu/test_store_cache.py
@@ -1,0 +1,486 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+
+# Reference implementation (from index_buf_accessor_v4.py)
+def _set_k_and_s_torch(buf, loc, k_nope, k_rope, scale_k_nope, page_size):
+    num_pages, buf_numel_per_page = buf.shape
+    (num_tokens_to_write,) = loc.shape
+
+    nope_dim = k_nope.shape[1]
+    rope_dim = k_rope.shape[1]
+    scale_dim = scale_k_nope.shape[1]
+
+    buf_fp8 = buf.view(fp8_dtype).flatten()
+    buf_bf16 = buf.view(torch.bfloat16).flatten()
+    buf_scale = buf.view(torch.uint8).flatten()
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    s_offset_nbytes_in_page = page_size * (nope_dim + rope_dim * 2)
+
+    nope_offset = loc_page_index * buf_numel_per_page + loc_token_offset_in_page * (
+        nope_dim + rope_dim * 2
+    )
+
+    rope_offset = (
+        loc_page_index * buf_numel_per_page // 2
+        + (loc_token_offset_in_page * (nope_dim + rope_dim * 2) + nope_dim) // 2
+    )
+
+    s_offset = (
+        loc_page_index * buf_numel_per_page
+        + s_offset_nbytes_in_page
+        + loc_token_offset_in_page * (scale_dim + 1)
+    )
+
+    for i in range(num_tokens_to_write):
+        buf_fp8[nope_offset[i] : nope_offset[i] + nope_dim] = k_nope[i]
+        buf_bf16[rope_offset[i] : rope_offset[i] + rope_dim] = k_rope[i]
+        buf_scale[s_offset[i] : s_offset[i] + scale_dim] = scale_k_nope[i]
+
+
+def make_test_data(
+    num_pages, page_size, num_tokens, nope_dim=448, rope_dim=64, scale_dim=7
+):
+    """Create test data matching the buffer layout."""
+    nope_rope_bytes_per_token = nope_dim + rope_dim * 2
+    s_bytes_per_token = scale_dim + 1
+    buf_numel_per_page = (
+        page_size * nope_rope_bytes_per_token + page_size * s_bytes_per_token
+    )
+
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    # Generate random non-overlapping locations
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    k_nope = torch.randint(0, 256, (num_tokens, nope_dim), dtype=torch.uint8).view(
+        fp8_dtype
+    )
+    k_rope = torch.randn(num_tokens, rope_dim, dtype=torch.bfloat16)
+    scale_k_nope = torch.randint(0, 256, (num_tokens, scale_dim), dtype=torch.uint8)
+
+    return buf, loc, k_nope, k_rope, scale_k_nope
+
+
+class TestSetKAndS(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_k_and_s(self, num_pages, page_size, num_tokens):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, page_size)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc, k_nope, k_rope, scale_k_nope, page_size
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_and_s(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_k_and_s(*params)
+
+    def test_set_k_and_s_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(8, 16, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, 16)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc_i32, k_nope, k_rope, scale_k_nope, 16
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_and_s_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 16, 512
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, page_size)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc, k_nope, k_rope, scale_k_nope, page_size
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
+# ===========================================================================
+# Reference for quant_to_nope_fp8_rope_bf16_pack
+# ===========================================================================
+
+
+def _cast_scale_inv_to_ue8m0(scales_inv, out_dtype=torch.float32):
+    return torch.pow(2, torch.clamp_min(scales_inv, 1e-4).log2().ceil()).to(out_dtype)
+
+
+def quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16):
+    """Reference implementation from quant_k_cache_v4.py."""
+    assert k_bf16.dtype == torch.bfloat16
+    _num_tokens, hidden_dim = k_bf16.shape
+    assert hidden_dim == 512
+    dim_nope = 448
+    dim_rope = 64
+
+    k_nope_bf16, k_rope_bf16 = k_bf16.split([dim_nope, dim_rope], dim=-1)
+
+    tile_size = 64
+    num_tiles = dim_nope // tile_size
+
+    x = k_nope_bf16.contiguous().view(-1, num_tiles, tile_size)
+    scale = x.abs().amax(dim=-1).float() / 448.0
+    scale_pow2_fp32 = _cast_scale_inv_to_ue8m0(scale, out_dtype=torch.float32)
+    scale_k_nope_ue8m0 = scale_pow2_fp32.to(torch.float8_e8m0fnu)
+    k_nope_fp8 = (x.float() / scale_pow2_fp32.unsqueeze(-1)).to(fp8_dtype)
+    k_nope_fp8 = k_nope_fp8.view(-1, tile_size * num_tiles)
+    scale_k_nope_ue8m0 = scale_k_nope_ue8m0.view(torch.uint8)
+
+    return k_nope_fp8, k_rope_bf16.contiguous(), scale_k_nope_ue8m0
+
+
+class TestQuantToNopeFp8RopeBf16Pack(CustomTestCase):
+    num_tokens_list = [1, 7, 32, 128, 512]
+
+    def _test_quant(self, num_tokens):
+        k_bf16 = torch.randn(num_tokens, 512, dtype=torch.bfloat16)
+
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_various_sizes(self):
+        for num_tokens in self.num_tokens_list:
+            with self.subTest(num_tokens=num_tokens):
+                self._test_quant(num_tokens)
+
+    def test_quant_small_values(self):
+        """Test with very small values that exercise the EPS clamp."""
+        k_bf16 = torch.randn(16, 512, dtype=torch.bfloat16) * 1e-6
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_large_values(self):
+        """Test with large values."""
+        k_bf16 = torch.randn(16, 512, dtype=torch.bfloat16) * 100.0
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_zeros(self):
+        """Test with zero input."""
+        k_bf16 = torch.zeros(8, 512, dtype=torch.bfloat16)
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_output_shapes_and_dtypes(self):
+        """Verify output shapes and dtypes."""
+        num_tokens = 16
+        k_bf16 = torch.randn(num_tokens, 512, dtype=torch.bfloat16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+
+        self.assertEqual(cpp_nope.shape, (num_tokens, 448))
+        self.assertEqual(cpp_rope.shape, (num_tokens, 64))
+        self.assertEqual(cpp_scale.shape, (num_tokens, 7))
+
+        self.assertEqual(cpp_nope.dtype, fp8_dtype)
+        self.assertEqual(cpp_rope.dtype, torch.bfloat16)
+        self.assertEqual(cpp_scale.dtype, torch.uint8)
+
+
+# ===========================================================================
+# Reference for set_k (from index_buf_accessor.py SetK.torch_fast)
+# ===========================================================================
+
+
+def _set_k_torch(buf, loc, index_k, page_size, index_head_dim):
+    """Reference implementation matching SetK.torch_fast."""
+    (num_tokens_to_write,) = loc.shape
+    buf_numel_per_page = buf.shape[1]
+    num_k_bytes_per_token = index_head_dim
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    flat_buf = buf.flatten()
+    flat_indices = (
+        (loc_page_index * buf_numel_per_page)[:, None]
+        + (loc_token_offset_in_page * num_k_bytes_per_token)[:, None]
+        + torch.arange(num_k_bytes_per_token, dtype=torch.int32, device="cpu")[None, :]
+    )
+    num_k_bytes_total = num_tokens_to_write * num_k_bytes_per_token
+    flat_indices = flat_indices.flatten()[:num_k_bytes_total]
+    flat_buf[flat_indices] = index_k.view(torch.uint8).flatten()
+
+
+def make_set_k_test_data(num_pages, page_size, num_tokens, index_head_dim=128):
+    """Create test data for set_k_cpu."""
+    buf_numel_per_page = page_size * index_head_dim + page_size * 4
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    index_k = torch.randint(
+        0, 256, (num_tokens, index_head_dim), dtype=torch.uint8
+    ).view(fp8_dtype)
+
+    return buf, loc, index_k
+
+
+class TestSetK(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16, 64]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_k(self, num_pages, page_size, num_tokens, index_head_dim=128):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, index_k = make_set_k_test_data(
+            num_pages, page_size, num_tokens, index_head_dim
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_k_torch(buf_ref, loc, index_k, page_size, index_head_dim)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_cpu(
+            buf_test, loc, index_k, page_size, index_head_dim
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_k(*params)
+
+    def test_set_k_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, index_k = make_set_k_test_data(8, 64, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_k_torch(buf_ref, loc, index_k, 64, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_cpu(buf_test, loc_i32, index_k, 64, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 64, 2048
+        buf, loc, index_k = make_set_k_test_data(num_pages, page_size, num_tokens)
+
+        buf_ref = buf.clone()
+        _set_k_torch(buf_ref, loc, index_k, page_size, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_cpu(buf_test, loc, index_k, page_size, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
+# ===========================================================================
+# Reference for set_s (from index_buf_accessor.py SetS.torch_fast)
+# ===========================================================================
+
+
+def _set_s_torch(buf, loc, index_k_scale, page_size, index_head_dim):
+    """Reference implementation matching SetS.torch_fast."""
+    (num_tokens_to_write,) = loc.shape
+    buf_numel_per_page = buf.shape[1]
+    num_s_bytes_per_token = 4
+    s_offset_in_page = page_size * index_head_dim
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    flat_buf = buf.flatten()
+    flat_indices = (
+        (loc_page_index * buf_numel_per_page)[:, None]
+        + s_offset_in_page
+        + (loc_token_offset_in_page * num_s_bytes_per_token)[:, None]
+        + torch.arange(num_s_bytes_per_token, dtype=torch.int32, device="cpu")[None, :]
+    )
+    number_s_bytes_total = num_tokens_to_write * num_s_bytes_per_token
+    flat_indices = flat_indices.flatten()[:number_s_bytes_total]
+    flat_buf[flat_indices] = index_k_scale.view(torch.uint8).flatten()
+
+
+def make_set_s_test_data(num_pages, page_size, num_tokens, index_head_dim=128):
+    """Create test data for set_s_cpu."""
+    buf_numel_per_page = page_size * index_head_dim + page_size * 4
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    index_k_scale = torch.randn(num_tokens, dtype=torch.float32)
+
+    return buf, loc, index_k_scale
+
+
+class TestSetS(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16, 64]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_s(self, num_pages, page_size, num_tokens, index_head_dim=128):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, index_k_scale = make_set_s_test_data(
+            num_pages, page_size, num_tokens, index_head_dim
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale, page_size, index_head_dim)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(
+            buf_test, loc, index_k_scale, page_size, index_head_dim
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_s(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_s(*params)
+
+    def test_set_s_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, index_k_scale = make_set_s_test_data(8, 64, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale, 64, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(buf_test, loc_i32, index_k_scale, 64, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_s_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 64, 2048
+        buf, loc, index_k_scale = make_set_s_test_data(num_pages, page_size, num_tokens)
+
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale, page_size, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(buf_test, loc, index_k_scale, page_size, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_s_2d_scale(self):
+        """Test with 2D scale tensor (num_tokens, 1)."""
+        num_pages, page_size, num_tokens = 8, 64, 20
+        buf_numel_per_page = page_size * 128 + page_size * 4
+        buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+        total_slots = num_pages * page_size
+        perm = torch.randperm(total_slots)[:num_tokens]
+        loc = perm.to(torch.int64)
+        index_k_scale = torch.randn(num_tokens, 1, dtype=torch.float32)
+
+        buf_ref = buf.clone()
+        _set_s_torch(buf_ref, loc, index_k_scale.squeeze(1), page_size, 128)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_s_cpu(buf_test, loc, index_k_scale, page_size, 128)
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_topk.py
+++ b/test/srt/cpu/test_topk.py
@@ -1,7 +1,15 @@
 import unittest
+from typing import Optional
 
 import torch
 
+from sglang.srt.eplb.expert_location_dispatch import (
+    ExpertLocationDispatchInfo,
+    topk_ids_logical_to_physical,
+)
+from sglang.srt.layers.moe.topk import (
+    _mask_topk_ids_padded_region,
+)
 from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
 )
@@ -11,6 +19,67 @@ from sglang.srt.models.llama4 import Llama4MoE
 from sglang.test.test_utils import CustomTestCase
 
 torch.manual_seed(1234)
+
+
+def native_biased_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    scoring_func: str = "sigmoid",
+    num_fused_shared_experts: int = 0,
+    routed_scaling_factor: Optional[float] = None,
+    num_token_non_padded: Optional[torch.Tensor] = None,
+    expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
+    apply_routed_scaling_factor_on_output: Optional[bool] = False,
+):
+    assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
+
+    if scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    elif scoring_func == "sqrtsoftplus":
+        scores = torch.nn.functional.softplus(gating_output).sqrt()
+
+    num_token = scores.shape[0]
+    num_experts = scores.shape[1]
+
+    scores_for_choice = scores.view(num_token, -1) + correction_bias.unsqueeze(0)
+    _, topk_ids = torch.topk(
+        scores_for_choice,
+        k=topk,
+        dim=-1,
+        sorted=(True if num_fused_shared_experts > 0 else False),
+    )
+    topk_weights = scores.gather(1, topk_ids)
+
+    if num_fused_shared_experts:
+        topk_ids[:, -1] = torch.randint(
+            low=num_experts,
+            high=num_experts + num_fused_shared_experts,
+            size=(topk_ids.size(0),),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        )
+        if routed_scaling_factor is not None:
+            topk_weights[:, -1] = (
+                topk_weights[:, :-1].sum(dim=-1) / routed_scaling_factor
+            )
+
+    if renormalize:
+        topk_weights_sum = (
+            topk_weights.sum(dim=-1, keepdim=True)
+            if num_fused_shared_experts == 0
+            else topk_weights[:, :-1].sum(dim=-1, keepdim=True)
+        )
+        topk_weights = topk_weights / topk_weights_sum
+        if apply_routed_scaling_factor_on_output:
+            topk_weights *= routed_scaling_factor
+
+    topk_weights, topk_ids = topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+    topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
+    _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    return topk_weights, topk_ids
 
 
 # This is used by the Deepseek-V2 model
@@ -214,6 +283,227 @@ class TestCustomTopK(CustomTestCase):
             self._run_single_test(
                 123, 32, 1, False, torch.bfloat16, native_custom_f, fused_custom_f
             )
+
+
+# biased topk (flat, non-grouped) for DeepSeek V4
+class TestBiasedTopK(CustomTestCase):
+    def _run_single_test(
+        self,
+        M,
+        E,
+        topk,
+        renormalize,
+        gating_dtype,
+        bias_dtype,
+        scoring_func,
+        num_fused_shared_experts=0,
+        routed_scaling_factor=None,
+    ):
+        torch.manual_seed(2024)
+
+        hidden_states = torch.randn(M, 100, dtype=torch.bfloat16)
+        gating_output = torch.randn(M, E, dtype=gating_dtype) * 2 * M
+        correction_bias = torch.randn(E, dtype=bias_dtype)
+
+        ref_topk_weights, ref_topk_ids = native_biased_topk(
+            hidden_states.float(),
+            gating_output.float(),
+            correction_bias.float(),
+            topk,
+            renormalize,
+            scoring_func=scoring_func,
+            num_fused_shared_experts=0,
+            routed_scaling_factor=None,
+        )
+
+        # fused version - use float32 inputs for consistent comparison
+        gating_float = gating_output.float()
+        bias_float = correction_bias.float()
+        topk_weights, topk_ids = torch.ops.sgl_kernel.biased_topk_cpu(
+            hidden_states,
+            gating_float,
+            bias_float,
+            topk,
+            renormalize,
+            scoring_func,
+            0,  # num_fused_shared_experts
+            None,  # routed_scaling_factor
+            False,  # apply_routed_scaling_factor_on_output
+        )
+
+        # Ties in biased scores can cause different expert selections between
+        # torch.topk and std::partial_sort, both are valid.
+        # We verify correctness by checking that all selected experts have biased
+        # scores >= all unselected experts (within tolerance).
+        gating_float = gating_output.float()
+        bias_float = correction_bias.float()
+        if scoring_func == "sigmoid":
+            scores = gating_float.sigmoid()
+        else:
+            scores = torch.nn.functional.softplus(gating_float).sqrt()
+        scores_biased = scores + bias_float.unsqueeze(0)
+
+        for i in range(M):
+            selected = topk_ids[i].long()
+            min_selected = scores_biased[i].gather(0, selected).min().item()
+            mask = torch.ones(E, dtype=torch.bool)
+            mask[selected] = False
+            if mask.any():
+                max_unselected = scores_biased[i][mask].max().item()
+                self.assertLessEqual(max_unselected, min_selected + 1e-5)
+
+        # For rows where the same experts are selected, weights should match
+        for i in range(M):
+            ref_set = set(ref_topk_ids[i].tolist())
+            fused_set = set(topk_ids[i].tolist())
+            if ref_set == fused_set:
+                # Same experts selected, compare weights via scatter
+                res_row = torch.zeros(E, dtype=torch.float)
+                ref_row = torch.zeros(E, dtype=torch.float)
+                res_row.scatter_(0, topk_ids[i].long(), topk_weights[i])
+                ref_row.scatter_(0, ref_topk_ids[i].long(), ref_topk_weights[i])
+                torch.testing.assert_close(res_row, ref_row, atol=1e-5, rtol=1e-4)
+
+    def test_biased_topk_sigmoid(self):
+        for renormalize in [True, False]:
+            for bias_dtype in [torch.float32, torch.bfloat16]:
+                for gating_dtype in [torch.float32, torch.bfloat16]:
+                    for E in [64, 128, 256]:
+                        self._run_single_test(
+                            34, E, 8, renormalize, gating_dtype, bias_dtype, "sigmoid"
+                        )
+
+    def test_biased_topk_sqrtsoftplus(self):
+        for renormalize in [True, False]:
+            for bias_dtype in [torch.float32, torch.bfloat16]:
+                for gating_dtype in [torch.float32, torch.bfloat16]:
+                    for E in [64, 128, 256]:
+                        self._run_single_test(
+                            34,
+                            E,
+                            8,
+                            renormalize,
+                            gating_dtype,
+                            bias_dtype,
+                            "sqrtsoftplus",
+                        )
+
+
+def hash_topk_native(
+    gating_output,
+    tid2eid,
+    topk,
+    scoring_func,
+    num_fused_shared_experts,
+    routed_scaling_factor,
+):
+    M = gating_output.size(0)
+    g = gating_output.float()
+    if scoring_func == "softmax":
+        scores = g.softmax(dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = g.sigmoid()
+    else:
+        scores = torch.nn.functional.softplus(g).sqrt()
+
+    topk_ids = torch.zeros(M, topk, dtype=torch.int32)
+    topk_weights = torch.zeros(M, topk, dtype=torch.float32)
+
+    if num_fused_shared_experts == 1:
+        topk_ids[:, :-1] = tid2eid
+        topk_weights[:, :-1] = scores.gather(1, tid2eid.long())
+        if scoring_func != "softmax":
+            topk_weights[:, :-1] /= topk_weights[:, :-1].sum(dim=-1, keepdim=True)
+        # shared expert weight = sum of routed weights / scaling_factor
+        topk_weights[:, -1] = topk_weights[:, :-1].sum(dim=-1) / routed_scaling_factor
+    else:
+        topk_ids[:, :] = tid2eid
+        topk_weights[:, :] = scores.gather(1, tid2eid.long())
+        if scoring_func != "softmax":
+            topk_weights[:, :] /= topk_weights[:, :].sum(dim=-1, keepdim=True)
+
+    return topk_weights, topk_ids
+
+
+# HashTopK for DeepSeek V4 (expert IDs from precomputed lookup table)
+class TestHashTopK(CustomTestCase):
+    def _run_single_test(
+        self,
+        M,
+        E,
+        topk,
+        scoring_func,
+        num_fused_shared_experts,
+        routed_scaling_factor,
+        gating_dtype,
+    ):
+        torch.manual_seed(2026)
+
+        routed_topk = topk - num_fused_shared_experts
+        # Simulate tid2eid: random expert assignments for each token
+        tid2eid = torch.randint(0, E, (M, routed_topk), dtype=torch.int32)
+        gating_output = torch.randn(M, E, dtype=gating_dtype) * 2 * M
+
+        ref_topk_weights, ref_topk_ids = hash_topk_native(
+            gating_output,
+            tid2eid,
+            topk,
+            scoring_func,
+            num_fused_shared_experts,
+            routed_scaling_factor,
+        )
+
+        # Fused kernel
+        fused_w, fused_ids = torch.ops.sgl_kernel.hash_topk_cpu(
+            gating_output,
+            tid2eid,
+            topk,
+            scoring_func,
+            num_fused_shared_experts,
+            E,
+            routed_scaling_factor,
+        )
+
+        # Compare routed expert IDs (all slots for no-fused, or :-1 for fused)
+        if num_fused_shared_experts == 1:
+            torch.testing.assert_close(
+                fused_ids[:, :-1], ref_topk_ids[:, :-1], atol=0, rtol=0
+            )
+            # Shared expert ID should be in [E, E + num_fused_shared_experts)
+            self.assertTrue((fused_ids[:, -1] >= E).all())
+            self.assertTrue((fused_ids[:, -1] < E + num_fused_shared_experts).all())
+            # Compare routed weights (use allclose to avoid NaN relative diff from underflow)
+            self.assertTrue(
+                torch.allclose(
+                    fused_w[:, :-1], ref_topk_weights[:, :-1], atol=2e-4, rtol=0
+                ),
+                f"routed weights mismatch: max abs diff = {(fused_w[:, :-1] - ref_topk_weights[:, :-1]).abs().max()}",
+            )
+            # Compare shared expert weights
+            self.assertTrue(
+                torch.allclose(
+                    fused_w[:, -1], ref_topk_weights[:, -1], atol=2e-4, rtol=0
+                ),
+                f"shared weights mismatch: max abs diff = {(fused_w[:, -1] - ref_topk_weights[:, -1]).abs().max()}",
+            )
+        else:
+            torch.testing.assert_close(fused_ids, ref_topk_ids, atol=0, rtol=0)
+            self.assertTrue(
+                torch.allclose(fused_w, ref_topk_weights, atol=2e-4, rtol=0),
+                f"weights mismatch: max abs diff = {(fused_w - ref_topk_weights).abs().max()}",
+            )
+
+    def test_hash_topk_no_fused(self):
+        for scoring_func in ["softmax", "sigmoid", "sqrtsoftplus"]:
+            for gating_dtype in [torch.float32, torch.bfloat16]:
+                for E in [64, 128, 256]:
+                    self._run_single_test(34, E, 8, scoring_func, 0, 1.5, gating_dtype)
+
+    def test_hash_topk_with_fused(self):
+        for scoring_func in ["sigmoid", "sqrtsoftplus"]:
+            for gating_dtype in [torch.float32, torch.bfloat16]:
+                for E in [64, 128, 256]:
+                    self._run_single_test(34, E, 8, scoring_func, 1, 1.5, gating_dtype)
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_topk_transform_512_cpu.py
+++ b/test/srt/cpu/test_topk_transform_512_cpu.py
@@ -1,0 +1,198 @@
+import unittest
+from typing import Optional
+
+import sgl_kernel  # noqa: F401
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+TOPK = 512
+
+
+def topk_transform_512_pytorch_vectorized(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+
+    TOPK = 512
+    batch_size = scores.shape[0]
+    max_seq_len = scores.shape[1]
+    device = scores.device
+
+    page_bits = (page_size - 1).bit_length() if page_size > 1 else 0
+    page_mask = page_size - 1
+
+    positions = (
+        torch.arange(max_seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+    )
+    valid_mask = positions < seq_lens.unsqueeze(1)
+
+    masked_scores = scores.clone()
+    masked_scores[~valid_mask] = float("-inf")
+
+    actual_k = min(TOPK, max_seq_len)
+    _, raw_indices = torch.topk(
+        masked_scores, k=actual_k, dim=1, largest=True, sorted=False
+    )
+    raw_indices = raw_indices.to(torch.int32)
+
+    if actual_k < TOPK:
+        padding = torch.zeros(
+            (batch_size, TOPK - actual_k), dtype=torch.int32, device=device
+        )
+        raw_indices = torch.cat([raw_indices, padding], dim=1)
+
+    batch_indices = (
+        torch.arange(batch_size, device=device).unsqueeze(1).expand(-1, TOPK)
+    )
+    gathered_scores = scores[
+        batch_indices.flatten(), raw_indices.clamp(min=0).flatten()
+    ].view(batch_size, TOPK)
+
+    valid_topk = gathered_scores != float("-inf")
+    if actual_k < TOPK:
+        pad_mask = torch.arange(TOPK, device=device).unsqueeze(0) >= actual_k
+        valid_topk = valid_topk & ~pad_mask
+
+    needs_sequential = seq_lens <= TOPK
+    if needs_sequential.any():
+        sequential_indices = (
+            torch.arange(TOPK, device=device, dtype=torch.int32)
+            .unsqueeze(0)
+            .expand(batch_size, -1)
+        )
+        sequential_valid = sequential_indices < seq_lens.unsqueeze(1)
+
+        raw_indices = torch.where(
+            needs_sequential.unsqueeze(1).expand(-1, TOPK),
+            torch.where(
+                sequential_valid,
+                sequential_indices,
+                torch.tensor(-1, device=device, dtype=torch.int32),
+            ),
+            raw_indices,
+        )
+        valid_topk = torch.where(
+            needs_sequential.unsqueeze(1).expand(-1, TOPK), sequential_valid, valid_topk
+        )
+
+    page_idx = raw_indices >> page_bits
+    offset_in_page = raw_indices & page_mask
+
+    page_idx_clamped = torch.clamp(page_idx, min=0)
+    physical_pages = torch.gather(page_tables, dim=1, index=page_idx_clamped.long())
+
+    page_indices = (physical_pages << page_bits) | offset_in_page
+    page_indices = page_indices.to(torch.int32)
+
+    page_indices = torch.where(
+        valid_topk, page_indices, torch.tensor(-1, device=device, dtype=torch.int32)
+    )
+
+    out_page_indices.copy_(page_indices)
+
+    if out_raw_indices is not None:
+        raw_indices = torch.where(
+            valid_topk, raw_indices, torch.tensor(-1, device=device, dtype=torch.int32)
+        )
+        out_raw_indices.copy_(raw_indices)
+
+
+class TestTopKTransform512CPU(CustomTestCase):
+    def _make_inputs(
+        self, batch_size, max_seq_len, page_size, seq_lens, page_dtype=torch.int32
+    ):
+        torch.manual_seed(2026)
+        scores = torch.randn(batch_size, max_seq_len, dtype=torch.float32)
+        scores += torch.arange(max_seq_len, dtype=torch.float32).unsqueeze(0) * 1e-6
+        seq_lens = torch.tensor(seq_lens, dtype=torch.int32)
+        num_pages = (max_seq_len + page_size - 1) // page_size
+        page_tables = (
+            torch.arange(batch_size * num_pages, dtype=page_dtype).reshape(
+                batch_size, num_pages
+            )
+            + 17
+        ).contiguous()
+        return scores.contiguous(), seq_lens, page_tables
+
+    def _run_pytorch_reference(self, scores, seq_lens, page_tables, page_size):
+        ref_page_indices = torch.empty((scores.size(0), TOPK), dtype=torch.int32)
+        ref_raw_indices = torch.empty_like(ref_page_indices)
+        topk_transform_512_pytorch_vectorized(
+            scores,
+            seq_lens,
+            page_tables,
+            ref_page_indices,
+            page_size,
+            ref_raw_indices,
+        )
+        return ref_page_indices, ref_raw_indices
+
+    def _assert_rows_equivalent(self, actual, expected, seq_lens):
+        for row, seq_len in enumerate(seq_lens.tolist()):
+            if seq_len <= TOPK:
+                torch.testing.assert_close(actual[row], expected[row], atol=0, rtol=0)
+            else:
+                actual_valid = actual[row][actual[row] >= 0].sort().values
+                expected_valid = expected[row][expected[row] >= 0].sort().values
+                torch.testing.assert_close(actual_valid, expected_valid, atol=0, rtol=0)
+                self.assertTrue((actual[row][actual[row] < 0] == -1).all())
+
+    def test_matches_reference_with_raw_indices(self):
+        page_size = 64
+        scores, seq_lens, page_tables = self._make_inputs(
+            batch_size=4,
+            max_seq_len=1536,
+            page_size=page_size,
+            seq_lens=[0, 17, 512, 1299],
+        )
+        out_page_indices = torch.empty((scores.size(0), TOPK), dtype=torch.int32)
+        out_raw_indices = torch.empty_like(out_page_indices)
+
+        torch.ops.sgl_kernel.topk_transform_512_cpu(
+            scores,
+            seq_lens,
+            page_tables,
+            out_page_indices,
+            page_size,
+            out_raw_indices,
+        )
+        ref_page_indices, ref_raw_indices = self._run_pytorch_reference(
+            scores, seq_lens, page_tables, page_size
+        )
+
+        self._assert_rows_equivalent(out_raw_indices, ref_raw_indices, seq_lens)
+        self._assert_rows_equivalent(out_page_indices, ref_page_indices, seq_lens)
+
+    def test_matches_reference_without_raw_indices(self):
+        page_size = 32
+        scores, seq_lens, page_tables = self._make_inputs(
+            batch_size=3,
+            max_seq_len=777,
+            page_size=page_size,
+            seq_lens=[1, 600, 777],
+            page_dtype=torch.int64,
+        )
+        out_page_indices = torch.empty((scores.size(0), TOPK), dtype=torch.int32)
+
+        torch.ops.sgl_kernel.topk_transform_512_cpu(
+            scores,
+            seq_lens.to(torch.int64),
+            page_tables,
+            out_page_indices,
+            page_size,
+            None,
+        )
+        ref_page_indices, _ = self._run_pytorch_reference(
+            scores, seq_lens, page_tables, page_size
+        )
+
+        self._assert_rows_equivalent(out_page_indices, ref_page_indices, seq_lens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/utils.py
+++ b/test/srt/cpu/utils.py
@@ -39,6 +39,15 @@ def GeluAndMul(x: torch.Tensor, approximate="tanh") -> torch.Tensor:
     return F.gelu(x[..., :d], approximate=approximate) * x[..., d:]
 
 
+# Reference: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/fd53f944496234770ba80e15004f9b6d269a71f5/inference/model.py#L600-L603
+def ClampedSiluAndMul(x: torch.Tensor, limit: float) -> torch.Tensor:
+    """DSV4-2604B activation: clamp gate upper, clamp up symmetric, silu(gate)*up."""
+    d = x.shape[-1] // 2
+    gate = x[..., :d].clamp(max=limit)
+    up = x[..., d:].clamp(min=-limit, max=limit)
+    return F.silu(gate) * up
+
+
 def per_token_quant_int8(x):
     x = x.float()
     absmax = x.abs().max(dim=-1).values
@@ -126,7 +135,9 @@ def native_w8a8_per_token_matmul(A, B, As, Bs, bias, output_dtype=torch.bfloat16
     return C.reshape(origin_C_shape).to(output_dtype)
 
 
-def torch_naive_moe(a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bfloat16):
+def _torch_naive_moe_with_act(
+    a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bfloat16, act_fn=SiluAndMul
+):
 
     a = a.to(torch.float32)
     w1 = w1.to(torch.float32)
@@ -134,12 +145,32 @@ def torch_naive_moe(a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bflo
     b = b.to(torch.float32) if b is not None else None
 
     ic1 = torch.matmul(a, w1.transpose(0, 1))
-    ic2 = SiluAndMul(ic1)
+    ic2 = act_fn(ic1)
     ic3 = torch.matmul(ic2, w2.transpose(0, 1))
 
     out = ic3 if b is None else ic3 + b * routed_scaling_factor
 
     return out.to(output_dtype)
+
+
+def torch_naive_moe(a, w1, w2, b, routed_scaling_factor, output_dtype=torch.bfloat16):
+    return _torch_naive_moe_with_act(
+        a, w1, w2, b, routed_scaling_factor, output_dtype, act_fn=SiluAndMul
+    )
+
+
+def torch_naive_clamped_silu_moe(
+    a, w1, w2, b, routed_scaling_factor, limit, output_dtype=torch.bfloat16
+):
+    return _torch_naive_moe_with_act(
+        a,
+        w1,
+        w2,
+        b,
+        routed_scaling_factor,
+        output_dtype,
+        act_fn=lambda x: ClampedSiluAndMul(x, limit),
+    )
 
 
 def torch_w8a8_per_column_moe(
@@ -221,6 +252,107 @@ def torch_naive_fused_moe(a, w1, w2, score, topk, renormalize):
     ).sum(dim=1)
 
 
+def moe_gptoss_act(x, alpha: float = 1.702, limit: float = 7.0):
+    x_glu, x_linear = x[..., ::2], x[..., 1::2]
+    # Clamp the input values
+    x_glu = x_glu.clamp(min=None, max=limit)
+    x_linear = x_linear.clamp(min=-limit, max=limit)
+    out_glu = x_glu * torch.sigmoid(alpha * x_glu)
+    # Note we add an extra bias of 1 to the linear layer
+    return out_glu * (x_linear + 1.0)
+
+
+def torch_naive_gptoss_fused_moe(
+    x,
+    w1,
+    w2,
+    w1_bias,
+    w2_bias,
+    topk_weights,
+    topk_ids,
+    activation_alpha,
+    swiglu_limit,
+    len_experts,
+) -> torch.Tensor:
+
+    # Ref code from https://huggingface.co/deepseek-ai/DeepSeek-V2/blob/e0828e3cc0a03408724b80c3cc92c8e072db8d01/modeling_deepseek.py#L589
+    cnts = topk_ids.new_zeros((topk_ids.shape[0], len_experts))
+    cnts.scatter_(1, topk_ids.to(torch.int64), 1)
+    tokens_per_expert = cnts.sum(dim=0)
+    idxs = topk_ids.view(-1).argsort()
+
+    sorted_tokens = x[idxs // topk_ids.shape[1]]
+    tokens_per_expert = tokens_per_expert.cpu().numpy()
+
+    outputs = []
+    start_idx = 0
+    for i, num_tokens in enumerate(tokens_per_expert):
+        end_idx = start_idx + num_tokens
+        if num_tokens == 0:
+            continue
+        tokens_for_this_expert = sorted_tokens[start_idx:end_idx]
+
+        layer_w13_weight = w1[i]
+        layer_w13_weight_bias = w1_bias[i]
+        layer_w2_weight_bias = w2_bias[i]
+        layer_w2_weight = w2[i]
+
+        gate_up = F.linear(
+            tokens_for_this_expert,
+            layer_w13_weight,
+            bias=layer_w13_weight_bias.to(torch.bfloat16),
+        )
+        gate_up = moe_gptoss_act(gate_up, activation_alpha, swiglu_limit)
+        expert_out = F.linear(
+            gate_up, layer_w2_weight, bias=layer_w2_weight_bias.to(torch.bfloat16)
+        )
+        outputs.append(expert_out)
+        start_idx = end_idx
+
+    outs = torch.cat(outputs, dim=0) if len(outputs) else sorted_tokens.new_empty(0)
+    new_x = torch.empty_like(outs)
+
+    new_x[idxs] = outs
+    final_out = (
+        new_x.view(*topk_ids.shape, -1)
+        .type(topk_weights.dtype)
+        .mul_(topk_weights.unsqueeze(dim=-1))
+        .sum(dim=1)
+        .type(new_x.dtype)
+    )
+    return final_out
+
+
+def torch_naive_fused_moe_gptoss(
+    a,
+    w1,
+    w2,
+    w1_bias,
+    w2_bias,
+    topk_weight,
+    topk_ids,
+    renormalize,
+    activation_alpha,
+    swiglu_limit,
+    len_experts,
+):
+    if renormalize:
+        topk_weight = topk_weight / topk_weight.sum(dim=-1, keepdim=True)
+
+    return torch_naive_gptoss_fused_moe(
+        a,
+        w1,
+        w2,
+        w1_bias,
+        w2_bias,
+        topk_weight,
+        topk_ids,
+        activation_alpha,
+        swiglu_limit,
+        len_experts,
+    )
+
+
 def torch_w8a8_per_column_fused_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, topk):
     """This function performs fused moe with per-column int8 quantization using native torch."""
 
@@ -272,6 +404,24 @@ def torch_w8a8_per_column_fused_moe(a, w1, w2, w1_s, w2_s, topk_weight, topk_ids
 
 
 def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
+    return _native_fused_moe_with_act(
+        a, w1, w2, topk_weight, topk_ids, topk, SiluAndMul
+    )
+
+
+def native_clamped_silu_fused_moe(a, w1, w2, topk_weight, topk_ids, topk, limit):
+    return _native_fused_moe_with_act(
+        a,
+        w1,
+        w2,
+        topk_weight,
+        topk_ids,
+        topk,
+        lambda x: ClampedSiluAndMul(x, limit),
+    )
+
+
+def _native_fused_moe_with_act(a, w1, w2, topk_weight, topk_ids, topk, act_fn):
     B, D = a.shape
     a = a.view(B, -1, D).repeat(1, topk, 1).reshape(-1, D).float()
     out = torch.zeros(B * topk, w2.shape[1], dtype=torch.float32, device=a.device)
@@ -284,7 +434,7 @@ def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
         mask = topk_ids == i
         if mask.sum():
             ic0 = torch.matmul(a[mask], w1[i].transpose(0, 1))
-            ic1 = SiluAndMul(ic0)
+            ic1 = act_fn(ic0)
             out[mask] = torch.matmul(ic1, w2[i].transpose(0, 1))
 
     return (
@@ -292,6 +442,121 @@ def native_fp8_fused_moe(a, w1, w2, topk_weight, topk_ids, topk):
         .sum(dim=1)
         .to(a.dtype)
     )
+
+
+# https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/modelopt/torch/quantization/qtensor/mxfp4_tensor.py
+class MXFP4QuantizeUtil:
+    E2M1_max = 6.0
+
+    E2M1_values = [0, 0.5, 1, 1.5, 2, 3, 4, 6]
+    E2M1_bounds = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5])
+
+    block_size = 32
+
+    @classmethod
+    def quantize(cls, input: torch.Tensor) -> tuple:
+        """Converting a tensor to a quantized format based on MXFP4 quantization. Only E4M3 is supported.
+        Args:
+            input (torch.Tensor): The input tensor to be quantized.
+        """
+
+        def cast_fp4(x):
+            sign = torch.sign(x)
+            sign_bit = (2 - sign) // 2
+            ord_ = torch.sum(
+                (x.abs().unsqueeze(-1) - cls.E2M1_bounds.to(x.device)) > 0, dim=-1
+            )
+            fp4_val = (sign_bit * 0b1000 + ord_).to(torch.uint8)
+            return fp4_val
+
+        def fuse_uint4_to_uint8(x):
+            # If the last dimension is odd, pad with zeros
+            # If this behavior is not desired, please modify the code accordingly
+            left_side = x[..., 0::2]  # Even indices (0, 2, 4...)
+            right_side = x[..., 1::2]  # Odd indices (1, 3, 5...)
+            new_data = (
+                right_side.clone() << 4
+            )  # Put odd indices (higher addresses) in high bits
+            new_data[
+                ..., : left_side.shape[-1]
+            ] += left_side  # Put even indices in low bits
+            return new_data
+
+        original_shape = input.shape
+        original_dtype = input.dtype
+        input = input.view(-1, cls.block_size)
+        # get scales
+        input_amax = input.abs().max(dim=-1, keepdim=True).values
+        descale = input_amax / cls.E2M1_max
+        min_value = torch.tensor(-127.0, device=descale.device)
+        e8m0_scale = torch.ceil(torch.maximum(torch.log2(descale), min_value))
+
+        input = (input / torch.exp2(e8m0_scale)).view(original_shape)
+        input_q = cast_fp4(input)
+        input_q = fuse_uint4_to_uint8(input_q)
+        e8m0_scale = (e8m0_scale + 127).to(torch.uint8)
+        return input_q, e8m0_scale
+
+    @classmethod
+    def dequantize(cls, quantized_data, dtype: torch.dtype, scale):
+        """Dequantze MXFP4 packed tensor to a target dtype."""
+
+        def unfuse_uint8_to_uint4(x):
+            """Unfuse uint8 values back to uint4 values.
+            This is the inverse operation of fuse_uint4_to_uint8.
+            """
+            # Extract the lower 4 bits (even indices)
+            left_side = x & 0x0F
+
+            # Extract the upper 4 bits (odd indices)
+            right_side = (x >> 4) & 0x0F
+
+            # Create a new tensor with alternating values
+            shape = list(x.shape)
+            shape[-1] = shape[-1] * 2
+            result = torch.zeros(shape, dtype=torch.uint8, device=x.device)
+
+            # Fill in the values - even indices get low bits, odd indices get high bits
+            result[..., 0::2] = left_side  # Even indices from low bits
+            result[..., 1::2] = right_side  # Odd indices from high bits
+
+            return result
+
+        e8m0_scale = scale
+
+        # Unfuse the uint8 values back to uint4
+        x_unfused = unfuse_uint8_to_uint4(quantized_data)
+        # print("@@@ x_unfused: ", x_unfused)
+        # Extract sign and magnitude
+        sign = 1 - 2 * ((x_unfused & 0b1000) >> 3).to(
+            torch.float32
+        )  # Extract sign bit and convert to +1/-1
+        magnitude = x_unfused & 0b0111  # Extract magnitude bits
+        magnitude = magnitude.to(torch.long)
+
+        # Create a tensor with the E2M1 values
+        values = torch.tensor(cls.E2M1_values, device=quantized_data.device)
+
+        # Use gather to index the values tensor properly
+        # We need to reshape magnitude to match the dimensions we want to gather along
+        original_shape = magnitude.shape
+        x_float = values[magnitude.reshape(-1)].reshape(original_shape)
+
+        # Apply sign and scale
+        x_float = sign.float() * x_float
+
+        # Reshape to apply block-wise scaling
+        x_float = x_float.reshape(-1, cls.block_size)
+
+        # Apply the E8M0 scale
+        scale_factor = torch.exp2(e8m0_scale.float() - 127)
+        scale_factor = scale_factor.reshape(-1, 1)  # Reshape for proper broadcasting
+
+        # Apply scaling and reshape back to original shape
+        x_float = x_float * scale_factor
+
+        # Reshape back to the original shape
+        return x_float.reshape(original_shape).to(dtype)
 
 
 def make_non_contiguous(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

Rewrite the DSV4 CPU support branch directly on top of `main` instead of rebasing through the divergent `intel_dev` history.

This keeps the current `main` baseline and replays the DeepSeek V4 CPU path files, including the request-state indexing fix for the non-paged DSV4 compressor state.

## Root Cause Fixed

`ReqToTokenPool` reserves row 0 as a dummy/padding row and allocates real request slots from `1..max_running_requests`. The DSV4 CPU non-paged compressor state must therefore allocate `max_num_reqs + 1` rows. Without the extra row, a request using the last valid pool slot can fail with:

```text
IndexError: index 2 is out of bounds for dimension 0 with size 2
```

## Rebase Strategy

`origin/master` does not exist; `origin/main` is the mainline branch. The earlier `intel_dev` history diverged heavily from `main`, so this PR now uses `main` directly and rewrites the DSV4 CPU changes onto it instead of resolving broad historical rebase/revert conflicts.

## Validation

- `PYTHONPATH=python:. .venv-mps312/bin/python -m unittest discover -s test/srt/cpu -p test_compressor.py -k state_includes_dummy`
- `py_compile` on DSV4 memory pool, compress state, compressor, and compressor test.

Remote AMX validation is being rerun on the rewritten main-based branch.