### PR TITLE
[AMD] Enable shared-experts fusion with new KIMI-K2.5-MXFP4 model.

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -71,7 +71,13 @@ class QuarkConfig(QuantizationConfig):
         return "quark"
 
     def apply_weight_name_mapper(self, hf_to_sglang_mapper):
-        self.exclude_layers = hf_to_sglang_mapper.apply_list(self.exclude_layers)
+        mapped = hf_to_sglang_mapper.apply_list(self.exclude_layers)
+        expanded = []
+        for name in mapped:
+            expanded.append(name)
+            if name.startswith("language_model."):
+                expanded.append(name.removeprefix("language_model."))
+        self.exclude_layers = list(dict.fromkeys(expanded))
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2355,6 +2355,12 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                 "kv_a_proj_with_mqa",
             ]
 
+        # Quant configs like Quark may rely on the model to provide fused-module
+        # mappings so exclusion checks can unfuse derived names back to the
+        # checkpoint's source layer names.
+        if quant_config is not None and hasattr(quant_config, "packed_modules_mapping"):
+            quant_config.packed_modules_mapping = self.packed_modules_mapping
+
         self.pp_group = get_pp_group()
         self.config = config
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -2422,7 +2428,11 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             disable_reason = "DeepEP: fusion off by default (use --enforce-shared-experts-fusion to enable)."
         elif (
             self.config.architectures[0] != architecture
-            or self.config.n_routed_experts != 256
+            # Allow-list of n_routed_experts values that have been validated
+            # for shared-experts fusion under this code path. Currently:
+            #   256 -> DeepSeek-V3 / R1
+            #   384 -> Kimi-K2.5 (text_config wraps DeepseekV3ForCausalLM)
+            or self.config.n_routed_experts not in (256, 384)
             or self.config.n_shared_experts != 1
         ):
             disable_reason = "Config does not support fused shared expert(s)."


### PR DESCRIPTION
co-author: @yuychang
## Motivation
Make `Kimi-K2.5-MXFP4`[a717d43](https://huggingface.co/amd/Kimi-K2.5-MXFP4/commit/a717d434531121079eef3dc0be9d0315d8960bcc) (Quark MXFP4 checkpoint) actually load
on AMD MI3xx and benefit from the shared-experts fusion optimization
that DeepSeek-V3/R1 already uses.

## Modifications
Two files, +18 / −2:
- `quark.py` — `apply_weight_name_mapper` keeps both `language_model.<…>`
  and `<…>` forms of exclusion entries so the multimodal-wrapped and
  unwrapped name lookups both hit. No-op for non-multimodal checkpoints.
- `deepseek_v2.py` — (a) propagate `self.packed_modules_mapping` into
  `quant_config` so derived fused names can be unfused back to source
  layer names; (b) extend the `n_routed_experts` allow-list in
  `determine_num_fused_shared_experts` from `{256}` to `{256, 384}` so
  Kimi-K2.5 qualifies. Behaviour for DeepSeek-V3/R1 unchanged; other
  unverified values still take the safe disabled path.

## Accuracy Tests
Accuracy pass with GSM8K, 0.93

## Speed Tests and Profiling
(MI355X / TP=4 / `bench_serving 8192/1024 c=4 np=40`)
| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Output throughput (tok/s) | 325.5 | **373.8** | **+14.8 %** |
| Mean ITL (ms)             | 11.66 | **10.11** | **−13.3 %** |
| Median TPOT (ms)          | 11.68 | 10.13 | −13.3 % |
| Mean E2E (ms)             | 10968 |  9554 | −12.9 % |

Server log gate flips from
`Config does not support fused shared expert(s). Shared experts fusion optimization is disabled.`
to `Shared experts fusion optimization enabled.`
Profile trace confirms shared-MLP kernels (`_dynamic_mxfp4_quant_kernel`,
`act_and_mul<silu>`, `CUDAFunctor_add<BF16>`, shared
`_gemm_afp4wfp4_kernel`) drop to ~0 calls/iter and
`_fused_append_shared_experts_kernel` takes their place; the per-MoE-layer
shared-MLP allreduce is halved.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->[Run #25912262065](https://github.com/sgl-project/sglang/actions/runs/25912262065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->