### PR TITLE
[HiSparse] Fix DeepSeek V4 direct-to-host page alignment

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -34,7 +34,6 @@ from torch.distributed import ProcessGroup
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.disaggregation.base import KVPoll
-from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVReceiver
 from sglang.srt.disaggregation.utils import (
     FAKE_BOOTSTRAP_HOST,
@@ -57,6 +56,7 @@ from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     page_align_floor,
@@ -64,11 +64,12 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
+    HybridLinearKVPool,
     HybridReqToTokenPool,
     KVCache,
+    NSATokenToKVPool,
     ReqToTokenPool,
 )
-from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
@@ -177,6 +178,7 @@ class DecodeReqToTokenPool:
 
 
 class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
+
     def __init__(
         self,
         size: int,
@@ -252,10 +254,6 @@ class DecodeRequest:
     def seqlen(self) -> int:
         return self.req.seqlen
 
-    @property
-    def priority(self) -> Optional[int]:
-        return self.req.priority
-
 
 class DecodePreallocQueue:
     """
@@ -321,54 +319,12 @@ class DecodePreallocQueue:
         if self.enable_staging:
             self.transfer_queue._init_staging_handler(self.kv_manager)
 
-        if (
-            self.scheduler.tp_worker.is_hybrid_swa
-            and not self._uses_swa_tail_prealloc()
-        ):
-            # Fallback for SWA allocators that still allocate the SWA pool at
-            # full prompt length.
+        if self.scheduler.tp_worker.is_hybrid_swa:
+            # FIXME: current SWA allocation allocate full kv cache size in prefill
             self.max_total_num_tokens = min(
                 self.max_total_num_tokens,
                 self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
             )
-
-    def _uses_swa_tail_prealloc(self) -> bool:
-        return (
-            isinstance(self.token_to_kv_pool, (SWAKVPool, DeepSeekV4TokenToKVPool))
-            and self.token_to_kv_pool_allocator.page_size > 1
-            and hasattr(self.token_to_kv_pool_allocator, "alloc_extend_swa_tail")
-        )
-
-    def _swa_tail_len(self, seq_len: int) -> int:
-        if not self._uses_swa_tail_prealloc() or seq_len <= 0:
-            return max(seq_len, 0)
-
-        window_size = self.scheduler.sliding_window_size
-        if window_size is None or window_size <= 0:
-            return seq_len
-
-        page_size = self.token_to_kv_pool_allocator.page_size
-        window_start = max(0, seq_len - window_size)
-        window_start = (window_start // page_size) * page_size
-        return seq_len - window_start
-
-    def _swa_retractable_len(self, req: Req) -> int:
-        if not self._uses_swa_tail_prealloc():
-            return len(req.origin_input_ids) + len(req.output_ids)
-        return self._swa_tail_len(len(req.origin_input_ids)) + len(req.output_ids)
-
-    def _prealloc_kv_lens(self, req: Req) -> Tuple[int, int]:
-        allocated_kv_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
-        if self._uses_swa_tail_prealloc():
-            return allocated_kv_len, self._swa_tail_len(allocated_kv_len)
-        return allocated_kv_len, allocated_kv_len
-
-    def _prealloc_required_tokens(self, req: Req) -> Tuple[int, int]:
-        full_len, swa_len = self._prealloc_kv_lens(req)
-        return (
-            full_len + self.num_reserved_decode_tokens,
-            swa_len + self.num_reserved_decode_tokens,
-        )
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
@@ -385,6 +341,17 @@ class DecodePreallocQueue:
             kv_data_ptrs, kv_data_lens, kv_item_lens = (
                 host_pool.get_contiguous_buf_infos()
             )
+            if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                # DSV4 HiSparse writes only C4 KV to host.  The c4_indexer and
+                # c128 KV remain device-to-device transfers and are appended
+                # after the host C4 entries in Mooncake's KV pointer table.
+                device_kv_data_ptrs, device_kv_data_lens, device_kv_item_lens = (
+                    self.token_to_kv_pool.get_contiguous_buf_infos()
+                )
+                c4_layer_num = host_pool.layer_num
+                kv_data_ptrs += device_kv_data_ptrs[c4_layer_num:]
+                kv_data_lens += device_kv_data_lens[c4_layer_num:]
+                kv_item_lens += device_kv_item_lens[c4_layer_num:]
         else:
             kv_data_ptrs, kv_data_lens, kv_item_lens = (
                 self.token_to_kv_pool.get_contiguous_buf_infos()
@@ -402,22 +369,13 @@ class DecodePreallocQueue:
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        # HiSparse Host pool has page_size=1; use it when hisparse is enabled
-        kv_args.page_size = (
-            1 if self.scheduler.enable_hisparse else self.token_to_kv_pool.page_size
-        )
+        kv_args.page_size = self.token_to_kv_pool.page_size
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
         )
 
-        setup_state_kv_args(
-            kv_args,
-            self.token_to_kv_pool,
-            self.draft_token_to_kv_pool,
-            total_kv_layers=self.scheduler.model_config.num_hidden_layers,
-            req_to_token_pool=getattr(self, "req_to_token_pool", None),
-        )
+        setup_state_kv_args(kv_args, self.token_to_kv_pool, self.draft_token_to_kv_pool)
 
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
         kv_args.gpu_id = self.scheduler.gpu_id
@@ -534,18 +492,6 @@ class DecodePreallocQueue:
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
             self.scheduler.stream_output([req], req.return_logprob)
             return True
-        if self._uses_swa_tail_prealloc():
-            _, swa_required = self._prealloc_required_tokens(req)
-            swa_capacity = self.token_to_kv_pool_allocator.size_swa
-            if swa_required > swa_capacity:
-                message = (
-                    f"Request {req.rid} requires too many SWA KV tokens for "
-                    f"decode preallocation: {swa_required} > {swa_capacity}"
-                )
-                logger.error(message)
-                prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
-                self.scheduler.stream_output([req], req.return_logprob)
-                return True
         return False
 
     def extend(self, reqs: List[Req], is_retracted: bool = False) -> None:
@@ -561,15 +507,7 @@ class DecodePreallocQueue:
         # allocate memory
         resumed_reqs = []
         indices_to_remove = set()
-        uses_swa_tail_prealloc = self._uses_swa_tail_prealloc()
-        if uses_swa_tail_prealloc:
-            full_allocatable_tokens, swa_allocatable_tokens = (
-                self._swa_aware_allocatable_token_budgets(count_retracted=False)
-            )
-        else:
-            full_allocatable_tokens = self._allocatable_token_budgets(
-                count_retracted=False
-            )
+        allocatable_tokens = self._allocatable_tokens(count_retracted=False)
 
         for i, req in enumerate(self.retracted_queue):
             if rids_to_check is not None and req.rid not in rids_to_check:
@@ -578,19 +516,19 @@ class DecodePreallocQueue:
             if self.req_to_token_pool.available_size() <= 0:
                 break
 
-            full_required, swa_required = self._prealloc_required_tokens(req)
-            if full_required > full_allocatable_tokens:
-                break
-            if uses_swa_tail_prealloc and swa_required > swa_allocatable_tokens:
+            required_tokens_for_request = (
+                len(req.origin_input_ids)
+                + len(req.output_ids)
+                + self.num_reserved_decode_tokens
+            )
+            if required_tokens_for_request > allocatable_tokens:
                 break
 
             resumed_reqs.append(req)
             indices_to_remove.add(i)
             req.is_retracted = False
             self._pre_alloc(req)
-            full_allocatable_tokens -= full_required
-            if uses_swa_tail_prealloc:
-                swa_allocatable_tokens -= swa_required
+            allocatable_tokens -= required_tokens_for_request
 
             # load from cpu, release the cpu copy
             req.load_kv_cache(self.req_to_token_pool, self.token_to_kv_pool_allocator)
@@ -745,34 +683,9 @@ class DecodePreallocQueue:
             len(r.origin_input_ids) + len(r.output_ids)
             for r in self.scheduler.running_batch.reqs
         )
-
-        uses_swa_tail_prealloc = self._uses_swa_tail_prealloc()
-        swa_allocatable_tokens = 0
-        if uses_swa_tail_prealloc:
-            retractable_swa_tokens = sum(
-                self._swa_retractable_len(r) for r in self.scheduler.running_batch.reqs
-            )
-            full_allocatable_tokens, swa_allocatable_tokens = (
-                self._swa_aware_allocatable_token_budgets(
-                    retractable_tokens=retractable_tokens,
-                    retractable_swa_tokens=retractable_swa_tokens,
-                    count_retracted=True,
-                )
-            )
-        else:
-            retractable_swa_tokens = 0
-            full_allocatable_tokens = self._allocatable_token_budgets(
-                retractable_tokens=retractable_tokens, count_retracted=True
-            )
-
-        # Sort by priority before any index-based bookkeeping so that both the
-        # abort-scan loop and the preallocation loop operate on the same order.
-        if self.scheduler.enable_priority_scheduling:
-            priority_sign = (
-                1 if self.scheduler.schedule_low_priority_values_first else -1
-            )
-            self.queue.sort(key=lambda r: r.req.priority * priority_sign)
-
+        allocatable_tokens = self._allocatable_tokens(
+            retractable_tokens=retractable_tokens, count_retracted=True
+        )
         # First, remove all failed requests from the queue
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
@@ -839,7 +752,7 @@ class DecodePreallocQueue:
                 # Matching may lock previously-evictable radix pages, so refresh
                 # the admission budget against the post-lock pool state before we
                 # decide whether this request still fits.
-                full_allocatable_tokens = self._allocatable_token_budgets(
+                allocatable_tokens = self._allocatable_tokens(
                     retractable_tokens=retractable_tokens,
                     count_retracted=True,
                     extra_reserved_reqs=len(preallocated_reqs),
@@ -864,49 +777,28 @@ class DecodePreallocQueue:
                     )
                     - retractable_tokens,
                 )
-                > full_allocatable_tokens
+                > allocatable_tokens
             ):
                 if prefix_len > 0:
                     self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
-            if required_tokens_for_request > full_allocatable_tokens:
+            if required_tokens_for_request > allocatable_tokens:
                 if prefix_len > 0:
                     self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
-
-            if uses_swa_tail_prealloc:
-                _, swa_required = self._prealloc_required_tokens(decode_req.req)
-                _, swa_len = self._prealloc_kv_lens(decode_req.req)
-                max_new_tokens = min(
-                    decode_req.req.sampling_params.max_new_tokens,
-                    CLIP_MAX_NEW_TOKEN,
-                )
-                if (
-                    max(
-                        swa_required,
-                        swa_len + max_new_tokens - retractable_swa_tokens,
-                    )
-                    > swa_allocatable_tokens
-                ):
-                    if prefix_len > 0:
-                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
-                    break
 
             dst_kv_indices = self._pre_alloc(decode_req.req, prefix_indices, prefix_len)
             hisparse_req_budget -= 1
             # Recompute from actual pool state for the next queue entry.
             # This accounts for page rounding and newly locked evictable cache.
-            full_allocatable_tokens = self._allocatable_token_budgets(
+            allocatable_tokens = self._allocatable_tokens(
                 retractable_tokens=retractable_tokens,
                 count_retracted=True,
                 extra_reserved_reqs=len(preallocated_reqs) + 1,
             )
-            if uses_swa_tail_prealloc:
-                # SWA budget uses simple decrement (no radix cache eviction in
-                # the SWA pool, so page-rounding drift is negligible).
-                swa_allocatable_tokens -= swa_required
             decode_req.req.cache_protected_len = prefix_len
 
+            page_size = self.token_to_kv_pool_allocator.page_size
             if self.scheduler.enable_hisparse:
                 # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
                 kv_indices = (
@@ -915,7 +807,18 @@ class DecodePreallocQueue:
                     .numpy()
                     .astype(np.int32)
                 )
-                page_size = 1  # host pool page_size
+                device_kv_page_indices = None
+                if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                    # DSV4 host C4 entries are token-linear, while non-sparse KV
+                    # still uses device page indices.
+                    page_size = 1
+                    kv_indices_full = self.req_to_token_pool.req_to_token[
+                        decode_req.req.req_pool_idx, prefix_len:origin_input_len
+                    ]
+                    device_kv_page_indices = kv_to_page_indices(
+                        kv_indices_full.cpu().numpy(),
+                        self.token_to_kv_pool.page_size,
+                    ).astype(np.int32)
             else:
                 # Only send delta indices (beyond prefix) to prefill.
                 kv_indices = (
@@ -925,68 +828,91 @@ class DecodePreallocQueue:
                     .cpu()
                     .numpy()
                 )
-                page_size = self.token_to_kv_pool_allocator.page_size
+                device_kv_page_indices = None
 
-            seq_len = len(decode_req.req.origin_input_ids)
-
-            def _mamba_payload():
-                return [
+            # Prepare extra pool indices for hybrid models
+            if isinstance(self.token_to_kv_pool, HybridLinearKVPool):
+                # Mamba hybrid model: single mamba state index
+                state_indices = [
                     self.req_to_token_pool.req_index_to_mamba_index_mapping[
                         decode_req.req.req_pool_idx
                     ]
                     .cpu()
                     .numpy()
                 ]
-
-            def _swa_payload():
+            elif isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                seq_len = len(decode_req.req.origin_input_ids)
                 window_size = self.scheduler.sliding_window_size
+                state_page_size = self.token_to_kv_pool.swa_page_size
+
                 window_start = max(0, seq_len - window_size)
-                window_start = page_align_floor(window_start, page_size)
+                window_start = page_align_floor(window_start, state_page_size)
                 window_kv_indices_full = self.req_to_token_pool.req_to_token[
                     decode_req.req.req_pool_idx, window_start:seq_len
                 ]
+
                 window_kv_indices_swa = (
                     self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
                         window_kv_indices_full
                     )
                 )
-                return kv_to_page_indices(
-                    window_kv_indices_swa.cpu().numpy(), page_size
-                )
+                state_indices = window_kv_indices_swa.cpu().numpy()
+                state_indices = kv_to_page_indices(state_indices, state_page_size)
+            elif isinstance(self.token_to_kv_pool, BaseSWAKVPool):
+                seq_len = len(decode_req.req.origin_input_ids)
+                window_size = self.scheduler.sliding_window_size
 
-            def _nsa_payload():
+                window_start = max(0, seq_len - window_size)
+                window_start = page_align_floor(window_start, page_size)
+                window_kv_indices_full = self.req_to_token_pool.req_to_token[
+                    decode_req.req.req_pool_idx, window_start:seq_len
+                ]
+
+                # Translate to SWA pool indices
+                window_kv_indices_swa = (
+                    self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                        window_kv_indices_full
+                    )
+                )
+                state_indices = window_kv_indices_swa.cpu().numpy()
+                state_indices = kv_to_page_indices(state_indices, page_size)
+            elif isinstance(self.token_to_kv_pool, NSATokenToKVPool):
+                seq_len = len(decode_req.req.origin_input_ids)
                 kv_indices_full = self.req_to_token_pool.req_to_token[
                     decode_req.req.req_pool_idx, :seq_len
                 ]
+                state_indices = kv_indices_full.cpu().numpy()
                 # Indexer lives on device pool; always use device page_size
                 device_page_size = self.token_to_kv_pool.page_size
-                return kv_to_page_indices(
-                    kv_indices_full.cpu().numpy(), device_page_size
-                )
-
-            state_types = self.kv_manager.kv_args.state_types
-            state_indices: Optional[List] = []
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.NSA:
-                    state_indices.append(_nsa_payload())
-                else:
-                    state_indices.append(None)
+                state_indices = kv_to_page_indices(state_indices, device_page_size)
+            else:
+                state_indices = None
 
             decode_req.metadata_buffer_index = (
                 self.req_to_metadata_buffer_idx_allocator.alloc()
             )
             assert decode_req.metadata_buffer_index is not None
             page_indices = kv_to_page_indices(kv_indices, page_size)
-            decode_req.kv_receiver.send_metadata(
-                page_indices,
-                decode_req.metadata_buffer_index,
-                state_indices,
-                decode_prefix_len=prefix_len,
-            )
+            if device_kv_page_indices is not None:
+                if self.transfer_backend != TransferBackend.MOONCAKE:
+                    raise NotImplementedError(
+                        "DeepSeek V4 HiSparse PD direct-to-host currently "
+                        "requires the Mooncake transfer backend."
+                    )
+                decode_req.kv_receiver.send_metadata(
+                    page_indices,
+                    decode_req.metadata_buffer_index,
+                    state_indices,
+                    decode_prefix_len=prefix_len,
+                    device_kv_indices=device_kv_page_indices,
+                )
+            else:
+                decode_req.kv_receiver.send_metadata(
+                    page_indices,
+                    decode_req.metadata_buffer_index,
+                    state_indices,
+                    decode_prefix_len=prefix_len,
+                )
             if (
                 self.transfer_queue.enable_staging
                 and hasattr(decode_req.kv_receiver, "require_staging")
@@ -1011,8 +937,11 @@ class DecodePreallocQueue:
             len(decode_req.req.fill_ids) for decode_req in self.transfer_queue.queue
         )
 
-    def _need_space_for_single_req(
-        self, retractable_tokens: Optional[int] = None
+    def _allocatable_tokens(
+        self,
+        retractable_tokens: Optional[int] = None,
+        count_retracted: bool = True,
+        extra_reserved_reqs: int = 0,
     ) -> int:
         need_space_for_single_req = (
             max(
@@ -1027,69 +956,12 @@ class DecodePreallocQueue:
             and len(self.scheduler.running_batch.reqs) > 0
             else 0
         )
-        return need_space_for_single_req
-
-    def _active_req_count(self, extra_reserved_reqs: int = 0) -> int:
-        return (
-            len(self.scheduler.running_batch.reqs)
-            + len(self.transfer_queue.queue)
-            + len(self.scheduler.waiting_queue)
-            + extra_reserved_reqs
-        )
-
-    def _active_reserved_tokens(
-        self, n_active: Optional[int] = None, extra_reserved_reqs: int = 0
-    ) -> int:
-        if n_active is None:
-            n_active = self._active_req_count(extra_reserved_reqs)
-        return self.num_reserved_decode_tokens * n_active
-
-    def _swa_aware_allocatable_token_budgets(
-        self,
-        retractable_tokens: Optional[int] = None,
-        retractable_swa_tokens: Optional[int] = None,
-        count_retracted: bool = True,
-    ) -> Tuple[int, int]:
-        n_active = self._active_req_count()
-        reserved_tokens = self._active_reserved_tokens(n_active)
-
-        full_allocatable_tokens = self._allocatable_token_budgets(
-            retractable_tokens=retractable_tokens,
-            count_retracted=count_retracted,
-            reserved_tokens=reserved_tokens,
-        )
-
-        return full_allocatable_tokens, self._swa_tail_allocatable_token_budget(
-            retractable_tokens=retractable_tokens,
-            retractable_swa_tokens=retractable_swa_tokens,
-            count_retracted=count_retracted,
-            n_active=n_active,
-            reserved_tokens=reserved_tokens,
-        )
-
-    def _allocatable_token_budgets(
-        self,
-        retractable_tokens: Optional[int] = None,
-        count_retracted: bool = True,
-        extra_reserved_reqs: int = 0,
-        reserved_tokens: Optional[int] = None,
-    ) -> int:
-        need_space_for_single_req = self._need_space_for_single_req(retractable_tokens)
-        if reserved_tokens is None:
-            reserved_tokens = self._active_reserved_tokens(
-                extra_reserved_reqs=extra_reserved_reqs
-            )
-
         if self.scheduler.enable_hisparse:
             # HiSparse pre-alloc only allocates logical indices (alloc_logical_only),
             # so the logical pool is the binding constraint for admission control.
             available_size = (
                 self.token_to_kv_pool_allocator.logical_attn_allocator.available_size()
             )
-        elif self._uses_swa_tail_prealloc():
-            available_size = self.token_to_kv_pool_allocator.full_available_size()
-            if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
-                available_size += self.tree_cache.evictable_size()
         else:
             available_size = self.token_to_kv_pool_allocator.available_size()
             # Include evictable decode-radix cache entries in the budget -- they
@@ -1097,7 +969,16 @@ class DecodePreallocQueue:
             if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
                 available_size += self.tree_cache.evictable_size()
         allocatable_tokens = available_size - max(
-            reserved_tokens, need_space_for_single_req
+            # preserve some space for future decode
+            self.num_reserved_decode_tokens
+            * (
+                len(self.scheduler.running_batch.reqs)
+                + len(self.transfer_queue.queue)
+                + len(self.scheduler.waiting_queue)
+                + extra_reserved_reqs
+            ),
+            # make sure each request can finish if reach max_tokens with all other requests retracted
+            need_space_for_single_req,
         )
 
         # Note: if the last prebuilt extend just finishes, and we enter `pop_preallocated` immediately in the next iteration
@@ -1111,74 +992,15 @@ class DecodePreallocQueue:
             )
 
         if count_retracted:
-            for req in self.retracted_queue:
-                full_required, _ = self._prealloc_required_tokens(req)
-                allocatable_tokens -= full_required
-
+            allocatable_tokens -= sum(
+                [
+                    len(req.origin_input_ids)
+                    + len(req.output_ids)
+                    + self.num_reserved_decode_tokens
+                    for req in self.retracted_queue
+                ]
+            )
         return allocatable_tokens
-
-    def _swa_tail_allocatable_token_budget(
-        self,
-        retractable_tokens: Optional[int] = None,
-        retractable_swa_tokens: Optional[int] = None,
-        count_retracted: bool = True,
-        n_active: Optional[int] = None,
-        reserved_tokens: Optional[int] = None,
-    ) -> int:
-        need_swa_space_for_single_req = self._need_space_for_single_req(
-            retractable_tokens
-        )
-        if (
-            retractable_swa_tokens is not None
-            and len(self.scheduler.running_batch.reqs) > 0
-        ):
-            need_swa_space_for_single_req = max(
-                self._swa_tail_len(len(x.origin_input_ids))
-                + min(x.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKEN)
-                - retractable_swa_tokens
-                for x in self.scheduler.running_batch.reqs
-            )
-
-        if n_active is None:
-            n_active = self._active_req_count()
-        if reserved_tokens is None:
-            reserved_tokens = self._active_reserved_tokens(n_active)
-
-        # SWA growth is bounded by the sliding window: once a req's SWA
-        # footprint reaches `sliding_window_size`, further decode tokens
-        # evict old ones and net growth is zero. The linear reservation
-        # `num_reserved_decode_tokens * n_active` (correct for the full
-        # pool) over-reserves SWA in steady state. Cap by the actual
-        # remaining headroom up to per-req window cap.
-        window_size = self.scheduler.sliding_window_size or 0
-        swa_total = self.token_to_kv_pool_allocator.size_swa
-        swa_used = swa_total - self.token_to_kv_pool_allocator.swa_available_size()
-        swa_growth_potential = max(0, n_active * window_size - swa_used)
-        swa_reserved_tokens = min(reserved_tokens, swa_growth_potential)
-        swa_allocatable_tokens = (
-            self.token_to_kv_pool_allocator.swa_available_size()
-            - max(swa_reserved_tokens, need_swa_space_for_single_req)
-        )
-
-        # Note: if the last prebuilt extend just finishes, and we enter `pop_preallocated` immediately in the next iteration
-        #       the extend batch is not in any queue, so we need to explicitly add the tokens slots here
-        if (
-            self.scheduler.last_batch
-            and self.scheduler.last_batch.forward_mode.is_prebuilt()
-        ):
-            prebuilt_reserved_tokens = self.num_reserved_decode_tokens * len(
-                self.scheduler.last_batch.reqs
-            )
-            prebuilt_n = len(self.scheduler.last_batch.reqs)
-            prebuilt_swa_growth = max(0, prebuilt_n * window_size - swa_used)
-            swa_allocatable_tokens -= min(prebuilt_reserved_tokens, prebuilt_swa_growth)
-
-        if count_retracted:
-            for req in self.retracted_queue:
-                _, swa_required = self._prealloc_required_tokens(req)
-                swa_allocatable_tokens -= swa_required
-
-        return swa_allocatable_tokens
 
     def _required_alloc_tokens(self, *, fill_len: int, prefix_len: int) -> int:
         page_size = self.token_to_kv_pool_allocator.page_size
@@ -1263,15 +1085,15 @@ class DecodePreallocQueue:
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
-            # Allocate host indices for the RDMA transfer target.
-            host_indices = coordinator.mem_pool_host.alloc(fill_len)
-            if host_indices is None:
-                raise RuntimeError(
-                    f"HiSparse host mem pool alloc failed for {fill_len} tokens "
-                    f"in _pre_alloc (req {req.rid})"
-                )
-            host_indices = host_indices.to(device=coordinator.device)
-            coordinator.req_to_host_pool[req.req_pool_idx, :fill_len] = host_indices
+            # Allocate host indices for the RDMA transfer target. DeepSeek V4
+            # stores HiSparse host KV at c4-token granularity.
+            host_len = (
+                (fill_len + coordinator.compress_ratio - 1)
+                // coordinator.compress_ratio
+                if coordinator.is_dsv4_hisparse
+                else fill_len
+            )
+            host_indices = coordinator.ensure_host_slots(req.req_pool_idx, 0, host_len)
         elif self.token_to_kv_pool_allocator.page_size == 1:
             kv_loc = self.token_to_kv_pool_allocator.alloc(delta_len)
         else:
@@ -1281,31 +1103,16 @@ class DecodePreallocQueue:
                 if prefix_len > 0
                 else torch.tensor([-1], dtype=torch.int64, device=device)
             )
-            if self._uses_swa_tail_prealloc() and prefix_len == 0:
-                # Tail-only SWA allocation: only valid when prefix_len == 0.
-                # When prefix_len > 0 (radix cache hit), we fall back to
-                # alloc_extend which allocates SWA at full page count; the
-                # SWA budget in that case may slightly under-estimate.
-                kv_loc = self.token_to_kv_pool_allocator.alloc_extend_swa_tail(
-                    prefix_lens=torch.tensor([0], dtype=torch.int64, device=device),
-                    prefix_lens_cpu=torch.tensor([0], dtype=torch.int64),
-                    seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                    seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
-                    last_loc=last_loc,
-                    extend_num_tokens=fill_len,
-                    swa_tail_len=self._swa_tail_len(fill_len),
-                )
-            else:
-                kv_loc = self.token_to_kv_pool_allocator.alloc_extend(
-                    prefix_lens=torch.tensor(
-                        [prefix_len], dtype=torch.int64, device=device
-                    ),
-                    prefix_lens_cpu=torch.tensor([prefix_len], dtype=torch.int64),
-                    seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
-                    seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
-                    last_loc=last_loc,
-                    extend_num_tokens=delta_len,
-                )
+            kv_loc = self.token_to_kv_pool_allocator.alloc_extend(
+                prefix_lens=torch.tensor(
+                    [prefix_len], dtype=torch.int64, device=device
+                ),
+                prefix_lens_cpu=torch.tensor([prefix_len], dtype=torch.int64),
+                seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
+                seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
+                last_loc=last_loc,
+                extend_num_tokens=delta_len,
+            )
 
         assert kv_loc is not None, (
             f"KV cache is full! Bug in memory estimation. "
@@ -1567,6 +1374,7 @@ class DecodeTransferQueue:
 
 
 class SchedulerDisaggregationDecodeMixin:
+
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
@@ -1684,9 +1492,6 @@ class SchedulerDisaggregationDecodeMixin:
 
         if len(self.waiting_queue) == 0:
             return None
-
-        if self.enable_priority_scheduling:
-            self.policy.calc_priority(self.waiting_queue, self.running_batch)
 
         curr_batch_size = self.running_batch.batch_size()
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 import numpy.typing as npt
 
-from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
 from sglang.srt.disaggregation.common.conn import (
     CommonKVBootstrapServer,
     CommonKVManager,
@@ -30,8 +30,6 @@ from sglang.srt.disaggregation.common.staging_handler import (
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
     group_concurrent_contiguous,
-    pack_int_lists,
-    unpack_int_lists,
 )
 from sglang.srt.disaggregation.mooncake.utils import (
     check_mooncake_custom_mem_pool_enabled,
@@ -66,7 +64,7 @@ class TransferKVChunk:
     index_slice: slice
     is_last_chunk: bool
     prefill_aux_index: Optional[int]
-    state_indices: Optional[List]
+    state_indices: Optional[List[int]]
 
 
 # decode
@@ -78,7 +76,8 @@ class TransferInfo:
     mooncake_session_id: str
     dst_kv_indices: npt.NDArray[np.int32]
     dst_aux_index: int
-    dst_state_indices: List[List[int]]  # parallel to receiver's state_types
+    dst_state_indices: List[int]
+    dst_device_kv_indices: Optional[npt.NDArray[np.int32]]
     required_dst_info_num: int
     is_dummy: bool
     decode_prefix_len: Optional[int] = None
@@ -92,10 +91,18 @@ class TransferInfo:
             dst_kv_indices = np.array([], dtype=np.int32)
             dst_aux_index = None
             dst_state_indices = []
+            dst_device_kv_indices = None
         else:
             dst_kv_indices = np.frombuffer(msg[4], dtype=np.int32)
             dst_aux_index = int(msg[5].decode("ascii"))
-            dst_state_indices = unpack_int_lists(msg[6], "i")
+            if msg[6] == b"":
+                dst_state_indices = []
+            else:
+                dst_state_indices = list(np.frombuffer(msg[6], dtype=np.int32))
+            if len(msg) > 9 and msg[9] != b"":
+                dst_device_kv_indices = np.frombuffer(msg[9], dtype=np.int32)
+            else:
+                dst_device_kv_indices = None
             is_dummy = False
         return cls(
             room=int(msg[0].decode("ascii")),
@@ -105,6 +112,7 @@ class TransferInfo:
             dst_kv_indices=dst_kv_indices,
             dst_aux_index=dst_aux_index,
             dst_state_indices=dst_state_indices,
+            dst_device_kv_indices=dst_device_kv_indices,
             required_dst_info_num=int(msg[7].decode("ascii")),
             is_dummy=is_dummy,
             decode_prefix_len=(
@@ -122,13 +130,13 @@ class KVArgsRegisterInfo:
     mooncake_session_id: str
     dst_kv_ptrs: list[int]
     dst_aux_ptrs: list[int]
-    dst_state_data_ptrs: List[List[int]]  # parallel to state_types (same below)
+    dst_state_data_ptrs: list[int]
     dst_tp_rank: int
     dst_attn_tp_size: int
     dst_kv_item_len: int
     # for mamba state different tp slice transfer
-    dst_state_item_lens: List[List[int]]
-    dst_state_dim_per_tensor: List[List[int]]
+    dst_state_item_lens: list[int]
+    dst_state_dim_per_tensor: list[int]
     # HiSparse: decode host pool stores KV at token granularity
     enable_hisparse: bool = False
     # Note: always put the staging field at the final (since the staging field is optional and contains multiple inputs)
@@ -143,15 +151,19 @@ class KVArgsRegisterInfo:
             mooncake_session_id=msg[3].decode("ascii"),
             dst_kv_ptrs=list(struct.unpack(f"{len(msg[4])//8}Q", msg[4])),
             dst_aux_ptrs=list(struct.unpack(f"{len(msg[5])//8}Q", msg[5])),
-            dst_state_data_ptrs=unpack_int_lists(msg[6], "Q"),
+            dst_state_data_ptrs=list(struct.unpack(f"{len(msg[6])//8}Q", msg[6])),
             dst_tp_rank=int(msg[7].decode("ascii")),
             dst_attn_tp_size=int(msg[8].decode("ascii")),
             dst_kv_item_len=int(msg[9].decode("ascii")),
             dst_state_item_lens=(
-                unpack_int_lists(msg[10], "I") if len(msg) > 10 else []
+                list(struct.unpack(f"{len(msg[10])//4}I", msg[10]))
+                if len(msg) > 10 and len(msg[10]) > 0
+                else []
             ),
             dst_state_dim_per_tensor=(
-                unpack_int_lists(msg[11], "I") if len(msg) > 11 else []
+                list(struct.unpack(f"{len(msg[11])//4}I", msg[11]))
+                if len(msg) > 11 and len(msg[11]) > 0
+                else []
             ),
             enable_hisparse=(
                 msg[12].decode("ascii") == "1" if len(msg) > 12 else False
@@ -267,11 +279,11 @@ class MooncakeKVManager(CommonKVManager):
                 self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
             )
 
-        for ptrs, lens in zip(
-            self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
-        ):
-            if ptrs and lens:
-                self.engine.batch_register(ptrs, lens)
+        # Batch register state/extra pool data buffers
+        if self.kv_args.state_data_ptrs and self.kv_args.state_data_lens:
+            self.engine.batch_register(
+                self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+            )
 
     # ------------------------------------------------------------------
     # Staging buffer methods (all delegate to staging_handler.py)
@@ -294,9 +306,7 @@ class MooncakeKVManager(CommonKVManager):
         )
 
         self._staging_ctx.buffers = init_staging_buffers(
-            lambda ptr, size: self.engine.batch_register([ptr], [size]),
-            self.kv_args,
-            count,
+            self.engine, self.kv_args, count
         )
         self.kv_buffer_tensors = None
 
@@ -305,10 +315,7 @@ class MooncakeKVManager(CommonKVManager):
             init_staging_allocator,
         )
 
-        self._staging_ctx.allocator = init_staging_allocator(
-            lambda ptr, size: self.engine.batch_register([ptr], [size]),
-            self.kv_args,
-        )
+        self._staging_ctx.allocator = init_staging_allocator(self.engine, self.kv_args)
         self.kv_buffer_tensors = None
 
     def _handle_staging_req(self, msg):
@@ -712,38 +719,181 @@ class MooncakeKVManager(CommonKVManager):
         dst_kv_indices: npt.NDArray[np.int32],
         page_index_slice: slice,
         executor: concurrent.futures.ThreadPoolExecutor,
+        dst_kv_item_len: Optional[int] = None,
+        dst_device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
     ):
-        """HiSparse transfer: prefill page_size > decode host page_size=1.
+        """HiSparse transfer uses page-level indices for source and host destination."""
+        if getattr(self.kv_args, "state_type", "none") == "dsv4":
+            if dst_kv_item_len is None:
+                raise RuntimeError("DeepSeek V4 HiSparse transfer needs dst item len")
+            return self._send_kvcache_hisparse_dsv4(
+                mooncake_session_id=mooncake_session_id,
+                prefill_kv_indices=prefill_kv_indices,
+                dst_kv_ptrs=dst_kv_ptrs,
+                dst_kv_indices=dst_kv_indices,
+                page_index_slice=page_index_slice,
+                executor=executor,
+                dst_kv_item_len=dst_kv_item_len,
+                dst_device_kv_indices=dst_device_kv_indices,
+            )
 
-        Receives page-level prefill_kv_indices and the full token-level
-        dst_kv_indices.  Expands both to token granularity before transfer.
-        """
-        page_size = self.kv_args.page_size
-        per_token_item_lens = [il // page_size for il in self.kv_args.kv_item_lens]
-
-        # Expand page-level src indices to token-level
-        base = np.repeat(prefill_kv_indices * page_size, page_size)
-        offsets = np.tile(np.arange(page_size, dtype=np.int32), len(prefill_kv_indices))
-        expanded_src = base + offsets
-
-        # Expand page-level index_slice to token-level for dst
-        token_start = page_index_slice.start * page_size
-        token_end = min(page_index_slice.stop * page_size, len(dst_kv_indices))
-        expanded_dst = dst_kv_indices[token_start:token_end]
-
-        # Clip src to match dst length (last page may be partial)
-        expanded_src = expanded_src[: len(expanded_dst)]
+        chunked_dst_kv_indices = dst_kv_indices[page_index_slice]
 
         logger.debug(
-            f"Send KVCache for hisparse: {expanded_src.shape} -> {expanded_dst.shape}"
+            f"Send KVCache for hisparse: {prefill_kv_indices.shape} -> {chunked_dst_kv_indices.shape}"
         )
         return self._send_kvcache_generic(
             mooncake_session_id=mooncake_session_id,
             src_data_ptrs=self.kv_args.kv_data_ptrs,
             dst_data_ptrs=dst_kv_ptrs,
-            item_lens=per_token_item_lens,
-            prefill_data_indices=expanded_src,
-            dst_data_indices=expanded_dst,
+            item_lens=self.kv_args.kv_item_lens,
+            prefill_data_indices=prefill_kv_indices,
+            dst_data_indices=chunked_dst_kv_indices,
+            executor=executor,
+        )
+
+    def _send_kvcache_hisparse_dsv4(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        dst_kv_item_len: int,
+        dst_device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
+    ) -> int:
+        """Transfer DeepSeek V4 C4 KV to host and non-sparse KV to device."""
+        c4_page_size = self.kv_args.page_size // 4
+        assert self.kv_args.page_size % 4 == 0
+        src_c4_layer_num = self._dsv4_c4_layer_count()
+        src_c4_layer_num = min(src_c4_layer_num, len(dst_kv_ptrs))
+
+        src_c4_indices, dst_c4_indices = self._dsv4_c4_token_indices(
+            prefill_kv_indices, dst_kv_indices, page_index_slice, c4_page_size
+        )
+        ret = self._send_dsv4_c4_to_host(
+            mooncake_session_id,
+            src_c4_indices,
+            dst_c4_indices,
+            self.kv_args.kv_data_ptrs[:src_c4_layer_num],
+            dst_kv_ptrs[:src_c4_layer_num],
+            dst_kv_item_len,
+            c4_page_size,
+        )
+        if ret != 0:
+            return ret
+
+        return self._send_dsv4_device_kv(
+            mooncake_session_id,
+            prefill_kv_indices,
+            dst_kv_ptrs,
+            page_index_slice,
+            src_c4_layer_num,
+            dst_device_kv_indices,
+            executor,
+        )
+
+    def _dsv4_c4_layer_count(self) -> int:
+        first_item_len = self.kv_args.kv_item_lens[0]
+        for i, item_len in enumerate(self.kv_args.kv_item_lens):
+            if item_len != first_item_len:
+                return i
+        return len(self.kv_args.kv_item_lens)
+
+    @staticmethod
+    def _dsv4_c4_token_indices(
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        c4_page_size: int,
+    ) -> Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        src_pages = prefill_kv_indices.astype(np.int64, copy=False)
+        src_indices = np.repeat(src_pages * c4_page_size, c4_page_size)
+        src_indices += np.tile(
+            np.arange(c4_page_size, dtype=np.int64), len(prefill_kv_indices)
+        )
+
+        dst_start = page_index_slice.start * c4_page_size
+        dst_end = min(page_index_slice.stop * c4_page_size, len(dst_kv_indices))
+        dst_indices = dst_kv_indices[dst_start:dst_end].astype(np.int64, copy=False)
+        return src_indices[: len(dst_indices)], dst_indices
+
+    def _send_dsv4_c4_to_host(
+        self,
+        mooncake_session_id: str,
+        src_indices: npt.NDArray[np.int64],
+        dst_indices: npt.NDArray[np.int64],
+        src_ptrs: list[int],
+        dst_ptrs: list[int],
+        dst_kv_item_len: int,
+        c4_page_size: int,
+    ) -> int:
+        value_bytes = dst_kv_item_len - 8
+        scale_bytes = 8
+        gpu_page_bytes = self.kv_args.kv_item_lens[0]
+        gpu_scale_page_offset = value_bytes * c4_page_size
+
+        # DSV4 host layout is token-linear.  GPU C4 pages store values first
+        # and scales after that, so each C4 token maps to two transfer blocks.
+        max_tokens_per_batch = 256
+        for src_ptr, dst_ptr in zip(src_ptrs, dst_ptrs):
+            for start in range(0, len(src_indices), max_tokens_per_batch):
+                transfer_blocks = []
+                src_chunk = src_indices[start : start + max_tokens_per_batch]
+                dst_chunk = dst_indices[start : start + max_tokens_per_batch]
+                for src_idx, dst_idx in zip(src_chunk, dst_chunk):
+                    src_page = int(src_idx) // c4_page_size
+                    src_offset = int(src_idx) % c4_page_size
+                    src_base = int(src_ptr) + src_page * gpu_page_bytes
+                    dst_base = int(dst_ptr) + int(dst_idx) * dst_kv_item_len
+                    transfer_blocks.append(
+                        (src_base + src_offset * value_bytes, dst_base, value_bytes)
+                    )
+                    transfer_blocks.append(
+                        (
+                            src_base + gpu_scale_page_offset + src_offset * scale_bytes,
+                            dst_base + value_bytes,
+                            scale_bytes,
+                        )
+                    )
+                ret = self._transfer_data(mooncake_session_id, transfer_blocks)
+                if ret != 0:
+                    return ret
+        return 0
+
+    def _send_dsv4_device_kv(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        page_index_slice: slice,
+        src_c4_layer_num: int,
+        dst_device_kv_indices: Optional[npt.NDArray[np.int32]],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        if len(dst_kv_ptrs) <= src_c4_layer_num:
+            return 0
+        if dst_device_kv_indices is None:
+            raise RuntimeError(
+                "DeepSeek V4 HiSparse transfer needs device KV indices for "
+                "c4_indexer/c128 KV"
+            )
+
+        src_pages = prefill_kv_indices.astype(np.int64, copy=False)
+        dst_pages = dst_device_kv_indices[page_index_slice].astype(
+            np.int64, copy=False
+        )
+        count = min(len(src_pages), len(dst_pages))
+        if count == 0:
+            return 0
+        return self._send_kvcache_generic(
+            mooncake_session_id=mooncake_session_id,
+            src_data_ptrs=self.kv_args.kv_data_ptrs[src_c4_layer_num:],
+            dst_data_ptrs=dst_kv_ptrs[src_c4_layer_num:],
+            item_lens=self.kv_args.kv_item_lens[src_c4_layer_num:],
+            prefill_data_indices=src_pages[:count].astype(np.int32, copy=False),
+            dst_data_indices=dst_pages[:count].astype(np.int32, copy=False),
             executor=executor,
         )
 
@@ -966,133 +1116,128 @@ class MooncakeKVManager(CommonKVManager):
     def maybe_send_extra(
         self,
         req: TransferInfo,
-        prefill_state_indices: List,
+        prefill_state_indices: list[int],
+        dst_state_data_ptrs: list[int],
         executor: concurrent.futures.ThreadPoolExecutor,
         target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
     ):
-        rc = 0
-        state_types = getattr(self.kv_args, "state_types", [])
-        for i, st in enumerate(state_types):
-            indices = (
-                prefill_state_indices[i] if i < len(prefill_state_indices) else None
-            )
-            if indices is None:
-                continue
-            src_data_ptrs = self.kv_args.state_data_ptrs[i]
-            src_item_lens = self.kv_args.state_item_lens[i]
-            src_dim_per_tensor = (
-                self.kv_args.state_dim_per_tensor[i]
-                if i < len(self.kv_args.state_dim_per_tensor)
-                else []
-            )
-            if target_rank_registration_info is not None:
-                dst_data_ptrs = (
-                    target_rank_registration_info.dst_state_data_ptrs[i]
-                    if i < len(target_rank_registration_info.dst_state_data_ptrs)
-                    else []
-                )
-                dst_item_lens = (
-                    target_rank_registration_info.dst_state_item_lens[i]
-                    if i < len(target_rank_registration_info.dst_state_item_lens)
-                    else []
-                )
-                dst_dim_per_tensor = (
-                    target_rank_registration_info.dst_state_dim_per_tensor[i]
-                    if i < len(target_rank_registration_info.dst_state_dim_per_tensor)
-                    else []
+        """Send state or extra pool data with type-specific handling."""
+        state_type = getattr(self.kv_args, "state_type", "none")
+
+        if state_type == "mamba":
+            # Check if we need slice transfer for different TP sizes
+            if (
+                target_rank_registration_info is not None
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                return self._send_mamba_state_slice(
+                    req,
+                    prefill_state_indices,
+                    dst_state_data_ptrs,
+                    target_rank_registration_info.dst_state_item_lens,
+                    target_rank_registration_info.dst_state_dim_per_tensor,
+                    target_rank_registration_info.dst_tp_rank,
+                    target_rank_registration_info.dst_attn_tp_size,
                 )
             else:
-                dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
-            dst_indices = (
-                req.dst_state_indices[i] if i < len(req.dst_state_indices) else []
+                return self._send_mamba_state(
+                    req,
+                    prefill_state_indices,
+                    dst_state_data_ptrs,
+                )
+        elif state_type in ["swa", "nsa"]:
+            # SWA and NSA hybrid models do not support different TP sizes yet
+            if (
+                target_rank_registration_info is not None
+                and not self.is_mla_backend
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                raise RuntimeError(
+                    f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {state_type.upper()} hybrid models yet."
+                )
+            dst_state_indices = req.dst_state_indices
+            if len(prefill_state_indices) > len(dst_state_indices):
+                logger.warning(
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
+                )
+                prefill_state_indices = prefill_state_indices[: len(dst_state_indices)]
+            elif len(prefill_state_indices) < len(dst_state_indices):
+                logger.warning(
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
+                )
+                dst_state_indices = dst_state_indices[: len(prefill_state_indices)]
+            # Reuse _send_kvcache_generic interface to send extra pool data
+            prefill_state_indices = np.array(prefill_state_indices, dtype=np.int32)
+            dst_state_indices = np.array(dst_state_indices, dtype=np.int32)
+            return self._send_kvcache_generic(
+                mooncake_session_id=req.mooncake_session_id,
+                src_data_ptrs=self.kv_args.state_data_ptrs,
+                dst_data_ptrs=dst_state_data_ptrs,
+                item_lens=self.kv_args.state_item_lens,
+                prefill_data_indices=prefill_state_indices,
+                dst_data_indices=dst_state_indices,
+                executor=executor,
+            )
+        elif state_type == "dsv4":
+            return self._send_dsv4_state(
+                req,
+                prefill_state_indices,
+                dst_state_data_ptrs,
+                target_rank_registration_info.dst_state_item_lens
+                if target_rank_registration_info is not None
+                else [],
+                executor,
+            )
+        else:
+            return 0
+
+    def _send_dsv4_state(
+        self,
+        req: TransferInfo,
+        prefill_state_indices: list[int],
+        dst_state_data_ptrs: list[int],
+        dst_state_item_lens: list[int],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        assert len(prefill_state_indices) == len(req.dst_state_indices), (
+            f"State index length mismatch: prefill={len(prefill_state_indices)}, "
+            f"dst={len(req.dst_state_indices)}"
+        )
+        assert len(self.kv_args.state_data_ptrs) == len(dst_state_data_ptrs)
+        assert len(self.kv_args.state_item_lens) == len(dst_state_item_lens)
+        for i, item_len in enumerate(self.kv_args.state_item_lens):
+            assert item_len == dst_state_item_lens[i], (
+                f"V4 state item length mismatch at index {i}: "
+                f"{item_len} != {dst_state_item_lens[i]}"
             )
 
-            if st == StateType.MAMBA:
-                if (
-                    target_rank_registration_info is not None
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    rc = (
-                        self._send_mamba_state_slice(
-                            req,
-                            indices,
-                            src_data_ptrs,
-                            src_item_lens,
-                            src_dim_per_tensor,
-                            dst_data_ptrs,
-                            dst_indices,
-                            dst_item_lens,
-                            dst_dim_per_tensor,
-                            target_rank_registration_info.dst_tp_rank,
-                            target_rank_registration_info.dst_attn_tp_size,
-                        )
-                        or rc
-                    )
-                else:
-                    rc = (
-                        self._send_mamba_state(
-                            req,
-                            indices,
-                            src_data_ptrs,
-                            src_item_lens,
-                            dst_data_ptrs,
-                            dst_indices,
-                        )
-                        or rc
-                    )
-            elif st in (StateType.SWA, StateType.NSA):
-                if (
-                    target_rank_registration_info is not None
-                    and not self.is_mla_backend
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    raise RuntimeError(
-                        f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
-                    )
-                src_indices = list(indices)
-                dst_indices_local = list(dst_indices)
-                if len(src_indices) > len(dst_indices_local):
-                    logger.warning(
-                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
-                    )
-                    src_indices = src_indices[: len(dst_indices_local)]
-                elif len(src_indices) < len(dst_indices_local):
-                    logger.warning(
-                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
-                    )
-                    dst_indices_local = dst_indices_local[: len(src_indices)]
-                rc = (
-                    self._send_kvcache_generic(
-                        mooncake_session_id=req.mooncake_session_id,
-                        src_data_ptrs=src_data_ptrs,
-                        dst_data_ptrs=dst_data_ptrs,
-                        item_lens=src_item_lens,
-                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
-                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
-                        executor=executor,
-                    )
-                    or rc
-                )
-        return rc
+        return self._send_kvcache_generic(
+            mooncake_session_id=req.mooncake_session_id,
+            src_data_ptrs=self.kv_args.state_data_ptrs,
+            dst_data_ptrs=dst_state_data_ptrs,
+            item_lens=self.kv_args.state_item_lens,
+            prefill_data_indices=np.asarray(prefill_state_indices, dtype=np.int32),
+            dst_data_indices=np.asarray(req.dst_state_indices, dtype=np.int32),
+            executor=executor,
+        )
 
     def _send_mamba_state(
         self,
         req: TransferInfo,
-        prefill_mamba_index: list,
-        src_state_data_ptrs: list[int],
-        src_state_item_lens: list[int],
+        prefill_mamba_index: list[int],
         dst_state_data_ptrs: list[int],
-        dst_mamba_index: list,
     ):
+        """Transfer Mamba states."""
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
 
         transfer_blocks = []
+        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
+        prefill_state_item_lens = self.kv_args.state_item_lens
+
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
-            length = src_state_item_lens[i]
-            src_addr = src_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
-            dst_addr = dst_state_ptr + length * int(dst_mamba_index[0])
+            length = prefill_state_item_lens[i]
+            src_addr = prefill_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
+            dst_addr = dst_state_ptr + length * int(req.dst_state_indices[0])
             transfer_blocks.append((src_addr, dst_addr, length))
 
         return self._transfer_data(req.mooncake_session_id, transfer_blocks)
@@ -1100,12 +1245,8 @@ class MooncakeKVManager(CommonKVManager):
     def _send_mamba_state_slice(
         self,
         req: TransferInfo,
-        prefill_mamba_index: list,
-        src_state_data_ptrs: list[int],
-        src_state_item_lens: list[int],
-        src_state_dim_per_tensor: list[int],
+        prefill_mamba_index: list[int],
         dst_state_data_ptrs: list[int],
-        dst_mamba_index: list,
         dst_state_item_lens: list[int],
         dst_state_dim_per_tensor: list[int],
         dst_tp_rank: int,
@@ -1127,33 +1268,33 @@ class MooncakeKVManager(CommonKVManager):
         )
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
 
+        transfer_blocks = []
+        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
+        prefill_state_item_lens = self.kv_args.state_item_lens
+        src_state_dim_per_tensor = getattr(self.kv_args, "state_dim_per_tensor", [])
+
         # If no dimension info available, fall back to regular transfer
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
-            return self._send_mamba_state(
-                req,
-                prefill_mamba_index,
-                src_state_data_ptrs,
-                src_state_item_lens,
-                dst_state_data_ptrs,
-                dst_mamba_index,
-            )
+            return self._send_mamba_state(req, prefill_mamba_index, dst_state_data_ptrs)
 
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
 
-        transfer_blocks = []
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
-            src_item_len = src_state_item_lens[i]
+            src_item_len = prefill_state_item_lens[i]
             dst_item_len = dst_state_item_lens[i]
             src_dim = src_state_dim_per_tensor[i]
             dst_dim = dst_state_dim_per_tensor[i]
 
+            # Calculate bytes per dimension slice
             # item_len = dim * trailing_dims_size, so trailing_dims_size = item_len / dim
             src_bytes_per_dim = src_item_len // src_dim
             dst_bytes_per_dim = dst_item_len // dst_dim
 
+            # Determine slicing parameters based on TP configuration
             if self.attn_tp_size > dst_attn_tp_size:
                 # Multiple prefill ranks send to 1 decode rank
+                # Each prefill sends all its dims to the appropriate offset in decode
                 src_dim_start = 0
                 num_dims_to_send = src_dim
                 writers_per_decode = self.attn_tp_size // dst_attn_tp_size
@@ -1161,21 +1302,26 @@ class MooncakeKVManager(CommonKVManager):
                 dst_dim_start = local_writer_idx * src_dim
             else:
                 # 1 prefill rank sends to multiple decode ranks
+                # Prefill sends a slice of its dims to each decode rank
                 src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
                 num_dims_to_send = dst_dim
                 dst_dim_start = 0
 
+            # Calculate byte offsets
             src_dim_offset = src_dim_start * src_bytes_per_dim
             dst_dim_offset = dst_dim_start * dst_bytes_per_dim
             bytes_to_send = num_dims_to_send * src_bytes_per_dim
 
+            # Calculate addresses for this state tensor
             src_addr = (
-                src_state_data_ptrs[i]
+                prefill_state_data_ptrs[i]
                 + src_item_len * int(prefill_mamba_index[0])
                 + src_dim_offset
             )
             dst_addr = (
-                dst_state_ptr + dst_item_len * int(dst_mamba_index[0]) + dst_dim_offset
+                dst_state_ptr
+                + dst_item_len * int(req.dst_state_indices[0])
+                + dst_dim_offset
             )
 
             transfer_blocks.append((src_addr, dst_addr, bytes_to_send))
@@ -1277,6 +1423,8 @@ class MooncakeKVManager(CommonKVManager):
                                     req.dst_kv_indices,
                                     kv_chunk.index_slice,
                                     executor,
+                                    target_rank_registration_info.dst_kv_item_len,
+                                    req.dst_device_kv_indices,
                                 )
                             else:
                                 ret = self.send_kvcache(
@@ -1341,10 +1489,11 @@ class MooncakeKVManager(CommonKVManager):
                             break
 
                         if kv_chunk.is_last_chunk:
-                            if kv_chunk.state_indices:
+                            if kv_chunk.state_indices is not None:
                                 self.maybe_send_extra(
                                     req,
                                     kv_chunk.state_indices,
+                                    target_rank_registration_info.dst_state_data_ptrs,
                                     executor,
                                     target_rank_registration_info,
                                 )
@@ -1404,19 +1553,47 @@ class MooncakeKVManager(CommonKVManager):
                 room = waiting_req_bytes[0].decode("ascii")
                 # Staging: decode reports consumption watermark back to prefill
                 if room == "WATERMARK":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_watermark_msg,
+                    wm_round = int(waiting_req_bytes[1].decode("ascii"))
+                    wm_tail = int(waiting_req_bytes[2].decode("ascii"))
+                    wm_session = (
+                        waiting_req_bytes[3].decode("ascii")
+                        if len(waiting_req_bytes) > 3
+                        else ""
                     )
-
-                    handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
+                    with self._staging_ctx.watermark_cv:
+                        prev = self._staging_ctx.remote_watermarks.get(
+                            wm_session, (0, 0)
+                        )
+                        if (wm_round, wm_tail) > prev:
+                            self._staging_ctx.remote_watermarks[wm_session] = (
+                                wm_round,
+                                wm_tail,
+                            )
+                            self._staging_ctx.watermark_cv.notify_all()
                     continue
                 # Staging: decode replies with allocated staging offset
                 if room == "STAGING_RSP":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_staging_rsp,
-                    )
-
-                    handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
+                    stg_room = int(waiting_req_bytes[1].decode("ascii"))
+                    stg_chunk_idx = int(waiting_req_bytes[2].decode("ascii"))
+                    stg_offset = int(waiting_req_bytes[3].decode("ascii"))
+                    stg_round = int(waiting_req_bytes[4].decode("ascii"))
+                    stg_end = int(waiting_req_bytes[5].decode("ascii"))
+                    stg_session = waiting_req_bytes[6].decode("ascii")
+                    room_infos = self.transfer_infos.get(stg_room, {})
+                    tinfo = room_infos.get(stg_session)
+                    if tinfo is not None:
+                        if tinfo.staging is None:
+                            tinfo.staging = StagingTransferInfo()
+                        tinfo.staging.set_chunk(
+                            stg_chunk_idx, stg_offset, stg_round, stg_end
+                        )
+                    else:
+                        logger.warning(
+                            "STAGING_RSP RECV but tinfo=None room=%s chunk=%d session=%s",
+                            stg_room,
+                            stg_chunk_idx,
+                            stg_session,
+                        )
                     continue
                 mooncake_session_id = waiting_req_bytes[3].decode("ascii")
                 if room == "None":
@@ -1470,18 +1647,28 @@ class MooncakeKVManager(CommonKVManager):
                     page_start = int(msg[3].decode("ascii"))
                     num_pages = int(msg[4].decode("ascii"))
                     session_id = msg[5].decode("ascii")
+                    self._chunk_writer_counts[room][chunk_idx].append(
+                        (page_start, num_pages, session_id)
+                    )
                     handler = self._staging_handler
                     assert (
                         handler is not None
                     ), "CHUNK_READY received before staging handler initialized"
-                    handler.handle_chunk_arrived(
-                        room,
-                        chunk_idx,
-                        page_start,
-                        num_pages,
-                        session_id,
-                        self._chunk_writer_counts,
-                    )
+                    writers_arrived = len(self._chunk_writer_counts[room][chunk_idx])
+                    decode_req = handler._room_to_decode_req.get(room)
+                    if decode_req is None:
+                        logger.warning(
+                            "CHUNK_READY received for unregistered room=%s chunk=%d, skipping",
+                            room,
+                            chunk_idx,
+                        )
+                        continue
+                    num_writers = handler.num_writers_for(decode_req)
+                    if writers_arrived >= num_writers:
+                        handler.submit_chunk_scatter(
+                            room, chunk_idx, page_start, num_pages
+                        )
+                        del self._chunk_writer_counts[room][chunk_idx]
                     continue
 
                 # Staging: prefill pre-requests staging allocation before forward
@@ -1581,7 +1768,7 @@ class MooncakeKVManager(CommonKVManager):
         index_slice: slice,
         is_last_chunk: bool,
         aux_index: Optional[int] = None,
-        state_indices: Optional[List] = None,
+        state_indices: Optional[List[int]] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
@@ -1677,7 +1864,7 @@ class MooncakeKVSender(CommonKVSender):
     def send(
         self,
         kv_indices: npt.NDArray[np.int32],
-        state_indices: Optional[List] = None,
+        state_indices: Optional[List[int]] = None,
     ):
         index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))
         self.curr_idx += len(kv_indices)
@@ -1774,14 +1961,19 @@ class MooncakeKVReceiver(CommonKVReceiver):
             packed_aux_data_ptrs = b"".join(
                 struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.aux_data_ptrs
             )
-            packed_state_data_ptrs = pack_int_lists(
-                self.kv_mgr.kv_args.state_data_ptrs, "Q"
+            packed_state_data_ptrs = b"".join(
+                struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.state_data_ptrs
             )
-            packed_state_item_lens = pack_int_lists(
-                self.kv_mgr.kv_args.state_item_lens, "I"
+            # Pack state_item_lens and state_dim_per_tensor for mamba state slice transfer
+            packed_state_item_lens = b"".join(
+                struct.pack("I", item_len)
+                for item_len in self.kv_mgr.kv_args.state_item_lens
             )
-            packed_state_dim_per_tensor = pack_int_lists(
-                getattr(self.kv_mgr.kv_args, "state_dim_per_tensor", []) or [], "I"
+            state_dim_per_tensor = getattr(
+                self.kv_mgr.kv_args, "state_dim_per_tensor", []
+            )
+            packed_state_dim_per_tensor = b"".join(
+                struct.pack("I", dim) for dim in state_dim_per_tensor
             )
             # Note(shangming): No need to add pp rank here since decode pp size should be equal to prefill pp size or 1
             tp_rank = self.kv_mgr.kv_args.engine_rank
@@ -1834,8 +2026,9 @@ class MooncakeKVReceiver(CommonKVReceiver):
         self,
         kv_indices: npt.NDArray[np.int32],
         aux_index: Optional[int] = None,
-        state_indices: Optional[List] = None,
+        state_indices: Optional[List[int]] = None,
         decode_prefix_len: Optional[int] = None,
+        device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
     ):
         if self.bootstrap_infos is None:
             self.kv_mgr.record_failure(
@@ -1868,12 +2061,20 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         kv_indices.tobytes() if not is_dummy else b"",
                         str(aux_index).encode("ascii") if not is_dummy else b"",
                         (
-                            pack_int_lists(state_indices, "i")
-                            if not is_dummy and state_indices
+                            np.array(
+                                state_indices,
+                                dtype=np.int32,
+                            ).tobytes()
+                            if not is_dummy and state_indices is not None
                             else b""
                         ),
                         str(self.required_dst_info_num).encode("ascii"),
                         str(decode_prefix_len or 0).encode("ascii"),
+                        (
+                            device_kv_indices.tobytes()
+                            if not is_dummy and device_kv_indices is not None
+                            else b""
+                        ),
                     ]
                 )
         self.init_time = time.time()

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -84,11 +84,12 @@ class HiSparseCoordinator:
                 device_pool=self.mem_pool_device,
                 host_to_device_ratio=host_to_device_ratio,
                 host_size=0,
-                page_size=1,
+                page_size=self.mem_pool_device.page_size,
                 layout="layer_first",
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
+        self.page_size = self.mem_pool_host.page_size
 
         max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
         max_context_len = req_to_token_pool.max_context_len
@@ -110,7 +111,7 @@ class HiSparseCoordinator:
             max_num_req_slots, dtype=torch.int64, device="cpu"
         )
         self.req_to_host_pool = torch.full(
-            (max_num_req_slots, max_compressed_context_len),
+            (max_num_req_slots, max_compressed_context_len + self.page_size),
             -1,
             dtype=torch.int64,
             device=device,
@@ -167,6 +168,69 @@ class HiSparseCoordinator:
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
 
+    def _round_up_to_host_page(self, size: int) -> int:
+        return (size + self.page_size - 1) // self.page_size * self.page_size
+
+    def ensure_host_slots(
+        self,
+        req_pool_idx: int,
+        start_pos: int,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        """Ensure host slots for compressed token positions."""
+        if num_tokens <= 0:
+            return torch.empty((0,), dtype=torch.int64, device=self.device)
+
+        page_start = (start_pos // self.page_size) * self.page_size
+        page_end = self._round_up_to_host_page(start_pos + num_tokens)
+
+        page_starts = torch.arange(
+            page_start,
+            page_end,
+            self.page_size,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        page_is_missing = self.req_to_host_pool[req_pool_idx, page_starts] < 0
+        num_missing_pages = int(page_is_missing.sum().item())
+
+        if num_missing_pages > 0:
+            host_locs = self.mem_pool_host.alloc(num_missing_pages * self.page_size)
+            if host_locs is None:
+                logger.error(
+                    "HiSparse: host mem pool alloc failed for %d host pages "
+                    "(req_pool_idx=%d, start_pos=%d, num_tokens=%d)",
+                    num_missing_pages,
+                    req_pool_idx,
+                    start_pos,
+                    num_tokens,
+                )
+                raise RuntimeError(
+                    f"HiSparse host mem pool alloc failed for {num_missing_pages} pages"
+                )
+            host_locs = host_locs.to(device=self.device)
+            if num_missing_pages == page_starts.numel():
+                self.req_to_host_pool[req_pool_idx, page_start:page_end] = host_locs
+            else:
+                missing_page_starts = page_starts[page_is_missing]
+                offsets = torch.arange(
+                    self.page_size, dtype=torch.int64, device=self.device
+                )
+                missing_indices = (
+                    missing_page_starts[:, None] + offsets[None, :]
+                ).reshape(-1)
+                self.req_to_host_pool[req_pool_idx, missing_indices] = host_locs
+
+        return self.req_to_host_pool[req_pool_idx, start_pos : start_pos + num_tokens]
+
+    def _allocated_host_indices(self, req: Req) -> torch.Tensor:
+        host_len = min(
+            self._round_up_to_host_page(self._host_token_len(req.kv_allocated_len)),
+            self.req_to_host_pool.shape[1],
+        )
+        host_indices = self.req_to_host_pool[req.req_pool_idx, :host_len]
+        return host_indices[host_indices >= 0]
+
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
 
@@ -200,18 +264,7 @@ class HiSparseCoordinator:
         )
 
         prefill_len = len(device_indices)
-        host_indices = self.mem_pool_host.alloc(prefill_len)
-        if host_indices is None:
-            logger.error(
-                "HiSparse: host mem pool alloc failed for %d tokens (req %s)",
-                prefill_len,
-                req.rid,
-            )
-            raise RuntimeError(
-                f"HiSparse host mem pool alloc failed for {prefill_len} tokens"
-            )
-        host_indices = host_indices.to(device=self.device)
-        self.req_to_host_pool[req.req_pool_idx, :prefill_len] = host_indices
+        host_indices = self.ensure_host_slots(req.req_pool_idx, 0, prefill_len)
 
         start_event = device_module.Event()
         finish_event = device_module.Event()
@@ -245,15 +298,10 @@ class HiSparseCoordinator:
           buffer.  In the staging path this is correct (prefill filled the buffer),
           but here the buffer is empty.
         """
-        if self.is_dsv4_hisparse:
-            # TODO(dsv4): wire PD direct-to-host. Needs (a) load_to_device_per_layer
-            raise NotImplementedError(
-                "PD direct-to-host admission is not supported for dsv4 hisparse yet."
-            )
-
         self.alloc_device_buffer(req)
 
-        if req.kv_allocated_len <= self.device_buffer_size:
+        host_len = self._host_token_len(req.kv_allocated_len)
+        if host_len <= self.device_buffer_size:
             # Short sequences (seq_len <= device_buffer_size): the kernel fast path
             # returns device_buffer_locs directly without any host loading, so we
             # must preload all tokens from host pool into the device buffer
@@ -270,12 +318,16 @@ class HiSparseCoordinator:
         self._skip_first_backup[req.req_pool_idx] = True
         logger.debug("HiSparse: admitting request %s directly", req.rid)
 
+    def _host_token_len(self, kv_allocated_len: int) -> int:
+        if self.is_dsv4_hisparse:
+            return (kv_allocated_len + self.compress_ratio - 1) // self.compress_ratio
+        return kv_allocated_len
+
     def _preload_to_device_buffer(self, req: Req) -> None:
         """Preload all tokens from host pool into the device buffer."""
-        n = req.kv_allocated_len
+        n = self._host_token_len(req.kv_allocated_len)
         host_indices = self.req_to_host_pool[req.req_pool_idx, :n]
         device_locs = self.req_to_device_buffer[req.req_pool_idx, :n]
-
         for layer_id in range(self.mem_pool_device.layer_num):
             self.mem_pool_host.load_to_device_per_layer(
                 self.mem_pool_device,
@@ -284,6 +336,10 @@ class HiSparseCoordinator:
                 layer_id,
                 io_backend="kernel",
             )
+        # Direct PD admission runs outside the model forward stream.  The preload
+        # must be complete before the request is marked ready, otherwise decode
+        # can race the H2D copy and read a partially populated hot buffer.
+        device_module.current_stream().synchronize()
 
     def alloc_device_buffer(self, req: Req) -> None:
         if self.is_dsv4_hisparse:
@@ -549,17 +605,17 @@ class HiSparseCoordinator:
 
         device_locs = self.req_to_device_buffer[backup_req_indices, buffer_slot]
 
-        host_locs = self.mem_pool_host.alloc(len(device_locs))
-        if host_locs is None:
-            logger.error(
-                "HiSparse: host mem pool alloc failed for %d decode backup tokens",
-                len(device_locs),
-            )
-            raise RuntimeError(
-                f"HiSparse host mem pool alloc failed for {len(device_locs)} decode backup tokens"
-            )
-        host_locs = host_locs.to(device=self.device)
-        self.req_to_host_pool[backup_req_indices, actual_compressed_pos] = host_locs
+        actual_compressed_pos_cpu = actual_compressed_pos.cpu()
+        host_locs = torch.cat(
+            [
+                self.ensure_host_slots(
+                    int(req_pool_indices_cpu[i]),
+                    int(actual_compressed_pos_cpu[j]),
+                    1,
+                )
+                for j, i in enumerate(backup_indices)
+            ]
+        )
 
         self.wait_for_pending_backup()
         schedule_stream = device_module.current_stream()
@@ -602,9 +658,8 @@ class HiSparseCoordinator:
         This is a naive per-request loop implementation for debugging/validation.
         Production code uses swap_in_selected_pages (JIT CUDA kernel) instead.
 
-        Note: dsv4 hisparse is not supported — DeepSeekV4SingleKVPoolHost has no
-        load_to_device_per_layer and indices live in compressed space. Currently
-        only used as a kernel oracle in test_hisparse_unit.py (non-dsv4 path).
+        Note: dsv4 hisparse is not supported here. This helper is only used as
+        a kernel oracle in test_hisparse_unit.py (non-dsv4 path).
 
         Args:
             req_pool_indices: Pool indices for each request.  Shape: (num_reqs,)
@@ -702,9 +757,7 @@ class HiSparseCoordinator:
         self.token_to_kv_pool_allocator.free_hisparse(allocated_locs)
 
         # Free host memory that was allocated during admit_request_into_staging
-        compressed_len = prefill_len // self.compress_ratio
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
-        host_indices = host_indices[host_indices >= 0]
+        host_indices = self._allocated_host_indices(req)
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
         self.req_to_host_pool[req.req_pool_idx, :] = -1
@@ -730,7 +783,6 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
-        compressed_len = allocated_len // self.compress_ratio
 
         # release memory -- only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
@@ -748,8 +800,7 @@ class HiSparseCoordinator:
         )
         self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
 
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
-        host_indices = host_indices[host_indices >= 0]
+        host_indices = self._allocated_host_indices(req)
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 


