### PR TITLE
pr-states: fix fork-PR token + add run-ci label awareness

### DIFF
--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -1,5 +1,6 @@
 name: PR States
-# Maintains a CI-states block at the bottom of the PR body.
+# Maintains a CI-states block at the bottom of the PR body, showing the
+# latest PR Test / PR Test Extra run URLs.
 
 on:
   pull_request:

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -61,13 +61,14 @@ jobs:
             const isReal = (run) => run && run.conclusion !== 'skipped';
 
             const missingCIText = ':x: **Missing `run-ci` label** — add it to run CI tests.';
+            const peBlockedByCIText = ':x: **Blocked** — `run-ci` is required first.';
             const notExtraEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
             const stalePushText = ':warning: **Not run on latest push** — push again or use `/rerun-failed-ci` to dispatch.';
             const ptText = !hasCI
               ? missingCIText
               : (isReal(ptRun) ? `[Run #${ptRun.id}](${ptRun.html_url})` : '_Not run yet_');
             const peText = !hasCI
-              ? missingCIText
+              ? peBlockedByCIText
               : !hasExtra
                 ? notExtraEnabledText
                 : (isReal(peRun) ? `[Run #${peRun.id}](${peRun.html_url})` : stalePushText);

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -26,6 +26,7 @@ jobs:
           script: |
             const sha = context.payload.pull_request.head.sha;
             const labels = context.payload.pull_request.labels.map(l => l.name);
+            const hasCI = labels.includes('run-ci');
             const hasExtra = labels.includes('run-ci-extra');
 
             // Retry briefly: pr-test* may not be API-visible yet when we start.
@@ -48,7 +49,7 @@ jobs:
               return null;
             }
 
-            const ptRun = await findRunWithRetry('pr-test.yml');
+            const ptRun = hasCI ? await findRunWithRetry('pr-test.yml') : null;
             const peRun = hasExtra ? await findRunWithRetry('pr-test-extra.yml') : null;
 
             // Treat a fully-skipped run as "no real run" — happens when the PR
@@ -56,11 +57,14 @@ jobs:
             // not retrigger on `labeled`).
             const isReal = (run) => run && run.conclusion !== 'skipped';
 
-            const notEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
+            const missingCIText = ':x: **Missing `run-ci` label** — add it to run CI tests.';
+            const notExtraEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
             const stalePushText = ':warning: **Not run on latest push** — push again or use `/rerun-failed-ci` to dispatch.';
-            const ptText = isReal(ptRun) ? `[Run #${ptRun.id}](${ptRun.html_url})` : '_Not run yet_';
+            const ptText = !hasCI
+              ? missingCIText
+              : (isReal(ptRun) ? `[Run #${ptRun.id}](${ptRun.html_url})` : '_Not run yet_');
             const peText = !hasExtra
-              ? notEnabledText
+              ? notExtraEnabledText
               : (isReal(peRun) ? `[Run #${peRun.id}](${peRun.html_url})` : stalePushText);
 
             const outerStart = '<!-- pr-states:start -->';

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -1,12 +1,8 @@
 name: PR States
-# Maintains a CI-states block at the bottom of the PR body, showing the
-# latest PR Test / PR Test Extra run URLs.
-#
-# Uses `pull_request_target` (not `pull_request`) so fork PRs receive a
-# write-enabled GITHUB_TOKEN. The job only reads PR metadata via the API and
-# PATCHes the PR body — it does NOT checkout PR head code, so the standard
-# `pull_request_target` supply-chain concern (running untrusted fork code with
-# a write token) does not apply here.
+# Maintains a CI-states block at the bottom of the PR body. Triggered by
+# `pull_request_target` (not `pull_request`) so fork PRs get a write-enabled
+# GITHUB_TOKEN. Safe because the workflow never checks out PR head code —
+# only reads metadata via API and PATCHes the PR body.
 
 on:
   pull_request_target:

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -50,7 +50,10 @@ jobs:
             }
 
             const ptRun = hasCI ? await findRunWithRetry('pr-test.yml') : null;
