### PR TITLE
fix(model_loader): trigger lazy attn_mha.kv_b_proj alias before reading state_dict in ShardedStateLoader

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -301,6 +301,30 @@ def _post_load_weights(model: nn.Module) -> None:
         model.post_load_weights()
 
 
+def _trigger_lazy_module_aliases(model: nn.Module) -> None:
+    """Eagerly install module aliases that some models otherwise defer until
+    the first forward pass.
+
+    Today this only handles the DeepSeek-V2 MLA pattern where
+    ``DeepseekV2AttentionMLA`` initializes ``self.attn_mha.kv_b_proj`` to
+    ``None`` and lazily binds ``self.attn_mha.kv_b_proj = self.kv_b_proj``
+    inside ``forward_prepare``. Saved sharded checkpoints are produced
+    after a warmup forward, so they encode the parameter under the
+    ``...attn_mha.kv_b_proj.*`` key (winning the dedup in
+    ``_filter_subtensors`` because it sorts before the outer
+    ``...kv_b_proj.*``). The load-time ``state_dict`` view must therefore
+    reflect the same aliasing or the checkpoint keys are unresolvable.
+    See sgl-project/sglang#25332.
+    """
+    for module in model.modules():
+        attn_mha = getattr(module, "attn_mha", None)
+        outer_kv_b_proj = getattr(module, "kv_b_proj", None)
+        if attn_mha is None or outer_kv_b_proj is None:
+            continue
+        if getattr(attn_mha, "kv_b_proj", "MISSING") is None:
+            attn_mha.kv_b_proj = outer_kv_b_proj
+
+
 class BaseModelLoader(ABC):
     """Base class for model loaders."""
 
@@ -1447,6 +1471,12 @@ class ShardedStateLoader(BaseModelLoader):
                     quant_method = getattr(module, "quant_method", None)
                     if quant_method is not None:
                         quant_method.process_weights_after_loading(module)
