### PR TITLE
Fix HiCache JIT support for AMD ROCm/HIP platforms

### DIFF
--- a/python/sglang/jit_kernel/tests/test_hicache.py
+++ b/python/sglang/jit_kernel/tests/test_hicache.py
@@ -11,10 +11,12 @@ from sglang.srt.mem_cache.memory_pool_host import (
     alloc_with_pin_memory,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="stage-b-kernel-unit-1-gpu-large")
 register_cuda_ci(est_time=120, suite="nightly-kernel-1-gpu", nightly=True)
+register_amd_ci(est_time=10, suite="jit-kernel-unit-test-amd")
+register_amd_ci(est_time=120, suite="nightly-amd-1-gpu", nightly=True)
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -37,9 +37,10 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     NSATokenToKVPool,
 )
-from sglang.srt.utils import is_cuda, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cuda, is_cuda_alike, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
+_is_cuda_alike = is_cuda_alike()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_mps = is_mps()
@@ -313,7 +314,7 @@ class MHATokenToKVPoolHost(HostKVCache):
             allocator_type,
         )
         self.element_dim = self.device_pool.head_num * self.device_pool.head_dim
-        self.can_use_jit = _is_cuda and can_use_hicache_jit_kernel(
+        self.can_use_jit = _is_cuda_alike and can_use_hicache_jit_kernel(
             element_size=self.element_dim * self.dtype.itemsize
         )
 
@@ -811,7 +812,7 @@ class MLATokenToKVPoolHost(HostKVCache):
             device,
             allocator_type,
         )
-        self.can_use_jit = _is_cuda and can_use_hicache_jit_kernel(
+        self.can_use_jit = _is_cuda_alike and can_use_hicache_jit_kernel(
             element_size=self.kv_cache_dim * self.dtype.itemsize
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

To complete the CI test of JIT kernels with AMD devices.

## Modifications

- Changed _is_cuda to _is_cuda_alike in python/sglang/srt/mem_cache/memory_pool_host.py
- Enables HiCache JIT kernels on AMD MI355X and other ROCm GPUs
- Maintains backward compatibility with NVIDIA CUDA GPUs
- Fixes test_hicache.py tests (10 failed -> 10 passed)


## Accuracy Tests

root@smci355-ccs-aus-n10-17:/sgl-workspace/sglang/python/sglang/jit_kernel/tests# pytest test_hicache.py -v
========================================= test session starts ==========================================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0 -- /opt/venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /sgl-workspace/sglang/python
configfile: pyproject.toml
plugins: hypothesis-6.150.2, anyio-4.13.0
collected 10 items                                                                                     

test_hicache.py::test_hicache_transfer_mha[128-layer_first] PASSED                               [ 10%]
test_hicache.py::test_hicache_transfer_mha[128-page_first] PASSED                                [ 20%]
test_hicache.py::test_hicache_transfer_mha[256-layer_first] PASSED                               [ 30%]
test_hicache.py::test_hicache_transfer_mha[256-page_first] PASSED                                [ 40%]
test_hicache.py::test_hicache_transfer_mha[512-layer_first] PASSED                               [ 50%]
test_hicache.py::test_hicache_transfer_mha[512-page_first] PASSED                                [ 60%]
test_hicache.py::test_hicache_transfer_mha[1024-layer_first] PASSED                              [ 70%]
test_hicache.py::test_hicache_transfer_mha[1024-page_first] PASSED                               [ 80%]
test_hicache.py::test_hicache_transfer_mla[576-layer_first] PASSED                               [ 90%]
test_hicache.py::test_hicache_transfer_mla[576-page_first] PASSED                                [100%]
=========================================== warnings summary ===========================================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../../../../opt/venv/lib/python3.10/site-packages/Cython/Distutils/old_build_ext.py:15
../../../../../../opt/venv/lib/python3.10/site-packages/Cython/Distutils/old_build_ext.py:15
  /opt/venv/lib/python3.10/site-packages/Cython/Distutils/old_build_ext.py:15: DeprecationWarning: dep_util is Deprecated. Use functions from setuptools instead.
    from distutils.dep_util import newer, newer_group

../../../../../aiter/aiter/jit/core.py:219
  /sgl-workspace/aiter/aiter/jit/core.py:219: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
    merge_df = pd.concat([df for _, df in source_pairs], ignore_index=True)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 10 passed, 5 warnings in 5.91s ====================================


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->