### PR TITLE
Fix LoRA prefix cache namespace collisions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -148,18 +148,25 @@ class OpenAIServingBase(ABC):
 
         return f"{self._request_id_prefix()}{uuid.uuid4().hex}"
 
+    def _get_string_request_key(
+        self, request: OpenAIServingRequest, key: str
+    ) -> Optional[str]:
+        value = getattr(request, key, None)
+        if value is None or value == "":
+            return None
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Value of {key} must be a string, but got {type(value).__name__}"
+            )
+        return value
+
     def _compute_extra_key(self, request: OpenAIServingRequest) -> Optional[str]:
-        """Compute the final extra_key by concatenating cache_salt and extra_key if both are provided."""
-        parts = []
-        for key in ["cache_salt", "extra_key"]:
-            value = getattr(request, key, None)
-            if value:
-                if not isinstance(value, str):
-                    raise TypeError(
-                        f"Value of {key} must be a string, but got {type(value).__name__}"
-                    )
-                parts.append(value)
-        return "".join(parts) if parts else None
+        """Return the user-provided extra_key without composing it with cache_salt."""
+        return self._get_string_request_key(request, "extra_key")
+
+    def _compute_cache_salt(self, request: OpenAIServingRequest) -> Optional[str]:
+        """Return the user-provided cache_salt as a separate namespace part."""
+        return self._get_string_request_key(request, "cache_salt")
 
     @abstractmethod
     def _convert_to_internal_request(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -439,6 +439,7 @@ class OpenAIServingChat(OpenAIServingBase):
             return_routed_experts=request.return_routed_experts,
             routed_experts_start_len=request.routed_experts_start_len,
             rid=request.rid,
+            cache_salt=self._compute_cache_salt(request),
             extra_key=self._compute_extra_key(request),
             require_reasoning=self._get_reasoning_from_request(request),
             priority=request.priority,

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -125,6 +125,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             return_routed_experts=request.return_routed_experts,
             routed_experts_start_len=request.routed_experts_start_len,
             rid=request.rid,
+            cache_salt=self._compute_cache_salt(request),
             extra_key=self._compute_extra_key(request),
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -281,6 +281,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         sampling_params=sampling_params,
                         stream=request.stream,
                         rid=request.request_id,
+                        cache_salt=self._compute_cache_salt(request),
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
                     )
@@ -1298,6 +1299,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 sampling_params=sampling_params,
                 stream=adapted_request.stream,
                 rid=request_id,
+                cache_salt=adapted_request.cache_salt,
                 extra_key=adapted_request.extra_key,
                 return_logprob=adapted_request.return_logprob,
                 logprob_start_len=adapted_request.logprob_start_len,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -224,7 +224,9 @@ class GenerateReqInput(BaseReq):
     # Priority for the request
     priority: Optional[int] = None
 
-    # Extra key for classifying the request (e.g. cache_salt)
+    # Cache salt for classifying the request namespace.
+    cache_salt: Optional[Union[List[str], str]] = None
+    # Extra key for classifying the request.
     extra_key: Optional[Union[List[str], str]] = None
 
     # Routing key for routing-key schedule policy
@@ -689,6 +691,7 @@ class GenerateReqInput(BaseReq):
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
             priority=self.priority,
+            cache_salt=self.cache_salt,
             extra_key=self.extra_key,
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
@@ -773,7 +776,9 @@ class TokenizedGenerateReqInput(BaseReq):
     # Priority for the request
     priority: Optional[int] = None
 
-    # Extra key for classifying the request (e.g. cache_salt)
+    # Cache salt for classifying the request namespace.
+    cache_salt: Optional[str] = None
+    # Extra key for classifying the request.
     extra_key: Optional[str] = None
 
     # Routing key for routing-key schedule policy

