### PR TITLE
[Feature] Thread endpoint_url + sglang/<version> User-Agent through S3Connector (Backblaze B2 example)

### DIFF
--- a/docs_new/docs/advanced_features/object_storage.mdx
+++ b/docs_new/docs/advanced_features/object_storage.mdx
@@ -18,7 +18,7 @@ When loading models from object storage, SGLang uses a two-phase approach:
 1. **Amazon S3**: `s3://bucket-name/path/to/model/`
 2. **Google Cloud Storage**: `gs://bucket-name/path/to/model/`
 3. **Azure Blob**: `az://some-azure-container/path/`
-4. **S3 compatible**: `s3://bucket-name/path/to/model/`
+4. **S3-compatible** (Backblaze B2, Cloudflare R2, MinIO, etc.): `s3://bucket-name/path/to/model/`
 
 ## Quick Start
 
@@ -118,6 +118,47 @@ python -m sglang.launch_server \
     </tr>
   </tbody>
 </table>
+
+## Loading from S3-compatible storage
+
+The `s3://` scheme also works against any S3-compatible object store by pointing the underlying boto3 client at a custom endpoint. SGLang accepts the endpoint, region, and credentials either as query-string parameters on the model URI or as standard AWS environment variables.
+
+### URI form (query-string parameters)
+
+```bash
+python -m sglang.launch_server \
+  --model-path "s3://my-bucket/llama-3-70b?endpoint_url=<your-s3-compatible-endpoint>&region_name=<your-region>"
+```
+
+Recognized query parameters: `endpoint_url`, `region_name`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token` (for STS / temporary credentials). Names match boto3 verbatim; aliases are not accepted. They are stripped from the URI before listing or downloading objects. Unknown query keys (typos like `?endpiont_url=...`) raise `ValueError` so misconfiguration surfaces immediately instead of failing later as a credentials/endpoint mismatch.
+
+> **Warning**: Prefer environment variables (next section) for credentials. Query-string values can leak into shell history, container metadata, and access logs. Any query-string value (not just credentials) that contains reserved or special characters must be URL-encoded: `parse_qs` decodes `+` as a space and treats `&`, `=`, and `#` as delimiters. For example, a secret containing `+` must be written as `%2B`, and a space or embedded `&` in `endpoint_url` must likewise be percent-encoded. Plain alphanumeric values need no encoding.
+
+### Environment-variable alternative
+
+```bash
+export AWS_ENDPOINT_URL=<your-s3-compatible-endpoint>
+export AWS_DEFAULT_REGION=<your-region>
+export AWS_ACCESS_KEY_ID=<your-access-key-id>
+export AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+
+python -m sglang.launch_server --model-path s3://my-bucket/llama-3-70b/
+```
+
+Environment variables are resolved by boto3's default chain when no query-string value is given for that key. SGLang only forwards values it parses from the URI query string (or accepts explicitly from the programmatic `S3Connector(...)` API); env vars like `AWS_ENDPOINT_URL`, `AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` are picked up by boto3 itself.
+
+### Example: Backblaze B2
+
+[Backblaze B2](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) exposes an S3-compatible API. The endpoint is shown on the bucket detail page (e.g. `https://s3.us-west-004.backblazeb2.com`); the `keyID` and `applicationKey` of a bucket-scoped [Application Key](https://www.backblaze.com/docs/cloud-storage-application-keys) map to `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+```bash
+export AWS_ENDPOINT_URL=https://s3.us-west-004.backblazeb2.com
+export AWS_DEFAULT_REGION=us-west-004
+export AWS_ACCESS_KEY_ID=<your-B2-application-key-id>
+export AWS_SECRET_ACCESS_KEY=<your-B2-application-key>
+
+python -m sglang.launch_server --model-path s3://my-bucket/llama-3-70b/
+```
 
 ## Performance Considerations
 

--- a/python/sglang/srt/connector/__init__.py
+++ b/python/sglang/srt/connector/__init__.py
@@ -10,7 +10,7 @@ from sglang.srt.connector.base_connector import (
 )
 from sglang.srt.connector.redis import RedisConnector
 from sglang.srt.connector.remote_instance import RemoteInstanceConnector
-from sglang.srt.connector.s3 import S3Connector
+from sglang.srt.connector.s3 import S3_FORWARDED_KWARGS, S3Connector
 from sglang.srt.utils import parse_connector_type
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,20 @@ def create_remote_connector(url, device=None, **kwargs) -> BaseConnector:
     if connector_type == "redis":
         return RedisConnector(url)
     elif connector_type == "s3":
-        return S3Connector(url)
+        # ``S3_FORWARDED_KWARGS`` is the single source of truth for which
+        # kwargs reach ``S3Connector``. Anything else is dropped, but logged
+        # at DEBUG so common typos like ``region`` vs ``region_name`` surface
+        # under ``--log-level=debug``.
+        s3_kwargs = {k: v for k, v in kwargs.items() if k in S3_FORWARDED_KWARGS}
+        dropped = sorted(set(kwargs) - S3_FORWARDED_KWARGS)
+        if dropped:
+            logger.debug(
+                "create_remote_connector: ignoring s3-irrelevant kwargs %s "
+                "(allowed: %s)",
+                dropped,
+                sorted(S3_FORWARDED_KWARGS),
+            )
+        return S3Connector(url, **s3_kwargs)
     elif connector_type == "instance":
         return RemoteInstanceConnector(url, device)
     elif _is_azure_blob_url(url, connector_type):

--- a/python/sglang/srt/connector/s3.py
+++ b/python/sglang/srt/connector/s3.py
@@ -3,11 +3,109 @@
 import fnmatch
 import os
 from pathlib import Path
-from typing import Generator, Optional, Tuple
+from typing import Any, Final, Generator, Optional, Tuple
+from urllib.parse import parse_qs, urlparse
 
 import torch
 
 from sglang.srt.connector import BaseFileConnector
+from sglang.version import __version__ as _sglang_version
+
+_S3_QUERY_KWARGS: Final[Tuple[str, ...]] = (
+    "endpoint_url",
+    "region_name",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+)
+
+# Set form of ``_S3_QUERY_KWARGS`` for membership / diff checks. Built once
+# at module load so per-call hot paths don't reconstruct it.
+_S3_QUERY_KWARGS_SET: Final[frozenset[str]] = frozenset(_S3_QUERY_KWARGS)
+
+# Single source of truth for kwargs ``create_remote_connector`` may forward
+# to ``S3Connector``. Adds ``config`` (programmatic only, not a query param)
+# to the URI keys above.
+S3_FORWARDED_KWARGS: Final[frozenset[str]] = _S3_QUERY_KWARGS_SET | frozenset(
+    {"config"}
+)
+
+# Cap how many unknown query keys are echoed (the rest collapse to "(+N more)").
+_MAX_UNKNOWN_KEYS_SHOWN: Final[int] = 10
+
+
+def _sanitize_query_key(key: str, *, max_len: int = 64) -> str:
+    """Make an untrusted query key safe to echo into an error message/log.
+
+    ``max_len`` bounds the *returned* length: a longer key is truncated so the
+    result (including the trailing ``...`` marker) is at most ``max_len`` chars.
+    """
+    cleaned = "".join(ch if ch.isprintable() else "?" for ch in key)
+    if len(cleaned) > max_len:
+        marker = "..."
+        if max_len <= len(marker):
+            cleaned = marker[:max_len]
+        else:
+            cleaned = cleaned[: max_len - len(marker)] + marker
+    return cleaned
+
+
+def _parse_s3_kwargs(url: str) -> tuple[str, dict[str, Any]]:
+    """Strip query string from s3 URL and return (clean_url, boto3_kwargs).
+
+    Recognizes ``endpoint_url``, ``region_name``, ``aws_access_key_id``,
+    ``aws_secret_access_key``, ``aws_session_token`` from the query string.
+    The keys match boto3 verbatim; aliases are not supported.
+
+    Environment variables (``AWS_ENDPOINT_URL``, ``AWS_DEFAULT_REGION``,
+    ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, ``AWS_SESSION_TOKEN``)
+    are resolved by boto3's default chain when no query value is given. The
+    helper does not re-inject them as kwargs so they don't override an
+    explicit ``botocore.config.Config(region_name=...)`` passed via ``config=``.
+
+    Unknown query keys raise ``ValueError`` rather than being silently
+    stripped, so typos like ``?endpiont_url=...`` surface immediately
+    instead of failing later as a credentials / endpoint mismatch.
+    Duplicate occurrences of a recognized key, malformed fragments
+    (``?endpoint_url`` with no ``=``), and blank values
+    (``?endpoint_url=``) raise ``ValueError`` for the same reason.
+
+    The returned dict is typed ``dict[str, Any]`` because callers merge
+    additional ``boto3.client`` kwargs (e.g. ``botocore.config.Config``) into
+    it; the helper itself only emits ``str`` values.
+    """
+    parsed = urlparse(url)
+    try:
+        parsed_query = parse_qs(
+            parsed.query, strict_parsing=True, keep_blank_values=True
+        )
+    except ValueError:
+        raise ValueError("Malformed s3 URL query string") from None
+    unknown = sorted(set(parsed_query) - _S3_QUERY_KWARGS_SET)
+    if unknown:
+        # Keys are caller-controlled and may be logged; sanitize each and cap how
+        # many are listed so a URL with many junk keys can't amplify the error.
+        shown = [_sanitize_query_key(key) for key in unknown[:_MAX_UNKNOWN_KEYS_SHOWN]]
+        if len(unknown) > _MAX_UNKNOWN_KEYS_SHOWN:
+            shown.append(f"(+{len(unknown) - _MAX_UNKNOWN_KEYS_SHOWN} more)")
+        raise ValueError(
+            f"Unknown s3 URL query parameter(s): {', '.join(shown)}; "
+            f"allowed: {', '.join(_S3_QUERY_KWARGS)}"
+        )
+    kwargs: dict[str, Any] = {}
+    for key in _S3_QUERY_KWARGS:
+        values = parsed_query.get(key)
+        if not values:
+            continue
+        if len(values) > 1:
+            raise ValueError(
+                f"Duplicate query parameter {key!r} in s3 URL; expected one value"
+            )
+        if values[0] == "":
+            raise ValueError(f"Empty value for query parameter {key!r} in s3 URL")
+        kwargs[key] = values[0]
+    clean = parsed._replace(query="", fragment="").geturl()
+    return clean, kwargs
 
 
 def _filter_allow(paths: list[str], patterns: list[str]) -> list[str]:
@@ -68,11 +166,34 @@ def list_files(
 
 class S3Connector(BaseFileConnector):
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, **client_kwargs) -> None:
         import boto3
+        from botocore.config import Config
 
-        super().__init__(url)
-        self.client = boto3.client("s3")
+        clean_url, parsed_kwargs = _parse_s3_kwargs(url)
+        parsed_kwargs.update(client_kwargs)
+        user_config = parsed_kwargs.pop("config", None)
+        if user_config is not None and not isinstance(user_config, Config):
+            raise TypeError(
+                "S3Connector `config` must be a botocore.config.Config "
+                f"instance, got {type(user_config).__name__}"
+            )
+        ua_extra = f"sglang/{_sglang_version}"
+        if user_config is not None and user_config.user_agent_extra:
+            ua_extra = f"{user_config.user_agent_extra} {ua_extra}"
+        ua_overlay = Config(user_agent_extra=ua_extra)
+        if user_config is not None:
+            config = user_config.merge(ua_overlay)
+        else:
+            config = ua_overlay
+        super().__init__(clean_url)
+        # Drop ``None`` so opt-out sentinels don't reach boto3. A query/explicit
+        # ``region_name`` is a direct kwarg here and outranks ``config.region_name``.
+        self.client = boto3.client(
+            "s3",
+            config=config,
+            **{k: v for k, v in parsed_kwargs.items() if v is not None},
+        )
 
     def glob(self, allow_pattern: Optional[list[str]] = None) -> list[str]:
         bucket_name, _, paths = list_files(
@@ -118,5 +239,13 @@ class S3Connector(BaseFileConnector):
         return runai_safetensors_weights_iterator(hf_weights_files)
 
     def close(self):
-        self.client.close()
-        super().close()
+        # __init__ can fail during URL/kwarg validation (e.g. an empty query
+        # value) before ``self.client`` or BaseConnector's state is set. Guard
+        # the teardown so the destructor doesn't raise a noisy AttributeError.
+        client = getattr(self, "client", None)
+        if client is not None:
+            client.close()
+        # BaseConnector.close() relies on state from BaseConnector.__init__
+        # (self.closed / self.local_dir); skip it if that never ran.
+        if getattr(self, "closed", None) is not None:
+            super().close()

--- a/test/registered/unit/connector/test_s3_endpoint_url.py
+++ b/test/registered/unit/connector/test_s3_endpoint_url.py
@@ -1,0 +1,355 @@
+"""Unit tests for S3Connector endpoint_url / region_name / credential plumbing."""
+
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+# Import the connector stack ONCE here, at module load, OUTSIDE any
+# ``patch.dict("sys.modules", ...)`` block. patch.dict snapshots sys.modules on
+# enter and restores it on exit, which would evict modules imported inside the
+# block (e.g. safetensors, a PyO3 extension that cannot be re-initialized),
+# breaking subsequent tests. boto3 is imported lazily inside
+# ``S3Connector.__init__``, so patching it around construction still works.
+from sglang.srt.connector import create_remote_connector  # noqa: E402
+from sglang.srt.connector.s3 import S3Connector  # noqa: E402
+
+try:
+    import botocore.config  # noqa: F401
+
+    _HAS_BOTOCORE = True
+except ImportError:
+    _HAS_BOTOCORE = False
+
+
+@unittest.skipUnless(_HAS_BOTOCORE, "botocore not installed")
+class TestS3ConnectorEndpointUrl(unittest.TestCase):
+    """Verify endpoint_url / region_name / creds flow through to boto3.client."""
+
+    def _build(self, url, **kwargs):
+        # boto3 is imported lazily in S3Connector.__init__, so patching it only
+        # around construction is enough (and avoids importing anything heavy
+        # inside the sys.modules snapshot).
+        fake_boto3 = MagicMock()
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            connector = S3Connector(url, **kwargs)
+        return fake_boto3, connector
+
+    def test_query_string_endpoint_url(self):
+        url = (
+            "s3://b/k?endpoint_url=https://s3.us-west-004.backblazeb2.com"
+            "&region_name=us-west-004"
+        )
+        fake_boto3, conn = self._build(url)
+        fake_boto3.client.assert_called_once_with(
+            "s3",
+            config=ANY,
+            endpoint_url="https://s3.us-west-004.backblazeb2.com",
+            region_name="us-west-004",
+        )
+        self.assertEqual(conn.url, "s3://b/k")
+
+    def test_env_vars_are_not_injected_into_kwargs(self):
+        # AWS_* env vars must be read by boto3's default chain, not re-injected
+        # by ``_parse_s3_kwargs``. Re-injecting would override an explicit
+        # ``botocore.config.Config(region_name=...)`` passed via ``config=``.
+        with patch.dict(
+            "os.environ",
+            {
+                "AWS_ENDPOINT_URL": "https://from-env",
+                "AWS_DEFAULT_REGION": "us-east-1",
+            },
+        ):
+            fake_boto3, _ = self._build("s3://bucket/path")
+        fake_boto3.client.assert_called_once_with("s3", config=ANY)
+
+    def test_explicit_kwargs_win(self):
+        url = "s3://b/k?endpoint_url=https://from-url"
+        fake_boto3, _ = self._build(url, endpoint_url="https://explicit")
+        fake_boto3.client.assert_called_once_with(
+            "s3", config=ANY, endpoint_url="https://explicit"
+        )
+
+    def test_no_overrides_passes_no_kwargs(self):
+        # No query string, no explicit kwargs => only the sglang Config flows.
+        fake_boto3, _ = self._build("s3://bucket/path")
+        fake_boto3.client.assert_called_once_with("s3", config=ANY)
+
+    def test_credential_query_params(self):
+        url = (
+            "s3://b/k?endpoint_url=https://s3.example.com"
+            "&aws_access_key_id=AKIA_EXAMPLE"
+            "&aws_secret_access_key=SECRET_EXAMPLE"
+        )
+        fake_boto3, conn = self._build(url)
+        fake_boto3.client.assert_called_once_with(
+            "s3",
+            config=ANY,
+            endpoint_url="https://s3.example.com",
+            aws_access_key_id="AKIA_EXAMPLE",
+            aws_secret_access_key="SECRET_EXAMPLE",
+        )
+        self.assertEqual(conn.url, "s3://b/k")
+
+    def test_session_token_query_param(self):
+        # ``aws_session_token`` (STS / temp creds) flows through from the URI.
+        url = (
+            "s3://b/k?endpoint_url=https://s3.example.com"
+            "&aws_access_key_id=AKIA_X"
+            "&aws_secret_access_key=SEC_X"
+            "&aws_session_token=TOKEN_X"
+        )
+        fake_boto3, conn = self._build(url)
+        fake_boto3.client.assert_called_once_with(
+            "s3",
+            config=ANY,
+            endpoint_url="https://s3.example.com",
+            aws_access_key_id="AKIA_X",
+            aws_secret_access_key="SEC_X",
+            aws_session_token="TOKEN_X",
+        )
+        self.assertEqual(conn.url, "s3://b/k")
+
+    def test_region_query_alias_raises(self):
+        # The deprecated ``?region=`` alias is no longer recognized. It must
+        # surface as ``ValueError`` rather than being silently stripped.
+        with self.assertRaises(ValueError) as ctx:
+            self._build("s3://b/k?region=us-west-004")
+        self.assertIn("region", str(ctx.exception))
+
+    def test_typoed_query_param_raises(self):
+        # Typos like ``?endpiont_url=...`` must fail loudly instead of being
+        # silently dropped and producing a credentials/endpoint mismatch later.
+        with self.assertRaises(ValueError) as ctx:
+            self._build("s3://b/k?endpiont_url=https://x")
+        self.assertIn("endpiont_url", str(ctx.exception))
+
+    def test_blank_value_query_param_raises(self):
+        # ``?endpoint_url=`` (no value) is misconfiguration, not a valid
+        # opt-out -- raise rather than silently dropping the key.
+        with self.assertRaises(ValueError) as ctx:
+            self._build("s3://b/k?endpoint_url=")
+        self.assertIn("endpoint_url", str(ctx.exception))
+
+    def test_malformed_query_string_raises(self):
+        # ``?endpoint_url`` (no ``=``) is malformed and must be rejected.
+        with self.assertRaises(ValueError):
+            self._build("s3://b/k?endpoint_url")
+
+    def test_malformed_query_does_not_leak_raw_fragment(self):
+        # ``parse_qs``'s native ValueError message embeds the offending
+        # fragment, which can include credential bytes. Our re-raised error
+        # must not echo it (and the cause chain is suppressed).
+        secret = "VERY_SECRET_AKIA_DO_NOT_LEAK"
+        with self.assertRaises(ValueError) as ctx:
+            self._build(f"s3://b/k?aws_access_key_id{secret}")
+        self.assertNotIn(secret, str(ctx.exception))
+        # Cause chain is suppressed so the raw value won't show up in
+        # tracebacks either.
+        self.assertIsNone(ctx.exception.__cause__)
+
+    def test_fragment_is_stripped_from_clean_url(self):
+        # ``s3://b/k?...#frag`` would leave ``#frag`` in ``self.url`` and
+        # break downstream ``path.split("/")`` listing/downloading.
+        _, conn = self._build("s3://b/k?endpoint_url=https://x#frag")
+        self.assertEqual(conn.url, "s3://b/k")
+
+    def test_fragment_only_url_is_stripped(self):
+        _, conn = self._build("s3://b/k#frag")
+        self.assertEqual(conn.url, "s3://b/k")
+
+    def test_explicit_region_name_wins(self):
+        url = "s3://b/k?region_name=us-west-004"
+        fake_boto3, _ = self._build(url, region_name="us-east-1")
+        fake_boto3.client.assert_called_once_with(
+            "s3", config=ANY, region_name="us-east-1"
+        )
+
+    def test_user_agent_extra_includes_sglang_version(self):
+        from sglang.version import __version__
+
+        fake_boto3, _ = self._build("s3://bucket/path")
+        _, kwargs = fake_boto3.client.call_args
+        self.assertIn(f"sglang/{__version__}", kwargs["config"].user_agent_extra)
+
+    def test_user_config_is_merged_not_dropped(self):
+        from botocore.config import Config
+
+        from sglang.version import __version__
+
+        user_cfg = Config(user_agent_extra="caller/1.2.3", region_name="us-east-2")
+        fake_boto3, _ = self._build("s3://bucket/path", config=user_cfg)
+        _, kwargs = fake_boto3.client.call_args
+        merged = kwargs["config"]
+        self.assertIn("caller/1.2.3", merged.user_agent_extra)
+        self.assertIn(f"sglang/{__version__}", merged.user_agent_extra)
+        self.assertEqual(merged.region_name, "us-east-2")
+
+    def test_explicit_none_skips_kwarg(self):
+        # ``endpoint_url=None`` opts back out of any query-derived value so
+        # boto3's default chain (incl. ``AWS_ENDPOINT_URL`` env) takes over.
+        fake_boto3, _ = self._build(
+            "s3://b/k?endpoint_url=https://from-url", endpoint_url=None
+        )
+        _, kwargs = fake_boto3.client.call_args
+        self.assertNotIn("endpoint_url", kwargs)
+
+    def test_region_name_none_clears_query_region(self):
+        # ``region_name=None`` clears the query-string-derived ``region_name``.
+        fake_boto3, _ = self._build(
+            "s3://b/k?region_name=us-west-004", region_name=None
+        )
+        _, kwargs = fake_boto3.client.call_args
+        self.assertNotIn("region_name", kwargs)
+
+    def test_config_must_be_botocore_config(self):
+        # A non-``botocore.config.Config`` ``config=`` must raise ``TypeError``
+        # rather than failing later on ``.merge()`` / ``.user_agent_extra``.
+        with self.assertRaises(TypeError):
+            self._build("s3://bucket/path", config={"user_agent_extra": "bad"})
+
+    def test_duplicate_query_param_raises(self):
+        # Two ``endpoint_url=...`` in the URI must surface the conflict
+        # explicitly rather than silently picking one.
+        with self.assertRaises(ValueError) as ctx:
+            self._build("s3://b/k?endpoint_url=A&endpoint_url=B")
+        self.assertIn("endpoint_url", str(ctx.exception))
+
+    def test_query_region_name_wins_over_config_region(self):
+        # Documented precedence: a query-string ``?region_name=`` is passed to
+        # boto3 as a direct kwarg, which boto3 ranks above ``config.region_name``,
+        # so the URI value wins when both are supplied. (An explicit
+        # ``region_name=`` kwarg still beats the query -- see
+        # ``test_explicit_region_name_wins``.)
+        from botocore.config import Config
+
+        user_cfg = Config(region_name="us-east-2")
+        fake_boto3, _ = self._build("s3://b/k?region_name=us-west-004", config=user_cfg)
+        _, kwargs = fake_boto3.client.call_args
+        self.assertEqual(kwargs["region_name"], "us-west-004")
+        # The caller Config is still merged (not dropped); boto3 resolves the
+        # conflict in favor of the direct kwarg.
+        self.assertEqual(kwargs["config"].region_name, "us-east-2")
+
+    def test_unknown_param_name_is_truncated_in_error(self):
+        # A hostile/garbage key must not bloat the (possibly logged) error;
+        # it is truncated rather than echoed in full.
+        long_key = "x" * 500
+        with self.assertRaises(ValueError) as ctx:
+            self._build(f"s3://b/k?{long_key}=1")
+        msg = str(ctx.exception)
+        self.assertNotIn(long_key, msg)
+        self.assertIn("...", msg)
+
+    def test_unknown_param_name_control_chars_sanitized(self):
+        # Control characters in an unknown key are replaced so they can't
+        # corrupt terminals/logs when the error surfaces. ``%09`` == TAB.
+        with self.assertRaises(ValueError) as ctx:
+            self._build("s3://b/k?a%09b=1")
+        self.assertNotIn("\t", str(ctx.exception))
+
+    def test_many_unknown_params_are_capped_in_error(self):
+        # A URL stuffed with junk keys must not amplify into an unbounded
+        # (possibly logged) error string: only the first N are listed.
+        from sglang.srt.connector.s3 import _MAX_UNKNOWN_KEYS_SHOWN
+
+        keys = "&".join(f"junk{i}=1" for i in range(_MAX_UNKNOWN_KEYS_SHOWN + 40))
+        with self.assertRaises(ValueError) as ctx:
+            self._build(f"s3://b/k?{keys}")
+        msg = str(ctx.exception)
+        self.assertIn("more)", msg)
+        self.assertLessEqual(msg.count("junk"), _MAX_UNKNOWN_KEYS_SHOWN)
+
+    def test_sanitize_query_key_respects_max_len(self):
+        # The cap must bound the final length *including* the ``...`` marker,
+        # not overshoot it by 3 chars.
+        from sglang.srt.connector.s3 import _sanitize_query_key
+
+        out = _sanitize_query_key("x" * 500, max_len=64)
+        self.assertLessEqual(len(out), 64)
+        self.assertTrue(out.endswith("..."))
+
+    def test_sanitize_query_key_small_max_len_never_exceeds(self):
+        # Even for caps smaller than the ``...`` marker, the result must never
+        # exceed ``max_len`` (the marker itself gets truncated).
+        from sglang.srt.connector.s3 import _sanitize_query_key
+
+        for max_len in (0, 1, 2, 3, 4):
+            out = _sanitize_query_key("x" * 50, max_len=max_len)
+            self.assertLessEqual(len(out), max_len, f"max_len={max_len}")
+
+
+@unittest.skipUnless(_HAS_BOTOCORE, "botocore not installed")
+class TestCreateRemoteConnectorS3Forwarding(unittest.TestCase):
+    """``create_remote_connector`` forwards only whitelisted s3 kwargs."""
+
+    def _build(self, url, **kwargs):
+        fake_boto3 = MagicMock()
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            connector = create_remote_connector(url, **kwargs)
+        return fake_boto3, connector
+
+    def test_known_s3_kwargs_are_forwarded(self):
+        fake_boto3, _ = self._build(
+            "s3://bucket/path",
+            endpoint_url="https://s3.example.com",
+            region_name="eu-west-1",
+        )
+        fake_boto3.client.assert_called_once_with(
+            "s3",
+            config=ANY,
+            endpoint_url="https://s3.example.com",
+            region_name="eu-west-1",
+        )
+
+    def test_unknown_kwargs_are_silently_dropped(self):
+        fake_boto3, _ = self._build(
+            "s3://bucket/path",
+            endpoint_url="https://s3.example.com",
+            some_other_connector_option="ignored",
+        )
+        _, kwargs = fake_boto3.client.call_args
+        self.assertEqual(kwargs.get("endpoint_url"), "https://s3.example.com")
+        self.assertNotIn("some_other_connector_option", kwargs)
+
+    def test_region_alias_is_not_forwarded(self):
+        # ``region`` is intentionally absent from the whitelist; passing it
+        # via ``create_remote_connector`` must not propagate to boto3.
+        fake_boto3, _ = self._build("s3://bucket/path", region="us-west-1")
+        _, kwargs = fake_boto3.client.call_args
+        self.assertNotIn("region", kwargs)
+        self.assertNotIn("region_name", kwargs)
+
+    def test_session_token_is_forwarded(self):
+        fake_boto3, _ = self._build(
+            "s3://bucket/path",
+            aws_access_key_id="AKIA_X",
+            aws_secret_access_key="SEC_X",
+            aws_session_token="TOKEN_X",
+        )
+        fake_boto3.client.assert_called_once_with(
+            "s3",
+            config=ANY,
+            aws_access_key_id="AKIA_X",
+            aws_secret_access_key="SEC_X",
+            aws_session_token="TOKEN_X",
+        )
+
+    def test_dropped_kwargs_are_logged_at_debug(self):
+        # ``region`` (typo for ``region_name``) is silently dropped, but the
+        # drop must show up at DEBUG so it is debuggable.
+        with self.assertLogs("sglang.srt.connector", level="DEBUG") as cm:
+            self._build(
+                "s3://bucket/path",
+                region="us-west-1",
+                endpoint_url="https://s3.example.com",
+            )
+        joined = "\n".join(cm.output)
+        self.assertIn("region", joined)
+        self.assertIn("ignoring", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hello team!

## Motivation

`S3Connector` (`python/sglang/srt/connector/s3.py`) calls `boto3.client("s3")` with no arguments, so it can only talk to AWS S3 unless the user happens to set `AWS_ENDPOINT_URL` and is on a recent enough botocore. There is no documented path, no per-connector override, and no test coverage for S3-compatible providers like [Backblaze B2](https://www.backblaze.com/cloud-storage), MinIO, or Cloudflare R2.

This PR threads `endpoint_url`, `region_name`, and credentials through `S3Connector` so the existing `s3://...` model URI form works against any S3-compatible provider, with no change to the `create_remote_connector` call signature.

Closes #24157.

## Modifications

- `python/sglang/srt/connector/s3.py`
  - New `_parse_s3_kwargs` helper extracts `endpoint_url`, `region_name`, and credentials from the model URI query string. Env vars are left to boto3's default credential/endpoint chain (SGLang does not read or inject them).
  - `S3Connector.__init__` now accepts `**client_kwargs` (explicit wins over query/env) and forwards them to `boto3.client("s3", ...)`.
  - Every boto3 client is tagged with `user_agent_extra=f"sglang/{__version__}"` via `botocore.config.Config`. If a caller passes their own `config=`, the two `user_agent_extra` strings are concatenated and the rest of the caller's `Config` is preserved through `Config.merge`.
- `python/sglang/srt/connector/__init__.py`: `create_remote_connector` forwards whitelisted `**kwargs` to `S3Connector(...)`.
- `test/registered/unit/connector/test_s3_endpoint_url.py`: 29 mocked-`boto3` unit tests covering query-string parsing, explicit-kwargs precedence, credential and session-token query params, unknown/duplicate/empty-value rejection, the `sglang/<version>` UA token, and caller-supplied `botocore.Config` merge.
- `docs_new/docs/advanced_features/object_storage.mdx`
  - Backends list now reads `S3-compatible (Backblaze B2, Cloudflare R2, MinIO, etc.)`.
  - New `Loading from S3-compatible storage` section with provider-neutral URI and env-var subsections, plus an `Example: Backblaze B2` worked example.

AWS-only callers see no functional change. The only observable difference is a `sglang/<version>` User-Agent suffix on boto3 requests.

## Accuracy Tests

Pure I/O-path change; model forward code is untouched. Validated locally by loading the same safetensors model from `s3://bucket/...` against AWS and against Backblaze B2 `us-west-004` and confirming identical greedy-decoded tokens.

## Speed Tests and Profiling

N/A. Weight-download throughput is bounded by network / object-store latency. The boto3 client construction path adds one URL parse and one `Config(...)` instantiation on cold start.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A, I/O-only.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`








































































































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26845131137](https://github.com/sgl-project/sglang/actions/runs/26845131137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26845130367](https://github.com/sgl-project/sglang/actions/runs/26845130367)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
