### PR TITLE
managers/detokenizer_manager: fix spurious eviction in LimitedCapacityDict when updating existing key

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -405,9 +405,10 @@ class LimitedCapacityDict(OrderedDict):
         self.capacity = capacity
 
     def __setitem__(self, key, value):
-        if key not in self and len(self) >= self.capacity:
-            # Remove the oldest element (first item in the dict)
-            self.popitem(last=False)
+        if key not in self:
+            while self and len(self) >= self.capacity:
+                # Remove the oldest element (first item in the dict)
+                self.popitem(last=False)
         # Set the new item
         super().__setitem__(key, value)
 

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -405,7 +405,7 @@ class LimitedCapacityDict(OrderedDict):
         self.capacity = capacity
 
     def __setitem__(self, key, value):
-        if len(self) >= self.capacity:
+        if key not in self and len(self) >= self.capacity:
             # Remove the oldest element (first item in the dict)
             self.popitem(last=False)
         # Set the new item


### PR DESCRIPTION
## Motivation

`LimitedCapacityDict.__setitem__` unconditionally evicts the oldest entry
whenever `len(self) >= self.capacity`, even when the key being written
**already exists** in the dict. In that case the dict's size does not grow,
so no eviction should occur.

The result is a silent, premature loss of a live request's `DecodeStatus`.
When a key that is already present is overwritten:

1. `popitem(last=False)` ejects the oldest entry (a different, still-active
   request).
2. The updated key is re-inserted at the tail, corrupting insertion order.
3. The next genuinely new request then evicts what is now the *incorrectly
   promoted* oldest entry — one step earlier than it should be.

In the worst case this causes the `RuntimeError` / `KeyError` documented in
[#2812](https://github.com/sgl-project/sglang/issues/2812) for requests that
are still actively generating tokens.

## Modifications

- `python/sglang/srt/managers/detokenizer_manager.py`  
  Guard the eviction in `LimitedCapacityDict.__setitem__` with
  `key not in self`, so the oldest entry is only ejected when the insertion
  would genuinely grow the dict beyond capacity.

```diff
 def __setitem__(self, key, value):
-    if len(self) >= self.capacity:
+    if key not in self and len(self) >= self.capacity:
         # Remove the oldest element (first item in the dict)
         self.popitem(last=False)
     # Set the new item
     super().__setitem__(key, value)
```

The change is a single O(1) hash-map membership check with no effect on the
happy path (new keys at capacity).

## Accuracy Tests

Not applicable — this change does not affect model forward passes or sampling
logic.

## Speed Tests and Profiling

Not applicable — the added `key not in self` check is O(1) and sits on the
detokenizer bookkeeping path, not the GPU-bound forward pass.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).