### PR TITLE
feat(moe): reuse prev-layer output as symm_output for FP4 routed MoE

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -305,6 +305,9 @@ class AttnTpContext:
         assert self.attn_inputs_ is not None
         return self.attn_inputs_.fetch_hidden_states()
 
+    def clear_attn_inputs(self) -> None:
+        self.attn_inputs_ = None
+
     @contextmanager
     def maybe_input_scattered(self, forward_batch: ForwardBatch):
         flag = self.use_input_scattered(forward_batch)

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -307,6 +307,10 @@ class FusedMoE(torch.nn.Module):
 
         self.quant_method.create_moe_runner(self, self.moe_runner_config)
         self.dispatcher = create_moe_dispatcher(self.moe_runner_config)
+        
+        if get_moe_runner_backend().is_flashinfer_trtllm_routed() or get_moe_runner_backend().is_flashinfer_trtllm():
+            logging.warning("Setting inplace to False for FlashInfer TRTLLM MoE backend.")
+            self.moe_runner_config.inplace = False
 
         self.should_fuse_routed_scaling_factor_in_topk = (
             isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -307,9 +307,14 @@ class FusedMoE(torch.nn.Module):
 
         self.quant_method.create_moe_runner(self, self.moe_runner_config)
         self.dispatcher = create_moe_dispatcher(self.moe_runner_config)
-        
-        if get_moe_runner_backend().is_flashinfer_trtllm_routed() or get_moe_runner_backend().is_flashinfer_trtllm():
-            logging.warning("Setting inplace to False for FlashInfer TRTLLM MoE backend.")
+
+        if (
+            get_moe_runner_backend().is_flashinfer_trtllm_routed()
+            or get_moe_runner_backend().is_flashinfer_trtllm()
+        ):
+            logging.warning(
+                "Setting inplace to False for FlashInfer TRTLLM MoE backend."
+            )
             self.moe_runner_config.inplace = False
 
         self.should_fuse_routed_scaling_factor_in_topk = (

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import contextvars
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, TypeGuard
+from typing import TYPE_CHECKING, Any, Callable, Generator, Optional, Tuple, TypeGuard
 
 import torch
 
@@ -24,6 +26,20 @@ if TYPE_CHECKING:
         DispatchOutput,
         DispatchOutputFormat,
     )
+
+
+_moe_output_buf: contextvars.ContextVar[Optional[torch.Tensor]] = (
+    contextvars.ContextVar("moe_output_buf", default=None)
+)
+
+
+@contextmanager
+def moe_output_buffer_ctx(buf: torch.Tensor) -> Generator[None, None, None]:
+    token = _moe_output_buf.set(buf)
+    try:
+        yield
+    finally:
+        _moe_output_buf.reset(token)
 
 
 @dataclass

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -10,6 +10,8 @@ from torch.nn.parameter import Parameter
 # Import to register custom ops for torch.compile compatibility
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    is_symmetric_memory_enabled,
+    is_tensor_in_symmetric_mempool,
     use_symmetric_memory,
 )
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
@@ -21,6 +23,7 @@ from sglang.srt.layers.moe.flashinfer_trtllm_moe import (
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeQuantInfo,
     MoeRunnerConfig,
+    _moe_output_buf,
     register_fused_func,
 )
 from sglang.srt.layers.quantization.fp8_kernel import (
@@ -877,14 +880,29 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     )
     activation_type = get_activation_type(runner_config.activation)
 
