### PR TITLE
Fix missing idle-batch handling in prepare_mlp_sync_batch_raw

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -147,7 +147,11 @@ def prepare_mlp_sync_batch_raw(
     offload_tags: set[str],
 ):
     # Check if other DP workers have running batches
-    if local_batch is None or local_batch.forward_mode.is_prebuilt():
+    if (
+        local_batch is None
+        or local_batch.forward_mode.is_prebuilt()
+        or local_batch.forward_mode.is_idle()
+    ):
         num_tokens = 0
         num_tokens_for_logprob = 0
     elif local_batch.forward_mode.is_decode():


### PR DESCRIPTION
## Summary

- Fix deadlock in DP attention + PD disaggregation decode mode caused by idle batch not being handled in `prepare_mlp_sync_batch_raw()`
- One-line fix: add `local_batch.forward_mode.is_idle()` check to the existing condition

## Problem

In DP=16 disagg decode, all 16 DP ranks must participate in `all_gather` inside `prepare_mlp_sync_batch_raw()`. When a rank has no decode work, it holds a `ForwardMode.IDLE` batch. The existing condition only checks for `None` and `is_prebuilt()`:

```python
if local_batch is None or local_batch.forward_mode.is_prebuilt():
    num_tokens = 0
```

The idle batch doesn't match either condition, so it falls through to the extend path which iterates over `extend_logprob_start_lens` — a `None` field on idle batches. This crashes the rank with `TypeError: 'NoneType' object is not iterable`, and since that rank never completes its `all_gather`, all other 15 ranks deadlock waiting.

## Fix

```python
if local_batch is None or local_batch.forward_mode.is_prebuilt() or local_batch.forward_mode.is_idle():
    num_tokens = 0
```

This lets idle batches take the `num_tokens = 0` path and correctly participate in the collective operation.

## Motivation

Required for running DeepSeek-V4 with `--enable-dp-attention --dp 16 --disaggregation-mode decode` on multi-node setups. Without this fix, the decode cluster deadlocks whenever any DP rank is temporarily idle.

## Test plan

- [x] Tested on 2-node H200 cluster with DeepSeek-V4-Pro-FP8, 2P2D (2 prefill + 2 decode nodes), DP=16, nixl LIBFABRIC backend
- [x] Tested same setup with mooncake EFA backend
- [x] Verified 200/200 requests complete at rates 0.7-1.0 req/s with 14K input tokens
- [x] Previously deadlocked consistently without this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26383054258](https://github.com/sgl-project/sglang/actions/runs/26383054258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26383054205](https://github.com/sgl-project/sglang/actions/runs/26383054205)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->