### PR TITLE
fix: fix deepseek v4 CP  error

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -388,6 +388,7 @@ class MQALayer(nn.Module):
             kv = qkv_a[..., self.q_lora_rank :]
         else:
             kv, _ = self.wkv(x)
+        kv = kv.contiguous()
         fused_norm_rope_inplace(
             kv,
             self.kv_norm.weight.data,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When I ran this command:
```
NCCL_IB_HCA=mlx5_ NCCL_IB_DISABLE=0 NCCL_SOCKET_IFNAME=eth0 NCCL_IB_GID_INDEX=3  SGLANG_DSV4_FP4_EXPERTS=0 SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 GLOO_SOCKET_IFNAME=eth0 \
sglang serve \
  --trust-remote-code \
  --model-path /data00/models/DeepSeek-V4-Flash-FP8 \
  --tp 8 \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.8 \
  --max-running-requests 128 \
  --enable-nsa-prefill-context-parallel \
  --nsa-prefill-cp-mode round-robin-split \
  --mem-fraction-static 0.8 \
  --max-running-requests 128 \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --disable-radix-cache \
  --host 0.0.0.0 \
  --port 30000 \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-ib-device mlx5_1,mlx5_2,mlx5_3,mlx5_4 \
```
an error occurred:
```
[2026-05-15 10:02:51 ATTN_CP1 TP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 4035, in run_scheduler_process
    scheduler.run_event_loop()
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 1534, in run_event_loop
    dispatch_event_loop(self)
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 3911, in dispatch_event_loop
    scheduler.event_loop_overlap_disagg_prefill()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/disaggregation/prefill.py", line 437, in event_loop_overlap_disagg_prefill
    batch_result = self.run_batch(batch)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 3039, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/managers/tp_worker.py", line 472, in forward_batch_generation
    out = self.model_runner.forward(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/model_executor/model_runner.py", line 3323, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/model_executor/model_runner.py", line 3451, in _forward_raw
    ret, can_run_graph = self.forward_extend(
                         ^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/model_executor/model_runner.py", line 3233, in forward_extend
    ret = self.model.forward(
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/models/deepseek_v4.py", line 1096, in forward
    hidden_states = self.model.forward(
                    ^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/models/deepseek_v4.py", line 981, in forward
    hidden_states = layer(
                    ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/models/deepseek_v4.py", line 799, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/models/deepseek_v4.py", line 555, in forward
    q, kv = self._forward_prepare(
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/models/deepseek_v4.py", line 489, in _forward_prepare
    kv = self._compute_kv_bf16(x, positions, qkv_a=qkv_a)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/models/deepseek_v4.py", line 398, in _compute_kv_bf16
    fused_norm_rope_inplace(
  File "/root/sglang/python/sglang/jit_kernel/deepseek_v4.py", line 629, in fused_norm_rope_inplace
    module.forward(
  File "python/tvm_ffi/cython/function.pxi", line 929, in tvm_ffi.core.Function.__call__
tvm.error.InternalError: Tensor match failed for Tensor<1024, 512>[strides=<1536, 1>, dtype=bfloat16, device=cuda:1] at /root/sglang/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope.cuh:192
- Root cause: Tensor is not contiguous as expected
```

I suspect this is caused by the qkv_a split operation at line 388 of `python/sglang/srt/models/deepseek_v4.py`.
```
        if qkv_a is not None:
            kv = qkv_a[..., self.q_lora_rank :]
        else:
            kv, _ = self.wkv(x)
```
## Modifications

Added an explicit call to `contiguous()`.
## Accuracy Tests

```
curl -X POST http://127.0.0.1:30000/v1/chat/completions -H "Content-Type: application/json" -d '{
    "model": "/data/models/DeepSeek-V4-Pro/",
    "messages": [
        {
            "role": "user",
            "content": "介绍下昆明这个城市"
        }
    ],
    "max_tokens": 1000,
    "temperature": 0.7
}'
{"id":"5cb62b46dd9748d9a041eed598902017","object":"chat.completion","created":1778846794,"model":"/data/models/DeepSeek-V4-Pro/","choices":[{"index":0,"message":{"role":"assistant","content":"好的，用户想了解昆明这个城市。这是一个比较基础但
开放的问题，需要提供一个全面、有重点的介绍。昆明是云南省会，以“春城”闻名，核心特
色应该是气候、旅游和民族文化。\n\n可以从几个主要维度来组织回复：首先是气候和“春
城”称号，这是最突出的标签。然后是自然风光和著名景点，比如石林、滇池。接着是人文
历史和少数民族风情，云南是多民族的省份，昆明是交汇点。美食也是一个很重要的吸引力
，过桥米线和野生菌火锅不能不提。最后可以提一下现代发展和作为门户枢纽的地位，让介
绍更有深度。\n\n回复结构可以先用一句话概括昆明的核心魅力，然后分板块展开，每个板
块用加粗标题突出，最后总结一下适合什么样的人群来访。语言要保持流畅、信息准确，避
免过于学术或冗长。</think>昆明，云南省会，常被称作“春城”，是一座融合了自然风光、
民族风情与闲适生活的城市。它最核心的魅力在于**“四季如春”的气候**——年平均气温约15
℃，冬无严寒、夏无酷暑，鲜花常年盛开，这也造就了它独特的慢节奏生活气息。\n\n以下
是昆明的几个关键侧面：\n\n### 1. 气候与自然风光\n- **“春城”之名**：名副其实。夏
季平均气温在20℃左右，是国内著名的避暑胜地；冬季阳光充足，白天温暖，很少低于0℃，
也是北方老人冬季旅居的热门目的地。\n- **滇池**：云南第一大淡水湖泊，被誉为昆明的
“母亲湖”。环滇池骑行、在海梗公园喂海鸥（冬季特有）、登上西山俯瞰滇池全景，是最经
典的游览线路。\n- **石林**：世界喀斯特地貌精华，距昆明市区约1.5小时车程。奇特的
石头森林景观，是世界遗产和国家地质公园的代表。\n- **翠湖公园**：市中心最具代表性
的公园。冬季有成群的西伯利亚红嘴殴越冬，市民喂海鸥的景象是其独特风景线；夏季则是
荷花盛开、市民休闲娱乐的中心。\n\n###2. 人文历史与多元民族\n- **云南陆军讲武学堂
旧址**：中国近代三大军校之一，培养了朱德、叶剑英等将领，是中国近代军事史上的一个
重要坐标。\n- **云南大学**：百年名校，校园古朴典雅，秋天的银杏大道是其著名景观。\n- **金马碧鸡坊**：昆明的象征性地标，夜晚灯光璀璨，周边是繁华的商业步行区和美食
聚集地。\n- **民族村**：集中展示了云南25个少数民族的风情、建筑与歌舞表演，是快速
感知云南多元文化的窗口。昆明本身就是多民族聚居的城市，彝族、白族、回族等少数民族
和谐相处。\n\n###3. 美食与休闲生活\n- **过桥米线**：昆明的味蕾名片。滚烫的鸡汤、
丰富的配菜（生肉片、蔬菜、鹌鹑蛋等）加上米线，自己动手烫熟，仪式感和风味俱佳。\n- **野生菌火锅**：夏季至秋季是云南野生菌丰收时节。松茸、牛肝菌、鸡枞菌等鲜美无比
  但务必选择正规餐厅食用，确保安全。\n- **小吃丰富**：烧饵块、烤豆腐、木瓜水、凉
  水果（辣椒拌草莓、拌菠萝）、鲜花饼等都是当地人日常喜爱的小吃。\n- **斗南花卉市
  **：亚洲最大的鲜花交易市场。这里的鲜花便宜到你难以置信（几十块钱能买到一大捧玫
  、百合等），夜晚更是繁忙的交易时段，是爱花人士的天堂。\n\n###4. 现代与发展\n- **西南门户枢纽**：昆明是国家面向东南亚、南亚的国际门户城市，长水机场是国内重要的
  空枢纽，高铁网络发达，前往大理、丽江、西双版纳等地极为便利。\n- **城市建设**：
  年来发展迅速，新区（如呈贡新区）高楼林立，地铁线路不断完善，老城区则保留着浓厚
  市井烟火气和悠闲氛围。\n\n### 总结\n昆明是一座**“被阳光眷顾的城市”**。它不像北
  广深那般高压繁忙，也不似丽江大理那般过于文艺商业化。它有属于自己的节奏：阳光灿
  的午后，在翠湖边喝茶喂海鸥；夜晚在夜市里品尝地道小吃；周末开车去郊区的湿地公园
  营。它更像是**云南之旅的理想起点或中转站**，也是许多人向往的**养老休闲目的地**
  \n\n**一句话形容昆明：**\n“这里四季都是春天，花开不败，阳光正好，适合发呆，也
  合重新爱上生活的模样。”\n\n如果你是游客，建议安排2-3天，感受它的气候、吃一碗正
  过桥米线、逛一次斗南花卉市场、在翠湖边晒晒太阳。如果是考虑定居或旅行，它一定是
  内最舒适","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null}],"usage":{"prompt_tokens":9,"total_tokens":1009,"completion_tokens":1000,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->