+                # Saved sharded checkpoints reflect aliases the model would only
+                # set up on first forward (e.g. DeepSeek-V2 MLA's
+                # `attn_mha.kv_b_proj`). Install them eagerly so the state_dict
+                # view we match against the checkpoint keys is consistent with
+                # what `save_model` produced. See #25332.
+                _trigger_lazy_module_aliases(model)
             rank = get_tensor_model_parallel_rank()
             pattern = os.path.join(
                 local_model_path,

--- a/test/registered/unit/model_loader/test_sharded_state_loader_lazy_aliases.py
+++ b/test/registered/unit/model_loader/test_sharded_state_loader_lazy_aliases.py
@@ -1,0 +1,117 @@
+"""Regression test for sgl-project/sglang#25332.
+
+DeepSeek-V2 MLA initializes ``self.attn_mha.kv_b_proj`` to ``None`` and
+lazily aliases it to the outer ``self.kv_b_proj`` inside ``forward_prepare``.
+Saved sharded checkpoints (produced after a warmup forward) encode the
+parameter under the ``...attn_mha.kv_b_proj.*`` key, so the load-time
+``state_dict`` view must reflect the same aliasing or the keys cannot be
+resolved. ``_trigger_lazy_module_aliases`` installs the alias eagerly in
+``ShardedStateLoader.load_model`` before reading ``state_dict``; this
+module covers that helper.
+"""
+
+import unittest
+
+import torch.nn as nn
+
+from sglang.srt.model_loader.loader import _trigger_lazy_module_aliases
+
+
+def _make_attn_module(out_features: int = 8) -> nn.Module:
+    """Mock ``DeepseekV2AttentionMLA``: outer kv_b_proj + attn_mha child
+    where ``attn_mha.kv_b_proj`` starts as None (the lazy alias slot)."""
+    attn = nn.Module()
+    attn.kv_b_proj = nn.Linear(4, out_features, bias=False)
+    attn.attn_mha = nn.Module()
+    attn.attn_mha.kv_b_proj = None
+    return attn
+
+
+class TestTriggerLazyModuleAliases(unittest.TestCase):
+    def test_alias_is_installed_eagerly(self):
+        model = nn.Module()
+        model.self_attn = _make_attn_module()
+
+        _trigger_lazy_module_aliases(model)
+
+        # attn_mha.kv_b_proj must point at the outer kv_b_proj module
+        # (not just an equal copy — same object).
+        self.assertIs(
+            model.self_attn.attn_mha.kv_b_proj,
+            model.self_attn.kv_b_proj,
+        )
+
+    def test_state_dict_includes_aliased_key(self):
+        """After aliasing, ``model.state_dict()`` must expose the
+        ``attn_mha.kv_b_proj.weight`` key the saved checkpoint uses."""
+        model = nn.Module()
+        model.self_attn = _make_attn_module()
+
+        _trigger_lazy_module_aliases(model)
+
+        keys = set(model.state_dict().keys())
+        self.assertIn("self_attn.kv_b_proj.weight", keys)
+        self.assertIn("self_attn.attn_mha.kv_b_proj.weight", keys)
+
+        # And both keys must share storage (alias, not copy) so loading the
+        # checkpoint into one populates the other.
+        outer = model.state_dict()["self_attn.kv_b_proj.weight"]
+        inner = model.state_dict()["self_attn.attn_mha.kv_b_proj.weight"]
+        self.assertEqual(
+            outer.untyped_storage().data_ptr(),
+            inner.untyped_storage().data_ptr(),
+        )
+
+    def test_idempotent_when_alias_already_installed(self):
+        model = nn.Module()
+        model.self_attn = _make_attn_module()
+
+        _trigger_lazy_module_aliases(model)
+        first_alias = model.self_attn.attn_mha.kv_b_proj
+
+        # Second call must be a no-op, not re-bind to a new object.
+        _trigger_lazy_module_aliases(model)
+        self.assertIs(model.self_attn.attn_mha.kv_b_proj, first_alias)
+
+    def test_skips_modules_without_attn_mha(self):
+        """Modules that don't have an ``attn_mha`` child must be left alone."""
+        model = nn.Module()
+        model.self_attn = nn.Module()
+        model.self_attn.kv_b_proj = nn.Linear(4, 8, bias=False)
+        # No attn_mha attribute on self_attn.
+
+        # Must not raise AttributeError or otherwise mutate.
+        _trigger_lazy_module_aliases(model)
+
+        self.assertFalse(hasattr(model.self_attn, "attn_mha"))
+
+    def test_skips_modules_without_outer_kv_b_proj(self):
+        """If a module has attn_mha but no outer kv_b_proj, leave the
+        attn_mha.kv_b_proj slot alone — there's nothing to alias to."""
+        model = nn.Module()
+        model.some_block = nn.Module()
+        model.some_block.attn_mha = nn.Module()
+        model.some_block.attn_mha.kv_b_proj = None
+
+        _trigger_lazy_module_aliases(model)
+
+        self.assertIsNone(model.some_block.attn_mha.kv_b_proj)
+
+    def test_does_not_overwrite_non_none_alias(self):
+        """If ``attn_mha.kv_b_proj`` is already set to something (e.g. a
+        different module on a subclass), don't clobber it."""
+        model = nn.Module()
+        model.self_attn = _make_attn_module()
+        sentinel = nn.Linear(4, 8, bias=False)
+        model.self_attn.attn_mha.kv_b_proj = sentinel
+
+        _trigger_lazy_module_aliases(model)
+
+        # Must keep the pre-existing alias, not replace it with the outer
+        # kv_b_proj.
+        self.assertIs(model.self_attn.attn_mha.kv_b_proj, sentinel)
+        self.assertIsNot(model.self_attn.attn_mha.kv_b_proj, model.self_attn.kv_b_proj)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes #25332.

`ShardedStateLoader` fails to load pre-sharded checkpoints generated by `examples/runtime/engine/save_sharded_state.py` for DeepSeek-V2 / V3 / V3.2 models because the saved keys carry an `attn_mha.` prefix that the load-time `state_dict` view doesn't have:

- saved key: `model.layers.0.self_attn.attn_mha.kv_b_proj.weight`
- model expects: `model.layers.0.self_attn.kv_b_proj.weight`

## Root cause

`DeepseekV2AttentionMLA.__init__` initializes `self.attn_mha.kv_b_proj = None` and lazily binds it to the outer `self.kv_b_proj` inside `forward_prepare` (`python/sglang/srt/models/deepseek_v2.py:1618-1619`). Because the alias is a child-module assignment, `model.state_dict()` then exposes the same parameter under two keys sharing storage:

- `...self_attn.kv_b_proj.weight`
- `...self_attn.attn_mha.kv_b_proj.weight`

`ShardedStateLoader._filter_subtensors` dedups same-storage tensors and keeps the lexicographically smaller key. Because `'a' < 'k'`, the saved checkpoint encodes the parameter under the `...attn_mha.kv_b_proj.*` key.

On the load side, `ShardedStateLoader.load_model` reads `model.state_dict()` immediately after `_initialize_model` and `process_weights_after_loading`, before any forward has run. The lazy alias is therefore still `None`, the load-time `state_dict` only contains `...kv_b_proj.*`, and the saved `...attn_mha.kv_b_proj.*` keys are unresolvable → KeyError.

## Fix

Add a small module-level helper `_trigger_lazy_module_aliases(model)` that walks `model.modules()` and, when a module has both `attn_mha` and an outer `kv_b_proj` and `attn_mha.kv_b_proj is None`, eagerly installs the alias. Call it from `ShardedStateLoader.load_model` after `_initialize_model` and `process_weights_after_loading`, before `_filter_subtensors(model.state_dict())`. The alias is a module reference, not a tensor copy, so it doesn't depend on weights being loaded yet — once the outer `kv_b_proj.weight` is populated from the checkpoint, the inner alias sees the same storage automatically.

The helper is conservatively guarded:

- skips modules that don't have `attn_mha` or don't have an outer `kv_b_proj`
- skips modules where `attn_mha.kv_b_proj` is already non-None (idempotent, doesn't clobber subclass overrides)

Verified that `sarvam_moe.py` (the only other model with both `self.attn_mha` and `self.kv_b_proj`) does **not** use the lazy-alias pattern, so it is unaffected.

## Test plan

CPU unit tests in `test/registered/unit/model_loader/test_sharded_state_loader_lazy_aliases.py`:

```bash
$ KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=python python -m pytest \
    test/registered/unit/model_loader/test_sharded_state_loader_lazy_aliases.py -v
test_alias_is_installed_eagerly                   PASSED
test_does_not_overwrite_non_none_alias            PASSED
test_idempotent_when_alias_already_installed      PASSED
test_skips_modules_without_attn_mha               PASSED
test_skips_modules_without_outer_kv_b_proj        PASSED
test_state_dict_includes_aliased_key              PASSED
======================== 6 passed ========================
```

The last test asserts that after aliasing, `model.state_dict()` contains both `...kv_b_proj.weight` and `...attn_mha.kv_b_proj.weight` and that they share storage — i.e. the load-time view now matches what `save_model` would produce post-warmup.

End-to-end Engine reload of a sharded DeepSeek-V2 checkpoint requires multi-GPU and a full DeepSeek-V2 setup; the CPU tests cover the helper logic and the structural property the loader relies on.