### PR TITLE
[HiSparse] Fix DeepSeek V4 multi-step EAGLE KV-slot mapping

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
     perl \
     patchelf \
     ccache \
-    git-lfs \
+    git \
     # MPI and NUMA
     libopenmpi-dev \
     libnuma1 \
@@ -139,8 +139,8 @@ RUN mkdir -p /tmp/gdrcopy && cd /tmp \
         https://${GITHUB_ARTIFACTORY}/NVIDIA/gdrcopy/archive/refs/tags/v${GDRCOPY_VERSION}.tar.gz \
     && tar -xzf v${GDRCOPY_VERSION}.tar.gz && rm v${GDRCOPY_VERSION}.tar.gz \
     && cd gdrcopy-${GDRCOPY_VERSION}/packages \
-    && CUDA=/usr/local/cuda ./build-deb-packages.sh \
-    && dpkg -i gdrdrv-dkms_*.deb libgdrapi_*.deb gdrcopy-tests_*.deb gdrcopy_*.deb \
+    && CUDA=/usr/local/cuda ./build-deb-packages.sh -t \
+    && dpkg -i gdrdrv-dkms_*.deb libgdrapi_*.deb \
     && cd / && rm -rf /tmp/gdrcopy
 
 # Fix DeepEP IBGDA symlink

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/hisparse_transfer.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/hisparse_transfer.cuh
@@ -18,24 +18,25 @@ inline constexpr uint32_t kBlockQuota = 4;
 
 #define OFFLOAD_KERNEL __global__ __launch_bounds__(kBlockSize, 1)
 
