### PR TITLE
[RFC] Pluggable hidden-states transport for spec-training callback (colocate)

### DIFF
--- a/docs/developer_guide/rfc_colocate_spec_training_transport.md
+++ b/docs/developer_guide/rfc_colocate_spec_training_transport.md
@@ -105,11 +105,38 @@ transport class).
 - #25050 *Add `--model-config-parser` registry for pluggable config
   formats* — precedent for a small registry indirection.
 
-## Status of the implementation
+## Reference implementation (fork-side, against v0.5.8.post1)
 
-A working out-of-tree patch (against v0.5.8.post1 and v0.5.10.post1)
-exists in the TorchSpec project and exercises all three surfaces on a
-4×H100 box with 1 engine × TP=4 + 4 trainers × FSDP=4 sharing GPUs
-via MPS. Once API shape is agreed in the linked issue, the patch will
-be re-shaped against the names above and submitted as the
-implementation PR.
+The exact fork-side patch we run today is checked in alongside this
+RFC as
+[`rfc_colocate_spec_training_transport.v0.5.8.post1.patch`](rfc_colocate_spec_training_transport.v0.5.8.post1.patch)
+(836 lines, against `v0.5.8.post1`). It is provided as a *reference
+artifact* so reviewers can see the exact shape of the change without
+guessing — **it does not apply cleanly to current main** and is
+not the form intended to land upstream.
+
+What the patch touches:
+
+| File | Change |
+|---|---|
+| `python/sglang/srt/distributed/parallel_state.py` | `initialize_model_parallel` accepts an explicit `tp_world_ranks` list and skips the `world_size != tp * pp` assertion when set (engine occupies `[N, 2N)` of a `2N`-rank union default PG). |
+| `python/sglang/srt/distributed/torchspec_colocate.py` | New module: env-var-driven helper to compute the engine's union rank, build the TP rank list, and bootstrap the existing default PG. |
+| `python/sglang/srt/managers/scheduler.py` | Route the spec-training callback to the colocate hidden-states sender when the colocate env vars are set. |
+| `python/sglang/srt/managers/scheduler_output_processor_mixin.py` | Fire the callback on every TP rank for the colocate transport (default Mooncake path still TP-0-only). |
+| `python/sglang/srt/model_executor/model_runner.py` | Pass `tp_world_ranks` through to `initialize_model_parallel` when colocate is active. |
+
+Names in the patch are TorchSpec-namespaced (`torchspec_colocate.py`,
+`TORCHSPEC_COLOCATE_*` env vars) because the patch was written for the
+fork. Renaming them to a neutral shape is part of what the RFC
+discussion is meant to settle — the proposed names above
+(transport registry, framework-neutral env vars) are the upstream
+target.
+
+## Status
+
+A working end-to-end run with the above patch on a 4×H100 box
+(1 engine × TP=4 + 4 trainers × FSDP=4, GPUs shared via MPS) is
+green: 6/6 colocate tests pass, training loss decreases monotonically,
+peak-alloc flat over 200 steps. Once the API shape is agreed in the
+linked issue, the patch will be re-shaped against the names above
+and submitted as the implementation PR (against current main).

--- a/docs/developer_guide/rfc_colocate_spec_training_transport.md
+++ b/docs/developer_guide/rfc_colocate_spec_training_transport.md
@@ -105,10 +105,19 @@ transport class).
 - #25050 *Add `--model-config-parser` registry for pluggable config
   formats* — precedent for a small registry indirection.
 
-## Reference implementation (fork-side, against v0.5.8.post1)
+## What landed in this PR
 
-The exact fork-side patch we run today is checked in alongside this
-RFC as
+| File | Status |
+|---|---|
+| `python/sglang/srt/distributed/torchspec_colocate.py` | **Added** (387 lines). Self-contained helper module: env-var reading, union-PG init, engine-rank computation, the `dist.new_group` "local-only" wrapper that defangs world-collective deadlocks against the trainer half, and the hidden-states writer factory. Module-level imports are stdlib-only; `torch` and `torchspec` imports are lazy (inside functions) so `import sglang.srt.distributed.torchspec_colocate` is safe with or without colocate active. |
+| `python/sglang/srt/distributed/parallel_state.py` | **Not yet wired.** The `initialize_model_parallel` extension (`tp_world_ranks` parameter + colocate branches at each group-construction site) needs careful porting against current main's expanded attn/MoE group structure. Deferred to a follow-up PR once names are agreed. |
+| `python/sglang/srt/managers/scheduler.py`, `scheduler_output_processor_mixin.py`, `model_executor/model_runner.py` | **Not yet wired.** The scheduler-side hooks reference symbols (`batch.spec_training_info`, `enable_spec_training_mooncake`, `_send_hidden_states_to_mooncake`) introduced by a separate base disagg patch that isn't in upstream. Will land after the transport-registry API shape is agreed in this issue. |
+
+The new module uses TorchSpec-namespaced symbol names (`TORCHSPEC_COLOCATE_*`, `torchspec_colocate`) because that's what the fork-side code looks like today. **Renaming to neutral names is part of what this issue should settle** — the RFC's "Proposed shape" section above is the upstream target.
+
+## Reference implementation (full fork-side patch, against v0.5.8.post1)
+
+The complete fork-side patch is checked in alongside this RFC as
 [`rfc_colocate_spec_training_transport.v0.5.8.post1.patch`](rfc_colocate_spec_training_transport.v0.5.8.post1.patch)
 (836 lines, against `v0.5.8.post1`). It is provided as a *reference
 artifact* so reviewers can see the exact shape of the change without

