### PR TITLE
Allow setting tmp dir via env var in numa_utils.py

### DIFF
--- a/python/sglang/srt/utils/numa_utils.py
+++ b/python/sglang/srt/utils/numa_utils.py
@@ -47,8 +47,10 @@ def _create_numactl_executable(numactl_args: str):
     old_executable = os.fsdecode(multiprocessing.spawn.get_executable())
     script = f'''#!/bin/sh
 exec numactl {numactl_args} {old_executable} "$@"'''
-    path = Path(
-        f"/tmp/sglang_temp_file_{time.time()}_{random.randrange(0, 10000000)}.sh"
+    tmp_dir = os.environ.get("SGLANG_TMP") or os.environ.get("TMPDIR") or "/tmp"
+    Path(tmp_dir).mkdir(parents=True, exist_ok=True)
+    path = Path(tmp_dir) / (
+        f"sglang_temp_file_{time.time()}_{random.randrange(0, 10000000)}.sh"
     )
     path.write_text(script)
     path.chmod(0o777)


### PR DESCRIPTION
Allow setting tmp dir via environment variable in `numa_utils.py`

## Motivation

Hard-code tmp dir in the following function causes problems on machines where `/tmp` is set to `noexec`:

```python
def _create_numactl_executable(numactl_args: str):
    old_executable = os.fsdecode(multiprocessing.spawn.get_executable())
    script = f'''#!/bin/sh
exec numactl {numactl_args} {old_executable} "$@"'''
    path = Path(
        f"/tmp/sglang_temp_file_{time.time()}_{random.randrange(0, 10000000)}.sh"
    )
    path.write_text(script)
    path.chmod(0o777)
    return str(path), f"{script=}"
```

## Modifications

The function is changed to:

```python
def _create_numactl_executable(numactl_args: str):
    old_executable = os.fsdecode(multiprocessing.spawn.get_executable())
    script = f'''#!/bin/sh
exec numactl {numactl_args} {old_executable} "$@"'''
    tmp_dir = os.environ.get("SGLANG_TMP") or os.environ.get("TMPDIR") or "/tmp"
    Path(tmp_dir).mkdir(parents=True, exist_ok=True)
    path = Path(tmp_dir) / (
        f"sglang_temp_file_{time.time()}_{random.randrange(0, 10000000)}.sh"
    )
    path.write_text(script)
    path.chmod(0o777)
    return str(path), f"{script=}"
```

to allow the user to be able to change tmp dir location.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).  -- N/A
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). -- N/A
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). -- N/A
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