-    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
-        num_tokens = hs_fp4.shape[0]
-        hidden_size = (
-            hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
+    num_tokens = hs_fp4.shape[0]
+    hidden_size = (
+        hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
+    )
+    _provided = _moe_output_buf.get()
+    _symm_required = is_allocation_symmetric()
+    if (
+        _provided is not None
+        and _provided.shape == (num_tokens, hidden_size)
+        and _provided.dtype == hidden_states.dtype
+        and _provided.device == hs_fp4.device
+        and (
+            not _symm_required
+            or not is_symmetric_memory_enabled()
+            or is_tensor_in_symmetric_mempool(_provided)
         )
-        symm_output = torch.empty(
-            num_tokens, hidden_size, dtype=hidden_states.dtype, device=hs_fp4.device
-        )
+    ):
+        symm_output = _provided
+    else:
+        with use_symmetric_memory(get_tp_group(), disabled=not _symm_required):
+            symm_output = torch.empty(
+                num_tokens, hidden_size, dtype=hidden_states.dtype, device=hs_fp4.device
+            )
 
     if use_routed_topk:
         assert TopKOutputChecker.format_is_standard(topk_output)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1930,6 +1930,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        hidden_states_orig = hidden_states
         hidden_states, residual = self.layer_communicator.prepare_attn(
             hidden_states,
             residual,
@@ -1969,13 +1970,24 @@ class DeepseekV2DecoderLayer(nn.Module):
         if isinstance(self.mlp, DeepseekV2MLP):
             gemm_output_zero_allocator = None
 
-        hidden_states = self.mlp(
-            hidden_states,
-            forward_batch,
-            should_allreduce_fusion,
-            use_reduce_scatter,
-            gemm_output_zero_allocator,
-        )
+        if (
+            isinstance(self.mlp, DeepseekV2MoE)
+            and not self.mlp.experts.moe_runner_config.inplace
+        ):
+            from sglang.srt.layers.moe.moe_runner.base import moe_output_buffer_ctx
+
+            _mlp_ctx = moe_output_buffer_ctx(hidden_states_orig)
+        else:
+            _mlp_ctx = nullcontext()
+
+        with _mlp_ctx:
+            hidden_states = self.mlp(
+                hidden_states,
+                forward_batch,
+                should_allreduce_fusion,
+                use_reduce_scatter,
+                gemm_output_zero_allocator,
+            )
 
         if not self.nsa_enable_prefill_cp and should_allreduce_fusion:
             hidden_states._sglang_needs_allreduce_fusion = True

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -167,6 +167,7 @@ from sglang.srt.utils import (
     BumpAllocator,
     LazyValue,
     add_prefix,
+    dispose_tensor,
     is_non_idle_and_non_empty,
     log_info_on_rank0,
     make_layers,
@@ -827,12 +828,6 @@ class DeepseekV2MoE(nn.Module):
             else None
         )
         if hidden_states.shape[0] > 0:
-            if (
-                not self._fuse_shared_experts_inside_sbo
-            ):  # TODO: check if it supports mtp
-                shared_output = self._forward_shared_experts(
-                    hidden_states, gemm_output_zero_allocator
-                )
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
             topk_kwargs = (
@@ -893,6 +888,12 @@ class DeepseekV2MoE(nn.Module):
         ):
             # fused in biased_grouped_topk so we can skip here
             final_hidden_states *= self.routed_scaling_factor
+
+        if hidden_states.shape[0] > 0:
+            if not self._fuse_shared_experts_inside_sbo:
+                shared_output = self._forward_shared_experts(
+                    hidden_states, gemm_output_zero_allocator
+                )
 
         final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
             self.experts,
@@ -1922,6 +1923,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        hidden_states_orig = hidden_states
         hidden_states, residual = self.layer_communicator.prepare_attn(
             hidden_states,
             residual,
@@ -1943,9 +1945,14 @@ class DeepseekV2DecoderLayer(nn.Module):
         else:
             topk_indices = None
 
+        get_attn_tp_context().attn_inputs_ = None
+
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch
         )
+
+        if residual is not hidden_states_orig:
+            dispose_tensor(hidden_states_orig)
 
         should_allreduce_fusion = (
             self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -167,7 +167,6 @@ from sglang.srt.utils import (
     BumpAllocator,
     LazyValue,
     add_prefix,
-    dispose_tensor,
     is_non_idle_and_non_empty,
     log_info_on_rank0,
     make_layers,
@@ -1931,7 +1930,6 @@ class DeepseekV2DecoderLayer(nn.Module):
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        hidden_states_orig = hidden_states
         hidden_states, residual = self.layer_communicator.prepare_attn(
             hidden_states,
             residual,
@@ -1956,9 +1954,6 @@ class DeepseekV2DecoderLayer(nn.Module):
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch
         )
-
-        if residual is not hidden_states_orig:
-            dispose_tensor(hidden_states_orig)
 
         should_allreduce_fusion = (
             self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1951,6 +1951,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states, topk_indices = hidden_states
         else:
             topk_indices = None
+        get_attn_tp_context().clear_attn_inputs()
 
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -894,7 +894,11 @@ class DeepseekV2MoE(nn.Module):
             # fused in biased_grouped_topk so we can skip here
             final_hidden_states *= self.routed_scaling_factor
 
-        if defer_shared and hidden_states.shape[0] > 0 and not self._fuse_shared_experts_inside_sbo:
+        if (
+            defer_shared
+            and hidden_states.shape[0] > 0
+            and not self._fuse_shared_experts_inside_sbo
+        ):
             shared_output = self._forward_shared_experts(
                 hidden_states, gemm_output_zero_allocator
             )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -827,7 +827,12 @@ class DeepseekV2MoE(nn.Module):
             if server_args.enable_eplb
             else None
         )
+        defer_shared = not self.experts.moe_runner_config.inplace
         if hidden_states.shape[0] > 0:
+            if not defer_shared and not self._fuse_shared_experts_inside_sbo:
+                shared_output = self._forward_shared_experts(
+                    hidden_states, gemm_output_zero_allocator
+                )
             # router_logits: (num_tokens, n_experts)
             router_logits = self.gate(hidden_states, gemm_output_zero_allocator)
             topk_kwargs = (
@@ -889,11 +894,10 @@ class DeepseekV2MoE(nn.Module):
             # fused in biased_grouped_topk so we can skip here
             final_hidden_states *= self.routed_scaling_factor
 
-        if hidden_states.shape[0] > 0:
-            if not self._fuse_shared_experts_inside_sbo:
-                shared_output = self._forward_shared_experts(
-                    hidden_states, gemm_output_zero_allocator
-                )
+        if defer_shared and hidden_states.shape[0] > 0 and not self._fuse_shared_experts_inside_sbo:
+            shared_output = self._forward_shared_experts(
+                hidden_states, gemm_output_zero_allocator
+            )
 
         final_hidden_states = maybe_fuse_routed_scale_and_shared_add(
             self.experts,
@@ -1944,8 +1948,6 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states, topk_indices = hidden_states
         else:
             topk_indices = None
-
-        get_attn_tp_context().attn_inputs_ = None
 
         hidden_states, residual = self.layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2976,11 +2976,19 @@ def load_json_config(data: str):
         return orjson.loads(Path(data).read_text())
 
 
+_DISPOSE_CLEAR_ALIAS_MIN_BYTES = 16 * 1024 * 1024
+
+
 def dispose_tensor(x: torch.Tensor):
     """
     Dispose a tensor by freeing its memory.
     During piecewise CUDA graph capture/replay, we skip disposal to avoid
     interfering with torch.compile's memory tracking and graph recording.
+
+    For large tensors (>= 16 MiB), also clear any aliased Python tensors that
+    share the same UntypedStorage. Some workspace/communication paths keep a
+    Python tensor pointing at the same data_ptr; without clearing it, x.set_()
+    alone does not free the underlying storage.
     """
 
     # Skip disposal during piecewise CUDA graph to avoid torch.compile issues
@@ -2991,6 +2999,41 @@ def dispose_tensor(x: torch.Tensor):
 
     if is_in_piecewise_cuda_graph():
         return
+
+    try:
+        nbytes = x.untyped_storage().nbytes()
+    except Exception:
+        nbytes = 0
+
+    if nbytes >= _DISPOSE_CLEAR_ALIAS_MIN_BYTES:
+        import gc
+
+        try:
+            from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+                is_tensor_in_symmetric_mempool,
+            )
+        except Exception:
+            is_tensor_in_symmetric_mempool = lambda _t: False
+
+        # NCCL symmetric-memory-registered tensors must stay live for collectives;
+        # skip them.
+        if is_tensor_in_symmetric_mempool(x):
+            x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
+            return
+
+        data_ptr = x.untyped_storage().data_ptr()
+        empty = torch.empty((0,), device=x.device, dtype=x.dtype)
+        for obj in gc.get_objects():
+            try:
+                if (
+                    isinstance(obj, torch.Tensor)
+                    and obj is not x
+                    and obj.untyped_storage().data_ptr() == data_ptr
+                    and not is_tensor_in_symmetric_mempool(obj)
+                ):
+                    obj.set_(empty)
+            except Exception:
+                pass
 
     x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2976,19 +2976,11 @@ def load_json_config(data: str):
         return orjson.loads(Path(data).read_text())
 
 
-_DISPOSE_CLEAR_ALIAS_MIN_BYTES = 16 * 1024 * 1024
-
-
 def dispose_tensor(x: torch.Tensor):
     """
     Dispose a tensor by freeing its memory.
     During piecewise CUDA graph capture/replay, we skip disposal to avoid
     interfering with torch.compile's memory tracking and graph recording.
-
-    For large tensors (>= 16 MiB), also clear any aliased Python tensors that
-    share the same UntypedStorage. Some workspace/communication paths keep a
-    Python tensor pointing at the same data_ptr; without clearing it, x.set_()
-    alone does not free the underlying storage.
     """
 
     # Skip disposal during piecewise CUDA graph to avoid torch.compile issues
@@ -2999,41 +2991,6 @@ def dispose_tensor(x: torch.Tensor):
 
     if is_in_piecewise_cuda_graph():
         return
-
-    try:
-        nbytes = x.untyped_storage().nbytes()
-    except Exception:
-        nbytes = 0
-
-    if nbytes >= _DISPOSE_CLEAR_ALIAS_MIN_BYTES:
-        import gc
-
-        try:
-            from sglang.srt.distributed.device_communicators.pynccl_allocator import (
-                is_tensor_in_symmetric_mempool,
-            )
-        except Exception:
-            is_tensor_in_symmetric_mempool = lambda _t: False
-
-        # NCCL symmetric-memory-registered tensors must stay live for collectives;
-        # skip them.
-        if is_tensor_in_symmetric_mempool(x):
-            x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
-            return
-
-        data_ptr = x.untyped_storage().data_ptr()
-        empty = torch.empty((0,), device=x.device, dtype=x.dtype)
-        for obj in gc.get_objects():
-            try:
-                if (
-                    isinstance(obj, torch.Tensor)
-                    and obj is not x
-                    and obj.untyped_storage().data_ptr() == data_ptr
-                    and not is_tensor_in_symmetric_mempool(obj)
-                ):
-                    obj.set_(empty)
-            except Exception:
-                pass
 
     x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
 


### PR DESCRIPTION
## Motivation

For Kimi-K2.5-NVFP4 with \`flashinfer_trtllm_routed\` on TP=4, two sources of unnecessary tensor lifetime were identified and eliminated:

1. **symm_output reuse**: each of the 60 MoE decoder layers allocated a fresh \`symm_output\` buffer (60 × 235 MB = 14 GB churn per 16K-token prefill). The previous layer's MoE output (\`hidden_states_orig\`) is stale by the time the MoE kernel runs and can be reused in-place.
2. **attn_inputs lifetime**: \`attn_tp_context.attn_inputs_\` holds the post-layernorm hidden_states for attention TP scatter. After \`self_attn\` returns the tensor is no longer needed, but it persisted until the next layer's \`prepare_attn\` overwrote it.

## Modifications

- **\`fused_moe_triton/layer.py\`**: set \`moe_runner_config.inplace = False\` for flashinfer_trtllm backends to opt into the output-buffer protocol
- **\`moe_runner/base.py\`**: add \`_moe_output_buf\` ContextVar and \`moe_output_buffer_ctx\` context manager
- **\`moe_runner/flashinfer_trtllm.py\`**: check \`_moe_output_buf\` before allocating \`symm_output\`; reuse if compatible; fall back to \`torch.empty\` only for layer 0
- **\`models/deepseek_v2.py\`**: capture \`hidden_states_orig\` and wrap MoE call with \`moe_output_buffer_ctx\`; call \`clear_attn_inputs()\` after \`self_attn\` returns
- **\`layers/communicator.py\`**: add \`AttnTpContext.clear_attn_inputs()\` method

## Accuracy Tests

| Config | Examples | GSM8K score |
|---|---:|---:|
| No CUDA graph | 20 | 0.95 |
| CUDA graph enabled | 100 | 0.94 |
| CUDA graph + clear_attn_inputs | 100 | **0.94** |

No accuracy regression across all configurations.

## Speed Tests and Profiling

Tested on TP=4 GB300 (Kimi-K2.5-NVFP4), 16K-token fresh prefill, \`--disable-cuda-graph\`, torch.cuda.memory snapshot (TP-0):

| Metric | Baseline | +symm_output reuse | +clear_attn_inputs |
|---|---:|---:|---:|
| \`symm_output\` allocs | 60 | **0** | **0** |
| Allocation churn | 14.1 GB | 0 GB | 0 GB |
| Peak activation memory | 3956 MB | 3486 MB | **3417 MB** |
| **Total reduction** | — | −470 MB | **−539 MB** |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include \`/tag-and-rerun-ci\`, \`/tag-run-ci-label\`, \`/rerun-failed-ci\`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.