### PR TITLE
Skip CI tests added in #24816 (broken on main)

### DIFF
--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_h200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_h200.py
@@ -91,6 +91,7 @@ class TestDSV4FlashFP4H200(ServerSanityMixin, CustomTestCase):
         self.assertGreater(metrics["score"], 0.93)
 
 
+@unittest.skip("broken on main, see #24816")
 @unittest.skipUnless(
     _flashinfer_has_sm90_cutlass_mxfp4(),
     "FlashInfer build lacks SM90 mixed-input MXFP4 helpers (PR #3084, >= 0.6.11)",

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py
@@ -20,7 +20,12 @@ import torch
 
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=120, stage="stage-b", runner_config="1-gpu-large")
+register_cuda_ci(
+    est_time=120,
+    stage="stage-b",
+    runner_config="1-gpu-large",
+    disabled="broken on main, see #24816",
+)
 
 flashinfer_fused_moe = pytest.importorskip("flashinfer.fused_moe")
 


### PR DESCRIPTION
## Motivation

The FlashInfer SM90 cutlass MXFP4 CI tests added by #24816 are currently broken on main. Skip them so CI stays green while a follow-up fix is investigated.

## Modifications

- `test/registered/unit/layers/quantization/test_mxfp4_sm90_cutlass.py`: pass `disabled="..."` to `register_cuda_ci` so the entire file is dropped from CI dispatch (file is whole-new in #24816, so disabling it doesn't affect anything that previously ran).
- `test/registered/dsv4/test_deepseek_v4_flash_fp4_h200.py`: only the new `TestDSV4FlashFP4H200FlashInferCutlass` class (added by #24816) is broken; mark it `@unittest.skip("broken on main, see #24816")`. The original `TestDSV4FlashFP4H200` (Marlin path) is left running.

The `disabled=` mechanism on `register_cuda_ci` is the standard SGLang convention for keeping a test file in-tree but excluded from CI dispatch — same approach used elsewhere in `test/registered/`.

## Accuracy Tests

N/A — only CI-registration changes; no model-output behavior affected.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).