### PR TITLE
Optimize detokenization without HF decode kwargs

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -44,6 +44,7 @@ from sglang.srt.utils import (
 )
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.srt.utils.network import get_zmq_socket
+from sglang.srt.utils.patch_tokenizer import decode_without_hf_kwargs
 from sglang.srt.utils.watchdog import Watchdog
 from sglang.utils import (
     TypeBasedDispatcher,
@@ -185,6 +186,12 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
         space_list: List[bool],
     ) -> List[str]:
         """Batch decode with grouping by (skip_special_tokens, spaces_between_special_tokens)."""
+
+        if not getattr(self.tokenizer, "is_fast", False):
+            return [
+                decode_without_hf_kwargs(self.tokenizer, ids, skip)
+                for ids, skip in zip(ids_list, skip_list)
+            ]
 
         # fast path
         first_skip, first_space = skip_list[0], space_list[0]

--- a/python/sglang/srt/utils/patch_tokenizer.py
+++ b/python/sglang/srt/utils/patch_tokenizer.py
@@ -29,6 +29,15 @@ def _is_kimi_tiktoken_tokenizer(tokenizer):
     return class_name == "TikTokenTokenizer" and "tokenization_kimi" in module_name
 
 
+def decode_without_hf_kwargs(tokenizer, token_ids, skip_special_tokens):
+    if skip_special_tokens:
+        special_ids = getattr(tokenizer, "all_special_ids_set", None)
+        if special_ids is None:
+            special_ids = set(tokenizer.all_special_ids)
+        token_ids = [tid for tid in token_ids if tid not in special_ids]
+    return tokenizer.decode(token_ids)
+
+
 class _SpecialTokensCachePatcher:
     _PATCHED_FLAG = "_sglang_special_tokens_patched"
     _CACHED_TOKENS_ATTR = "_sglang_cached_special_tokens"

--- a/test/registered/unit/utils/test_patch_tokenizer.py
+++ b/test/registered/unit/utils/test_patch_tokenizer.py
@@ -6,6 +6,7 @@ from transformers import AutoTokenizer
 
 from sglang.srt.utils.patch_tokenizer import (
     _SpecialTokensCachePatcher,
+    decode_without_hf_kwargs,
     unpatch_tokenizer,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -150,6 +151,19 @@ class TestPatchTokenizerUnitTest(unittest.TestCase):
 
         unpatch_tokenizer(tokenizer)
 
+    def test_decode_without_hf_kwargs_uses_native_decode(self):
+        tokenizer = _FakeDecodeTokenizer()
+
+        self.assertEqual(
+            decode_without_hf_kwargs(tokenizer, [1, 99, 2], True),
+            "ab",
+        )
+        self.assertEqual(
+            decode_without_hf_kwargs(tokenizer, [1, 99, 2], False),
+            "a<special>b",
+        )
+        self.assertEqual(tokenizer.decode_calls, [[1, 2], [1, 99, 2]])
+
 
 def _get_class_attr_ids(cls):
     return {
@@ -172,6 +186,19 @@ def _patched_tokenizer():
         yield tokenizer
     finally:
         unpatch_tokenizer(tokenizer)
+
+
+class _FakeDecodeTokenizer:
+    all_special_ids_set = {99}
+
+    def __init__(self):
+        self.decode_calls = []
+
+    def decode(self, token_ids):
+        token_ids = list(token_ids)
+        self.decode_calls.append(token_ids)
+        token_text = {1: "a", 2: "b", 99: "<special>"}
+        return "".join(token_text[token_id] for token_id in token_ids)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Optimize the detokenizer path for tokenizers where `tokenizer.is_fast` is false by avoiding `batch_decode(..., skip_special_tokens=..., spaces_between_special_tokens=...)` in the hot path.

The detokenizer now filters special token ids when `skip_special_tokens=True` and then calls native `tokenizer.decode(ids)` directly, without generic HuggingFace decode kwargs. This avoids forcing tokenizers such as Kimi's tiktoken tokenizer away from their native no-kwargs decode implementation.

## Benchmark

Local tokenizer-only microbenchmark with `moonshotai/Kimi-K2-Instruct`, one sequence of 80,002 token ids. The "Before" column includes SGLang's existing Kimi special-token cache patch from #16427.

| Case | Before | After | Speedup |
|---|---:|---:|---:|
| `skip_special_tokens=True` | 52.57 ms | 2.22 ms | 23.6x |
| `skip_special_tokens=False` | 39.58 ms | 1.15 ms | 34.6x |

For reference, without the existing #16427 special-token cache patch, the raw HuggingFace kwargs path was ~727 ms for `skip_special_tokens=True` in the same local setup.

## Tests

- `PYTHONPATH=python USE_TF=0 TRANSFORMERS_NO_TF=1 python -m pytest -q test/registered/unit/utils/test_patch_tokenizer.py`
- `python -m py_compile python/sglang/srt/managers/detokenizer_manager.py python/sglang/srt/utils/patch_tokenizer.py test/registered/unit/utils/test_patch_tokenizer.py`
- `git diff --check`