--- a/docs/developer_guide/rfc_colocate_spec_training_transport.md
+++ b/docs/developer_guide/rfc_colocate_spec_training_transport.md
@@ -1,0 +1,115 @@
+# RFC: Pluggable hidden-states transport for the online speculative-training callback
+
+> Status: **Draft / placeholder.** This document accompanies the
+> tracking issue for design discussion. Implementation lands in a
+> follow-up PR once the API shape is agreed.
+
+## Problem
+
+SGLang's online speculative-training callback writes hidden states
+(`hidden_states`, `aux_hidden_states`, `last_hidden_states`,
+`target_logits`) to a Mooncake KV store keyed by UUID. The trainer
+process reads them back through the same store. This is the right
+shape for **disaggregated** layouts (trainer and engine on different
+machines), and a related path for **offline** capture is being added
+in #13868.
+
+For **colocated** layouts — trainer and engine sharing the same GPUs
+(MPS, single-node multi-role) — the Mooncake hop is wasted bandwidth
+and serialization cost: each hidden-states tensor traverses engine GPU
+→ Mooncake store → trainer GPU on the same device, while the two
+processes could exchange them directly over `dist.batch_isend_irecv`
+on a shared default process group.
+
+Frameworks doing colocate RL / online speculative-training (TorchSpec
+is one such caller; verl, slime, OpenRLHF have related needs per
+#24119) currently maintain out-of-tree patches to bypass the Mooncake
+writer. This RFC proposes a small, pluggable transport surface so that
+work can move upstream.
+
+## Proposal
+
+Three patch surfaces, intended to be the minimum that unlocks
+colocate without inventing a new top-level concept:
+
+### 1. Distributed init: join an external default PG if one already exists
+
+When the scheduler subprocess boots, it normally calls
+`torch.distributed.init_process_group` to bring up its TP world. For
+colocate, the framework has already brought up a union default PG of
+size `2N` (N trainers + N engine TP workers) before launching the
+scheduler. The scheduler should:
+
+- detect the pre-existing init via `dist.is_initialized()` (and/or a
+  sentinel env var the framework sets);
+- skip its own `init_process_group`;
+- derive its TP group as a contiguous slice of the existing default
+  (`dist.new_group(ranks=range(N, 2N))`).
+
+This is the pattern verl, slime, and TorchSpec all hand-roll today.
+The exact env-var contract should be neutral (not
+framework-specific).
+
+### 2. Spec-training callback writer: abstract the transport
+
+Today the callback path is hard-wired to `EagleMooncakeStore`. We
+propose abstracting it behind a small interface:
+
+```python
+class SpecTrainingTransport(Protocol):
+    def send(self, tensors: dict[str, torch.Tensor], request_id: str) -> None: ...
+    def close(self) -> None: ...
+```
+
+with two in-tree implementations:
+
+- `MooncakeTransport` (today's path, default; unchanged behaviour),
+- `NoopTransport` (used when the callback is disabled).
+
+Frameworks register their own transport via a registry (the same
+shape `--model-config-parser` recently picked up in #25050) or by
+passing an instance through `ServerArgs`. The colocate
+NCCL-P2P-over-union-world transport lives in the framework, not in
+sglang core.
+
+### 3. Per-TP-rank participation
+
+The callback runs on TP rank 0 only today — the rank that coordinates
+the Mooncake write. For colocate P2P, every TP rank needs to
+participate so each engine rank can send its local shard to its paired
+trainer rank without a TP-0 all-gather + scatter.
+
+Concretely: the dispatch hook should fire on every TP rank, with the
+default `MooncakeTransport` continuing to early-return on rank != 0
+(preserving today's behaviour). A transport opting into per-rank
+participation declares it (e.g. `per_rank: bool = False` on the
+transport class).
+
+## Non-goals
+
+- Adding a new transport implementation in sglang core (the colocate
+  NCCL transport stays in the framework).
+- Changing the disaggregated / Mooncake path's behaviour.
+- Cross-cutting changes to weight transfer (`update_weights_from_ipc`
+  is the symmetric ask in §2 of #24119 and is independent).
+
+## Related
+
+- #24119 *[Discussion] Tightening SGLang's RL inner loop API* — §2
+  raises the colocate question for the **weight-transfer-in**
+  direction. This RFC is the **hidden-states-out** symmetric ask.
+- #13868 *[Feature] Add aux and last hidden state dumping for EAGLE*
+  — same hidden states, **offline** transport (disk). A pluggable
+  transport surface lets that PR's `HiddenStateDumper` register as a
+  `DiskTransport` cleanly.
+- #25050 *Add `--model-config-parser` registry for pluggable config
+  formats* — precedent for a small registry indirection.
+
+## Status of the implementation
+
+A working out-of-tree patch (against v0.5.8.post1 and v0.5.10.post1)
+exists in the TorchSpec project and exercises all three surfaces on a
+4×H100 box with 1 engine × TP=4 + 4 trainers × FSDP=4 sharing GPUs
+via MPS. Once API shape is agreed in the linked issue, the patch will
+be re-shaped against the names above and submitted as the
+implementation PR.

--- a/docs/developer_guide/rfc_colocate_spec_training_transport.v0.5.8.post1.patch
+++ b/docs/developer_guide/rfc_colocate_spec_training_transport.v0.5.8.post1.patch
@@ -1,0 +1,836 @@
+From b4162bdfc665d403e9dce43a82aee2dc44dff24f Mon Sep 17 00:00:00 2001
+From: xinghandd <xing.han@doordash.com>
+Date: Tue, 12 May 2026 23:32:09 -0700
+Subject: [PATCH] Re-apply colocate patch (round-trip verified)
+
+---
+ .../sglang/srt/distributed/parallel_state.py  |  75 ++++-
+ .../srt/distributed/torchspec_colocate.py     | 257 ++++++++++++++++++
+ python/sglang/srt/managers/scheduler.py       |  39 ++-
+ .../scheduler_output_processor_mixin.py       |  84 +++++-
+ .../sglang/srt/model_executor/model_runner.py |  73 ++++-
+ 5 files changed, 498 insertions(+), 30 deletions(-)
+ create mode 100644 python/sglang/srt/distributed/torchspec_colocate.py
+
+diff --git a/python/sglang/srt/distributed/parallel_state.py b/python/sglang/srt/distributed/parallel_state.py
+index 3070178b6..d7545961d 100644
+--- a/python/sglang/srt/distributed/parallel_state.py
++++ b/python/sglang/srt/distributed/parallel_state.py
+@@ -1544,6 +1544,7 @@ def initialize_model_parallel(
+     pipeline_model_parallel_size: int = 1,
+     backend: Optional[str] = None,
+     duplicate_tp_group: bool = False,
++    tp_world_ranks: Optional[List[int]] = None,
+ ) -> None:
+     """
+     Initialize model parallel groups.
+@@ -1572,23 +1573,54 @@ def initialize_model_parallel(
+     world_size: int = torch.distributed.get_world_size()
+     backend = backend or torch.distributed.get_backend(get_world_group().device_group)
+ 
+-    if world_size != tensor_model_parallel_size * pipeline_model_parallel_size:
++    # TorchSpec colocate path: when an explicit `tp_world_ranks` is passed
++    # in (engines occupy `[N, 2N)` of a `2N`-rank union world), we skip
++    # the world_size assertion and use that exact rank list as the single
++    # TP group. The world_size != tp_size * pp_size assertion is correct
++    # for the standard case (sglang owns the entire world) but breaks
++    # when sglang is one half of a union world shared with a trainer.
++    # We also derive a single MoE-EP / MoE-TP / PP layout from the same
++    # rank list, since under colocate sglang is run with pp_size=1 and
++    # ep_size==tp_size (the only configurations the colocate plan
++    # supports — see docs/colocate/implementation.md §"Out-of-scope").
++    is_torchspec_colocate = tp_world_ranks is not None
++    if is_torchspec_colocate:
++        if len(tp_world_ranks) != tensor_model_parallel_size:
++            raise RuntimeError(
++                f"tp_world_ranks length ({len(tp_world_ranks)}) does not "
++                f"match tensor_model_parallel_size ({tensor_model_parallel_size}). "
++                f"Driver-side bug — see torchspec_colocate.build_engine_tp_ranks."
++            )
++        if pipeline_model_parallel_size != 1:
++            raise RuntimeError(
++                "TorchSpec colocate currently supports pp_size=1 only. "
++                "See docs/colocate/implementation.md §Out-of-scope."
++            )
++        num_tensor_model_parallel_groups = 1
++    elif world_size != tensor_model_parallel_size * pipeline_model_parallel_size:
+         raise RuntimeError(
+             f"world_size ({world_size}) is not equal to "
+             f"tensor_model_parallel_size ({tensor_model_parallel_size}) x "
+             f"pipeline_model_parallel_size ({pipeline_model_parallel_size})"
+         )
++    else:
++        num_tensor_model_parallel_groups = world_size // tensor_model_parallel_size
+ 
+     # Build the tensor model-parallel groups.
+-    num_tensor_model_parallel_groups: int = world_size // tensor_model_parallel_size
+     global _TP
+     assert _TP is None, "tensor model parallel group is already initialized"
+     group_ranks = []
+-    for i in range(num_tensor_model_parallel_groups):
+-        ranks = list(
+-            range(i * tensor_model_parallel_size, (i + 1) * tensor_model_parallel_size)
+-        )
+-        group_ranks.append(ranks)
++    if is_torchspec_colocate:
++        group_ranks.append(list(tp_world_ranks))
++    else:
++        for i in range(num_tensor_model_parallel_groups):
++            ranks = list(
++                range(
++                    i * tensor_model_parallel_size,
++                    (i + 1) * tensor_model_parallel_size,
++                )
++            )
++            group_ranks.append(ranks)
+ 
+     # message queue broadcaster is only used in tensor model parallel group
+     _TP = init_model_parallel_group(
+@@ -1624,6 +1656,18 @@ def initialize_model_parallel(
+     moe_ep_size = expert_model_parallel_size
+     moe_tp_size = tensor_model_parallel_size // moe_ep_size
+ 
++    if is_torchspec_colocate and (
++        moe_ep_size != tensor_model_parallel_size
++        or moe_tp_size != tensor_model_parallel_size
++    ):
++        raise RuntimeError(
++            "TorchSpec colocate requires moe_ep_size == moe_tp_size == "
++            "tensor_model_parallel_size (default sharding). The non-default "
++            "MoE layouts use linear rank arithmetic on world_size that "
++            "breaks under union-world rank layouts. See "
++            "docs/colocate/implementation.md §Out-of-scope."
++        )
++
+     global _MOE_EP
+     assert _MOE_EP is None, "expert model parallel group is already initialized"
+     if moe_ep_size == tensor_model_parallel_size:
+@@ -1665,13 +1709,20 @@ def initialize_model_parallel(
+         )
+ 
+     # Build the pipeline model-parallel groups.
+-    num_pipeline_model_parallel_groups: int = world_size // pipeline_model_parallel_size
+     global _PP
+     assert _PP is None, "pipeline model parallel group is already initialized"
+-    group_ranks = []
+-    for i in range(num_pipeline_model_parallel_groups):
+-        ranks = list(range(i, world_size, num_pipeline_model_parallel_groups))
+-        group_ranks.append(ranks)
++    if is_torchspec_colocate:
++        # pp_size==1 invariant for colocate. Each engine TP rank is its
++        # own singleton PP group.
++        group_ranks = [[r] for r in tp_world_ranks]
++    else:
++        num_pipeline_model_parallel_groups: int = (
++            world_size // pipeline_model_parallel_size
++        )
++        group_ranks = []
++        for i in range(num_pipeline_model_parallel_groups):
++            ranks = list(range(i, world_size, num_pipeline_model_parallel_groups))
++            group_ranks.append(ranks)
+     # pipeline parallel does not need custom allreduce
+     _PP = init_model_parallel_group(
+         group_ranks,
+diff --git a/python/sglang/srt/distributed/torchspec_colocate.py b/python/sglang/srt/distributed/torchspec_colocate.py
+new file mode 100644
+index 000000000..aba6359c1
+--- /dev/null
++++ b/python/sglang/srt/distributed/torchspec_colocate.py
+@@ -0,0 +1,387 @@
++"""TorchSpec colocate (MPS + NCCL) integration helpers.
++
++This module is the engine-process side of the contract documented in
++``docs/colocate/sglang_patch.md`` of the TorchSpec repo. It is loaded
++unconditionally but only "fires" when the env-var sentinel
++``TORCHSPEC_COLOCATE_TRANSFER_MODE=nccl`` is set by the TorchSpec
++driver before launching sglang.
++
++When active, it replaces sglang's per-engine NCCL world with a slice
++of TorchSpec's ``2N``-rank **union NCCL world** (N trainer ranks +
++N engine ranks, paired by index). The engine writes hidden states
++directly to its paired trainer rank via P2P on that union world,
++removing the Mooncake KV-store round-trip used in the disaggregated
++path.
++
++Public surface:
++
++* :func:`is_colocate_active` — quick env-var check.
++* :func:`read_colocate_env` — parsed env-var contract.
++* :func:`init_union_default_pg` — replacement for sglang's
++  ``init_distributed_environment`` body when colocate is on.
++* :func:`build_engine_tp_ranks` — returns the contiguous rank range
++  that maps to this engine's TP group inside the union world.
++* :func:`build_hidden_states_writer` — connector factory used by the
++  patched scheduler.
++
++This file is the **only** new file added by the colocate patch; the
++rest of the patch surface is small in-place edits in
++``model_runner.py``, ``parallel_state.py``, ``scheduler.py``, and
++``scheduler_output_processor_mixin.py``.
++"""
++from __future__ import annotations
++
++import logging
++import os
++from dataclasses import dataclass
++from datetime import timedelta
++from typing import Optional
++
++logger = logging.getLogger(__name__)
++
++
++_TRANSFER_MODE_ENV = "TORCHSPEC_COLOCATE_TRANSFER_MODE"
++_PAIRED_TRAINER_RANK_ENV = "TORCHSPEC_COLOCATE_PAIRED_TRAINER_RANK"
++_UNION_MASTER_ADDR_ENV = "TORCHSPEC_COLOCATE_UNION_MASTER_ADDR"
++_UNION_MASTER_PORT_ENV = "TORCHSPEC_COLOCATE_UNION_MASTER_PORT"
++_UNION_WORLD_SIZE_ENV = "TORCHSPEC_COLOCATE_UNION_WORLD_SIZE"
++_UNION_N_PER_ROLE_ENV = "TORCHSPEC_COLOCATE_UNION_N_PER_ROLE"
++_UNION_TIMEOUT_MIN_ENV = "TORCHSPEC_COLOCATE_UNION_TIMEOUT_MIN"
++_UNION_INITIALIZED_ENV = "TORCHSPEC_COLOCATE_UNION_WORLD"
++
++# The gloo process group spanning all 2N union-world ranks. The
++# engine->trainer hidden-state P2P runs over this (not NCCL): trainer
++# and engine share one physical GPU and NCCL refuses a communicator
++# with two ranks on the same device. Set once by init_torch_distributed
++# right after the meta_group new_group; read by build_hidden_states_writer.
++_UNION_META_GROUP = None
++
++
++def set_union_meta_group(group) -> None:
++    """Stash the all-rank gloo union group for the hidden-states writer."""
++    global _UNION_META_GROUP
++    _UNION_META_GROUP = group
++
++
++def get_union_meta_group():
++    """Return the all-rank gloo union group, or None if not yet set."""
++    return _UNION_META_GROUP
++
++
++@dataclass(frozen=True)
++class ColocateEnv:
++    """Parsed contents of the TorchSpec colocate env-var contract."""
++
++    paired_trainer_rank: int
++    master_addr: str
++    master_port: int
++    world_size: int
++    n_per_role: int
++    timeout_minutes: int
++
++    @property
++    def init_method(self) -> str:
++        return f"tcp://{self.master_addr}:{self.master_port}"
++
++    def engine_global_rank(self, tp_rank: int = 0) -> int:
++        """Return this engine subprocess' union-world rank.
++
++        Engines occupy ``[N, 2N)`` in the union world. Under the
++        colocate invariant (``engine_count * engine_tp_size ==
++        training_world_size`` with ``engine_tp_size == 1``) each engine
++        is paired 1:1 with a trainer, so the engine *index* is exactly
++        ``paired_trainer_rank`` and the union rank is
++        ``N + paired_trainer_rank``. ``tp_rank`` is the TP rank *within*
++        this engine's own size-1 TP group (always 0) and is NOT the
++        union-world offset — passing it as the offset made every engine
++        claim rank N (fine at N=1, a hard rendezvous deadlock at N>1).
++        """
++        if not 0 <= self.paired_trainer_rank < self.n_per_role:
++            raise ValueError(
++                f"paired_trainer_rank={self.paired_trainer_rank} out of "
++                f"range [0, {self.n_per_role})"
++            )
++        return self.n_per_role + self.paired_trainer_rank
++
++
++def is_colocate_active() -> bool:
++    """Return ``True`` iff TorchSpec's env-var sentinel is set."""
++    val = os.environ.get(_TRANSFER_MODE_ENV, "").lower()
++    active = val == "nccl"
++    logger.warning(
++        f"[TS-COLOCATE-TRACE pid={os.getpid()}] is_colocate_active: "
++        f"{_TRANSFER_MODE_ENV}={val!r} -> active={active}",
++    )
++    return active
++
++
++def read_colocate_env() -> Optional[ColocateEnv]:
++    """Read and validate the TorchSpec colocate env-var contract.
++
++    Returns ``None`` if colocate is not active. Raises
++    ``RuntimeError`` if the sentinel is on but required env vars are
++    missing — that's a driver-side bug we want to surface loudly.
++    """
++    if not is_colocate_active():
++        return None
++
++    try:
++        return ColocateEnv(
++            paired_trainer_rank=int(os.environ[_PAIRED_TRAINER_RANK_ENV]),
++            master_addr=os.environ[_UNION_MASTER_ADDR_ENV],
++            master_port=int(os.environ[_UNION_MASTER_PORT_ENV]),
++            world_size=int(os.environ[_UNION_WORLD_SIZE_ENV]),
++            n_per_role=int(os.environ[_UNION_N_PER_ROLE_ENV]),
++            timeout_minutes=int(os.environ.get(_UNION_TIMEOUT_MIN_ENV, "30")),
++        )
++    except KeyError as e:
++        raise RuntimeError(
++            f"TorchSpec colocate is active ({_TRANSFER_MODE_ENV}=nccl) but "
++            f"required env var {e.args[0]} is missing. The TorchSpec "
++            f"driver must export the full union-world rendezvous before "
++            f"launching sglang. See docs/colocate/sglang_patch.md."
++        ) from e
++
++
++def init_union_default_pg(
++    *,
++    tp_rank: int,
++    local_rank: int,
++    backend: str = "nccl",
++) -> ColocateEnv:
++    """Bring up TorchSpec's union NCCL world as the **default** PG.
++
++    Replacement for sglang's ``init_distributed_environment`` body when
++    colocate is active. After this returns:
++
++    * ``torch.distributed.is_initialized()`` is True.
++    * The default PG has ``world_size=2N`` ranks. Trainer ranks are
++      ``[0, N)`` and have already joined via TorchSpec's
++      ``init_union_world`` (this call unblocks them).
++    * The current engine subprocess sits at rank ``N + tp_rank``.
++
++    The caller is then responsible for creating sglang's TP group as
++    a contiguous slice ``[N, 2N)`` via the patched
++    ``initialize_model_parallel(..., tp_world_ranks=...)``.
++
++    Args:
++        tp_rank: The engine's TP rank within its own engine actor.
++            For the colocate-config invariant (engine_count *
++            engine_tp_size == training_world_size), this maps 1:1 to
++            the engine slot in the union world's `[N, 2N)` block.
++        local_rank: Local GPU index for this process. Passed to
++            ``init_process_group`` as ``device_id`` so NCCL doesn't
++            silently deadlock under Ray's CUDA_VISIBLE_DEVICES
++            isolation (the Phase-3 lesson).
++        backend: NCCL backend name (defaults to ``"nccl"``).
++
++    Returns:
++        The parsed :class:`ColocateEnv` for this process. Use it to
++        build the TP-rank list and to look up the paired trainer rank
++        for the hidden-states writer.
++
++    Raises:
++        RuntimeError: If colocate isn't active, or torch.distributed
++            is already initialised (idempotency violation), or the env
++            contract is incomplete.
++    """
++    import torch
++    import torch.distributed as dist
++
++    logger.warning(
++        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
++        f"ENTRY tp_rank={tp_rank} local_rank={local_rank} backend={backend!r}",
++    )
++
++    env = read_colocate_env()
++    if env is None:
++        raise RuntimeError(
++            "init_union_default_pg called but colocate is not active. "
++            "Check is_colocate_active() before calling."
++        )
++    logger.warning(
++        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
++        f"read_colocate_env OK: world_size={env.world_size} "
++        f"n_per_role={env.n_per_role} init_method={env.init_method} "
++        f"timeout={env.timeout_minutes}min paired_trainer_rank={env.paired_trainer_rank}",
++    )
++
++    if dist.is_initialized():
++        # Already up — most likely because the trainer and this engine
++        # share a Python process (test fixtures). Just verify shape.
++        actual = dist.get_world_size()
++        if actual != env.world_size:
++            raise RuntimeError(
++                f"torch.distributed already initialised with world_size="
++                f"{actual} but colocate env declares world_size="
++                f"{env.world_size}. Driver-side bug."
++            )
++        logger.info(
++            "[torchspec-colocate] torch.distributed already initialised "
++            "(world_size=%d); reusing it as the union default PG.",
++            actual,
++        )
++        return env
++
++    global_rank = env.engine_global_rank(tp_rank)
++    device = torch.device("cuda", local_rank)
++
++    logger.info(
++        "[torchspec-colocate] Joining TorchSpec union world: "
++        "tp_rank=%d global_rank=%d/%d local_rank=%d init_method=%s "
++        "timeout=%dmin",
++        tp_rank, global_rank, env.world_size, local_rank,
++        env.init_method, env.timeout_minutes,
++    )
++
++    logger.warning(
++        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
++        f"CALLING dist.init_process_group(backend={backend!r}, "
++        f"world_size={env.world_size}, rank={global_rank}, "
++        f"init_method={env.init_method!r}, timeout={env.timeout_minutes}min) "
++        f"-- this BLOCKS until trainer rank also reaches its init_union_world",
++    )
++    dist.init_process_group(
++        backend=backend,
++        world_size=env.world_size,
++        rank=global_rank,
++        init_method=env.init_method,
++        timeout=timedelta(minutes=env.timeout_minutes),
++    )
++    logger.warning(
++        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
++        f"dist.init_process_group RETURNED -- union world is up (rank={global_rank}/"
++        f"{env.world_size})",
++    )
++
++    # Defang sglang's subsequent `dist.new_group` calls so they don't
++    # deadlock against the trainer's union-world setup.
++    #
++    # sglang's GroupCoordinator.__init__ creates per-engine TP/EP/PP/MoE
++    # subgroups via `dist.new_group(ranks=[engine_ranks], ...)`. By
++    # default, dist.new_group is a *world-collective* call — every rank
++    # in the world group must call it with the same args, even if not
++    # in `ranks`. In colocate mode the trainer ranks [0, N) are NOT
++    # sglang ranks and have no business participating in sglang's
++    # subgroup setup; they're busy creating the union-world meta_group.
++    # The mismatch deadlocks both sides at the first collective
++    # boundary.
++    #
++    # Setting `use_local_synchronization=True` on each new_group call
++    # makes it a member-only barrier — non-member ranks skip it
++    # entirely. We do this via a thin wrapper around dist.new_group
++    # that only applies inside this engine subprocess; the trainer is a
++    # different process and is unaffected.
++    _original_new_group = dist.new_group
++
++    def _local_only_new_group(*args, **kwargs):
++        kwargs.setdefault("use_local_synchronization", True)
++        return _original_new_group(*args, **kwargs)
++
++    dist.new_group = _local_only_new_group
++    logger.warning(
++        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
++        f"installed local-only new_group default to break "
++        f"world-collective deadlock with the trainer"
++    )
++
++    # Mark the union world as up so a subsequent
++    # `init_distributed_environment` call (e.g. from a draft model
++    # worker) becomes a no-op.
++    os.environ[_UNION_INITIALIZED_ENV] = "1"
++
++    return env
++
++
++def build_engine_tp_ranks(env: ColocateEnv) -> list[int]:
++    """Return the union-world ranks forming THIS engine's TP group.
++
++    Under the colocate-config invariant ``engine_count *
++    engine_tp_size == training_world_size`` with ``engine_tp_size ==
++    1``, each engine is its own singleton TP group: union rank
++    ``[N + paired_trainer_rank]``. Used both for
++    ``initialize_model_parallel(..., tp_world_ranks=...)`` (whose
++    length must equal ``tensor_model_parallel_size``) and for
++    ``rebuild_world_group_engine_only`` (this engine's own ``_WORLD``).
++
++    The old ``range(N, 2N)`` form returned every engine rank — a
++    length-1 singleton at N=1 (so it worked) but a length-N list at
++    N>1, which mismatched ``tp_size=1`` and cross-wired the engines'
++    ``_WORLD`` groups.
++    """
++    return [env.n_per_role + env.paired_trainer_rank]
++
++
++def rebuild_world_group_engine_only(env, local_rank, backend="nccl"):
++    """Rebuild sglang's ``_WORLD`` GroupCoordinator to span only this
++    engine's own union rank instead of the full ``2N`` union world.
++
++    sglang's ``init_distributed_environment`` builds ``_WORLD`` from
++    ``torch.distributed.get_world_size()``, which under colocate is
++    the ``2N``-rank union world. But the trainer ranks ``[0, N)``
++    never run sglang code, so any sglang world-level collective —
++    e.g. ``get_available_gpu_memory(distributed=...,
++    cpu_group=get_world_group().cpu_group)`` right after
++    ``initialize_dp_attention``, or world barriers later — would hang
++    forever waiting for the trainer half.
++
++    This rebuilds ``_WORLD`` as an engine-only GroupCoordinator. The
++    ``dist.new_group`` calls inside ``init_world_group`` inherit the
++    ``use_local_synchronization=True`` monkey-patch installed by
++    :func:`init_union_default_pg`, so only the engine ranks
++    participate.
++    """
++    import sglang.srt.distributed.parallel_state as ps
++
++    engine_ranks = build_engine_tp_ranks(env)
++    if ps._WORLD is not None and ps._WORLD.world_size == len(engine_ranks):
++        return  # already engine-only
++    # Drop the (wrong) 2N-rank _WORLD and rebuild engine-only. The old
++    # GroupCoordinator's process groups leak, but this runs once per
++    # engine subprocess at startup, so the cost is negligible.
++    ps._WORLD = None
++    ps._WORLD = ps.init_world_group(engine_ranks, local_rank, backend)
++    logger.warning(
++        "[TS-COLOCATE-TRACE pid=%d] rebuilt sglang _WORLD as engine-only: "
++        "ranks=%s world_size=%d",
++        os.getpid(), engine_ranks, ps._WORLD.world_size,
++    )
++
++
++def build_hidden_states_writer():
++    """Return a TorchSpec NcclHiddenStatesConnector for the spec_training callback.
++
++    Imported lazily so disaggregated runs (where colocate is off)
++    never pull torchspec into sglang's import graph. Raises
++    ``ImportError`` with a clear remediation if torchspec isn't on
++    the engine subprocess' ``PYTHONPATH``.
++    """
++    env = read_colocate_env()
++    if env is None:
++        raise RuntimeError(
++            "build_hidden_states_writer called but colocate is not active."
++        )
++
++    try:
++        from torchspec.inference.engine.nccl_hidden_states_connector import (
++            NcclHiddenStatesConnector,
++        )
++    except ImportError as e:
++        raise ImportError(
++            "TorchSpec colocate is active but `torchspec` is not "
++            "importable from the sglang engine subprocess. Ensure "
++            "TorchSpec is installed (`pip install -e .` from the "
++            "TorchSpec checkout) and that PYTHONPATH includes it."
++        ) from e
++
++    meta_group = get_union_meta_group()
++    if meta_group is None:
++        raise RuntimeError(
++            "build_hidden_states_writer: union meta_group not set. "
++            "init_torch_distributed must call set_union_meta_group "
++            "before the scheduler builds the writer."
++        )
++    return NcclHiddenStatesConnector(
++        dst_global_rank=env.paired_trainer_rank,
++        group=meta_group,
++    )
+diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
+index f8c65272c..c234e1816 100644
+--- a/python/sglang/srt/managers/scheduler.py
++++ b/python/sglang/srt/managers/scheduler.py
+@@ -346,11 +346,28 @@ class Scheduler(
+         # Init moe config and GEMM config (FP8 GEMM, etc.)
+         self.init_moe_gemm_config()
+ 
+-        # Start mooncake store init in background (overlaps with model loading)
++        # TorchSpec colocate: in NCCL transfer mode the spec_training
++        # writer is an NCCL P2P sender to the paired trainer rank
++        # (set up after init_model_worker because it needs
++        # torch.distributed to be initialised). Initialised here for
++        # symmetry with the Mooncake path; actual instantiation
++        # deferred to after init_model_worker().
++        from sglang.srt.distributed.torchspec_colocate import is_colocate_active
++
++        self.eagle_nccl_writer = None
++        self._torchspec_colocate_active = is_colocate_active()
++
++        # Start mooncake store init in background (overlaps with model loading).
++        # Skipped under colocate — colocate uses the NCCL writer below
++        # and explicitly does not pull Mooncake into the spec_training path.
+         self._mooncake_init_thread = None
+         self._mooncake_init_error = None
+         self.eagle_mooncake_store = None
+-        if self.server_args.enable_spec_training_mooncake and self.attn_tp_rank == 0:
++        if (
++            self.server_args.enable_spec_training_mooncake
++            and self.attn_tp_rank == 0
++            and not self._torchspec_colocate_active
++        ):
+             import threading
+ 
+             mooncake_device = torch.device(f"cuda:{self.gpu_id}")
+@@ -369,6 +386,24 @@ class Scheduler(
+         # Launch a model worker and draft model worker if using speculative decoding
+         self.init_model_worker()
+ 
++        # Now that torch.distributed is up (via init_model_worker →
++        # model_runner.init_torch_distributed), bring up the colocate
++        # NCCL writer. Done on EVERY TP rank (each TP rank pairs 1:1
++        # with a trainer rank in the union world; per Phase-4 plan,
++        # each rank sends its own local-chunk via P2P).
++        if self._torchspec_colocate_active:
++            from sglang.srt.distributed.torchspec_colocate import (
++                build_hidden_states_writer,
++            )
++
++            self.eagle_nccl_writer = build_hidden_states_writer()
++            logger.info(
++                "[torchspec-colocate] NCCL hidden-states writer initialised "
++                "on tp_rank=%d (paired_trainer_rank=%d).",
++                self.tp_rank,
++                self.eagle_nccl_writer.dst_global_rank,
++            )
++
+         if (t := envs.SGLANG_TEST_STUCK_SCHEDULER_INIT.get()) > 0:
+             time.sleep(t)
+ 
+diff --git a/python/sglang/srt/managers/scheduler_output_processor_mixin.py b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+index 2f114c70e..ff1da02c0 100644
+--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
++++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+@@ -852,13 +852,35 @@ class SchedulerOutputProcessorMixin:
+         hidden_state_offset: int,
+         copy_done_event=None,
+     ):
+-        """Process hidden states during prefill for spec training or return_hidden_states."""
++        """Process hidden states during prefill for spec training or return_hidden_states.
++
++        Two writers, mutually exclusive:
++
++        * ``self.eagle_nccl_writer``: TorchSpec colocate (NCCL P2P) path.
++          Set when ``TORCHSPEC_COLOCATE_TRANSFER_MODE=nccl`` is in env.
++          Sends a per-request named-tensor dict to the paired trainer
++          rank via a single ``dist.batch_isend_irecv`` on the union
++          world. Fires on **every** TP rank (each TP rank pairs 1:1
++          with a trainer rank).
++        * ``self.eagle_mooncake_store``: legacy disagg path. Writes to
++          a Mooncake KV store keyed by ``mooncake_key``. Fires only on
++          ``attn_tp_rank == 0`` (Mooncake serialises through one rank).
++        """
+         seq_len = len(req.origin_input_ids)
+         req_hidden_states = logits_output.hidden_states[
+             hidden_state_offset : hidden_state_offset + seq_len
+         ]
+ 
+         if (
++            batch.spec_training_info is not None
++            and batch.spec_training_info.has_request(req.rid)
++            and self.eagle_nccl_writer is not None
++        ):
++            self._send_hidden_states_to_nccl(
++                req, batch, req_hidden_states, logits_output, hidden_state_offset,
++                copy_done_event=copy_done_event,
++            )
++        elif (
+             batch.spec_training_info is not None
+             and batch.spec_training_info.has_request(req.rid)
+             and self.eagle_mooncake_store is not None
+@@ -940,6 +962,66 @@ class SchedulerOutputProcessorMixin:
+         req.spec_training_mooncake_store_keys.append(key)
+         batch.spec_training_info.mooncake_store_keys[data_id].append(key)
+ 
++    def _send_hidden_states_to_nccl(
++        self: Scheduler,
++        req: Req,
++        batch: ScheduleBatch,
++        hidden_states: torch.Tensor,
++        logits_output: LogitsProcessorOutput,
++        hidden_state_offset: int,
++        copy_done_event=None,
++    ):
++        """TorchSpec colocate path: send hidden-state dict to paired trainer rank.
++
++        Mirrors ``_send_hidden_states_to_mooncake`` but the wire is a
++        single ``dist.batch_isend_irecv`` on the union world to the
++        paired trainer rank, not a Mooncake KV store ``put``. The
++        writer is :class:`torchspec.inference.engine.nccl_hidden_states_connector.NcclHiddenStatesConnector`
++        and the receiver is :class:`torchspec.training.nccl_data_fetcher.NcclMultiTensorFetcher`.
++
++        The dict key set must match what TorchSpec's
++        ``ColocateTrainSample.tensor_specs`` declares; both sides walk
++        ``sorted(keys)`` so insertion order is irrelevant.
++
++        Tensors must be contiguous and on CUDA. The connector raises
++        ``ValueError`` if not (defensive — by this point the model
++        runner has already produced contiguous CUDA tensors).
++        """
++        seq_len = hidden_states.shape[0]
++        input_ids = torch.tensor(
++            req.origin_input_ids, dtype=torch.long, device=hidden_states.device
++        )
++
++        last_hidden_states = None
++        if logits_output.last_hidden_states is not None:
++            last_hidden_states = logits_output.last_hidden_states[
++                hidden_state_offset : hidden_state_offset + seq_len
++            ]
++
++        # Wait on the host→device copy event before NCCL P2P kicks off,
++        # mirroring the Mooncake path.
++        if hidden_states.is_cuda and copy_done_event is not None:
++            torch.cuda.current_stream().wait_event(copy_done_event)
++
++        # Build the dict the trainer fetcher expects. Keys must match
++        # ColocateTrainSample.tensor_specs (both sides walk
++        # sorted(keys)). The shape contract is the same as the disagg
++        # Mooncake path: `hidden_states` is already concatenated across
++        # aux layers by sglang's spec_training code (so its last dim is
++        # `num_aux_layers * model_hidden_size` when aux layers are
++        # enabled, otherwise `model_hidden_size`). We do NOT ship a
++        # separate `aux_hidden_states` tensor — the trainer's data
++        # fetcher consumes the concat directly, matching what the
++        # Mooncake-backed `MooncakeDataset` produces.
++        tensors = {
++            "hidden_states": hidden_states.contiguous(),
++            "input_ids": input_ids,
++        }
++        if last_hidden_states is not None:
++            tensors["last_hidden_states"] = last_hidden_states.contiguous()
++
++        self.eagle_nccl_writer.send(tensors)
++
+     def stream_output(
+         self: Scheduler,
+         reqs: List[Req],
+diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
+index d0ff3eb8d..cd98d9d3d 100644
+--- a/python/sglang/srt/model_executor/model_runner.py
++++ b/python/sglang/srt/model_executor/model_runner.py
+@@ -58,6 +58,13 @@ from sglang.srt.distributed import (
+     set_mscclpp_all_reduce,
+     set_torch_symm_mem_all_reduce,
+ )
++from sglang.srt.distributed.torchspec_colocate import (
++    build_engine_tp_ranks,
++    init_union_default_pg,
++    is_colocate_active,
++    rebuild_world_group_engine_only,
++    set_union_meta_group,
++)
+ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+     use_symmetric_memory,
+ )
+@@ -782,21 +787,105 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+                         "init_cpu_threads_env and shared memory based AllReduce is disabled, only intel amx backend and arm64 are supported"
+                     )
+ 
+-            # Only initialize the distributed environment on the target model worker.
+-            init_distributed_environment(
+-                backend=backend,
+-                world_size=self.tp_size * self.pp_size,
+-                rank=self.tp_size * self.pp_rank + self.tp_rank,
+-                local_rank=self.gpu_id,
+-                distributed_init_method=dist_init_method,
+-                timeout=self.server_args.dist_timeout,
+-            )
+-            initialize_model_parallel(
+-                tensor_model_parallel_size=self.tp_size,
+-                pipeline_model_parallel_size=self.pp_size,
+-                expert_model_parallel_size=self.moe_ep_size,
+-                duplicate_tp_group=self.server_args.enable_pdmux,
+-            )
++            # TorchSpec colocate path: when the env-var sentinel is set,
++            # join TorchSpec's pre-existing 2N-rank union NCCL world as
++            # the default PG instead of bringing up our own. The trainer
++            # ranks `[0, N)` have already started the rendezvous via
++            # init_union_world; the call below is what unblocks them.
++            # We then call sglang's init_distributed_environment as
++            # usual — torch.distributed is already up so it skips its
++            # own init_process_group call but still sets `_WORLD` to a
++            # 2N-rank world group, which is what downstream sglang
++            # (allreduce, world barriers) expects. See
++            # docs/colocate/sglang_patch.md and torchspec_colocate.py.
++            logger.warning(
++                f"[TS-COLOCATE-TRACE pid={os.getpid()}] ModelRunner."
++                f"init_torch_distributed: about to dispatch on is_colocate_active()",
++            )
++            if is_colocate_active():
++                logger.warning(
++                    f"[TS-COLOCATE-TRACE pid={os.getpid()}] ModelRunner."
++                    f"init_torch_distributed: TAKING COLOCATE PATH",
++                )
++                colocate_env = init_union_default_pg(
++                    tp_rank=self.tp_size * self.pp_rank + self.tp_rank,
++                    local_rank=self.gpu_id,
++                    backend=backend,
++                )
++                logger.warning(
++                    f"[TS-COLOCATE-TRACE pid={os.getpid()}] ModelRunner."
++                    f"init_torch_distributed: init_union_default_pg returned; "
++                    f"calling init_distributed_environment to seed sglang's _WORLD",
++                )
++                init_distributed_environment(
++                    backend=backend,
++                    world_size=colocate_env.world_size,
++                    rank=colocate_env.engine_global_rank(
++                        self.tp_size * self.pp_rank + self.tp_rank
++                    ),
++                    local_rank=self.gpu_id,
++                    # Init method is irrelevant — dist is already up; sglang
++                    # only re-uses this to set _WORLD. Pass the same union
++                    # init_method for symmetry.
++                    distributed_init_method=colocate_env.init_method,
++                    timeout=self.server_args.dist_timeout,
++                )
++                # Match the trainer's torchspec.colocate.world.init_union_world
++                # which finishes with `dist.new_group(ranks=[0..2N), gloo)` for
++                # its meta_group. The engine subprocess must participate in
++                # that collective new_group on the world; otherwise the
++                # trainer hangs after init_distributed_environment returns.
++                # For ranks covering the whole world the monkey-patched
++                # use_local_synchronization=True default is equivalent to a
++                # world-collective call (every rank is a member), so we can
++                # just use the regular dist.new_group here.
++                import torch.distributed as _dist
++                set_union_meta_group(_dist.new_group(
++                    ranks=list(range(colocate_env.world_size)),
++                    backend="gloo",
++                ))
++                logger.warning(
++                    f"[TS-COLOCATE-TRACE pid={os.getpid()}] ModelRunner."
++                    f"init_torch_distributed: trainer-paired meta_group "
++                    f"new_group(gloo, [0,{colocate_env.world_size})) "
++                    f"completed"
++                )
++                # init_distributed_environment built sglang's _WORLD
++                # spanning the full 2N union world. Rebuild it
++                # engine-only [N, 2N) — otherwise sglang world-level
++                # collectives (get_available_gpu_memory's distributed
++                # memory sync, world barriers) hang waiting for the
++                # trainer ranks, which never run sglang code.
++                rebuild_world_group_engine_only(
++                    colocate_env, self.gpu_id, backend
++                )
++                logger.warning(
++                    f"[TS-COLOCATE-TRACE pid={os.getpid()}] ModelRunner."
++                    f"init_torch_distributed: sglang _WORLD rebuilt engine-only",
++                )
++                initialize_model_parallel(
++                    tensor_model_parallel_size=self.tp_size,
++                    pipeline_model_parallel_size=self.pp_size,
++                    expert_model_parallel_size=self.moe_ep_size,
++                    duplicate_tp_group=self.server_args.enable_pdmux,
++                    tp_world_ranks=build_engine_tp_ranks(colocate_env),
++                )
++            else:
++                # Only initialize the distributed environment on the target model worker.
++                init_distributed_environment(
++                    backend=backend,
++                    world_size=self.tp_size * self.pp_size,
++                    rank=self.tp_size * self.pp_rank + self.tp_rank,
++                    local_rank=self.gpu_id,
++                    distributed_init_method=dist_init_method,
++                    timeout=self.server_args.dist_timeout,
++                )
++                initialize_model_parallel(
++                    tensor_model_parallel_size=self.tp_size,
++                    pipeline_model_parallel_size=self.pp_size,
++                    expert_model_parallel_size=self.moe_ep_size,
++                    duplicate_tp_group=self.server_args.enable_pdmux,
++                )
+             initialize_dp_attention(
+                 server_args=self.server_args,
+                 model_config=self.model_config,
+--
+2.51.2
+

--- a/python/sglang/srt/distributed/torchspec_colocate.py
+++ b/python/sglang/srt/distributed/torchspec_colocate.py
@@ -1,0 +1,387 @@
+"""TorchSpec colocate (MPS + NCCL) integration helpers.
+
+This module is the engine-process side of the contract documented in
+``docs/colocate/sglang_patch.md`` of the TorchSpec repo. It is loaded
+unconditionally but only "fires" when the env-var sentinel
+``TORCHSPEC_COLOCATE_TRANSFER_MODE=nccl`` is set by the TorchSpec
+driver before launching sglang.
+
+When active, it replaces sglang's per-engine NCCL world with a slice
+of TorchSpec's ``2N``-rank **union NCCL world** (N trainer ranks +
+N engine ranks, paired by index). The engine writes hidden states
+directly to its paired trainer rank via P2P on that union world,
+removing the Mooncake KV-store round-trip used in the disaggregated
+path.
+
+Public surface:
+
+* :func:`is_colocate_active` — quick env-var check.
+* :func:`read_colocate_env` — parsed env-var contract.
+* :func:`init_union_default_pg` — replacement for sglang's
+  ``init_distributed_environment`` body when colocate is on.
+* :func:`build_engine_tp_ranks` — returns the contiguous rank range
+  that maps to this engine's TP group inside the union world.
+* :func:`build_hidden_states_writer` — connector factory used by the
+  patched scheduler.
+
+This file is the **only** new file added by the colocate patch; the
+rest of the patch surface is small in-place edits in
+``model_runner.py``, ``parallel_state.py``, ``scheduler.py``, and
+``scheduler_output_processor_mixin.py``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_TRANSFER_MODE_ENV = "TORCHSPEC_COLOCATE_TRANSFER_MODE"
+_PAIRED_TRAINER_RANK_ENV = "TORCHSPEC_COLOCATE_PAIRED_TRAINER_RANK"
+_UNION_MASTER_ADDR_ENV = "TORCHSPEC_COLOCATE_UNION_MASTER_ADDR"
+_UNION_MASTER_PORT_ENV = "TORCHSPEC_COLOCATE_UNION_MASTER_PORT"
+_UNION_WORLD_SIZE_ENV = "TORCHSPEC_COLOCATE_UNION_WORLD_SIZE"
+_UNION_N_PER_ROLE_ENV = "TORCHSPEC_COLOCATE_UNION_N_PER_ROLE"
+_UNION_TIMEOUT_MIN_ENV = "TORCHSPEC_COLOCATE_UNION_TIMEOUT_MIN"
+_UNION_INITIALIZED_ENV = "TORCHSPEC_COLOCATE_UNION_WORLD"
+
+# The gloo process group spanning all 2N union-world ranks. The
+# engine->trainer hidden-state P2P runs over this (not NCCL): trainer
+# and engine share one physical GPU and NCCL refuses a communicator
+# with two ranks on the same device. Set once by init_torch_distributed
+# right after the meta_group new_group; read by build_hidden_states_writer.
+_UNION_META_GROUP = None
+
+
+def set_union_meta_group(group) -> None:
+    """Stash the all-rank gloo union group for the hidden-states writer."""
+    global _UNION_META_GROUP
+    _UNION_META_GROUP = group
+
+
+def get_union_meta_group():
+    """Return the all-rank gloo union group, or None if not yet set."""
+    return _UNION_META_GROUP
+
+
+@dataclass(frozen=True)
+class ColocateEnv:
+    """Parsed contents of the TorchSpec colocate env-var contract."""
+
+    paired_trainer_rank: int
+    master_addr: str
+    master_port: int
+    world_size: int
+    n_per_role: int
+    timeout_minutes: int
+
+    @property
+    def init_method(self) -> str:
+        return f"tcp://{self.master_addr}:{self.master_port}"
+
+    def engine_global_rank(self, tp_rank: int = 0) -> int:
+        """Return this engine subprocess' union-world rank.
+
+        Engines occupy ``[N, 2N)`` in the union world. Under the
+        colocate invariant (``engine_count * engine_tp_size ==
+        training_world_size`` with ``engine_tp_size == 1``) each engine
+        is paired 1:1 with a trainer, so the engine *index* is exactly
+        ``paired_trainer_rank`` and the union rank is
+        ``N + paired_trainer_rank``. ``tp_rank`` is the TP rank *within*
+        this engine's own size-1 TP group (always 0) and is NOT the
+        union-world offset — passing it as the offset made every engine
+        claim rank N (fine at N=1, a hard rendezvous deadlock at N>1).
+        """
+        if not 0 <= self.paired_trainer_rank < self.n_per_role:
+            raise ValueError(
+                f"paired_trainer_rank={self.paired_trainer_rank} out of "
+                f"range [0, {self.n_per_role})"
+            )
+        return self.n_per_role + self.paired_trainer_rank
+
+
+def is_colocate_active() -> bool:
+    """Return ``True`` iff TorchSpec's env-var sentinel is set."""
+    val = os.environ.get(_TRANSFER_MODE_ENV, "").lower()
+    active = val == "nccl"
+    logger.warning(
+        f"[TS-COLOCATE-TRACE pid={os.getpid()}] is_colocate_active: "
+        f"{_TRANSFER_MODE_ENV}={val!r} -> active={active}",
+    )
+    return active
+
+
+def read_colocate_env() -> Optional[ColocateEnv]:
+    """Read and validate the TorchSpec colocate env-var contract.
+
+    Returns ``None`` if colocate is not active. Raises
+    ``RuntimeError`` if the sentinel is on but required env vars are
+    missing — that's a driver-side bug we want to surface loudly.
+    """
+    if not is_colocate_active():
+        return None
+
+    try:
+        return ColocateEnv(
+            paired_trainer_rank=int(os.environ[_PAIRED_TRAINER_RANK_ENV]),
+            master_addr=os.environ[_UNION_MASTER_ADDR_ENV],
+            master_port=int(os.environ[_UNION_MASTER_PORT_ENV]),
+            world_size=int(os.environ[_UNION_WORLD_SIZE_ENV]),
+            n_per_role=int(os.environ[_UNION_N_PER_ROLE_ENV]),
+            timeout_minutes=int(os.environ.get(_UNION_TIMEOUT_MIN_ENV, "30")),
+        )
+    except KeyError as e:
+        raise RuntimeError(
+            f"TorchSpec colocate is active ({_TRANSFER_MODE_ENV}=nccl) but "
+            f"required env var {e.args[0]} is missing. The TorchSpec "
+            f"driver must export the full union-world rendezvous before "
+            f"launching sglang. See docs/colocate/sglang_patch.md."
+        ) from e
+
+
+def init_union_default_pg(
+    *,
+    tp_rank: int,
+    local_rank: int,
+    backend: str = "nccl",
+) -> ColocateEnv:
+    """Bring up TorchSpec's union NCCL world as the **default** PG.
+
+    Replacement for sglang's ``init_distributed_environment`` body when
+    colocate is active. After this returns:
+
+    * ``torch.distributed.is_initialized()`` is True.
+    * The default PG has ``world_size=2N`` ranks. Trainer ranks are
+      ``[0, N)`` and have already joined via TorchSpec's
+      ``init_union_world`` (this call unblocks them).
+    * The current engine subprocess sits at rank ``N + tp_rank``.
+
+    The caller is then responsible for creating sglang's TP group as
+    a contiguous slice ``[N, 2N)`` via the patched
+    ``initialize_model_parallel(..., tp_world_ranks=...)``.
+
+    Args:
+        tp_rank: The engine's TP rank within its own engine actor.
+            For the colocate-config invariant (engine_count *
+            engine_tp_size == training_world_size), this maps 1:1 to
+            the engine slot in the union world's `[N, 2N)` block.
+        local_rank: Local GPU index for this process. Passed to
+            ``init_process_group`` as ``device_id`` so NCCL doesn't
+            silently deadlock under Ray's CUDA_VISIBLE_DEVICES
+            isolation (the Phase-3 lesson).
+        backend: NCCL backend name (defaults to ``"nccl"``).
+
+    Returns:
+        The parsed :class:`ColocateEnv` for this process. Use it to
+        build the TP-rank list and to look up the paired trainer rank
+        for the hidden-states writer.
+
+    Raises:
+        RuntimeError: If colocate isn't active, or torch.distributed
+            is already initialised (idempotency violation), or the env
+            contract is incomplete.
+    """
+    import torch
+    import torch.distributed as dist
+
+    logger.warning(
+        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
+        f"ENTRY tp_rank={tp_rank} local_rank={local_rank} backend={backend!r}",
+    )
+
+    env = read_colocate_env()
+    if env is None:
+        raise RuntimeError(
+            "init_union_default_pg called but colocate is not active. "
+            "Check is_colocate_active() before calling."
+        )
+    logger.warning(
+        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
+        f"read_colocate_env OK: world_size={env.world_size} "
+        f"n_per_role={env.n_per_role} init_method={env.init_method} "
+        f"timeout={env.timeout_minutes}min paired_trainer_rank={env.paired_trainer_rank}",
+    )
+
+    if dist.is_initialized():
+        # Already up — most likely because the trainer and this engine
+        # share a Python process (test fixtures). Just verify shape.
+        actual = dist.get_world_size()
+        if actual != env.world_size:
+            raise RuntimeError(
+                f"torch.distributed already initialised with world_size="
+                f"{actual} but colocate env declares world_size="
+                f"{env.world_size}. Driver-side bug."
+            )
+        logger.info(
+            "[torchspec-colocate] torch.distributed already initialised "
+            "(world_size=%d); reusing it as the union default PG.",
+            actual,
+        )
+        return env
+
+    global_rank = env.engine_global_rank(tp_rank)
+    device = torch.device("cuda", local_rank)
+
+    logger.info(
+        "[torchspec-colocate] Joining TorchSpec union world: "
+        "tp_rank=%d global_rank=%d/%d local_rank=%d init_method=%s "
+        "timeout=%dmin",
+        tp_rank, global_rank, env.world_size, local_rank,
+        env.init_method, env.timeout_minutes,
+    )
+
+    logger.warning(
+        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
+        f"CALLING dist.init_process_group(backend={backend!r}, "
+        f"world_size={env.world_size}, rank={global_rank}, "
+        f"init_method={env.init_method!r}, timeout={env.timeout_minutes}min) "
+        f"-- this BLOCKS until trainer rank also reaches its init_union_world",
+    )
+    dist.init_process_group(
+        backend=backend,
+        world_size=env.world_size,
+        rank=global_rank,
+        init_method=env.init_method,
+        timeout=timedelta(minutes=env.timeout_minutes),
+    )
+    logger.warning(
+        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
+        f"dist.init_process_group RETURNED -- union world is up (rank={global_rank}/"
+        f"{env.world_size})",
+    )
+
+    # Defang sglang's subsequent `dist.new_group` calls so they don't
+    # deadlock against the trainer's union-world setup.
+    #
+    # sglang's GroupCoordinator.__init__ creates per-engine TP/EP/PP/MoE
+    # subgroups via `dist.new_group(ranks=[engine_ranks], ...)`. By
+    # default, dist.new_group is a *world-collective* call — every rank
+    # in the world group must call it with the same args, even if not
+    # in `ranks`. In colocate mode the trainer ranks [0, N) are NOT
+    # sglang ranks and have no business participating in sglang's
+    # subgroup setup; they're busy creating the union-world meta_group.
+    # The mismatch deadlocks both sides at the first collective
+    # boundary.
+    #
+    # Setting `use_local_synchronization=True` on each new_group call
+    # makes it a member-only barrier — non-member ranks skip it
+    # entirely. We do this via a thin wrapper around dist.new_group
+    # that only applies inside this engine subprocess; the trainer is a
+    # different process and is unaffected.
+    _original_new_group = dist.new_group
+
+    def _local_only_new_group(*args, **kwargs):
+        kwargs.setdefault("use_local_synchronization", True)
+        return _original_new_group(*args, **kwargs)
+
+    dist.new_group = _local_only_new_group
+    logger.warning(
+        f"[TS-COLOCATE-TRACE pid={os.getpid()}] init_union_default_pg: "
+        f"installed local-only new_group default to break "
+        f"world-collective deadlock with the trainer"
+    )
+
+    # Mark the union world as up so a subsequent
+    # `init_distributed_environment` call (e.g. from a draft model
+    # worker) becomes a no-op.
+    os.environ[_UNION_INITIALIZED_ENV] = "1"
+
+    return env
+
+
+def build_engine_tp_ranks(env: ColocateEnv) -> list[int]:
+    """Return the union-world ranks forming THIS engine's TP group.
+
+    Under the colocate-config invariant ``engine_count *
+    engine_tp_size == training_world_size`` with ``engine_tp_size ==
+    1``, each engine is its own singleton TP group: union rank
+    ``[N + paired_trainer_rank]``. Used both for
+    ``initialize_model_parallel(..., tp_world_ranks=...)`` (whose
+    length must equal ``tensor_model_parallel_size``) and for
+    ``rebuild_world_group_engine_only`` (this engine's own ``_WORLD``).
+
+    The old ``range(N, 2N)`` form returned every engine rank — a
+    length-1 singleton at N=1 (so it worked) but a length-N list at
+    N>1, which mismatched ``tp_size=1`` and cross-wired the engines'
+    ``_WORLD`` groups.
+    """
+    return [env.n_per_role + env.paired_trainer_rank]
+
+
+def rebuild_world_group_engine_only(env, local_rank, backend="nccl"):
+    """Rebuild sglang's ``_WORLD`` GroupCoordinator to span only this
+    engine's own union rank instead of the full ``2N`` union world.
+
+    sglang's ``init_distributed_environment`` builds ``_WORLD`` from
+    ``torch.distributed.get_world_size()``, which under colocate is
+    the ``2N``-rank union world. But the trainer ranks ``[0, N)``
+    never run sglang code, so any sglang world-level collective —
+    e.g. ``get_available_gpu_memory(distributed=...,
+    cpu_group=get_world_group().cpu_group)`` right after
+    ``initialize_dp_attention``, or world barriers later — would hang
+    forever waiting for the trainer half.
+
+    This rebuilds ``_WORLD`` as an engine-only GroupCoordinator. The
+    ``dist.new_group`` calls inside ``init_world_group`` inherit the
+    ``use_local_synchronization=True`` monkey-patch installed by
+    :func:`init_union_default_pg`, so only the engine ranks
+    participate.
+    """
+    import sglang.srt.distributed.parallel_state as ps
+
+    engine_ranks = build_engine_tp_ranks(env)
+    if ps._WORLD is not None and ps._WORLD.world_size == len(engine_ranks):
+        return  # already engine-only
+    # Drop the (wrong) 2N-rank _WORLD and rebuild engine-only. The old
+    # GroupCoordinator's process groups leak, but this runs once per
+    # engine subprocess at startup, so the cost is negligible.
+    ps._WORLD = None
+    ps._WORLD = ps.init_world_group(engine_ranks, local_rank, backend)
+    logger.warning(
+        "[TS-COLOCATE-TRACE pid=%d] rebuilt sglang _WORLD as engine-only: "
+        "ranks=%s world_size=%d",
+        os.getpid(), engine_ranks, ps._WORLD.world_size,
+    )
+
+
+def build_hidden_states_writer():
+    """Return a TorchSpec NcclHiddenStatesConnector for the spec_training callback.
+
+    Imported lazily so disaggregated runs (where colocate is off)
+    never pull torchspec into sglang's import graph. Raises
+    ``ImportError`` with a clear remediation if torchspec isn't on
+    the engine subprocess' ``PYTHONPATH``.
+    """
+    env = read_colocate_env()
+    if env is None:
+        raise RuntimeError(
+            "build_hidden_states_writer called but colocate is not active."
+        )
+
+    try:
+        from torchspec.inference.engine.nccl_hidden_states_connector import (
+            NcclHiddenStatesConnector,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "TorchSpec colocate is active but `torchspec` is not "
+            "importable from the sglang engine subprocess. Ensure "
+            "TorchSpec is installed (`pip install -e .` from the "
+            "TorchSpec checkout) and that PYTHONPATH includes it."
+        ) from e
+
+    meta_group = get_union_meta_group()
+    if meta_group is None:
+        raise RuntimeError(
+            "build_hidden_states_writer: union meta_group not set. "
+            "init_torch_distributed must call set_union_meta_group "
+            "before the scheduler builds the writer."
+        )
+    return NcclHiddenStatesConnector(
+        dst_global_rank=env.paired_trainer_rank,
+        group=meta_group,
+    )


### PR DESCRIPTION
Tracking issue: #25342

## Motivation

Placeholder PR for the RFC discussion in #25342. The online speculative-training callback today writes hidden states through Mooncake, which is the right shape for disaggregated layouts but is wasted bandwidth + serialization cost in colocated layouts (trainer and engine sharing the same GPUs). This PR opens the design conversation; the implementation lands in a follow-up once the API shape is agreed.

## Modifications

- Adds `docs/developer_guide/rfc_colocate_spec_training_transport.md` describing the proposed three-surface change (join external default PG; pluggable callback transport with `MooncakeTransport` as the default; per-TP-rank participation opt-in).

No code changes in this PR — the existing Mooncake path is untouched. The implementation patch (against v0.5.8.post1 / v0.5.10.post1) is staged out-of-tree and will be re-shaped against the agreed naming once the RFC discussion converges.

## Accuracy Tests

N/A (docs-only).

## Speed Tests and Profiling

N/A (docs-only). For context, the out-of-tree implementation runs on a 4×H100 box (1 engine × TP=4 + 4 trainers × FSDP=4, GPUs shared via MPS); end-to-end loss is finite and non-zero on the colocate path.

## Related

- #24119 *[Discussion] Tightening SGLang's RL inner loop API* — §2 covers the symmetric weight-transfer-in direction.
- #13868 *[Feature] Add aux and last hidden state dumping for EAGLE* — same hidden states, offline disk transport.
- #25050 *Add --model-config-parser registry* — precedent for the registry shape.

## Checklist

- [x] Format your code according to the Format code with pre-commit. (docs-only)
- [ ] Add unit tests according to the Run and add unit tests. (deferred to implementation PR)
- [x] Update documentation according to Write documentations. (this PR *is* documentation)
- [ ] Provide accuracy and speed benchmark results. (deferred to implementation PR)