### PR TITLE
amd/deepseek_v4: drop is_v4_compressed short-circuit so V4 uses SWAChunkCache

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_radix.py
@@ -128,6 +128,14 @@ def _copy_metadata(
 
 
 def _create_flashmla_metadata():
+    # flash_mla is CUDA-only. On HIP the radix backend uses the tilelang /
+    # triton flashmla shim (SGLANG_HACK_FLASHMLA_BACKEND), which ignores the
+    # returned tile_scheduler_metadata, so returning None here is safe and
+    # avoids forcing a CUDA-only dependency on ROCm.
+    from sglang.srt.utils import is_hip
+
+    if is_hip():
+        return None
     import flash_mla
 
     return flash_mla.get_mla_metadata()[0]

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -866,10 +866,7 @@ class Scheduler(
         )
 
         if effective_chunked_prefill_size is not None and self.disable_radix_cache:
-            is_v4_compressed = getattr(
-                self.model_config, "is_swa_with_compressed_attention", False
-            )
-            if not self.is_hybrid_swa or is_v4_compressed:
+            if not self.is_hybrid_swa:
                 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 
                 self.tree_cache = ChunkCache(params)

--- a/python/sglang/srt/mem_cache/base_swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/base_swa_memory_pool.py
@@ -1,0 +1,33 @@
+import abc
+from typing import List, Tuple
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class BaseSWAKVPool(KVCache):
+    """ABC for SWA-like KV pools.
+
+    Subclasses expose a `swa_kv_pool` sub-pool plus a full -> swa index
+    mapping. Used by `SWATokenToKVPoolAllocator` and the disagg paths to
+    handle SWA state separately from the full KV state.
+    """
+
+    swa_kv_pool: KVCache
+
+    @abc.abstractmethod
+    def register_mapping(self, full_to_swa_index_mapping: torch.Tensor) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def set_swa_loc(self, loc: torch.Tensor) -> None:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_state_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseekv4_memory_pool.py
@@ -17,6 +17,7 @@ from sglang.srt.mem_cache.compress_state import (
     DeepSeekV4CompressState,
     KVAndScore,
 )
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import ceil_div
@@ -404,7 +405,7 @@ class DeepSeekV4LayerItem(NamedTuple):
     compress_kv_pool: Optional[DeepSeekV4SingleKVPool] = None
 
 
-class DeepSeekV4TokenToKVPool(KVCache):
+class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     def __init__(
         self,
@@ -527,6 +528,11 @@ class DeepSeekV4TokenToKVPool(KVCache):
 
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
+
+    def set_swa_loc(self, loc: torch.Tensor) -> None:
+        # No-op: DSv4 caches its own SWA loc via _should_cache_swa + cached_loc
+        # in set_swa_key_buffer_radix_fused; we ignore main's precomputed loc.
+        pass
 
     def get_ring_size(self, compress_ratio: int) -> int:
         server_args = get_global_server_args()

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -9,6 +9,7 @@ from sglang.srt.mem_cache.allocator import (
     PagedTokenToKVPoolAllocator,
     TokenToKVPoolAllocator,
 )
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVCache, MHATokenToKVPool
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
 from sglang.srt.utils import is_npu
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 GB = 1024 * 1024 * 1024
 
 
-class SWAKVPool(KVCache):
+class SWAKVPool(BaseSWAKVPool):
     """KV cache with separate pools for full and SWA attention layers."""
 
     def __init__(
@@ -253,29 +254,32 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         page_size: int,
         dtype: torch.dtype,
         device: str,
-        kvcache: SWAKVPool,
+        kvcache: BaseSWAKVPool,
         need_sort: bool,
     ):
-        assert isinstance(kvcache, SWAKVPool)
+        assert isinstance(kvcache, BaseSWAKVPool)
         self._size_full = size
         self._size_swa = size_swa
         self.dtype = dtype
         self.device = device
         self.page_size = page_size
 
+        full_kv_pool = getattr(kvcache, "full_kv_pool", None)
+        swa_kv_pool = getattr(kvcache, "swa_kv_pool", None)
+
         if page_size == 1:
             self.full_attn_allocator = TokenToKVPoolAllocator(
                 size,
                 dtype,
                 device,
-                kvcache.full_kv_pool,
+                full_kv_pool,
                 need_sort,
             )
             self.swa_attn_allocator = TokenToKVPoolAllocator(
                 size_swa,
                 dtype,
                 device,
-                kvcache.swa_kv_pool,
+                swa_kv_pool,
                 need_sort,
             )
         else:
@@ -288,7 +292,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 page_size,
                 dtype,
                 device,
-                kvcache.full_kv_pool,
+                full_kv_pool,
                 need_sort,
             )
             self.swa_attn_allocator = PagedTokenToKVPoolAllocatorClass(
@@ -296,7 +300,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 page_size,
                 dtype,
                 device,
-                kvcache.swa_kv_pool,
+                swa_kv_pool,
                 need_sort,
             )
         # Note: append one more item of value -1 in the end so -1 maps to -1.

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -651,19 +651,10 @@ class ModelRunnerKVCacheMixin:
                         need_sort=need_sort,
                     )
             else:
-                if self.is_hybrid_swa and not is_v4_model:
+                if self.is_hybrid_swa:
                     self.token_to_kv_pool_allocator = SWATokenToKVPoolAllocator(
                         self.full_max_total_num_tokens,
                         self.swa_max_total_num_tokens,
-                        page_size=self.page_size,
-                        dtype=self.kv_cache_dtype,
-                        device=self.device,
-                        kvcache=self.token_to_kv_pool,
-                        need_sort=need_sort,
-                    )
-                elif is_v4_model:
-                    self.token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
-                        self.max_total_num_tokens,
                         page_size=self.page_size,
                         dtype=self.kv_cache_dtype,
                         device=self.device,

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -111,6 +111,22 @@ try:
         model_type = "deepseek_v32"
 
     _CONFIG_REGISTRY["deepseek_v32"] = _DeepseekV32ConfigAlias
+
+    class _DeepseekV4ConfigAlias(_HFDeepseekV3Config):
+        model_type = "deepseek_v4"
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            for key in (
+                "rope_theta", "compress_rope_theta", "window_size",
+                "qk_nope_head_dim", "v_head_dim", "o_lora_rank",
+                "o_groups", "n_hash_layers", "hc_mult",
+                "hc_sinkhorn_iters", "hc_eps", "expert_dtype",
+            ):
+                if key in kwargs and not hasattr(self, key):
+                    setattr(self, key, kwargs[key])
+
+    _CONFIG_REGISTRY["deepseek_v4"] = _DeepseekV4ConfigAlias
 except ImportError:
     pass
 


### PR DESCRIPTION
## Summary

When sglang is launched with both `--disable-radix-cache` **and** `SGLANG_OPT_DPSK_V4_RADIX=1`, the scheduler crashes every TP rank on the first incoming request with:

```
AttributeError: 'ChunkCache' object has no attribute 'sliding_window_size'
  at schedule_policy.py:541 in _swa_budget_for_req
```

## Root cause

The bug requires two PRs to collide:

1. PR #23787 (`amd/deepseek_v4 integration 0426`) introduced an extra clause in `scheduler.py` that routes V4 compressed runs back to plain `ChunkCache` even when `is_hybrid_swa` is True:

   ```python
   is_v4_compressed = getattr(self.model_config, "is_swa_with_compressed_attention", False)
   if not self.is_hybrid_swa or is_v4_compressed:
       self.tree_cache = ChunkCache(params)
   else:
       self.tree_cache = SWAChunkCache(params)
   ```

   At the time this clause was added, no V4 model was ever marked `is_hybrid_swa=True`, so the `or is_v4_compressed` branch was dead code — its inclusion was a no-op.

