### PR TITLE
[SMG] Support regular worker discovery alongside PD workers in IGW mode

### DIFF
--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -985,6 +985,7 @@ impl Router {
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
                 router_selector: HashMap::new(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
+                igw_mode: self.enable_igw,
             })
         } else {
             None

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -973,7 +973,7 @@ impl Router {
         })?;
 
         let service_discovery_config = if self.service_discovery {
-            Some(service_discovery::ServiceDiscoveryConfig {
+            let config = service_discovery::ServiceDiscoveryConfig {
                 enabled: true,
                 selector: self.selector.clone(),
                 check_interval: std::time::Duration::from_secs(60),
@@ -986,7 +986,9 @@ impl Router {
                 router_selector: HashMap::new(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
                 igw_mode: self.enable_igw,
-            })
+            };
+            config.warn_if_misconfigured();
+            Some(config)
         } else {
             None
         };

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -1091,15 +1091,7 @@ impl CliArgs {
 
             let selector = Self::parse_selector(&self.selector);
 
-            if self.pd_disaggregation && !self.enable_igw && !selector.is_empty() {
-                tracing::warn!(
-                    "--selector is set in PD mode without --enable-igw; \
-                    regular worker discovery alongside PD workers requires IGW mode, \
-                    selector will be ignored"
-                );
-            }
-
-            Some(ServiceDiscoveryConfig {
+            let service_discovery_config = ServiceDiscoveryConfig {
                 enabled: true,
                 selector,
                 check_interval: std::time::Duration::from_secs(60),
@@ -1112,7 +1104,9 @@ impl CliArgs {
                 router_selector,
                 router_mesh_port_annotation,
                 igw_mode: self.enable_igw,
-            })
+            };
+            service_discovery_config.warn_if_misconfigured();
+            Some(service_discovery_config)
         } else {
             None
         };

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -1089,9 +1089,19 @@ impl CliArgs {
                 })
                 .unwrap_or_else(|| (HashMap::new(), "sglang.ai/mesh-port".to_string()));
 
+            let selector = Self::parse_selector(&self.selector);
+
+            if self.pd_disaggregation && !self.enable_igw && !selector.is_empty() {
+                tracing::warn!(
+                    "--selector is set in PD mode without --enable-igw; \
+                    regular worker discovery alongside PD workers requires IGW mode, \
+                    selector will be ignored"
+                );
+            }
+
             Some(ServiceDiscoveryConfig {
                 enabled: true,
-                selector: Self::parse_selector(&self.selector),
+                selector,
                 check_interval: std::time::Duration::from_secs(60),
                 port: self.service_discovery_port,
                 namespace: self.service_discovery_namespace.clone(),
@@ -1101,6 +1111,7 @@ impl CliArgs {
                 bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
                 router_selector,
                 router_mesh_port_annotation,
+                igw_mode: self.enable_igw,
             })
         } else {
             None

--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -45,6 +45,8 @@ pub struct ServiceDiscoveryConfig {
     // Router node discovery for mesh
     pub router_selector: HashMap<String, String>,
     pub router_mesh_port_annotation: String,
+    // When true (IGW mode), also discover selector pods as Regular workers alongside PD workers
+    pub igw_mode: bool,
 }
 
 impl Default for ServiceDiscoveryConfig {
@@ -61,6 +63,7 @@ impl Default for ServiceDiscoveryConfig {
             bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
             router_selector: HashMap::new(),
             router_mesh_port_annotation: "sglang.ai/ha-port".to_string(),
+            igw_mode: false,
         }
     }
 }
@@ -102,8 +105,13 @@ impl PodInfo {
                 warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
                 return false;
             }
-            Self::matches_selector(pod, &config.prefill_selector)
-                || Self::matches_selector(pod, &config.decode_selector)
+            let matches_pd = Self::matches_selector(pod, &config.prefill_selector)
+                || Self::matches_selector(pod, &config.decode_selector);
+            // In IGW mode, also discover regular workers via the selector field
+            let matches_regular = config.igw_mode
+                && !config.selector.is_empty()
+                && Self::matches_selector(pod, &config.selector);
+            matches_pd || matches_regular
         } else {
             if config.selector.is_empty() {
                 warn!("Regular mode enabled but selector is empty");
@@ -884,6 +892,35 @@ mod tests {
             bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
             router_selector: HashMap::new(),
             router_mesh_port_annotation: "sglang.ai/ha-port".to_string(),
+            igw_mode: false,
+        }
+    }
+
+    fn create_regular_k8s_pod(name: &str, ip: &str) -> Pod {
+        let mut labels = std::collections::BTreeMap::new();
+        labels.insert("app".to_string(), "regular-worker".to_string());
+
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                labels: Some(labels),
+                ..Default::default()
+            },
+            spec: Some(PodSpec::default()),
+            status: Some(PodStatus {
+                pod_ip: Some(ip.to_string()),
+                phase: Some("Running".to_string()),
+                conditions: Some(vec![PodCondition {
+                    type_: "Ready".to_string(),
+                    status: "True".to_string(),
+                    last_probe_time: None,
+                    last_transition_time: None,
+                    message: None,
+                    reason: None,
+                    observed_generation: None,
+                }]),
+                ..Default::default()
+            }),
         }
     }
 
