### PR TITLE
[diffusion]  Mount Cache-DiT before torch.compile in native denoising

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -172,6 +172,10 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         super().__init__()
         self.transformer = transformer
         self.transformer_2 = transformer_2
+        # cache-dit state (for delayed mounting and idempotent control)
+        self._cache_dit_enabled = False
+        self._cached_num_steps = None
+        self._torch_compiled_module_ids: set[int] = set()
 
         hidden_size = self.server_args.pipeline_config.dit_config.hidden_size
         num_attention_heads = (
@@ -199,9 +203,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
 
         # misc
         self.profiler = None
-        # cache-dit state (for delayed mounting and idempotent control)
-        self._cache_dit_enabled = False
-        self._cached_num_steps = None
         self._is_warmed_up = False
         self._extra_func_kwarg_names_cache: dict[int, tuple[bool, frozenset[str]]] = {}
 
@@ -277,6 +278,13 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             module, nn.Module
         ):
             return
+        if envs.SGLANG_CACHE_DIT_ENABLED and not self._cache_dit_enabled:
+            logger.debug("Deferring torch.compile until cache-dit is enabled")
+            return
+        module_id = id(module)
+        if module_id in self._torch_compiled_module_ids:
+            return
+
         compile_kwargs: dict[str, Any] = {"fullgraph": False, "dynamic": None}
 
         if current_platform.is_npu():
@@ -306,6 +314,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
 
         # TODO(triple-mu): support customized fullgraph and dynamic in the future
         module.compile(**compile_kwargs)
+        self._torch_compiled_module_ids.add(module_id)
 
     @staticmethod
     def _needs_nvfp4_jit_prewarm(module: nn.Module) -> bool:
@@ -352,8 +361,11 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 )
             return
 
-        # check if cache-dit is enabled in config
-        if not envs.SGLANG_CACHE_DIT_ENABLED or batch.is_warmup:
+        # Keep cache-dit disabled for ordinary warmup, but allow torch.compile
+        # warmup to mount cache-dit before Dynamo traces the transformer.
+        if not envs.SGLANG_CACHE_DIT_ENABLED:
+            return
+        if batch.is_warmup and not self.server_args.enable_torch_compile:
             return
 
         world_size = get_world_size()
@@ -601,12 +613,14 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             )
             # enable cache-dit before torch.compile (delayed mounting)
             self._maybe_enable_cache_dit(cache_dit_num_inference_steps, batch)
-            self._maybe_enable_torch_compile(self.transformer)
             if pipeline:
                 pipeline.add_module("transformer", self.transformer)
             server_args.model_loaded["transformer"] = True
         else:
             self._maybe_enable_cache_dit(cache_dit_num_inference_steps, batch)
+
+        for transformer in filter(None, [self.transformer, self.transformer_2]):
+            self._maybe_enable_torch_compile(transformer)
 
         if batch.rollout:
             self._maybe_prepare_rollout(batch)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -316,6 +316,14 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         module.compile(**compile_kwargs)
         self._torch_compiled_module_ids.add(module_id)
 
+    def _maybe_enable_cache_dit_and_torch_compile(
+        self, num_inference_steps: int | tuple[int, int], batch: Req
+    ) -> None:
+        """Apply request-dependent transformer acceleration in trace-safe order."""
+        self._maybe_enable_cache_dit(num_inference_steps, batch)
+        for transformer in filter(None, [self.transformer, self.transformer_2]):
+            self._maybe_enable_torch_compile(transformer)
+
     @staticmethod
     def _needs_nvfp4_jit_prewarm(module: nn.Module) -> bool:
         for submodule in module.modules():
@@ -605,22 +613,22 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         else:
             cache_dit_num_inference_steps = num_inference_steps
 
-        if not server_args.model_loaded["transformer"]:
+        transformer_was_loaded = server_args.model_loaded["transformer"]
+        if not transformer_was_loaded:
             # FIXME: reuse more code
             loader = TransformerLoader()
             self.transformer = loader.load(
                 server_args.model_paths["transformer"], server_args, "transformer"
             )
-            # enable cache-dit before torch.compile (delayed mounting)
-            self._maybe_enable_cache_dit(cache_dit_num_inference_steps, batch)
+
+        self._maybe_enable_cache_dit_and_torch_compile(
+            cache_dit_num_inference_steps, batch
+        )
+
+        if not transformer_was_loaded:
             if pipeline:
                 pipeline.add_module("transformer", self.transformer)
             server_args.model_loaded["transformer"] = True
-        else:
-            self._maybe_enable_cache_dit(cache_dit_num_inference_steps, batch)
-
-        for transformer in filter(None, [self.transformer, self.transformer_2]):
-            self._maybe_enable_torch_compile(transformer)
 
         if batch.rollout:
             self._maybe_prepare_rollout(batch)


### PR DESCRIPTION
## Summary
Across 5 runs, the first real request after `--warmup` reduced `DenoisingStage` time from 5.2370s to 2.9449s on average, reducing latency of this request by 43.77%
## Motivation

After some profiling, I find Cache-DiT (via sglang-diffusion native) should be mounted before the denoising transformer is compiled, as otherwise warmup can compile the unwrapped transformer path, while real requests later use the Cache-DiT path.

With `--warmup`, this warms up the unwrapped transformer, then mounts Cache-DiT on the first actual request, so warmup did not prepare the path real requests use properly

  ## Modifications

Defer `torch.compile` until Cache-DiT is mounted.

  ## Speed Tests and Profiling

1x h200

```
  SGLANG_CACHE_DIT_ENABLED=true
  SGLANG_CACHE_DIT_WARMUP=4
  SGLANG_DIFFUSION_STAGE_LOGGING=1
```
```
  sglang serve \
    --model-path Qwen/Qwen-Image-2512 \
    --model-type diffusion \
    --backend sglang \
    --enable-torch-compile \
    --warmup 
```

  Request settings:

Qwen/Qwen-Image-2512, 1024x1024
  steps: 20
  seed: 42
  concurrency: 1
  requests per run: 1
  paired runs: 5


  `DenoisingStage` time for the first real request after warmup:
  
  | Run | Baseline | Patched | Reduction |
  |---:|---:|---:|---:|
  | r1 | 5.2040s | 2.9329s | 43.64% |
  | r2 | 5.2066s | 2.9935s | 42.51% |
  | r3 | 5.2888s | 2.9220s | 44.75% |
  | r4 | 5.2033s | 2.9528s | 43.25% |
  | r5 | 5.2824s | 2.9234s | 44.66% |
  | **Mean** | **5.2370s** | **2.9449s** | **43.77%** |

  mean: baseline 5.2370s -> patched 2.9449s
  mean reduction: 43.77%
  speedup: 77.83%

  Client latency including default request-based warmup:

  mean: baseline 58.2542s -> patched 56.5716s
  mean reduction: 2.89%
  speedup: 2.97%

 also changed log ordering:

  Baseline:

  Compiling transformer ...
  Processing warmup req ...
  Warmup req processed ...
  Enabling cache-dit ... steps=20
  [DenoisingStage] finished in ~5.2s

  Patched:

  Processing warmup req ...
  Enabling cache-dit ... steps=1
  Compiling transformer ...
  Warmup req processed ...
  [DenoisingStage] finished in ~2.9s