2. PR #25164 (22/N) enabled `SGLANG_OPT_DPSK_V4_RADIX=1`, which marks V4 as a hybrid SWA model. With `is_hybrid_swa=True`, the `or is_v4_compressed` branch first becomes reachable, and it now redirects V4 compressed runs to plain `ChunkCache` — which does not carry a `sliding_window_size`, while the rest of the scheduler (`_swa_budget_for_req`, `maybe_evict_swa`, `_evict_swa`) continues to walk the SWA path and dereferences that attribute.

Upstream `main` does not have the `is_v4_compressed` clause; this PR aligns `amd/deepseek_v4` with the main-line behavior.

## Change

Remove the `is_v4_compressed` clause and the dead local:

```diff
 if effective_chunked_prefill_size is not None and self.disable_radix_cache:
-    is_v4_compressed = getattr(
-        self.model_config, "is_swa_with_compressed_attention", False
-    )
-    if not self.is_hybrid_swa or is_v4_compressed:
+    if not self.is_hybrid_swa:
         from sglang.srt.mem_cache.chunk_cache import ChunkCache
         self.tree_cache = ChunkCache(params)
     else:
         from sglang.srt.mem_cache.chunk_cache import SWAChunkCache
         self.tree_cache = SWAChunkCache(params)
```

After the change, V4 compressed runs with `--disable-radix-cache + SGLANG_OPT_DPSK_V4_RADIX=1` use `SWAChunkCache` like every other hybrid SWA model. `SWAChunkCache` is a subclass of `ChunkCache` that adds `sliding_window_size`; the V4 SWA budget / eviction paths are then reached with a tree_cache that already exposes the attribute, with no schedule_policy.py change needed.

## Behavior surface

The only config whose `tree_cache` selection changes is `is_hybrid_swa=True AND is_v4_compressed=True`. All other combinations are unaffected:

| `is_hybrid_swa` | `is_v4_compressed` | before | after |
|---|---|---|---|
| False | False | ChunkCache | ChunkCache |
| False | True | (unreachable today) | (unreachable today) |
| True | False | SWAChunkCache | SWAChunkCache |
| **True** | **True** | **ChunkCache (crashes)** | **SWAChunkCache (works)** |

A repo-wide grep finds zero `isinstance(..., ChunkCache)` checks that would be sensitive to the substitution.

## Reproduction

Branch `bug/dsv4-chunkcache-22n-radix1-0515` is a minimal repro:

* Code: 22/N (`de1aebe50`) + the flash_mla HIP guard (so ROCm boots).
* `repro/run_dsv4.sh` is the launch script with `SGLANG_OPT_DPSK_V4_RADIX=1 + --disable-radix-cache`.

Link: https://github.com/XinyuJiangCMU/sglang/tree/bug/dsv4-chunkcache-22n-radix1-0515

The `repro/run_dsv4.sh` commit message has step-by-step instructions; in short, after `bash repro/run_dsv4.sh` reaches `Application startup complete`, any `/v1/completions` request crashes every TP rank on `schedule_policy.py:541`.

## Validation (this PR's branch)

On 8x MI350X (ROCm 7.2, rocm/sgl-dev:rocm720-mi35x-721f045-20260513-DSv4):

* CUDA graph capture completes cleanly
* `Application startup complete` reached, server stable
* 25+ `/v1/completions` requests across single-stream, multi-round sequential, longer prompt (174 tokens), different sampling params, stop tokens, and streaming SSE — all returned correct output, zero `Scheduler hit / AttributeError / Traceback / Aborted` in the server log
* `sglang.bench_one_batch_server --batch-size 1 --input-len 128 --output-len 128` completes with TTFT 2.61s, decode 46.8 tok/s

## Test plan

- [x] Server reaches ready under the bug-triggering config (`SGLANG_OPT_DPSK_V4_RADIX=1` + `--disable-radix-cache`)
- [x] Sanity request succeeds against the same server (was the original crash signature)
- [x] Sequential 10-request and multi-round smoke pass with zero exceptions
- [x] Streaming SSE works
- [x] No `isinstance(..., ChunkCache)` regressions across the repo

Co-authored-by: Zhiyao Jiang <jessicajiang324@gmail.com>

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->