### PR TITLE
[diffusion] Default Qwen Image VAE precision to bf16

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/flux.py
@@ -48,6 +48,7 @@ class FluxPipelineConfig(ImagePipelineConfig):
     dit_config: DiTConfig = field(default_factory=FluxConfig)
     # VAE
     vae_config: VAEConfig = field(default_factory=FluxVAEConfig)
+    vae_precision: str = "bf16"
 
     enable_autocast: bool = False
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2.py
@@ -179,8 +179,9 @@ class LTX2PipelineConfig(PipelineConfig):
 
     # Audio VAE configuration
     vae_config: LTXVideoVAEConfig = field(default_factory=LTXVideoVAEConfig)
+    vae_precision: str = "bf16"
     audio_vae_config: LTXAudioVAEConfig = field(default_factory=LTXAudioVAEConfig)
-    audio_vae_precision: str = "fp32"
+    audio_vae_precision: str = "bf16"
 
     @property
     def vae_scale_factor(self):

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/mova.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/mova.py
@@ -38,8 +38,9 @@ class MOVAPipelineConfig(PipelineConfig):
 
     # Video VAE (Wan) + Audio VAE (DAC)
     vae_config: WanVAEConfig = field(default_factory=WanVAEConfig)
+    vae_precision: str = "bf16"
     audio_vae_config: DacVAEConfig = field(default_factory=DacVAEConfig)
-    audio_vae_precision: str = "fp32"
+    audio_vae_precision: str = "bf16"
 
     # Text encoder (UMT5 compatible)
     text_encoder_configs: tuple = field(default_factory=lambda: (T5Config(),))

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/qwen_image.py
@@ -148,6 +148,8 @@ class QwenImagePipelineConfig(QwenImageRolloutPipelineMixin, ImagePipelineConfig
 
     vae_sp: bool = False
 
+    vae_precision: str = "bf16"
+
     dit_config: DiTConfig = field(default_factory=QwenImageDitConfig)
     # VAE
     vae_config: VAEConfig = field(default_factory=QwenImageVAEConfig)

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/zimage.py
@@ -67,6 +67,7 @@ class ZImagePipelineConfig(ZImageRolloutPipelineMixin, ImagePipelineConfig):
     task_type: ModelTaskType = ModelTaskType.T2I
     dit_config: DiTConfig = field(default_factory=ZImageDitConfig)
     vae_config: VAEConfig = field(default_factory=FluxVAEConfig)
+    vae_precision: str = "bf16"
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("bf16",))
     text_encoder_configs: tuple[EncoderConfig, ...] = field(
         default_factory=lambda: (Qwen3TextConfig(),)

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "3ca3bad088ecc9ef80947d85c551cd335c75b87f"
+SGL_TEST_FILES_CI_DATA_REVISION = "c8305f1dd8cc82197f36c17d0f503adc94016cc7"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"


### PR DESCRIPTION
## Summary

Peak memory: `64098 MB` -> `58518 MB`, 8.71% decrease

## Motivation

  I find that Qwen-Image checkpoints store vae weights in `bf16`, but our Qwen image pipeline currently sets `vae_precision="fp32"` as default, so we're essentially upcasting bf16 checkpoint tensors into fp32.

Previously users could set `--vae-precision bf16` by default, but this is not intuitive and I believe it would be better as a default

  ## Modifications

Set `QwenImagePipelineConfig.vae_precision = "bf16"`.

  ## Accuracy Tests

before:
<img width="1024" height="1024" alt="qwen_baseline" src="https://github.com/user-attachments/assets/a05a54cc-a7a2-4670-b243-6572d4e68724" />

after:
<img width="1024" height="1024" alt="qwen_candidate" src="https://github.com/user-attachments/assets/1d3387db-eb48-4058-86b7-c7e5d88d9029" />

  ## Speed Tests and Profiling

1xh200
```
  sglang serve \
    --model-path Qwen/Qwen-Image-2512 \
    --backend sglang \
    --dit-cpu-offload false \
    --text-encoder-cpu-offload false \
    --vae-cpu-offload false \
    --warmup true \
    --warmup-steps 1 \
```
```
      "model": "Qwen/Qwen-Image-2512",
      "prompt": "A sharp studio product photo of a brushed steel espresso machine on a matte white counter, softbox lighting, realistic reflections",
      "height": 1024,
      "width": 1024,
      "num_inference_steps": 20,
      "seed": 1234,
```
 Results over 2 runs, warmup excluded:

  | run | total ms | denoise ms | decode ms | peak MB |
  |---|---:|---:|---:|---:|
  | baseline rep1 | 4952.16 | 4846.34 | 65.13 | 64098 |
  | baseline rep2 | 4967.65 | 4862.68 | 65.13 | 64098 |
  | candidate rep1 | 4949.90 | 4845.97 | 63.82 | 58518 |
  | candidate rep2 | 4957.75 | 4853.67 | 64.12 | 58518 |

  Summary:

  - Total mean: `4959.90 ms` -> `4953.82 ms`
  - Decode mean: `65.13 ms` -> `63.97 ms`
  - Peak memory: `64098 MB` -> `58518 MB`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25962245755](https://github.com/sgl-project/sglang/actions/runs/25962245755)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->