### PR TITLE
fix(responses): fix /v1/responses 400 error for multimodal models (gemma-4)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -250,7 +250,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         # Multimodal text prompt: tokenize to get accurate
                         # length so default_max_tokens doesn't exceed context_len.
                         prompt_length = len(
-                            self.tokenizer_manager.tokenizer.encode(engine_prompt)
+                            tokenizer.encode(engine_prompt, add_special_tokens=False)
                         )
                     else:
                         prompt_length = 0

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -244,10 +244,14 @@ class OpenAIServingResponses(OpenAIServingChat):
                     tool_sessions = {}
                 for i, engine_prompt in enumerate(engine_prompts):
                     # Calculate default max tokens from context length minus prompt length
-                    if hasattr(engine_prompt, "__len__"):
+                    if isinstance(engine_prompt, list):
                         prompt_length = len(engine_prompt)
-                    elif isinstance(engine_prompt, list):
-                        prompt_length = len(engine_prompt)
+                    elif isinstance(engine_prompt, str):
+                        # Multimodal text prompt: tokenize to get accurate
+                        # length so default_max_tokens doesn't exceed context_len.
+                        prompt_length = len(
+                            self.tokenizer_manager.tokenizer.encode(engine_prompt)
+                        )
                     else:
                         prompt_length = 0
 
@@ -276,8 +280,15 @@ class OpenAIServingResponses(OpenAIServingChat):
                         context = SimpleContext()
 
                     # Create GenerateReqInput for SGLang
