### PR TITLE
Fix Mistral Large 3 nightly test

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4_moe.py
@@ -311,10 +311,10 @@ class CompressedTensorsW4A4Nvfp4MoE(CompressedTensorsMoEScheme):
             router_logits = topk_output.router_logits
             topk_config = topk_output.topk_config
 
-            # Quantize input hidden states using fp4_quantize
+            # global_scale must be shape [1] (strict in cute-dsl backend).
             hs_fp4_bytes, hs_sf_bytes = fp4_quantize(
                 x,
-                layer.w13_input_scale_quant,
+                layer.w13_input_scale_quant[:1],
                 self.group_size,  # sf_vec_size
                 False,  # use_ue8m0
                 False,  # is_sf_swizzled_layout


### PR DESCRIPTION
`python /sgl-workspace/sglang/test/registered/8-gpu-models/test_mistral_large3.py`

```

============================================================
Mistral-Large-3 Results Summary
Dataset: gsm8k
Baseline: 0.85
============================================================

Model 1: mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4
  Performance: PASS, output: 3773.9 tok/s
  Accuracy: PASS
  Score: 0.957

============================================================
OVERALL: ALL TESTS PASSED
============================================================

.
----------------------------------------------------------------------
Ran 1 test in 2366.479s

OK
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->