### PR DESCRIPTION
## Motivation

This PR is a follow-up fix for the interaction between the following two PRs:

- #23606: `[HiSparse & PD] Support hisparse memory pool host page > 1`
- #24880: `[PD] Add DeepSeek V4 support for HiSparse direct Prefill-to-Decode DRAM`

#23606 introduces host-page-aware HiSparse memory pool semantics, while #24880 adds DeepSeek V4 direct Prefill-to-Decode DRAM transfer for HiSparse. When these two changes are combined, DeepSeek V4 HiSparse PD needs to handle two different indexing/page-size semantics correctly:

- DSV4 C4 host KV is stored as token-linear compressed C4 entries.
- Non-sparse DSV4 KV, such as `c4_indexer` and `c128`, still uses device page indices.
- Generic HiSparse host KV with host `page_size > 1` should use page-level transfer semantics.

This PR fixes the follow-up edge cases caused by that interaction, especially when the committed KV length is not aligned to the C4 compression ratio. Without this fix, DSV4 HiSparse PD may allocate or release incorrect host slots, or use inconsistent page-size metadata during direct-to-host transfer.

## Modifications

- Make `HiSparseCoordinator` host-slot management page-aware.
  - Use the host pool page size for `req_to_host_pool` padding.
  - Add `ensure_host_slots(...)` to allocate host slots by page while returning token-position host indices.
  - Add `_allocated_host_indices(...)` to release only actually allocated host slots.
