### PR TITLE
Fix pause-aware weight update race

### DIFF
--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -493,8 +493,10 @@ class TokenizerWorker(TokenizerManager):
         async with self.is_pause_cond:
             if obj.is_pause:
                 self.is_pause = True
+                self._pause_notify.set()
             else:
                 self.is_pause = False
+                self._pause_notify.clear()
                 self.is_pause_cond.notify_all()
 
         # Resolve the pending future if this worker initiated the pause/continue

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -422,15 +422,8 @@ class TokenizerControlMixin:
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        # Hold is_pause_cond while updating to prevent unpause from racing.
-        async with self.is_pause_cond:
-            is_paused = self.is_pause
-            if is_paused:
-                results = await self.update_weights_from_distributed_communicator(obj)
-
-        if not is_paused:
-            async with self.model_update_lock.writer_lock:
-                results = await self.update_weights_from_distributed_communicator(obj)
+        async with self._ensure_paused_or_model_locked():
+            results = await self.update_weights_from_distributed_communicator(obj)
 
         success, message = FanOutCommunicator.merge_results(results)
         if success and obj.weight_version is not None:
@@ -480,14 +473,8 @@ class TokenizerControlMixin:
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        async with self.is_pause_cond:
-            is_paused = self.is_pause
-            if is_paused:
-                results = await self.update_weights_from_tensor_communicator(obj)
-
-        if not is_paused:
-            async with self.model_update_lock.writer_lock:
-                results = await self.update_weights_from_tensor_communicator(obj)
+        async with self._ensure_paused_or_model_locked():
+            results = await self.update_weights_from_tensor_communicator(obj)
 
         success, message = FanOutCommunicator.merge_results(results)
         if success and obj.weight_version is not None:
@@ -510,16 +497,9 @@ class TokenizerControlMixin:
             ), "dp_size must be 1 or dp attention must be enabled for update weights from IPC"
             logger.info("Starting IPC weight update")
 
-            async with self.is_pause_cond:
-                is_paused = self.is_pause
-                if is_paused:
-                    result = (await self.update_weights_from_ipc_communicator(obj))[0]
-                    success, message = result.success, result.message
-
-            if not is_paused:
-                async with self.model_update_lock.writer_lock:
-                    result = (await self.update_weights_from_ipc_communicator(obj))[0]
-                    success, message = result.success, result.message
+            async with self._ensure_paused_or_model_locked():
+                result = (await self.update_weights_from_ipc_communicator(obj))[0]
+                success, message = result.success, result.message
         except Exception as e:
             error_msg = f"IPC weight update failed: {str(e)}"
             logger.error(error_msg)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -25,7 +25,7 @@ import socket
 import sys
 import threading
 from collections import deque
-from contextlib import nullcontext
+from contextlib import asynccontextmanager, nullcontext, suppress
 from datetime import datetime
 from enum import Enum
 from http import HTTPStatus
@@ -420,6 +420,69 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         )
         self.is_pause = False
         self.is_pause_cond = asyncio.Condition()
+        self._pause_notify = asyncio.Event()
+
+    @asynccontextmanager
+    async def _ensure_paused_or_model_locked(self):
+        """Run while paused, or with the model update writer lock held.
+
+        _pause_notify is only a wakeup signal. When it fires, we still acquire
+        is_pause_cond and re-check is_pause, then hold the condition through the
+        update so continue_generation cannot unpause concurrently.
+        """
+
+        async def cancel_wait(task: asyncio.Task):
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+        async def cancel_writer_acquire(task: asyncio.Task):
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+                await self.model_update_lock.release_writer()
+
+        async with self.is_pause_cond:
+            if self.is_pause:
+                yield
+                return
+
+        writer_task = asyncio.create_task(self.model_update_lock.acquire_writer())
+        pause_task = asyncio.create_task(self._pause_notify.wait())
+        writer_held = False
+        try:
+            while True:
+                done, _ = await asyncio.wait(
+                    (writer_task, pause_task), return_when=asyncio.FIRST_COMPLETED
+                )
+
+                if writer_task in done:
+                    writer_task.result()
+                    writer_held = True
+                    await cancel_wait(pause_task)
+                    yield
+                    return
+
+                pause_task.result()
+                async with self.is_pause_cond:
+                    if self.is_pause:
+                        await cancel_writer_acquire(writer_task)
+                        writer_task = None
+                        yield
+                        return
+
+                    # Stale wakeup: continue_generation cleared is_pause before
+                    # we could hold is_pause_cond. Keep racing the writer lock.
+                    self._pause_notify.clear()
+
+                pause_task = asyncio.create_task(self._pause_notify.wait())
+        finally:
+            if not pause_task.done():
+                await cancel_wait(pause_task)
+            if writer_held:
+                await self.model_update_lock.release_writer()
+            elif writer_task is not None:
+                await cancel_writer_acquire(writer_task)
 
     def init_lora(self):
         # LoRA
@@ -1493,6 +1556,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     async def pause_generation(self, obj: PauseGenerationReqInput):
         async with self.is_pause_cond:
             self.is_pause = True
+            self._pause_notify.set()
             if obj.mode != "abort":
                 await self.send_to_scheduler.send_pyobj(obj)
             else:
