### PR TITLE
[Bugfix] MiMoV2MTP: select checkpoint MTP layer by draft_model_idx

### DIFF
--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -248,6 +248,14 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.quant_config = quant_config
 
+        # Which MTP layer in the checkpoint this instance owns. Multi-layer EAGLE creates
+        # one MiMoV2MTP per speculative step (idx in [0, speculative_num_steps)); single-
+        # layer EAGLE passes None and uses layer 0. Without this, the layer-stripping
+        # rewrite in `map_model_name_to_mtp_param_name` collapsed every checkpoint layer
+        # (`model.mtp.layers.{0,1,2}.*`) onto the same `model.mtp_block.*` params, so all
+        # draft runners loaded the same (last-write-wins) weights and accept rate cratered.
+        self.draft_model_idx = draft_model_idx if draft_model_idx is not None else 0
+
         self.model = MiMoV2ModelNextN(
             config, quant_config, prefix=add_prefix("model", prefix)
         )
@@ -300,7 +308,10 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
                 continue
             if name.startswith("model.vision_tower") and name not in params_dict:
                 continue
-            name = self.map_model_name_to_mtp_param_name(name)
+            mapped = self.map_model_name_to_mtp_param_name(name)
+            if mapped is None:
+                continue
+            name = mapped
 
             # Support fused qkv_proj checkpoint (Pro format)
             if "qkv_proj" in name:
@@ -357,7 +368,7 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
 
-    def map_model_name_to_mtp_param_name(self, name: str) -> str:
+    def map_model_name_to_mtp_param_name(self, name: str) -> Optional[str]:
         import re
 
         if "pre_mlp_layernorm" in name:
@@ -372,6 +383,10 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
         pattern = r"model.mtp.layers.(\d+)."
         group = re.match(pattern, name)
         if group is not None:
+            # Multi-layer EAGLE: each draft runner owns a single MTP layer. Skip checkpoint
+            # entries for the other layers so they don't overwrite this instance's params.
+            if int(group.group(1)) != self.draft_model_idx:
+                return None
             for sub_name in name_without_prefix:
                 if sub_name in name:
                     name = name.replace(group.group(), "model.")


### PR DESCRIPTION
## Motivation

`MiMoV2MTP.__init__` accepts a `draft_model_idx` kwarg but immediately drops it, and `map_model_name_to_mtp_param_name` rewrites every checkpoint MTP layer (`model.mtp.layers.{0,1,2}.*`) onto the **same** `model.mtp_block.*` params. The MiMo-V2.5-Pro checkpoint ships with a 3-layer MTP module; under multi-layer EAGLE each speculative step spins up its own draft `ModelRunner` with `draft_model_idx=0,1,2` (see `TpModelWorker._init_multi_layer_eagle_model_runners`), but they all end up loading the same last-write-wins weights. Every chain step then runs the same draft function and accept-rate collapses.

This is observable on B200 today:

| metric (B200 8× FP8, `random` 1024/1024) | no EAGLE | EAGLE pre-fix (`--enable-multi-layer-eagle`) |
| --- | --- | --- |
| Latency `c=1` — Mean TPOT | 9.19 ms | 14.20 ms (+54%) |
| Latency `c=1` — Output tok/s | 101.41 | 67.37 (-33%) |
| Throughput `c=100` — Mean TPOT | 50.63 ms | 86.26 ms (+70%) |
| Throughput `c=100` — Output tok/s | 1735.90 | 1051.38 (-39%) |

EAGLE is supposed to give a 2–3× decode speedup; instead it actively regressed every workload.

There's a second symptom: dropping `--enable-multi-layer-eagle` (which is what `docs_new/src/snippets/autoregressive/mimo-v25-deployment.jsx` currently generates for Blackwell — `if (!blackwell) flags.push("--enable-multi-layer-eagle")`) makes the draft init silently hang because the single-`mtp_block` model on the Python side can't host the checkpoint's three layers either. The cookbook deployment generator therefore needs a follow-up to drop the `!blackwell` guard once this PR lands; I'll send that as a separate cookbook PR.

## Modifications

`python/sglang/srt/models/mimo_v2_nextn.py`:

1. `MiMoV2MTP.__init__` now stores `self.draft_model_idx = draft_model_idx if draft_model_idx is not None else 0`. Single-layer EAGLE keeps its existing behaviour (loads layer 0).
2. `map_model_name_to_mtp_param_name` is now declared as returning `Optional[str]` and returns `None` for any `model.mtp.layers.<N>.*` entry whose `N` doesn't match `self.draft_model_idx` — i.e. each draft runner only consumes its own layer.
3. `MiMoV2MTP.load_weights` checks the mapping result and `continue`s on `None`, so the foreign-layer entries are cleanly skipped.

Net diff: +17 / −2 in one file. No public API changes; the kwarg was already there, this just plumbs it through.

## Test plan

- [x] Pre-fix benchmarks above reproduce the regression on 8× B200 with `lmsysorg/sglang:latest` (sglang 0.5.11).
- [ ] Post-fix benchmarks on 8× B200 to confirm EAGLE matches or beats the no-EAGLE numbers (currently blocked on hardware availability; my devbox failed to schedule and `rx xpus` shows 0 B200 free in `b200-verda-k8s`). Will rerun and post here as soon as a slot opens.
- [ ] Single-layer EAGLE smoke test (idx defaults to 0, loads only layer-0 weights).

## Notes for reviewers

- I'm running the locally-needed `MIMO_V2_MULTIMODAL_ARCHS = ()` workaround in `python/sglang/srt/configs/model_config.py:46` to load the Pro checkpoint (which has no `vision_config`). That's a separate bug worth a follow-up — happy to send it as another small PR.
- Related cookbook PR with the B200 benchmark numbers: #25359.