### PR TITLE
[perf][mem_cache] Use deque for ReqToTokenPool.free_slots

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -27,6 +27,7 @@ KVCache actually holds the physical kv cache.
 import abc
 import dataclasses
 import logging
+from collections import deque
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
@@ -149,7 +150,7 @@ class ReqToTokenPool:
             self.req_to_token = torch.zeros(
                 (self._alloc_size, max_context_len), dtype=torch.int32, device=device
             )
-        self.free_slots = list(range(1, self._alloc_size))
+        self.free_slots: deque[int] = deque(range(1, self._alloc_size))
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -174,8 +175,7 @@ class ReqToTokenPool:
         need_size = len(reqs) - len(reusing)
         if need_size > len(self.free_slots):
             return None
-        select_index = self.free_slots[:need_size]
-        self.free_slots = self.free_slots[need_size:]
+        select_index = [self.free_slots.popleft() for _ in range(need_size)]
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
@@ -189,7 +189,7 @@ class ReqToTokenPool:
         req.req_pool_idx = None
 
     def clear(self):
-        self.free_slots = list(range(1, self._alloc_size))
+        self.free_slots = deque(range(1, self._alloc_size))
 
 
 class MambaPool:


### PR DESCRIPTION
`free_slots` is a free-row index pool for the `req_to_token` table. Previously it was a Python list; `alloc()` did
  `self.free_slots = self.free_slots[need_size:]`
to drop the first `need_size` elements, which rebuilds a new list of length `size - need_size` -- O(size) per allocation.

Switch to `collections.deque`. `popleft()` is O(1), so `alloc()` becomes O(B) in batch size instead of O(size). `free()` (append) and `available_size()` (len) keep the same complexity.

`size` is typically only a few thousand, so the absolute speedup on the end-to-end critical path is small -- but the change itself is tiny (swap the container type, replace a slice with a comprehension), the correctness story is unchanged, and the asymptotic improvement is the textbook fix for "pop-front on a Python list." Worth doing.