+                    # For multimodal models, engine_prompt is a text string;
+                    # for text-only models, it is a list of token IDs.
+                    if isinstance(engine_prompt, str):
+                        prompt_kwargs = {"text": engine_prompt}
+                    else:
+                        prompt_kwargs = {"input_ids": engine_prompt}
+
                     adapted_request = GenerateReqInput(
-                        input_ids=engine_prompt,
+                        **prompt_kwargs,
                         sampling_params=sampling_params,
                         stream=request.stream,
                         rid=request.request_id,
@@ -378,37 +389,24 @@ class OpenAIServingResponses(OpenAIServingChat):
         messages = self._construct_input_messages(request, prev_response)
 
         # Follow SGLang's pattern: create a ChatCompletionRequest and process messages
-        try:
-            # Convert ResponsesRequest to ChatCompletionRequest for processing
-            chat_request = ChatCompletionRequest(
-                model=request.model,
-                messages=messages,
-                stream=request.stream,
-            )
+        # Convert ResponsesRequest to ChatCompletionRequest for processing
+        chat_request = ChatCompletionRequest(
+            model=request.model,
+            messages=messages,
+            stream=request.stream,
+        )
 
-            # Follow SGLang's _process_messages pattern
-            is_multimodal = self.tokenizer_manager.model_config.is_multimodal
-            processed_messages = self._process_messages(chat_request, is_multimodal)
+        # Follow SGLang's _process_messages pattern
+        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
+        processed_messages = self._process_messages(chat_request, is_multimodal)
 
-            # Extract the results
-            if is_multimodal:
-                request_prompts = [processed_messages.prompt]
-                engine_prompts = [processed_messages.prompt]
-            else:
-                request_prompts = [processed_messages.prompt_ids]
-                engine_prompts = [processed_messages.prompt_ids]
-
-        except Exception as e:
-            logger.warning(f"Chat processing failed, using fallback: {e}")
-            # Fallback to simple encoding
-            prompt_text = ""
-            for msg in messages:
-                role = msg.get("role", "user")
-                content = msg.get("content", "")
-                prompt_text += f"{role}: {content}\n"
-            prompt_ids = tokenizer.encode(prompt_text)
-            request_prompts = [prompt_ids]
-            engine_prompts = [prompt_ids]
+        # Extract the results
+        if is_multimodal:
+            request_prompts = [processed_messages.prompt]
+            engine_prompts = [processed_messages.prompt]
+        else:
+            request_prompts = [processed_messages.prompt_ids]
+            engine_prompts = [processed_messages.prompt_ids]
 
         return messages, request_prompts, engine_prompts
 


### PR DESCRIPTION
## Summary

Fixes #25127

`/v1/responses` returns `400 Bad Request` for multimodal models (e.g., `gemma-4-E2B-it`) while `/v1/chat/completions` works fine with the same model.

When `_make_request()` processes messages for multimodal models, `_process_messages` returns `processed_messages.prompt` — a rendered text string — rather than `processed_messages.prompt_ids` (a `list[int]` of token IDs). However, `create_responses()` unconditionally passes the result as `input_ids=` to `GenerateReqInput`. This causes `GenerateReqInput` validation to fail with `"input_ids should be a list of lists for batch processing."` because `str` is not `list[list[int]]`.

https://github.com/sgl-project/sglang/blob/c67b2870569a1a639459389b0355641074ea9a74/python/sglang/srt/entrypoints/openai/serving_chat.py#L399-L405
The `/v1/chat/completions` path already handles this correctly by dispatching on type — this PR applies the same pattern to `/v1/responses`, plus two additional fixes discovered during investigation:

**Fix 1 — Correct prompt type dispatch (root cause)**: `_process_messages` returns `processed_messages.prompt` (a rendered text string) for multimodal models, vs `processed_messages.prompt_ids` (a list of token IDs) for text-only models. `create_responses` now dispatches on type — `text=` for `str`, `input_ids=` for `list` — matching the `serving_chat.py` pattern.

**Fix 2 — Fix `prompt_length` calculation**: The original code used `hasattr(engine_prompt, "__len__")` to branch, but `str` also has `__len__`, making the `elif isinstance(engine_prompt, list)` branch dead code. For multimodal text prompts, `len("hello")` = 5 characters was silently used as the "token count". Fixed to actually tokenize the text prompt for an accurate count, consistent with how the engine tokenizes it downstream.

**Fix 3 — Remove silent exception fallback**: `_make_request()` had a blanket `except Exception` that silently fell back to naive `"{role}: {content}\n"` concatenation, producing malformed prompts and hiding the real error. Removed in favor of letting exceptions propagate to `create_responses()`'s existing handler which already does `logger.exception()` and returns proper error responses.

> **Note:** This PR fixes the routing of multimodal text prompts. Actual image/audio/video data attached to Responses API requests is not yet forwarded to `GenerateReqInput` — that's a separate gap to be addressed in a follow-up.

<details>
<summary>Before (with silent fallback removed, showing the real underlying error)</summary>

```bash
$ curl http://localhost:30000/v1/responses \
  -H "Authorization: Bearer test-key-123" \
  -d '{"model": "gemma-4-E2B-it", "input": "hello"}'

# HTTP 400
{"error": {"message": "input_ids should be a list of lists for batch processing.", ...}}
```

</details>

<details>
<summary>After</summary>

```bash
$ curl http://localhost:30000/v1/responses \
  -H "Authorization: Bearer test-key-123" \
  -d '{"model": "gemma-4-E2B-it", "input": "hello"}'

# HTTP 200
{"output": [{"content": [{"text": "Hello! How can I help you today? 😊", ...}], ...}]}
```

</details>

<details>
<summary>Test results</summary>

Tested on RTX 3090 (24GB) with both `gemma-4-E2B-it` (multimodal) and `Qwen2.5-0.5B-Instruct` (text-only):

```
=== gemma-4-E2B-it (multimodal, was broken) ===
  [Short prompt /v1/responses] HTTP 200 PASS
    Output (34 chars): Hello! How can I help you today? 😊...
  [Short prompt /v1/chat/completions] HTTP 200 PASS
    Output (32 chars): Hello! How can I help you today?...
  [Long prompt /v1/responses] HTTP 200 PASS
    Output (233 chars): Please provide the list of topics you would like me to analyze...
  [Long prompt /v1/chat/completions] HTTP 200 PASS
    Output (250 chars): Please provide the list of topics you would like me to analyze...
  [Multi-turn /v1/responses] HTTP 200 PASS
    Output (19 chars): Your name is Alice....
  [Stream /v1/responses] HTTP 200 PASS (6 chunks)

6/6 passed

=== Qwen2.5-0.5B-Instruct (text-only, regression check) ===
  [Short prompt /v1/responses] HTTP 200 PASS
    Output (34 chars): Hello! How can I assist you today?...
  [Short prompt /v1/chat/completions] HTTP 200 PASS
    Output (34 chars): Hello! How can I assist you today?...
  [Long prompt /v1/responses] HTTP 200 PASS
    Output (222 chars): I will not analyze any topic as it is not clear what topics you are referring to...
  [Long prompt /v1/chat/completions] HTTP 200 PASS
    Output (48 chars): I'm sorry, but I can't assist with that request....
  [Multi-turn /v1/responses] HTTP 200 PASS
    Output (19 chars): Your name is Alice....
  [Stream /v1/responses] HTTP 200 PASS (6 chunks)

6/6 passed
```

Long prompt: `"Please analyze the following comprehensive list of topics in detail. "` repeated 80 times (~800 tokens of repeated text).

</details>

## Test plan
- [x] Reproduced 400 error with `gemma-4-E2B-it` on `/v1/responses` (before fix)
- [x] Verified fix returns 200 with correct output on `gemma-4-E2B-it` (after fix)
- [x] Verified short prompt, long prompt, multi-turn conversation, and streaming all pass on `gemma-4-E2B-it`
- [x] Regression test: all 6 test cases pass on `Qwen2.5-0.5B-Instruct` (text-only model)
- [x] Harmony path not directly tested but unchanged by this diff
- [ ] **Follow-up**: No existing unit tests for `/v1/responses` — consider adding a regression test that mocks `_process_messages` to return a `str` prompt (simulating multimodal path) and asserts the request is routed via `text=` not `input_ids=`. Out of scope for this PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #25915106059](https://github.com/sgl-project/sglang/actions/runs/25915106059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->