@@ -1508,6 +1572,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     async def continue_generation(self, obj: ContinueGenerationReqInput):
         async with self.is_pause_cond:
             self.is_pause = False
+            self._pause_notify.clear()
             await self.send_to_scheduler.send_pyobj(obj)
             self.is_pause_cond.notify_all()
 
@@ -1526,14 +1591,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        # Immediately update the weights if the engine is in paused state
-        async with self.is_pause_cond:
-            is_paused = self.is_pause
-
-        lock_context = (
-            self.model_update_lock.writer_lock if not is_paused else nullcontext()
-        )
-        async with lock_context:
+        async with self._ensure_paused_or_model_locked():
             success, message, num_paused_requests = (
                 await self._wait_for_model_update_from_disk(obj)
             )

--- a/test/registered/unit/managers/test_tokenizer_pause_update_locking.py
+++ b/test/registered/unit/managers/test_tokenizer_pause_update_locking.py
@@ -1,0 +1,106 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import (
+    PauseContinueBroadcast,
+    PauseGenerationReqInput,
+)
+from sglang.srt.managers.multi_tokenizer_mixin import TokenizerWorker
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.utils.aio_rwlock import RWLock
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class TestTokenizerPauseUpdateLocking(unittest.IsolatedAsyncioTestCase):
+    def _new_tokenizer_manager(self, paused: bool = False) -> TokenizerManager:
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager.is_pause = paused
+        manager.is_pause_cond = asyncio.Condition()
+        manager._pause_notify = asyncio.Event()
+        if paused:
+            manager._pause_notify.set()
+        manager.model_update_lock = RWLock()
+        manager.send_to_scheduler = MagicMock()
+        manager.send_to_scheduler.send_pyobj = AsyncMock()
+        return manager
+
+    async def test_update_guard_acquires_writer_when_not_paused(self):
+        manager = self._new_tokenizer_manager(paused=False)
+
+        async with manager._ensure_paused_or_model_locked():
+            self.assertTrue(await manager.model_update_lock.is_locked())
+
+        self.assertFalse(await manager.model_update_lock.is_locked())
+
+    async def test_pause_generation_wakes_update_guard_blocked_on_writer(self):
+        manager = self._new_tokenizer_manager(paused=False)
+        await manager.model_update_lock.acquire_reader()
+
+        entered_update = asyncio.Event()
+        release_update = asyncio.Event()
+
+        async def run_update_guard():
+            async with manager._ensure_paused_or_model_locked():
+                entered_update.set()
+                await release_update.wait()
+
+        update_task = asyncio.create_task(run_update_guard())
+        await asyncio.sleep(0)
+
+        self.assertFalse(entered_update.is_set())
+
+        await manager.pause_generation(PauseGenerationReqInput(mode="in_place"))
+        await asyncio.wait_for(entered_update.wait(), timeout=1.0)
+
+        # The reader is still held, so the update guard must have entered
+        # through the paused path instead of waiting for the writer lock.
+        self.assertTrue(await manager.model_update_lock.is_locked())
+
+        release_update.set()
+        await asyncio.wait_for(update_task, timeout=1.0)
+        await manager.model_update_lock.release_reader()
+        self.assertFalse(await manager.model_update_lock.is_locked())
+
+    async def test_pause_broadcast_wakes_update_guard_blocked_on_writer(self):
+        worker = TokenizerWorker.__new__(TokenizerWorker)
+        worker.is_pause = False
+        worker.is_pause_cond = asyncio.Condition()
+        worker._pause_notify = asyncio.Event()
+        worker.model_update_lock = RWLock()
+        worker._pause_continue_future = None
+
+        await worker.model_update_lock.acquire_reader()
+
+        entered_update = asyncio.Event()
+        release_update = asyncio.Event()
+
+        async def run_update_guard():
+            async with worker._ensure_paused_or_model_locked():
+                entered_update.set()
+                await release_update.wait()
+
+        update_task = asyncio.create_task(run_update_guard())
+        await asyncio.sleep(0)
+
+        self.assertFalse(entered_update.is_set())
+
+        await worker._apply_pause_continue_broadcast(
+            PauseContinueBroadcast(is_pause=True)
+        )
+        await asyncio.wait_for(entered_update.wait(), timeout=1.0)
+
+        release_update.set()
+        await asyncio.wait_for(update_task, timeout=1.0)
+        await worker.model_update_lock.release_reader()
+        self.assertFalse(await worker.model_update_lock.is_locked())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a pause notification event so weight updates can race pause arrival against writer-lock acquisition
- keep the existing pause condition as the critical-section guard so continue_generation cannot unpause during paused updates
- apply the guard to distributed, tensor, IPC, and disk weight update paths
- add unit coverage for pause and multi-tokenizer pause broadcasts waking an update blocked behind reader locks

## Test Plan
- pre-commit run --all-files
- python -m py_compile python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/managers/tokenizer_control_mixin.py python/sglang/srt/managers/multi_tokenizer_mixin.py test/registered/unit/managers/test_tokenizer_pause_update_locking.py

Note: local pytest collection is blocked in this shell by dependency drift versus the repo pin (local transformers lacks Lfm2VlConfig, and a CUDA private torch symbol is also missing).