-struct OffloadParams {
-  void** gpu_caches;
-  void** cpu_caches;
+struct IOParams {
+  void* gpu_cache;
+  void* cpu_cache;
   const int64_t* gpu_indices;
   const int64_t* cpu_indices;
   uint32_t num_items;
   uint32_t num_layers;
 };
 
-OFFLOAD_KERNEL void offload_to_cpu(const __grid_constant__ OffloadParams params) {
+OFFLOAD_KERNEL void offload_to_cpu(const __grid_constant__ IOParams params) {
   using namespace device::hisparse;
-  const auto [gpu_caches, cpu_caches, gpu_indices, cpu_indices, num_items, num_layers] = params;
+  const auto gpu_caches = static_cast<void**>(params.gpu_cache);
+  const auto cpu_caches = static_cast<void**>(params.cpu_cache);
   const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
   constexpr auto kNumWarps = (kBlockSize / 32) * kBlockQuota;
-  for (auto i = global_tid / 32; i < num_items; i += kNumWarps) {
-    const int32_t gpu_index = gpu_indices[i];
-    const int32_t cpu_index = cpu_indices[i];
-    for (auto j = 0u; j < num_layers; ++j) {
+  for (auto i = global_tid / 32; i < params.num_items; i += kNumWarps) {
+    const int32_t gpu_index = params.gpu_indices[i];
+    const int32_t cpu_index = params.cpu_indices[i];
+    for (auto j = 0u; j < params.num_layers; ++j) {
       const auto gpu_cache = gpu_caches[j];
       const auto cpu_cache = cpu_caches[j];
       transfer_item<TransferDirection::DeviceToHost>(
@@ -44,6 +45,21 @@ OFFLOAD_KERNEL void offload_to_cpu(const __grid_constant__ OffloadParams params)
           /*dst_index=*/cpu_index,
           /*src_index=*/gpu_index);
     }
+  }
+}
+
+OFFLOAD_KERNEL void load_to_gpu(const __grid_constant__ IOParams params) {
+  using namespace device::hisparse;
+  const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  constexpr auto kNumWarps = (kBlockSize / 32) * kBlockQuota;
+  for (auto i = global_tid / 32; i < params.num_items; i += kNumWarps) {
+    const int32_t gpu_index = params.gpu_indices[i];
+    const int32_t cpu_index = params.cpu_indices[i];
+    transfer_item<TransferDirection::HostToDevice>(
+        /*dst_cache=*/params.gpu_cache,
+        /*src_cache=*/params.cpu_cache,
+        /*dst_index=*/gpu_index,
+        /*src_index=*/cpu_index);
   }
 }
 
@@ -68,15 +84,48 @@ void hisparse_transfer(
       .with_device(device_)
       .verify(gpu_indices)
       .verify(cpu_indices);
-  const auto params = OffloadParams{
-      .gpu_caches = static_cast<void**>(gpu_ptrs.data_ptr()),
-      .cpu_caches = static_cast<void**>(cpu_ptrs.data_ptr()),
+  const auto params = IOParams{
+      .gpu_cache = gpu_ptrs.data_ptr(),
+      .cpu_cache = cpu_ptrs.data_ptr(),
       .gpu_indices = static_cast<const int64_t*>(gpu_indices.data_ptr()),
       .cpu_indices = static_cast<const int64_t*>(cpu_indices.data_ptr()),
       .num_items = static_cast<uint32_t>(N.unwrap()),
       .num_layers = static_cast<uint32_t>(L.unwrap()),
   };
   LaunchKernel(kBlockQuota, kBlockSize, device_.unwrap())(offload_to_cpu, params);
+}
+
+[[maybe_unused]]
+void hisparse_load_to_device(
+    tvm::ffi::TensorView gpu_cache,
+    tvm::ffi::TensorView cpu_cache,
+    tvm::ffi::TensorView gpu_indices,
+    tvm::ffi::TensorView cpu_indices) {
+  using namespace host;
+  auto N = SymbolicSize{"num_items"};
+  auto device_ = SymbolicDevice{};
+  TensorMatcher({-1, -1})  // DSV4 page-padded C4 cache on GPU
+      .with_dtype<uint8_t>()
+      .with_device<kDLCUDA>(device_)
+      .verify(gpu_cache);
+  TensorMatcher({-1, -1})  // token-linear registered host C4 cache
+      .with_dtype<uint8_t>()
+      .with_device<kDLCPU, kDLCUDAHost>()
+      .verify(cpu_cache);
+  TensorMatcher({N})  // 1D indices
+      .with_dtype<int64_t>()
+      .with_device<kDLCUDA>(device_)
+      .verify(gpu_indices)
+      .verify(cpu_indices);
+  const auto params = IOParams{
+      .gpu_cache = gpu_cache.data_ptr(),
+      .cpu_cache = cpu_cache.data_ptr(),
+      .gpu_indices = static_cast<const int64_t*>(gpu_indices.data_ptr()),
+      .cpu_indices = static_cast<const int64_t*>(cpu_indices.data_ptr()),
+      .num_items = static_cast<uint32_t>(N.unwrap()),
+      .num_layers = 1,
+  };
+  LaunchKernel(kBlockQuota, kBlockSize, device_.unwrap())(load_to_gpu, params);
 }
 
 }  // namespace

--- a/python/sglang/jit_kernel/csrc/gemm/marlin_moe/moe_wna16_marlin.cuh
+++ b/python/sglang/jit_kernel/csrc/gemm/marlin_moe/moe_wna16_marlin.cuh
@@ -1006,6 +1006,16 @@ void moe_wna16_marlin_gemm(
         "points.");
   }
 
+  if (b_q_type == kFE2M1f) {
+    RuntimeCheck(
+        group_size == 16 || group_size == 32,
+        "float4_e2m1f only supports group_size == 16 (NVFP4) or group_size == 32 (MXFP4). Got group_size = ",
+        group_size);
+    RuntimeCheck(
+        group_size != 32 || std::is_same<scalar_t, nv_bfloat16>::value,
+        "MXFP4 Marlin with E8M0 scales is only instantiated for bfloat16 activations.");
+  }
+
   // Verify b_zeros
   if (has_zp) {
     RuntimeCheck(b_zeros.dim() == 3, "b_zeros rank = ", b_zeros.dim(), " is not 3");

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -278,7 +278,10 @@ def _jit_hisparse_transfer_module() -> Module:
     return load_jit(
         make_name("hisparse_transfer"),
         cuda_files=["deepseek_v4/hisparse_transfer.cuh"],
-        cuda_wrappers=[("hisparse_transfer", "hisparse_transfer")],
+        cuda_wrappers=[
+            ("hisparse_transfer", "hisparse_transfer"),
+            ("hisparse_load_to_device", "hisparse_load_to_device"),
+        ],
     )
 
 
@@ -290,6 +293,16 @@ def hisparse_offload_to_host(
 ) -> None:
     module = _jit_hisparse_transfer_module()
     module.hisparse_transfer(gpu_ptrs, cpu_ptrs, gpu_indices, cpu_indices)
+
+
+def hisparse_load_to_device(
+    gpu_cache: torch.Tensor,
+    cpu_cache: torch.Tensor,
+    gpu_indices: torch.Tensor,
+    cpu_indices: torch.Tensor,
+) -> None:
+    module = _jit_hisparse_transfer_module()
+    module.hisparse_load_to_device(gpu_cache, cpu_cache, gpu_indices, cpu_indices)
 
 
 def topk_transform_512(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -45,6 +45,34 @@ from sglang.srt.utils.network import (
 logger = logging.getLogger(__name__)
 
 
+def _count_nested_indices(indices) -> int:
+    if indices is None:
+        return 0
+    if isinstance(indices, np.ndarray):
+        return len(indices)
+    if isinstance(indices, (list, tuple)):
+        if not indices:
+            return 0
+        if isinstance(indices[0], (list, tuple, np.ndarray)):
+            return sum(_count_nested_indices(component) for component in indices)
+        return len(indices)
+    return 1
+
+
+def _sum_nested_ints(values) -> int:
+    if values is None:
+        return 0
+    if isinstance(values, np.ndarray):
+        return int(values.sum())
+    if isinstance(values, (list, tuple)):
+        if not values:
+            return 0
+        if isinstance(values[0], (list, tuple, np.ndarray)):
+            return sum(_sum_nested_ints(component) for component in values)
+        return sum(int(value) for value in values)
+    return int(values)
+
+
 @dataclasses.dataclass
 class PrefillServerInfo:
     # Topology fields (fetched from bootstrap server)
@@ -96,7 +124,7 @@ class CommonKVManager(BaseKVManager):
     ):
         self.kv_args = args
         self.kv_item_lens_sum = sum(args.kv_item_lens)
-        self.state_item_lens_sum = sum(x for comp in args.state_item_lens for x in comp)
+        self.state_item_lens_sum = _sum_nested_ints(args.state_item_lens)
         self.is_mla_backend = is_mla_backend
         self.disaggregation_mode = disaggregation_mode
         self.server_args = server_args
@@ -515,10 +543,7 @@ class CommonKVSender(BaseKVSender):
         state_indices: Optional[List],
     ):
         self._transfer_num_kv_indices += len(kv_indices)
-        if state_indices:
-            for component_indices in state_indices:
-                if component_indices is not None:
-                    self._transfer_num_state_indices += len(component_indices)
+        self._transfer_num_state_indices += _count_nested_indices(state_indices)
 
     def send(
         self,

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -227,19 +227,11 @@ class CommonKVManager(BaseKVManager):
 
         # Sanity checks
         if info.page_size is not None and info.page_size != self.kv_args.page_size:
-            if self.server_args.enable_hisparse:
-                # HiSparse: decode host pool page_size=1, prefill device pool page_size >= 1.
-                # Transfer will use send_kvcache_hisparse with per-token item_lens.
-                logger.info(
-                    f"HiSparse PD transfer mode: prefill page_size={info.page_size}, "
-                    f"decode host page_size={self.kv_args.page_size}"
-                )
-            else:
-                raise RuntimeError(
-                    f"Page size mismatch: prefill server has page_size={info.page_size}, "
-                    f"but decode server has page_size={self.kv_args.page_size}. "
-                    f"Both servers must use the same --page-size value."
-                )
+            raise RuntimeError(
+                f"Page size mismatch: prefill server has page_size={info.page_size}, "
+                f"but decode server has page_size={self.kv_args.page_size}. "
+                f"Both servers must use the same --page-size value."
+            )
 
         if (
             info.kv_cache_dtype is not None

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -100,6 +100,52 @@ def _bootstrap_addr(req: Req) -> str:
     return NetworkAddress(req.bootstrap_host, req.bootstrap_port).to_host_port_str()
 
 
+def _release_decode_metadata_buffer(
+    decode_req: "DecodeRequest",
+    req_to_metadata_buffer_idx_allocator: ReqToMetadataIdxAllocator,
+) -> None:
+    idx = decode_req.metadata_buffer_index
+    if idx >= 0:
+        req_to_metadata_buffer_idx_allocator.free(idx)
+        decode_req.metadata_buffer_index = -1
+
+
+def _release_decode_kv_resources(
+    req: Req,
+    scheduler: Scheduler,
+    tree_cache: BasePrefixCache,
+    *,
+    is_insert: bool = False,
+) -> None:
+    if req.req_pool_idx is None:
+        return
+
+    if scheduler.enable_hisparse and scheduler.hisparse_coordinator is not None:
+        scheduler.hisparse_coordinator.request_finished(req)
+    release_kv_cache(req, tree_cache, is_insert=is_insert)
+
+
+def _cleanup_decode_request_resources(
+    decode_req: "DecodeRequest",
+    scheduler: Scheduler,
+    tree_cache: BasePrefixCache,
+    req_to_metadata_buffer_idx_allocator: Optional[ReqToMetadataIdxAllocator] = None,
+    *,
+    is_insert: bool = False,
+) -> None:
+    _release_decode_kv_resources(
+        decode_req.req,
+        scheduler,
+        tree_cache,
+        is_insert=is_insert,
+    )
+    if req_to_metadata_buffer_idx_allocator is not None:
+        _release_decode_metadata_buffer(
+            decode_req,
+            req_to_metadata_buffer_idx_allocator,
+        )
+
+
 class DecodeReqToTokenPool:
     """
     The difference of DecodeReqToTokenPool and ReqToTokenPool is that
@@ -319,7 +365,9 @@ class DecodePreallocQueue:
         if self.enable_staging:
             self.transfer_queue._init_staging_handler(self.kv_manager)
 
-        if self.scheduler.tp_worker.is_hybrid_swa:
+        if self.scheduler.tp_worker.is_hybrid_swa and not isinstance(
+            self.token_to_kv_pool, DeepSeekV4TokenToKVPool
+        ):
             # FIXME: current SWA allocation allocate full kv cache size in prefill
             self.max_total_num_tokens = min(
                 self.max_total_num_tokens,
@@ -498,6 +546,55 @@ class DecodePreallocQueue:
         """Add a request to the pending queue."""
         for req in reqs:
             self.add(req, is_retracted=is_retracted)
+
+    def _cleanup_decode_req(self, decode_req: DecodeRequest) -> None:
+        if (
+            self.transfer_queue.enable_staging
+            and self.transfer_queue.staging_handler is not None
+            and self.transfer_queue.staging_handler.is_staging_room(
+                decode_req.req.bootstrap_room
+            )
+        ):
+            self.transfer_queue.staging_handler.unregister_decode_req(
+                decode_req.req.bootstrap_room
+            )
+        _cleanup_decode_request_resources(
+            decode_req,
+            self.scheduler,
+            self.tree_cache,
+            self.req_to_metadata_buffer_idx_allocator,
+            is_insert=False,
+        )
+
+    def _abort_and_cleanup_decode_req(self, decode_req: DecodeRequest) -> None:
+        try:
+            decode_req.kv_receiver.abort()
+        except Exception:
+            logger.exception(
+                "Failed to abort decode receiver for req %s", decode_req.req.rid
+            )
+        decode_req.req.finished_reason = FINISH_ABORT()
+        self.scheduler.stream_output([decode_req.req], decode_req.req.return_logprob)
+        self._cleanup_decode_req(decode_req)
+
+    def abort_requests(self, rid: str, abort_all: bool) -> None:
+        remaining_queue = []
+        aborted_ids = set()
+        for decode_req in self.queue:
+            if abort_all or decode_req.req.rid.startswith(rid):
+                logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
+                self._abort_and_cleanup_decode_req(decode_req)
+                aborted_ids.add(id(decode_req))
+            else:
+                remaining_queue.append(decode_req)
+        self.queue = remaining_queue
+
+        if aborted_ids:
+            self.pending_reqs = [
+                decode_req
+                for decode_req in self.pending_reqs
+                if id(decode_req) not in aborted_ids
+            ]
 
     def resume_retracted_reqs(
         self, rids_to_check: Optional[List[str]] = None
@@ -694,6 +791,7 @@ class DecodePreallocQueue:
                 self.scheduler.stream_output(
                     [decode_req.req], decode_req.req.return_logprob
                 )
+                self._cleanup_decode_req(decode_req)
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
 
@@ -855,143 +953,166 @@ class DecodePreallocQueue:
                 required_tokens_for_request=required_tokens_for_request,
                 projected_need=projected_need,
             )
-            dst_kv_indices = self._pre_alloc(decode_req.req, prefix_indices, prefix_len)
-            hisparse_req_budget -= 1
-            # Recompute from actual pool state for the next queue entry.
-            # This accounts for page rounding and newly locked evictable cache.
-            allocatable_tokens = self._allocatable_tokens(
-                retractable_tokens=retractable_tokens,
-                count_retracted=True,
-                extra_reserved_reqs=len(preallocated_reqs) + 1,
-            )
-            decode_req.req.cache_protected_len = prefix_len
-
-            page_size = self.token_to_kv_pool_allocator.page_size
-            if self.scheduler.enable_hisparse:
-                # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
-                kv_indices = (
-                    dst_kv_indices[: origin_input_len - prefix_len]
-                    .cpu()
-                    .numpy()
-                    .astype(np.int32)
+            try:
+                dst_kv_indices = self._pre_alloc(
+                    decode_req.req, prefix_indices, prefix_len
                 )
-                device_kv_page_indices = None
-                if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
-                    # DSV4 host C4 entries are token-linear, while non-sparse KV
-                    # still uses device page indices.
-                    page_size = 1
+                # Recompute from actual pool state for the next queue entry.
+                # This accounts for page rounding and newly locked evictable cache.
+                allocatable_tokens = self._allocatable_tokens(
+                    retractable_tokens=retractable_tokens,
+                    count_retracted=True,
+                    extra_reserved_reqs=len(preallocated_reqs) + 1,
+                )
+                decode_req.req.cache_protected_len = prefix_len
+
+                page_size = self.token_to_kv_pool_allocator.page_size
+                if self.scheduler.enable_hisparse:
+                    # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
+                    kv_indices = (
+                        dst_kv_indices[: origin_input_len - prefix_len]
+                        .cpu()
+                        .numpy()
+                        .astype(np.int32)
+                    )
+                    device_kv_page_indices = None
+                    if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                        # DSV4 host C4 entries are token-linear, while non-sparse KV
+                        # still uses device page indices.
+                        page_size = 1
+                        kv_indices_full = self.req_to_token_pool.req_to_token[
+                            decode_req.req.req_pool_idx, prefix_len:origin_input_len
+                        ]
+                        device_kv_page_indices = kv_to_page_indices(
+                            kv_indices_full.cpu().numpy(),
+                            self.token_to_kv_pool.page_size,
+                        ).astype(np.int32)
+                else:
+                    # Only send delta indices (beyond prefix) to prefill.
+                    kv_indices = (
+                        self.req_to_token_pool.req_to_token[
+                            decode_req.req.req_pool_idx
+                        ][prefix_len:origin_input_len]
+                        .cpu()
+                        .numpy()
+                    )
+                    device_kv_page_indices = None
+
+                # Prepare extra pool indices for hybrid models
+                if isinstance(self.token_to_kv_pool, HybridLinearKVPool):
+                    # Mamba hybrid model: single mamba state index
+                    state_indices = [
+                        self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                            decode_req.req.req_pool_idx
+                        ]
+                        .cpu()
+                        .numpy()
+                    ]
+                elif isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                    seq_len = len(decode_req.req.origin_input_ids)
+                    window_size = self.scheduler.sliding_window_size
+                    state_page_size = self.token_to_kv_pool.swa_page_size
+
+                    window_start = max(0, seq_len - window_size)
+                    window_start = page_align_floor(window_start, state_page_size)
+                    window_kv_indices_full = self.req_to_token_pool.req_to_token[
+                        decode_req.req.req_pool_idx, window_start:seq_len
+                    ]
+
+                    window_kv_indices_swa = (
+                        self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                            window_kv_indices_full
+                        )
+                    )
+                    state_indices = window_kv_indices_swa.cpu().numpy()
+                    state_indices = kv_to_page_indices(state_indices, state_page_size)
+                elif isinstance(self.token_to_kv_pool, BaseSWAKVPool):
+                    seq_len = len(decode_req.req.origin_input_ids)
+                    window_size = self.scheduler.sliding_window_size
+
+                    window_start = max(0, seq_len - window_size)
+                    window_start = page_align_floor(window_start, page_size)
+                    window_kv_indices_full = self.req_to_token_pool.req_to_token[
+                        decode_req.req.req_pool_idx, window_start:seq_len
+                    ]
+
+                    # Translate to SWA pool indices
+                    window_kv_indices_swa = (
+                        self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                            window_kv_indices_full
+                        )
+                    )
+                    state_indices = window_kv_indices_swa.cpu().numpy()
+                    state_indices = kv_to_page_indices(state_indices, page_size)
+                elif isinstance(self.token_to_kv_pool, NSATokenToKVPool):
+                    seq_len = len(decode_req.req.origin_input_ids)
                     kv_indices_full = self.req_to_token_pool.req_to_token[
-                        decode_req.req.req_pool_idx, prefix_len:origin_input_len
+                        decode_req.req.req_pool_idx, :seq_len
                     ]
-                    device_kv_page_indices = kv_to_page_indices(
-                        kv_indices_full.cpu().numpy(),
-                        self.token_to_kv_pool.page_size,
-                    ).astype(np.int32)
-            else:
-                # Only send delta indices (beyond prefix) to prefill.
-                kv_indices = (
-                    self.req_to_token_pool.req_to_token[decode_req.req.req_pool_idx][
-                        prefix_len:origin_input_len
-                    ]
-                    .cpu()
-                    .numpy()
+                    state_indices = kv_indices_full.cpu().numpy()
+                    # Indexer lives on device pool; always use device page_size
+                    device_page_size = self.token_to_kv_pool.page_size
+                    state_indices = kv_to_page_indices(state_indices, device_page_size)
+                else:
+                    state_indices = None
+
+                decode_req.metadata_buffer_index = (
+                    self.req_to_metadata_buffer_idx_allocator.alloc()
                 )
-                device_kv_page_indices = None
-
-            # Prepare extra pool indices for hybrid models
-            if isinstance(self.token_to_kv_pool, HybridLinearKVPool):
-                # Mamba hybrid model: single mamba state index
-                state_indices = [
-                    self.req_to_token_pool.req_index_to_mamba_index_mapping[
-                        decode_req.req.req_pool_idx
-                    ]
-                    .cpu()
-                    .numpy()
-                ]
-            elif isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
-                seq_len = len(decode_req.req.origin_input_ids)
-                window_size = self.scheduler.sliding_window_size
-                state_page_size = self.token_to_kv_pool.swa_page_size
-
-                window_start = max(0, seq_len - window_size)
-                window_start = page_align_floor(window_start, state_page_size)
-                window_kv_indices_full = self.req_to_token_pool.req_to_token[
-                    decode_req.req.req_pool_idx, window_start:seq_len
-                ]
-
-                window_kv_indices_swa = (
-                    self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
-                        window_kv_indices_full
+                assert decode_req.metadata_buffer_index is not None
+                page_indices = kv_to_page_indices(kv_indices, page_size)
+                if device_kv_page_indices is not None:
+                    if self.transfer_backend != TransferBackend.MOONCAKE:
+                        raise NotImplementedError(
+                            "DeepSeek V4 HiSparse PD direct-to-host currently "
+                            "requires the Mooncake transfer backend."
+                        )
+                    decode_req.kv_receiver.send_metadata(
+                        page_indices,
+                        decode_req.metadata_buffer_index,
+                        state_indices,
+                        decode_prefix_len=prefix_len,
+                        device_kv_indices=device_kv_page_indices,
                     )
-                )
-                state_indices = window_kv_indices_swa.cpu().numpy()
-                state_indices = kv_to_page_indices(state_indices, state_page_size)
-            elif isinstance(self.token_to_kv_pool, BaseSWAKVPool):
-                seq_len = len(decode_req.req.origin_input_ids)
-                window_size = self.scheduler.sliding_window_size
-
-                window_start = max(0, seq_len - window_size)
-                window_start = page_align_floor(window_start, page_size)
-                window_kv_indices_full = self.req_to_token_pool.req_to_token[
-                    decode_req.req.req_pool_idx, window_start:seq_len
-                ]
-
-                # Translate to SWA pool indices
-                window_kv_indices_swa = (
-                    self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
-                        window_kv_indices_full
+                else:
+                    decode_req.kv_receiver.send_metadata(
+                        page_indices,
+                        decode_req.metadata_buffer_index,
+                        state_indices,
+                        decode_prefix_len=prefix_len,
                     )
-                )
-                state_indices = window_kv_indices_swa.cpu().numpy()
-                state_indices = kv_to_page_indices(state_indices, page_size)
-            elif isinstance(self.token_to_kv_pool, NSATokenToKVPool):
-                seq_len = len(decode_req.req.origin_input_ids)
-                kv_indices_full = self.req_to_token_pool.req_to_token[
-                    decode_req.req.req_pool_idx, :seq_len
-                ]
-                state_indices = kv_indices_full.cpu().numpy()
-                # Indexer lives on device pool; always use device page_size
-                device_page_size = self.token_to_kv_pool.page_size
-                state_indices = kv_to_page_indices(state_indices, device_page_size)
-            else:
-                state_indices = None
-
-            decode_req.metadata_buffer_index = (
-                self.req_to_metadata_buffer_idx_allocator.alloc()
-            )
-            assert decode_req.metadata_buffer_index is not None
-            page_indices = kv_to_page_indices(kv_indices, page_size)
-            if device_kv_page_indices is not None:
-                if self.transfer_backend != TransferBackend.MOONCAKE:
-                    raise NotImplementedError(
-                        "DeepSeek V4 HiSparse PD direct-to-host currently "
-                        "requires the Mooncake transfer backend."
+                if (
+                    self.transfer_queue.enable_staging
+                    and hasattr(decode_req.kv_receiver, "require_staging")
+                    and decode_req.kv_receiver.require_staging
+                ):
+                    self.transfer_queue.staging_handler.register_decode_req(
+                        decode_req.req.bootstrap_room, decode_req
                     )
-                decode_req.kv_receiver.send_metadata(
-                    page_indices,
-                    decode_req.metadata_buffer_index,
-                    state_indices,
-                    decode_prefix_len=prefix_len,
-                    device_kv_indices=device_kv_page_indices,
+                hisparse_req_budget -= 1
+                preallocated_reqs.append(decode_req)
+                indices_to_remove.add(i)
+                decode_req.req.time_stats.set_decode_transfer_queue_entry_time()
+            except Exception as e:
+                if prefix_len > 0 and decode_req.req.req_pool_idx is None:
+                    self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                error_message = (
+                    f"Decode prealloc failed for request rank={self.tp_rank} "
+                    f"{decode_req.req.rid=} {decode_req.req.bootstrap_room=}: {e}"
                 )
-            else:
-                decode_req.kv_receiver.send_metadata(
-                    page_indices,
-                    decode_req.metadata_buffer_index,
-                    state_indices,
-                    decode_prefix_len=prefix_len,
+                logger.exception(error_message)
+                prepare_abort(
+                    decode_req.req,
+                    error_message,
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 )
-            if (
-                self.transfer_queue.enable_staging
-                and hasattr(decode_req.kv_receiver, "require_staging")
-                and decode_req.kv_receiver.require_staging
-            ):
-                self.transfer_queue.staging_handler.register_decode_req(
-                    decode_req.req.bootstrap_room, decode_req
+                self.scheduler.stream_output(
+                    [decode_req.req], decode_req.req.return_logprob
                 )
-            preallocated_reqs.append(decode_req)
-            indices_to_remove.add(i)
-            decode_req.req.time_stats.set_decode_transfer_queue_entry_time()
+                self._cleanup_decode_req(decode_req)
+                failed_reqs.append(decode_req)
+                indices_to_remove.add(i)
+                continue
 
         self.queue = [
             entry for i, entry in enumerate(self.queue) if i not in indices_to_remove
@@ -1082,6 +1203,39 @@ class DecodePreallocQueue:
         )
         return num_new_pages * page_size
 
+    def _rollback_partial_pre_alloc(
+        self,
+        req: Req,
+        *,
+        kv_loc: Optional[torch.Tensor] = None,
+        host_indices: Optional[torch.Tensor] = None,
+    ) -> None:
+        if self.scheduler.enable_hisparse:
+            coordinator = self.scheduler.hisparse_coordinator
+            mapped_host_indices = torch.empty(
+                (0,), dtype=torch.int64, device=coordinator.device
+            )
+            if req.req_pool_idx is not None:
+                mapped_host_indices = coordinator._allocated_host_indices(req)
+            if mapped_host_indices.numel() > 0:
+                coordinator.mem_pool_host.free(mapped_host_indices)
+            elif host_indices is not None and host_indices.numel() > 0:
+                coordinator.mem_pool_host.free(host_indices)
+            if req.req_pool_idx is not None:
+                coordinator.req_to_host_pool[req.req_pool_idx, :] = -1
+                coordinator.req_to_device_buffer[req.req_pool_idx, :] = 0
+                coordinator.req_device_buffer_size[req.req_pool_idx] = 0
+                coordinator.req_draft_buffer_size[req.req_pool_idx] = 0
+                coordinator._skip_first_backup[req.req_pool_idx] = False
+
+        if kv_loc is not None and kv_loc.numel() > 0:
+            self.token_to_kv_pool_allocator.free(kv_loc)
+
+        if req.req_pool_idx is not None:
+            self.req_to_token_pool.free(req)
+        req.kv_allocated_len = 0
+        req.kv_committed_len = 0
+
     def _pre_alloc(
         self,
         req: Req,
@@ -1114,6 +1268,8 @@ class DecodePreallocQueue:
         required_alloc_tokens = self._required_alloc_tokens(
             fill_len=fill_len, prefix_len=prefix_len
         )
+        kv_loc = None
+        host_indices = None
 
         # Evict cached entries if the pool doesn't have enough free pages.
         if (
@@ -1153,18 +1309,29 @@ class DecodePreallocQueue:
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
+            if kv_loc is None:
+                self._rollback_partial_pre_alloc(req)
+                raise RuntimeError(
+                    f"HiSparse logical KV alloc failed for {fill_len} tokens "
+                    f"in _pre_alloc (req {req.rid})"
+                )
             if coordinator.is_dsv4_hisparse:
                 # DSV4 stores HiSparse host KV at compressed C4-token granularity.
                 host_len = (
                     fill_len + coordinator.compress_ratio - 1
                 ) // coordinator.compress_ratio
-                host_indices = coordinator.ensure_host_slots(
-                    req.req_pool_idx, 0, host_len
-                )
+                try:
+                    host_indices = coordinator.ensure_host_slots(
+                        req.req_pool_idx, 0, host_len
+                    )
+                except Exception:
+                    self._rollback_partial_pre_alloc(req, kv_loc=kv_loc)
+                    raise
             else:
                 # Keep the upstream HiSparse path: one host KV slot per token.
                 host_indices = coordinator.mem_pool_host.alloc(fill_len)
                 if host_indices is None:
+                    self._rollback_partial_pre_alloc(req, kv_loc=kv_loc)
                     raise RuntimeError(
                         f"HiSparse host mem pool alloc failed for {fill_len} tokens "
                         f"in _pre_alloc (req {req.rid})"
@@ -1193,33 +1360,45 @@ class DecodePreallocQueue:
                 extend_num_tokens=delta_len,
             )
 
-        assert kv_loc is not None, (
-            f"KV cache is full! Bug in memory estimation. "
-            f"available={self.token_to_kv_pool_allocator.available_size()}, "
-            f"evictable={self.tree_cache.evictable_size()}, "
-            f"protected={self.tree_cache.protected_size()}, "
-            f"required_alloc={required_alloc_tokens}, delta={delta_len}, "
-            f"fill={fill_len}, prefix={prefix_len}, "
-            f"page_size={self.token_to_kv_pool_allocator.page_size}, "
-            f"req={req.rid}"
-        )
+        if kv_loc is None:
+            self._rollback_partial_pre_alloc(req, host_indices=host_indices)
+            raise RuntimeError(
+                f"KV cache is full! Bug in memory estimation. "
+                f"available={self.token_to_kv_pool_allocator.available_size()}, "
+                f"evictable={self.tree_cache.evictable_size()}, "
+                f"protected={self.tree_cache.protected_size()}, "
+                f"required_alloc={required_alloc_tokens}, delta={delta_len}, "
+                f"fill={fill_len}, prefix={prefix_len}, "
+                f"page_size={self.token_to_kv_pool_allocator.page_size}, "
+                f"req={req.rid}"
+            )
 
-        self.req_to_token_pool.write(
-            (req.req_pool_idx, slice(prefix_len, prefix_len + len(kv_loc))), kv_loc
-        )
+        try:
+            self.req_to_token_pool.write(
+                (req.req_pool_idx, slice(prefix_len, prefix_len + len(kv_loc))), kv_loc
+            )
 
-        # Truncate fill_ids to kv_committed_len so cache_unfinished_req only
-        # inserts committed KV into the radix tree. The last output token
-        # hasn't had KV committed yet (fill_ids is 1 ahead).
-        req.fill_ids = (req.origin_input_ids + req.output_ids)[: req.kv_committed_len]
-        # Set prefix_indices so downstream consumers (init_next_round_input,
-        # prepare_for_extend) see the correct prefix length. In the agg path
-        # this is done inside init_next_round_input, but decode-disagg needs
-        # allocation info before batch assembly so we set it here.
-        req.prefix_indices = (
-            prefix_indices if prefix_len > 0 else torch.empty((0,), dtype=torch.int64)
-        )
-        req.set_extend_input_len(len(req.fill_ids) - prefix_len)
+            # Truncate fill_ids to kv_committed_len so cache_unfinished_req only
+            # inserts committed KV into the radix tree. The last output token
+            # hasn't had KV committed yet (fill_ids is 1 ahead).
+            req.fill_ids = (req.origin_input_ids + req.output_ids)[
+                : req.kv_committed_len
+            ]
+            # Set prefix_indices so downstream consumers (init_next_round_input,
+            # prepare_for_extend) see the correct prefix length. In the agg path
+            # this is done inside init_next_round_input, but decode-disagg needs
+            # allocation info before batch assembly so we set it here.
+            req.prefix_indices = (
+                prefix_indices
+                if prefix_len > 0
+                else torch.empty((0,), dtype=torch.int64)
+            )
+            req.set_extend_input_len(len(req.fill_ids) - prefix_len)
+        except Exception:
+            self._rollback_partial_pre_alloc(
+                req, kv_loc=kv_loc, host_indices=host_indices
+            )
+            raise
 
         # Return the transfer destination indices:
         if self.scheduler.enable_hisparse:
@@ -1264,6 +1443,45 @@ class DecodeTransferQueue:
                     and dr.kv_receiver.require_staging
                 ):
                     self.staging_handler.register_decode_req(dr.req.bootstrap_room, dr)
+
+    def _unregister_staging_req(self, decode_req: DecodeRequest) -> None:
+        if (
+            self.enable_staging
+            and self.staging_handler is not None
+            and self.staging_handler.is_staging_room(decode_req.req.bootstrap_room)
+        ):
+            self.staging_handler.unregister_decode_req(decode_req.req.bootstrap_room)
+
+    def _cleanup_decode_req(self, decode_req: DecodeRequest) -> None:
+        self._unregister_staging_req(decode_req)
+        _cleanup_decode_request_resources(
+            decode_req,
+            self.scheduler,
+            self.tree_cache,
+            self.req_to_metadata_buffer_idx_allocator,
+            is_insert=False,
+        )
+
+    def _abort_and_cleanup_decode_req(self, decode_req: DecodeRequest) -> None:
+        try:
+            decode_req.kv_receiver.abort()
+        except Exception:
+            logger.exception(
+                "Failed to abort decode receiver for req %s", decode_req.req.rid
+            )
+        decode_req.req.finished_reason = FINISH_ABORT()
+        self.scheduler.stream_output([decode_req.req], decode_req.req.return_logprob)
+        self._cleanup_decode_req(decode_req)
+
+    def abort_requests(self, rid: str, abort_all: bool) -> None:
+        remaining_queue = []
+        for decode_req in self.queue:
+            if abort_all or decode_req.req.rid.startswith(rid):
+                logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
+                self._abort_and_cleanup_decode_req(decode_req)
+            else:
+                remaining_queue.append(decode_req)
+        self.queue = remaining_queue
 
     def _commit_transfer_to_req(self, decode_req: DecodeRequest) -> bool:
         """
@@ -1397,10 +1615,7 @@ class DecodeTransferQueue:
                 self.scheduler.stream_output(
                     [decode_req.req], decode_req.req.return_logprob
                 )
-                if self.scheduler.enable_hisparse:
-                    self.scheduler.hisparse_coordinator.request_finished(decode_req.req)
-                # release pre-allocated kv cache, but don't insert into the tree since it's failed
-                release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+                self._cleanup_decode_req(decode_req)
                 indices_to_remove.add(i)
                 if self.scheduler.enable_metrics:
                     self.scheduler.metrics_collector.increment_transfer_failed_reqs()
@@ -1414,13 +1629,7 @@ class DecodeTransferQueue:
                         self.scheduler.stream_output(
                             [decode_req.req], decode_req.req.return_logprob
                         )
-                        if self.scheduler.enable_hisparse:
-                            self.scheduler.hisparse_coordinator.request_finished(
-                                decode_req.req
-                            )
-                        release_kv_cache(
-                            decode_req.req, self.tree_cache, is_insert=False
-                        )
+                        self._cleanup_decode_req(decode_req)
                         if self.scheduler.enable_metrics:
                             self.scheduler.metrics_collector.increment_transfer_failed_reqs()
                     else:
@@ -1435,15 +1644,10 @@ class DecodeTransferQueue:
                 raise ValueError(f"Unexpected poll case: {poll}")
 
         for i in indices_to_remove:
-            if self.enable_staging and self.staging_handler.is_staging_room(
-                self.queue[i].req.bootstrap_room
-            ):
-                self.staging_handler.unregister_decode_req(
-                    self.queue[i].req.bootstrap_room
-                )
-            idx = self.queue[i].metadata_buffer_index
-            assert idx != -1
-            self.req_to_metadata_buffer_idx_allocator.free(idx)
+            self._unregister_staging_req(self.queue[i])
+            _release_decode_metadata_buffer(
+                self.queue[i], self.req_to_metadata_buffer_idx_allocator
+            )
 
         self.queue = [
             entry for i, entry in enumerate(self.queue) if i not in indices_to_remove

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -355,6 +355,8 @@ class DecodePreallocQueue:
         self._max_ensure_retries: int = 15  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
         self._ensure_retry_interval: float = 1.0  # seconds
+        self._prealloc_reason_last_log: Dict[str, float] = {}
+        self._prealloc_reason_log_interval: float = 5.0
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         if self.enable_staging and self.is_mla_backend:
             raise RuntimeError(
@@ -373,6 +375,34 @@ class DecodePreallocQueue:
                 self.max_total_num_tokens,
                 self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
             )
+
+    def _is_dsv4_hisparse(self) -> bool:
+        return (
+            self.scheduler.enable_hisparse
+            and self.scheduler.hisparse_coordinator is not None
+            and self.scheduler.hisparse_coordinator.is_dsv4_hisparse
+        )
+
+    def _reserved_decode_tokens(self) -> int:
+        if self._is_dsv4_hisparse():
+            return max(128, self.num_reserved_decode_tokens // 2)
+        return self.num_reserved_decode_tokens
+
+    def _projected_decode_tokens(self, req: Req) -> int:
+        max_new_tokens = req.sampling_params.max_new_tokens
+        if self._is_dsv4_hisparse():
+            return min(max_new_tokens, self._reserved_decode_tokens())
+        return min(max_new_tokens, CLIP_MAX_NEW_TOKEN)
+
+    def _hisparse_hot_slots_per_req(self) -> int:
+        if not self.scheduler.enable_hisparse:
+            return 0
+        coordinator = self.scheduler.hisparse_coordinator
+        draft_slots = int(self.scheduler.server_args.speculative_num_draft_tokens or 0)
+        return max(
+            coordinator.padded_buffer_size,
+            coordinator.device_buffer_size + 1 + draft_slots,
+        )
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
@@ -796,29 +826,44 @@ class DecodePreallocQueue:
                 indices_to_remove.add(i)
 
         # HiSparse physical constraint: max requests by device buffer capacity.
-        # Each admitted req needs padded_buffer_size from hisparse device pool.
+        # Each admitted req needs a side buffer from hisparse device pool.
+        # Account for draft slots explicitly so admission does not over-commit
+        # the hot pool and fail later in draft_extend.
         # waiting_queue reqs already have device buffers (allocated in admit_request_direct),
         # only transfer_queue reqs are pending device buffer allocation.
         hisparse_avail = None
         hisparse_req_budget = float("inf")
+        hisparse_hot_slots_per_req = None
         if self.scheduler.enable_hisparse:
             hisparse_avail = (
                 self.token_to_kv_pool_allocator.hisparse_attn_allocator.available_size()
             )
+            hisparse_hot_slots_per_req = self._hisparse_hot_slots_per_req()
             hisparse_req_budget = max(
                 0,
-                hisparse_avail // self.scheduler.hisparse_coordinator.padded_buffer_size
+                hisparse_avail // hisparse_hot_slots_per_req
                 - len(self.transfer_queue.queue),
             )
 
-        def log_health_prealloc(reason: str, decode_req: DecodeRequest, **kwargs):
-            if not decode_req.req.rid.startswith(HEALTH_CHECK_RID_PREFIX):
+        def log_prealloc_reason(reason: str, decode_req: DecodeRequest, **kwargs):
+            is_health = decode_req.req.rid.startswith(HEALTH_CHECK_RID_PREFIX)
+            should_log_hisparse = False
+            if self.scheduler.enable_hisparse and reason.startswith("break_"):
+                now = time.time()
+                last = self._prealloc_reason_last_log.get(reason, 0.0)
+                if now - last >= self._prealloc_reason_log_interval:
+                    self._prealloc_reason_last_log[reason] = now
+                    should_log_hisparse = True
+            if not is_health and not should_log_hisparse:
                 return
             logger.warning(
-                "Health prealloc %s: rid=%s waiting=%s req_pool_avail=%s "
+                "Decode prealloc %s%s: rid=%s waiting=%s req_pool_avail=%s "
                 "metadata_avail=%s hisparse_budget=%s hisparse_avail=%s "
-                "padded_buffer_size=%s allocatable=%s transfer_q=%s waiting_q=%s "
-                "running=%s retracted_q=%s pending_q=%s prealloc_q=%s extra=%s",
+                "hisparse_hot_slots_per_req=%s padded_buffer_size=%s "
+                "reserved_decode_tokens=%s allocatable=%s transfer_q=%s "
+                "waiting_q=%s running=%s retracted_q=%s pending_q=%s "
+                "prealloc_q=%s extra=%s",
+                "health " if is_health else "",
                 reason,
                 decode_req.req.rid,
                 decode_req.waiting_for_input,
@@ -826,11 +871,13 @@ class DecodePreallocQueue:
                 self.req_to_metadata_buffer_idx_allocator.available_size(),
                 hisparse_req_budget,
                 hisparse_avail,
+                hisparse_hot_slots_per_req,
                 (
                     self.scheduler.hisparse_coordinator.padded_buffer_size
                     if self.scheduler.enable_hisparse
                     else None
                 ),
+                self._reserved_decode_tokens(),
                 allocatable_tokens,
                 len(self.transfer_queue.queue),
                 len(self.scheduler.waiting_queue),
@@ -844,7 +891,7 @@ class DecodePreallocQueue:
         # Then, preallocate the remaining requests if possible
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
-                log_health_prealloc(
+                log_prealloc_reason(
                     "skip_rid_not_in_check",
                     decode_req,
                     rids_to_check=rids_to_check,
@@ -852,23 +899,23 @@ class DecodePreallocQueue:
                 continue
 
             if i in indices_to_remove:
-                log_health_prealloc("skip_already_marked_remove", decode_req, index=i)
+                log_prealloc_reason("skip_already_marked_remove", decode_req, index=i)
                 continue
 
             if not decode_req.waiting_for_input:
-                log_health_prealloc("skip_waiting_for_input_false", decode_req)
+                log_prealloc_reason("skip_waiting_for_input_false", decode_req)
                 continue
 
             if self.req_to_token_pool.available_size() <= 0:
-                log_health_prealloc("break_req_to_token_pool_full", decode_req)
+                log_prealloc_reason("break_req_to_token_pool_full", decode_req)
                 break
 
             if self.req_to_metadata_buffer_idx_allocator.available_size() <= 0:
-                log_health_prealloc("break_metadata_buffer_full", decode_req)
+                log_prealloc_reason("break_metadata_buffer_full", decode_req)
                 break
 
             if hisparse_req_budget <= 0:
-                log_health_prealloc("break_hisparse_budget_exhausted", decode_req)
+                log_prealloc_reason("break_hisparse_budget_exhausted", decode_req)
                 break
 
             # Memory estimation: don't add if the projected memory cannot be met
@@ -901,57 +948,58 @@ class DecodePreallocQueue:
                 prefix_len = 0
                 required_alloc_tokens = origin_input_len
 
-            required_tokens_for_request = (
-                required_alloc_tokens + self.num_reserved_decode_tokens
-            )
+            reserved_decode_tokens = self._reserved_decode_tokens()
+            projected_decode_tokens = self._projected_decode_tokens(decode_req.req)
+            required_tokens_for_request = required_alloc_tokens + reserved_decode_tokens
             projected_need = max(
                 required_tokens_for_request,
                 origin_input_len
                 - prefix_len
-                + min(
-                    decode_req.req.sampling_params.max_new_tokens,
-                    CLIP_MAX_NEW_TOKEN,
-                )
+                + projected_decode_tokens
                 - retractable_tokens,
             )
 
             if projected_need > allocatable_tokens:
-                log_health_prealloc(
+                log_prealloc_reason(
                     "break_projected_need_exceeds_allocatable",
                     decode_req,
                     origin_input_len=origin_input_len,
                     prefix_len=prefix_len,
                     required_alloc_tokens=required_alloc_tokens,
                     required_tokens_for_request=required_tokens_for_request,
+                    reserved_decode_tokens=reserved_decode_tokens,
                     projected_need=projected_need,
                     retractable_tokens=retractable_tokens,
                     max_new_tokens=decode_req.req.sampling_params.max_new_tokens,
-                    clip_max_new_token=CLIP_MAX_NEW_TOKEN,
+                    projected_decode_tokens=projected_decode_tokens,
                 )
                 if prefix_len > 0:
                     self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
             if required_tokens_for_request > allocatable_tokens:
-                log_health_prealloc(
+                log_prealloc_reason(
                     "break_required_tokens_exceeds_allocatable",
                     decode_req,
                     origin_input_len=origin_input_len,
                     prefix_len=prefix_len,
                     required_alloc_tokens=required_alloc_tokens,
                     required_tokens_for_request=required_tokens_for_request,
+                    reserved_decode_tokens=reserved_decode_tokens,
                 )
                 if prefix_len > 0:
                     self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
 
-            log_health_prealloc(
+            log_prealloc_reason(
                 "admit_pre_alloc",
                 decode_req,
                 origin_input_len=origin_input_len,
                 prefix_len=prefix_len,
                 required_alloc_tokens=required_alloc_tokens,
                 required_tokens_for_request=required_tokens_for_request,
+                reserved_decode_tokens=reserved_decode_tokens,
                 projected_need=projected_need,
+                projected_decode_tokens=projected_decode_tokens,
             )
             try:
                 dst_kv_indices = self._pre_alloc(
@@ -1135,7 +1183,7 @@ class DecodePreallocQueue:
         need_space_for_single_req = (
             max(
                 [
-                    min(x.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKEN)
+                    self._projected_decode_tokens(x)
                     + len(x.origin_input_ids)
                     - retractable_tokens
                     for x in self.scheduler.running_batch.reqs
@@ -1157,9 +1205,10 @@ class DecodePreallocQueue:
             # can be freed on demand before allocation.
             if self.scheduler.server_args.disaggregation_decode_enable_radix_cache:
                 available_size += self.tree_cache.evictable_size()
+        reserved_decode_tokens = self._reserved_decode_tokens()
         allocatable_tokens = available_size - max(
             # preserve some space for future decode
-            self.num_reserved_decode_tokens
+            reserved_decode_tokens
             * (
                 len(self.scheduler.running_batch.reqs)
                 + len(self.transfer_queue.queue)
@@ -1176,7 +1225,7 @@ class DecodePreallocQueue:
             self.scheduler.last_batch
             and self.scheduler.last_batch.forward_mode.is_prebuilt()
         ):
-            allocatable_tokens -= self.num_reserved_decode_tokens * len(
+            allocatable_tokens -= reserved_decode_tokens * len(
                 self.scheduler.last_batch.reqs
             )
 
@@ -1185,7 +1234,7 @@ class DecodePreallocQueue:
                 [
                     len(req.origin_input_ids)
                     + len(req.output_ids)
-                    + self.num_reserved_decode_tokens
+                    + reserved_decode_tokens
                     for req in self.retracted_queue
                 ]
             )

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -788,23 +788,13 @@ class DecodePreallocQueue:
             decode_req.req.cache_protected_len = prefix_len
 
             page_size = self.token_to_kv_pool_allocator.page_size
-            if self.scheduler.enable_hisparse:
-                # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
-                kv_indices = (
-                    dst_kv_indices[: origin_input_len - prefix_len]
-                    .cpu()
-                    .numpy()
-                    .astype(np.int32)
-                )
-            else:
-                # Only send delta indices (beyond prefix) to prefill.
-                kv_indices = (
-                    self.req_to_token_pool.req_to_token[decode_req.req.req_pool_idx][
-                        prefix_len:origin_input_len
-                    ]
-                    .cpu()
-                    .numpy()
-                )
+            # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
+            kv_indices = (
+                dst_kv_indices[: origin_input_len - prefix_len]
+                .cpu()
+                .numpy()
+                .astype(np.int32)
+            )
 
             seq_len = len(decode_req.req.origin_input_ids)
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -355,9 +355,10 @@ class DecodePreallocQueue:
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        # HiSparse Host pool has page_size=1; use it when hisparse is enabled
         kv_args.page_size = (
-            1 if self.scheduler.enable_hisparse else self.token_to_kv_pool.page_size
+            self.scheduler.hisparse_coordinator.mem_pool_host.page_size
+            if self.scheduler.enable_hisparse
+            else self.token_to_kv_pool.page_size
         )
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
@@ -800,7 +801,7 @@ class DecodePreallocQueue:
                     .numpy()
                     .astype(np.int32)
                 )
-                page_size = 1  # host pool page_size
+                page_size = self.scheduler.hisparse_coordinator.mem_pool_host.page_size
             else:
                 # Only send delta indices (beyond prefix) to prefill.
                 kv_indices = (
@@ -1045,14 +1046,7 @@ class DecodePreallocQueue:
                 extend_num_tokens=fill_len,
             )
             # Allocate host indices for the RDMA transfer target.
-            host_indices = coordinator.mem_pool_host.alloc(fill_len)
-            if host_indices is None:
-                raise RuntimeError(
-                    f"HiSparse host mem pool alloc failed for {fill_len} tokens "
-                    f"in _pre_alloc (req {req.rid})"
-                )
-            host_indices = host_indices.to(device=coordinator.device)
-            coordinator.req_to_host_pool[req.req_pool_idx, :fill_len] = host_indices
+            host_indices = coordinator.ensure_host_slots(req.req_pool_idx, 0, fill_len)
         elif self.token_to_kv_pool_allocator.page_size == 1:
             kv_loc = self.token_to_kv_pool_allocator.alloc(delta_len)
         else:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -332,16 +332,14 @@ class DecodePreallocQueue:
 
         kv_args.pp_rank = self.pp_rank
         kv_args.system_dp_rank = self.scheduler.dp_rank
-        if self.scheduler.enable_hisparse:
-            # Direct-to-host: register host pool pointers so P writes to D's host memory
-            host_pool = self.scheduler.hisparse_coordinator.mem_pool_host
-            kv_data_ptrs, kv_data_lens, kv_item_lens = (
-                host_pool.get_contiguous_buf_infos()
-            )
-        else:
-            kv_data_ptrs, kv_data_lens, kv_item_lens = (
-                self.token_to_kv_pool.get_contiguous_buf_infos()
-            )
+        transfer_kv_pool = (
+            self.scheduler.hisparse_coordinator.mem_pool_host
+            if self.scheduler.enable_hisparse
+            else self.token_to_kv_pool
+        )
+        kv_data_ptrs, kv_data_lens, kv_item_lens = (
+            transfer_kv_pool.get_contiguous_buf_infos()
+        )
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
@@ -355,11 +353,7 @@ class DecodePreallocQueue:
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.page_size = (
-            self.scheduler.hisparse_coordinator.mem_pool_host.page_size
-            if self.scheduler.enable_hisparse
-            else self.token_to_kv_pool.page_size
-        )
+        kv_args.page_size = self.token_to_kv_pool.page_size
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
@@ -793,6 +787,7 @@ class DecodePreallocQueue:
             )
             decode_req.req.cache_protected_len = prefix_len
 
+            page_size = self.token_to_kv_pool_allocator.page_size
             if self.scheduler.enable_hisparse:
                 # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
                 kv_indices = (
@@ -801,7 +796,6 @@ class DecodePreallocQueue:
                     .numpy()
                     .astype(np.int32)
                 )
-                page_size = self.scheduler.hisparse_coordinator.mem_pool_host.page_size
             else:
                 # Only send delta indices (beyond prefix) to prefill.
                 kv_indices = (
@@ -811,7 +805,6 @@ class DecodePreallocQueue:
                     .cpu()
                     .numpy()
                 )
-                page_size = self.token_to_kv_pool_allocator.page_size
 
             seq_len = len(decode_req.req.origin_input_ids)
 
@@ -1537,6 +1530,4 @@ class SchedulerDisaggregationDecodeMixin:
                 for req in transferred_reqs:
                     # Direct-to-host: KV data already in host pool, skip staging
                     self.hisparse_coordinator.admit_request_direct(req)
-                self.waiting_queue.extend(transferred_reqs)
-            else:
-                self.waiting_queue.extend(transferred_reqs)
+            self.waiting_queue.extend(transferred_reqs)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -32,9 +32,8 @@ import torch
 from torch.distributed import ProcessGroup
 
 from sglang.srt.configs.mamba_utils import Mamba2CacheParams
-from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE, HEALTH_CHECK_RID_PREFIX
 from sglang.srt.disaggregation.base import KVPoll
-from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVReceiver
 from sglang.srt.disaggregation.utils import (
     FAKE_BOOTSTRAP_HOST,
@@ -57,14 +56,18 @@ from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     page_align_floor,
     release_kv_cache,
 )
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
+    HybridLinearKVPool,
     HybridReqToTokenPool,
     KVCache,
+    NSATokenToKVPool,
     ReqToTokenPool,
 )
 from sglang.srt.observability.req_time_stats import (
@@ -332,14 +335,27 @@ class DecodePreallocQueue:
 
         kv_args.pp_rank = self.pp_rank
         kv_args.system_dp_rank = self.scheduler.dp_rank
-        transfer_kv_pool = (
-            self.scheduler.hisparse_coordinator.mem_pool_host
-            if self.scheduler.enable_hisparse
-            else self.token_to_kv_pool
-        )
-        kv_data_ptrs, kv_data_lens, kv_item_lens = (
-            transfer_kv_pool.get_contiguous_buf_infos()
-        )
+        if self.scheduler.enable_hisparse:
+            # Direct-to-host: register host pool pointers so P writes to D's host memory
+            host_pool = self.scheduler.hisparse_coordinator.mem_pool_host
+            kv_data_ptrs, kv_data_lens, kv_item_lens = (
+                host_pool.get_contiguous_buf_infos()
+            )
+            if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                # DSV4 HiSparse writes only C4 KV to host.  The c4_indexer and
+                # c128 KV remain device-to-device transfers and are appended
+                # after the host C4 entries in Mooncake's KV pointer table.
+                device_kv_data_ptrs, device_kv_data_lens, device_kv_item_lens = (
+                    self.token_to_kv_pool.get_contiguous_buf_infos()
+                )
+                c4_layer_num = host_pool.layer_num
+                kv_data_ptrs += device_kv_data_ptrs[c4_layer_num:]
+                kv_data_lens += device_kv_data_lens[c4_layer_num:]
+                kv_item_lens += device_kv_item_lens[c4_layer_num:]
+        else:
+            kv_data_ptrs, kv_data_lens, kv_item_lens = (
+                self.token_to_kv_pool.get_contiguous_buf_infos()
+            )
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
@@ -359,12 +375,7 @@ class DecodePreallocQueue:
             self.metadata_buffers.get_buf_infos()
         )
 
-        setup_state_kv_args(
-            kv_args,
-            self.token_to_kv_pool,
-            self.draft_token_to_kv_pool,
-            req_to_token_pool=getattr(self, "req_to_token_pool", None),
-        )
+        setup_state_kv_args(kv_args, self.token_to_kv_pool, self.draft_token_to_kv_pool)
 
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
         kv_args.gpu_id = self.scheduler.gpu_id
@@ -690,6 +701,7 @@ class DecodePreallocQueue:
         # Each admitted req needs padded_buffer_size from hisparse device pool.
         # waiting_queue reqs already have device buffers (allocated in admit_request_direct),
         # only transfer_queue reqs are pending device buffer allocation.
+        hisparse_avail = None
         hisparse_req_budget = float("inf")
         if self.scheduler.enable_hisparse:
             hisparse_avail = (
@@ -701,24 +713,64 @@ class DecodePreallocQueue:
                 - len(self.transfer_queue.queue),
             )
 
+        def log_health_prealloc(reason: str, decode_req: DecodeRequest, **kwargs):
+            if not decode_req.req.rid.startswith(HEALTH_CHECK_RID_PREFIX):
+                return
+            logger.warning(
+                "Health prealloc %s: rid=%s waiting=%s req_pool_avail=%s "
+                "metadata_avail=%s hisparse_budget=%s hisparse_avail=%s "
+                "padded_buffer_size=%s allocatable=%s transfer_q=%s waiting_q=%s "
+                "running=%s retracted_q=%s pending_q=%s prealloc_q=%s extra=%s",
+                reason,
+                decode_req.req.rid,
+                decode_req.waiting_for_input,
+                self.req_to_token_pool.available_size(),
+                self.req_to_metadata_buffer_idx_allocator.available_size(),
+                hisparse_req_budget,
+                hisparse_avail,
+                (
+                    self.scheduler.hisparse_coordinator.padded_buffer_size
+                    if self.scheduler.enable_hisparse
+                    else None
+                ),
+                allocatable_tokens,
+                len(self.transfer_queue.queue),
+                len(self.scheduler.waiting_queue),
+                len(self.scheduler.running_batch.reqs),
+                len(self.retracted_queue),
+                len(self.pending_reqs),
+                len(self.queue),
+                kwargs,
+            )
+
         # Then, preallocate the remaining requests if possible
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
+                log_health_prealloc(
+                    "skip_rid_not_in_check",
+                    decode_req,
+                    rids_to_check=rids_to_check,
+                )
                 continue
 
             if i in indices_to_remove:
+                log_health_prealloc("skip_already_marked_remove", decode_req, index=i)
                 continue
 
             if not decode_req.waiting_for_input:
+                log_health_prealloc("skip_waiting_for_input_false", decode_req)
                 continue
 
             if self.req_to_token_pool.available_size() <= 0:
+                log_health_prealloc("break_req_to_token_pool_full", decode_req)
                 break
 
             if self.req_to_metadata_buffer_idx_allocator.available_size() <= 0:
+                log_health_prealloc("break_metadata_buffer_full", decode_req)
                 break
 
             if hisparse_req_budget <= 0:
+                log_health_prealloc("break_hisparse_budget_exhausted", decode_req)
                 break
 
             # Memory estimation: don't add if the projected memory cannot be met
@@ -754,28 +806,55 @@ class DecodePreallocQueue:
             required_tokens_for_request = (
                 required_alloc_tokens + self.num_reserved_decode_tokens
             )
-
-            if (
-                max(
-                    required_tokens_for_request,
-                    origin_input_len
-                    - prefix_len
-                    + min(
-                        decode_req.req.sampling_params.max_new_tokens,
-                        CLIP_MAX_NEW_TOKEN,
-                    )
-                    - retractable_tokens,
+            projected_need = max(
+                required_tokens_for_request,
+                origin_input_len
+                - prefix_len
+                + min(
+                    decode_req.req.sampling_params.max_new_tokens,
+                    CLIP_MAX_NEW_TOKEN,
                 )
-                > allocatable_tokens
-            ):
+                - retractable_tokens,
+            )
+
+            if projected_need > allocatable_tokens:
+                log_health_prealloc(
+                    "break_projected_need_exceeds_allocatable",
+                    decode_req,
+                    origin_input_len=origin_input_len,
+                    prefix_len=prefix_len,
+                    required_alloc_tokens=required_alloc_tokens,
+                    required_tokens_for_request=required_tokens_for_request,
+                    projected_need=projected_need,
+                    retractable_tokens=retractable_tokens,
+                    max_new_tokens=decode_req.req.sampling_params.max_new_tokens,
+                    clip_max_new_token=CLIP_MAX_NEW_TOKEN,
+                )
                 if prefix_len > 0:
                     self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
             if required_tokens_for_request > allocatable_tokens:
+                log_health_prealloc(
+                    "break_required_tokens_exceeds_allocatable",
+                    decode_req,
+                    origin_input_len=origin_input_len,
+                    prefix_len=prefix_len,
+                    required_alloc_tokens=required_alloc_tokens,
+                    required_tokens_for_request=required_tokens_for_request,
+                )
                 if prefix_len > 0:
                     self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                 break
 
+            log_health_prealloc(
+                "admit_pre_alloc",
+                decode_req,
+                origin_input_len=origin_input_len,
+                prefix_len=prefix_len,
+                required_alloc_tokens=required_alloc_tokens,
+                required_tokens_for_request=required_tokens_for_request,
+                projected_need=projected_need,
+            )
             dst_kv_indices = self._pre_alloc(decode_req.req, prefix_indices, prefix_len)
             hisparse_req_budget -= 1
             # Recompute from actual pool state for the next queue entry.
@@ -796,6 +875,18 @@ class DecodePreallocQueue:
                     .numpy()
                     .astype(np.int32)
                 )
+                device_kv_page_indices = None
+                if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                    # DSV4 host C4 entries are token-linear, while non-sparse KV
+                    # still uses device page indices.
+                    page_size = 1
+                    kv_indices_full = self.req_to_token_pool.req_to_token[
+                        decode_req.req.req_pool_idx, prefix_len:origin_input_len
+                    ]
+                    device_kv_page_indices = kv_to_page_indices(
+                        kv_indices_full.cpu().numpy(),
+                        self.token_to_kv_pool.page_size,
+                    ).astype(np.int32)
             else:
                 # Only send delta indices (beyond prefix) to prefill.
                 kv_indices = (
@@ -805,67 +896,91 @@ class DecodePreallocQueue:
                     .cpu()
                     .numpy()
                 )
+                device_kv_page_indices = None
 
-            seq_len = len(decode_req.req.origin_input_ids)
-
-            def _mamba_payload():
-                return [
+            # Prepare extra pool indices for hybrid models
+            if isinstance(self.token_to_kv_pool, HybridLinearKVPool):
+                # Mamba hybrid model: single mamba state index
+                state_indices = [
                     self.req_to_token_pool.req_index_to_mamba_index_mapping[
                         decode_req.req.req_pool_idx
                     ]
                     .cpu()
                     .numpy()
                 ]
-
-            def _swa_payload():
+            elif isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+                seq_len = len(decode_req.req.origin_input_ids)
                 window_size = self.scheduler.sliding_window_size
+                state_page_size = self.token_to_kv_pool.swa_page_size
+
                 window_start = max(0, seq_len - window_size)
-                window_start = page_align_floor(window_start, page_size)
+                window_start = page_align_floor(window_start, state_page_size)
                 window_kv_indices_full = self.req_to_token_pool.req_to_token[
                     decode_req.req.req_pool_idx, window_start:seq_len
                 ]
+
                 window_kv_indices_swa = (
                     self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
                         window_kv_indices_full
                     )
                 )
-                return kv_to_page_indices(
-                    window_kv_indices_swa.cpu().numpy(), page_size
-                )
+                state_indices = window_kv_indices_swa.cpu().numpy()
+                state_indices = kv_to_page_indices(state_indices, state_page_size)
+            elif isinstance(self.token_to_kv_pool, BaseSWAKVPool):
+                seq_len = len(decode_req.req.origin_input_ids)
+                window_size = self.scheduler.sliding_window_size
 
-            def _nsa_payload():
+                window_start = max(0, seq_len - window_size)
+                window_start = page_align_floor(window_start, page_size)
+                window_kv_indices_full = self.req_to_token_pool.req_to_token[
+                    decode_req.req.req_pool_idx, window_start:seq_len
+                ]
+
+                # Translate to SWA pool indices
+                window_kv_indices_swa = (
+                    self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                        window_kv_indices_full
+                    )
+                )
+                state_indices = window_kv_indices_swa.cpu().numpy()
+                state_indices = kv_to_page_indices(state_indices, page_size)
+            elif isinstance(self.token_to_kv_pool, NSATokenToKVPool):
+                seq_len = len(decode_req.req.origin_input_ids)
                 kv_indices_full = self.req_to_token_pool.req_to_token[
                     decode_req.req.req_pool_idx, :seq_len
                 ]
+                state_indices = kv_indices_full.cpu().numpy()
                 # Indexer lives on device pool; always use device page_size
                 device_page_size = self.token_to_kv_pool.page_size
-                return kv_to_page_indices(
-                    kv_indices_full.cpu().numpy(), device_page_size
-                )
-
-            state_types = self.kv_manager.kv_args.state_types
-            state_indices: Optional[List] = []
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.NSA:
-                    state_indices.append(_nsa_payload())
-                else:
-                    state_indices.append(None)
+                state_indices = kv_to_page_indices(state_indices, device_page_size)
+            else:
+                state_indices = None
 
             decode_req.metadata_buffer_index = (
                 self.req_to_metadata_buffer_idx_allocator.alloc()
             )
             assert decode_req.metadata_buffer_index is not None
             page_indices = kv_to_page_indices(kv_indices, page_size)
-            decode_req.kv_receiver.send_metadata(
-                page_indices,
-                decode_req.metadata_buffer_index,
-                state_indices,
-                decode_prefix_len=prefix_len,
-            )
+            if device_kv_page_indices is not None:
+                if self.transfer_backend != TransferBackend.MOONCAKE:
+                    raise NotImplementedError(
+                        "DeepSeek V4 HiSparse PD direct-to-host currently "
+                        "requires the Mooncake transfer backend."
+                    )
+                decode_req.kv_receiver.send_metadata(
+                    page_indices,
+                    decode_req.metadata_buffer_index,
+                    state_indices,
+                    decode_prefix_len=prefix_len,
+                    device_kv_indices=device_kv_page_indices,
+                )
+            else:
+                decode_req.kv_receiver.send_metadata(
+                    page_indices,
+                    decode_req.metadata_buffer_index,
+                    state_indices,
+                    decode_prefix_len=prefix_len,
+                )
             if (
                 self.transfer_queue.enable_staging
                 and hasattr(decode_req.kv_receiver, "require_staging")
@@ -1038,8 +1153,26 @@ class DecodePreallocQueue:
                 last_loc=torch.tensor([-1], dtype=torch.int64, device=device),
                 extend_num_tokens=fill_len,
             )
-            # Allocate host indices for the RDMA transfer target.
-            host_indices = coordinator.ensure_host_slots(req.req_pool_idx, 0, fill_len)
+            if coordinator.is_dsv4_hisparse:
+                # DSV4 stores HiSparse host KV at compressed C4-token granularity.
+                host_len = (
+                    fill_len + coordinator.compress_ratio - 1
+                ) // coordinator.compress_ratio
+                host_indices = coordinator.ensure_host_slots(
+                    req.req_pool_idx, 0, host_len
+                )
+            else:
+                # Keep the upstream HiSparse path: one host KV slot per token.
+                host_indices = coordinator.mem_pool_host.alloc(fill_len)
+                if host_indices is None:
+                    raise RuntimeError(
+                        f"HiSparse host mem pool alloc failed for {fill_len} tokens "
+                        f"in _pre_alloc (req {req.rid})"
+                    )
+                host_indices = host_indices.to(device=coordinator.device)
+                coordinator.req_to_host_pool[req.req_pool_idx, :fill_len] = (
+                    host_indices
+                )
         elif self.token_to_kv_pool_allocator.page_size == 1:
             kv_loc = self.token_to_kv_pool_allocator.alloc(delta_len)
         else:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -788,13 +788,23 @@ class DecodePreallocQueue:
             decode_req.req.cache_protected_len = prefix_len
 
             page_size = self.token_to_kv_pool_allocator.page_size
-            # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
-            kv_indices = (
-                dst_kv_indices[: origin_input_len - prefix_len]
-                .cpu()
-                .numpy()
-                .astype(np.int32)
-            )
+            if self.scheduler.enable_hisparse:
+                # Must cast to int32 for ZMQ serialization -- from_zmq reads np.int32.
+                kv_indices = (
+                    dst_kv_indices[: origin_input_len - prefix_len]
+                    .cpu()
+                    .numpy()
+                    .astype(np.int32)
+                )
+            else:
+                # Only send delta indices (beyond prefix) to prefill.
+                kv_indices = (
+                    self.req_to_token_pool.req_to_token[decode_req.req.req_pool_idx][
+                        prefix_len:origin_input_len
+                    ]
+                    .cpu()
+                    .numpy()
+                )
 
             seq_len = len(decode_req.req.origin_input_ids)
 

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -113,6 +113,7 @@ class FakeKVReceiver(BaseKVReceiver):
         aux_index: Optional[int] = None,
         state_indices: Optional[List] = None,
         decode_prefix_len: Optional[int] = None,
+        **kwargs,
     ):
         self.has_sent_metadata = True
         logger.debug(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -46,6 +46,55 @@ from sglang.srt.utils.network import NetworkAddress
 logger = logging.getLogger(__name__)
 
 
+def _flatten_int_values(values) -> List[int]:
+    if values is None:
+        return []
+    if isinstance(values, np.ndarray):
+        return [int(v) for v in values.reshape(-1)]
+    if not values:
+        return []
+
+    flat = []
+    for value in values:
+        if isinstance(value, (list, tuple, np.ndarray)):
+            flat.extend(int(v) for v in np.asarray(value).reshape(-1))
+        else:
+            flat.append(int(value))
+    return flat
+
+
+def _component_int_values(values, index: int = 0) -> List[int]:
+    if values is None:
+        return []
+    if isinstance(values, np.ndarray):
+        if values.ndim <= 1:
+            return [int(v) for v in values.reshape(-1)]
+        if index >= values.shape[0]:
+            return []
+        return [int(v) for v in values[index].reshape(-1)]
+    if not values:
+        return []
+    if isinstance(values[0], (list, tuple, np.ndarray)):
+        if index >= len(values):
+            return []
+        return [int(v) for v in np.asarray(values[index]).reshape(-1)]
+    return [int(v) for v in values]
+
+
+def _state_type_values(kv_args: KVArgs) -> List[str]:
+    state_types = getattr(kv_args, "state_types", None)
+    if state_types:
+        return [
+            str(getattr(state_type, "value", state_type)).lower()
+            for state_type in state_types
+        ]
+
+    state_type = getattr(kv_args, "state_type", None)
+    if state_type is None or state_type == "none":
+        return []
+    return [str(getattr(state_type, "value", state_type)).lower()]
+
+
 class KVTransferError(Exception):
     def __init__(self, bootstrap_room: int, failure_reason: str):
         super().__init__(failure_reason)
@@ -282,7 +331,8 @@ class MooncakeKVManager(CommonKVManager):
         # Batch register state/extra pool data buffers
         if self.kv_args.state_data_ptrs and self.kv_args.state_data_lens:
             self.engine.batch_register(
-                self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+                _flatten_int_values(self.kv_args.state_data_ptrs),
+                _flatten_int_values(self.kv_args.state_data_lens),
             )
 
     # ------------------------------------------------------------------
@@ -723,7 +773,7 @@ class MooncakeKVManager(CommonKVManager):
         dst_device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
     ):
         """HiSparse transfer uses page-level indices for source and host destination."""
-        if getattr(self.kv_args, "state_type", "none") == "dsv4":
+        if dst_device_kv_indices is not None:
             if dst_kv_item_len is None:
                 raise RuntimeError("DeepSeek V4 HiSparse transfer needs dst item len")
             return self._send_kvcache_hisparse_dsv4(
@@ -1122,7 +1172,22 @@ class MooncakeKVManager(CommonKVManager):
         target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
     ):
         """Send state or extra pool data with type-specific handling."""
-        state_type = getattr(self.kv_args, "state_type", "none")
+        state_types = _state_type_values(self.kv_args)
+        if not state_types:
+            return 0
+
+        if len(state_types) > 1:
+            logger.warning_once(
+                "Mooncake state transfer only handles the first state component; "
+                f"state_types={state_types}"
+            )
+
+        state_type = state_types[0]
+        src_state_data_ptrs = _component_int_values(self.kv_args.state_data_ptrs)
+        src_state_item_lens = _component_int_values(self.kv_args.state_item_lens)
+        src_state_dim_per_tensor = _component_int_values(
+            getattr(self.kv_args, "state_dim_per_tensor", [])
+        )
 
         if state_type == "mamba":
             # Check if we need slice transfer for different TP sizes
@@ -1136,6 +1201,9 @@ class MooncakeKVManager(CommonKVManager):
                     dst_state_data_ptrs,
                     target_rank_registration_info.dst_state_item_lens,
                     target_rank_registration_info.dst_state_dim_per_tensor,
+                    src_state_data_ptrs,
+                    src_state_item_lens,
+                    src_state_dim_per_tensor,
                     target_rank_registration_info.dst_tp_rank,
                     target_rank_registration_info.dst_attn_tp_size,
                 )
@@ -1144,6 +1212,8 @@ class MooncakeKVManager(CommonKVManager):
                     req,
                     prefill_state_indices,
                     dst_state_data_ptrs,
+                    src_state_data_ptrs,
+                    src_state_item_lens,
                 )
         elif state_type in ["swa", "nsa"]:
             # SWA and NSA hybrid models do not support different TP sizes yet
@@ -1171,9 +1241,9 @@ class MooncakeKVManager(CommonKVManager):
             dst_state_indices = np.array(dst_state_indices, dtype=np.int32)
             return self._send_kvcache_generic(
                 mooncake_session_id=req.mooncake_session_id,
-                src_data_ptrs=self.kv_args.state_data_ptrs,
+                src_data_ptrs=src_state_data_ptrs,
                 dst_data_ptrs=dst_state_data_ptrs,
-                item_lens=self.kv_args.state_item_lens,
+                item_lens=src_state_item_lens,
                 prefill_data_indices=prefill_state_indices,
                 dst_data_indices=dst_state_indices,
                 executor=executor,
@@ -1203,9 +1273,11 @@ class MooncakeKVManager(CommonKVManager):
             f"State index length mismatch: prefill={len(prefill_state_indices)}, "
             f"dst={len(req.dst_state_indices)}"
         )
-        assert len(self.kv_args.state_data_ptrs) == len(dst_state_data_ptrs)
-        assert len(self.kv_args.state_item_lens) == len(dst_state_item_lens)
-        for i, item_len in enumerate(self.kv_args.state_item_lens):
+        src_state_data_ptrs = _component_int_values(self.kv_args.state_data_ptrs)
+        src_state_item_lens = _component_int_values(self.kv_args.state_item_lens)
+        assert len(src_state_data_ptrs) == len(dst_state_data_ptrs)
+        assert len(src_state_item_lens) == len(dst_state_item_lens)
+        for i, item_len in enumerate(src_state_item_lens):
             assert item_len == dst_state_item_lens[i], (
                 f"V4 state item length mismatch at index {i}: "
                 f"{item_len} != {dst_state_item_lens[i]}"
@@ -1213,9 +1285,9 @@ class MooncakeKVManager(CommonKVManager):
 
         return self._send_kvcache_generic(
             mooncake_session_id=req.mooncake_session_id,
-            src_data_ptrs=self.kv_args.state_data_ptrs,
+            src_data_ptrs=src_state_data_ptrs,
             dst_data_ptrs=dst_state_data_ptrs,
-            item_lens=self.kv_args.state_item_lens,
+            item_lens=src_state_item_lens,
             prefill_data_indices=np.asarray(prefill_state_indices, dtype=np.int32),
             dst_data_indices=np.asarray(req.dst_state_indices, dtype=np.int32),
             executor=executor,
@@ -1226,17 +1298,17 @@ class MooncakeKVManager(CommonKVManager):
         req: TransferInfo,
         prefill_mamba_index: list[int],
         dst_state_data_ptrs: list[int],
+        src_state_data_ptrs: list[int],
+        src_state_item_lens: list[int],
     ):
         """Transfer Mamba states."""
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
 
         transfer_blocks = []
-        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
-        prefill_state_item_lens = self.kv_args.state_item_lens
 
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
-            length = prefill_state_item_lens[i]
-            src_addr = prefill_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
+            length = src_state_item_lens[i]
+            src_addr = src_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
             dst_addr = dst_state_ptr + length * int(req.dst_state_indices[0])
             transfer_blocks.append((src_addr, dst_addr, length))
 
@@ -1249,6 +1321,9 @@ class MooncakeKVManager(CommonKVManager):
         dst_state_data_ptrs: list[int],
         dst_state_item_lens: list[int],
         dst_state_dim_per_tensor: list[int],
+        src_state_data_ptrs: list[int],
+        src_state_item_lens: list[int],
+        src_state_dim_per_tensor: list[int],
         dst_tp_rank: int,
         dst_attn_tp_size: int,
     ):
@@ -1269,19 +1344,22 @@ class MooncakeKVManager(CommonKVManager):
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
 
         transfer_blocks = []
-        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
-        prefill_state_item_lens = self.kv_args.state_item_lens
-        src_state_dim_per_tensor = getattr(self.kv_args, "state_dim_per_tensor", [])
 
         # If no dimension info available, fall back to regular transfer
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
-            return self._send_mamba_state(req, prefill_mamba_index, dst_state_data_ptrs)
+            return self._send_mamba_state(
+                req,
+                prefill_mamba_index,
+                dst_state_data_ptrs,
+                src_state_data_ptrs,
+                src_state_item_lens,
+            )
 
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
 
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
-            src_item_len = prefill_state_item_lens[i]
+            src_item_len = src_state_item_lens[i]
             dst_item_len = dst_state_item_lens[i]
             src_dim = src_state_dim_per_tensor[i]
             dst_dim = dst_state_dim_per_tensor[i]
@@ -1314,7 +1392,7 @@ class MooncakeKVManager(CommonKVManager):
 
             # Calculate addresses for this state tensor
             src_addr = (
-                prefill_state_data_ptrs[i]
+                src_state_data_ptrs[i]
                 + src_item_len * int(prefill_mamba_index[0])
                 + src_dim_offset
             )
@@ -1961,16 +2039,17 @@ class MooncakeKVReceiver(CommonKVReceiver):
             packed_aux_data_ptrs = b"".join(
                 struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.aux_data_ptrs
             )
+            state_data_ptrs = _flatten_int_values(self.kv_mgr.kv_args.state_data_ptrs)
             packed_state_data_ptrs = b"".join(
-                struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.state_data_ptrs
+                struct.pack("Q", ptr) for ptr in state_data_ptrs
             )
             # Pack state_item_lens and state_dim_per_tensor for mamba state slice transfer
+            state_item_lens = _flatten_int_values(self.kv_mgr.kv_args.state_item_lens)
             packed_state_item_lens = b"".join(
-                struct.pack("I", item_len)
-                for item_len in self.kv_mgr.kv_args.state_item_lens
+                struct.pack("I", item_len) for item_len in state_item_lens
             )
-            state_dim_per_tensor = getattr(
-                self.kv_mgr.kv_args, "state_dim_per_tensor", []
+            state_dim_per_tensor = _flatten_int_values(
+                getattr(self.kv_mgr.kv_args, "state_dim_per_tensor", [])
             )
             packed_state_dim_per_tensor = b"".join(
                 struct.pack("I", dim) for dim in state_dim_per_tensor

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -708,37 +708,19 @@ class MooncakeKVManager(CommonKVManager):
         page_index_slice: slice,
         executor: concurrent.futures.ThreadPoolExecutor,
     ):
-        """HiSparse transfer: prefill page_size > decode host page_size=1.
-
-        Receives page-level prefill_kv_indices and the full token-level
-        dst_kv_indices.  Expands both to token granularity before transfer.
-        """
-        page_size = self.kv_args.page_size
-        per_token_item_lens = [il // page_size for il in self.kv_args.kv_item_lens]
-
-        # Expand page-level src indices to token-level
-        base = np.repeat(prefill_kv_indices * page_size, page_size)
-        offsets = np.tile(np.arange(page_size, dtype=np.int32), len(prefill_kv_indices))
-        expanded_src = base + offsets
-
-        # Expand page-level index_slice to token-level for dst
-        token_start = page_index_slice.start * page_size
-        token_end = min(page_index_slice.stop * page_size, len(dst_kv_indices))
-        expanded_dst = dst_kv_indices[token_start:token_end]
-
-        # Clip src to match dst length (last page may be partial)
-        expanded_src = expanded_src[: len(expanded_dst)]
+        """HiSparse transfer uses page-level indices for both source and host destination."""
+        chunked_dst_kv_indices = dst_kv_indices[page_index_slice]
 
         logger.debug(
-            f"Send KVCache for hisparse: {expanded_src.shape} -> {expanded_dst.shape}"
+            f"Send KVCache for hisparse: {prefill_kv_indices.shape} -> {chunked_dst_kv_indices.shape}"
         )
         return self._send_kvcache_generic(
             mooncake_session_id=mooncake_session_id,
             src_data_ptrs=self.kv_args.kv_data_ptrs,
             dst_data_ptrs=dst_kv_ptrs,
-            item_lens=per_token_item_lens,
-            prefill_data_indices=expanded_src,
-            dst_data_indices=expanded_dst,
+            item_lens=self.kv_args.kv_item_lens,
+            prefill_data_indices=prefill_kv_indices,
+            dst_data_indices=chunked_dst_kv_indices,
             executor=executor,
         )
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 import numpy.typing as npt
 
-from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
+from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
 from sglang.srt.disaggregation.common.conn import (
     CommonKVBootstrapServer,
     CommonKVManager,
@@ -30,8 +30,6 @@ from sglang.srt.disaggregation.common.staging_handler import (
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
     group_concurrent_contiguous,
-    pack_int_lists,
-    unpack_int_lists,
 )
 from sglang.srt.disaggregation.mooncake.utils import (
     check_mooncake_custom_mem_pool_enabled,
@@ -66,7 +64,7 @@ class TransferKVChunk:
     index_slice: slice
     is_last_chunk: bool
     prefill_aux_index: Optional[int]
-    state_indices: Optional[List]
+    state_indices: Optional[List[int]]
 
 
 # decode
@@ -78,7 +76,8 @@ class TransferInfo:
     mooncake_session_id: str
     dst_kv_indices: npt.NDArray[np.int32]
     dst_aux_index: int
-    dst_state_indices: List[List[int]]  # parallel to receiver's state_types
+    dst_state_indices: List[int]
+    dst_device_kv_indices: Optional[npt.NDArray[np.int32]]
     required_dst_info_num: int
     is_dummy: bool
     decode_prefix_len: Optional[int] = None
@@ -92,10 +91,18 @@ class TransferInfo:
             dst_kv_indices = np.array([], dtype=np.int32)
             dst_aux_index = None
             dst_state_indices = []
+            dst_device_kv_indices = None
         else:
             dst_kv_indices = np.frombuffer(msg[4], dtype=np.int32)
             dst_aux_index = int(msg[5].decode("ascii"))
-            dst_state_indices = unpack_int_lists(msg[6], "i")
+            if msg[6] == b"":
+                dst_state_indices = []
+            else:
+                dst_state_indices = list(np.frombuffer(msg[6], dtype=np.int32))
+            if len(msg) > 9 and msg[9] != b"":
+                dst_device_kv_indices = np.frombuffer(msg[9], dtype=np.int32)
+            else:
+                dst_device_kv_indices = None
             is_dummy = False
         return cls(
             room=int(msg[0].decode("ascii")),
@@ -105,6 +112,7 @@ class TransferInfo:
             dst_kv_indices=dst_kv_indices,
             dst_aux_index=dst_aux_index,
             dst_state_indices=dst_state_indices,
+            dst_device_kv_indices=dst_device_kv_indices,
             required_dst_info_num=int(msg[7].decode("ascii")),
             is_dummy=is_dummy,
             decode_prefix_len=(
@@ -122,13 +130,13 @@ class KVArgsRegisterInfo:
     mooncake_session_id: str
     dst_kv_ptrs: list[int]
     dst_aux_ptrs: list[int]
-    dst_state_data_ptrs: List[List[int]]  # parallel to state_types (same below)
+    dst_state_data_ptrs: list[int]
     dst_tp_rank: int
     dst_attn_tp_size: int
     dst_kv_item_len: int
     # for mamba state different tp slice transfer
-    dst_state_item_lens: List[List[int]]
-    dst_state_dim_per_tensor: List[List[int]]
+    dst_state_item_lens: list[int]
+    dst_state_dim_per_tensor: list[int]
     # HiSparse: decode host pool stores KV at token granularity
     enable_hisparse: bool = False
     # Note: always put the staging field at the final (since the staging field is optional and contains multiple inputs)
@@ -143,15 +151,19 @@ class KVArgsRegisterInfo:
             mooncake_session_id=msg[3].decode("ascii"),
             dst_kv_ptrs=list(struct.unpack(f"{len(msg[4])//8}Q", msg[4])),
             dst_aux_ptrs=list(struct.unpack(f"{len(msg[5])//8}Q", msg[5])),
-            dst_state_data_ptrs=unpack_int_lists(msg[6], "Q"),
+            dst_state_data_ptrs=list(struct.unpack(f"{len(msg[6])//8}Q", msg[6])),
             dst_tp_rank=int(msg[7].decode("ascii")),
             dst_attn_tp_size=int(msg[8].decode("ascii")),
             dst_kv_item_len=int(msg[9].decode("ascii")),
             dst_state_item_lens=(
-                unpack_int_lists(msg[10], "I") if len(msg) > 10 else []
+                list(struct.unpack(f"{len(msg[10])//4}I", msg[10]))
+                if len(msg) > 10 and len(msg[10]) > 0
+                else []
             ),
             dst_state_dim_per_tensor=(
-                unpack_int_lists(msg[11], "I") if len(msg) > 11 else []
+                list(struct.unpack(f"{len(msg[11])//4}I", msg[11]))
+                if len(msg) > 11 and len(msg[11]) > 0
+                else []
             ),
             enable_hisparse=(
                 msg[12].decode("ascii") == "1" if len(msg) > 12 else False
@@ -267,11 +279,11 @@ class MooncakeKVManager(CommonKVManager):
                 self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
             )
 
-        for ptrs, lens in zip(
-            self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
-        ):
-            if ptrs and lens:
-                self.engine.batch_register(ptrs, lens)
+        # Batch register state/extra pool data buffers
+        if self.kv_args.state_data_ptrs and self.kv_args.state_data_lens:
+            self.engine.batch_register(
+                self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+            )
 
     # ------------------------------------------------------------------
     # Staging buffer methods (all delegate to staging_handler.py)
@@ -699,6 +711,192 @@ class MooncakeKVManager(CommonKVManager):
             executor=executor,
         )
 
+    def send_kvcache_hisparse(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        dst_kv_item_len: Optional[int] = None,
+        dst_device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
+    ):
+        """HiSparse transfer uses page-level indices for source and host destination."""
+        if getattr(self.kv_args, "state_type", "none") == "dsv4":
+            if dst_kv_item_len is None:
+                raise RuntimeError("DeepSeek V4 HiSparse transfer needs dst item len")
+            return self._send_kvcache_hisparse_dsv4(
+                mooncake_session_id=mooncake_session_id,
+                prefill_kv_indices=prefill_kv_indices,
+                dst_kv_ptrs=dst_kv_ptrs,
+                dst_kv_indices=dst_kv_indices,
+                page_index_slice=page_index_slice,
+                executor=executor,
+                dst_kv_item_len=dst_kv_item_len,
+                dst_device_kv_indices=dst_device_kv_indices,
+            )
+
+        chunked_dst_kv_indices = dst_kv_indices[page_index_slice]
+
+        logger.debug(
+            f"Send KVCache for hisparse: {prefill_kv_indices.shape} -> {chunked_dst_kv_indices.shape}"
+        )
+        return self._send_kvcache_generic(
+            mooncake_session_id=mooncake_session_id,
+            src_data_ptrs=self.kv_args.kv_data_ptrs,
+            dst_data_ptrs=dst_kv_ptrs,
+            item_lens=self.kv_args.kv_item_lens,
+            prefill_data_indices=prefill_kv_indices,
+            dst_data_indices=chunked_dst_kv_indices,
+            executor=executor,
+        )
+
+    def _send_kvcache_hisparse_dsv4(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        dst_kv_item_len: int,
+        dst_device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
+    ) -> int:
+        """Transfer DeepSeek V4 C4 KV to host and non-sparse KV to device."""
+        c4_page_size = self.kv_args.page_size // 4
+        assert self.kv_args.page_size % 4 == 0
+        src_c4_layer_num = self._dsv4_c4_layer_count()
+        src_c4_layer_num = min(src_c4_layer_num, len(dst_kv_ptrs))
+
+        src_c4_indices, dst_c4_indices = self._dsv4_c4_token_indices(
+            prefill_kv_indices, dst_kv_indices, page_index_slice, c4_page_size
+        )
+        ret = self._send_dsv4_c4_to_host(
+            mooncake_session_id,
+            src_c4_indices,
+            dst_c4_indices,
+            self.kv_args.kv_data_ptrs[:src_c4_layer_num],
+            dst_kv_ptrs[:src_c4_layer_num],
+            dst_kv_item_len,
+            c4_page_size,
+        )
+        if ret != 0:
+            return ret
+
+        return self._send_dsv4_device_kv(
+            mooncake_session_id,
+            prefill_kv_indices,
+            dst_kv_ptrs,
+            page_index_slice,
+            src_c4_layer_num,
+            dst_device_kv_indices,
+            executor,
+        )
+
+    def _dsv4_c4_layer_count(self) -> int:
+        first_item_len = self.kv_args.kv_item_lens[0]
+        for i, item_len in enumerate(self.kv_args.kv_item_lens):
+            if item_len != first_item_len:
+                return i
+        return len(self.kv_args.kv_item_lens)
+
+    @staticmethod
+    def _dsv4_c4_token_indices(
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        c4_page_size: int,
+    ) -> Tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+        src_pages = prefill_kv_indices.astype(np.int64, copy=False)
+        src_indices = np.repeat(src_pages * c4_page_size, c4_page_size)
+        src_indices += np.tile(
+            np.arange(c4_page_size, dtype=np.int64), len(prefill_kv_indices)
+        )
+
+        dst_start = page_index_slice.start * c4_page_size
+        dst_end = min(page_index_slice.stop * c4_page_size, len(dst_kv_indices))
+        dst_indices = dst_kv_indices[dst_start:dst_end].astype(np.int64, copy=False)
+        return src_indices[: len(dst_indices)], dst_indices
+
+    def _send_dsv4_c4_to_host(
+        self,
+        mooncake_session_id: str,
+        src_indices: npt.NDArray[np.int64],
+        dst_indices: npt.NDArray[np.int64],
+        src_ptrs: list[int],
+        dst_ptrs: list[int],
+        dst_kv_item_len: int,
+        c4_page_size: int,
+    ) -> int:
+        value_bytes = dst_kv_item_len - 8
+        scale_bytes = 8
+        gpu_page_bytes = self.kv_args.kv_item_lens[0]
+        gpu_scale_page_offset = value_bytes * c4_page_size
+
+        # DSV4 host layout is token-linear.  GPU C4 pages store values first
+        # and scales after that, so each C4 token maps to two transfer blocks.
+        max_tokens_per_batch = 256
+        for src_ptr, dst_ptr in zip(src_ptrs, dst_ptrs):
+            for start in range(0, len(src_indices), max_tokens_per_batch):
+                transfer_blocks = []
+                src_chunk = src_indices[start : start + max_tokens_per_batch]
+                dst_chunk = dst_indices[start : start + max_tokens_per_batch]
+                for src_idx, dst_idx in zip(src_chunk, dst_chunk):
+                    src_page = int(src_idx) // c4_page_size
+                    src_offset = int(src_idx) % c4_page_size
+                    src_base = int(src_ptr) + src_page * gpu_page_bytes
+                    dst_base = int(dst_ptr) + int(dst_idx) * dst_kv_item_len
+                    transfer_blocks.append(
+                        (src_base + src_offset * value_bytes, dst_base, value_bytes)
+                    )
+                    transfer_blocks.append(
+                        (
+                            src_base + gpu_scale_page_offset + src_offset * scale_bytes,
+                            dst_base + value_bytes,
+                            scale_bytes,
+                        )
+                    )
+                ret = self._transfer_data(mooncake_session_id, transfer_blocks)
+                if ret != 0:
+                    return ret
+        return 0
+
+    def _send_dsv4_device_kv(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        page_index_slice: slice,
+        src_c4_layer_num: int,
+        dst_device_kv_indices: Optional[npt.NDArray[np.int32]],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        if len(dst_kv_ptrs) <= src_c4_layer_num:
+            return 0
+        if dst_device_kv_indices is None:
+            raise RuntimeError(
+                "DeepSeek V4 HiSparse transfer needs device KV indices for "
+                "c4_indexer/c128 KV"
+            )
+
+        src_pages = prefill_kv_indices.astype(np.int64, copy=False)
+        dst_pages = dst_device_kv_indices[page_index_slice].astype(
+            np.int64, copy=False
+        )
+        count = min(len(src_pages), len(dst_pages))
+        if count == 0:
+            return 0
+        return self._send_kvcache_generic(
+            mooncake_session_id=mooncake_session_id,
+            src_data_ptrs=self.kv_args.kv_data_ptrs[src_c4_layer_num:],
+            dst_data_ptrs=dst_kv_ptrs[src_c4_layer_num:],
+            item_lens=self.kv_args.kv_item_lens[src_c4_layer_num:],
+            prefill_data_indices=src_pages[:count].astype(np.int32, copy=False),
+            dst_data_indices=dst_pages[:count].astype(np.int32, copy=False),
+            executor=executor,
+        )
+
     def send_kvcache_slice(
         self,
         mooncake_session_id: str,
@@ -918,133 +1116,128 @@ class MooncakeKVManager(CommonKVManager):
     def maybe_send_extra(
         self,
         req: TransferInfo,
-        prefill_state_indices: List,
+        prefill_state_indices: list[int],
+        dst_state_data_ptrs: list[int],
         executor: concurrent.futures.ThreadPoolExecutor,
         target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
     ):
-        rc = 0
-        state_types = getattr(self.kv_args, "state_types", [])
-        for i, st in enumerate(state_types):
-            indices = (
-                prefill_state_indices[i] if i < len(prefill_state_indices) else None
-            )
-            if indices is None:
-                continue
-            src_data_ptrs = self.kv_args.state_data_ptrs[i]
-            src_item_lens = self.kv_args.state_item_lens[i]
-            src_dim_per_tensor = (
-                self.kv_args.state_dim_per_tensor[i]
-                if i < len(self.kv_args.state_dim_per_tensor)
-                else []
-            )
-            if target_rank_registration_info is not None:
-                dst_data_ptrs = (
-                    target_rank_registration_info.dst_state_data_ptrs[i]
-                    if i < len(target_rank_registration_info.dst_state_data_ptrs)
-                    else []
-                )
-                dst_item_lens = (
-                    target_rank_registration_info.dst_state_item_lens[i]
-                    if i < len(target_rank_registration_info.dst_state_item_lens)
-                    else []
-                )
-                dst_dim_per_tensor = (
-                    target_rank_registration_info.dst_state_dim_per_tensor[i]
-                    if i < len(target_rank_registration_info.dst_state_dim_per_tensor)
-                    else []
+        """Send state or extra pool data with type-specific handling."""
+        state_type = getattr(self.kv_args, "state_type", "none")
+
+        if state_type == "mamba":
+            # Check if we need slice transfer for different TP sizes
+            if (
+                target_rank_registration_info is not None
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                return self._send_mamba_state_slice(
+                    req,
+                    prefill_state_indices,
+                    dst_state_data_ptrs,
+                    target_rank_registration_info.dst_state_item_lens,
+                    target_rank_registration_info.dst_state_dim_per_tensor,
+                    target_rank_registration_info.dst_tp_rank,
+                    target_rank_registration_info.dst_attn_tp_size,
                 )
             else:
-                dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
-            dst_indices = (
-                req.dst_state_indices[i] if i < len(req.dst_state_indices) else []
+                return self._send_mamba_state(
+                    req,
+                    prefill_state_indices,
+                    dst_state_data_ptrs,
+                )
+        elif state_type in ["swa", "nsa"]:
+            # SWA and NSA hybrid models do not support different TP sizes yet
+            if (
+                target_rank_registration_info is not None
+                and not self.is_mla_backend
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                raise RuntimeError(
+                    f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {state_type.upper()} hybrid models yet."
+                )
+            dst_state_indices = req.dst_state_indices
+            if len(prefill_state_indices) > len(dst_state_indices):
+                logger.warning(
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
+                )
+                prefill_state_indices = prefill_state_indices[: len(dst_state_indices)]
+            elif len(prefill_state_indices) < len(dst_state_indices):
+                logger.warning(
+                    f"len(prefill_state_indices) = {len(prefill_state_indices)}, len(dst_state_indices) = {len(dst_state_indices)}"
+                )
+                dst_state_indices = dst_state_indices[: len(prefill_state_indices)]
+            # Reuse _send_kvcache_generic interface to send extra pool data
+            prefill_state_indices = np.array(prefill_state_indices, dtype=np.int32)
+            dst_state_indices = np.array(dst_state_indices, dtype=np.int32)
+            return self._send_kvcache_generic(
+                mooncake_session_id=req.mooncake_session_id,
+                src_data_ptrs=self.kv_args.state_data_ptrs,
+                dst_data_ptrs=dst_state_data_ptrs,
+                item_lens=self.kv_args.state_item_lens,
+                prefill_data_indices=prefill_state_indices,
+                dst_data_indices=dst_state_indices,
+                executor=executor,
+            )
+        elif state_type == "dsv4":
+            return self._send_dsv4_state(
+                req,
+                prefill_state_indices,
+                dst_state_data_ptrs,
+                target_rank_registration_info.dst_state_item_lens
+                if target_rank_registration_info is not None
+                else [],
+                executor,
+            )
+        else:
+            return 0
+
+    def _send_dsv4_state(
+        self,
+        req: TransferInfo,
+        prefill_state_indices: list[int],
+        dst_state_data_ptrs: list[int],
+        dst_state_item_lens: list[int],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        assert len(prefill_state_indices) == len(req.dst_state_indices), (
+            f"State index length mismatch: prefill={len(prefill_state_indices)}, "
+            f"dst={len(req.dst_state_indices)}"
+        )
+        assert len(self.kv_args.state_data_ptrs) == len(dst_state_data_ptrs)
+        assert len(self.kv_args.state_item_lens) == len(dst_state_item_lens)
+        for i, item_len in enumerate(self.kv_args.state_item_lens):
+            assert item_len == dst_state_item_lens[i], (
+                f"V4 state item length mismatch at index {i}: "
+                f"{item_len} != {dst_state_item_lens[i]}"
             )
 
-            if st == StateType.MAMBA:
-                if (
-                    target_rank_registration_info is not None
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    rc = (
-                        self._send_mamba_state_slice(
-                            req,
-                            indices,
-                            src_data_ptrs,
-                            src_item_lens,
-                            src_dim_per_tensor,
-                            dst_data_ptrs,
-                            dst_indices,
-                            dst_item_lens,
-                            dst_dim_per_tensor,
-                            target_rank_registration_info.dst_tp_rank,
-                            target_rank_registration_info.dst_attn_tp_size,
-                        )
-                        or rc
-                    )
-                else:
-                    rc = (
-                        self._send_mamba_state(
-                            req,
-                            indices,
-                            src_data_ptrs,
-                            src_item_lens,
-                            dst_data_ptrs,
-                            dst_indices,
-                        )
-                        or rc
-                    )
-            elif st in (StateType.SWA, StateType.NSA):
-                if (
-                    target_rank_registration_info is not None
-                    and not self.is_mla_backend
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    raise RuntimeError(
-                        f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
-                    )
-                src_indices = list(indices)
-                dst_indices_local = list(dst_indices)
-                if len(src_indices) > len(dst_indices_local):
-                    logger.warning(
-                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
-                    )
-                    src_indices = src_indices[: len(dst_indices_local)]
-                elif len(src_indices) < len(dst_indices_local):
-                    logger.warning(
-                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
-                    )
-                    dst_indices_local = dst_indices_local[: len(src_indices)]
-                rc = (
-                    self._send_kvcache_generic(
-                        mooncake_session_id=req.mooncake_session_id,
-                        src_data_ptrs=src_data_ptrs,
-                        dst_data_ptrs=dst_data_ptrs,
-                        item_lens=src_item_lens,
-                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
-                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
-                        executor=executor,
-                    )
-                    or rc
-                )
-        return rc
+        return self._send_kvcache_generic(
+            mooncake_session_id=req.mooncake_session_id,
+            src_data_ptrs=self.kv_args.state_data_ptrs,
+            dst_data_ptrs=dst_state_data_ptrs,
+            item_lens=self.kv_args.state_item_lens,
+            prefill_data_indices=np.asarray(prefill_state_indices, dtype=np.int32),
+            dst_data_indices=np.asarray(req.dst_state_indices, dtype=np.int32),
+            executor=executor,
+        )
 
     def _send_mamba_state(
         self,
         req: TransferInfo,
-        prefill_mamba_index: list,
-        src_state_data_ptrs: list[int],
-        src_state_item_lens: list[int],
+        prefill_mamba_index: list[int],
         dst_state_data_ptrs: list[int],
-        dst_mamba_index: list,
     ):
+        """Transfer Mamba states."""
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
 
         transfer_blocks = []
+        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
+        prefill_state_item_lens = self.kv_args.state_item_lens
+
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
-            length = src_state_item_lens[i]
-            src_addr = src_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
-            dst_addr = dst_state_ptr + length * int(dst_mamba_index[0])
+            length = prefill_state_item_lens[i]
+            src_addr = prefill_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
+            dst_addr = dst_state_ptr + length * int(req.dst_state_indices[0])
             transfer_blocks.append((src_addr, dst_addr, length))
 
         return self._transfer_data(req.mooncake_session_id, transfer_blocks)
@@ -1052,12 +1245,8 @@ class MooncakeKVManager(CommonKVManager):
     def _send_mamba_state_slice(
         self,
         req: TransferInfo,
-        prefill_mamba_index: list,
-        src_state_data_ptrs: list[int],
-        src_state_item_lens: list[int],
-        src_state_dim_per_tensor: list[int],
+        prefill_mamba_index: list[int],
         dst_state_data_ptrs: list[int],
-        dst_mamba_index: list,
         dst_state_item_lens: list[int],
         dst_state_dim_per_tensor: list[int],
         dst_tp_rank: int,
@@ -1079,33 +1268,33 @@ class MooncakeKVManager(CommonKVManager):
         )
         assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
 
+        transfer_blocks = []
+        prefill_state_data_ptrs = self.kv_args.state_data_ptrs
+        prefill_state_item_lens = self.kv_args.state_item_lens
+        src_state_dim_per_tensor = getattr(self.kv_args, "state_dim_per_tensor", [])
+
         # If no dimension info available, fall back to regular transfer
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
-            return self._send_mamba_state(
-                req,
-                prefill_mamba_index,
-                src_state_data_ptrs,
-                src_state_item_lens,
-                dst_state_data_ptrs,
-                dst_mamba_index,
-            )
+            return self._send_mamba_state(req, prefill_mamba_index, dst_state_data_ptrs)
 
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
 
-        transfer_blocks = []
         for i, dst_state_ptr in enumerate(dst_state_data_ptrs):
-            src_item_len = src_state_item_lens[i]
+            src_item_len = prefill_state_item_lens[i]
             dst_item_len = dst_state_item_lens[i]
             src_dim = src_state_dim_per_tensor[i]
             dst_dim = dst_state_dim_per_tensor[i]
 
+            # Calculate bytes per dimension slice
             # item_len = dim * trailing_dims_size, so trailing_dims_size = item_len / dim
             src_bytes_per_dim = src_item_len // src_dim
             dst_bytes_per_dim = dst_item_len // dst_dim
 
+            # Determine slicing parameters based on TP configuration
             if self.attn_tp_size > dst_attn_tp_size:
                 # Multiple prefill ranks send to 1 decode rank
+                # Each prefill sends all its dims to the appropriate offset in decode
                 src_dim_start = 0
                 num_dims_to_send = src_dim
                 writers_per_decode = self.attn_tp_size // dst_attn_tp_size
@@ -1113,21 +1302,26 @@ class MooncakeKVManager(CommonKVManager):
                 dst_dim_start = local_writer_idx * src_dim
             else:
                 # 1 prefill rank sends to multiple decode ranks
+                # Prefill sends a slice of its dims to each decode rank
                 src_dim_start = (dst_tp_rank_in_group * dst_dim) % src_dim
                 num_dims_to_send = dst_dim
                 dst_dim_start = 0
 
+            # Calculate byte offsets
             src_dim_offset = src_dim_start * src_bytes_per_dim
             dst_dim_offset = dst_dim_start * dst_bytes_per_dim
             bytes_to_send = num_dims_to_send * src_bytes_per_dim
 
+            # Calculate addresses for this state tensor
             src_addr = (
-                src_state_data_ptrs[i]
+                prefill_state_data_ptrs[i]
                 + src_item_len * int(prefill_mamba_index[0])
                 + src_dim_offset
             )
             dst_addr = (
-                dst_state_ptr + dst_item_len * int(dst_mamba_index[0]) + dst_dim_offset
+                dst_state_ptr
+                + dst_item_len * int(req.dst_state_indices[0])
+                + dst_dim_offset
             )
 
             transfer_blocks.append((src_addr, dst_addr, bytes_to_send))
@@ -1221,13 +1415,25 @@ class MooncakeKVManager(CommonKVManager):
                             self.attn_tp_size
                             == target_rank_registration_info.dst_attn_tp_size
                         ):
-                            ret = self.send_kvcache(
-                                req.mooncake_session_id,
-                                kv_chunk.prefill_kv_indices,
-                                target_rank_registration_info.dst_kv_ptrs,
-                                chunked_dst_kv_indice,
-                                executor,
-                            )
+                            if target_rank_registration_info.enable_hisparse:
+                                ret = self.send_kvcache_hisparse(
+                                    req.mooncake_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    req.dst_kv_indices,
+                                    kv_chunk.index_slice,
+                                    executor,
+                                    target_rank_registration_info.dst_kv_item_len,
+                                    req.dst_device_kv_indices,
+                                )
+                            else:
+                                ret = self.send_kvcache(
+                                    req.mooncake_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    executor,
+                                )
                         elif (
                             self.enable_staging
                             and staging_strategy is not None
@@ -1283,10 +1489,11 @@ class MooncakeKVManager(CommonKVManager):
                             break
 
                         if kv_chunk.is_last_chunk:
-                            if kv_chunk.state_indices:
+                            if kv_chunk.state_indices is not None:
                                 self.maybe_send_extra(
                                     req,
                                     kv_chunk.state_indices,
+                                    target_rank_registration_info.dst_state_data_ptrs,
                                     executor,
                                     target_rank_registration_info,
                                 )
@@ -1561,7 +1768,7 @@ class MooncakeKVManager(CommonKVManager):
         index_slice: slice,
         is_last_chunk: bool,
         aux_index: Optional[int] = None,
-        state_indices: Optional[List] = None,
+        state_indices: Optional[List[int]] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
@@ -1657,7 +1864,7 @@ class MooncakeKVSender(CommonKVSender):
     def send(
         self,
         kv_indices: npt.NDArray[np.int32],
-        state_indices: Optional[List] = None,
+        state_indices: Optional[List[int]] = None,
     ):
         index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))
         self.curr_idx += len(kv_indices)
@@ -1754,14 +1961,19 @@ class MooncakeKVReceiver(CommonKVReceiver):
             packed_aux_data_ptrs = b"".join(
                 struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.aux_data_ptrs
             )
-            packed_state_data_ptrs = pack_int_lists(
-                self.kv_mgr.kv_args.state_data_ptrs, "Q"
+            packed_state_data_ptrs = b"".join(
+                struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.state_data_ptrs
             )
-            packed_state_item_lens = pack_int_lists(
-                self.kv_mgr.kv_args.state_item_lens, "I"
+            # Pack state_item_lens and state_dim_per_tensor for mamba state slice transfer
+            packed_state_item_lens = b"".join(
+                struct.pack("I", item_len)
+                for item_len in self.kv_mgr.kv_args.state_item_lens
             )
-            packed_state_dim_per_tensor = pack_int_lists(
-                getattr(self.kv_mgr.kv_args, "state_dim_per_tensor", []) or [], "I"
+            state_dim_per_tensor = getattr(
+                self.kv_mgr.kv_args, "state_dim_per_tensor", []
+            )
+            packed_state_dim_per_tensor = b"".join(
+                struct.pack("I", dim) for dim in state_dim_per_tensor
             )
             # Note(shangming): No need to add pp rank here since decode pp size should be equal to prefill pp size or 1
             tp_rank = self.kv_mgr.kv_args.engine_rank
@@ -1769,6 +1981,8 @@ class MooncakeKVReceiver(CommonKVReceiver):
             dst_tp_rank = str(tp_rank).encode("ascii")
             dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
             dst_kv_item_len = str(kv_item_len).encode("ascii")
+            enable_hisparse = b"1" if self.kv_mgr.server_args.enable_hisparse else b"0"
+
             if (
                 self.kv_mgr.enable_staging
                 and self.kv_mgr._staging_ctx.allocator is not None
@@ -1796,6 +2010,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         dst_kv_item_len,
                         packed_state_item_lens,
                         packed_state_dim_per_tensor,
+                        enable_hisparse,
                         packed_staging_base_ptr,
                         staging_total_size_str,
                     ]
@@ -1811,8 +2026,9 @@ class MooncakeKVReceiver(CommonKVReceiver):
         self,
         kv_indices: npt.NDArray[np.int32],
         aux_index: Optional[int] = None,
-        state_indices: Optional[List] = None,
+        state_indices: Optional[List[int]] = None,
         decode_prefix_len: Optional[int] = None,
+        device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
     ):
         if self.bootstrap_infos is None:
             self.kv_mgr.record_failure(
@@ -1845,12 +2061,20 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         kv_indices.tobytes() if not is_dummy else b"",
                         str(aux_index).encode("ascii") if not is_dummy else b"",
                         (
-                            pack_int_lists(state_indices, "i")
-                            if not is_dummy and state_indices
+                            np.array(
+                                state_indices,
+                                dtype=np.int32,
+                            ).tobytes()
+                            if not is_dummy and state_indices is not None
                             else b""
                         ),
                         str(self.required_dst_info_num).encode("ascii"),
                         str(decode_prefix_len or 0).encode("ascii"),
+                        (
+                            device_kv_indices.tobytes()
+                            if not is_dummy and device_kv_indices is not None
+                            else b""
+                        ),
                     ]
                 )
         self.init_time = time.time()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -699,31 +699,6 @@ class MooncakeKVManager(CommonKVManager):
             executor=executor,
         )
 
-    def send_kvcache_hisparse(
-        self,
-        mooncake_session_id: str,
-        prefill_kv_indices: npt.NDArray[np.int32],
-        dst_kv_ptrs: list[int],
-        dst_kv_indices: npt.NDArray[np.int32],
-        page_index_slice: slice,
-        executor: concurrent.futures.ThreadPoolExecutor,
-    ):
-        """HiSparse transfer uses page-level indices for both source and host destination."""
-        chunked_dst_kv_indices = dst_kv_indices[page_index_slice]
-
-        logger.debug(
-            f"Send KVCache for hisparse: {prefill_kv_indices.shape} -> {chunked_dst_kv_indices.shape}"
-        )
-        return self._send_kvcache_generic(
-            mooncake_session_id=mooncake_session_id,
-            src_data_ptrs=self.kv_args.kv_data_ptrs,
-            dst_data_ptrs=dst_kv_ptrs,
-            item_lens=self.kv_args.kv_item_lens,
-            prefill_data_indices=prefill_kv_indices,
-            dst_data_indices=chunked_dst_kv_indices,
-            executor=executor,
-        )
-
     def send_kvcache_slice(
         self,
         mooncake_session_id: str,
@@ -1246,23 +1221,13 @@ class MooncakeKVManager(CommonKVManager):
                             self.attn_tp_size
                             == target_rank_registration_info.dst_attn_tp_size
                         ):
-                            if target_rank_registration_info.enable_hisparse:
-                                ret = self.send_kvcache_hisparse(
-                                    req.mooncake_session_id,
-                                    kv_chunk.prefill_kv_indices,
-                                    target_rank_registration_info.dst_kv_ptrs,
-                                    req.dst_kv_indices,
-                                    kv_chunk.index_slice,
-                                    executor,
-                                )
-                            else:
-                                ret = self.send_kvcache(
-                                    req.mooncake_session_id,
-                                    kv_chunk.prefill_kv_indices,
-                                    target_rank_registration_info.dst_kv_ptrs,
-                                    chunked_dst_kv_indice,
-                                    executor,
-                                )
+                            ret = self.send_kvcache(
+                                req.mooncake_session_id,
+                                kv_chunk.prefill_kv_indices,
+                                target_rank_registration_info.dst_kv_ptrs,
+                                chunked_dst_kv_indice,
+                                executor,
+                            )
                         elif (
                             self.enable_staging
                             and staging_strategy is not None
@@ -1804,8 +1769,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
             dst_tp_rank = str(tp_rank).encode("ascii")
             dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
             dst_kv_item_len = str(kv_item_len).encode("ascii")
-            enable_hisparse = b"1" if self.kv_mgr.server_args.enable_hisparse else b"0"
-
             if (
                 self.kv_mgr.enable_staging
                 and self.kv_mgr._staging_ctx.allocator is not None
@@ -1833,7 +1796,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         dst_kv_item_len,
                         packed_state_item_lens,
                         packed_state_dim_per_tensor,
-                        enable_hisparse,
                         packed_staging_base_ptr,
                         staging_total_size_str,
                     ]

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -134,7 +134,9 @@ class PrefillBootstrapQueue:
             )
         self.kv_manager = self._init_kv_manager()
 
-        if self.scheduler.tp_worker.is_hybrid_swa:
+        if self.scheduler.tp_worker.is_hybrid_swa and not isinstance(
+            self.token_to_kv_pool, DeepSeekV4TokenToKVPool
+        ):
             # FIXME: current SWA allocation allocate full kv cache size in prefill
             self.max_total_num_tokens = min(
                 self.max_total_num_tokens,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING, List, Optional
 import torch
 
 from sglang.srt.disaggregation.base import KVPoll
-from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.utils import (
     FAKE_BOOTSTRAP_HOST,
@@ -49,12 +48,15 @@ from sglang.srt.managers.schedule_batch import (
     Req,
     ScheduleBatch,
 )
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     kv_to_page_num,
     maybe_cache_unfinished_req,
     release_kv_cache,
 )
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, NSATokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
 
 if TYPE_CHECKING:
@@ -176,13 +178,7 @@ class PrefillBootstrapQueue:
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
         kv_args.gpu_id = self.scheduler.gpu_id
 
-        req_to_token_pool = getattr(self.scheduler, "req_to_token_pool", None)
-        setup_state_kv_args(
-            kv_args,
-            self.token_to_kv_pool,
-            self.draft_token_to_kv_pool,
-            req_to_token_pool=req_to_token_pool,
-        )
+        setup_state_kv_args(kv_args, self.token_to_kv_pool, self.draft_token_to_kv_pool)
 
         kv_manager_class = get_kv_class(self.transfer_backend, KVClassType.MANAGER)
         kv_manager = kv_manager_class(
@@ -618,9 +614,9 @@ class SchedulerDisaggregationPrefillMixin:
                     KVPoll.Success,
                     KVPoll.Failed,
                 ):
-                    logger.warning_once(
+                    logger.warning(
                         f"PP rank {self.pp_rank}: unexpected poll state {poll} for rid {req.rid} "
-                        f"from consensus; treating as undone",
+                        f"from consensus; treating as undone"
                     )
                     undone_reqs.append(req)
                     continue
@@ -651,9 +647,9 @@ class SchedulerDisaggregationPrefillMixin:
                 if self.enable_metrics:
                     self.metrics_collector.increment_transfer_failed_reqs()
             else:
-                logger.warning_once(
+                logger.warning(
                     f"Unexpected polling state {poll} for rid {req.rid} in inflight queue; "
-                    f"treating as undone",
+                    f"treating as undone"
                 )
                 undone_reqs.append(req)
 
@@ -776,56 +772,58 @@ class SchedulerDisaggregationPrefillMixin:
             .cpu()
             .numpy()
         )
-        state_indices: Optional[List] = None
+        state_indices = None
         if last_chunk:
             self.disagg_metadata_buffers.set_buf(req)
 
-            seq_len = len(req.fill_ids)
-
-            def _mamba_payload():
-                return [
+            # Prepare extra pool indices for hybrid models
+            if isinstance(
+                self.token_to_kv_pool_allocator.get_kvcache(), HybridLinearKVPool
+            ):
+                # Mamba hybrid model: send single mamba state index
+                state_indices = [
                     self.req_to_token_pool.req_index_to_mamba_index_mapping[
                         req.req_pool_idx
                     ]
                     .cpu()
                     .numpy()
                 ]
-
-            def _swa_payload():
+            elif isinstance(
+                self.token_to_kv_pool_allocator.get_kvcache(), BaseSWAKVPool
+            ):
+                # SWA hybrid model: send last window KV indices
+                seq_len = len(req.fill_ids)
                 window_size = self.sliding_window_size
+                kvcache = self.token_to_kv_pool_allocator.get_kvcache()
+                state_page_size = (
+                    kvcache.swa_page_size
+                    if isinstance(kvcache, DeepSeekV4TokenToKVPool)
+                    else page_size
+                )
                 window_start = max(0, seq_len - window_size)
-                window_start = (window_start // page_size) * page_size
+                window_start = (window_start // state_page_size) * state_page_size
+
                 window_kv_indices_full = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, window_start:seq_len
                 ]
+
+                # Translate to SWA pool indices
                 window_kv_indices_swa = (
                     self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
                         window_kv_indices_full
                     )
                 )
-                return kv_to_page_indices(
-                    window_kv_indices_swa.cpu().numpy(), page_size
-                )
-
-            def _nsa_payload():
+                state_indices = window_kv_indices_swa.cpu().numpy()
+                state_indices = kv_to_page_indices(state_indices, state_page_size)
+            elif isinstance(
+                self.token_to_kv_pool_allocator.get_kvcache(), NSATokenToKVPool
+            ):
+                seq_len = len(req.fill_ids)
                 kv_indices_full = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, :seq_len
                 ]
-                return kv_to_page_indices(kv_indices_full.cpu().numpy(), page_size)
-
-            state_types = (
-                self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
-            )
-            state_indices = []
-            for st in state_types:
-                if st == StateType.MAMBA:
-                    state_indices.append(_mamba_payload())
-                elif st == StateType.SWA:
-                    state_indices.append(_swa_payload())
-                elif st == StateType.NSA:
-                    state_indices.append(_nsa_payload())
-                else:
-                    state_indices.append(None)
+                state_indices = kv_indices_full.cpu().numpy()
+                state_indices = kv_to_page_indices(state_indices, page_size)
 
         page_indices = kv_to_page_indices(kv_indices, page_size)
         if not req.disagg_kv_sender.should_send_kv_chunk(len(page_indices), last_chunk):

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -119,13 +119,9 @@ def fused_marlin_moe(
         and w2_scale.dtype == torch.float8_e8m0fnu
     )
     if is_mxfp4_marlin:
-        assert w1_scale.dtype == torch.float8_e8m0fnu, (
-            "MXFP4 Marlin expects w1_scale to be torch.float8_e8m0fnu, "
-            f"got {w1_scale.dtype}"
-        )
-        assert w2_scale.dtype == torch.float8_e8m0fnu, (
-            "MXFP4 Marlin expects w2_scale to be torch.float8_e8m0fnu, "
-            f"got {w2_scale.dtype}"
+        assert hidden_states.dtype == torch.bfloat16, (
+            "MXFP4 Marlin with E8M0 scales is only instantiated for bfloat16 "
+            f"activations, got {hidden_states.dtype}"
         )
     else:
         assert (

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -364,6 +364,11 @@ class _DeepEPDispatcherImplBase:
     def _get_buffer(self):
         raise NotImplementedError
 
+    def _buffer_deepep_mode(self):
+        if self.deepep_mode == DeepEPMode.LOW_LATENCY:
+            return DeepEPMode.AUTO
+        return self.deepep_mode
+
     def set_quant_config(self, quant_config: dict) -> None:
         self.quant_config = quant_config
 
@@ -536,7 +541,7 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
             self.group,
             self.hidden_size,
             self.params_bytes,
-            self.deepep_mode,
+            self._buffer_deepep_mode(),
             self.num_max_dispatch_tokens_per_rank,
             self.num_experts,
         )
@@ -744,7 +749,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
             self.group,
             self.hidden_size,
             self.params_bytes,
-            self.deepep_mode,
+            self._buffer_deepep_mode(),
             self.num_max_dispatch_tokens_per_rank,
             self.num_experts,
         )
@@ -792,7 +797,7 @@ class DeepEPDispatcher(BaseDispatcher):
                 return_recv_hook=return_recv_hook,
                 **common_kwargs,
             )
-        if self.deepep_mode.enable_normal():
+        if self.deepep_mode.enable_normal() or self.deepep_mode.enable_low_latency():
             self._normal_dispatcher = _DeepEPDispatcherImplNormal(
                 async_finish=async_finish,
                 **common_kwargs,
@@ -818,7 +823,9 @@ class DeepEPDispatcher(BaseDispatcher):
         topk_output: TopKOutput,
     ):
         self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
-        inner_state = self._get_impl().dispatch_a(
+        impl = self._get_dispatch_impl(hidden_states, topk_output)
+        self._active_dispatch_impl = impl
+        inner_state = impl.dispatch_a(
             hidden_states=hidden_states,
             topk_output=topk_output,
         )
@@ -828,7 +835,9 @@ class DeepEPDispatcher(BaseDispatcher):
         self._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
         inner_state = self._dispatch_intermediate_state
         del self._dispatch_intermediate_state
-        return self._get_impl().dispatch_b(*inner_state)
+        impl = self._active_dispatch_impl
+        del self._active_dispatch_impl
+        return impl.dispatch_b(*inner_state)
 
     def combine(
         self,
@@ -844,7 +853,9 @@ class DeepEPDispatcher(BaseDispatcher):
     ):
         hidden_states, topk_ids, topk_weights = combine_input
         self._update_stage(_Stage.AFTER_DISPATCH_B, _Stage.AFTER_COMBINE_A)
-        inner_state = self._get_impl().combine_a(
+        impl = self._get_combine_impl(combine_input)
+        self._active_combine_impl = impl
+        inner_state = impl.combine_a(
             hidden_states=hidden_states,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
@@ -855,7 +866,54 @@ class DeepEPDispatcher(BaseDispatcher):
         self._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
         inner_state = self._combine_intermediate_state
         del self._combine_intermediate_state
-        return self._get_impl().combine_b(*inner_state)
+        impl = self._active_combine_impl
+        del self._active_combine_impl
+        return impl.combine_b(*inner_state)
+
+    def _get_dispatch_impl(
+        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+    ) -> _DeepEPDispatcherImplBase:
+        impl = self._get_impl()
+        if not isinstance(impl, _DeepEPDispatcherImplLowLatency):
+            return impl
+
+        num_tokens = (
+            hidden_states[0].shape[0]
+            if isinstance(hidden_states, tuple)
+            else hidden_states.shape[0]
+        )
+        topk_rows = topk_output.topk_ids.shape[0]
+        if num_tokens != topk_rows:
+            raise RuntimeError(
+                "DeepEP low-latency dispatch shape mismatch: "
+                f"hidden_states.shape={hidden_states.shape if not isinstance(hidden_states, tuple) else hidden_states[0].shape}, "
+                f"topk_ids.shape={topk_output.topk_ids.shape}"
+            )
+        if num_tokens > impl.num_max_dispatch_tokens_per_rank:
+            if not hasattr(self, "_normal_dispatcher"):
+                raise RuntimeError(
+                    "DeepEP low-latency dispatch token count exceeds capacity: "
+                    f"num_tokens={num_tokens}, "
+                    f"num_max_dispatch_tokens_per_rank={impl.num_max_dispatch_tokens_per_rank}"
+                )
+            if not getattr(self, "_warned_low_latency_fallback", False):
+                logger.warning(
+                    "DeepEP low-latency dispatch token count exceeds capacity "
+                    "(num_tokens=%s, num_max_dispatch_tokens_per_rank=%s); "
+                    "falling back to normal dispatch.",
+                    num_tokens,
+                    impl.num_max_dispatch_tokens_per_rank,
+                )
+                self._warned_low_latency_fallback = True
+            return self._normal_dispatcher
+        return impl
+
+    def _get_combine_impl(self, combine_input: CombineInput) -> _DeepEPDispatcherImplBase:
+        if combine_input.format == CombineInputFormat.DEEPEP_NORMAL:
+            return self._normal_dispatcher
+        if combine_input.format == CombineInputFormat.DEEPEP_LL:
+            return self._low_latency_dispatcher
+        return self._get_impl()
 
     def _get_impl(self) -> _DeepEPDispatcherImplBase:
         is_extend_in_batch = get_is_extend_in_batch()

--- a/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
@@ -52,14 +52,30 @@ def _normalize_scale_tensor(
     raise TypeError(f"Unsupported MXFP4 scale dtype for Marlin: {scales.dtype}")
 
 
+def _get_optional_param(layer: torch.nn.Module, *names: str) -> torch.Tensor | None:
+    for name in names:
+        value = getattr(layer, name, None)
+        if value is not None:
+            return value
+    return None
+
+
 def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
     group_size = 32
     w13 = layer.w13_weight.data
     w2 = layer.w2_weight.data
-    w13_scale = layer.w13_weight_scale_inv.data
-    w2_scale = layer.w2_weight_scale_inv.data
-    w13_bias = getattr(layer, "w13_bias", None)
-    w2_bias = getattr(layer, "w2_bias", None)
+    w13_scale = _get_optional_param(layer, "w13_weight_scale", "w13_weight_scale_inv")
+    w2_scale = _get_optional_param(layer, "w2_weight_scale", "w2_weight_scale_inv")
+    w13_bias = _get_optional_param(layer, "w13_weight_bias", "w13_bias")
+    w2_bias = _get_optional_param(layer, "w2_weight_bias", "w2_bias")
+
+    if w13_scale is None or w2_scale is None:
+        raise ValueError("MXFP4 Marlin requires w13/w2 weight scales.")
+
+    w13_scale_data = w13_scale.data if hasattr(w13_scale, "data") else w13_scale
+    w2_scale_data = w2_scale.data if hasattr(w2_scale, "data") else w2_scale
+    w13_bias_data = w13_bias.data if hasattr(w13_bias, "data") else w13_bias
+    w2_bias_data = w2_bias.data if hasattr(w2_bias, "data") else w2_bias
 
     num_experts = w13.shape[0]
     intermediate_size = w13.shape[1] // 2
@@ -67,7 +83,7 @@ def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
     param_dtype = getattr(
         layer,
         "orig_dtype",
-        w13_bias.dtype if w13_bias is not None else torch.bfloat16,
+        w13_bias_data.dtype if w13_bias_data is not None else torch.bfloat16,
     )
 
     device = w13.device
@@ -129,19 +145,19 @@ def prepare_moe_mxfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
 
     w13_marlin = _repack_weight(w13, True)
     w2_marlin = _repack_weight(w2, False)
-    w13_scale_marlin = _permute_scales(w13_scale, True)
-    w2_scale_marlin = _permute_scales(w2_scale, False)
+    w13_scale_marlin = _permute_scales(w13_scale_data, True)
+    w2_scale_marlin = _permute_scales(w2_scale_data, False)
 
     layer.w13_weight = torch.nn.Parameter(w13_marlin, requires_grad=False)
     layer.w2_weight = torch.nn.Parameter(w2_marlin, requires_grad=False)
-    layer.w13_weight_scale_inv = torch.nn.Parameter(
-        w13_scale_marlin, requires_grad=False
-    )
-    layer.w2_weight_scale_inv = torch.nn.Parameter(w2_scale_marlin, requires_grad=False)
+    layer.w13_weight_scale = torch.nn.Parameter(w13_scale_marlin, requires_grad=False)
+    layer.w2_weight_scale = torch.nn.Parameter(w2_scale_marlin, requires_grad=False)
 
-    if w13_bias is not None:
-        layer.w13_bias = torch.nn.Parameter(
-            _permute_bias(w13_bias), requires_grad=False
+    if w13_bias_data is not None:
+        layer.w13_weight_bias = torch.nn.Parameter(
+            _permute_bias(w13_bias_data), requires_grad=False
         )
-    if w2_bias is not None:
-        layer.w2_bias = torch.nn.Parameter(_permute_bias(w2_bias), requires_grad=False)
+    if w2_bias_data is not None:
+        layer.w2_weight_bias = torch.nn.Parameter(
+            _permute_bias(w2_bias_data), requires_grad=False
+        )

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -28,6 +28,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 from sglang.srt.layers.quantization.base_config import (
@@ -315,6 +316,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
+        self.use_marlin = get_moe_runner_backend().is_marlin()
         self.flashinfer_mxfp4_moe_precision = (
             get_global_server_args().flashinfer_mxfp4_moe_precision
         )
@@ -438,6 +440,25 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
+        if self.use_marlin:
+            from sglang.srt.layers.quantization.marlin_utils import (
+                check_moe_marlin_supports_layer,
+            )
+            from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+                prepare_moe_mxfp4_layer_for_marlin,
+            )
+
+            if not is_sm90_supported():
+                raise RuntimeError("MXFP4 Marlin requires Hopper/SM90 or above.")
+            if not check_moe_marlin_supports_layer(layer, 32):
+                raise RuntimeError(
+                    "Current MXFP4 MoE layer is not supported by Marlin."
+                )
+
+            prepare_moe_mxfp4_layer_for_marlin(layer)
+            layer._mxfp4_backend = "marlin"
+            return
+
         if self.use_flashinfer:
             # TODO: these values are hardcoded for now, we need to get them from the model
             layer.gemm1_alpha = Parameter(
@@ -755,7 +776,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.runner = MoeRunner(
                 moe_runner_backend, replace(moe_runner_config, activation="swiglu")
             )
-        elif moe_runner_backend.is_triton_kernels() or moe_runner_backend.is_triton():
+        elif (
+            moe_runner_backend.is_triton_kernels()
+            or moe_runner_backend.is_triton()
+            or moe_runner_backend.is_marlin()
+        ):
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         else:
             # TODO(cwan): refactor other backends
@@ -772,6 +797,20 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         x = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
+
+        if self.use_marlin:
+            assert TopKOutputChecker.format_is_standard(topk_output)
+            quant_info = MarlinMoeQuantInfo(
+                w13_qweight=layer.w13_weight,
+                w2_qweight=layer.w2_weight,
+                w13_scales=layer.w13_weight_scale,
+                w2_scales=layer.w2_weight_scale,
+                w13_g_idx_sort_indices=None,
+                w2_g_idx_sort_indices=None,
+                weight_bits=4,
+                is_k_full=True,
+            )
+            return self.runner.run(dispatch_output, quant_info)
 
         if self.use_flashinfer:
             # When bf16 mode is enabled, we don't need to quantize the input,

--- a/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
@@ -38,16 +38,62 @@ class Mxfp4MarlinMoEMethod:
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
-        # Delegate to the underlying FP8 method for weight creation —
-        # the raw weight shapes are the same; only post-loading processing differs.
-        self._fp8.create_weights(
-            layer,
-            num_experts,
-            hidden_size,
-            intermediate_size_per_partition,
-            params_dtype,
-            **extra_weight_attrs,
+        from sglang.srt.layers.moe.fused_moe_triton import (
+            FusedMoeWeightScaleSupported,
         )
+        from sglang.srt.model_loader.weight_utils import set_weight_attrs
+
+        fp4_block_k = 32
+
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // 2,
+                dtype=torch.int8,
+            ),
+            requires_grad=False,
+        )
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // 2,
+                dtype=torch.int8,
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+        w13_weight_scale = torch.nn.Parameter(
+            torch.ones(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size // fp4_block_k,
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        w2_weight_scale = torch.nn.Parameter(
+            torch.ones(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition // fp4_block_k,
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        w13_weight_scale.format_ue8m0 = False
+        w2_weight_scale.format_ue8m0 = False
+        scale_attrs = dict(extra_weight_attrs)
+        scale_attrs["quant_method"] = FusedMoeWeightScaleSupported.BLOCK.value
+        layer.register_parameter("w13_weight_scale_inv", w13_weight_scale)
+        set_weight_attrs(w13_weight_scale, scale_attrs)
+        layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
+        set_weight_attrs(w2_weight_scale, scale_attrs)
 
     def process_weights_after_loading(self, layer: Module) -> None:
         from sglang.srt.layers.quantization.marlin_utils import (
@@ -102,8 +148,8 @@ class Mxfp4MarlinMoEMethod:
         quant_info = MarlinMoeQuantInfo(
             w13_qweight=layer.w13_weight,
             w2_qweight=layer.w2_weight,
-            w13_scales=layer.w13_weight_scale_inv,
-            w2_scales=layer.w2_weight_scale_inv,
+            w13_scales=layer.w13_weight_scale,
+            w2_scales=layer.w2_weight_scale,
             w13_g_idx_sort_indices=None,
             w2_g_idx_sort_indices=None,
             weight_bits=4,

--- a/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
@@ -8,7 +8,7 @@ from torch.nn import Module
 
 from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
-from sglang.srt.utils import log_info_on_rank0
+from sglang.srt.utils import log_info_on_rank0, set_weight_attrs
 from sglang.srt.utils.common import is_sm90_supported
 
 if TYPE_CHECKING:
@@ -41,7 +41,6 @@ class Mxfp4MarlinMoEMethod:
         from sglang.srt.layers.moe.fused_moe_triton import (
             FusedMoeWeightScaleSupported,
         )
-        from sglang.srt.model_loader.weight_utils import set_weight_attrs
 
         fp4_block_k = 32
 

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -150,7 +150,7 @@ class HiSparseCoordinator:
             .contiguous()
         )
         self._device_buffer_arange_i32 = torch.arange(
-            self.device_buffer_size, dtype=torch.int32, device=device
+            self.padded_buffer_size, dtype=torch.int32, device=device
         )
 
         # Pre-allocated output buffer for swap_in_selected_pages (CUDA-graph safe)
@@ -381,9 +381,9 @@ class HiSparseCoordinator:
         self.req_to_device_buffer[req.req_pool_idx, :alloc_size] = buffer_indices
         self.req_device_buffer_size[req.req_pool_idx] = alloc_size
 
-        self.req_device_buffer_tokens[
-            :, req.req_pool_idx, : self.device_buffer_size
-        ] = self._device_buffer_arange_i32
+        self.req_device_buffer_tokens[:, req.req_pool_idx, :alloc_size] = (
+            self._device_buffer_arange_i32[:alloc_size]
+        )
         self.req_device_buffer_token_locs[:, req.req_pool_idx, :alloc_size] = (
             buffer_indices[:alloc_size]
         )
@@ -645,6 +645,316 @@ class HiSparseCoordinator:
             return
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
+
+    def supports_hisparse_draft_slots(self) -> bool:
+        return True
+
+    def _ensure_padded_buffer(self, req_pool_indices: torch.Tensor) -> None:
+        req_indices_cpu = req_pool_indices.cpu().tolist()
+        grow_reqs = []
+        total_grow = 0
+        for req_idx in req_indices_cpu:
+            current_cap = int(self.req_device_buffer_size[req_idx])
+            if current_cap >= self.padded_buffer_size:
+                continue
+            grow_reqs.append((req_idx, current_cap))
+            total_grow += self.padded_buffer_size - current_cap
+
+        if total_grow == 0:
+            return
+
+        all_new = self.token_to_kv_pool_allocator.hisparse_attn_allocator.alloc(
+            total_grow
+        )
+        if all_new is None:
+            raise RuntimeError(
+                f"HiSparse: failed to grow buffers for draft slots (need {total_grow})"
+            )
+
+        offset = 0
+        for req_idx, current_cap in grow_reqs:
+            grow_size = self.padded_buffer_size - current_cap
+            chunk = all_new[offset : offset + grow_size]
+            offset += grow_size
+            self.req_to_device_buffer[req_idx, current_cap : self.padded_buffer_size] = (
+                chunk
+            )
+            self.req_device_buffer_tokens[
+                :, req_idx, current_cap : self.padded_buffer_size
+            ] = self._device_buffer_arange_i32[current_cap : self.padded_buffer_size]
+            self.req_device_buffer_token_locs[
+                :, req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            self.req_device_buffer_size[req_idx] = self.padded_buffer_size
+
+    def get_draft_device_slots(
+        self,
+        req_pool_indices: torch.Tensor,
+        num_tokens_per_req: int,
+    ) -> torch.Tensor:
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens_per_req} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})."
+            )
+        self._ensure_padded_buffer(req_pool_indices)
+        return self.req_to_device_buffer[req_pool_indices, start:end].reshape(-1)
+
+    def get_draft_device_slots_variable(
+        self,
+        req_pool_indices: torch.Tensor,
+        tokens_per_req_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        if tokens_per_req_cpu.numel() == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        start = self.device_buffer_size + 1
+        max_tokens = int(tokens_per_req_cpu.max().item())
+        if start + max_tokens > self.padded_buffer_size:
+            raise ValueError(
+                f"Max per-request draft slots ({max_tokens}) exceeds extra page "
+                f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+
+        total_slots = int(tokens_per_req_cpu.sum().item())
+        if total_slots == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        tokens_per_req = tokens_per_req_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        row_indices = torch.repeat_interleave(req_pool_indices, tokens_per_req)
+        offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=tokens_per_req.device),
+                tokens_per_req.cumsum(0),
+            ]
+        )
+        pos_in_segment = torch.arange(total_slots, device=tokens_per_req.device) - (
+            torch.repeat_interleave(offsets[:-1], tokens_per_req)
+        )
+        col_indices = start + pos_in_segment
+
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def finalize_accepted_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        draft_cache_locs: torch.Tensor,
+        num_correct_drafts: torch.Tensor,
+        num_correct_drafts_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> None:
+        if accepted_cache_locs.numel() == 0:
+            return
+
+        if self.is_dsv4_hisparse:
+            self._finalize_accepted_tokens_dsv4(
+                req_pool_indices,
+                accepted_cache_locs,
+                draft_cache_locs,
+                num_correct_drafts,
+                num_correct_drafts_cpu,
+                seq_lens,
+            )
+            return
+
+        counts = num_correct_drafts.to(torch.int64) + 1
+        counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
+        total_accepted = int(counts_cpu.sum().item())
+        if total_accepted != accepted_cache_locs.numel():
+            raise ValueError(
+                "HiSparse accepted token bookkeeping mismatch: "
+                f"expected {total_accepted} cache locs, got {accepted_cache_locs.numel()}."
+            )
+
+        all_device_locs = self.mem_pool_device._translate_loc_to_hisparse_device(
+            accepted_cache_locs
+        )
+        full_to_device_mapping = (
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        )
+        draft_mapping_snapshot = full_to_device_mapping[draft_cache_locs].clone()
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        starts = seq_lens - counts
+        all_indices = torch.arange(total_accepted, device=counts.device)
+        req_indices_expanded = torch.repeat_interleave(req_pool_indices, counts)
+        pos_in_segment = all_indices - torch.repeat_interleave(offsets[:-1], counts)
+        col_indices = torch.repeat_interleave(starts, counts) + pos_in_segment
+
+        col_indices_cpu = col_indices.cpu()
+        req_indices_cpu = req_indices_expanded.cpu()
+        host_locs = torch.cat(
+            [
+                self.ensure_host_slots(int(req_idx), int(col_idx), 1)
+                for req_idx, col_idx in zip(req_indices_cpu, col_indices_cpu)
+            ]
+        )
+        if host_locs.numel() != total_accepted:
+            full_to_device_mapping[draft_cache_locs] = draft_mapping_snapshot
+            raise RuntimeError("HiSparse host slot allocation mismatch for draft accept")
+
+        full_to_device_mapping[draft_cache_locs] = 0
+
+        with device_module.stream(self.decode_backup_stream):
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                all_device_locs.contiguous(),
+                io_backend="kernel",
+            )
+            if host_locs.is_cuda:
+                host_locs.record_stream(self.decode_backup_stream)
+            if all_device_locs.is_cuda:
+                all_device_locs.record_stream(self.decode_backup_stream)
+        event = device_module.Event()
+        event.record(self.decode_backup_stream)
+        device_module.current_stream().wait_event(event)
+
+        newest_slots = self.req_to_device_buffer[
+            req_pool_indices, self.device_buffer_size
+        ]
+        for idx in req_pool_indices.tolist():
+            self._skip_first_backup[idx] = True
+
+        last_offsets = offsets[1:] - 1
+        last_logical = accepted_cache_locs[last_offsets]
+        last_device = all_device_locs[last_offsets]
+        full_to_device_mapping[last_logical] = newest_slots
+        self.mem_pool_device.transfer_values_on_device(
+            dst_indices=newest_slots,
+            src_indices=last_device,
+        )
+
+    def _finalize_accepted_tokens_dsv4(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        draft_cache_locs: torch.Tensor,
+        num_correct_drafts: torch.Tensor,
+        num_correct_drafts_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> None:
+        counts = num_correct_drafts.to(torch.int64) + 1
+        counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
+        total_accepted = int(counts_cpu.sum().item())
+        if total_accepted != accepted_cache_locs.numel():
+            raise ValueError(
+                "DeepSeek V4 HiSparse accepted token bookkeeping mismatch: "
+                f"expected {total_accepted} cache locs, got {accepted_cache_locs.numel()}."
+            )
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        all_indices = torch.arange(total_accepted, device=counts.device)
+        pos_in_segment = all_indices - torch.repeat_interleave(offsets[:-1], counts)
+        starts = seq_lens - counts
+        full_positions = torch.repeat_interleave(starts, counts) + pos_in_segment
+        compressed_mask = (accepted_cache_locs + 1) % self.compress_ratio == 0
+
+        full_to_device_mapping = (
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        )
+        draft_compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
+            draft_cache_locs
+        )
+        draft_mapping_snapshot = full_to_device_mapping[draft_compressed_locs].clone()
+
+        if not torch.any(compressed_mask):
+            full_to_device_mapping[draft_compressed_locs] = 0
+            return
+
+        compressed_locs = self.mem_pool_device.translate_loc_from_full_to_compressed(
+            accepted_cache_locs
+        )
+        device_locs = full_to_device_mapping[compressed_locs]
+
+        req_indices_expanded = torch.repeat_interleave(req_pool_indices, counts)
+        compressed_req_indices = req_indices_expanded[compressed_mask]
+        compressed_positions = full_positions[compressed_mask] // self.compress_ratio
+        if compressed_locs.numel() != compressed_req_indices.numel():
+            full_to_device_mapping[draft_compressed_locs] = draft_mapping_snapshot
+            raise RuntimeError(
+                "DeepSeek V4 HiSparse compressed draft bookkeeping mismatch: "
+                f"{compressed_locs.numel()} compressed locs vs "
+                f"{compressed_req_indices.numel()} compressed positions."
+            )
+
+        compressed_req_indices_cpu = compressed_req_indices.cpu()
+        compressed_positions_cpu = compressed_positions.cpu()
+        host_locs = torch.cat(
+            [
+                self.ensure_host_slots(int(req_idx), int(pos), 1)
+                for req_idx, pos in zip(
+                    compressed_req_indices_cpu, compressed_positions_cpu
+                )
+            ]
+        )
+        if host_locs.numel() != compressed_locs.numel():
+            full_to_device_mapping[draft_compressed_locs] = draft_mapping_snapshot
+            raise RuntimeError(
+                "DeepSeek V4 HiSparse host slot allocation mismatch for draft accept"
+            )
+
+        full_to_device_mapping[draft_compressed_locs] = 0
+
+        with device_module.stream(self.decode_backup_stream):
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                device_locs.contiguous(),
+                io_backend="kernel",
+            )
+            if host_locs.is_cuda:
+                host_locs.record_stream(self.decode_backup_stream)
+            if device_locs.is_cuda:
+                device_locs.record_stream(self.decode_backup_stream)
+        event = device_module.Event()
+        event.record(self.decode_backup_stream)
+        device_module.current_stream().wait_event(event)
+
+        newest_slots = self.req_to_device_buffer[
+            req_pool_indices, self.device_buffer_size
+        ]
+        for idx in req_pool_indices.tolist():
+            self._skip_first_backup[idx] = True
+
+        compressed_offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=counts.device),
+                torch.cumsum(
+                    torch.bincount(
+                        compressed_req_indices,
+                        minlength=self.req_to_device_buffer.shape[0],
+                    )[req_pool_indices].to(torch.int64),
+                    dim=0,
+                ),
+            ]
+        )
+        has_compressed = compressed_offsets[1:] > compressed_offsets[:-1]
+        if not torch.any(has_compressed):
+            return
+
+        active_newest_slots = newest_slots[has_compressed]
+        last_compressed_offsets = compressed_offsets[1:][has_compressed] - 1
+        last_compressed_locs = compressed_locs[last_compressed_offsets]
+        last_device_locs = device_locs[last_compressed_offsets]
+        full_to_device_mapping[last_compressed_locs] = active_newest_slots
+        self.mem_pool_device.transfer_values_on_device(
+            dst_indices=active_newest_slots,
+            src_indices=last_device_locs,
+        )
 
     def naive_load_topk(
         self,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -110,6 +110,9 @@ class HiSparseCoordinator:
         self.req_device_buffer_size = torch.zeros(
             max_num_req_slots, dtype=torch.int64, device="cpu"
         )
+        self.req_draft_buffer_size = torch.zeros(
+            max_num_req_slots, dtype=torch.int64, device="cpu"
+        )
         self.req_to_host_pool = torch.full(
             (max_num_req_slots, max_compressed_context_len + self.page_size),
             -1,
@@ -649,16 +652,35 @@ class HiSparseCoordinator:
     def supports_hisparse_draft_slots(self) -> bool:
         return True
 
-    def _ensure_padded_buffer(self, req_pool_indices: torch.Tensor) -> None:
+    def _ensure_draft_buffer(
+        self, req_pool_indices: torch.Tensor, num_tokens: int
+    ) -> None:
+        if num_tokens <= 0:
+            return
+
+        start = self.device_buffer_size + 1
+        end = start + num_tokens
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})."
+            )
+
         req_indices_cpu = req_pool_indices.cpu().tolist()
         grow_reqs = []
         total_grow = 0
         for req_idx in req_indices_cpu:
-            current_cap = int(self.req_device_buffer_size[req_idx])
-            if current_cap >= self.padded_buffer_size:
+            current_cap = int(self.req_draft_buffer_size[req_idx])
+            existing_device_cap = int(self.req_device_buffer_size[req_idx])
+            if existing_device_cap >= end:
+                self.req_draft_buffer_size[req_idx] = max(current_cap, num_tokens)
+                continue
+            if current_cap >= num_tokens:
                 continue
             grow_reqs.append((req_idx, current_cap))
-            total_grow += self.padded_buffer_size - current_cap
+            total_grow += num_tokens - current_cap
 
         if total_grow == 0:
             return
@@ -673,19 +695,22 @@ class HiSparseCoordinator:
 
         offset = 0
         for req_idx, current_cap in grow_reqs:
-            grow_size = self.padded_buffer_size - current_cap
+            grow_size = num_tokens - current_cap
             chunk = all_new[offset : offset + grow_size]
             offset += grow_size
-            self.req_to_device_buffer[req_idx, current_cap : self.padded_buffer_size] = (
-                chunk
+            slot_start = start + current_cap
+            slot_end = slot_start + grow_size
+            self.req_to_device_buffer[req_idx, slot_start:slot_end] = chunk
+            self.req_device_buffer_tokens[:, req_idx, slot_start:slot_end] = (
+                self._device_buffer_arange_i32[slot_start:slot_end]
             )
-            self.req_device_buffer_tokens[
-                :, req_idx, current_cap : self.padded_buffer_size
-            ] = self._device_buffer_arange_i32[current_cap : self.padded_buffer_size]
-            self.req_device_buffer_token_locs[
-                :, req_idx, current_cap : self.padded_buffer_size
-            ] = chunk
-            self.req_device_buffer_size[req_idx] = self.padded_buffer_size
+            self.req_device_buffer_token_locs[:, req_idx, slot_start:slot_end] = chunk
+            self.req_draft_buffer_size[req_idx] = num_tokens
+
+    def _ensure_padded_buffer(self, req_pool_indices: torch.Tensor) -> None:
+        self._ensure_draft_buffer(
+            req_pool_indices, self.padded_buffer_size - self.device_buffer_size - 1
+        )
 
     def get_draft_device_slots(
         self,
@@ -701,7 +726,7 @@ class HiSparseCoordinator:
                 f"available (padded_buffer_size={self.padded_buffer_size}, "
                 f"device_buffer_size={self.device_buffer_size})."
             )
-        self._ensure_padded_buffer(req_pool_indices)
+        self._ensure_draft_buffer(req_pool_indices, num_tokens_per_req)
         return self.req_to_device_buffer[req_pool_indices, start:end].reshape(-1)
 
     def get_draft_device_slots_variable(
@@ -720,7 +745,7 @@ class HiSparseCoordinator:
                 f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})."
             )
 
-        self._ensure_padded_buffer(req_pool_indices)
+        self._ensure_draft_buffer(req_pool_indices, max_tokens)
 
         total_slots = int(tokens_per_req_cpu.sum().item())
         if total_slots == 0:
@@ -1096,9 +1121,29 @@ class HiSparseCoordinator:
 
         # release memory -- only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req.req_pool_idx])
+        draft_cap = int(self.req_draft_buffer_size[req.req_pool_idx])
         if current_cap > 0:
             side_buf_hi = self.req_to_device_buffer[req.req_pool_idx, :current_cap]
+        else:
+            side_buf_hi = torch.empty(0, dtype=torch.int64, device=self.device)
+        if draft_cap > 0:
+            draft_start = self.device_buffer_size + 1
+            draft_end = draft_start + draft_cap
+            draft_buf_hi = self.req_to_device_buffer[
+                req.req_pool_idx, draft_start:draft_end
+            ]
+            all_hi = torch.unique(
+                torch.cat(
+                    [
+                        side_buf_hi[side_buf_hi > 0],
+                        draft_buf_hi[draft_buf_hi > 0],
+                    ]
+                )
+            )
+        else:
             all_hi = torch.unique(side_buf_hi[side_buf_hi > 0])
+
+        if current_cap > 0 or draft_cap > 0:
             if all_hi.numel() > 0:
                 self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
 
@@ -1119,6 +1164,7 @@ class HiSparseCoordinator:
         self.req_device_buffer_token_locs[:, req.req_pool_idx, :] = -1
         self.req_to_device_buffer[req.req_pool_idx, :] = 0
         self.req_device_buffer_size[req.req_pool_idx] = 0
+        self.req_draft_buffer_size[req.req_pool_idx] = 0
         self.req_to_host_pool[req.req_pool_idx, :] = -1
         self.lru_slots[:, req.req_pool_idx, :].copy_(self._lru_init)
         self._skip_first_backup[req.req_pool_idx] = False

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -163,6 +163,7 @@ class HiSparseCoordinator:
         self.raw_indices_buffer = torch.full(
             (max_num_req_slots, self.top_k), -1, dtype=torch.int32, device=device
         )
+        self._non_decode_c4_fallback_warned = False
         # Scalar tensor: number of real (non-padded) requests in the batch.
         # Updated before each graph replay so padded blocks early-return.
         self.num_real_reqs = torch.zeros(1, dtype=torch.int32, device=device)
@@ -1168,6 +1169,73 @@ class HiSparseCoordinator:
         self.req_to_host_pool[req.req_pool_idx, :] = -1
         self.lru_slots[:, req.req_pool_idx, :].copy_(self._lru_init)
         self._skip_first_backup[req.req_pool_idx] = False
+
+    def cleanup_idle_orphan_device_buffers(self) -> int:
+        """Release side-buffer slots left without live logical/host ownership.
+
+        This is a defensive cleanup for warmup/capture or abnormal finish paths:
+        if logical and host pools are already idle, any per-request HiSparse
+        side-buffer capacity is no longer reachable from a live request.
+        """
+        self.wait_for_pending_backup()
+
+        req_indices = torch.nonzero(
+            (self.req_device_buffer_size > 0) | (self.req_draft_buffer_size > 0),
+            as_tuple=False,
+        ).flatten()
+        if req_indices.numel() == 0:
+            device_allocator = self.token_to_kv_pool_allocator.hisparse_attn_allocator
+            leaked = device_allocator.size - device_allocator.available_size()
+            if leaked <= 0:
+                return 0
+
+            # If there is no per-request owner but the allocator still reports
+            # used slots, the leak came from an abnormal warmup/capture path
+            # after req metadata was already cleared. At idle with logical/host
+            # pools empty, clearing the side allocator is safe and prevents
+            # repeated invariant spam.
+            device_allocator.clear()
+            mapping = getattr(
+                self.mem_pool_device, "full_to_hisparse_device_index_mapping", None
+            )
+            if mapping is not None:
+                mapping[:-1].fill_(0)
+            self.req_device_buffer_tokens[:, :, :] = -1
+            self.req_device_buffer_token_locs[:, :, :] = -1
+            self.req_to_device_buffer[:, :] = 0
+            self.lru_slots[:, :, :].copy_(self._lru_init)
+            return leaked
+
+        released = 0
+        for req_idx in req_indices.tolist():
+            current_cap = int(self.req_device_buffer_size[req_idx])
+            draft_cap = int(self.req_draft_buffer_size[req_idx])
+
+            bufs = []
+            if current_cap > 0:
+                bufs.append(self.req_to_device_buffer[req_idx, :current_cap])
+            if draft_cap > 0:
+                draft_start = self.device_buffer_size + 1
+                draft_end = draft_start + draft_cap
+                bufs.append(self.req_to_device_buffer[req_idx, draft_start:draft_end])
+
+            if bufs:
+                all_hi = torch.unique(torch.cat(bufs))
+                all_hi = all_hi[all_hi > 0]
+                if all_hi.numel() > 0:
+                    self.token_to_kv_pool_allocator.free_hisparse_indices(all_hi)
+                    released += int(all_hi.numel())
+
+            self.req_device_buffer_tokens[:, req_idx, :] = -1
+            self.req_device_buffer_token_locs[:, req_idx, :] = -1
+            self.req_to_device_buffer[req_idx, :] = 0
+            self.req_device_buffer_size[req_idx] = 0
+            self.req_draft_buffer_size[req_idx] = 0
+            self.req_to_host_pool[req_idx, :] = -1
+            self.lru_slots[:, req_idx, :].copy_(self._lru_init)
+            self._skip_first_backup[req_idx] = False
+
+        return released
 
     def swap_in_selected_pages(
         self,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -172,6 +172,25 @@ class HiSparseCoordinator:
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
 
+        logger.info(
+            "HiSparse coordinator initialized: dsv4=%s top_k=%d "
+            "device_buffer_size=%d page_size=%d padded_buffer_size=%d "
+            "compress_ratio=%d logical_size=%d device_hot_size=%d "
+            "host_size=%d max_req_slots=%d max_context_len=%d item_size_bytes=%d",
+            self.is_dsv4_hisparse,
+            self.top_k,
+            self.device_buffer_size,
+            self.mem_pool_device.page_size,
+            self.padded_buffer_size,
+            self.compress_ratio,
+            self.token_to_kv_pool_allocator.size_full,
+            self.token_to_kv_pool_allocator.hisparse_attn_allocator.size,
+            self.mem_pool_host.size,
+            max_num_req_slots,
+            max_context_len,
+            self.item_size_bytes,
+        )
+
     def _round_up_to_host_page(self, size: int) -> int:
         return (size + self.page_size - 1) // self.page_size * self.page_size
 

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -73,6 +73,7 @@ class HiSparseCoordinator:
                 self.mem_pool_host.kv_cache_total_dim
                 * self.mem_pool_host.dtype.itemsize
             )
+            self.page_size = self.mem_pool_host.page_size
         else:
             assert isinstance(
                 self.token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator
@@ -84,11 +85,12 @@ class HiSparseCoordinator:
                 device_pool=self.mem_pool_device,
                 host_to_device_ratio=host_to_device_ratio,
                 host_size=0,
-                page_size=1,
+                page_size=self.mem_pool_device.page_size,
                 layout="layer_first",
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
+            self.page_size = self.mem_pool_host.page_size
 
         max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
         max_context_len = req_to_token_pool.max_context_len
@@ -110,7 +112,7 @@ class HiSparseCoordinator:
             max_num_req_slots, dtype=torch.int64, device="cpu"
         )
         self.req_to_host_pool = torch.full(
-            (max_num_req_slots, max_compressed_context_len),
+            (max_num_req_slots, max_compressed_context_len + self.page_size),
             -1,
             dtype=torch.int64,
             device=device,
@@ -167,6 +169,72 @@ class HiSparseCoordinator:
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
 
+    def _round_up_to_host_page(self, size: int) -> int:
+        return (size + self.page_size - 1) // self.page_size * self.page_size
+
+    def ensure_host_slots(
+        self,
+        req_pool_idx: int,
+        start_pos: int,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        """Ensure token-position host slots, backed by page-granular allocation."""
+        if num_tokens <= 0:
+            return torch.empty((0,), dtype=torch.int64, device=self.device)
+
+        page_start = (start_pos // self.page_size) * self.page_size
+        page_end = self._round_up_to_host_page(start_pos + num_tokens)
+
+        page_starts = torch.arange(
+            page_start,
+            page_end,
+            self.page_size,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        page_is_missing = self.req_to_host_pool[req_pool_idx, page_starts] < 0
+        num_missing_pages = int(page_is_missing.sum().item())
+
+        if num_missing_pages > 0:
+            host_locs = self.mem_pool_host.alloc(num_missing_pages * self.page_size)
+            if host_locs is None:
+                logger.error(
+                    "HiSparse: host mem pool alloc failed for %d host pages "
+                    "(req_pool_idx=%d, start_pos=%d, num_tokens=%d)",
+                    num_missing_pages,
+                    req_pool_idx,
+                    start_pos,
+                    num_tokens,
+                )
+                raise RuntimeError(
+                    f"HiSparse host mem pool alloc failed for {num_missing_pages} pages"
+                )
+            host_locs = host_locs.to(device=self.device)
+            if num_missing_pages == page_starts.numel():
+                self.req_to_host_pool[req_pool_idx, page_start:page_end] = host_locs
+            else:
+                missing_page_starts = page_starts[page_is_missing]
+                offsets = torch.arange(
+                    self.page_size, dtype=torch.int64, device=self.device
+                )
+                missing_indices = (
+                    missing_page_starts[:, None] + offsets[None, :]
+                ).reshape(-1)
+                self.req_to_host_pool[req_pool_idx, missing_indices] = host_locs
+
+        return self.req_to_host_pool[req_pool_idx, start_pos : start_pos + num_tokens]
+
+    def _allocated_host_indices(self, req: Req) -> torch.Tensor:
+        allocated_len = req.kv_allocated_len
+        if self.is_dsv4_hisparse:
+            allocated_len = allocated_len // self.compress_ratio
+        host_len = min(
+            self._round_up_to_host_page(allocated_len),
+            self.req_to_host_pool.shape[1],
+        )
+        host_indices = self.req_to_host_pool[req.req_pool_idx, :host_len]
+        return host_indices[host_indices >= 0]
+
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
 
@@ -200,18 +268,7 @@ class HiSparseCoordinator:
         )
 
         prefill_len = len(device_indices)
-        host_indices = self.mem_pool_host.alloc(prefill_len)
-        if host_indices is None:
-            logger.error(
-                "HiSparse: host mem pool alloc failed for %d tokens (req %s)",
-                prefill_len,
-                req.rid,
-            )
-            raise RuntimeError(
-                f"HiSparse host mem pool alloc failed for {prefill_len} tokens"
-            )
-        host_indices = host_indices.to(device=self.device)
-        self.req_to_host_pool[req.req_pool_idx, :prefill_len] = host_indices
+        host_indices = self.ensure_host_slots(req.req_pool_idx, 0, prefill_len)
 
         start_event = device_module.Event()
         finish_event = device_module.Event()
@@ -549,17 +606,16 @@ class HiSparseCoordinator:
 
         device_locs = self.req_to_device_buffer[backup_req_indices, buffer_slot]
 
-        host_locs = self.mem_pool_host.alloc(len(device_locs))
-        if host_locs is None:
-            logger.error(
-                "HiSparse: host mem pool alloc failed for %d decode backup tokens",
-                len(device_locs),
-            )
-            raise RuntimeError(
-                f"HiSparse host mem pool alloc failed for {len(device_locs)} decode backup tokens"
-            )
-        host_locs = host_locs.to(device=self.device)
-        self.req_to_host_pool[backup_req_indices, actual_compressed_pos] = host_locs
+        host_locs = torch.cat(
+            [
+                self.ensure_host_slots(
+                    int(req_pool_indices_cpu[i]),
+                    int(actual_compressed_pos[j].item()),
+                    1,
+                )
+                for j, i in enumerate(backup_indices)
+            ]
+        )
 
         self.wait_for_pending_backup()
         schedule_stream = device_module.current_stream()
@@ -702,9 +758,7 @@ class HiSparseCoordinator:
         self.token_to_kv_pool_allocator.free_hisparse(allocated_locs)
 
         # Free host memory that was allocated during admit_request_into_staging
-        compressed_len = prefill_len // self.compress_ratio
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
-        host_indices = host_indices[host_indices >= 0]
+        host_indices = self._allocated_host_indices(req)
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
         self.req_to_host_pool[req.req_pool_idx, :] = -1
@@ -748,8 +802,7 @@ class HiSparseCoordinator:
         )
         self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
 
-        host_indices = self.req_to_host_pool[req.req_pool_idx, :compressed_len]
-        host_indices = host_indices[host_indices >= 0]
+        host_indices = self._allocated_host_indices(req)
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -73,7 +73,6 @@ class HiSparseCoordinator:
                 self.mem_pool_host.kv_cache_total_dim
                 * self.mem_pool_host.dtype.itemsize
             )
-            self.page_size = self.mem_pool_host.page_size
         else:
             assert isinstance(
                 self.token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator
@@ -90,7 +89,7 @@ class HiSparseCoordinator:
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
-            self.page_size = self.mem_pool_host.page_size
+        self.page_size = self.mem_pool_host.page_size
 
         max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
         max_context_len = req_to_token_pool.max_context_len
@@ -178,7 +177,7 @@ class HiSparseCoordinator:
         start_pos: int,
         num_tokens: int,
     ) -> torch.Tensor:
-        """Ensure token-position host slots, backed by page-granular allocation."""
+        """Ensure host slots for compressed token positions."""
         if num_tokens <= 0:
             return torch.empty((0,), dtype=torch.int64, device=self.device)
 
@@ -225,9 +224,8 @@ class HiSparseCoordinator:
         return self.req_to_host_pool[req_pool_idx, start_pos : start_pos + num_tokens]
 
     def _allocated_host_indices(self, req: Req) -> torch.Tensor:
-        allocated_len = req.kv_allocated_len // self.compress_ratio
         host_len = min(
-            self._round_up_to_host_page(allocated_len),
+            self._round_up_to_host_page(self._host_token_len(req.kv_allocated_len)),
             self.req_to_host_pool.shape[1],
         )
         host_indices = self.req_to_host_pool[req.req_pool_idx, :host_len]
@@ -300,15 +298,10 @@ class HiSparseCoordinator:
           buffer.  In the staging path this is correct (prefill filled the buffer),
           but here the buffer is empty.
         """
-        if self.is_dsv4_hisparse:
-            # TODO(dsv4): wire PD direct-to-host. Needs (a) load_to_device_per_layer
-            raise NotImplementedError(
-                "PD direct-to-host admission is not supported for dsv4 hisparse yet."
-            )
-
         self.alloc_device_buffer(req)
 
-        if req.kv_allocated_len <= self.device_buffer_size:
+        host_len = self._host_token_len(req.kv_allocated_len)
+        if host_len <= self.device_buffer_size:
             # Short sequences (seq_len <= device_buffer_size): the kernel fast path
             # returns device_buffer_locs directly without any host loading, so we
             # must preload all tokens from host pool into the device buffer
@@ -325,12 +318,16 @@ class HiSparseCoordinator:
         self._skip_first_backup[req.req_pool_idx] = True
         logger.debug("HiSparse: admitting request %s directly", req.rid)
 
+    def _host_token_len(self, kv_allocated_len: int) -> int:
+        if self.is_dsv4_hisparse:
+            return (kv_allocated_len + self.compress_ratio - 1) // self.compress_ratio
+        return kv_allocated_len
+
     def _preload_to_device_buffer(self, req: Req) -> None:
         """Preload all tokens from host pool into the device buffer."""
-        n = req.kv_allocated_len
+        n = self._host_token_len(req.kv_allocated_len)
         host_indices = self.req_to_host_pool[req.req_pool_idx, :n]
         device_locs = self.req_to_device_buffer[req.req_pool_idx, :n]
-
         for layer_id in range(self.mem_pool_device.layer_num):
             self.mem_pool_host.load_to_device_per_layer(
                 self.mem_pool_device,
@@ -339,6 +336,10 @@ class HiSparseCoordinator:
                 layer_id,
                 io_backend="kernel",
             )
+        # Direct PD admission runs outside the model forward stream.  The preload
+        # must be complete before the request is marked ready, otherwise decode
+        # can race the H2D copy and read a partially populated hot buffer.
+        device_module.current_stream().synchronize()
 
     def alloc_device_buffer(self, req: Req) -> None:
         if self.is_dsv4_hisparse:
@@ -604,11 +605,12 @@ class HiSparseCoordinator:
 
         device_locs = self.req_to_device_buffer[backup_req_indices, buffer_slot]
 
+        actual_compressed_pos_cpu = actual_compressed_pos.cpu()
         host_locs = torch.cat(
             [
                 self.ensure_host_slots(
                     int(req_pool_indices_cpu[i]),
-                    int(actual_compressed_pos[j].item()),
+                    int(actual_compressed_pos_cpu[j]),
                     1,
                 )
                 for j, i in enumerate(backup_indices)
@@ -656,9 +658,8 @@ class HiSparseCoordinator:
         This is a naive per-request loop implementation for debugging/validation.
         Production code uses swap_in_selected_pages (JIT CUDA kernel) instead.
 
-        Note: dsv4 hisparse is not supported — DeepSeekV4SingleKVPoolHost has no
-        load_to_device_per_layer and indices live in compressed space. Currently
-        only used as a kernel oracle in test_hisparse_unit.py (non-dsv4 path).
+        Note: dsv4 hisparse is not supported here. This helper is only used as
+        a kernel oracle in test_hisparse_unit.py (non-dsv4 path).
 
         Args:
             req_pool_indices: Pool indices for each request.  Shape: (num_reqs,)
@@ -782,7 +783,6 @@ class HiSparseCoordinator:
         # subsequent release_kv_cache -> allocator.free -> free_hisparse path
         # re-frees them (double-free into the page allocator's free list).
         allocated_len = req.kv_allocated_len
-        compressed_len = allocated_len // self.compress_ratio
 
         # release memory -- only free actually-allocated buffer indices
         current_cap = int(self.req_device_buffer_size[req.req_pool_idx])

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -99,9 +99,7 @@ class HiSparseCoordinator:
         ) // self.compress_ratio
 
         # to have an extra page for new tokens
-        self.padded_buffer_size = (
-            self.device_buffer_size + self.mem_pool_device.page_size
-        )
+        self.padded_buffer_size = self.device_buffer_size + self.page_size
 
         self.req_to_device_buffer = torch.zeros(
             (max_num_req_slots, self.padded_buffer_size),

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -99,7 +99,9 @@ class HiSparseCoordinator:
         ) // self.compress_ratio
 
         # to have an extra page for new tokens
-        self.padded_buffer_size = self.device_buffer_size + self.page_size
+        self.padded_buffer_size = (
+            self.device_buffer_size + self.mem_pool_device.page_size
+        )
 
         self.req_to_device_buffer = torch.zeros(
             (max_num_req_slots, self.padded_buffer_size),
@@ -223,9 +225,7 @@ class HiSparseCoordinator:
         return self.req_to_host_pool[req_pool_idx, start_pos : start_pos + num_tokens]
 
     def _allocated_host_indices(self, req: Req) -> torch.Tensor:
-        allocated_len = req.kv_allocated_len
-        if self.is_dsv4_hisparse:
-            allocated_len = allocated_len // self.compress_ratio
+        allocated_len = req.kv_allocated_len // self.compress_ratio
         host_len = min(
             self._round_up_to_host_page(allocated_len),
             self.req_to_host_pool.shape[1],

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3535,7 +3535,11 @@ class Scheduler(
             self.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
-                release_kv_cache(req, self.tree_cache)
+                if self.enable_hisparse:
+                    self.hisparse_coordinator.request_finished(req)
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
+                else:
+                    release_kv_cache(req, self.tree_cache)
             # For disaggregation prefill mode, free the metadata buffer index
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
                 release_req_to_metadata_buffer(
@@ -3574,16 +3578,14 @@ class Scheduler(
 
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             # Abort requests that have not yet finished preallocation
-            for decode_req in self.disagg_decode_prealloc_queue.queue:
-                if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
-                    logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
-                    decode_req.kv_receiver.abort()
+            self.disagg_decode_prealloc_queue.abort_requests(
+                recv_req.rid, recv_req.abort_all
+            )
 
             # Abort requests waiting for kvcache to release tree cache
-            for decode_req in self.disagg_decode_transfer_queue.queue:
-                if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
-                    logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
-                    decode_req.kv_receiver.abort()
+            self.disagg_decode_transfer_queue.abort_requests(
+                recv_req.rid, recv_req.abort_all
+            )
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -253,6 +253,8 @@ class SchedulerOutputProcessorMixin:
                     if req.finished():
                         self.maybe_collect_routed_experts(req)
                         self.maybe_collect_indexer_topk(req)
+                        if self.enable_hisparse:
+                            self.hisparse_coordinator.request_finished(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
@@ -387,6 +389,8 @@ class SchedulerOutputProcessorMixin:
                     req.check_finished()
 
                     if req.finished():
+                        if self.enable_hisparse:
+                            self.hisparse_coordinator.request_finished(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     else:

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -548,6 +548,56 @@ class SchedulerRuntimeCheckerMixin:
         ):
             self.tree_cache.sanity_check()
 
+    def _check_hisparse_idle_invariant(self: Scheduler):
+        if not self.enable_hisparse or self.hisparse_coordinator is None:
+            return
+        if not (
+            self.running_batch.is_empty()
+            and len(self.waiting_queue) == 0
+            and self.disaggregation_mode == DisaggregationMode.DECODE
+            and len(self.disagg_decode_prealloc_queue.queue) == 0
+            and len(self.disagg_decode_prealloc_queue.pending_reqs) == 0
+            and len(self.disagg_decode_prealloc_queue.retracted_queue) == 0
+            and len(self.disagg_decode_transfer_queue.queue) == 0
+        ):
+            return
+
+        logical_allocator = getattr(
+            self.token_to_kv_pool_allocator, "logical_attn_allocator", None
+        )
+        logical_used = 0
+        if logical_allocator is not None:
+            logical_used = logical_allocator.size - logical_allocator.available_size()
+        h = self.hisparse_coordinator.get_token_stats()
+        if logical_used != 0 or h.host_tokens != 0 or h.device_tokens != 0:
+            if logical_used == 0 and h.host_tokens == 0 and h.device_tokens > 0:
+                released = (
+                    self.hisparse_coordinator.cleanup_idle_orphan_device_buffers()
+                )
+                h_after = self.hisparse_coordinator.get_token_stats()
+                if h_after.device_tokens == 0:
+                    logger.warning(
+                        "Cleaned HiSparse idle orphan device buffers: "
+                        "released=%s, previous_device_tokens=%s",
+                        released,
+                        h.device_tokens,
+                    )
+                    return
+
+            last_state = getattr(self, "_last_hisparse_idle_violation", None)
+            state = (logical_used, h.host_tokens, h.device_tokens)
+            if last_state != state:
+                setattr(self, "_last_hisparse_idle_violation", state)
+                logger.error(
+                    "HiSparse idle invariant violated: logical_used=%s, "
+                    "host_tokens=%s, device_tokens=%s",
+                    logical_used,
+                    h.host_tokens,
+                    h.device_tokens,
+                )
+        else:
+            setattr(self, "_last_hisparse_idle_violation", None)
+
     def on_idle(self: Scheduler):
         """Idle housekeeping: guard, check, metrics, reset, sleep."""
         if not self.is_fully_idle():
@@ -560,6 +610,8 @@ class SchedulerRuntimeCheckerMixin:
             if has_leak:
                 self._report_leak("pool", "\n".join(messages))
             self._check_req_pool()
+        else:
+            self._check_hisparse_idle_invariant()
 
         # tree cache sanity check
         self._check_tree_cache()

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -232,6 +232,43 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         loc = self.translate_loc_to_hisparse_device(loc)
         return super().set_key_buffer_fused(layer_id, loc, cache_k)
 
+    def transfer_values_on_device(
+        self, dst_indices: torch.Tensor, src_indices: torch.Tensor
+    ) -> None:
+        if dst_indices.numel() == 0:
+            return
+        if dst_indices.numel() != src_indices.numel():
+            raise RuntimeError(
+                "HiSparseC4DevicePool device transfer mismatch: "
+                f"{dst_indices.numel()} dst indices vs {src_indices.numel()} src indices."
+            )
+
+        dst_indices = dst_indices.to(device=self.device, dtype=torch.int64)
+        src_indices = src_indices.to(device=self.device, dtype=torch.int64)
+
+        bytes_per_token = self.get_bytes_per_token()
+        byte_offsets = torch.arange(bytes_per_token, device=self.device)
+
+        src_pages = src_indices // self.page_size
+        dst_pages = dst_indices // self.page_size
+        src_offsets = (src_indices % self.page_size) * bytes_per_token
+        dst_offsets = (dst_indices % self.page_size) * bytes_per_token
+
+        src_flat_indices = (
+            src_pages[:, None] * self.bytes_per_page_padded
+            + src_offsets[:, None]
+            + byte_offsets[None, :]
+        ).reshape(-1)
+        dst_flat_indices = (
+            dst_pages[:, None] * self.bytes_per_page_padded
+            + dst_offsets[:, None]
+            + byte_offsets[None, :]
+        ).reshape(-1)
+
+        for buf in self.kv_buffer:
+            flat = buf.reshape(-1)
+            flat[dst_flat_indices] = flat[src_flat_indices].clone()
+
     def get_cpu_copy(self, indices, mamba_indices=None):
         raise NotImplementedError("HiSparseC4DevicePool does not support get_cpu_copy")
 

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -286,6 +286,89 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
         return self._kvcache._translate_loc_to_hisparse_device(last_locs)
 
+    def alloc_extend_logical_only(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        backup_state: bool = False,
+    ):
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
+                f"{avail} are available."
+            )
+
+        logical_state = (
+            self.logical_attn_allocator.backup_state() if backup_state else None
+        )
+        logical_indices = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if logical_indices is None:
+            raise RuntimeError(
+                f"HiSparse logical alloc failed for {extend_num_tokens} tokens. "
+                f"Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+
+        if backup_state:
+            return logical_indices, (logical_state, logical_indices.clone())
+        return logical_indices
+
+    def bind_device_mapping(
+        self, logical_indices: torch.Tensor, device_slots: torch.Tensor
+    ):
+        if logical_indices.numel() != device_slots.numel():
+            raise RuntimeError(
+                "HiSparse draft mapping mismatch: "
+                f"{logical_indices.numel()} logical locs vs "
+                f"{device_slots.numel()} device slots."
+            )
+        self.full_to_hisparse_device_index_mapping[logical_indices] = device_slots
+
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        out = self.alloc_extend_logical_only(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            backup_state=backup_state,
+        )
+        if backup_state:
+            logical_indices, state = out
+        else:
+            logical_indices = out
+            state = None
+
+        self.bind_device_mapping(logical_indices, device_slots)
+        if backup_state:
+            return logical_indices, state
+        return logical_indices
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        self.full_to_hisparse_device_index_mapping[logical_indices] = 0
+
     def alloc_extend(
         self,
         prefix_lens: torch.Tensor,
@@ -721,6 +804,103 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return self.hisparse_kvcache._translate_loc_to_hisparse_device(
             self.get_last_loc_compressed(last_locs)
         )
+
+    def alloc_extend_logical_only(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        backup_state: bool = False,
+    ):
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"DeepSeek V4 HiSparse logical alloc: need {extend_num_tokens} "
+                f"tokens but only {avail} are available."
+            )
+
+        logical_state = (
+            self.logical_attn_allocator.backup_state() if backup_state else None
+        )
+        logical_indices = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if logical_indices is None:
+            raise RuntimeError(
+                f"DeepSeek V4 HiSparse logical alloc failed for {extend_num_tokens} "
+                f"tokens. Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+
+        if backup_state:
+            return logical_indices, (logical_state, logical_indices.clone())
+        return logical_indices
+
+    def bind_device_mapping(
+        self, logical_indices: torch.Tensor, device_slots: torch.Tensor
+    ):
+        compressed_logical_indices = (
+            self.hisparse_kvcache.translate_loc_from_full_to_compressed(
+                logical_indices
+            )
+        )
+        compressed_mask = (logical_indices + 1) % self.compress_ratio == 0
+        compressed_device_slots = device_slots[compressed_mask]
+        if compressed_logical_indices.numel() != compressed_device_slots.numel():
+            raise RuntimeError(
+                "DeepSeek V4 HiSparse draft mapping mismatch: "
+                f"{compressed_logical_indices.numel()} compressed locs vs "
+                f"{compressed_device_slots.numel()} device slots."
+            )
+        self.full_to_hisparse_device_index_mapping[compressed_logical_indices] = (
+            compressed_device_slots.to(torch.int64)
+        )
+
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        out = self.alloc_extend_logical_only(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+            backup_state=backup_state,
+        )
+        if backup_state:
+            logical_indices, state = out
+        else:
+            logical_indices = out
+            state = None
+
+        self.bind_device_mapping(logical_indices, device_slots)
+        if backup_state:
+            return logical_indices, state
+        return logical_indices
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        compressed_indices = (
+            self.hisparse_kvcache.translate_loc_from_full_to_compressed(
+                logical_indices
+            )
+        )
+        self.full_to_hisparse_device_index_mapping[compressed_indices] = 0
 
     def alloc_extend(
         self,

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -703,10 +703,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return self.logical_attn_allocator.translate_loc_from_full_to_swa(kv_indices)
 
     def full_available_size(self):
-        return min(
-            self.logical_attn_allocator.full_available_size(),
-            self.hisparse_attn_allocator.available_size() * self.compress_ratio,
-        )
+        return self.logical_attn_allocator.full_available_size()
 
     def swa_available_size(self):
         return self.logical_attn_allocator.swa_available_size()
@@ -715,10 +712,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.logical_attn_allocator.free_swa(free_indices)
 
     def available_size(self) -> int:
-        return min(
-            self.logical_attn_allocator.available_size(),
-            self.hisparse_attn_allocator.available_size() * self.compress_ratio,
-        )
+        return self.logical_attn_allocator.available_size()
 
     def alloc(self, need_size: int):
         raise NotImplementedError(

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -483,6 +483,42 @@ class DeepSeekV4SingleKVPoolHost:
             cpu_indices=host_indices_i64,
         )
 
+    def get_contiguous_buf_infos(self):
+        """Return host C4 buffers as token-linear transfer targets."""
+        data_ptrs = [int(self.data_ptrs[i].item()) for i in range(self.layer_num)]
+        data_lens = [self.kv_buffer[i].nbytes for i in range(self.layer_num)]
+        item_lens = [
+            self.kv_cache_total_dim * self.dtype.itemsize
+        ] * self.layer_num
+        return data_ptrs, data_lens, item_lens
+
+    def load_to_device_per_layer(
+        self, device_pool, host_indices, device_indices, layer_id, io_backend="kernel"
+    ):
+        if io_backend != "kernel":
+            raise ValueError(f"Unsupported IO backend: {io_backend}")
+
+        from sglang.jit_kernel.deepseek_v4 import hisparse_load_to_device
+
+        if host_indices.device != device_indices.device:
+            host_indices = host_indices.to(device=device_indices.device)
+        host_indices_i64 = (
+            host_indices.to(torch.int64)
+            if host_indices.dtype != torch.int64
+            else host_indices
+        )
+        device_indices_i64 = (
+            device_indices.to(torch.int64)
+            if device_indices.dtype != torch.int64
+            else device_indices
+        )
+        hisparse_load_to_device(
+            gpu_cache=device_pool.kv_buffer[layer_id],
+            cpu_cache=self.kv_buffer[layer_id],
+            gpu_indices=device_indices_i64,
+            cpu_indices=host_indices_i64,
+        )
+
     def available_size(self):
         return len(self.free_slots)
 
@@ -607,10 +643,29 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             "use alloc_extend or alloc_decode instead."
         )
 
+    def alloc_logical_only(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+    ):
+        return self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+
     def alloc_device_buffer(self, allocated_indices, need_size: int):
         assert need_size % self.page_size == 0
         hisparse_indices = self.full_to_hisparse_device_index_mapping[allocated_indices]
         self.full_to_hisparse_device_index_mapping[allocated_indices] = 0
+        hisparse_indices = hisparse_indices[hisparse_indices > 0]
 
         device_buffer_size = need_size - self.page_size
         P = len(hisparse_indices)

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -833,7 +833,7 @@ class MLATokenToKVPoolHost(HostKVCache):
         for registering host memory with the disaggregation transfer engine."""
         data_ptrs = [int(self.data_ptrs[i].item()) for i in range(self.layer_num)]
         data_lens = [self.kv_buffer[i].nbytes for i in range(self.layer_num)]
-        item_lens = [self.token_stride_size] * self.layer_num
+        item_lens = [self.token_stride_size * self.page_size] * self.layer_num
         return data_ptrs, data_lens, item_lens
 
     def get_size_per_token(self):

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -408,8 +408,13 @@ class EAGLEDraftCudaGraphRunner:
 
         # Common inputs
         buffers.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
+        out_cache_loc = (
+            forward_batch.spec_info.draft_cache_locs
+            if forward_batch.spec_info.draft_cache_locs is not None
+            else forward_batch.out_cache_loc
+        )
         buffers.out_cache_loc[: raw_num_token * self.speculative_num_steps].copy_(
-            forward_batch.out_cache_loc
+            out_cache_loc
         )
         buffers.positions[:raw_num_token].copy_(forward_batch.positions)
         maybe_detect_nan(

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
@@ -143,15 +144,40 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 batch.req_pool_indices,
                 prefix_lens,
             )
-            batch.out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                prefix_lens,
-                prefix_lens_cpu,
-                end_offset,
-                end_offset_cpu,
-                last_loc,
-                len(batch.input_ids),
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                self.topk == 1
+                and hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    len(batch.input_ids) + len(prefix_lens_cpu) * allocator.page_size,
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots(
+                    batch.req_pool_indices,
+                    self.draft_token_num,
+                )
+                batch.out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                    device_slots,
+                )
+            else:
+                batch.out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                )
 
         bs = batch.batch_size()
         assign_req_to_token_pool_func(
@@ -481,6 +507,21 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         # try to unify the tensor representation and list representation
         num_correct_drafts_list = num_correct_drafts_cpu.tolist()
         num_accept_tokens_list = num_accept_tokens_cpu.tolist()
+
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            self.topk == 1
+            and hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            hisparse_coordinator.finalize_accepted_tokens(
+                batch.req_pool_indices,
+                batch.out_cache_loc[accept_index],
+                batch.out_cache_loc,
+                num_correct_drafts,
+                num_correct_drafts_cpu,
+                batch.seq_lens + num_accept_tokens_cpu.to(batch.seq_lens.device),
+            )
 
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -729,6 +729,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     # `EagleDraftExtendInput` for these). Set during V2's draft-extend.
     num_correct_drafts: Optional[torch.Tensor] = None
     num_accept_tokens: Optional[torch.Tensor] = None
+    draft_cache_locs: Optional[torch.Tensor] = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_DRAFT)

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -19,6 +19,7 @@ from sglang.srt.managers.utils import get_alloc_len_per_decode
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -118,6 +119,11 @@ class EagleDraftInputV2Mixin:
         page_size = batch.token_to_kv_pool_allocator.page_size
         alloc_len_per_decode = get_alloc_len_per_decode()
         double_alloc = alloc_len_per_decode + alloc_len_per_decode
+        topk = (
+            self.topk_p.shape[1]
+            if self.topk_p is not None
+            else get_global_server_args().speculative_eagle_topk
+        )
 
         cur_kv_lens = [0] * bs
         nxt_kv_lens = [0] * bs
@@ -151,15 +157,37 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 cur_kv_lens,
             )
-            out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                cur_kv_lens,
-                cur_kv_lens_cpu,
-                nxt_kv_lens,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                topk == 1
+                and hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    num_needed_tokens + len(cur_kv_lens_cpu) * allocator.page_size,
+                )
+                # Spec V2 over-allocates logical slots across iterations. Bind
+                # HiSparse device slots only for the active draft/verify window.
+                out_cache_loc = allocator.alloc_extend_logical_only(
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
+            else:
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
 
         assign_req_to_token_pool_func(
             batch.req_pool_indices,
@@ -202,6 +230,25 @@ class EagleDraftInputV2Mixin:
                 topk,
                 num_steps,
             )
+            hisparse_coordinator = getattr(
+                draft_model_runner, "hisparse_coordinator", None
+            )
+            if (
+                topk == 1
+                and hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                tokens_per_req_cpu = torch.full(
+                    (bs,), num_steps, dtype=torch.int64, device="cpu"
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    tokens_per_req_cpu,
+                )
+                draft_model_runner.token_to_kv_pool_allocator.bind_device_mapping(
+                    batch.out_cache_loc,
+                    device_slots,
+                )
 
         # Get a forward batch
         self.num_tokens_per_req = topk
@@ -266,6 +313,25 @@ class EagleVerifyInputV2Mixin:
                 draft_token_num=self.draft_token_num,
                 device=device,
             )
+            hisparse_coordinator = getattr(
+                target_worker.model_runner, "hisparse_coordinator", None
+            )
+            if (
+                self.topk == 1
+                and hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                tokens_per_req_cpu = torch.full(
+                    (bs,), self.draft_token_num, dtype=torch.int64, device="cpu"
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    tokens_per_req_cpu,
+                )
+                target_worker.model_runner.token_to_kv_pool_allocator.bind_device_mapping(
+                    batch.out_cache_loc,
+                    device_slots,
+                )
 
             # Set mamba_track_indices for mamba prefix-cache state tracking
             if get_global_server_args().enable_mamba_extra_buffer():

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -216,7 +216,7 @@ class EagleDraftInputV2Mixin:
             bs = len(batch.seq_lens)
 
             # Assign cache locations
-            batch.out_cache_loc = torch.empty(
+            draft_cache_locs = torch.empty(
                 (bs * topk * num_steps,),
                 dtype=torch.int64,
                 device=batch.input_ids.device,
@@ -226,11 +226,15 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 req_to_token_pool.req_to_token,
                 batch.seq_lens,
-                batch.out_cache_loc,
+                draft_cache_locs,
                 req_to_token_pool.req_to_token.shape[1],
                 topk,
                 num_steps,
             )
+            self.draft_cache_locs = draft_cache_locs
+            batch.out_cache_loc = draft_cache_locs.view(bs, topk, num_steps)[
+                :, :, 0
+            ].reshape(-1)
             hisparse_coordinator = getattr(
                 target_model_runner, "hisparse_coordinator", None
             )
@@ -247,9 +251,11 @@ class EagleDraftInputV2Mixin:
                     tokens_per_req_cpu,
                 )
                 target_model_runner.token_to_kv_pool_allocator.bind_device_mapping(
-                    batch.out_cache_loc,
+                    draft_cache_locs,
                     device_slots,
                 )
+        else:
+            self.draft_cache_locs = None
 
         # Get a forward batch
         self.num_tokens_per_req = topk

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -208,6 +208,7 @@ class EagleDraftInputV2Mixin:
         batch: ModelWorkerBatch,
         cuda_graph_runner: EAGLEDraftCudaGraphRunner,
         draft_model_runner: ModelRunner,
+        target_model_runner: ModelRunner,
         topk: int,
         num_steps: int,
     ):
@@ -231,7 +232,7 @@ class EagleDraftInputV2Mixin:
                 num_steps,
             )
             hisparse_coordinator = getattr(
-                draft_model_runner, "hisparse_coordinator", None
+                target_model_runner, "hisparse_coordinator", None
             )
             if (
                 topk == 1
@@ -245,7 +246,7 @@ class EagleDraftInputV2Mixin:
                     batch.req_pool_indices,
                     tokens_per_req_cpu,
                 )
-                draft_model_runner.token_to_kv_pool_allocator.bind_device_mapping(
+                target_model_runner.token_to_kv_pool_allocator.bind_device_mapping(
                     batch.out_cache_loc,
                     device_slots,
                 )

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -291,6 +291,39 @@ class EagleDraftInputV2Mixin:
             if batch.forward_mode.is_idle()
             else ForwardMode.DRAFT_EXTEND_V2
         )
+        # Use target worker's hisparse_coordinator (same instance that
+        # admit_request_direct() populated). Draft model runner has a separate
+        # coordinator whose req_device_buffer_size is never updated by admission.
+        target_model_runner = getattr(draft_model_runner, "_target_model_runner", None)
+        hisparse_coordinator = getattr(
+            target_model_runner, "hisparse_coordinator", None
+        ) if target_model_runner is not None else getattr(
+            draft_model_runner, "hisparse_coordinator", None
+        )
+        token_to_kv_pool_allocator = getattr(
+            target_model_runner, "token_to_kv_pool_allocator", None
+        ) if target_model_runner is not None else getattr(
+            draft_model_runner, "token_to_kv_pool_allocator", None
+        )
+        if (
+            hisparse_coordinator is not None
+            and token_to_kv_pool_allocator is not None
+            and hasattr(token_to_kv_pool_allocator, "bind_device_mapping")
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+            and not batch.forward_mode.is_idle()
+        ):
+            bs = len(batch.req_pool_indices)
+            tokens_per_req_cpu = torch.full(
+                (bs,), num_draft_tokens, dtype=torch.int64, device="cpu"
+            )
+            device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                batch.req_pool_indices,
+                tokens_per_req_cpu,
+            )
+            token_to_kv_pool_allocator.bind_device_mapping(
+                batch.out_cache_loc,
+                device_slots,
+            )
         forward_batch = ForwardBatch.init_new(batch, draft_model_runner)
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -23,6 +23,7 @@ from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
@@ -665,18 +666,46 @@ class EAGLEWorker(TpModelWorker):
                 )
                 extend_num_tokens = torch.sum((seq_lens_cpu - prefix_lens_cpu)).item()
 
-            out_cache_loc, token_to_kv_pool_state_backup = (
-                alloc_paged_token_slots_extend(
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                self.topk == 1
+                and hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = self.token_to_kv_pool_allocator
+                evict_from_tree_cache(
                     batch.tree_cache,
-                    prefix_lens,
-                    prefix_lens_cpu,
-                    seq_lens,
-                    seq_lens_cpu,
-                    last_loc,
-                    extend_num_tokens,
-                    backup_state=True,
+                    extend_num_tokens + len(prefix_lens_cpu) * allocator.page_size,
                 )
-            )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    seq_lens_cpu - prefix_lens_cpu,
+                )
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    allocator.alloc_extend_with_device_mapping(
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        device_slots,
+                        backup_state=True,
+                    )
+                )
+            else:
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    alloc_paged_token_slots_extend(
+                        batch.tree_cache,
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        backup_state=True,
+                    )
+                )
 
         if self.page_size > 1 and self.topk > 1:
             last_page_lens_cumsum = torch.cumsum(last_page_lens, dim=0)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -417,7 +417,11 @@ class EagleDraftWorker(BaseDraftWorker):
     def draft_forward(self, forward_batch: ForwardBatch):
         # Parse args
         spec_info: EagleDraftInput = forward_batch.spec_info
-        out_cache_loc = forward_batch.out_cache_loc
+        out_cache_loc = (
+            spec_info.draft_cache_locs
+            if spec_info.draft_cache_locs is not None
+            else forward_batch.out_cache_loc
+        )
         topk_p, topk_index, hidden_states = (
             spec_info.topk_p,
             spec_info.topk_index,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1040,6 +1040,26 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ) = verify_input.sample(batch, logits_output, vocab_mask)
         new_seq_lens = batch.seq_lens + accept_lens
 
+        hisparse_coordinator = getattr(
+            self.target_worker.model_runner, "hisparse_coordinator", None
+        )
+        if (
+            verify_input.topk == 1
+            and hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+            and not batch.forward_mode.is_idle()
+        ):
+            accept_index_flat = accept_index[accept_index != -1]
+            num_correct_drafts = accept_lens - 1
+            hisparse_coordinator.finalize_accepted_tokens(
+                batch.req_pool_indices,
+                batch.out_cache_loc[accept_index_flat],
+                batch.out_cache_loc,
+                num_correct_drafts,
+                num_correct_drafts.cpu(),
+                new_seq_lens,
+            )
+
         # Update mamba state for hybrid GDN models after verification
         if (
             self.target_worker.model_runner.hybrid_gdn_config is not None

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -341,6 +341,7 @@ class EagleDraftWorker(BaseDraftWorker):
             model_worker_batch,
             self.cuda_graph_runner,
             self.draft_runner,
+            self.target_worker.model_runner,
             self.topk,
             self.speculative_num_steps,
         )

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -165,6 +165,9 @@ class EagleDraftWorker(BaseDraftWorker):
 
         # Alias for better readability
         self.draft_runner = self.draft_worker.model_runner
+        # Expose target model runner on draft runner so that HiSparse draft_extend
+        # can access the target coordinator (which is the one updated by admit_request_direct).
+        self.draft_runner._target_model_runner = self.target_worker.model_runner
         self.eagle_use_aux_hidden_state = False
         if self.speculative_algorithm.is_eagle3():
             eagle_config = getattr(

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -26,11 +26,14 @@ register_cuda_ci(est_time=10, suite="stage-b-test-1-gpu-small")
 register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.disaggregation.decode import DecodePreallocQueue
+from sglang.srt.disaggregation.decode import (
+    DecodePreallocQueue,
+    _cleanup_decode_request_resources,
+)
 from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
@@ -94,6 +97,67 @@ def _make_req(fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
 
 class TestDecodeLockRefScenarios(unittest.TestCase):
     """Test lock_ref balance across decode transfer scenarios."""
+
+    def test_hisparse_cleanup_releases_all_decode_resources(self):
+        req = MagicMock()
+        req.req_pool_idx = 7
+        decode_req = MagicMock()
+        decode_req.req = req
+        decode_req.metadata_buffer_index = 3
+
+        scheduler = MagicMock()
+        scheduler.enable_hisparse = True
+        scheduler.hisparse_coordinator = MagicMock()
+        tree_cache = MagicMock()
+        metadata_allocator = MagicMock()
+        events = []
+
+        scheduler.hisparse_coordinator.request_finished.side_effect = (
+            lambda _: events.append("hisparse")
+        )
+        metadata_allocator.free.side_effect = lambda idx: events.append(
+            ("metadata", idx)
+        )
+
+        with patch("sglang.srt.disaggregation.decode.release_kv_cache") as release:
+            release.side_effect = lambda *args, **kwargs: events.append(
+                ("kv", kwargs["is_insert"])
+            )
+
+            _cleanup_decode_request_resources(
+                decode_req,
+                scheduler,
+                tree_cache,
+                metadata_allocator,
+                is_insert=False,
+            )
+
+        self.assertEqual(events, ["hisparse", ("kv", False), ("metadata", 3)])
+        self.assertEqual(decode_req.metadata_buffer_index, -1)
+
+    def test_prealloc_abort_removes_pending_and_cleans_allocated_req(self):
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+
+        req = MagicMock()
+        req.rid = "req-abort"
+        req.return_logprob = False
+        decode_req = MagicMock()
+        decode_req.req = req
+        decode_req.kv_receiver.abort = MagicMock()
+
+        queue.queue = [decode_req]
+        queue.pending_reqs = [decode_req]
+        queue.scheduler = MagicMock()
+        queue.scheduler.stream_output = MagicMock()
+        queue._cleanup_decode_req = MagicMock()
+
+        queue.abort_requests("req-abort", abort_all=False)
+
+        self.assertEqual(queue.queue, [])
+        self.assertEqual(queue.pending_reqs, [])
+        decode_req.kv_receiver.abort.assert_called_once()
+        queue.scheduler.stream_output.assert_called_once_with([req], False)
+        queue._cleanup_decode_req.assert_called_once_with(decode_req)
 
     def _populate_prefix(self, cache, prefix_ids, prefix_values):
         """Insert a prefix into the tree so future requests can match it."""


### PR DESCRIPTION
## Motivation

This PR fixes the HiSparse KV-slot handling needed by DeepSeek V4 when multi-step EAGLE is enabled.

DeepSeek V4 uses a compressed HiSparse KV layout, while multi-step EAGLE creates a speculative KV lifecycle that is different from normal one-token decode. In the Spec V2 path, we may preallocate a logical KV window for several draft/verify steps, but only a small subset of that window is active in the current draft or verify step.

Previously, the HiSparse path could bind the speculative logical window too broadly, or keep temporary draft mappings alive across iterations. This is unsafe for DeepSeek V4 because full logical KV locations must be translated into compressed HiSparse locations before updating the device mapping. If stale or overly broad mappings are reused, later draft/verify steps may read from the wrong HiSparse slot or put extra pressure on the per-request device buffer.

This PR keeps the speculative logical allocation separate from the temporary HiSparse device mapping, and only binds the KV slots needed by the active multi-step EAGLE window.

## What changed

- Split speculative logical allocation from HiSparse device mapping.
  - `prepare_for_decode()` only reserves logical KV locations.
  - `prepare_for_v2_draft()` binds the draft slots used by the current draft step.
  - `prepare_for_v2_verify()` binds the target-verify slots used by the current verify window.

- Add explicit HiSparse allocator APIs for this lifecycle.
  - `alloc_extend_logical_only()`
  - `bind_device_mapping()`

- Add DeepSeek V4 compressed-location handling.
  - Convert full logical KV locations to compressed HiSparse locations before updating mappings.
  - Only bind compressed boundary locations for DSV4.

- Track draft-only slots separately from the normal HiSparse hot buffer.
  - Add `req_draft_buffer_size`.
  - Allocate only the number of draft slots needed by the active speculative window.
  - Release draft-only slots when the request finishes.

- Clean up temporary mappings after accepted-token finalization.
  - Accepted tokens are committed through `finalize_accepted_tokens()`.
  - Temporary draft mappings are cleared after the accepted tokens are finalized.
  - Rejected or inactive draft slots do not leak stale mappings into the next EAGLE iteration.

## Why this approach

The main issue is that multi-step EAGLE has two different lifetimes:

1. The logical KV lifetime, which can span the whole speculative window.
2. The temporary device-slot lifetime, which should only cover the current draft/verify step.

HiSparse needs the second lifetime to be explicit because its device slots are backed by a compressed logical-to-physical mapping. For DSV4, binding the whole preallocated logical window is both unnecessary and unsafe. Instead, this PR keeps the full speculative window as logical-only allocation and updates the HiSparse device mapping only for the active draft/verify slots.

This also avoids growing each request to the full padded HiSparse buffer when only a few draft slots are needed.

## Scope

This PR focuses on:

- DeepSeek V4
- HiSparse enabled
- Spec V2 / multi-step EAGLE path
- `topk=1` EAGLE/MTP-style decoding

It should not affect:

- Non-HiSparse paths
- Non-speculative decoding
- Regular one-token decode
- Non-DSV4 models

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->