--- a/python/sglang/srt/managers/prefix_cache_key.py
+++ b/python/sglang/srt/managers/prefix_cache_key.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+STRUCTURED_PREFIX_CACHE_KEY_PREFIX = "__sglang_prefix_cache_namespace__:"
+ESCAPED_PREFIX_CACHE_KEY_PREFIX = "__sglang_prefix_cache_raw__:"
+_RESERVED_PREFIX_CACHE_KEY_PREFIXES = (
+    STRUCTURED_PREFIX_CACHE_KEY_PREFIX,
+    ESCAPED_PREFIX_CACHE_KEY_PREFIX,
+)
+
+
+def _validate_prefix_cache_key_part(name: str, value: Optional[str]) -> None:
+    if value is not None and not isinstance(value, str):
+        raise TypeError(
+            f"Prefix-cache namespace part {name} must be a string, "
+            f"but got {type(value).__name__}"
+        )
+
+
+def escape_prefix_cache_user_key(
+    value: Optional[str],
+    *,
+    name: str = "extra_key",
+) -> Optional[str]:
+    """Escape user-controlled keys that overlap internal namespace prefixes."""
+    _validate_prefix_cache_key_part(name, value)
+    if value is None:
+        return None
+    if value.startswith(_RESERVED_PREFIX_CACHE_KEY_PREFIXES):
+        return ESCAPED_PREFIX_CACHE_KEY_PREFIX + value
+    return value
+
+
+def encode_prefix_cache_key_parts(
+    parts: list[tuple[str, Optional[str]]],
+) -> Optional[str]:
+    """Encode prefix-cache namespace parts without string concatenation ambiguity."""
+    encoded_parts: list[list[str]] = []
+    for name, value in parts:
+        if value is None:
+            continue
+        _validate_prefix_cache_key_part(name, value)
+        encoded_parts.append([name, value])
+
+    if not encoded_parts:
+        return None
+    return STRUCTURED_PREFIX_CACHE_KEY_PREFIX + json.dumps(
+        encoded_parts, separators=(",", ":"), ensure_ascii=True
+    )
+
+
+def build_prefix_cache_extra_key(
+    cache_salt: Optional[str],
+    extra_key: Optional[str],
+    lora_id: Optional[str],
+) -> Optional[str]:
+    """Build the radix-cache extra key namespace for a request."""
+    _validate_prefix_cache_key_part("cache_salt", cache_salt)
+    _validate_prefix_cache_key_part("extra_key", extra_key)
+    _validate_prefix_cache_key_part("lora_id", lora_id)
+    if cache_salt is None and lora_id is None:
+        return escape_prefix_cache_user_key(extra_key)
+    if extra_key is None and lora_id is None:
+        return escape_prefix_cache_user_key(cache_salt, name="cache_salt")
+
+    return encode_prefix_cache_key_parts(
+        [
+            ("cache_salt", cache_salt or None),
+            ("extra_key", extra_key or None),
+            ("lora_id", lora_id or None),
+        ]
+    )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -60,6 +60,7 @@ from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.prefix_cache_key import build_prefix_cache_extra_key
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -611,6 +612,7 @@ class Req(ReqDllmMixin):
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
+        cache_salt: Optional[str] = None,
         extra_key: Optional[str] = None,
         routing_key: Optional[str] = None,
         dimensions: Optional[int] = None,
@@ -679,11 +681,8 @@ class Req(ReqDllmMixin):
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
 
-        # extra key for classifying the request (e.g. cache_salt)
-        if lora_id is not None:
-            extra_key = (
-                extra_key or ""
-            ) + lora_id  # lora_id is concatenated to the extra key
+        # Extra key for classifying the request cache namespace.
+        extra_key = build_prefix_cache_extra_key(cache_salt, extra_key, lora_id)
 
         self.extra_key = extra_key
         self.lora_id = lora_id

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2040,6 +2040,7 @@ class Scheduler(
                     self.metrics_collector if self.enable_metrics else None
                 ),
                 routing_key=recv_req.routing_key,
+                cache_salt=recv_req.cache_salt,
                 extra_key=recv_req.extra_key,
                 http_worker_ipc=recv_req.http_worker_ipc,
                 dllm_config=self.dllm_config,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1023,6 +1023,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 routed_dp_rank=obj.routed_dp_rank,
                 disagg_prefill_dp_rank=obj.disagg_prefill_dp_rank,
                 priority=obj.priority,
+                cache_salt=obj.cache_salt,
                 extra_key=obj.extra_key,
                 routing_key=obj.routing_key,
                 token_type_ids=token_type_ids,