- Fix DSV4 compressed host length calculation.
  - Use ceil division for DSV4 host token length instead of floor division.
  - This avoids missing the last C4 host slot when `kv_allocated_len` or `fill_len` is not aligned to `compress_ratio`.
- Fix DSV4 direct-to-host preallocation.
  - Allocate DSV4 host C4 slots with ceil-compressed length.
  - Keep DSV4 C4 host metadata token-linear with `page_size = 1`.
  - Preserve device page indices for non-sparse KV transfer such as `c4_indexer` and `c128`.
- Fix HiSparse PD transfer page-size semantics.
  - Keep global KV args page size aligned with the device KV pool.
  - Remove the HiSparse-specific page-size mismatch bypass in the common connection check.
  - Use page-level transfer for non-DSV4 HiSparse host KV instead of expanding page indices to token indices.
- Fix host transfer item length.
  - Report `token_stride_size * page_size` for MLA host pool contiguous buffer items.

## Accuracy Tests

This change affects KV transfer/allocation semantics for DSV4 HiSparse PD, but does not change model math or attention kernels.
Validation performed:
```bash
python3 -m compileall \
  python/sglang/srt/managers/hisparse_coordinator.py \
  python/sglang/srt/disaggregation/decode.py \
  python/sglang/srt/disaggregation/mooncake/conn.py \
  python/sglang/srt/disaggregation/common/conn.py \
  python/sglang/srt/mem_cache/memory_pool_host.py
```

End-to-end DSV4 PD + HiSparse direct-to-host validation will be added once the required multi-node/Mooncake environment is available.

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.