### PR TITLE
[CI] slash handler: lookup `runs_on` from `runner_configs.yml`

### DIFF
--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -63,7 +63,7 @@ jobs:
             const missingCIText = ':x: **Missing `run-ci` label** — add it to run CI tests.';
             const peBlockedByCIText = ':x: **Blocked** — `run-ci` is required first.';
             const notExtraEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
-            const stalePushText = ':warning: **Not run on latest push** — push again or use `/rerun-failed-ci` to dispatch.';
+            const stalePushText = ':warning: **Not run on latest push** — push again to dispatch.';
             const ptText = !hasCI
               ? missingCIText
               : (isReal(ptRun) ? `[Run #${ptRun.id}](${ptRun.html_url})` : '_Not run yet_');

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -4,46 +4,43 @@ run-name: ${{ inputs.pr_head_sha && format('[rerun-test] {0} {1}', inputs.test_c
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Dispatch mode: cuda | multimodal_gen | cpu"
+        required: true
+        type: choice
+        options:
+          - cuda
+          - multimodal_gen
+          - cpu
       test_command:
         description: "Test command(s) to run, one per line (e.g. 'registered/core/test_srt_endpoint.py TestSRTEndpoint.test_simple_decode')"
         required: true
         type: string
-      runner_label:
-        description: "Runner label"
-        required: true
-        type: choice
-        options:
-          - 1-gpu-h100
-          - 1-gpu-5090
-          - 2-gpu-h100
-          - 4-gpu-h100
-          - 4-gpu-a10
-          - 4-gpu-b200
-          - 8-gpu-h200
-          - 8-gpu-h200-deepep
-          - 8-gpu-h20
-          - 8-gpu-b200
-          - ubuntu-latest
+      runs_on:
+        description: "GHA runner label (cuda/multimodal_gen only; ignored for cpu)"
+        required: false
+        type: string
+        default: ""
+      install_script:
+        description: "Install script path (cuda only). E.g. scripts/ci/cuda/ci_install_dependency.sh"
+        required: false
+        type: string
+        default: ""
+      install_timeout:
+        description: "Install-step timeout minutes (cuda only)"
+        required: false
+        type: string
+        default: "20"
+      rdma_devices:
+        description: "SGLANG_CI_RDMA_ALL_DEVICES csv (cuda only; empty = unset)"
+        required: false
+        type: string
+        default: ""
       pr_head_sha:
         description: "PR head SHA to checkout (for /rerun-test on fork PRs)"
         required: false
         type: string
         default: ""
-      use_deepep:
-        description: "Use ci_install_deepep.sh instead of ci_install_dependency.sh"
-        required: false
-        type: string
-        default: "false"
-      is_cpu:
-        description: "Run as CPU-only test (uses ubuntu-latest with uv pip install)"
-        required: false
-        type: string
-        default: "false"
-      install_diffusion:
-        description: "Install diffusion dependencies (for multimodal gen tests)"
-        required: false
-        type: string
-        default: "false"
       reply_comment_id:
         description: "Reply comment ID to write back result to"
         required: false
@@ -69,15 +66,15 @@ permissions:
 
 jobs:
   rerun-test-cuda:
-    if: inputs.is_cpu != 'true'
-    runs-on: ${{ inputs.runner_label }}
+    if: inputs.mode == 'cuda'
+    runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 120
     permissions:
       contents: read
       issues: write
     env:
-      RUNNER_LABELS: ${{ inputs.runner_label }}
-      SGLANG_CI_RDMA_ALL_DEVICES: ${{ inputs.runner_label == '8-gpu-h20' && 'mlx5_1,mlx5_2,mlx5_3,mlx5_4' || '' }}
+      RUNNER_LABELS: ${{ inputs.runs_on }}
+      SGLANG_CI_RDMA_ALL_DEVICES: ${{ inputs.rdma_devices }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -90,7 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${{ inputs.runner_label }}" == "1-gpu-5090" ]]; then
+          if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
           fi
           python3 scripts/ci/utils/update_rerun_test_status.py \
@@ -102,26 +99,19 @@ jobs:
       - uses: ./.github/actions/check-maintenance
 
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: ${{ fromJson(inputs.install_timeout) }}
         run: |
-          if [[ "${{ inputs.runner_label }}" == "1-gpu-5090" ]]; then
+          if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
           fi
-          if [[ "${{ inputs.use_deepep }}" == "true" ]]; then
-            bash scripts/ci/cuda/ci_install_deepep.sh
-          elif [[ "${{ inputs.install_diffusion }}" == "true" ]]; then
-            bash scripts/ci/cuda/ci_install_dependency.sh diffusion
-          else
-            bash scripts/ci/cuda/ci_install_dependency.sh
-          fi
+          bash ${{ inputs.install_script }}
 
       - name: Run test
         timeout-minutes: 60
         run: |
-          if [[ "${{ inputs.runner_label }}" == "1-gpu-5090" ]]; then
+          if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
           fi
-          # Collect non-empty commands into an array for counting.
           cmds=()
           while IFS= read -r cmd; do
             [ -z "$cmd" ] && continue
@@ -134,17 +124,74 @@ jobs:
             cmd="${cmds[$idx]}"
             echo ""
             echo "."
-            if [[ "${{ inputs.install_diffusion }}" == "true" ]]; then
-              echo "Begin ($i/$total): python3 -m pytest $cmd -x"
-              echo "."
-              file_start=$SECONDS
-              python3 -m pytest $cmd -x || exit 1
-            else
-              echo "Begin ($i/$total): python3 $cmd"
-              echo "."
-              file_start=$SECONDS
-              (cd test/ && python3 $cmd -f) || exit 1
-            fi
+            echo "Begin ($i/$total): python3 $cmd"
+            echo "."
+            file_start=$SECONDS
+            (cd test/ && python3 $cmd -f) || exit 1
+            elapsed=$(( SECONDS - file_start ))
+            echo "."
+            echo "End ($i/$total): elapsed=${elapsed}s"
+            echo "."
+            echo ""
+          done
+          total_elapsed=$(( SECONDS - suite_start ))
+          echo "All $total test(s) passed in ${total_elapsed}s"
+
+      - uses: ./.github/actions/upload-cuda-coredumps
+        if: failure()
+
+  rerun-test-multimodal-gen:
+    if: inputs.mode == 'multimodal_gen'
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      issues: write
+    env:
+      RUNNER_LABELS: ${{ inputs.runs_on }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr_head_sha || github.sha }}
+
+      - name: Mark runner picked up
+        if: inputs.reply_comment_id != '' && inputs.reply_marker != ''
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/ci/utils/update_rerun_test_status.py \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --status running \
+            --repo "${{ github.repository }}"
+
+      - uses: ./.github/actions/check-maintenance
+
+      - name: Install dependencies (diffusion)
+        timeout-minutes: 20
+        run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
+
+      - name: Run test
+        timeout-minutes: 60
+        run: |
+          cmds=()
+          while IFS= read -r cmd; do
+            [ -z "$cmd" ] && continue
+            cmds+=("$cmd")
+          done <<< "${{ inputs.test_command }}"
+          total=${#cmds[@]}
+          suite_start=$SECONDS
+          for idx in "${!cmds[@]}"; do
+            i=$((idx + 1))
+            cmd="${cmds[$idx]}"
+            echo ""
+            echo "."
+            echo "Begin ($i/$total): python3 -m pytest $cmd -x"
+            echo "."
+            file_start=$SECONDS
+            python3 -m pytest $cmd -x || exit 1
             elapsed=$(( SECONDS - file_start ))
             echo "."
             echo "End ($i/$total): elapsed=${elapsed}s"
@@ -158,7 +205,7 @@ jobs:
         if: failure()
 
   rerun-test-cpu:
-    if: inputs.is_cpu == 'true'
+    if: inputs.mode == 'cpu'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -214,7 +261,6 @@ jobs:
         timeout-minutes: 60
         run: |
           cd test/
-          # Collect non-empty commands into an array for counting.
           cmds=()
           while IFS= read -r cmd; do
             [ -z "$cmd" ] && continue
@@ -241,7 +287,7 @@ jobs:
           echo "All $total test(s) passed in ${total_elapsed}s"
 
   write-back-result:
-    needs: [rerun-test-cuda, rerun-test-cpu]
+    needs: [rerun-test-cuda, rerun-test-multimodal-gen, rerun-test-cpu]
     if: always() && inputs.reply_comment_id != '' && inputs.reply_marker != ''
     runs-on: ubuntu-latest
     permissions:
@@ -263,7 +309,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${{ needs.rerun-test-cuda.result }}" == "success" || "${{ needs.rerun-test-cpu.result }}" == "success" ]]; then
+          if [[ "${{ needs.rerun-test-cuda.result }}" == "success" \
+             || "${{ needs.rerun-test-multimodal-gen.result }}" == "success" \
+             || "${{ needs.rerun-test-cpu.result }}" == "success" ]]; then
             STATUS=success
           else
             STATUS=failure

--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install PyGithub
+          pip install PyGithub PyYAML
 
       - name: Handle Slash Command
         env:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -397,22 +397,11 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
         return False
 
 
+# Legacy `suite="..."` table — only nightly / weekly entries left; stage / extra
+# tests use the new-style `register_cuda_ci(stage=..., runner_config=...)` form,
+# which resolves runs_on via scripts/ci/runner_configs.yml (see detect_suite).
 CUDA_SUITE_TO_RUNNER = {
-    # PR test suites
-    "stage-a-test-1-gpu-small": "1-gpu-5090",
     "stage-a-test-cpu": "ubuntu-latest",
-    "stage-b-test-1-gpu-small": "1-gpu-5090",
-    "stage-b-test-1-gpu-large": "1-gpu-h100",
-    "stage-b-test-2-gpu-large": "2-gpu-h100",
-    "stage-b-test-4-gpu-b200": "4-gpu-b200",
-    "stage-c-test-4-gpu-h100": "4-gpu-h100",
-    "stage-c-test-8-gpu-h200": "8-gpu-h200",
-    "stage-c-test-8-gpu-h20": "8-gpu-h20",
-    "stage-c-test-4-gpu-b200": "4-gpu-b200",
-    "stage-c-test-deepep-4-gpu-h100": "4-gpu-h100",
-    "stage-c-test-deepep-8-gpu-h200": "8-gpu-h200-deepep",
-    "stage-c-test-dsv4-4-gpu-b200": "4-gpu-b200",
-    "stage-c-test-dsv4-8-gpu-h200": "8-gpu-h200",
     # Nightly test suites (NVIDIA)
     "nightly-1-gpu": "1-gpu-h100",
     "nightly-4-gpu": "4-gpu-h100",
@@ -431,13 +420,9 @@ CUDA_SUITE_TO_RUNNER = {
     "weekly-8-gpu-h200": "8-gpu-h200",
 }
 
-DEEPEP_SUITES = {
-    "stage-c-test-8-gpu-h20",
-    "stage-c-test-deepep-4-gpu-h100",
-    "stage-c-test-deepep-8-gpu-h200",
-    "stage-c-test-dsv4-4-gpu-b200",
-    "stage-c-test-dsv4-8-gpu-h200",
-}
+# Legacy suite-name set for stage-c-test-8-gpu-h20-ish patterns; left empty
+# now that all stage tests use the new-style yml-derived path (see detect_suite).
+DEEPEP_SUITES = set()
 
 
 MULTIMODAL_TEST_DIR = "python/sglang/multimodal_gen/test"

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -17,6 +17,13 @@ import runner_configs as _runner_configs  # noqa: E402
 # non-kernel pool when resolving the `$b200_runner` sentinel from runner_configs.yml.
 _B200_DEFAULT_RUNNER = "4-gpu-b200"
 
+# install_script values from runner_configs.yml are passed verbatim into a
+# `bash ${{ inputs.install_script }}` step in rerun-test.yml. GHA expression
+# substitution happens before bash parses, so shell metacharacters in the
+# string would inject. Restrict the allowed shape to `scripts/ci/cuda/*.sh`
+# (single path component under that dir, no whitespace/operators).
+_ALLOWED_INSTALL_SCRIPT = re.compile(r"^scripts/ci/cuda/[\w.-]+\.sh$")
+
 # Configuration
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
 
@@ -590,6 +597,15 @@ def detect_suite(file_path_from_test):
                 f"— not in scripts/ci/runner_configs.yml.\n\n"
                 f"Known runner_configs: {known}",
             )
+        install_script = cfg["install"]
+        if not _ALLOWED_INSTALL_SCRIPT.match(install_script):
+            return _err(
+                rc,
+                f"Disallowed `install` value `{install_script}` for runner_config "
+                f"`{rc}` in scripts/ci/runner_configs.yml. The slash handler "
+                f"passes this string verbatim into a shell step, so it must "
+                f"match `scripts/ci/cuda/*.sh`.",
+            )
         runs_on = cfg.get("runs_on")
         # Resolve $b200_runner sentinel: rerun-test never builds sgl-kernel,
         # so always pick the non-kernel b200 pool.
@@ -600,7 +616,7 @@ def detect_suite(file_path_from_test):
         return {
             "suite": suite,
             "runner_label": runs_on,
-            "install_script": cfg["install"],
+            "install_script": install_script,
             "install_timeout": str(cfg["install_timeout"]),
             "rdma_devices": cfg.get("rdma_devices", ""),
             "is_cpu": False,

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -9,6 +9,15 @@ from datetime import datetime, timezone
 import requests
 from github import Auth, Github
 
+# Import scripts/ci/runner_configs.py (sibling-up dir) for runner_config -> runs_on lookup.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+import runner_configs as _runner_configs  # noqa: E402
+
+# rerun-test workflow doesn't build sgl-kernel, so b200 stages always use the
+# non-kernel pool. Keep this aligned with the legacy CUDA_SUITE_TO_RUNNER below.
+_B200_DEFAULT_RUNNER = "4-gpu-b200"
+_DEFAULT_INSTALL = "scripts/ci/cuda/ci_install_dependency.sh"
+
 # Configuration
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
 
@@ -598,15 +607,63 @@ def _extract_suite(content, func_name):
     return None
 
 
+def _extract_runner_config(content):
+    """Pull `runner_config` from a new-style `register_cuda_ci(...)` call."""
+    args = re.search(r"^[^#\n]*register_cuda_ci\(([^)]*)\)", content, re.MULTILINE)
+    if not args:
+        return None
+    m = re.search(r'runner_config\s*=\s*["\']([^"\']+)["\']', args.group(1))
+    return m.group(1) if m else None
+
+
 def detect_suite(file_path_from_test):
     """
     Read a test file and extract the suite from register_cuda_ci or register_cpu_ci.
+
+    For new-style `register_cuda_ci(runner_config="...")`, resolves the runner
+    label from scripts/ci/runner_configs.yml — works for any stage (stage-a/b/c,
+    extra-a/b, etc.) without a hard-coded suite table.
+
+    Legacy `register_cuda_ci(suite="...")` (nightly/weekly/manual tests) still
+    uses CUDA_SUITE_TO_RUNNER.
 
     Returns (suite_name, runner_label, use_deepep, is_cpu, error_message).
     """
     full_path = f"test/{file_path_from_test}"
     with open(full_path, "r") as f:
         content = f.read()
+
+    # New style: runner_config="..." -> look up runs_on from runner_configs.yml.
+    rc = _extract_runner_config(content)
+    if rc:
+        cfg = _runner_configs.load().get(rc)
+        if cfg is None:
+            known = ", ".join(f"`{k}`" for k in sorted(_runner_configs.load()))
+            return (
+                rc,
+                None,
+                False,
+                False,
+                (
+                    f"Unknown runner_config `{rc}` in `{full_path}` "
+                    f"— not in scripts/ci/runner_configs.yml.\n\n"
+                    f"Known runner_configs: {known}"
+                ),
+            )
+        runs_on = cfg.get("runs_on")
+        # Resolve $b200_runner sentinel: rerun-test never builds sgl-kernel,
+        # so always pick the non-kernel b200 pool.
+        if runs_on == "$b200_runner":
+            runs_on = _B200_DEFAULT_RUNNER
+        # Stage is informational for telemetry/messages; not used for dispatch.
+        stage_m = re.search(
+            r'^[^#\n]*register_cuda_ci\([^)]*stage\s*=\s*["\']([^"\']+)["\']',
+            content,
+            re.MULTILINE,
+        )
+        suite = f"{stage_m.group(1)}-test-{rc}" if stage_m else rc
+        use_deepep = cfg.get("install", _DEFAULT_INSTALL) != _DEFAULT_INSTALL
+        return suite, runs_on, use_deepep, False, None
 
     suite = _extract_suite(content, "register_cuda_ci")
     if suite:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -14,9 +14,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."
 import runner_configs as _runner_configs  # noqa: E402
 
 # rerun-test workflow doesn't build sgl-kernel, so b200 stages always use the
-# non-kernel pool. Keep this aligned with the legacy CUDA_SUITE_TO_RUNNER below.
+# non-kernel pool when resolving the `$b200_runner` sentinel from runner_configs.yml.
 _B200_DEFAULT_RUNNER = "4-gpu-b200"
-_DEFAULT_INSTALL = "scripts/ci/cuda/ci_install_dependency.sh"
 
 # Configuration
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
@@ -397,34 +396,6 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
         return False
 
 
-# Legacy `suite="..."` table — only nightly / weekly entries left; stage / extra
-# tests use the new-style `register_cuda_ci(stage=..., runner_config=...)` form,
-# which resolves runs_on via scripts/ci/runner_configs.yml (see detect_suite).
-CUDA_SUITE_TO_RUNNER = {
-    "stage-a-test-cpu": "ubuntu-latest",
-    # Nightly test suites (NVIDIA)
-    "nightly-1-gpu": "1-gpu-h100",
-    "nightly-4-gpu": "4-gpu-h100",
-    "nightly-4-gpu-b200": "4-gpu-b200",
-    "nightly-8-gpu-common": "8-gpu-h200",
-    "nightly-8-gpu-h200": "8-gpu-h200",
-    "nightly-8-gpu-h20": "8-gpu-h20",
-    "nightly-8-gpu-b200": "8-gpu-b200",
-    "nightly-eval-text-2-gpu": "2-gpu-h100",
-    "nightly-eval-vlm-2-gpu": "2-gpu-h100",
-    "nightly-perf-text-2-gpu": "2-gpu-h100",
-    "nightly-perf-vlm-2-gpu": "2-gpu-h100",
-    "nightly-kernel-1-gpu": "1-gpu-h100",
-    "nightly-kernel-8-gpu-h200": "8-gpu-h200",
-    # Weekly test suites
-    "weekly-8-gpu-h200": "8-gpu-h200",
-}
-
-# Legacy suite-name set for stage-c-test-8-gpu-h20-ish patterns; left empty
-# now that all stage tests use the new-style yml-derived path (see detect_suite).
-DEEPEP_SUITES = set()
-
-
 MULTIMODAL_TEST_DIR = "python/sglang/multimodal_gen/test"
 
 MULTIMODAL_PATH_TO_RUNNER = {
@@ -568,32 +539,8 @@ def detect_multimodal_suite(file_path):
     return MULTIMODAL_DEFAULT_RUNNER, None
 
 
-def _extract_suite(content, func_name):
-    """Pull a suite name out of a `register_{cuda,cpu}_ci(...)` call.
-
-    Two styles are supported:
-      1. legacy: register_cuda_ci(..., suite="stage-X-test-Y")
-      2. new:    register_cuda_ci(..., stage="stage-X", runner_config="Y")
-                 -> suite = f"{stage}-test-{runner_config}"
-    """
-    legacy = re.search(
-        rf'^[^#\n]*{func_name}\([^)]*suite\s*=\s*["\']([^"\']+)["\']',
-        content,
-        re.MULTILINE,
-    )
-    if legacy:
-        return legacy.group(1)
-    args = re.search(rf"^[^#\n]*{func_name}\(([^)]*)\)", content, re.MULTILINE)
-    if args:
-        stage_m = re.search(r'stage\s*=\s*["\']([^"\']+)["\']', args.group(1))
-        rc_m = re.search(r'runner_config\s*=\s*["\']([^"\']+)["\']', args.group(1))
-        if stage_m and rc_m:
-            return f"{stage_m.group(1)}-test-{rc_m.group(1)}"
-    return None
-
-
 def _extract_runner_config(content):
-    """Pull `runner_config` and the args string from a new-style `register_cuda_ci(...)` call."""
+    """Pull `runner_config` and the args string from a `register_cuda_ci(...)` call."""
     args = re.search(r"^[^#\n]*register_cuda_ci\s*\(([^)]*)\)", content, re.MULTILINE)
     if not args:
         return None, None
@@ -603,81 +550,80 @@ def _extract_runner_config(content):
 
 def detect_suite(file_path_from_test):
     """
-    Read a test file and extract the suite from register_cuda_ci or register_cpu_ci.
+    Read a test file and extract dispatch info from register_cuda_ci or
+    register_cpu_ci.
 
-    For new-style `register_cuda_ci(runner_config="...")`, resolves the runner
-    label from scripts/ci/runner_configs.yml — works for any stage (stage-a/b/c,
-    extra-a/b, etc.) without a hard-coded suite table.
+    CUDA tests must use `register_cuda_ci(stage=..., runner_config=...)`;
+    runner label, install script, timeout, and rdma_devices are all resolved
+    from scripts/ci/runner_configs.yml — the same single source of truth that
+    drives the main PR test pipeline.
 
-    Legacy `register_cuda_ci(suite="...")` (nightly/weekly/manual tests) still
-    uses CUDA_SUITE_TO_RUNNER.
+    CPU tests (`register_cpu_ci(...)`) dispatch to the CPU job (ubuntu-latest).
 
-    Returns (suite_name, runner_label, use_deepep, is_cpu, error_message).
+    Returns dict with keys: suite, runner_label, install_script,
+    install_timeout, rdma_devices, is_cpu, error.
     """
     full_path = f"test/{file_path_from_test}"
     with open(full_path, "r") as f:
         content = f.read()
 
-    # New style: runner_config="..." -> look up runs_on from runner_configs.yml.
+    def _err(suite, msg):
+        return {
+            "suite": suite,
+            "runner_label": None,
+            "install_script": "",
+            "install_timeout": "",
+            "rdma_devices": "",
+            "is_cpu": False,
+            "error": msg,
+        }
+
     rc, args_str = _extract_runner_config(content)
     if rc:
         configs = _runner_configs.load()
         cfg = configs.get(rc)
         if cfg is None:
             known = ", ".join(f"`{k}`" for k in sorted(configs))
-            return (
+            return _err(
                 rc,
-                None,
-                False,
-                False,
-                (
-                    f"Unknown runner_config `{rc}` in `{full_path}` "
-                    f"— not in scripts/ci/runner_configs.yml.\n\n"
-                    f"Known runner_configs: {known}"
-                ),
+                f"Unknown runner_config `{rc}` in `{full_path}` "
+                f"— not in scripts/ci/runner_configs.yml.\n\n"
+                f"Known runner_configs: {known}",
             )
         runs_on = cfg.get("runs_on")
         # Resolve $b200_runner sentinel: rerun-test never builds sgl-kernel,
         # so always pick the non-kernel b200 pool.
         if runs_on == "$b200_runner":
             runs_on = _B200_DEFAULT_RUNNER
-        # Stage is informational for telemetry/messages; not used for dispatch.
         stage_m = re.search(r'stage\s*=\s*["\']([^"\']+)["\']', args_str)
         suite = f"{stage_m.group(1)}-test-{rc}" if stage_m else rc
-        use_deepep = cfg.get("install", _DEFAULT_INSTALL) != _DEFAULT_INSTALL
-        return suite, runs_on, use_deepep, False, None
+        return {
+            "suite": suite,
+            "runner_label": runs_on,
+            "install_script": cfg["install"],
+            "install_timeout": str(cfg["install_timeout"]),
+            "rdma_devices": cfg.get("rdma_devices", ""),
+            "is_cpu": False,
+            "error": None,
+        }
 
-    suite = _extract_suite(content, "register_cuda_ci")
-    if suite:
-        runner = CUDA_SUITE_TO_RUNNER.get(suite)
-        if not runner:
-            known = ", ".join(f"`{s}`" for s in sorted(CUDA_SUITE_TO_RUNNER))
-            return (
-                suite,
-                None,
-                False,
-                False,
-                (
-                    f"Unknown CUDA suite `{suite}` in `{full_path}`.\n\n"
-                    f"Known suites: {known}"
-                ),
-            )
-        use_deepep = suite in DEEPEP_SUITES
-        return suite, runner, use_deepep, False, None
+    if re.search(r"^[^#\n]*register_cpu_ci\s*\(", content, re.MULTILINE):
+        return {
+            "suite": "cpu",
+            "runner_label": "ubuntu-latest",
+            "install_script": "",
+            "install_timeout": "",
+            "rdma_devices": "",
+            "is_cpu": True,
+            "error": None,
+        }
 
-    suite = _extract_suite(content, "register_cpu_ci")
-    if suite:
-        return suite, "ubuntu-latest", False, True, None
-
-    return (
+    return _err(
         None,
-        None,
-        False,
-        False,
-        (
-            f"No `register_cuda_ci()` or `register_cpu_ci()` found in `{full_path}`.\n\n"
-            f"This file may not be a registered CI test."
-        ),
+        f"No `register_cuda_ci(runner_config=...)` or `register_cpu_ci()` "
+        f"found in `{full_path}`. /rerun-test only supports tests registered "
+        f"via the new-style yml-driven API; nightly/weekly tests aren't "
+        f"dispatchable through this command.",
     )
 
 
@@ -685,8 +631,8 @@ def _resolve_test_spec(test_spec):
     """
     Resolve a single test spec into its components without dispatching.
 
-    Returns a dict with keys: spec, resolved_path, test_command, suite,
-    runner_label, use_deepep, is_cpu, error.
+    Returns a dict with keys: spec, test_command, mode, runs_on,
+    install_script, install_timeout, rdma_devices, error.
     """
     if "::" in test_spec:
         file_part, test_selector = test_spec.split("::", 1)
@@ -713,57 +659,61 @@ def _resolve_test_spec(test_spec):
             test_command = f"{resolved_path}::{test_selector}"
 
         print(
-            f"Resolved (multimodal): file={resolved_path}, selector={test_selector}, "
+            f"Resolved (multimodal_gen): file={resolved_path}, selector={test_selector}, "
             f"runner={runner_label}, command='{test_command}'"
         )
         return {
             "spec": test_spec,
             "test_command": test_command,
-            "suite": "multimodal",
-            "runner_label": runner_label,
-            "use_deepep": False,
-            "is_cpu": False,
-            "install_diffusion": True,
+            "mode": "multimodal_gen",
+            "runs_on": runner_label,
+            "install_script": "",
+            "install_timeout": "",
+            "rdma_devices": "",
             "error": None,
         }
 
-    suite, runner_label, use_deepep, is_cpu, err = detect_suite(resolved_path)
-    if err:
-        return {"spec": test_spec, "error": err}
+    info = detect_suite(resolved_path)
+    if info["error"]:
+        return {"spec": test_spec, "error": info["error"]}
 
     test_command = resolved_path
     if test_selector:
         test_command = f"{resolved_path} {test_selector}"
 
+    mode = "cpu" if info["is_cpu"] else "cuda"
     print(
         f"Resolved: file={resolved_path}, selector={test_selector}, "
-        f"suite={suite}, runner={runner_label}, deepep={use_deepep}, "
-        f"cpu={is_cpu}, command='{test_command}'"
+        f"suite={info['suite']}, mode={mode}, runs_on={info['runner_label']}, "
+        f"install={info['install_script']}, rdma={info['rdma_devices']}, "
+        f"command='{test_command}'"
     )
     return {
         "spec": test_spec,
         "test_command": test_command,
-        "suite": suite,
-        "runner_label": runner_label,
-        "use_deepep": use_deepep,
-        "is_cpu": is_cpu,
-        "install_diffusion": False,
+        "mode": mode,
+        "runs_on": info["runner_label"],
+        "install_script": info["install_script"],
+        "install_timeout": info["install_timeout"],
+        "rdma_devices": info["rdma_devices"],
         "error": None,
     }
 
 
 def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker=""):
     """
-    Dispatch a single workflow run for a batch of resolved test specs
-    that share the same (runner_label, use_deepep, is_cpu).
+    Dispatch a single workflow run for a batch of resolved test specs that
+    share the same dispatch shape (mode + runs_on + install_script +
+    install_timeout + rdma_devices).
 
     Returns a dict with keys: specs, success, test_commands, runner_label, run_url, error.
     """
     test_commands = [r["test_command"] for r in batch]
-    runner_label = batch[0]["runner_label"]
-    use_deepep = batch[0]["use_deepep"]
-    is_cpu = batch[0]["is_cpu"]
-    install_diffusion = batch[0].get("install_diffusion", False)
+    mode = batch[0]["mode"]
+    runs_on = batch[0]["runs_on"]
+    install_script = batch[0]["install_script"]
+    install_timeout = batch[0]["install_timeout"]
+    rdma_devices = batch[0]["rdma_devices"]
 
     # Join multiple commands with newlines for the workflow to iterate over
     combined_command = "\n".join(test_commands)
@@ -790,11 +740,12 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
 
         pr_head_sha = None
         inputs = {
+            "mode": mode,
             "test_command": combined_command,
-            "runner_label": runner_label,
-            "use_deepep": str(use_deepep).lower(),
-            "is_cpu": str(is_cpu).lower(),
-            "install_diffusion": str(install_diffusion).lower(),
+            "runs_on": runs_on or "",
+            "install_script": install_script,
+            "install_timeout": install_timeout or "20",
+            "rdma_devices": rdma_devices,
             "reply_comment_id": str(reply_comment_id) if reply_comment_id else "",
             "reply_marker": reply_marker,
         }
@@ -842,7 +793,8 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
             "specs": [r["spec"] for r in batch],
             "success": True,
             "test_commands": test_commands,
-            "runner_label": runner_label,
+            "mode": mode,
+            "runs_on": runs_on,
             "run_url": run_url,
             "reply_marker": reply_marker,
         }
@@ -892,7 +844,8 @@ def handle_rerun_test(
 ):
     """
     Handles the /rerun-test command. Resolves all test specs, groups them by
-    (runner_label, use_deepep, is_cpu), and dispatches one workflow per group.
+    dispatch shape (mode + runs_on + install_script + install_timeout +
+    rdma_devices), and dispatches one workflow per group.
     """
     if not skip_permission_check and not _check_rerun_test_permissions(
         gh_repo, pr, comment, user_perms, "rerun-test"
@@ -927,14 +880,15 @@ def handle_rerun_test(
         else:
             resolved.append(r)
 
-    # Phase 2: Group by (runner_label, use_deepep, is_cpu, install_diffusion)
+    # Phase 2: Group by dispatch shape.
     groups = {}
     for r in resolved:
         key = (
-            r["runner_label"],
-            r["use_deepep"],
-            r["is_cpu"],
-            r.get("install_diffusion", False),
+            r["mode"],
+            r["runs_on"],
+            r["install_script"],
+            r["install_timeout"],
+            r["rdma_devices"],
         )
         groups.setdefault(key, []).append(r)
 
@@ -965,12 +919,7 @@ def handle_rerun_test(
     lines = []
     for dr in dispatch_results:
         if dr["success"]:
-            install_diff = any(
-                r.get("install_diffusion", False)
-                for r in resolved
-                if r["spec"] in dr["specs"]
-            )
-            if install_diff:
+            if dr["mode"] == "multimodal_gen":
                 cmds = "\n".join(
                     f"python3 -m pytest {cmd} -x" for cmd in dr["test_commands"]
                 )
@@ -979,15 +928,16 @@ def handle_rerun_test(
                     f"cd test/ && python3 {cmd}" for cmd in dr["test_commands"]
                 )
             marker = dr.get("reply_marker", "")
+            label = dr["runs_on"] or dr["mode"]
             if dr.get("run_url"):
                 lines.append(
-                    f"🚀 `{dr['runner_label']}` ({len(dr['test_commands'])} test{'s' if len(dr['test_commands']) > 1 else ''}): "
+                    f"🚀 `{label}` ({len(dr['test_commands'])} test{'s' if len(dr['test_commands']) > 1 else ''}): "
                     f"⏳ [View workflow run]({dr['run_url']}) {marker}\n"
                     f"```\n{cmds}\n```"
                 )
             else:
                 lines.append(
-                    f"🚀 `{dr['runner_label']}` ({len(dr['test_commands'])} test{'s' if len(dr['test_commands']) > 1 else ''}): ⏳ {marker}\n"
+                    f"🚀 `{label}` ({len(dr['test_commands'])} test{'s' if len(dr['test_commands']) > 1 else ''}): ⏳ {marker}\n"
                     f"```\n{cmds}\n```\n"
                     f"⚠️ Could not retrieve workflow run URL. "
                     f"Check the [Actions tab](https://github.com/{gh_repo.full_name}/actions) for progress."

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -593,12 +593,12 @@ def _extract_suite(content, func_name):
 
 
 def _extract_runner_config(content):
-    """Pull `runner_config` from a new-style `register_cuda_ci(...)` call."""
-    args = re.search(r"^[^#\n]*register_cuda_ci\(([^)]*)\)", content, re.MULTILINE)
+    """Pull `runner_config` and the args string from a new-style `register_cuda_ci(...)` call."""
+    args = re.search(r"^[^#\n]*register_cuda_ci\s*\(([^)]*)\)", content, re.MULTILINE)
     if not args:
-        return None
+        return None, None
     m = re.search(r'runner_config\s*=\s*["\']([^"\']+)["\']', args.group(1))
-    return m.group(1) if m else None
+    return (m.group(1), args.group(1)) if m else (None, None)
 
 
 def detect_suite(file_path_from_test):
@@ -619,11 +619,12 @@ def detect_suite(file_path_from_test):
         content = f.read()
 
     # New style: runner_config="..." -> look up runs_on from runner_configs.yml.
-    rc = _extract_runner_config(content)
+    rc, args_str = _extract_runner_config(content)
     if rc:
-        cfg = _runner_configs.load().get(rc)
+        configs = _runner_configs.load()
+        cfg = configs.get(rc)
         if cfg is None:
-            known = ", ".join(f"`{k}`" for k in sorted(_runner_configs.load()))
+            known = ", ".join(f"`{k}`" for k in sorted(configs))
             return (
                 rc,
                 None,
@@ -641,11 +642,7 @@ def detect_suite(file_path_from_test):
         if runs_on == "$b200_runner":
             runs_on = _B200_DEFAULT_RUNNER
         # Stage is informational for telemetry/messages; not used for dispatch.
-        stage_m = re.search(
-            r'^[^#\n]*register_cuda_ci\([^)]*stage\s*=\s*["\']([^"\']+)["\']',
-            content,
-            re.MULTILINE,
-        )
+        stage_m = re.search(r'stage\s*=\s*["\']([^"\']+)["\']', args_str)
         suite = f"{stage_m.group(1)}-test-{rc}" if stage_m else rc
         use_deepep = cfg.get("install", _DEFAULT_INSTALL) != _DEFAULT_INSTALL
         return suite, runs_on, use_deepep, False, None

--- a/test/README.md
+++ b/test/README.md
@@ -66,12 +66,12 @@ Every CI-discovered test file must call a registration function at module level:
 ```python
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=80, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=80, stage="stage-b", runner_config="1-gpu-small")
 ```
 
-Parameters: `est_time` (seconds), `suite` (target suite), `nightly=True` (nightly-only), `disabled="reason"` (temporarily disable).
+Parameters: `est_time` (seconds), `stage` + `runner_config` (target stage and runner pool from `scripts/ci/runner_configs.yml`), `nightly=True` (nightly-only), `disabled="reason"` (temporarily disable).
 
-Keep `est_time` and `suite` as **literal values** — `run_suite.py` collects them by AST parsing.
+Keep `est_time`, `stage`, `runner_config` as **literal values** — `run_suite.py` collects them by AST parsing.
 
 JIT kernel files live outside `test/registered/` but still use registration:
 - Correctness tests: `python/sglang/jit_kernel/tests/test_*.py` → `stage-b-kernel-unit-1-gpu-large`

--- a/test/manual/4-gpu-models/test_qwen35_fp4_triton.py
+++ b/test/manual/4-gpu-models/test_qwen35_fp4_triton.py
@@ -1,7 +1,6 @@
 import unittest
 
 from sglang.test.accuracy_test_runner import AccuracyTestParams
-from sglang.test.ci.ci_register import register_cuda_ci
 
 # This eval harness applies the chat_template, which is critical for qwen3.5
 # to get good accuracy on gsm8k
@@ -10,8 +9,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     ModelLaunchSettings,
 )
-
-register_cuda_ci(est_time=720, stage="stage-c", runner_config="4-gpu-b200")
 
 QWEN35_FP4_MODEL = "nvidia/Qwen3.5-397B-A17B-NVFP4"
 ACC_THRESHOLDS = {QWEN35_FP4_MODEL: {"gsm8k": 0.95}}

--- a/test/manual/4-gpu-models/test_qwen35_fp4_triton.py
+++ b/test/manual/4-gpu-models/test_qwen35_fp4_triton.py
@@ -11,7 +11,7 @@ from sglang.test.test_utils import (
     ModelLaunchSettings,
 )
 
-register_cuda_ci(est_time=720, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=720, stage="stage-c", runner_config="4-gpu-b200")
 
 QWEN35_FP4_MODEL = "nvidia/Qwen3.5-397B-A17B-NVFP4"
 ACC_THRESHOLDS = {QWEN35_FP4_MODEL: {"gsm8k": 0.95}}

--- a/test/manual/4-gpu-models/test_qwen3_next_models.py
+++ b/test/manual/4-gpu-models/test_qwen3_next_models.py
@@ -1,12 +1,9 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
-
-register_cuda_ci(est_time=142, stage="stage-c", runner_config="4-gpu-h100")
 
 QWEN3_NEXT_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 

--- a/test/manual/4-gpu-models/test_qwen3_next_models.py
+++ b/test/manual/4-gpu-models/test_qwen3_next_models.py
@@ -6,7 +6,7 @@ from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
 from sglang.test.kits.prefix_cache_branching_kit import PrefixCacheBranchingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=142, suite="stage-c-test-4-gpu-h100")
+register_cuda_ci(est_time=142, stage="stage-c", runner_config="4-gpu-h100")
 
 QWEN3_NEXT_MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 

--- a/test/manual/8-gpu-models/test_deepseek_v3_basic.py
+++ b/test/manual/8-gpu-models/test_deepseek_v3_basic.py
@@ -2,7 +2,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.send_one import BenchArgs, send_one_prompt
 from sglang.test.test_utils import (
@@ -14,8 +13,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-
-register_cuda_ci(est_time=301, stage="stage-c", runner_config="8-gpu-h200")
 
 FULL_DEEPSEEK_V3_MODEL_PATH = "deepseek-ai/DeepSeek-V3-0324"
 

--- a/test/manual/8-gpu-models/test_deepseek_v3_basic.py
+++ b/test/manual/8-gpu-models/test_deepseek_v3_basic.py
@@ -15,7 +15,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=301, suite="stage-c-test-8-gpu-h200")
+register_cuda_ci(est_time=301, stage="stage-c", runner_config="8-gpu-h200")
 
 FULL_DEEPSEEK_V3_MODEL_PATH = "deepseek-ai/DeepSeek-V3-0324"
 

--- a/test/manual/8-gpu-models/test_dsa_models_basic.py
+++ b/test/manual/8-gpu-models/test_dsa_models_basic.py
@@ -14,7 +14,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=1047, suite="stage-c-test-8-gpu-h200")
+register_cuda_ci(est_time=1047, stage="stage-c", runner_config="8-gpu-h200")
 
 DEEPSEEK_V32_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2"
 GLM5_MODEL_PATH = "zai-org/GLM-5-FP8"

--- a/test/manual/8-gpu-models/test_dsa_models_basic.py
+++ b/test/manual/8-gpu-models/test_dsa_models_basic.py
@@ -2,7 +2,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.send_one import BenchArgs, send_one_prompt
 from sglang.test.test_utils import (
@@ -13,8 +12,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-
-register_cuda_ci(est_time=1047, stage="stage-c", runner_config="8-gpu-h200")
 
 DEEPSEEK_V32_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2"
 GLM5_MODEL_PATH = "zai-org/GLM-5-FP8"

--- a/test/manual/attention/test_fa3.py
+++ b/test/manual/attention/test_fa3.py
@@ -20,7 +20,7 @@ from sglang.test.test_utils import (
 
 # FlashAttention3 integration tests (requires SM 90+ / H100)
 # Multiple test classes: FA3, FA3+MLA, FA3+SpecDecode variants
-register_cuda_ci(est_time=551, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=551, stage="stage-b", runner_config="1-gpu-large")
 
 GSM_DATASET_PATH = None
 

--- a/test/manual/attention/test_fa3.py
+++ b/test/manual/attention/test_fa3.py
@@ -5,7 +5,6 @@ import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import get_device_sm, kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE3,
@@ -20,8 +19,6 @@ from sglang.test.test_utils import (
 
 # FlashAttention3 integration tests (requires SM 90+ / H100)
 # Multiple test classes: FA3, FA3+MLA, FA3+SpecDecode variants
-register_cuda_ci(est_time=551, stage="stage-b", runner_config="1-gpu-large")
-
 GSM_DATASET_PATH = None
 
 # In case of some machine lack internet connection, we can set OFFLINE_MODE to True.

--- a/test/manual/attention/test_local_attn.py
+++ b/test/manual/attention/test_local_attn.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
 )
 
 # Local attention with FA3 (requires SM 90+ / H100, tp=4)
-register_cuda_ci(est_time=217, suite="stage-c-test-4-gpu-h100")
+register_cuda_ci(est_time=217, stage="stage-c", runner_config="4-gpu-h100")
 
 
 @unittest.skipIf(get_device_sm() < 90, "Test requires CUDA SM 90 or higher")

--- a/test/manual/attention/test_local_attn.py
+++ b/test/manual/attention/test_local_attn.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import get_device_sm, kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST_LOCAL_ATTENTION,
@@ -15,10 +14,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
+
 # Local attention with FA3 (requires SM 90+ / H100, tp=4)
-register_cuda_ci(est_time=217, stage="stage-c", runner_config="4-gpu-h100")
-
-
 @unittest.skipIf(get_device_sm() < 90, "Test requires CUDA SM 90 or higher")
 class TestFlashAttention3LocalAttn(CustomTestCase):
     model = DEFAULT_MODEL_NAME_FOR_TEST_LOCAL_ATTENTION

--- a/test/manual/core/test_gpt_oss_1gpu.py
+++ b/test/manual/core/test_gpt_oss_1gpu.py
@@ -1,10 +1,6 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.gpt_oss_common import BaseTestGptOss
-
-register_cuda_ci(est_time=408, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=750, stage="stage-b", runner_config="1-gpu-small-amd-mi35x")
 
 
 class TestGptOss1Gpu(BaseTestGptOss):

--- a/test/manual/core/test_gpt_oss_1gpu.py
+++ b/test/manual/core/test_gpt_oss_1gpu.py
@@ -3,8 +3,8 @@ import unittest
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.gpt_oss_common import BaseTestGptOss
 
-register_cuda_ci(est_time=408, suite="stage-b-test-1-gpu-large")
-register_amd_ci(est_time=750, suite="stage-b-test-1-gpu-small-amd-mi35x")
+register_cuda_ci(est_time=408, stage="stage-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=750, stage="stage-b", runner_config="1-gpu-small-amd-mi35x")
 
 
 class TestGptOss1Gpu(BaseTestGptOss):

--- a/test/manual/distributed/test_dp_attention_large.py
+++ b/test/manual/distributed/test_dp_attention_large.py
@@ -22,8 +22,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=245, suite="stage-c-test-4-gpu-h100")
-register_amd_ci(est_time=350, suite="stage-c-test-4-gpu-amd")
+register_cuda_ci(est_time=245, stage="stage-c", runner_config="4-gpu-h100")
+register_amd_ci(est_time=350, stage="stage-c", runner_config="4-gpu-amd")
 
 
 @unittest.skipIf(

--- a/test/manual/distributed/test_dp_attention_large.py
+++ b/test/manual/distributed/test_dp_attention_large.py
@@ -5,7 +5,6 @@ import requests
 
 from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.ebnf_constrained_kit import EBNFConstrainedMixin
 from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
 from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
@@ -21,9 +20,6 @@ from sglang.test.test_utils import (
     is_in_amd_ci,
     popen_launch_server,
 )
-
-register_cuda_ci(est_time=245, stage="stage-c", runner_config="4-gpu-h100")
-register_amd_ci(est_time=350, stage="stage-c", runner_config="4-gpu-amd")
 
 
 @unittest.skipIf(

--- a/test/manual/eval/test_eval_accuracy_large.py
+++ b/test/manual/eval/test_eval_accuracy_large.py
@@ -6,7 +6,6 @@ python -m unittest test_eval_accuracy_large.TestEvalAccuracyLarge.test_mmlu
 import unittest
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import HumanEvalMixin, MGSMEnMixin, MMLUMixin
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -15,9 +14,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
-
-register_cuda_ci(est_time=496, stage="stage-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=420, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestEvalAccuracyLarge(CustomTestCase, MMLUMixin, HumanEvalMixin, MGSMEnMixin):

--- a/test/manual/eval/test_eval_accuracy_large.py
+++ b/test/manual/eval/test_eval_accuracy_large.py
@@ -16,8 +16,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=496, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=420, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=496, stage="stage-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=420, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestEvalAccuracyLarge(CustomTestCase, MMLUMixin, HumanEvalMixin, MGSMEnMixin):

--- a/test/manual/lora/test_lora_backend.py
+++ b/test/manual/lora/test_lora_backend.py
@@ -29,10 +29,11 @@ from sglang.test.lora_utils import (
 )
 from sglang.test.test_utils import CustomTestCase, is_in_ci
 
-register_cuda_ci(est_time=224, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=224, stage="stage-b", runner_config="1-gpu-small")
 register_amd_ci(
     est_time=200,
-    suite="stage-b-test-1-gpu-small-amd",
+    stage="stage-b",
+    runner_config="1-gpu-small-amd",
     disabled="see https://github.com/sgl-project/sglang/issues/13107",
 )
 

--- a/test/manual/lora/test_lora_backend.py
+++ b/test/manual/lora/test_lora_backend.py
@@ -17,7 +17,6 @@ import os
 import unittest
 from typing import List
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.lora_utils import (
     ALL_OTHER_LORA_MODELS,
     BACKENDS,
@@ -28,14 +27,6 @@ from sglang.test.lora_utils import (
     run_lora_test_one_by_one,
 )
 from sglang.test.test_utils import CustomTestCase, is_in_ci
-
-register_cuda_ci(est_time=224, stage="stage-b", runner_config="1-gpu-small")
-register_amd_ci(
-    est_time=200,
-    stage="stage-b",
-    runner_config="1-gpu-small-amd",
-    disabled="see https://github.com/sgl-project/sglang/issues/13107",
-)
 
 
 class TestLoRABackend(CustomTestCase):

--- a/test/manual/mla/test_mla.py
+++ b/test/manual/mla/test_mla.py
@@ -1,7 +1,6 @@
 import unittest
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import MGSMEnMixin
 from sglang.test.test_utils import (
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
@@ -11,11 +10,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
+
 # MLA attention test with MGSM evaluation
-register_cuda_ci(est_time=181, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=1100, stage="stage-b", runner_config="1-gpu-small-amd")
-
-
 class TestMLA(CustomTestCase, MGSMEnMixin):
     mgsm_en_score_threshold = 0.8
 

--- a/test/manual/mla/test_mla.py
+++ b/test/manual/mla/test_mla.py
@@ -12,8 +12,8 @@ from sglang.test.test_utils import (
 )
 
 # MLA attention test with MGSM evaluation
-register_cuda_ci(est_time=181, suite="stage-b-test-1-gpu-large")
-register_amd_ci(est_time=1100, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=181, stage="stage-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=1100, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestMLA(CustomTestCase, MGSMEnMixin):

--- a/test/manual/mla/test_mla_deepseek_v3.py
+++ b/test/manual/mla/test_mla_deepseek_v3.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_cuda, is_hip, kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -13,15 +12,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     is_in_ci,
     popen_launch_server,
-)
-
-# DeepSeek-V3 MLA tests with torch compile, FA3, and MTP speculative decoding
-register_cuda_ci(est_time=543, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(
-    est_time=221,
-    stage="stage-b",
-    runner_config="1-gpu-small-amd",
-    disabled="see https://github.com/sgl-project/sglang/issues/12574",
 )
 
 

--- a/test/manual/mla/test_mla_deepseek_v3.py
+++ b/test/manual/mla/test_mla_deepseek_v3.py
@@ -16,10 +16,11 @@ from sglang.test.test_utils import (
 )
 
 # DeepSeek-V3 MLA tests with torch compile, FA3, and MTP speculative decoding
-register_cuda_ci(est_time=543, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=543, stage="stage-b", runner_config="1-gpu-large")
 register_amd_ci(
     est_time=221,
-    suite="stage-b-test-1-gpu-small-amd",
+    stage="stage-b",
+    runner_config="1-gpu-small-amd",
     disabled="see https://github.com/sgl-project/sglang/issues/12574",
 )
 

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -5,7 +5,7 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=249, suite="stage-b-test-2-gpu-large")
+register_cuda_ci(est_time=249, stage="stage-b", runner_config="2-gpu-large")
 
 
 class TestNvidiaNemotronNanoV2BF16(GSM8KMixin, DefaultServerBase):

--- a/test/manual/models/test_nvidia_nemotron_nano_v2.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2.py
@@ -1,11 +1,8 @@
 import unittest
 
 from sglang.srt.utils import is_blackwell
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
-
-register_cuda_ci(est_time=249, stage="stage-b", runner_config="2-gpu-large")
 
 
 class TestNvidiaNemotronNanoV2BF16(GSM8KMixin, DefaultServerBase):

--- a/test/manual/models/test_nvidia_nemotron_nano_v2_vl.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2_vl.py
@@ -10,7 +10,7 @@ from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 # GSM8k + MMMU evaluation
 
 
-register_cuda_ci(est_time=256, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=256, stage="stage-b", runner_config="1-gpu-large")
 
 MODEL = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
 

--- a/test/manual/models/test_nvidia_nemotron_nano_v2_vl.py
+++ b/test/manual/models/test_nvidia_nemotron_nano_v2_vl.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.mmmu_vlm_kit import MMMUMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
@@ -9,8 +8,6 @@ from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
 # NVIDIA Nemotron Nano V2 VL model tests (CUDA only)
 # GSM8k + MMMU evaluation
 
-
-register_cuda_ci(est_time=256, stage="stage-b", runner_config="1-gpu-large")
 
 MODEL = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
 

--- a/test/manual/models/test_qwen_models.py
+++ b/test/manual/models/test_qwen_models.py
@@ -13,8 +13,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=108, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=130, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=108, stage="stage-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=130, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestQwen2(CustomTestCase):

--- a/test/manual/models/test_qwen_models.py
+++ b/test/manual/models/test_qwen_models.py
@@ -4,7 +4,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -12,9 +11,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
-
-register_cuda_ci(est_time=108, stage="stage-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=130, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestQwen2(CustomTestCase):

--- a/test/manual/openai_server/function_call/test_tool_choice.py
+++ b/test/manual/openai_server/function_call/test_tool_choice.py
@@ -14,16 +14,12 @@ import openai
 
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
 )
-
-register_cuda_ci(est_time=204, stage="stage-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=258, suite="stage-b-test-1-gpu-small-amd")
 
 
 class TestToolChoiceLlama32(CustomTestCase):

--- a/test/manual/perf/test_bench_one_batch_1gpu.py
+++ b/test/manual/perf/test_bench_one_batch_1gpu.py
@@ -16,8 +16,8 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=95, suite="stage-b-test-1-gpu-large")
-register_amd_ci(est_time=120, suite="stage-b-test-1-gpu-large-amd")
+register_cuda_ci(est_time=95, stage="stage-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=120, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 class TestBenchOneBatch1GPU(CustomTestCase):

--- a/test/manual/perf/test_bench_one_batch_1gpu.py
+++ b/test/manual/perf/test_bench_one_batch_1gpu.py
@@ -5,7 +5,6 @@ import unittest
 
 import numpy as np
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -15,9 +14,6 @@ from sglang.test.test_utils import (
     run_bench_one_batch,
     write_github_step_summary,
 )
-
-register_cuda_ci(est_time=95, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=120, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 class TestBenchOneBatch1GPU(CustomTestCase):

--- a/test/manual/prefill_only/test_cross_encoder_models.py
+++ b/test/manual/prefill_only/test_cross_encoder_models.py
@@ -4,15 +4,11 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.runners import TEST_RERANK_QUERY_DOCS, HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, is_in_ci
 
 # Cross encoder model tests
 
-
-register_cuda_ci(est_time=125, stage="stage-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=150, stage="stage-b", runner_config="1-gpu-small-amd")
 
 MODELS = [
     ("cross-encoder/ms-marco-MiniLM-L6-v2", 1, 1e-2),

--- a/test/manual/prefill_only/test_cross_encoder_models.py
+++ b/test/manual/prefill_only/test_cross_encoder_models.py
@@ -11,8 +11,8 @@ from sglang.test.test_utils import CustomTestCase, is_in_ci
 # Cross encoder model tests
 
 
-register_cuda_ci(est_time=125, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=150, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=125, stage="stage-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=150, stage="stage-b", runner_config="1-gpu-small-amd")
 
 MODELS = [
     ("cross-encoder/ms-marco-MiniLM-L6-v2", 1, 1e-2),

--- a/test/manual/prefill_only/test_encoder_embedding_models.py
+++ b/test/manual/prefill_only/test_encoder_embedding_models.py
@@ -29,7 +29,7 @@ from sglang.test.test_utils import CustomTestCase, get_similarities, is_in_ci
 # python -m unittest test_encoder_embedding_models.TestEncoderEmbeddingModels.test_prefill_logits
 
 
-register_cuda_ci(est_time=444, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=444, stage="stage-b", runner_config="1-gpu-small")
 
 MODELS = [("BAAI/bge-small-en", 1, 1e-5), ("BAAI/bge-m3", 1, 1e-5)]
 

--- a/test/manual/prefill_only/test_encoder_embedding_models.py
+++ b/test/manual/prefill_only/test_encoder_embedding_models.py
@@ -6,7 +6,6 @@ import unittest
 import torch
 from transformers import AutoConfig, AutoTokenizer
 
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.runners import DEFAULT_PROMPTS, HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, get_similarities, is_in_ci
 
@@ -28,8 +27,6 @@ from sglang.test.test_utils import CustomTestCase, get_similarities, is_in_ci
 
 # python -m unittest test_encoder_embedding_models.TestEncoderEmbeddingModels.test_prefill_logits
 
-
-register_cuda_ci(est_time=444, stage="stage-b", runner_config="1-gpu-small")
 
 MODELS = [("BAAI/bge-small-en", 1, 1e-5), ("BAAI/bge-m3", 1, 1e-5)]
 

--- a/test/manual/quant/test_autoround.py
+++ b/test/manual/quant/test_autoround.py
@@ -7,7 +7,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_AUTOROUND_MODEL_NAME_FOR_TEST,
@@ -16,8 +15,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
-
-register_cuda_ci(est_time=99, stage="stage-b", runner_config="1-gpu-large")
 
 
 class TestAutoRound(CustomTestCase):

--- a/test/manual/quant/test_autoround.py
+++ b/test/manual/quant/test_autoround.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=99, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=99, stage="stage-b", runner_config="1-gpu-large")
 
 
 class TestAutoRound(CustomTestCase):

--- a/test/manual/quant/test_deepseek_v32_fp4_4gpu.py
+++ b/test/manual/quant/test_deepseek_v32_fp4_4gpu.py
@@ -2,7 +2,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.send_one import BenchArgs, send_one_prompt
 from sglang.test.test_utils import (
@@ -12,8 +11,6 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
-
-register_cuda_ci(est_time=874, stage="stage-c", runner_config="4-gpu-b200")
 
 FULL_DEEPSEEK_V3_FP4_MODEL_PATH = "nvidia/DeepSeek-V3.2-NVFP4"
 SERVER_LAUNCH_TIMEOUT = 1200

--- a/test/manual/quant/test_deepseek_v32_fp4_4gpu.py
+++ b/test/manual/quant/test_deepseek_v32_fp4_4gpu.py
@@ -13,7 +13,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=874, suite="stage-c-test-4-gpu-b200")
+register_cuda_ci(est_time=874, stage="stage-c", runner_config="4-gpu-b200")
 
 FULL_DEEPSEEK_V3_FP4_MODEL_PATH = "nvidia/DeepSeek-V3.2-NVFP4"
 SERVER_LAUNCH_TIMEOUT = 1200

--- a/test/manual/quant/test_eval_fp8_accuracy.py
+++ b/test/manual/quant/test_eval_fp8_accuracy.py
@@ -14,8 +14,8 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=351, suite="stage-b-test-1-gpu-large")
-register_amd_ci(est_time=600, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=351, stage="stage-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=600, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestEvalFP8Accuracy(CustomTestCase):

--- a/test/manual/quant/test_eval_fp8_accuracy.py
+++ b/test/manual/quant/test_eval_fp8_accuracy.py
@@ -2,7 +2,6 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import is_hip, kill_process_tree
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_ACCURACY_TEST_FP8,
@@ -13,9 +12,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
-
-register_cuda_ci(est_time=351, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=600, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestEvalFP8Accuracy(CustomTestCase):

--- a/test/manual/quant/test_quantization.py
+++ b/test/manual/quant/test_quantization.py
@@ -4,7 +4,6 @@ import warnings
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
-from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_QUANT_TP1,
@@ -15,8 +14,6 @@ from sglang.test.test_utils import (
     write_github_step_summary,
     write_results_to_json,
 )
-
-register_cuda_ci(est_time=460, stage="stage-b", runner_config="1-gpu-large")
 
 MODEL_SCORE_THRESHOLDS = {
     # Baselines observed with gsm8k 5-shot concatenated format via chat API,

--- a/test/manual/quant/test_quantization.py
+++ b/test/manual/quant/test_quantization.py
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     write_results_to_json,
 )
 
-register_cuda_ci(est_time=460, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=460, stage="stage-b", runner_config="1-gpu-large")
 
 MODEL_SCORE_THRESHOLDS = {
     # Baselines observed with gsm8k 5-shot concatenated format via chat API,

--- a/test/manual/scheduler/test_no_chunked_prefill.py
+++ b/test/manual/scheduler/test_no_chunked_prefill.py
@@ -8,8 +8,8 @@ from sglang.test.test_utils import (
     run_mmlu_test,
 )
 
-register_cuda_ci(est_time=131, suite="stage-b-test-1-gpu-large")
-register_amd_ci(est_time=108, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=131, stage="stage-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=108, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestNoChunkedPrefill(CustomTestCase):

--- a/test/manual/scheduler/test_no_chunked_prefill.py
+++ b/test/manual/scheduler/test_no_chunked_prefill.py
@@ -1,15 +1,11 @@
 import unittest
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     CustomTestCase,
     run_bench_serving,
     run_mmlu_test,
 )
-
-register_cuda_ci(est_time=131, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=108, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestNoChunkedPrefill(CustomTestCase):

--- a/test/manual/scheduler/test_no_overlap_scheduler.py
+++ b/test/manual/scheduler/test_no_overlap_scheduler.py
@@ -9,8 +9,8 @@ import unittest
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase, run_mmlu_test
 
-register_cuda_ci(est_time=267, suite="stage-b-test-1-gpu-large")
-register_amd_ci(est_time=275, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=267, stage="stage-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=275, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestOverlapSchedule(CustomTestCase):

--- a/test/manual/scheduler/test_no_overlap_scheduler.py
+++ b/test/manual/scheduler/test_no_overlap_scheduler.py
@@ -6,11 +6,7 @@ python3 test_overlap_schedule.py
 
 import unittest
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase, run_mmlu_test
-
-register_cuda_ci(est_time=267, stage="stage-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=275, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 class TestOverlapSchedule(CustomTestCase):

--- a/test/manual/spec/eagle/test_eagle3_basic.py
+++ b/test/manual/spec/eagle/test_eagle3_basic.py
@@ -4,16 +4,12 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_hip
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.server_fixtures.eagle_fixture import EagleServerBase
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE3,
     DEFAULT_TARGET_MODEL_EAGLE3,
 )
-
-register_cuda_ci(est_time=88, stage="stage-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=50, stage="stage-b", runner_config="1-gpu-small")
 
 _is_hip = is_hip()
 

--- a/test/manual/spec/eagle/test_eagle3_basic.py
+++ b/test/manual/spec/eagle/test_eagle3_basic.py
@@ -12,8 +12,8 @@ from sglang.test.test_utils import (
     DEFAULT_TARGET_MODEL_EAGLE3,
 )
 
-register_cuda_ci(est_time=88, suite="stage-b-test-1-gpu-small")
-register_amd_ci(est_time=50, suite="stage-b-test-1-gpu-small")
+register_cuda_ci(est_time=88, stage="stage-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=50, stage="stage-b", runner_config="1-gpu-small")
 
 _is_hip = is_hip()
 

--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_megamoe_b200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_megamoe_b200.py
@@ -21,7 +21,7 @@ from sglang.test.test_utils import (
     try_cached_model,
 )
 
-register_cuda_ci(est_time=900, suite="stage-c-test-dsv4-4-gpu-b200")
+register_cuda_ci(est_time=900, stage="stage-c", runner_config="dsv4-4-gpu-b200")
 
 MODEL = "deepseek-ai/DeepSeek-V4-Flash"
 SERVER_LAUNCH_TIMEOUT = 3600

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -14,7 +14,7 @@ from sglang.srt.managers.schedule_batch import FINISH_ABORT  # noqa: E402
 from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=5, stage="stage-a", runner_config="1-gpu-small")
+register_cuda_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small")
 
 
 class TestDisaggregationPriorityQueueing(unittest.TestCase):

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -12,9 +12,9 @@ from sglang.srt.disaggregation.decode import (  # noqa: E402
 from sglang.srt.disaggregation.utils import DisaggregationMode  # noqa: E402
 from sglang.srt.managers.schedule_batch import FINISH_ABORT  # noqa: E402
 from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+register_cuda_ci(est_time=5, stage="stage-a", runner_config="1-gpu-small")
 
 
 class TestDisaggregationPriorityQueueing(unittest.TestCase):

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -12,9 +12,9 @@ from sglang.srt.disaggregation.decode import (  # noqa: E402
 from sglang.srt.disaggregation.utils import DisaggregationMode  # noqa: E402
 from sglang.srt.managers.schedule_batch import FINISH_ABORT  # noqa: E402
 from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cuda_ci(est_time=5, stage="stage-a", runner_config="1-gpu-small")
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
 class TestDisaggregationPriorityQueueing(unittest.TestCase):


### PR DESCRIPTION
## Summary

Make `runner_configs.yml` the single source of truth for `/rerun-test` (matches the main PR test pipeline) and refactor `rerun-test.yml` to consume it directly. Drop the hardcoded `CUDA_SUITE_TO_RUNNER` stage table and the bespoke `use_deepep` / `install_diffusion` flag soup.

## Changes

**`slash_command_handler.py`**
- `detect_suite` resolves `runs_on`, `install_script`, `install_timeout`, `rdma_devices` from `runner_configs.yml` for new-style `register_cuda_ci(stage=..., runner_config=...)`
- `register_cpu_ci(...)` routes to the CPU job (no yml lookup needed)
- Drop `CUDA_SUITE_TO_RUNNER`, `DEEPEP_SUITES`, `_LEGACY_RDMA_DEVICES`, `_extract_suite` legacy fallbacks — legacy `suite="..."` is no longer dispatchable via `/rerun-test`
- Resolve `$b200_runner` sentinel to `4-gpu-b200` (rerun-test never builds sgl-kernel, always non-kernel pool)

**`rerun-test.yml`**
- Split into three standalone jobs gated by a `mode` input: `cuda` / `multimodal_gen` / `cpu`
- CUDA job takes `runs_on` / `install_script` / `install_timeout` / `rdma_devices` directly — no more `use_deepep` / `install_diffusion` flag mux
- Fixes previously-broken paths:
  - dsv4 b200 now runs `ci_install_dsv4_dep.sh` (was incorrectly hitting `ci_install_deepep.sh`)
  - 8-gpu-h20 now exports `SGLANG_CI_RDMA_ALL_DEVICES=mlx5_1,mlx5_2,mlx5_3,mlx5_4`
  - dsv4 install honors its 30-minute yml timeout (was hardcoded to 20)

**Test registrations**
- Migrate 27 `test/manual/*` + 1 `test/registered/dsv4/*` callers from `suite="stage-..."` to `stage=..., runner_config=...`
- Remove dead `register_*_ci(...)` calls from `test/manual/` (run_suite.py only scans `test/registered/` — these were no-ops)
- Move `test_priority_scheduling_disaggregation.py` from `stage-a` GPU to `stage-a-test-cpu` (pure mock-based unit test, no CUDA needed)
- Update `test/README.md` example to the new form

**`pr-states.yml`**
- Drop misleading "use `/rerun-failed-ci` to dispatch" suggestion for stale-push runs — `/rerun-failed-ci` can't help when there's no run for the head SHA












<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->[Run #25941090953](https://github.com/sgl-project/sglang/actions/runs/25941090953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->[Run #25941090904](https://github.com/sgl-project/sglang/actions/runs/25941090904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