-            const peRun = hasExtra ? await findRunWithRetry('pr-test-extra.yml') : null;
+            // pr-test-extra's gate requires BOTH run-ci AND run-ci-extra
+            // (see pr-test-extra.yml check-changes if-condition), so without
+            // run-ci the extra workflow doesn't run either.
+            const peRun = (hasCI && hasExtra) ? await findRunWithRetry('pr-test-extra.yml') : null;
 
             // Treat a fully-skipped run as "no real run" — happens when the PR
             // was opened without the label and label was added later (GHA does
@@ -63,9 +66,11 @@ jobs:
             const ptText = !hasCI
               ? missingCIText
               : (isReal(ptRun) ? `[Run #${ptRun.id}](${ptRun.html_url})` : '_Not run yet_');
-            const peText = !hasExtra
-              ? notExtraEnabledText
-              : (isReal(peRun) ? `[Run #${peRun.id}](${peRun.html_url})` : stalePushText);
+            const peText = !hasCI
+              ? missingCIText
+              : !hasExtra
+                ? notExtraEnabledText
+                : (isReal(peRun) ? `[Run #${peRun.id}](${peRun.html_url})` : stalePushText);
 
             const outerStart = '<!-- pr-states:start -->';
             const outerEnd   = '<!-- pr-states:end -->';

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -1,9 +1,15 @@
 name: PR States
 # Maintains a CI-states block at the bottom of the PR body, showing the
 # latest PR Test / PR Test Extra run URLs.
+#
+# Uses `pull_request_target` (not `pull_request`) so fork PRs receive a
+# write-enabled GITHUB_TOKEN. The job only reads PR metadata via the API and
+# PATCHes the PR body — it does NOT checkout PR head code, so the standard
+# `pull_request_target` supply-chain concern (running untrusted fork code with
+# a write token) does not apply here.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -1098,10 +1098,6 @@ def main():
             print("Combined command finished, but no actions were taken.")
 
     elif first_line.startswith("/rerun-stage"):
-        # /rerun-stage is deprecated. Stage-level granularity is too coarse to map to
-        # a specific feature, and a stage rerun re-pays the cost of all unrelated tests
-        # in that stage. Use /rerun-test for selective UT runs, or /rerun-failed-ci /
-        # `run-ci` / `run-ci-extra` labels for a full rerun.
         print("/rerun-stage is deprecated; posting deprecation notice.")
         comment.create_reaction("-1")
         pr.create_issue_comment(


### PR DESCRIPTION
## Summary
- Switch `pr-states.yml` trigger from `pull_request` to `pull_request_target` so fork PRs receive a write-enabled `GITHUB_TOKEN` and the awareness comment update succeeds
- Show a red ❌ when the PR is missing the `run-ci` label (parallel to the existing `run-ci-extra` warning)
- Drop a redundant 4-line code comment in `slash_command_handler.py` (the deprecation message posted right below already states the rationale)

## Background — fork PR token
- On `pull_request` events from a fork, GitHub forces `GITHUB_TOKEN` to be read-only — this is a platform-level security policy that ignores the `permissions: pull-requests: write` declaration in the workflow file
- `pr-states / update-pr-body` calls `PATCH /repos/.../pulls/<n>` which fails with `403 Resource not accessible by integration` on every fork PR (reproduced on this PR's first run before the fix: [Run 25913505322](https://github.com/sgl-project/sglang/actions/runs/25913505322/job/76164267156))
- 100% of fork PRs end up with a red `pr-states / update-pr-body` check in their checks list, which is confusing for external contributors

## Fix — `pull_request_target`
- `pull_request_target` runs in the context of the base branch and grants the workflow a write-enabled token, so the API PATCH succeeds for both fork and non-fork PRs
- This workflow does **not** checkout PR head code — it only reads PR metadata via the GitHub API and PATCHes the PR body. The standard `pull_request_target` supply-chain concern (running untrusted fork code with a write token) does not apply

## `run-ci` label awareness
- Without the `run-ci` label, `pr-test.yml`'s gate (`pr-gate.yml:57`) fails and all downstream stages skip — but the awareness block previously linked to the (effectively empty) run, which was misleading
- Now mirrors the `run-ci-extra` pattern: show `:x: **Missing run-ci label**` instead of a stale link

## Verification
- The `pull_request_target` switch cannot be observed on this PR's CI: GitHub runs the workflow file from the **base branch**, so until this is merged the fork PR still hits 403. The fix is reviewable as code; merge will activate it for the next fork PR

Follows up on #25387.
