### PR TITLE
fix: strip "[asctime]" prefix when parsing JSON log lines in nightly tests

### DIFF
--- a/test/registered/bench_fn/test_bench_serving_functionality.py
+++ b/test/registered/bench_fn/test_bench_serving_functionality.py
@@ -74,9 +74,13 @@ class TestBenchServingFunctionality(CustomTestCase):
     def _verify_multi_turn_logs(self, content: str):
         reqs = []
         for line in content.splitlines():
-            if not line.startswith("{"):
+            idx = line.find("{")
+            if idx == -1:
                 continue
-            obj = json.loads(line)
+            try:
+                obj = json.loads(line[idx:])
+            except json.JSONDecodeError:
+                continue
             if obj.get("event") != "request.finished":
                 continue
             text = obj.get("obj", {}).get("text")

--- a/test/registered/utils/test_request_logger.py
+++ b/test/registered/utils/test_request_logger.py
@@ -190,10 +190,11 @@ class TestRequestLoggerJson(BaseTestRequestLogger, CustomTestCase):
         received_found = False
         finished_found = False
         for line in content.splitlines():
-            if not line.strip() or not line.startswith("{"):
+            idx = line.find("{")
+            if idx == -1:
                 continue
             try:
-                data = json.loads(line)
+                data = json.loads(line[idx:])
             except json.JSONDecodeError:
                 continue
 
@@ -227,10 +228,11 @@ class TestRequestLoggerJson(BaseTestRequestLogger, CustomTestCase):
     def _verify_openai_logs(self, content: str, source_name: str):
         openai_received_found = False
         for line in content.splitlines():
-            if not line.strip() or not line.startswith("{"):
+            idx = line.find("{")
+            if idx == -1:
                 continue
             try:
-                data = json.loads(line)
+                data = json.loads(line[idx:])
             except json.JSONDecodeError:
                 continue
             if data.get("event") != "request.received.openai":

--- a/test/registered/utils/test_scheduler_status_logger.py
+++ b/test/registered/utils/test_scheduler_status_logger.py
@@ -64,10 +64,15 @@ class TestSchedulerStatusLogger(CustomTestCase):
 def _find_log_events(log_dir: str, event_name: str):
     for f in Path(log_dir).glob("*.log"):
         for line in f.read_text().splitlines():
-            if line.startswith("{"):
-                data = json.loads(line)
-                if data.get("event") == event_name:
-                    yield data
+            idx = line.find("{")
+            if idx == -1:
+                continue
+            try:
+                data = json.loads(line[idx:])
+            except json.JSONDecodeError:
+                continue
+            if data.get("event") == event_name:
+                yield data
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three nightly-1-gpu tests have been failing on `main` because they parse JSON log events by filtering `line.startswith("{")`, but PR #24521 added a `[YYYY-MM-DD HH:MM:SS] ` prefix to every line emitted by `log_json` (and to text-format request logs) — see `python/sglang/srt/utils/log_utils.py:53`. Every JSON event now starts with the timestamp prefix, so the filter drops them and the tests fail with `request.received event not found`, `scheduler.status event not found`, etc.

This PR fixes the three tests' parsers to locate the first `{` on each line and parse from there with a try/except, so they handle both the prefixed and the unprefixed forms and gracefully skip text-format lines.

**Files changed (test-only, +21/−10):**
- `test/registered/utils/test_request_logger.py` (two call sites)
- `test/registered/utils/test_scheduler_status_logger.py` (one call site)
- `test/registered/bench_fn/test_bench_serving_functionality.py` (one call site)

Failing CI run that motivated this: https://github.com/sgl-project/sglang/actions/runs/25835354140/job/75909128186

## Test plan

Validated locally on a 1×H200 devbox against current `main` (post-#24521):

- [x] `test_scheduler_status_logger.py` — 1/1 PASS (88s)
- [x] `test_request_logger.py` (Text + Json + CustomHeaderViaEnvVar × 2) — 6/6 PASS (123s)
- [x] `test_bench_serving_functionality.py` (gsp_multi_turn + 2 header tests) — 3/3 PASS (50s)
- [x] `pre-commit run --files <changed>` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)