--- a/test/registered/unit/managers/test_prefix_cache_key.py
+++ b/test/registered/unit/managers/test_prefix_cache_key.py
@@ -1,0 +1,119 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CI_REGISTER_PATH = REPO_ROOT / "python" / "sglang" / "test" / "ci" / "ci_register.py"
+PREFIX_CACHE_KEY_PATH = (
+    REPO_ROOT / "python" / "sglang" / "srt" / "managers" / "prefix_cache_key.py"
+)
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+register_cpu_ci = _load_module("ci_register", CI_REGISTER_PATH).register_cpu_ci
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+prefix_cache_key = _load_module("prefix_cache_key", PREFIX_CACHE_KEY_PATH)
+build_prefix_cache_extra_key = prefix_cache_key.build_prefix_cache_extra_key
+encode_prefix_cache_key_parts = prefix_cache_key.encode_prefix_cache_key_parts
+escape_prefix_cache_user_key = prefix_cache_key.escape_prefix_cache_user_key
+STRUCTURED_PREFIX_CACHE_KEY_PREFIX = prefix_cache_key.STRUCTURED_PREFIX_CACHE_KEY_PREFIX
+ESCAPED_PREFIX_CACHE_KEY_PREFIX = prefix_cache_key.ESCAPED_PREFIX_CACHE_KEY_PREFIX
+
+
+class TestPrefixCacheKey(unittest.TestCase):
+    def test_no_extra_key_and_no_lora_stays_none(self):
+        self.assertIsNone(build_prefix_cache_extra_key(None, None, None))
+
+    def test_base_extra_key_is_preserved_without_lora(self):
+        self.assertEqual(
+            build_prefix_cache_extra_key(None, "adapter-a", None), "adapter-a"
+        )
+
+    def test_base_cache_salt_is_preserved_without_extra_key_or_lora(self):
+        self.assertEqual(build_prefix_cache_extra_key("salt", None, None), "salt")
+
+    def test_reserved_base_extra_key_is_escaped_without_lora(self):
+        user_key = STRUCTURED_PREFIX_CACHE_KEY_PREFIX + '[["lora_id","adapter-a"]]'
+
+        self.assertEqual(
+            build_prefix_cache_extra_key(None, user_key, None),
+            ESCAPED_PREFIX_CACHE_KEY_PREFIX + user_key,
+        )
+
+    def test_lora_id_is_namespaced_without_extra_key(self):
+        self.assertEqual(
+            build_prefix_cache_extra_key(None, None, "adapter-a"),
+            encode_prefix_cache_key_parts([("lora_id", "adapter-a")]),
+        )
+
+    def test_lora_id_does_not_collide_with_base_extra_key(self):
+        base_key = build_prefix_cache_extra_key(None, "adapter-a", None)
+        lora_key = build_prefix_cache_extra_key(None, None, "adapter-a")
+
+        self.assertNotEqual(base_key, lora_key)
+
+    def test_encoded_lora_namespace_does_not_collide_with_base_extra_key(self):
+        lora_key = build_prefix_cache_extra_key(None, None, "adapter-a")
+        base_key = build_prefix_cache_extra_key(None, lora_key, None)
+
+        self.assertNotEqual(base_key, lora_key)
+
+    def test_extra_key_and_lora_id_boundaries_are_preserved(self):
+        first = build_prefix_cache_extra_key(None, "ab", "c")
+        second = build_prefix_cache_extra_key(None, "a", "bc")
+
+        self.assertNotEqual(first, second)
+
+    def test_cache_salt_and_extra_key_boundaries_are_preserved(self):
+        first = build_prefix_cache_extra_key("ab", "c", None)
+        second = build_prefix_cache_extra_key("a", "bc", None)
+
+        self.assertNotEqual(first, second)
+
+    def test_cache_salt_namespace_does_not_alias_crafted_extra_key(self):
+        composed = build_prefix_cache_extra_key("salt", "key", None)
+        crafted = build_prefix_cache_extra_key(None, composed, None)
+
+        self.assertNotEqual(composed, crafted)
+
+    def test_cache_salt_lora_namespace_does_not_alias_crafted_extra_key(self):
+        composed = build_prefix_cache_extra_key("salt", "key", "adapter-a")
+        crafted = build_prefix_cache_extra_key(None, composed, "adapter-a")
+
+        self.assertNotEqual(composed, crafted)
+
+    def test_escaped_user_key_cannot_alias_escaped_internal_key(self):
+        internal_key = encode_prefix_cache_key_parts([("lora_id", "adapter-a")])
+        escaped_internal_key = escape_prefix_cache_user_key(internal_key)
+
+        self.assertNotEqual(
+            escape_prefix_cache_user_key(escaped_internal_key),
+            escaped_internal_key,
+        )
+
+    def test_type_error_identifies_component_name(self):
+        with self.assertRaisesRegex(TypeError, "Prefix-cache namespace part lora_id"):
+            encode_prefix_cache_key_parts([("lora_id", ["not", "a", "str"])])
+        with self.assertRaisesRegex(TypeError, "Prefix-cache namespace part extra_key"):
+            build_prefix_cache_extra_key(None, ["not", "a", "str"], "adapter-a")
+        with self.assertRaisesRegex(
+            TypeError, "Prefix-cache namespace part cache_salt"
+        ):
+            build_prefix_cache_extra_key(["not", "a", "str"], None, "adapter-a")
+
+    def test_no_parts_stays_none(self):
+        self.assertIsNone(encode_prefix_cache_key_parts([]))
+        self.assertIsNone(
+            encode_prefix_cache_key_parts([("extra_key", None), ("lora_id", None)])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #24638.

This PR fixes prefix-cache namespace collisions caused by raw string concatenation of `cache_salt`, `extra_key`, and `lora_id`.

Before this change, a base-model request could craft `extra_key` values that alias LoRA radix-cache namespaces. The same string-composition pattern also made `cache_salt` and `extra_key` boundary-sensitive.

The fix keeps the change narrow:

- Domain-separate internal prefix-cache namespaces with a reserved structured prefix.
- Preserve existing single-component base `extra_key` / `cache_salt` behavior when no composition is needed.
- Escape user-provided keys that start with reserved internal prefixes, so crafted raw strings cannot alias structured namespaces.
- Keep `cache_salt` separate from user `extra_key` through OpenAI request adaptation, tokenization, and scheduler request construction.
- Encode composed `cache_salt`, `extra_key`, and LoRA namespaces as tagged parts only at final prefix-cache key construction.
- Add CPU unit coverage for raw LoRA collisions, encoded namespace collisions, `cache_salt` / `extra_key` boundary collisions, reserved-prefix escaping, and crafted `extra_key` aliases of composed `cache_salt` namespaces.

This supersedes #25214, which was closed while validation was incomplete. I tried updating and reopening #25214 after refreshing the branch, but GitHub kept that closed PR pinned to the old head SHA and rejected reopening it.

## Validation

Validated locally on latest commit `f7bd60040`:

- `python -m pytest test/registered/unit/managers/test_prefix_cache_key.py -q` - 14 passed
- `python -m py_compile python/sglang/srt/managers/prefix_cache_key.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/schedule_batch.py python/sglang/srt/entrypoints/openai/serving_base.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py python/sglang/srt/entrypoints/openai/serving_responses.py`
- `python -m ruff check --select=F401,F821 python/sglang/srt/managers/prefix_cache_key.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/schedule_batch.py python/sglang/srt/entrypoints/openai/serving_base.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py python/sglang/srt/entrypoints/openai/serving_responses.py test/registered/unit/managers/test_prefix_cache_key.py`
- `uvx black --check python/sglang/srt/managers/prefix_cache_key.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/schedule_batch.py python/sglang/srt/entrypoints/openai/serving_base.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py python/sglang/srt/entrypoints/openai/serving_responses.py test/registered/unit/managers/test_prefix_cache_key.py`
- `uvx isort --check-only python/sglang/srt/managers/prefix_cache_key.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/tokenizer_manager.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/schedule_batch.py python/sglang/srt/entrypoints/openai/serving_base.py python/sglang/srt/entrypoints/openai/serving_chat.py python/sglang/srt/entrypoints/openai/serving_completions.py python/sglang/srt/entrypoints/openai/serving_responses.py test/registered/unit/managers/test_prefix_cache_key.py`
- `python scripts/ci/check_registered_tests.py`
- `git diff --check`

Current GitHub CI note: `pr-gate` is blocked before running tests because the PR has no `run-ci` label. The failing gate logs report `Missing required label 'run-ci'`; my account does not have permission to add that label.

## Duplicate / Value Check

I re-checked before opening:

- #24638 is still open.
- Current `origin/main` still contains the raw concatenation paths.
- No open PR currently fixes #24638.
- #24579 is related to KV-event block hashes for #24568, not this in-memory LoRA radix-cache namespace collision.

## AI Assistance

This patch was developed with assistance from OpenAI Codex.