@@ -1440,5 +1477,72 @@ mod tests {
 
         // Pod should be removed from tracking
         assert!(!tracked_pods.lock().unwrap().contains(&pod_info));
+    }
+
+    #[test]
+    fn test_should_include_mixed_pd_igw_regular_pod_included() {
+        let mut regular_selector = HashMap::new();
+        regular_selector.insert("app".to_string(), "regular-worker".to_string());
+
+        let mut prefill_selector = HashMap::new();
+        prefill_selector.insert("app".to_string(), "sglang".to_string());
+        prefill_selector.insert("component".to_string(), "prefill".to_string());
+
+        let mut decode_selector = HashMap::new();
+        decode_selector.insert("app".to_string(), "sglang".to_string());
+        decode_selector.insert("component".to_string(), "decode".to_string());
+
+        let config = ServiceDiscoveryConfig {
+            enabled: true,
+            selector: regular_selector,
+            check_interval: Duration::from_secs(60),
+            port: 8080,
+            namespace: None,
+            pd_mode: true,
+            prefill_selector,
+            decode_selector,
+            bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
+            router_selector: HashMap::new(),
+            router_mesh_port_annotation: "sglang.ai/ha-port".to_string(),
+            igw_mode: true,
+        };
+
+        let regular_pod = create_regular_k8s_pod("regular-pod", "10.0.1.1");
+        assert!(PodInfo::should_include(&regular_pod, &config));
+
+        let pod_info = PodInfo::from_pod(&regular_pod, Some(&config)).unwrap();
+        assert_eq!(pod_info.pod_type, Some(PodType::Regular));
+    }
+
+    #[test]
+    fn test_should_include_mixed_pd_no_igw_regular_pod_excluded() {
+        let mut regular_selector = HashMap::new();
+        regular_selector.insert("app".to_string(), "regular-worker".to_string());
+
+        let mut prefill_selector = HashMap::new();
+        prefill_selector.insert("app".to_string(), "sglang".to_string());
+        prefill_selector.insert("component".to_string(), "prefill".to_string());
+
+        let mut decode_selector = HashMap::new();
+        decode_selector.insert("app".to_string(), "sglang".to_string());
+        decode_selector.insert("component".to_string(), "decode".to_string());
+
+        let config = ServiceDiscoveryConfig {
+            enabled: true,
+            selector: regular_selector,
+            check_interval: Duration::from_secs(60),
+            port: 8080,
+            namespace: None,
+            pd_mode: true,
+            prefill_selector,
+            decode_selector,
+            bootstrap_port_annotation: "sglang.ai/bootstrap-port".to_string(),
+            router_selector: HashMap::new(),
+            router_mesh_port_annotation: "sglang.ai/ha-port".to_string(),
+            igw_mode: false,
+        };
+
+        let regular_pod = create_regular_k8s_pod("regular-pod", "10.0.1.1");
+        assert!(!PodInfo::should_include(&regular_pod, &config));
     }
 }

--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -948,6 +948,33 @@ mod tests {
     }
 
     #[test]
+    fn test_should_include_regular_pod_in_pd_igw_mode() {
+        let mut config = create_pd_config();
+        config.igw_mode = true;
+        config
+            .selector
+            .insert("app".to_string(), "regular-worker".to_string());
+
+        let regular_pod = create_regular_k8s_pod("regular-pod", "10.0.0.5");
+        assert!(PodInfo::should_include(&regular_pod, &config));
+
+        let pod_info = PodInfo::from_pod(&regular_pod, Some(&config)).unwrap();
+        assert_eq!(pod_info.pod_type, Some(PodType::Regular));
+    }
+
+    #[test]
+    fn test_should_exclude_regular_pod_in_pd_mode_without_igw() {
+        let mut config = create_pd_config();
+        config.igw_mode = false;
+        config
+            .selector
+            .insert("app".to_string(), "regular-worker".to_string());
+
+        let regular_pod = create_regular_k8s_pod("regular-pod", "10.0.0.5");
+        assert!(!PodInfo::should_include(&regular_pod, &config));
+    }
+
+    #[test]
     fn test_service_discovery_config_default() {
         let config = ServiceDiscoveryConfig::default();
         assert!(!config.enabled);

--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -68,6 +68,18 @@ impl Default for ServiceDiscoveryConfig {
     }
 }
 
+impl ServiceDiscoveryConfig {
+    pub fn warn_if_misconfigured(&self) {
+        if self.pd_mode && !self.igw_mode && !self.selector.is_empty() {
+            warn!(
+                "--selector is set in PD mode without IGW mode enabled; \
+                regular worker discovery alongside PD workers requires IGW mode, \
+                selector will be ignored"
+            );
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PodType {
     Prefill,
@@ -102,8 +114,10 @@ impl PodInfo {
     pub fn should_include(pod: &Pod, config: &ServiceDiscoveryConfig) -> bool {
         if config.pd_mode {
             if config.prefill_selector.is_empty() && config.decode_selector.is_empty() {
-                warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
-                return false;
+                if !(config.igw_mode && !config.selector.is_empty()) {
+                    warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
+                    return false;
+                }
             }
             let matches_pd = Self::matches_selector(pod, &config.prefill_selector)
                 || Self::matches_selector(pod, &config.decode_selector);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When running with `--pd-disaggregation`, service discovery only accepts pods matching `prefill_selector` or `decode_selector`. Pods matching `--selector` (regular workers) are silently dropped, making it impossible to serve multiple models (some via PD, some via regular routing) from a single router.

In IGW mode the RouterManager already creates both Regular and PD routers and dispatches per-request by worker type — the routing infrastructure supports this, but discovery was missing.

## Modifications

- Add `igw_mode: bool` to `ServiceDiscoveryConfig`
- When `pd_mode=true` and `igw_mode=true`, `should_include()` also accepts pods matching `--selector` and registers them as `PodType::Regular` (no new CLI arg — reuses existing `--selector`)
- Emit a warning if `--selector` is set with `--pd-disaggregation` but without `--enable-igw`
- Wire through `main.rs` and Python bindings

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->