### PR TITLE
[lora] Fix overlap loading for cancelled requests

### DIFF
--- a/python/sglang/srt/lora/lora_overlap_loader.py
+++ b/python/sglang/srt/lora/lora_overlap_loader.py
@@ -63,12 +63,6 @@ class LoRAOverlapLoader:
 
         return LoRAOverlapLoadStatus.NOT_LOADED
 
-    def _mark_overlap_load_complete(
-        self, lora_id: Optional[str], event: CudaEvent
-    ) -> None:
-        torch.cuda.current_stream().wait_event(event)
-        del self.lora_to_overlap_load_event[lora_id]
-
     def _drain_completed_overlap_loads(self) -> None:
         completed_loads = [
             (lora_id, event)
@@ -76,7 +70,8 @@ class LoRAOverlapLoader:
             if event.query()
         ]
         for lora_id, event in completed_loads:
-            self._mark_overlap_load_complete(lora_id, event)
+            torch.cuda.current_stream().wait_event(event)
+            del self.lora_to_overlap_load_event[lora_id]
 
     def _try_start_overlap_load(
         self, lora_id: Optional[str], running_loras: set[Optional[str]]

--- a/python/sglang/srt/lora/lora_overlap_loader.py
+++ b/python/sglang/srt/lora/lora_overlap_loader.py
@@ -59,14 +59,29 @@ class LoRAOverlapLoader:
         if not event.query():
             return LoRAOverlapLoadStatus.LOADING
 
+        self._mark_overlap_load_complete(lora_id, event)
+
+        return LoRAOverlapLoadStatus.LOADED
+
+    def _mark_overlap_load_complete(
+        self, lora_id: Optional[str], event: CudaEvent
+    ) -> None:
         torch.cuda.current_stream().wait_event(event)
         del self.lora_to_overlap_load_event[lora_id]
 
-        return LoRAOverlapLoadStatus.LOADED
+    def _drain_completed_overlap_loads(self) -> None:
+        completed_loads = [
+            (lora_id, event)
+            for lora_id, event in self.lora_to_overlap_load_event.items()
+            if event.query()
+        ]
+        for lora_id, event in completed_loads:
+            self._mark_overlap_load_complete(lora_id, event)
 
     def _try_start_overlap_load(
         self, lora_id: Optional[str], running_loras: set[Optional[str]]
     ) -> bool:
+        self._drain_completed_overlap_loads()
         loras_to_be_loaded = running_loras | self.lora_to_overlap_load_event.keys()
 
         new_lora_set = {lora_id} | loras_to_be_loaded

--- a/python/sglang/srt/lora/lora_overlap_loader.py
+++ b/python/sglang/srt/lora/lora_overlap_loader.py
@@ -51,17 +51,17 @@ class LoRAOverlapLoader:
     def _check_overlap_load_status(
         self, lora_id: Optional[str]
     ) -> LoRAOverlapLoadStatus:
-        if lora_id not in self.lora_to_overlap_load_event:
-            return LoRAOverlapLoadStatus.NOT_LOADED
+        self._drain_completed_overlap_loads()
 
-        event = self.lora_to_overlap_load_event[lora_id]
-
-        if not event.query():
+        if lora_id in self.lora_to_overlap_load_event:
             return LoRAOverlapLoadStatus.LOADING
 
-        self._mark_overlap_load_complete(lora_id, event)
+        # After completed events are drained, a memory-pool entry with no pending
+        # event is safe to use on the current stream.
+        if lora_id in self.lora_manager.memory_pool.uid_to_buffer_id:
+            return LoRAOverlapLoadStatus.LOADED
 
-        return LoRAOverlapLoadStatus.LOADED
+        return LoRAOverlapLoadStatus.NOT_LOADED
 
     def _mark_overlap_load_complete(
         self, lora_id: Optional[str], event: CudaEvent
@@ -81,7 +81,6 @@ class LoRAOverlapLoader:
     def _try_start_overlap_load(
         self, lora_id: Optional[str], running_loras: set[Optional[str]]
     ) -> bool:
-        self._drain_completed_overlap_loads()
         loras_to_be_loaded = running_loras | self.lora_to_overlap_load_event.keys()
 
         new_lora_set = {lora_id} | loras_to_be_loaded

--- a/python/sglang/srt/lora/lora_overlap_loader.py
+++ b/python/sglang/srt/lora/lora_overlap_loader.py
@@ -35,6 +35,10 @@ class LoRAOverlapLoader:
         Check a LoRA adapter's asynchronous load status, and try to load it if there's capacity
         in the memory pool. Returns whether or not the adapter has been loaded.
         """
+        # Drain completed async loads before status/capacity checks so finished
+        # adapters no longer count as in-flight.
+        self._drain_completed_overlap_loads()
+
         lora_pipeline_load_status = self._check_overlap_load_status(lora_id)
         if lora_pipeline_load_status == LoRAOverlapLoadStatus.LOADING:
             return False
@@ -51,13 +55,11 @@ class LoRAOverlapLoader:
     def _check_overlap_load_status(
         self, lora_id: Optional[str]
     ) -> LoRAOverlapLoadStatus:
-        self._drain_completed_overlap_loads()
-
         if lora_id in self.lora_to_overlap_load_event:
             return LoRAOverlapLoadStatus.LOADING
 
-        # After completed events are drained, a memory-pool entry with no pending
-        # event is safe to use on the current stream.
+        # After completed events have been drained, a memory-pool entry with no
+        # pending event is safe to use on the current stream.
         if lora_id in self.lora_manager.memory_pool.uid_to_buffer_id:
             return LoRAOverlapLoadStatus.LOADED
 

--- a/test/registered/lora/test_lora_overlap_loading.py
+++ b/test/registered/lora/test_lora_overlap_loading.py
@@ -208,6 +208,7 @@ class TestLoRAOverlapLoaderUnitTests(CustomTestCase):
         # First lora completes, freeing capacity
         loader.lora_to_overlap_load_event["lora_0"].query.return_value = True
 
+        loader._drain_completed_overlap_loads()
         self.assertEqual(
             loader._check_overlap_load_status("lora_0"), LoRAOverlapLoadStatus.LOADED
         )

--- a/test/registered/lora/test_lora_overlap_loading.py
+++ b/test/registered/lora/test_lora_overlap_loading.py
@@ -78,6 +78,32 @@ class TestLoRAOverlapLoaderUnitTests(CustomTestCase):
         event.query.return_value = query_return
         return event
 
+    def test_completed_stale_loads_are_reaped_before_capacity_check(self):
+        loader = self._create_loader()
+        events = [
+            self._create_mock_event(query_return=True),
+            self._create_mock_event(query_return=False),
+        ]
+        self.mock_device_module.Event.side_effect = events
+        self.mock_lora_manager.validate_lora_batch.side_effect = (
+            lambda lora_ids: len(lora_ids) <= 1
+        )
+
+        self.assertTrue(
+            loader._try_start_overlap_load("stale_lora", running_loras=set())
+        )
+        self.assertIn("stale_lora", loader.lora_to_overlap_load_event)
+
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        result = loader.try_overlap_load_lora("new_lora", running_loras=set())
+
+        self.assertFalse(result)
+        self.assertNotIn("stale_lora", loader.lora_to_overlap_load_event)
+        self.assertIn("new_lora", loader.lora_to_overlap_load_event)
+        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
+            {"new_lora"}, set()
+        )
+
     def test_full_lifecycle_single_lora_load(self):
         loader = self._create_loader()
 

--- a/test/registered/lora/test_lora_overlap_loading.py
+++ b/test/registered/lora/test_lora_overlap_loading.py
@@ -65,13 +65,22 @@ class TestLoRAOverlapLoaderUnitTests(CustomTestCase):
 
         self.mock_lora_manager = MagicMock(spec=LoRAManager)
         self.mock_lora_manager.device = "cuda:0"
+        self.mock_lora_manager.memory_pool = MagicMock()
+        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {}
         self.mock_lora_manager.validate_lora_batch.return_value = True
+        self.mock_lora_manager.fetch_new_loras.side_effect = self._mark_loras_loaded
 
     def tearDown(self):
         self.torch_patcher.stop()
 
     def _create_loader(self) -> LoRAOverlapLoader:
         return LoRAOverlapLoader(cast(LoRAManager, self.mock_lora_manager))
+
+    def _mark_loras_loaded(self, new_loras, _loras_to_be_loaded):
+        for lora_id in new_loras:
+            self.mock_lora_manager.memory_pool.uid_to_buffer_id[lora_id] = len(
+                self.mock_lora_manager.memory_pool.uid_to_buffer_id
+            )
 
     def _create_mock_event(self, query_return: bool = False) -> MagicMock:
         event = MagicMock(spec=CudaEvent)
@@ -103,6 +112,48 @@ class TestLoRAOverlapLoaderUnitTests(CustomTestCase):
         self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
             {"new_lora"}, set()
         )
+
+    def test_loaded_lora_reused_after_stale_event_drain(self):
+        loader = self._create_loader()
+        self.mock_lora_manager.memory_pool = MagicMock()
+        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {}
+        events = [
+            self._create_mock_event(query_return=True),
+            self._create_mock_event(query_return=False),
+        ]
+        self.mock_device_module.Event.side_effect = events
+        self.mock_lora_manager.validate_lora_batch.side_effect = (
+            lambda lora_ids: len(lora_ids) <= 2
+        )
+
+        self.assertTrue(loader._try_start_overlap_load("lora_A", running_loras=set()))
+        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
+
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        self.assertFalse(loader.try_overlap_load_lora("lora_B", running_loras=set()))
+        self.assertNotIn("lora_A", loader.lora_to_overlap_load_event)
+        self.assertIn("lora_B", loader.lora_to_overlap_load_event)
+        self.mock_lora_manager.fetch_new_loras.assert_called_once_with(
+            {"lora_B"}, set()
+        )
+
+        self.mock_lora_manager.fetch_new_loras.reset_mock()
+        self.assertTrue(loader.try_overlap_load_lora("lora_A", running_loras=set()))
+        self.assertIn("lora_B", loader.lora_to_overlap_load_event)
+        self.mock_lora_manager.fetch_new_loras.assert_not_called()
+
+    def test_pending_lora_load_must_complete_even_if_memory_pool_has_slot(self):
+        loader = self._create_loader()
+        self.mock_lora_manager.memory_pool = MagicMock()
+        self.mock_lora_manager.memory_pool.uid_to_buffer_id = {"lora_A": 0}
+
+        loader.lora_to_overlap_load_event["lora_A"] = self._create_mock_event(False)
+
+        result = loader.try_overlap_load_lora("lora_A", running_loras=set())
+
+        self.assertFalse(result)
+        self.mock_lora_manager.fetch_new_loras.assert_not_called()
+        self.assertIn("lora_A", loader.lora_to_overlap_load_event)
 
     def test_full_lifecycle_single_lora_load(self):
         loader = self._create_loader()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Currently events are only removed from `lora_to_overlap_load_event` when the scheduler actually schedules a request for that lora. If all requests from for that lora are cancelled before it is actually loaded, the load will never be reaped from `lora_to_overlap_load_event`. This has the impact of leaking a lora slot and can cause the whole engine to stall if all slots are leaked.

## Modifications

Changes the contract in `LoRAOverlapLoader`. Instead of knowing that a lora is ready by checking the status of its event in `lora_to_overlap_load_event`, we instead consider a lora to be ready if it isn't in `lora_to_overlap_load_event` but _is_ in the lora mem pool's `uid_to_buffer_id`. This is correct since the only way for a lora to be added to `uid_to_buffer_id` is for us to have started the load and added that even in `lora_to_overlap_load_event`. So if it is no longer in `lora_to_overlap_load_event`, the load must have completed. The upshot is that we can now safely always drain all completed loads from `lora_to_overlap_load_event` and won't leak slots!

## Accuracy Tests

Added tests for the new logic and regression tests around the existing bug.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #26005536734](https://github.com/sgl-project/sglang/actions/runs/26005536734)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->