### PR TITLE
[diffusion] Add memory-aware dynamic batching admission

### DIFF
--- a/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
@@ -30,7 +30,7 @@ When dynamic batching is enabled, SGLang-Diffusion records peak GPU memory from 
 
 Profiles are keyed by runtime settings and request shape. By default, they are cached under `${SGLANG_DIFFUSION_BATCH_MEMORY_CACHE:-~/.cache/sglang/diffusion_batch_memory}`. Set `--batching-memory-profile-cache none` to disable persistence.
 
-For a new shape, admission starts with a geometric ramp (`1`, `2`, `4`, ...). After enough successful batches are observed, SGLang-Diffusion predicts candidate peak memory from measured peaks and rejects candidates that exceed the current safe GPU memory budget.
+For a new shape, admission starts with a singleton measurement. During cold start, SGLang-Diffusion uses that singleton as a rough estimate to reject candidates that appear too large. After enough successful batches are observed, it predicts candidate peak memory from measured peaks and rejects candidates that exceed the current safe GPU memory budget.
 
 `--batching-memory-reserve-fraction` controls the fraction of total device memory held back from memory-aware batching as allocator and workspace slack. The default is `0.02`. Increase it on shared or memory-volatile GPUs to reduce OOM risk; lower it only for dedicated, calibrated workloads when the reserve is the binding limit. If you override it, use the same value during calibration and serving.
 

--- a/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
@@ -10,7 +10,7 @@ Use it for concurrent T2I or T2V traffic with the same model and sampling shape.
 
 ## Enable
 
-Dynamic batching is disabled by default with `--batching-max-size 1`.
+Dynamic batching is disabled by default. Set `--batching-max-size` above `1` to enable it.
 
 ```bash Command
 sglang serve \
@@ -24,19 +24,26 @@ sglang serve \
 
 For request formats, see the [OpenAI-Compatible API](./api/openai_api).
 
-Use `--batching-config /path/to/batching_config.json` to load JSON rules when a model or resolution needs a lower cap than `--batching-max-size`:
+## Memory-Aware Admission
 
-```json Config
-{
-  "schema_version": 1,
-  "rules": [
-    {
-      "model_contains": "Qwen-Image",
-      "resolution": "1024x1024",
-      "max_batch_size": 1
-    }
-  ]
-}
+When dynamic batching is enabled, SGLang-Diffusion records peak GPU memory from completed batches and uses those measurements for future admission decisions.
+
+Profiles are keyed by runtime settings and request shape. By default, they are cached under `${SGLANG_DIFFUSION_BATCH_MEMORY_CACHE:-~/.cache/sglang/diffusion_batch_memory}`. Set `--batching-memory-profile-cache none` to disable persistence.
+
+For a new shape, admission starts with a geometric ramp (`1`, `2`, `4`, ...). After enough successful batches are observed, SGLang-Diffusion predicts candidate peak memory from measured peaks and rejects candidates that exceed the current safe GPU memory budget.
+
+This is measured runtime prediction, not exact byte-level tensor accounting. It reduces OOM risk for repeated shapes, but first-time shapes and backend/runtime changes can still require calibration.
+
+## Calibration
+
+Production deployments can prefill the memory profile cache before serving traffic:
+
+```bash Command
+python -m sglang.multimodal_gen.tools.calibrate_batch_memory \
+  --model-path black-forest-labs/FLUX.1-dev \
+  --shapes 1024x1024 \
+  --batch-sizes 1,2,4,8 \
+  --batching-memory-profile-cache /path/to/diffusion_batch_memory
 ```
 
 ## Compatibility
@@ -134,13 +141,15 @@ An initial implementation of dynamic batching for T2I and T2V models can be foun
 
 ## Notes
 
-- Requests batch only when model inputs, sampling parameters, output handling, and any configured rules are compatible.
-- There is no startup probing, runtime learning, OOM retry, or automatic fallback to singletons. If a merged batch fails or cannot be split, every request in that batch receives an error.
+- Requests batch only when model inputs, sampling parameters, and output handling are compatible.
+- `--batching-max-size` remains the hard user ceiling.
+- Memory-aware admission uses measured runtime profiles. It is not exact byte-level tensor accounting and cannot guarantee OOM-free execution for every unseen shape or backend change.
+- There is no automatic fallback to singletons. If a merged batch fails or cannot be split, every request in that batch receives an error.
 - Batch shape can change kernels, so singleton and dynamic outputs are not expected to be bit-exact.
 - Use `--enable-batching-metrics` to inspect realized batches:
 
 ```text
 Dynamic batch dispatch: size=2/8, user_max=8, queue_wait=5.12ms, stop_reason=delay
-Dynamic batch dispatch: size=1/8, user_max=8, queue_wait=0.04ms, stop_reason=config_cap:1
+Dynamic batch dispatch: size=1/8, user_max=8, queue_wait=0.04ms, stop_reason=memory_uncalibrated:allow=1
 Dynamic batch stats (last 5 dispatches): avg_size=2.80, merged_rate=60.0%, full_rate=20.0%, utilization=35.0%, wait_avg=3.21ms, wait_p95=5.12ms, top_rejects=none
 ```

--- a/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
+++ b/docs_new/docs/sglang-diffusion/dynamic_batching.mdx
@@ -32,6 +32,8 @@ Profiles are keyed by runtime settings and request shape. By default, they are c
 
 For a new shape, admission starts with a geometric ramp (`1`, `2`, `4`, ...). After enough successful batches are observed, SGLang-Diffusion predicts candidate peak memory from measured peaks and rejects candidates that exceed the current safe GPU memory budget.
 
+`--batching-memory-reserve-fraction` controls the fraction of total device memory held back from memory-aware batching as allocator and workspace slack. The default is `0.02`. Increase it on shared or memory-volatile GPUs to reduce OOM risk; lower it only for dedicated, calibrated workloads when the reserve is the binding limit. If you override it, use the same value during calibration and serving.
+
 This is measured runtime prediction, not exact byte-level tensor accounting. It reduces OOM risk for repeated shapes, but first-time shapes and backend/runtime changes can still require calibration.
 
 ## Calibration

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -85,8 +85,7 @@ class MemoryAdmissionPolicy:
     save_interval_s: float = 60.0
     # Successes required near safe cost before clearing an OOM boundary.
     oom_clear_successes: int = 8
-    # Internal allocator slack.
-    internal_reserve_fraction: float = 0.02
+    # Minimum allocator slack.
     internal_reserve_min_mb: float = 512.0
 
 
@@ -408,6 +407,9 @@ class BatchAdmissionController:
         self._gpu_id = gpu_id
         self._device_name = self._get_device_name(gpu_id)
         self._device_memory_gb = self._get_device_memory_gb(gpu_id)
+        self._memory_reserve_fraction = float(
+            server_args.batching_memory_reserve_fraction
+        )
         self._rules = load_batching_config(server_args.batching_config)
         self._pipeline_config = server_args.pipeline_config
         self._limit_cache: dict[str | None, AdmissionLimit] = {}
@@ -806,7 +808,7 @@ class BatchAdmissionController:
 
         internal_reserve_mb = max(
             _MEMORY_POLICY.internal_reserve_min_mb,
-            total_mb * _MEMORY_POLICY.internal_reserve_fraction,
+            total_mb * self._memory_reserve_fraction,
         )
         budget_mb = max(0.0, total_mb - internal_reserve_mb)
         if available_mb is not None and reserved_mb is not None:

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -255,6 +255,7 @@ class MemoryProfile:
         batch_size: int,
         baseline_memory_mb: float | None = None,
     ) -> None:
+        """Record a successful batch and update prediction residuals."""
         if batch_cost <= 0.0 or peak_memory_mb <= 0.0:
             return
 
@@ -305,6 +306,7 @@ class MemoryProfile:
         )
 
     def estimate_rough_peak_memory_mb(self, batch_cost: float) -> float | None:
+        """Estimate cold-start memory before the measured fit is available."""
         if batch_cost <= 0.0:
             return None
         seeds = [
@@ -384,6 +386,7 @@ class MemoryProfile:
         return profile
 
     def _recompute_residuals_from_successes(self) -> None:
+        """Rebuild adaptive residuals after loading cached observations."""
         replay = type(self)()
         for obs in self.successes:
             replay.observe_success(
@@ -493,8 +496,8 @@ class BatchAdmissionController:
     def enabled(self) -> bool:
         return self._mode == "dynamic" and self._user_max_batch_size > 1
 
-    def update_memory_budget(self) -> None:
-        """Refresh the memory budget for one scheduler pass."""
+    def refresh_memory_budget(self) -> None:
+        """Refresh the memory budget for one scheduler selection pass."""
         if not self.enabled:
             self._memory_budget_mb = None
             return
@@ -546,7 +549,7 @@ class BatchAdmissionController:
             is not None
         )
 
-    def get_batch_limit_reason(self, reqs: list[Req]) -> str | None:
+    def get_batch_stop_reason(self, reqs: list[Req]) -> str | None:
         if not self.enabled or not reqs:
             return None
 
@@ -592,7 +595,7 @@ class BatchAdmissionController:
                 low = mid
         return low
 
-    def record_batch_result(self, reqs: list[Req], output_batch: OutputBatch) -> None:
+    def observe_batch_result(self, reqs: list[Req], output_batch: OutputBatch) -> None:
         if not self.enabled or not reqs:
             return
 
@@ -686,6 +689,7 @@ class BatchAdmissionController:
         memory_key: tuple[Any, ...],
         next_batch: bool = False,
     ) -> str | None:
+        """Apply OOM, calibration, and budget gates."""
         profile = self._memory_profiles.get(memory_key)
         if profile is not None and profile.oom_cost is not None:
             if batch_cost + 1e-9 >= profile.oom_cost:
@@ -724,6 +728,7 @@ class BatchAdmissionController:
         batch_size: int,
         batch_cost: float,
     ) -> str | None:
+        """Gate new profiles through a geometric cold-start ramp."""
         if profile is None or not profile.successes:
             if batch_size > 1:
                 return "memory_uncalibrated:allow=1"
@@ -842,6 +847,10 @@ class BatchAdmissionController:
             ("cfg_parallel_degree", server_args.cfg_parallel_degree),
             ("dit_cpu_offload", server_args.dit_cpu_offload),
             ("dit_layerwise_offload", server_args.dit_layerwise_offload),
+            (
+                "layerwise_offload_components",
+                _freeze_key_value(server_args.layerwise_offload_components),
+            ),
             ("dit_offload_prefetch_size", server_args.dit_offload_prefetch_size),
             ("text_encoder_cpu_offload", server_args.text_encoder_cpu_offload),
             ("image_encoder_cpu_offload", server_args.image_encoder_cpu_offload),

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -51,14 +51,26 @@ _SAMPLING_MEMORY_EXCLUDE = frozenset(
     {
         "prompt",
         "negative_prompt",
+        "prompt_path",
         "seed",
         "request_id",
         "output_path",
         "output_file_name",
+        "output_quality",
+        "output_compression",
+        "fps",
         "save_output",
         "return_file_paths_only",
+        "generator_device",
+        "supported_resolutions",
+        "profile",
+        "num_profiled_timesteps",
+        "profile_all_stages",
+        "debug",
         "suppress_logs",
         "perf_dump_path",
+        "no_override_protected_fields",
+        "adjust_frames",
     }
 )
 
@@ -237,8 +249,9 @@ class MemoryProfile:
         if batch_cost <= 0.0 or peak_memory_mb <= 0.0:
             return
 
+        previous_max_cost = self.get_max_success_cost()
         predicted = self._estimate_base_peak_memory_mb(batch_cost)
-        if predicted is not None and predicted > 0.0:
+        if predicted is not None and predicted > 0.0 and batch_cost > previous_max_cost:
             self.ratio_residuals.append(max(1.0, peak_memory_mb / predicted))
             self.absolute_residuals_mb.append(max(0.0, peak_memory_mb - predicted))
             del self.ratio_residuals[: -_MEMORY_POLICY.history_size]
@@ -268,6 +281,8 @@ class MemoryProfile:
         predicted = self._estimate_base_peak_memory_mb(batch_cost)
         if predicted is None:
             return None
+        if batch_cost <= self.get_max_success_cost():
+            return predicted
         return max(
             predicted * self._get_residual_ratio(),
             predicted + self._get_residual_mb(),
@@ -883,6 +898,15 @@ class BatchAdmissionController:
             self._memory_profiles[_unjsonable(key)] = MemoryProfile.from_dict(
                 profile_data
             )
+        observation_count = sum(
+            len(profile.successes) for profile in self._memory_profiles.values()
+        )
+        logger.info(
+            "Loaded memory profile cache: path=%s, profiles=%d, observations=%d",
+            path,
+            len(self._memory_profiles),
+            observation_count,
+        )
 
     def _save_memory_profile_cache(self) -> None:
         path = self._memory_profile_cache_path
@@ -919,6 +943,11 @@ class BatchAdmissionController:
             os.replace(tmp_path, path)
             self._memory_profiles_dirty = False
             self._last_profile_save_s = time.monotonic()
+            logger.info(
+                "Saved memory profile cache: path=%s, profiles=%d",
+                path,
+                len(payload["profiles"]),
+            )
         except Exception:
             try:
                 os.unlink(tmp_path)

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -1,22 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Admission control for native diffusion batching.
-
-Native diffusion batching is model, resolution, device, and implementation
-dependent. The scheduler treats `--batching-max-size` as the public ceiling;
-`--batching-config` can apply stricter caps for specific model and shape
-combinations.
-"""
+"""Admission control for native diffusion dynamic batching."""
 
 from __future__ import annotations
 
+import dataclasses
+import hashlib
 import json
+import math
 import os
-from dataclasses import dataclass
+import tempfile
+import time
+from dataclasses import dataclass, field, fields, is_dataclass
 from difflib import get_close_matches
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from sglang.multimodal_gen.runtime.loader.utils import BYTES_PER_GB
+import torch
+
+from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.runtime.pipelines_core import Req
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -35,16 +38,52 @@ _BATCHING_RULE_KEYS = frozenset(
         "offload",
         "max_batch_size",
         "max_cost",
-        # Free-form provenance/benchmark metadata. It is intentionally ignored
-        # by admission, but accepted so production configs can explain caps.
+        # Accepted for config provenance; ignored by admission.
         "calibration",
+    }
+)
+
+_MEMORY_PROFILE_SCHEMA_VERSION = 1
+_CACHE_ENV = "SGLANG_DIFFUSION_BATCH_MEMORY_CACHE"
+
+# Request identity/output fields do not affect memory profile reuse.
+_SAMPLING_MEMORY_EXCLUDE = frozenset(
+    {
+        "prompt",
+        "negative_prompt",
+        "seed",
+        "request_id",
+        "output_path",
+        "output_file_name",
+        "save_output",
+        "return_file_paths_only",
+        "suppress_logs",
+        "perf_dump_path",
     }
 )
 
 
 @dataclass(frozen=True)
+class MemoryAdmissionPolicy:
+    """Internal policy for measured memory admission."""
+
+    # Recent observations kept per profile.
+    history_size: int = 32
+    # Minimum interval between profile cache writes.
+    save_interval_s: float = 60.0
+    # Successes required near safe cost before clearing an OOM boundary.
+    oom_clear_successes: int = 8
+    # Internal allocator slack.
+    internal_reserve_fraction: float = 0.02
+    internal_reserve_min_mb: float = 512.0
+
+
+_MEMORY_POLICY = MemoryAdmissionPolicy()
+
+
+@dataclass(frozen=True)
 class AdmissionLimit:
-    """Effective batch size and cost caps after matching batching rules."""
+    """Batch size and cost caps after batching rule matching."""
 
     max_batch_size: int
     max_cost: float | None = None
@@ -65,7 +104,7 @@ class AdmissionLimit:
 
 @dataclass(frozen=True)
 class BatchingRule:
-    """One user-provided batching admission rule loaded from batching config."""
+    """Batching config admission rule."""
 
     model: str | None = None
     model_contains: str | None = None
@@ -153,73 +192,387 @@ class BatchingRule:
         return True
 
 
+@dataclass(frozen=True)
+class MemoryObservation:
+    batch_cost: float
+    peak_memory_mb: float
+    batch_size: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MemoryObservation":
+        return cls(
+            batch_cost=float(data["batch_cost"]),
+            peak_memory_mb=float(data["peak_memory_mb"]),
+            batch_size=max(1, int(data.get("batch_size", 1))),
+        )
+
+
+@dataclass
+class MemoryProfile:
+    """Memory observations for one runtime/request key."""
+
+    successes: list[MemoryObservation] = field(default_factory=list)
+    ratio_residuals: list[float] = field(default_factory=list)
+    absolute_residuals_mb: list[float] = field(default_factory=list)
+    oom_cost: float | None = None
+    recovery_cost: float | None = None
+    recovery_successes: int = 0
+
+    _cache_dirty: bool = field(default=True, init=False, repr=False)
+    _distinct_success_cost_count: int = field(default=0, init=False, repr=False)
+    _max_success_batch_size: int = field(default=0, init=False, repr=False)
+    _max_success_cost: float = field(default=0.0, init=False, repr=False)
+    _residual_ratio: float = field(default=1.0, init=False, repr=False)
+    _residual_abs_mb: float = field(default=0.0, init=False, repr=False)
+    _points: list[tuple[float, float]] = field(
+        default_factory=list, init=False, repr=False
+    )
+
+    def observe_success(
+        self, batch_cost: float, peak_memory_mb: float, *, batch_size: int
+    ) -> None:
+        if batch_cost <= 0.0 or peak_memory_mb <= 0.0:
+            return
+
+        predicted = self._estimate_base_peak_memory_mb(batch_cost)
+        if predicted is not None and predicted > 0.0:
+            self.ratio_residuals.append(max(1.0, peak_memory_mb / predicted))
+            self.absolute_residuals_mb.append(max(0.0, peak_memory_mb - predicted))
+            del self.ratio_residuals[: -_MEMORY_POLICY.history_size]
+            del self.absolute_residuals_mb[: -_MEMORY_POLICY.history_size]
+
+        self.successes.append(
+            MemoryObservation(
+                batch_cost=float(batch_cost),
+                peak_memory_mb=float(peak_memory_mb),
+                batch_size=max(1, int(batch_size)),
+            )
+        )
+        del self.successes[: -_MEMORY_POLICY.history_size]
+        self._update_oom_boundary_after_success(batch_cost)
+        self._cache_dirty = True
+
+    def observe_oom(self, batch_cost: float) -> None:
+        if batch_cost <= 0.0:
+            return
+        if self.oom_cost is None or batch_cost < self.oom_cost:
+            self.oom_cost = float(batch_cost)
+            self.recovery_cost = self.get_max_success_cost()
+            self.recovery_successes = 0
+            self._cache_dirty = True
+
+    def estimate_peak_memory_mb(self, batch_cost: float) -> float | None:
+        predicted = self._estimate_base_peak_memory_mb(batch_cost)
+        if predicted is None:
+            return None
+        return max(
+            predicted * self._get_residual_ratio(),
+            predicted + self._get_residual_mb(),
+        )
+
+    def get_num_success_costs(self) -> int:
+        self._update_cached_stats()
+        return self._distinct_success_cost_count
+
+    def get_max_success_batch_size(self) -> int:
+        self._update_cached_stats()
+        return self._max_success_batch_size
+
+    def get_max_success_cost(self) -> float:
+        self._update_cached_stats()
+        return self._max_success_cost
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "successes": [obs.to_dict() for obs in self.successes],
+            "ratio_residuals": list(self.ratio_residuals),
+            "absolute_residuals_mb": list(self.absolute_residuals_mb),
+            "oom_cost": self.oom_cost,
+            "recovery_cost": self.recovery_cost,
+            "recovery_successes": self.recovery_successes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MemoryProfile":
+        profile = cls(
+            successes=[
+                MemoryObservation.from_dict(item)
+                for item in data.get("successes", [])
+                if isinstance(item, dict)
+            ],
+            ratio_residuals=[
+                float(item)
+                for item in data.get("ratio_residuals", [])[
+                    -_MEMORY_POLICY.history_size :
+                ]
+            ],
+            absolute_residuals_mb=[
+                float(item)
+                for item in data.get("absolute_residuals_mb", [])[
+                    -_MEMORY_POLICY.history_size :
+                ]
+            ],
+            oom_cost=_optional_float(data.get("oom_cost")),
+            recovery_cost=_optional_float(data.get("recovery_cost")),
+            recovery_successes=int(data.get("recovery_successes", 0)),
+        )
+        profile._cache_dirty = True
+        return profile
+
+    def _update_oom_boundary_after_success(self, batch_cost: float) -> None:
+        if self.oom_cost is None or self.recovery_cost is None:
+            return
+        if batch_cost + 1e-9 < self.recovery_cost:
+            return
+        self.recovery_successes += 1
+        if self.recovery_successes >= _MEMORY_POLICY.oom_clear_successes:
+            self.oom_cost = None
+            self.recovery_cost = None
+            self.recovery_successes = 0
+
+    def _estimate_base_peak_memory_mb(self, batch_cost: float) -> float | None:
+        self._update_cached_stats()
+        if not self._points:
+            return None
+        if len(self._points) == 1:
+            return self._points[0][1]
+        if batch_cost <= self._points[-1][0]:
+            return _interpolate_peak_memory_mb(self._points, batch_cost)
+        return _extrapolate_peak_memory_mb(self._points, batch_cost)
+
+    def _get_residual_ratio(self) -> float:
+        self._update_cached_stats()
+        return self._residual_ratio
+
+    def _get_residual_mb(self) -> float:
+        self._update_cached_stats()
+        return self._residual_abs_mb
+
+    def _update_cached_stats(self) -> None:
+        if not self._cache_dirty:
+            return
+
+        self._distinct_success_cost_count = len(
+            {obs.batch_cost for obs in self.successes}
+        )
+        self._max_success_batch_size = max(
+            (obs.batch_size for obs in self.successes), default=0
+        )
+        self._max_success_cost = max(
+            (obs.batch_cost for obs in self.successes), default=0.0
+        )
+        self._residual_ratio = max(self.ratio_residuals, default=1.0)
+        self._residual_abs_mb = max(self.absolute_residuals_mb, default=0.0)
+
+        by_cost: dict[float, float] = {}
+        for obs in self.successes:
+            by_cost[obs.batch_cost] = max(
+                by_cost.get(obs.batch_cost, 0.0), obs.peak_memory_mb
+            )
+        self._points = _get_monotone_upper_points(sorted(by_cost.items()))
+        self._cache_dirty = False
+
+
 class BatchAdmissionController:
-    """Applies configured caps before adding requests to a batch."""
+    """Apply static and memory caps before adding requests to a batch."""
 
     def __init__(self, server_args: "ServerArgs", gpu_id: int):
         self._mode = getattr(server_args, "batching_mode", "dynamic")
-        self._user_max_batch_size = max(1, int(server_args.batching_max_size))
+        self._user_max_batch_size = int(server_args.batching_max_size)
         self._model_path = server_args.model_path
         self._offload = bool(server_args.layerwise_offload_components)
+        self._gpu_id = gpu_id
+        self._device_name = self._get_device_name(gpu_id)
         self._device_memory_gb = self._get_device_memory_gb(gpu_id)
         self._rules = load_batching_config(server_args.batching_config)
         self._pipeline_config = server_args.pipeline_config
+        self._limit_cache: dict[str | None, AdmissionLimit] = {}
+
+        self._runtime_memory_key = self._build_runtime_memory_key(server_args)
+        self._runtime_memory_hash = _stable_hash(self._runtime_memory_key)
+        self._lora_revision = 0
+        self._memory_profiles: dict[tuple[Any, ...], MemoryProfile] = {}
+        self._memory_budget_mb: float | None = None
+        self._memory_profiles_dirty = False
+        self._last_profile_save_s = 0.0
+        self._memory_profile_cache_path = self._get_memory_profile_cache_path(
+            getattr(server_args, "batching_memory_profile_cache", None)
+        )
+        self._load_memory_profile_cache()
 
         if self.enabled:
             logger.info(
-                "Batch admission enabled: user_max=%d, device_memory=%.1fGiB, rules=%d",
+                "Batch admission enabled: user_max=%d, device=%s %.1fGiB, rules=%d, memory_profiles=%d",
                 self._user_max_batch_size,
+                self._device_name or "unknown",
                 self._device_memory_gb or 0.0,
                 len(self._rules),
+                len(self._memory_profiles),
             )
 
     @property
     def enabled(self) -> bool:
         return self._mode == "dynamic" and self._user_max_batch_size > 1
 
-    def reject_reason_for_candidate(
+    def update_memory_budget(self) -> None:
+        """Refresh the memory budget for one scheduler pass."""
+        if not self.enabled:
+            self._memory_budget_mb = None
+            return
+        self._memory_budget_mb = self._compute_memory_budget_mb()
+
+    def get_reject_reason_for_candidate(
         self, current_reqs: list[Req], candidate_req: Req
     ) -> str | None:
         if not self.enabled:
             return None
-        proposed = current_reqs + [candidate_req]
-        limit = self.limit_for(proposed[0])
-        return limit.reject_reason(
-            batch_size=len(proposed),
-            batch_cost=self.estimate_batch_cost(proposed),
+
+        batch_size = len(current_reqs) + 1
+        batch_cost = self.get_batch_cost(current_reqs) + self.get_request_cost(
+            candidate_req
+        )
+        first_req = current_reqs[0] if current_reqs else candidate_req
+        limit = self.get_admission_limit(first_req)
+        reject_reason = limit.reject_reason(
+            batch_size=batch_size,
+            batch_cost=batch_cost,
+        )
+        if reject_reason is not None:
+            return reject_reason
+        return self._get_memory_reject_reason(
+            batch_size=batch_size,
+            batch_cost=batch_cost,
+            memory_key=self._get_memory_key(first_req),
         )
 
-    def batch_is_full(self, reqs: list[Req]) -> bool:
-        """Return whether another roughly similar request would exceed the cap."""
+    def is_batch_full(self, reqs: list[Req]) -> bool:
+        """Return whether one more compatible request would exceed admission."""
         if not self.enabled or not reqs:
             return len(reqs) >= self._user_max_batch_size
 
-        limit = self.limit_for(reqs[0])
-        if len(reqs) >= limit.max_batch_size:
+        next_batch_size = len(reqs) + 1
+        next_cost = self.get_batch_cost(reqs) + self.get_request_cost(reqs[0])
+        limit = self.get_admission_limit(reqs[0])
+        if next_batch_size > limit.max_batch_size:
             return True
+        if limit.max_cost is not None and next_cost > limit.max_cost:
+            return True
+        return (
+            self._get_memory_reject_reason(
+                batch_size=next_batch_size,
+                batch_cost=next_cost,
+                memory_key=self._get_memory_key(reqs[0]),
+                next_batch=True,
+            )
+            is not None
+        )
 
-        next_cost = self.estimate_batch_cost(reqs + [reqs[0]])
-        return limit.max_cost is not None and next_cost > limit.max_cost
-
-    def limit_reason_for_batch(self, reqs: list[Req]) -> str | None:
+    def get_batch_limit_reason(self, reqs: list[Req]) -> str | None:
         if not self.enabled or not reqs:
             return None
 
-        limit = self.limit_for(reqs[0])
-        if len(reqs) >= limit.max_batch_size:
+        next_batch_size = len(reqs) + 1
+        next_cost = self.get_batch_cost(reqs) + self.get_request_cost(reqs[0])
+        limit = self.get_admission_limit(reqs[0])
+        if next_batch_size > limit.max_batch_size:
             return limit.cap_reason or f"config_cap:{limit.max_batch_size}"
+        reason = limit.stop_reason_for_next_cost(next_cost)
+        if reason is not None:
+            return reason
+        return self._get_memory_reject_reason(
+            batch_size=next_batch_size,
+            batch_cost=next_cost,
+            memory_key=self._get_memory_key(reqs[0]),
+            next_batch=True,
+        )
 
-        next_cost = self.estimate_batch_cost(reqs + [reqs[0]])
-        return limit.stop_reason_for_next_cost(next_cost)
+    def get_max_admissible_batch_size(self, req: Req) -> int:
+        if not self.enabled:
+            return 1
 
-    def max_admissible_batch_size(self, req: Req) -> int:
-        return self.limit_for(req).max_batch_size
+        limit = self.get_admission_limit(req)
+        high = limit.max_batch_size
+        cost_per_req = self.get_request_cost(req)
+        memory_key = self._get_memory_key(req)
+        low = 1
+        while low < high:
+            mid = (low + high + 1) // 2
+            batch_cost = cost_per_req * mid
+            if limit.reject_reason(batch_size=mid, batch_cost=batch_cost) is not None:
+                high = mid - 1
+            elif (
+                self._get_memory_reject_reason(
+                    batch_size=mid,
+                    batch_cost=batch_cost,
+                    memory_key=memory_key,
+                )
+                is not None
+            ):
+                high = mid - 1
+            else:
+                low = mid
+        return low
 
-    def limit_for(self, req: Req) -> AdmissionLimit:
-        """Return the effective admission limit for the request's model and shape."""
-        rules = self._matching_rules(req)
+    def record_batch_result(self, reqs: list[Req], output_batch: OutputBatch) -> None:
+        if not self.enabled or not reqs:
+            return
+
+        batch_cost = self.get_batch_cost(reqs)
+        if batch_cost <= 0.0:
+            return
+
+        profile = self._memory_profiles.setdefault(
+            self._get_memory_key(reqs[0]), MemoryProfile()
+        )
+        if output_batch.is_oom:
+            profile.observe_oom(batch_cost)
+            self._memory_profiles_dirty = True
+            self._save_memory_profile_cache_if_due()
+            return
+
+        if output_batch.error is not None:
+            return
+
+        if output_batch.peak_memory_mb > 0.0:
+            profile.observe_success(
+                batch_cost,
+                output_batch.peak_memory_mb,
+                batch_size=len(reqs),
+            )
+            self._memory_profiles_dirty = True
+            self._save_memory_profile_cache_if_due()
+
+    def update_lora_revision(self) -> None:
+        """Bump the LoRA revision used in memory profile keys."""
+        self._lora_revision += 1
+
+    def flush_memory_profile_cache(self) -> None:
+        if not self._memory_profiles_dirty:
+            return
+        self._save_memory_profile_cache()
+
+    def _save_memory_profile_cache_if_due(self) -> None:
+        if not self._memory_profiles_dirty:
+            return
+        now = time.monotonic()
+        if now - self._last_profile_save_s >= _MEMORY_POLICY.save_interval_s:
+            self._save_memory_profile_cache()
+
+    def get_admission_limit(self, req: Req) -> AdmissionLimit:
+        """Return the admission limit for a request shape."""
+        cache_key = req.resolution_key
+        cached = self._limit_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        rules = self._get_matching_rules(req)
         if not rules:
-            return AdmissionLimit(max_batch_size=self._user_max_batch_size)
+            limit = AdmissionLimit(max_batch_size=self._user_max_batch_size)
+            self._limit_cache[cache_key] = limit
+            return limit
 
         config_cap = min(rule.max_batch_size for rule in rules)
         max_batch_size = min(self._user_max_batch_size, config_cap)
@@ -229,18 +582,187 @@ class BatchAdmissionController:
             else None
         )
         costs = [rule.max_cost for rule in rules if rule.max_cost is not None]
-        return AdmissionLimit(
+        limit = AdmissionLimit(
             max_batch_size=max(1, max_batch_size),
             max_cost=min(costs) if costs else None,
             cap_reason=cap_reason,
         )
+        self._limit_cache[cache_key] = limit
+        return limit
 
-    def estimate_batch_cost(self, reqs: list[Req]) -> float:
-        return sum(
-            float(self._pipeline_config.estimate_request_cost(req)) for req in reqs
+    def get_batch_cost(self, reqs: list[Req]) -> float:
+        return sum(self.get_request_cost(req) for req in reqs)
+
+    def get_request_cost(self, req: Req) -> float:
+        cached = getattr(req, "_batch_admission_cost", None)
+        if cached is not None:
+            return float(cached)
+        cost = float(self._pipeline_config.estimate_request_cost(req))
+        req._batch_admission_cost = cost  # type: ignore[attr-defined]
+        return cost
+
+    def _get_memory_reject_reason(
+        self,
+        *,
+        batch_size: int,
+        batch_cost: float,
+        memory_key: tuple[Any, ...],
+        next_batch: bool = False,
+    ) -> str | None:
+        profile = self._memory_profiles.get(memory_key)
+        if profile is not None and profile.oom_cost is not None:
+            if batch_cost + 1e-9 >= profile.oom_cost:
+                return f"memory_oom:{batch_cost:.0f}>={profile.oom_cost:.0f}"
+
+        calibration_reject = self._get_memory_calibration_reject_reason(
+            profile,
+            batch_size=batch_size,
+            batch_cost=batch_cost,
+        )
+        if calibration_reject is not None:
+            return calibration_reject
+
+        predicted_mb = None
+        if profile is not None:
+            predicted_mb = profile.estimate_peak_memory_mb(batch_cost)
+        if predicted_mb is None or self._memory_budget_mb is None:
+            return None
+        if predicted_mb > self._memory_budget_mb:
+            suffix = "_next" if next_batch else ""
+            return f"memory_budget{suffix}:{predicted_mb:.0f}>{self._memory_budget_mb:.0f}MiB"
+        return None
+
+    def _get_memory_calibration_reject_reason(
+        self,
+        profile: MemoryProfile | None,
+        *,
+        batch_size: int,
+        batch_cost: float,
+    ) -> str | None:
+        if profile is None or not profile.successes:
+            if batch_size > 1:
+                return "memory_uncalibrated:allow=1"
+            return None
+
+        max_observed_batch = profile.get_max_success_batch_size()
+        allowed_batch = max(1, max_observed_batch * 2)
+        if batch_size > allowed_batch:
+            return f"memory_uncalibrated:allow={allowed_batch}"
+
+        if profile.get_num_success_costs() < 2 and batch_size > max(
+            2, max_observed_batch
+        ):
+            return f"memory_uncalibrated:allow={max(2, max_observed_batch)}"
+
+        return None
+
+    def _get_memory_key(self, req: Req) -> tuple[Any, ...]:
+        return (
+            ("runtime", self._runtime_memory_key),
+            ("lora_revision", self._lora_revision),
+            ("request", self._get_request_memory_key(req)),
         )
 
-    def _matching_rules(self, req: Req) -> list[BatchingRule]:
+    def _get_request_memory_key(self, req: Req) -> tuple[Any, ...]:
+        cached = getattr(req, "_batch_request_memory_key", None)
+        if cached is not None:
+            return cached
+
+        key = (
+            ("resolution", req.resolution_key),
+            ("width", getattr(req, "width", None)),
+            ("height", getattr(req, "height", None)),
+            ("num_frames", getattr(req, "num_frames", None)),
+            ("num_outputs_per_prompt", getattr(req, "num_outputs_per_prompt", None)),
+            ("data_type", _freeze_key_value(getattr(req, "data_type", None))),
+            ("max_sequence_length", getattr(req, "max_sequence_length", None)),
+            (
+                "prompt_template",
+                _freeze_key_value(getattr(req, "prompt_template", None)),
+            ),
+            (
+                "do_classifier_free_guidance",
+                getattr(req, "do_classifier_free_guidance", False),
+            ),
+            ("condition_image", getattr(req, "condition_image", None) is not None),
+            ("image_path", bool(getattr(req, "image_path", None))),
+            ("return_frames", getattr(req, "return_frames", None)),
+            ("return_trajectory", getattr(req, "return_trajectory", None)),
+            ("enable_upscaling", getattr(req, "enable_upscaling", None)),
+            (
+                "enable_frame_interpolation",
+                getattr(req, "enable_frame_interpolation", None),
+            ),
+            ("sampling", _get_sampling_memory_key(req)),
+            (
+                "diffusers_kwargs",
+                _freeze_key_value(
+                    (getattr(req, "extra", None) or {}).get("diffusers_kwargs")
+                ),
+            ),
+        )
+        req._batch_request_memory_key = key  # type: ignore[attr-defined]
+        return key
+
+    def _build_runtime_memory_key(self, server_args: "ServerArgs") -> tuple[Any, ...]:
+        return (
+            ("model_path", server_args.model_path),
+            ("model_id", server_args.model_id),
+            ("pipeline_class_name", server_args.pipeline_class_name),
+            ("backend", _freeze_key_value(server_args.backend)),
+            ("device_name", self._device_name),
+            ("device_memory_gb", self._device_memory_gb),
+            ("attention_backend", server_args.attention_backend),
+            (
+                "component_attention_backends",
+                _freeze_key_value(server_args.component_attention_backends),
+            ),
+            (
+                "dit_precision",
+                getattr(server_args.pipeline_config, "dit_precision", None),
+            ),
+            (
+                "vae_precision",
+                getattr(server_args.pipeline_config, "vae_precision", None),
+            ),
+            (
+                "text_encoder_precisions",
+                _freeze_key_value(
+                    getattr(
+                        server_args.pipeline_config, "text_encoder_precisions", None
+                    )
+                ),
+            ),
+            (
+                "image_encoder_precision",
+                getattr(server_args.pipeline_config, "image_encoder_precision", None),
+            ),
+            ("quantization", server_args.quantization),
+            ("transformer_weights_path", server_args.transformer_weights_path),
+            ("num_gpus", server_args.num_gpus),
+            ("tp_size", server_args.tp_size),
+            ("sp_degree", server_args.sp_degree),
+            ("ulysses_degree", server_args.ulysses_degree),
+            ("ring_degree", server_args.ring_degree),
+            ("dp_size", server_args.dp_size),
+            ("dp_degree", server_args.dp_degree),
+            ("enable_cfg_parallel", server_args.enable_cfg_parallel),
+            ("cfg_parallel_degree", server_args.cfg_parallel_degree),
+            ("dit_cpu_offload", server_args.dit_cpu_offload),
+            ("dit_layerwise_offload", server_args.dit_layerwise_offload),
+            ("dit_offload_prefetch_size", server_args.dit_offload_prefetch_size),
+            ("text_encoder_cpu_offload", server_args.text_encoder_cpu_offload),
+            ("image_encoder_cpu_offload", server_args.image_encoder_cpu_offload),
+            ("vae_cpu_offload", server_args.vae_cpu_offload),
+            ("use_fsdp_inference", server_args.use_fsdp_inference),
+            ("enable_torch_compile", server_args.enable_torch_compile),
+            ("lora_path", server_args.lora_path),
+            ("lora_nickname", server_args.lora_nickname),
+            ("lora_scale", server_args.lora_scale),
+            ("lora_weight_name", server_args.lora_weight_name),
+        )
+
+    def _get_matching_rules(self, req: Req) -> list[BatchingRule]:
         return [
             rule
             for rule in self._rules
@@ -252,12 +774,157 @@ class BatchAdmissionController:
             )
         ]
 
+    def _compute_memory_budget_mb(self) -> float | None:
+        if current_platform.is_cpu():
+            return None
+        total_mb = self._get_device_memory_mb(self._gpu_id)
+        available_mb = self._get_available_memory_mb(self._gpu_id)
+        reserved_mb = self._get_process_reserved_memory_mb()
+        if total_mb is None:
+            return None
+
+        internal_reserve_mb = max(
+            _MEMORY_POLICY.internal_reserve_min_mb,
+            total_mb * _MEMORY_POLICY.internal_reserve_fraction,
+        )
+        budget_mb = max(0.0, total_mb - internal_reserve_mb)
+        if available_mb is not None and reserved_mb is not None:
+            external_used_mb = max(0.0, total_mb - available_mb - reserved_mb)
+            budget_mb = max(0.0, budget_mb - external_used_mb)
+        return budget_mb
+
     @staticmethod
     def _get_device_memory_gb(gpu_id: int) -> float | None:
+        device_mb = BatchAdmissionController._get_device_memory_mb(gpu_id)
+        return None if device_mb is None else device_mb / 1024.0
+
+    @staticmethod
+    def _get_device_memory_mb(gpu_id: int) -> float | None:
         try:
-            return current_platform.get_device_total_memory(gpu_id) / BYTES_PER_GB
+            return current_platform.get_device_total_memory(gpu_id) / (1024**2)
         except Exception:
             return None
+
+    @staticmethod
+    def _get_device_name(gpu_id: int) -> str | None:
+        try:
+            return current_platform.get_device_name(gpu_id)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _get_available_memory_mb(gpu_id: int) -> float | None:
+        try:
+            return (
+                current_platform.get_available_gpu_memory(gpu_id, empty_cache=False)
+                * 1024.0
+            )
+        except Exception:
+            return None
+
+    @staticmethod
+    def _get_process_reserved_memory_mb() -> float | None:
+        if current_platform.is_cpu():
+            return None
+        try:
+            device_module = torch.get_device_module()
+            if hasattr(device_module, "memory_reserved"):
+                return float(device_module.memory_reserved()) / (1024**2)
+        except Exception:
+            return None
+        return None
+
+    def _get_memory_profile_cache_path(self, configured: str | None) -> str | None:
+        path = configured or os.getenv(_CACHE_ENV)
+        if path is None:
+            path = os.path.join(
+                os.path.expanduser("~"),
+                ".cache",
+                "sglang",
+                "diffusion_batch_memory",
+            )
+        if str(path).lower() in ("", "none", "off", "false"):
+            return None
+        path = os.path.expanduser(path)
+        if path.endswith(".json"):
+            return path
+        return os.path.join(path, f"{self._runtime_memory_hash}.json")
+
+    def _load_memory_profile_cache(self) -> None:
+        path = self._memory_profile_cache_path
+        if path is None or not os.path.exists(path):
+            return
+        try:
+            with open(path, encoding="utf-8") as f:
+                payload = json.load(f)
+        except Exception as exc:
+            logger.warning("Failed to load memory profile cache %s: %s", path, exc)
+            return
+
+        if payload.get("schema_version") != _MEMORY_PROFILE_SCHEMA_VERSION:
+            logger.warning(
+                "Ignoring memory profile cache with unsupported schema: %s", path
+            )
+            return
+        if payload.get("runtime_hash") != self._runtime_memory_hash:
+            logger.warning(
+                "Ignoring memory profile cache for different runtime: %s", path
+            )
+            return
+
+        profiles = payload.get("profiles", [])
+        for item in profiles:
+            if not isinstance(item, dict):
+                continue
+            key = item.get("key")
+            profile_data = item.get("profile")
+            if key is None or not isinstance(profile_data, dict):
+                continue
+            self._memory_profiles[_unjsonable(key)] = MemoryProfile.from_dict(
+                profile_data
+            )
+
+    def _save_memory_profile_cache(self) -> None:
+        path = self._memory_profile_cache_path
+        if path is None:
+            self._memory_profiles_dirty = False
+            return
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        payload = {
+            "schema_version": _MEMORY_PROFILE_SCHEMA_VERSION,
+            "runtime_hash": self._runtime_memory_hash,
+            "runtime_key": _jsonable(self._runtime_memory_key),
+            "profiles": [
+                {
+                    "key": _jsonable(key),
+                    "profile": profile.to_dict(),
+                }
+                for key, profile in self._memory_profiles.items()
+                if profile.successes or profile.oom_cost is not None
+            ],
+        }
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".memory_profiles_",
+            suffix=".json",
+            dir=os.path.dirname(path),
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2, sort_keys=True)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+            self._memory_profiles_dirty = False
+            self._last_profile_save_s = time.monotonic()
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
 
 def load_batching_config(path: str | None) -> list[BatchingRule]:
@@ -317,6 +984,111 @@ def _validate_rule_keys(data: dict[str, Any], *, source: str) -> None:
         f"batching config rule from {source} contains unknown key(s): "
         f"{', '.join(hints)}"
     )
+
+
+def _get_sampling_memory_key(req: Req) -> tuple[Any, ...] | None:
+    sp = getattr(req, "sampling_params", None)
+    if sp is None:
+        return None
+
+    items = []
+    for field_info in fields(SamplingParams):
+        name = field_info.name
+        if name in _SAMPLING_MEMORY_EXCLUDE or name.startswith("_"):
+            continue
+        items.append((name, _freeze_key_value(getattr(sp, name, None))))
+    return tuple(items)
+
+
+def _freeze_key_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        return tuple(
+            (field_info.name, _freeze_key_value(getattr(value, field_info.name)))
+            for field_info in fields(value)
+        )
+    if isinstance(value, dict):
+        return tuple(
+            (str(key), _freeze_key_value(item))
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_key_value(item) for item in value)
+    if isinstance(value, set):
+        return tuple(sorted(_freeze_key_value(item) for item in value))
+    if hasattr(value, "shape") and hasattr(value, "dtype"):
+        return ("tensor", tuple(value.shape), str(value.dtype))
+    return repr(value)
+
+
+def _get_monotone_upper_points(
+    points: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    monotone: list[tuple[float, float]] = []
+    current_peak = 0.0
+    for cost, peak in points:
+        current_peak = max(current_peak, peak)
+        monotone.append((cost, current_peak))
+    return monotone
+
+
+def _interpolate_peak_memory_mb(
+    points: list[tuple[float, float]], batch_cost: float
+) -> float:
+    if batch_cost <= points[0][0]:
+        return points[0][1]
+    for idx in range(1, len(points)):
+        low_cost, low_peak = points[idx - 1]
+        high_cost, high_peak = points[idx]
+        if batch_cost <= high_cost:
+            if math.isclose(high_cost, low_cost):
+                return max(low_peak, high_peak)
+            fraction = (batch_cost - low_cost) / (high_cost - low_cost)
+            return low_peak + fraction * (high_peak - low_peak)
+    return points[-1][1]
+
+
+def _extrapolate_peak_memory_mb(
+    points: list[tuple[float, float]], batch_cost: float
+) -> float:
+    n = len(points)
+    mean_cost = sum(cost for cost, _ in points) / n
+    mean_peak = sum(peak for _, peak in points) / n
+    denominator = sum((cost - mean_cost) ** 2 for cost, _ in points)
+    if denominator == 0.0:
+        return points[-1][1]
+    slope = sum((cost - mean_cost) * (peak - mean_peak) for cost, peak in points)
+    slope = max(0.0, slope / denominator)
+    intercept = mean_peak - slope * mean_cost
+    return max(points[-1][1], intercept + slope * batch_cost)
+
+
+def _stable_hash(value: Any) -> str:
+    encoded = json.dumps(
+        _jsonable(value), sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _unjsonable(value: Any) -> Any:
+    if isinstance(value, list):
+        return tuple(_unjsonable(item) for item in value)
+    if isinstance(value, dict):
+        return tuple((key, _unjsonable(item)) for key, item in sorted(value.items()))
+    return value
 
 
 def _optional_str(value: Any) -> str | None:

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -87,6 +87,9 @@ class MemoryAdmissionPolicy:
     oom_clear_successes: int = 8
     # Minimum allocator slack.
     internal_reserve_min_mb: float = 512.0
+    # Headroom used only by the cold-start rough estimate.
+    rough_headroom_fraction: float = 0.10
+    rough_headroom_min_mb: float = 512.0
 
 
 _MEMORY_POLICY = MemoryAdmissionPolicy()
@@ -208,6 +211,7 @@ class MemoryObservation:
     batch_cost: float
     peak_memory_mb: float
     batch_size: int
+    baseline_memory_mb: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -218,6 +222,7 @@ class MemoryObservation:
             batch_cost=float(data["batch_cost"]),
             peak_memory_mb=float(data["peak_memory_mb"]),
             batch_size=max(1, int(data.get("batch_size", 1))),
+            baseline_memory_mb=_optional_float(data.get("baseline_memory_mb")),
         )
 
 
@@ -243,7 +248,12 @@ class MemoryProfile:
     )
 
     def observe_success(
-        self, batch_cost: float, peak_memory_mb: float, *, batch_size: int
+        self,
+        batch_cost: float,
+        peak_memory_mb: float,
+        *,
+        batch_size: int,
+        baseline_memory_mb: float | None = None,
     ) -> None:
         if batch_cost <= 0.0 or peak_memory_mb <= 0.0:
             return
@@ -267,6 +277,7 @@ class MemoryProfile:
                 batch_cost=float(batch_cost),
                 peak_memory_mb=float(peak_memory_mb),
                 batch_size=max(1, int(batch_size)),
+                baseline_memory_mb=_optional_float(baseline_memory_mb),
             )
         )
         del self.successes[: -_MEMORY_POLICY.history_size]
@@ -291,6 +302,47 @@ class MemoryProfile:
         return max(
             predicted * self._get_residual_ratio(),
             predicted + self._get_residual_mb(),
+        )
+
+    def estimate_rough_peak_memory_mb(self, batch_cost: float) -> float | None:
+        if batch_cost <= 0.0:
+            return None
+        seeds = [
+            obs
+            for obs in self.successes
+            if obs.batch_cost > 0.0
+            and obs.peak_memory_mb > 0.0
+            and obs.baseline_memory_mb is not None
+        ]
+        if not seeds:
+            return None
+
+        lower_or_equal = [obs for obs in seeds if obs.batch_cost <= batch_cost]
+        seed = max(
+            lower_or_equal or seeds,
+            key=lambda obs: obs.batch_cost,
+        )
+        baseline_mb = min(
+            max(0.0, float(seed.baseline_memory_mb or 0.0)),
+            seed.peak_memory_mb,
+        )
+        variable_mb_per_cost = max(0.0, seed.peak_memory_mb - baseline_mb) / max(
+            seed.batch_cost, 1e-9
+        )
+        extra_cost = max(0.0, batch_cost - seed.batch_cost)
+        rough_headroom_mb = (
+            max(
+                _MEMORY_POLICY.rough_headroom_min_mb,
+                variable_mb_per_cost
+                * extra_cost
+                * _MEMORY_POLICY.rough_headroom_fraction,
+            )
+            if extra_cost > 0.0
+            else 0.0
+        )
+        return max(
+            seed.peak_memory_mb,
+            baseline_mb + variable_mb_per_cost * batch_cost + rough_headroom_mb,
         )
 
     def get_num_success_costs(self) -> int:
@@ -338,6 +390,7 @@ class MemoryProfile:
                 obs.batch_cost,
                 obs.peak_memory_mb,
                 batch_size=obs.batch_size,
+                baseline_memory_mb=obs.baseline_memory_mb,
             )
         self.ratio_residuals = replay.ratio_residuals
         self.absolute_residuals_mb = replay.absolute_residuals_mb
@@ -564,6 +617,7 @@ class BatchAdmissionController:
                 batch_cost,
                 output_batch.peak_memory_mb,
                 batch_size=len(reqs),
+                baseline_memory_mb=output_batch.pre_forward_reserved_memory_mb,
             )
             self._memory_profiles_dirty = True
             self._save_memory_profile_cache_if_due()
@@ -637,6 +691,7 @@ class BatchAdmissionController:
             if batch_cost + 1e-9 >= profile.oom_cost:
                 return f"memory_oom:{batch_cost:.0f}>={profile.oom_cost:.0f}"
 
+        rough_predicted_mb = self._estimate_rough_peak_memory_mb(profile, batch_cost)
         calibration_reject = self._get_memory_calibration_reject_reason(
             profile,
             batch_size=batch_size,
@@ -646,13 +701,20 @@ class BatchAdmissionController:
             return calibration_reject
 
         predicted_mb = None
-        if profile is not None:
+        used_rough_prediction = False
+        if profile is not None and profile.get_num_success_costs() >= 2:
             predicted_mb = profile.estimate_peak_memory_mb(batch_cost)
+        elif rough_predicted_mb is not None:
+            predicted_mb = rough_predicted_mb
+            used_rough_prediction = True
         if predicted_mb is None or self._memory_budget_mb is None:
             return None
         if predicted_mb > self._memory_budget_mb:
+            prefix = "memory_rough_budget" if used_rough_prediction else "memory_budget"
             suffix = "_next" if next_batch else ""
-            return f"memory_budget{suffix}:{predicted_mb:.0f}>{self._memory_budget_mb:.0f}MiB"
+            return (
+                f"{prefix}{suffix}:{predicted_mb:.0f}>{self._memory_budget_mb:.0f}MiB"
+            )
         return None
 
     def _get_memory_calibration_reject_reason(
@@ -678,6 +740,13 @@ class BatchAdmissionController:
             return f"memory_uncalibrated:allow={max(2, max_observed_batch)}"
 
         return None
+
+    def _estimate_rough_peak_memory_mb(
+        self, profile: MemoryProfile | None, batch_cost: float
+    ) -> float | None:
+        if profile is None:
+            return None
+        return profile.estimate_rough_peak_memory_mb(batch_cost)
 
     def _get_memory_key(self, req: Req) -> tuple[Any, ...]:
         return (

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -249,9 +249,15 @@ class MemoryProfile:
         if batch_cost <= 0.0 or peak_memory_mb <= 0.0:
             return
 
+        previous_success_costs = self.get_num_success_costs()
         previous_max_cost = self.get_max_success_cost()
         predicted = self._estimate_base_peak_memory_mb(batch_cost)
-        if predicted is not None and predicted > 0.0 and batch_cost > previous_max_cost:
+        if (
+            previous_success_costs >= 2
+            and predicted is not None
+            and predicted > 0.0
+            and batch_cost > previous_max_cost
+        ):
             self.ratio_residuals.append(max(1.0, peak_memory_mb / predicted))
             self.absolute_residuals_mb.append(max(0.0, peak_memory_mb - predicted))
             del self.ratio_residuals[: -_MEMORY_POLICY.history_size]
@@ -318,24 +324,24 @@ class MemoryProfile:
                 for item in data.get("successes", [])
                 if isinstance(item, dict)
             ],
-            ratio_residuals=[
-                float(item)
-                for item in data.get("ratio_residuals", [])[
-                    -_MEMORY_POLICY.history_size :
-                ]
-            ],
-            absolute_residuals_mb=[
-                float(item)
-                for item in data.get("absolute_residuals_mb", [])[
-                    -_MEMORY_POLICY.history_size :
-                ]
-            ],
             oom_cost=_optional_float(data.get("oom_cost")),
             recovery_cost=_optional_float(data.get("recovery_cost")),
             recovery_successes=int(data.get("recovery_successes", 0)),
         )
+        profile._recompute_residuals_from_successes()
         profile._cache_dirty = True
         return profile
+
+    def _recompute_residuals_from_successes(self) -> None:
+        replay = type(self)()
+        for obs in self.successes:
+            replay.observe_success(
+                obs.batch_cost,
+                obs.peak_memory_mb,
+                batch_size=obs.batch_size,
+            )
+        self.ratio_residuals = replay.ratio_residuals
+        self.absolute_residuals_mb = replay.absolute_residuals_mb
 
     def _update_oom_boundary_after_success(self, batch_cost: float) -> None:
         if self.oom_cost is None or self.recovery_cost is None:

--- a/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
+++ b/python/sglang/multimodal_gen/runtime/managers/dynamic_batch_admission.py
@@ -13,9 +13,8 @@ import time
 from dataclasses import dataclass, field, fields, is_dataclass
 from difflib import get_close_matches
 from enum import Enum
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
-
-import torch
 
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.runtime.pipelines_core import Req
@@ -45,34 +44,6 @@ _BATCHING_RULE_KEYS = frozenset(
 
 _MEMORY_PROFILE_SCHEMA_VERSION = 1
 _CACHE_ENV = "SGLANG_DIFFUSION_BATCH_MEMORY_CACHE"
-
-# Request identity/output fields do not affect memory profile reuse.
-_SAMPLING_MEMORY_EXCLUDE = frozenset(
-    {
-        "prompt",
-        "negative_prompt",
-        "prompt_path",
-        "seed",
-        "request_id",
-        "output_path",
-        "output_file_name",
-        "output_quality",
-        "output_compression",
-        "fps",
-        "save_output",
-        "return_file_paths_only",
-        "generator_device",
-        "supported_resolutions",
-        "profile",
-        "num_profiled_timesteps",
-        "profile_all_stages",
-        "debug",
-        "suppress_logs",
-        "perf_dump_path",
-        "no_override_protected_fields",
-        "adjust_frames",
-    }
-)
 
 
 @dataclass(frozen=True)
@@ -228,7 +199,14 @@ class MemoryObservation:
 
 @dataclass
 class MemoryProfile:
-    """Memory observations for one runtime/request key."""
+    """Memory observations for one runtime/request key.
+
+    ``successes`` stores recent successful batch measurements. Predictions use
+    a monotone upper envelope over those points, indexed by relative batch cost.
+    ``ratio_residuals`` and ``absolute_residuals_mb`` keep recent extrapolation
+    misses as adaptive headroom. ``oom_cost`` is the lowest observed cost that
+    ran out of memory and is treated as a hard boundary until recovery succeeds.
+    """
 
     successes: list[MemoryObservation] = field(default_factory=list)
     ratio_residuals: list[float] = field(default_factory=list)
@@ -461,8 +439,11 @@ class BatchAdmissionController:
         self._model_path = server_args.model_path
         self._offload = bool(server_args.layerwise_offload_components)
         self._gpu_id = gpu_id
-        self._device_name = self._get_device_name(gpu_id)
-        self._device_memory_gb = self._get_device_memory_gb(gpu_id)
+        self._device_name = _get_device_name(gpu_id)
+        device_memory_mb = _get_device_total_memory_mb(gpu_id)
+        self._device_memory_gb = (
+            None if device_memory_mb is None else device_memory_mb / 1024.0
+        )
         self._memory_reserve_fraction = float(
             server_args.batching_memory_reserve_fraction
         )
@@ -475,6 +456,7 @@ class BatchAdmissionController:
         self._lora_revision = 0
         self._memory_profiles: dict[tuple[Any, ...], MemoryProfile] = {}
         self._memory_budget_mb: float | None = None
+        self._memory_profile_revision = 0
         self._memory_profiles_dirty = False
         self._last_profile_save_s = 0.0
         self._memory_profile_cache_path = self._get_memory_profile_cache_path(
@@ -569,18 +551,45 @@ class BatchAdmissionController:
         )
 
     def get_max_admissible_batch_size(self, req: Req) -> int:
+        """Return the largest homogeneous batch size currently admissible.
+
+        This is used for metrics/capacity reporting, so it mirrors candidate
+        admission instead of using a looser static cap. The binary search is
+        cached on primitive inputs plus memory budget/profile revision because
+        it can be called several times in one scheduler selection pass while the
+        profile and budget are unchanged.
+        """
         if not self.enabled:
             return 1
 
         limit = self.get_admission_limit(req)
-        high = limit.max_batch_size
         cost_per_req = self.get_request_cost(req)
-        memory_key = self._get_memory_key(req)
+        return self._compute_max_admissible_batch_size_cached(
+            limit.max_batch_size,
+            limit.max_cost,
+            cost_per_req,
+            self._get_memory_key(req),
+            self._memory_budget_mb,
+            self._memory_profile_revision,
+        )
+
+    @lru_cache(maxsize=1024)
+    def _compute_max_admissible_batch_size_cached(
+        self,
+        max_batch_size: int,
+        max_cost: float | None,
+        cost_per_req: float,
+        memory_key: tuple[Any, ...],
+        memory_budget_mb: float | None,
+        memory_profile_revision: int,
+    ) -> int:
+        del memory_budget_mb, memory_profile_revision
         low = 1
+        high = max_batch_size
         while low < high:
             mid = (low + high + 1) // 2
             batch_cost = cost_per_req * mid
-            if limit.reject_reason(batch_size=mid, batch_cost=batch_cost) is not None:
+            if max_cost is not None and batch_cost > max_cost:
                 high = mid - 1
             elif (
                 self._get_memory_reject_reason(
@@ -608,7 +617,7 @@ class BatchAdmissionController:
         )
         if output_batch.is_oom:
             profile.observe_oom(batch_cost)
-            self._memory_profiles_dirty = True
+            self._mark_memory_profiles_changed()
             self._save_memory_profile_cache_if_due()
             return
 
@@ -622,7 +631,7 @@ class BatchAdmissionController:
                 batch_size=len(reqs),
                 baseline_memory_mb=output_batch.pre_forward_reserved_memory_mb,
             )
-            self._memory_profiles_dirty = True
+            self._mark_memory_profiles_changed()
             self._save_memory_profile_cache_if_due()
 
     def update_lora_revision(self) -> None:
@@ -633,6 +642,10 @@ class BatchAdmissionController:
         if not self._memory_profiles_dirty:
             return
         self._save_memory_profile_cache()
+
+    def _mark_memory_profiles_changed(self) -> None:
+        self._memory_profiles_dirty = True
+        self._memory_profile_revision += 1
 
     def _save_memory_profile_cache_if_due(self) -> None:
         if not self._memory_profiles_dirty:
@@ -784,7 +797,6 @@ class BatchAdmissionController:
             ("condition_image", getattr(req, "condition_image", None) is not None),
             ("image_path", bool(getattr(req, "image_path", None))),
             ("return_frames", getattr(req, "return_frames", None)),
-            ("return_trajectory", getattr(req, "return_trajectory", None)),
             ("enable_upscaling", getattr(req, "enable_upscaling", None)),
             (
                 "enable_frame_interpolation",
@@ -803,64 +815,87 @@ class BatchAdmissionController:
 
     def _build_runtime_memory_key(self, server_args: "ServerArgs") -> tuple[Any, ...]:
         return (
-            ("model_path", server_args.model_path),
-            ("model_id", server_args.model_id),
-            ("pipeline_class_name", server_args.pipeline_class_name),
-            ("backend", _freeze_key_value(server_args.backend)),
-            ("device_name", self._device_name),
-            ("device_memory_gb", self._device_memory_gb),
-            ("attention_backend", server_args.attention_backend),
             (
-                "component_attention_backends",
-                _freeze_key_value(server_args.component_attention_backends),
-            ),
-            (
-                "dit_precision",
-                getattr(server_args.pipeline_config, "dit_precision", None),
-            ),
-            (
-                "vae_precision",
-                getattr(server_args.pipeline_config, "vae_precision", None),
-            ),
-            (
-                "text_encoder_precisions",
-                _freeze_key_value(
-                    getattr(
-                        server_args.pipeline_config, "text_encoder_precisions", None
-                    )
+                "model",
+                (
+                    ("model_path", server_args.model_path),
+                    ("model_id", server_args.model_id),
+                    ("pipeline_class_name", server_args.pipeline_class_name),
+                    ("pipeline_config", _freeze_key_value(server_args.pipeline_config)),
                 ),
             ),
             (
-                "image_encoder_precision",
-                getattr(server_args.pipeline_config, "image_encoder_precision", None),
+                "device",
+                (
+                    ("name", self._device_name),
+                    ("memory_gb", self._device_memory_gb),
+                ),
             ),
-            ("quantization", server_args.quantization),
-            ("transformer_weights_path", server_args.transformer_weights_path),
-            ("num_gpus", server_args.num_gpus),
-            ("tp_size", server_args.tp_size),
-            ("sp_degree", server_args.sp_degree),
-            ("ulysses_degree", server_args.ulysses_degree),
-            ("ring_degree", server_args.ring_degree),
-            ("dp_size", server_args.dp_size),
-            ("dp_degree", server_args.dp_degree),
-            ("enable_cfg_parallel", server_args.enable_cfg_parallel),
-            ("cfg_parallel_degree", server_args.cfg_parallel_degree),
-            ("dit_cpu_offload", server_args.dit_cpu_offload),
-            ("dit_layerwise_offload", server_args.dit_layerwise_offload),
             (
-                "layerwise_offload_components",
-                _freeze_key_value(server_args.layerwise_offload_components),
+                "runtime",
+                (
+                    ("backend", _freeze_key_value(server_args.backend)),
+                    ("attention_backend", server_args.attention_backend),
+                    (
+                        "component_attention_backends",
+                        _freeze_key_value(server_args.component_attention_backends),
+                    ),
+                    ("quantization", server_args.quantization),
+                    (
+                        "transformer_weights_path",
+                        server_args.transformer_weights_path,
+                    ),
+                    ("enable_torch_compile", server_args.enable_torch_compile),
+                ),
             ),
-            ("dit_offload_prefetch_size", server_args.dit_offload_prefetch_size),
-            ("text_encoder_cpu_offload", server_args.text_encoder_cpu_offload),
-            ("image_encoder_cpu_offload", server_args.image_encoder_cpu_offload),
-            ("vae_cpu_offload", server_args.vae_cpu_offload),
-            ("use_fsdp_inference", server_args.use_fsdp_inference),
-            ("enable_torch_compile", server_args.enable_torch_compile),
-            ("lora_path", server_args.lora_path),
-            ("lora_nickname", server_args.lora_nickname),
-            ("lora_scale", server_args.lora_scale),
-            ("lora_weight_name", server_args.lora_weight_name),
+            (
+                "parallelism",
+                (
+                    ("num_gpus", server_args.num_gpus),
+                    ("tp_size", server_args.tp_size),
+                    ("sp_degree", server_args.sp_degree),
+                    ("ulysses_degree", server_args.ulysses_degree),
+                    ("ring_degree", server_args.ring_degree),
+                    ("dp_size", server_args.dp_size),
+                    ("dp_degree", server_args.dp_degree),
+                    ("enable_cfg_parallel", server_args.enable_cfg_parallel),
+                    ("cfg_parallel_degree", server_args.cfg_parallel_degree),
+                ),
+            ),
+            (
+                "offload",
+                (
+                    ("dit_cpu_offload", server_args.dit_cpu_offload),
+                    ("dit_layerwise_offload", server_args.dit_layerwise_offload),
+                    (
+                        "layerwise_offload_components",
+                        _freeze_key_value(server_args.layerwise_offload_components),
+                    ),
+                    (
+                        "dit_offload_prefetch_size",
+                        server_args.dit_offload_prefetch_size,
+                    ),
+                    (
+                        "text_encoder_cpu_offload",
+                        server_args.text_encoder_cpu_offload,
+                    ),
+                    (
+                        "image_encoder_cpu_offload",
+                        server_args.image_encoder_cpu_offload,
+                    ),
+                    ("vae_cpu_offload", server_args.vae_cpu_offload),
+                    ("use_fsdp_inference", server_args.use_fsdp_inference),
+                ),
+            ),
+            (
+                "lora",
+                (
+                    ("path", server_args.lora_path),
+                    ("nickname", server_args.lora_nickname),
+                    ("scale", server_args.lora_scale),
+                    ("weight_name", server_args.lora_weight_name),
+                ),
+            ),
         )
 
     def _get_matching_rules(self, req: Req) -> list[BatchingRule]:
@@ -878,9 +913,9 @@ class BatchAdmissionController:
     def _compute_memory_budget_mb(self) -> float | None:
         if current_platform.is_cpu():
             return None
-        total_mb = self._get_device_memory_mb(self._gpu_id)
-        available_mb = self._get_available_memory_mb(self._gpu_id)
-        reserved_mb = self._get_process_reserved_memory_mb()
+        total_mb = _get_device_total_memory_mb(self._gpu_id)
+        available_mb = _get_available_device_memory_mb(self._gpu_id)
+        reserved_mb = current_platform.get_process_reserved_memory_mb()
         if total_mb is None:
             return None
 
@@ -893,47 +928,6 @@ class BatchAdmissionController:
             external_used_mb = max(0.0, total_mb - available_mb - reserved_mb)
             budget_mb = max(0.0, budget_mb - external_used_mb)
         return budget_mb
-
-    @staticmethod
-    def _get_device_memory_gb(gpu_id: int) -> float | None:
-        device_mb = BatchAdmissionController._get_device_memory_mb(gpu_id)
-        return None if device_mb is None else device_mb / 1024.0
-
-    @staticmethod
-    def _get_device_memory_mb(gpu_id: int) -> float | None:
-        try:
-            return current_platform.get_device_total_memory(gpu_id) / (1024**2)
-        except Exception:
-            return None
-
-    @staticmethod
-    def _get_device_name(gpu_id: int) -> str | None:
-        try:
-            return current_platform.get_device_name(gpu_id)
-        except Exception:
-            return None
-
-    @staticmethod
-    def _get_available_memory_mb(gpu_id: int) -> float | None:
-        try:
-            return (
-                current_platform.get_available_gpu_memory(gpu_id, empty_cache=False)
-                * 1024.0
-            )
-        except Exception:
-            return None
-
-    @staticmethod
-    def _get_process_reserved_memory_mb() -> float | None:
-        if current_platform.is_cpu():
-            return None
-        try:
-            device_module = torch.get_device_module()
-            if hasattr(device_module, "memory_reserved"):
-                return float(device_module.memory_reserved()) / (1024**2)
-        except Exception:
-            return None
-        return None
 
     def _get_memory_profile_cache_path(self, configured: str | None) -> str | None:
         path = configured or os.getenv(_CACHE_ENV)
@@ -1102,6 +1096,12 @@ def _validate_rule_keys(data: dict[str, Any], *, source: str) -> None:
 
 
 def _get_sampling_memory_key(req: Req) -> tuple[Any, ...] | None:
+    """Reuse the scheduler's SamplingParams compatibility boundary.
+
+    Dynamic batching only co-batches requests whose non-``batch_sig_exclude``
+    sampling fields match. Reusing the same metadata keeps memory profile reuse
+    conservative without maintaining a second include/exclude list here.
+    """
     sp = getattr(req, "sampling_params", None)
     if sp is None:
         return None
@@ -1109,10 +1109,34 @@ def _get_sampling_memory_key(req: Req) -> tuple[Any, ...] | None:
     items = []
     for field_info in fields(SamplingParams):
         name = field_info.name
-        if name in _SAMPLING_MEMORY_EXCLUDE or name.startswith("_"):
+        if name.startswith("_") or field_info.metadata.get("batch_sig_exclude", False):
             continue
         items.append((name, _freeze_key_value(getattr(sp, name, None))))
     return tuple(items)
+
+
+def _get_device_name(gpu_id: int) -> str | None:
+    try:
+        return current_platform.get_device_name(gpu_id)
+    except Exception:
+        return None
+
+
+def _get_device_total_memory_mb(gpu_id: int) -> float | None:
+    try:
+        return current_platform.get_device_total_memory(gpu_id) / (1024**2)
+    except Exception:
+        return None
+
+
+def _get_available_device_memory_mb(gpu_id: int) -> float | None:
+    try:
+        return (
+            current_platform.get_available_gpu_memory(gpu_id, empty_cache=False)
+            * 1024.0
+        )
+    except Exception:
+        return None
 
 
 def _freeze_key_value(value: Any) -> Any:
@@ -1136,6 +1160,12 @@ def _freeze_key_value(value: Any) -> Any:
         return tuple(sorted(_freeze_key_value(item) for item in value))
     if hasattr(value, "shape") and hasattr(value, "dtype"):
         return ("tensor", tuple(value.shape), str(value.dtype))
+    if callable(value):
+        return (
+            "callable",
+            getattr(value, "__module__", None),
+            getattr(value, "__qualname__", type(value).__qualname__),
+        )
     return repr(value)
 
 

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -330,6 +330,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             forward_fn: the actual forward function for reqs
         """
         output_batch = None
+        pre_forward_reserved_mb = self._get_current_reserved_memory_mb()
         try:
             if self.rank == 0 and not current_platform.is_cpu():
                 torch.get_device_module().reset_peak_memory_stats()
@@ -361,7 +362,10 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 return result
 
             output_batch = self._to_output_batch(result)
-            self._record_output_memory_stats(output_batch)
+            self._record_output_memory_stats(
+                output_batch,
+                pre_forward_reserved_mb=pre_forward_reserved_mb,
+            )
 
             output_metrics = self._iter_output_metrics(output_batch)
             if self.rank == 0 and output_metrics and not current_platform.is_cpu():
@@ -418,7 +422,10 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 output_batch = OutputBatch()
             output_batch.error = f"Error executing {error_context}: {e}"
             output_batch.is_oom = is_oom
-            self._record_output_memory_stats(output_batch)
+            self._record_output_memory_stats(
+                output_batch,
+                pre_forward_reserved_mb=pre_forward_reserved_mb,
+            )
             # clean cache if OOM
             if torch.cuda.is_initialized():
                 torch.cuda.empty_cache()
@@ -532,7 +539,21 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         )
         return np.asarray(materialized.frames)
 
-    def _record_output_memory_stats(self, output_batch: OutputBatch) -> None:
+    @staticmethod
+    def _get_current_reserved_memory_mb() -> float:
+        if current_platform.is_cpu():
+            return 0.0
+        try:
+            device_module = torch.get_device_module()
+            if hasattr(device_module, "memory_reserved"):
+                return float(device_module.memory_reserved()) / (1024**2)
+        except Exception:
+            return 0.0
+        return 0.0
+
+    def _record_output_memory_stats(
+        self, output_batch: OutputBatch, *, pre_forward_reserved_mb: float
+    ) -> None:
         if current_platform.is_cpu():
             return
         device_module = torch.get_device_module()
@@ -551,16 +572,18 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 else current_platform.device_name.lower()
             )
             peaks = torch.tensor(
-                [peak_reserved_mb, peak_allocated_mb],
+                [pre_forward_reserved_mb, peak_reserved_mb, peak_allocated_mb],
                 dtype=torch.float32,
                 device=f"{device_type}:{device_module.current_device()}",
             )
             torch.distributed.all_reduce(peaks, op=torch.distributed.ReduceOp.MAX)
-            peak_reserved_mb = float(peaks[0].item())
-            peak_allocated_mb = float(peaks[1].item())
+            pre_forward_reserved_mb = float(peaks[0].item())
+            peak_reserved_mb = float(peaks[1].item())
+            peak_allocated_mb = float(peaks[2].item())
 
         if self.rank != 0:
             return
+        output_batch.pre_forward_reserved_memory_mb = pre_forward_reserved_mb
         output_batch.peak_memory_mb = peak_reserved_mb
         output_batch.peak_allocated_memory_mb = peak_allocated_mb
 
@@ -737,6 +760,10 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         if output_batch.error is not None and merged.error is None:
             merged.error = output_batch.error
         merged.is_oom = merged.is_oom or output_batch.is_oom
+        merged.pre_forward_reserved_memory_mb = max(
+            merged.pre_forward_reserved_memory_mb,
+            output_batch.pre_forward_reserved_memory_mb,
+        )
         merged.peak_memory_mb = max(merged.peak_memory_mb, output_batch.peak_memory_mb)
         merged.peak_allocated_memory_mb = max(
             merged.peak_allocated_memory_mb,

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -325,10 +325,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         save_output_paths: Callable[[OutputBatch], None],
         error_context: str,
     ) -> OutputBatch | Req:
-        """
-        Args:
-            forward_fn: the actual forward function for reqs
-        """
+        """Run a pipeline forward and attach runtime metadata."""
         output_batch = None
         pre_forward_reserved_mb = self._get_current_reserved_memory_mb()
         try:
@@ -338,7 +335,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             start_time = time.monotonic()
             self._realtime_sessions.attach(req)
 
-            # capture memory baseline for each req in grouped forward on rank-0
+            # Capture request memory baselines for grouped forwards on rank 0.
             request_metrics = [
                 item.metrics for item in log_reqs if item.metrics is not None
             ]
@@ -356,8 +353,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                     )
                 result = forward_fn()
 
-            # disagg roles return raw Req so callers can keep and transfer intermediate tensors
-            # before converting it to OutputBatch
+            # Disagg roles keep intermediate tensors on Req until transfer finishes.
             if return_req and isinstance(result, Req):
                 return result
 
@@ -426,7 +422,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 output_batch,
                 pre_forward_reserved_mb=pre_forward_reserved_mb,
             )
-            # clean cache if OOM
+            # Release cached blocks after failures.
             if torch.cuda.is_initialized():
                 torch.cuda.empty_cache()
         return output_batch
@@ -541,6 +537,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
     @staticmethod
     def _get_current_reserved_memory_mb() -> float:
+        """Return current allocator-reserved memory in MiB."""
         if current_platform.is_cpu():
             return 0.0
         try:
@@ -554,6 +551,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
     def _record_output_memory_stats(
         self, output_batch: OutputBatch, *, pre_forward_reserved_mb: float
     ) -> None:
+        """Attach allocator peak stats used by memory-aware admission."""
         if current_platform.is_cpu():
             return
         device_module = torch.get_device_module()

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -325,7 +325,11 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         save_output_paths: Callable[[OutputBatch], None],
         error_context: str,
     ) -> OutputBatch | Req:
-        """Run a pipeline forward and attach runtime metadata."""
+        """Run a pipeline forward and attach runtime metadata.
+
+        Args:
+            forward_fn: The forward function for the request group.
+        """
         output_batch = None
         pre_forward_reserved_mb = self._get_current_reserved_memory_mb()
         try:
@@ -353,7 +357,8 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                     )
                 result = forward_fn()
 
-            # Disagg roles keep intermediate tensors on Req until transfer finishes.
+            # disagg roles return raw Req so callers can keep and transfer
+            # intermediate tensors before converting it to OutputBatch
             if return_req and isinstance(result, Req):
                 return result
 
@@ -538,15 +543,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
     @staticmethod
     def _get_current_reserved_memory_mb() -> float:
         """Return current allocator-reserved memory in MiB."""
-        if current_platform.is_cpu():
-            return 0.0
-        try:
-            device_module = torch.get_device_module()
-            if hasattr(device_module, "memory_reserved"):
-                return float(device_module.memory_reserved()) / (1024**2)
-        except Exception:
-            return 0.0
-        return 0.0
+        return current_platform.get_process_reserved_memory_mb() or 0.0
 
     def _record_output_memory_stats(
         self, output_batch: OutputBatch, *, pre_forward_reserved_mb: float
@@ -554,16 +551,20 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         """Attach allocator peak stats used by memory-aware admission."""
         if current_platform.is_cpu():
             return
+        should_reduce_peaks = (
+            output_batch.error is None
+            and torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        )
+        if self.rank != 0 and not should_reduce_peaks:
+            return
+
         device_module = torch.get_device_module()
         peak_reserved_mb = float(device_module.max_memory_reserved()) / (1024**2)
         peak_allocated_mb = float(device_module.max_memory_allocated()) / (1024**2)
 
         # Avoid collectives on error paths; failed ranks may not reach this point.
-        if (
-            output_batch.error is None
-            and torch.distributed.is_available()
-            and torch.distributed.is_initialized()
-        ):
+        if should_reduce_peaks:
             device_type = (
                 "cuda"
                 if current_platform.is_cuda() or current_platform.is_rocm()
@@ -611,6 +612,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             dynamic_output_paths = None
 
         if dynamic_output_paths is not None:
+
             def build_output_path(idx: int) -> str:
                 return dynamic_output_paths[idx]
 

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -361,7 +361,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 return result
 
             output_batch = self._to_output_batch(result)
-            self._record_output_peak_memory(output_batch)
+            self._record_output_memory_stats(output_batch)
 
             output_metrics = self._iter_output_metrics(output_batch)
             if self.rank == 0 and output_metrics and not current_platform.is_cpu():
@@ -411,12 +411,14 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 f"Error executing {error_context}: {e}",
                 exc_info=True,
             )
-            if isinstance(e, _oom_exceptions()):
+            is_oom = isinstance(e, _oom_exceptions())
+            if is_oom:
                 logger.warning(OOM_MSG)
             if output_batch is None:
                 output_batch = OutputBatch()
             output_batch.error = f"Error executing {error_context}: {e}"
-            self._record_output_peak_memory(output_batch)
+            output_batch.is_oom = is_oom
+            self._record_output_memory_stats(output_batch)
             # clean cache if OOM
             if torch.cuda.is_initialized():
                 torch.cuda.empty_cache()
@@ -530,11 +532,37 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         )
         return np.asarray(materialized.frames)
 
-    def _record_output_peak_memory(self, output_batch: OutputBatch) -> None:
-        if self.rank != 0 or current_platform.is_cpu():
+    def _record_output_memory_stats(self, output_batch: OutputBatch) -> None:
+        if current_platform.is_cpu():
             return
-        peak_reserved_bytes = torch.get_device_module().max_memory_reserved()
-        output_batch.peak_memory_mb = peak_reserved_bytes / (1024**2)
+        device_module = torch.get_device_module()
+        peak_reserved_mb = float(device_module.max_memory_reserved()) / (1024**2)
+        peak_allocated_mb = float(device_module.max_memory_allocated()) / (1024**2)
+
+        # Avoid collectives on error paths; failed ranks may not reach this point.
+        if (
+            output_batch.error is None
+            and torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        ):
+            device_type = (
+                "cuda"
+                if current_platform.is_cuda() or current_platform.is_rocm()
+                else current_platform.device_name.lower()
+            )
+            peaks = torch.tensor(
+                [peak_reserved_mb, peak_allocated_mb],
+                dtype=torch.float32,
+                device=f"{device_type}:{device_module.current_device()}",
+            )
+            torch.distributed.all_reduce(peaks, op=torch.distributed.ReduceOp.MAX)
+            peak_reserved_mb = float(peaks[0].item())
+            peak_allocated_mb = float(peaks[1].item())
+
+        if self.rank != 0:
+            return
+        output_batch.peak_memory_mb = peak_reserved_mb
+        output_batch.peak_allocated_memory_mb = peak_allocated_mb
 
     def _forward_group(self, batch: list[Req]) -> OutputBatch:
         assert self.pipeline is not None
@@ -562,7 +590,6 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             dynamic_output_paths = None
 
         if dynamic_output_paths is not None:
-
             def build_output_path(idx: int) -> str:
                 return dynamic_output_paths[idx]
 
@@ -709,7 +736,12 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
     ) -> None:
         if output_batch.error is not None and merged.error is None:
             merged.error = output_batch.error
+        merged.is_oom = merged.is_oom or output_batch.is_oom
         merged.peak_memory_mb = max(merged.peak_memory_mb, output_batch.peak_memory_mb)
+        merged.peak_allocated_memory_mb = max(
+            merged.peak_allocated_memory_mb,
+            output_batch.peak_allocated_memory_mb,
+        )
         if (
             merged.trajectory_timesteps is None
             and output_batch.trajectory_timesteps is not None

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -850,6 +850,9 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 ),
                 peak_memory_mb=output_batch.peak_memory_mb,
                 peak_allocated_memory_mb=output_batch.peak_allocated_memory_mb,
+                pre_forward_reserved_memory_mb=(
+                    output_batch.pre_forward_reserved_memory_mb
+                ),
                 is_oom=output_batch.is_oom,
                 dynamic_batch_size=output_batch.dynamic_batch_size,
                 dynamic_batch_capacity=output_batch.dynamic_batch_capacity,

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -331,7 +331,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             if len(reqs) == 1 or not allow_dynamic_batching:
                 output_batch = self.worker.execute_forward(reqs)
                 self._set_output_dynamic_batch_metadata(output_batch, reqs)
-                self._batch_admission.record_batch_result(reqs, output_batch)
+                self._batch_admission.observe_batch_result(reqs, output_batch)
                 return output_batch
 
             merged_req = self._try_merge_generation_reqs(reqs)
@@ -342,7 +342,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             try:
                 output_batch = self.worker.execute_forward([merged_req])
                 self._set_output_dynamic_batch_metadata(output_batch, reqs)
-                self._batch_admission.record_batch_result(reqs, output_batch)
+                self._batch_admission.observe_batch_result(reqs, output_batch)
                 if output_batch.error:
                     logger.error(
                         "Dynamic batch execution returned error. Skipping sequential fallback and returning errors: %s",
@@ -389,7 +389,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             output_batch.dynamic_batch_size = 1
             output_batch.dynamic_batch_capacity = 1
             output_batch.dynamic_batch_stop_reason = "sequential_fallback"
-            self._batch_admission.record_batch_result([req], output_batch)
+            self._batch_admission.observe_batch_result([req], output_batch)
             outputs.append(output_batch)
         return outputs
 
@@ -905,7 +905,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 )
             return [(identity, req)]
 
-        self._batch_admission.update_memory_budget()
+        self._batch_admission.refresh_memory_budget()
 
         identity, req, enqueue_time = self.waiting_queue[0]
         if not isinstance(req, Req):
@@ -983,7 +983,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             item_identity, item_req, _ = self.waiting_queue[idx]
             batch_items[batch_len - 1 - pos] = (item_identity, item_req)
             del self.waiting_queue[idx]
-        stop_reason = self._batch_admission.get_batch_limit_reason(compatible_reqs)
+        stop_reason = self._batch_admission.get_batch_stop_reason(compatible_reqs)
         if stop_reason is None:
             if batch_len >= self._batching_max_size:
                 stop_reason = "max_size"

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -330,6 +330,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         ):
             if len(reqs) == 1 or not allow_dynamic_batching:
                 output_batch = self.worker.execute_forward(reqs)
+                self._set_output_dynamic_batch_metadata(output_batch, reqs)
                 self._batch_admission.record_batch_result(reqs, output_batch)
                 return output_batch
 
@@ -340,6 +341,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             batch_size = len(reqs)
             try:
                 output_batch = self.worker.execute_forward([merged_req])
+                self._set_output_dynamic_batch_metadata(output_batch, reqs)
                 self._batch_admission.record_batch_result(reqs, output_batch)
                 if output_batch.error:
                     logger.error(
@@ -384,6 +386,9 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         outputs = []
         for req in reqs:
             output_batch = self.worker.execute_forward([req])
+            output_batch.dynamic_batch_size = 1
+            output_batch.dynamic_batch_capacity = 1
+            output_batch.dynamic_batch_stop_reason = "sequential_fallback"
             self._batch_admission.record_batch_result([req], output_batch)
             outputs.append(output_batch)
         return outputs
@@ -629,7 +634,48 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         error_msg: str,
         is_oom: bool = False,
     ) -> List[OutputBatch]:
-        return [OutputBatch(error=error_msg, is_oom=is_oom) for _ in reqs]
+        batch_size, capacity, stop_reason = self._get_dynamic_batch_metadata(reqs)
+        return [
+            OutputBatch(
+                error=error_msg,
+                is_oom=is_oom,
+                dynamic_batch_size=batch_size,
+                dynamic_batch_capacity=capacity,
+                dynamic_batch_stop_reason=stop_reason,
+            )
+            for _ in reqs
+        ]
+
+    @staticmethod
+    def _set_req_dynamic_batch_metadata(
+        reqs: List[Req],
+        *,
+        batch_size: int,
+        capacity: int,
+        stop_reason: str,
+    ) -> None:
+        for req in reqs:
+            req._dynamic_batch_size = batch_size  # type: ignore[attr-defined]
+            req._dynamic_batch_capacity = capacity  # type: ignore[attr-defined]
+            req._dynamic_batch_stop_reason = stop_reason  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _get_dynamic_batch_metadata(reqs: List[Req]) -> tuple[int, int, str | None]:
+        if not reqs:
+            return 1, 1, None
+        req = reqs[0]
+        batch_size = int(getattr(req, "_dynamic_batch_size", max(1, len(reqs))))
+        capacity = int(getattr(req, "_dynamic_batch_capacity", batch_size))
+        stop_reason = getattr(req, "_dynamic_batch_stop_reason", None)
+        return max(1, batch_size), max(1, capacity), stop_reason
+
+    def _set_output_dynamic_batch_metadata(
+        self, output_batch: OutputBatch, reqs: List[Req]
+    ) -> None:
+        batch_size, capacity, stop_reason = self._get_dynamic_batch_metadata(reqs)
+        output_batch.dynamic_batch_size = batch_size
+        output_batch.dynamic_batch_capacity = capacity
+        output_batch.dynamic_batch_stop_reason = stop_reason
 
     def return_result(
         self,
@@ -805,6 +851,9 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 peak_memory_mb=output_batch.peak_memory_mb,
                 peak_allocated_memory_mb=output_batch.peak_allocated_memory_mb,
                 is_oom=output_batch.is_oom,
+                dynamic_batch_size=output_batch.dynamic_batch_size,
+                dynamic_batch_capacity=output_batch.dynamic_batch_capacity,
+                dynamic_batch_stop_reason=output_batch.dynamic_batch_stop_reason,
             )
             if split.metrics is not None:
                 split.metrics.request_id = req.request_id
@@ -839,6 +888,12 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         if not self._dynamic_batching_enabled():
             identity, req, enqueue_time = self.waiting_queue.popleft()
             if isinstance(req, Req):
+                self._set_req_dynamic_batch_metadata(
+                    [req],
+                    batch_size=1,
+                    capacity=1,
+                    stop_reason="dynamic_disabled",
+                )
                 self._record_batch_dispatch_metrics(
                     batch_size=1,
                     queue_wait_ms=(time.monotonic() - enqueue_time) * 1000.0,
@@ -863,12 +918,19 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 reason = self._get_dynamic_batch_reject_reason(req, req)
                 if reason is not None:
                     reject_reasons.append(f"head:{reason}")
+            stop_reason = reject_reasons[0] if reject_reasons else "head_ineligible"
+            self._set_req_dynamic_batch_metadata(
+                [req],
+                batch_size=1,
+                capacity=1,
+                stop_reason=stop_reason,
+            )
             self._record_batch_dispatch_metrics(
                 batch_size=1,
                 queue_wait_ms=(time.monotonic() - head_enqueue_time) * 1000.0,
                 effective_max_batch_size=1,
                 reject_reasons=reject_reasons,
-                stop_reason=reject_reasons[0] if reject_reasons else "head_ineligible",
+                stop_reason=stop_reason,
             )
             return [(identity, req)]
 
@@ -928,12 +990,19 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 stop_reason = "delay"
             else:
                 stop_reason = "ready"
+        effective_max_batch_size = self._batch_admission.get_max_admissible_batch_size(
+            compatible_reqs[0]
+        )
+        self._set_req_dynamic_batch_metadata(
+            compatible_reqs,
+            batch_size=batch_len,
+            capacity=effective_max_batch_size,
+            stop_reason=stop_reason,
+        )
         self._record_batch_dispatch_metrics(
             batch_size=batch_len,
             queue_wait_ms=oldest_wait_s * 1000.0,
-            effective_max_batch_size=(
-                self._batch_admission.get_max_admissible_batch_size(compatible_reqs[0])
-            ),
+            effective_max_batch_size=effective_max_batch_size,
             reject_reasons=reject_reasons,
             stop_reason=stop_reason,
         )

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -193,27 +193,37 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         # TODO: return set status
         # TODO: return with SetLoRAResponse or something more appropriate
         req = reqs[0]
-        return self.worker.set_lora(
+        output = self.worker.set_lora(
             req.lora_nickname,
             req.lora_path,
             req.target,
             req.strength,
             req.merge_mode,
         )
+        if output.error is None:
+            self._batch_admission.update_lora_revision()
+        return output
 
     def _handle_merge_lora(self, reqs: List[Any]):
         req = reqs[0]
-        return self.worker.merge_lora_weights(req.target, req.strength)
+        output = self.worker.merge_lora_weights(req.target, req.strength)
+        if output.error is None:
+            self._batch_admission.update_lora_revision()
+        return output
 
     def _handle_unmerge_lora(self, reqs: List[Any]) -> OutputBatch:
         req = reqs[0]
-        return self.worker.unmerge_lora_weights(req.target)
+        output = self.worker.unmerge_lora_weights(req.target)
+        if output.error is None:
+            self._batch_admission.update_lora_revision()
+        return output
 
     def _handle_list_loras(self, _reqs: List[Any]) -> OutputBatch:
         return self.worker.list_loras()
 
     def _handle_shutdown(self, _reqs: List[Any]) -> OutputBatch:
         self._running = False
+        self._batch_admission.flush_memory_profile_cache()
         return OutputBatch()
 
     def _handle_release_realtime_session(self, reqs: List[Any]) -> OutputBatch:
@@ -319,7 +329,9 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             thread_finish_flag=True,
         ):
             if len(reqs) == 1 or not allow_dynamic_batching:
-                return self.worker.execute_forward(reqs)
+                output_batch = self.worker.execute_forward(reqs)
+                self._batch_admission.record_batch_result(reqs, output_batch)
+                return output_batch
 
             merged_req = self._try_merge_generation_reqs(reqs)
             if merged_req is None:
@@ -328,6 +340,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             batch_size = len(reqs)
             try:
                 output_batch = self.worker.execute_forward([merged_req])
+                self._batch_admission.record_batch_result(reqs, output_batch)
                 if output_batch.error:
                     logger.error(
                         "Dynamic batch execution returned error. Skipping sequential fallback and returning errors: %s",
@@ -336,6 +349,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                     return self._build_dynamic_batch_error_outputs(
                         reqs=reqs,
                         error_msg=output_batch.error,
+                        is_oom=output_batch.is_oom,
                     )
 
                 split_outputs = self._split_batched_output(output_batch, reqs)
@@ -367,7 +381,12 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 )
 
     def _execute_generation_sequential(self, reqs: List[Req]) -> List[OutputBatch]:
-        return [self.worker.execute_forward([req]) for req in reqs]
+        outputs = []
+        for req in reqs:
+            output_batch = self.worker.execute_forward([req])
+            self._batch_admission.record_batch_result([req], output_batch)
+            outputs.append(output_batch)
+        return outputs
 
     @staticmethod
     def _percentile(values: list[float], percentile: float) -> float:
@@ -608,8 +627,9 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         self,
         reqs: List[Req],
         error_msg: str,
+        is_oom: bool = False,
     ) -> List[OutputBatch]:
-        return [OutputBatch(error=error_msg) for _ in reqs]
+        return [OutputBatch(error=error_msg, is_oom=is_oom) for _ in reqs]
 
     def return_result(
         self,
@@ -783,6 +803,8 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                     output_batch.noise_pred, start, end, total_items
                 ),
                 peak_memory_mb=output_batch.peak_memory_mb,
+                peak_allocated_memory_mb=output_batch.peak_allocated_memory_mb,
+                is_oom=output_batch.is_oom,
             )
             if split.metrics is not None:
                 split.metrics.request_id = req.request_id
@@ -825,6 +847,8 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
                 )
             return [(identity, req)]
 
+        self._batch_admission.update_memory_budget()
+
         identity, req, enqueue_time = self.waiting_queue[0]
         if not isinstance(req, Req):
             identity, req, _ = self.waiting_queue.popleft()
@@ -854,7 +878,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         for idx in range(1, len(self.waiting_queue)):
             if len(
                 compatible_indices
-            ) >= self._batching_max_size or self._batch_admission.batch_is_full(
+            ) >= self._batching_max_size or self._batch_admission.is_batch_full(
                 compatible_reqs
             ):
                 break
@@ -862,8 +886,10 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             if isinstance(candidate_req, Req) and self._can_dynamic_batch(
                 req, candidate_req
             ):
-                admission_reject = self._batch_admission.reject_reason_for_candidate(
-                    compatible_reqs, candidate_req
+                admission_reject = (
+                    self._batch_admission.get_reject_reason_for_candidate(
+                        compatible_reqs, candidate_req
+                    )
                 )
                 if admission_reject is None:
                     compatible_indices.append(idx)
@@ -881,7 +907,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
 
         should_wait_for_more = (
             batch_len < self._batching_max_size
-            and not self._batch_admission.batch_is_full(compatible_reqs)
+            and not self._batch_admission.is_batch_full(compatible_reqs)
             and oldest_wait_s < self._batching_delay_s
         )
         if should_wait_for_more:
@@ -892,7 +918,7 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
             item_identity, item_req, _ = self.waiting_queue[idx]
             batch_items[batch_len - 1 - pos] = (item_identity, item_req)
             del self.waiting_queue[idx]
-        stop_reason = self._batch_admission.limit_reason_for_batch(compatible_reqs)
+        stop_reason = self._batch_admission.get_batch_limit_reason(compatible_reqs)
         if stop_reason is None:
             if batch_len >= self._batching_max_size:
                 stop_reason = "max_size"
@@ -905,8 +931,8 @@ class Scheduler(SchedulerPostTrainingMixin, SchedulerDisaggMixin):
         self._record_batch_dispatch_metrics(
             batch_size=batch_len,
             queue_wait_ms=oldest_wait_s * 1000.0,
-            effective_max_batch_size=self._batch_admission.max_admissible_batch_size(
-                compatible_reqs[0]
+            effective_max_batch_size=(
+                self._batch_admission.get_max_admissible_batch_size(compatible_reqs[0])
             ),
             reject_reasons=reject_reasons,
             stop_reason=stop_reason,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -225,13 +225,13 @@ class Req:
 
     def __init__(self, **kwargs):
         # Initialize dataclass fields
-        for name, field in self.__class__.__dataclass_fields__.items():
+        for name, field_info in self.__class__.__dataclass_fields__.items():
             if name in kwargs:
                 object.__setattr__(self, name, kwargs.pop(name))
-            elif field.default is not MISSING:
-                object.__setattr__(self, name, field.default)
-            elif field.default_factory is not MISSING:
-                object.__setattr__(self, name, field.default_factory())
+            elif field_info.default is not MISSING:
+                object.__setattr__(self, name, field_info.default)
+            elif field_info.default_factory is not MISSING:
+                object.__setattr__(self, name, field_info.default_factory())
 
         for name, value in kwargs.items():
             setattr(self, name, value)
@@ -427,6 +427,8 @@ class OutputBatch:
     # For ComfyUI integration: noise prediction from denoising stage
     noise_pred: torch.Tensor | None = None
     peak_memory_mb: float = 0.0
+    peak_allocated_memory_mb: float = 0.0
+    is_oom: bool = False
 
     def drop_payload_for_warmup(self) -> None:
         self.output = None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -429,6 +429,9 @@ class OutputBatch:
     peak_memory_mb: float = 0.0
     peak_allocated_memory_mb: float = 0.0
     is_oom: bool = False
+    dynamic_batch_size: int = 1
+    dynamic_batch_capacity: int = 1
+    dynamic_batch_stop_reason: str | None = None
 
     def drop_payload_for_warmup(self) -> None:
         self.output = None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -426,6 +426,8 @@ class OutputBatch:
 
     # For ComfyUI integration: noise prediction from denoising stage
     noise_pred: torch.Tensor | None = None
+
+    # Runtime memory metadata used by dynamic batch admission.
     pre_forward_reserved_memory_mb: float = 0.0
     peak_memory_mb: float = 0.0
     peak_allocated_memory_mb: float = 0.0

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -426,6 +426,7 @@ class OutputBatch:
 
     # For ComfyUI integration: noise prediction from denoising stage
     noise_pred: torch.Tensor | None = None
+    pre_forward_reserved_memory_mb: float = 0.0
     peak_memory_mb: float = 0.0
     peak_allocated_memory_mb: float = 0.0
     is_oom: bool = False

--- a/python/sglang/multimodal_gen/runtime/platforms/interface.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/interface.py
@@ -394,6 +394,18 @@ class Platform:
         """
         raise NotImplementedError
 
+    def get_process_reserved_memory_mb(self) -> float | None:
+        """Return allocator-reserved memory for the current process in MiB."""
+        if self.is_cpu():
+            return None
+        try:
+            device_module = torch.get_device_module()
+            if hasattr(device_module, "memory_reserved"):
+                return float(device_module.memory_reserved()) / (1024**2)
+        except Exception:
+            return None
+        return None
+
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         """

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -256,6 +256,7 @@ class ServerArgs(DisaggServerArgsMixin):
     batching_delay_ms: float = 0.0
     batching_config: str | None = None
     batching_memory_profile_cache: str | None = None
+    batching_memory_reserve_fraction: float = 0.02
     enable_batching_metrics: bool = False
 
     # Strict port mode: fail if requested port is unavailable instead of auto-selecting
@@ -1454,6 +1455,15 @@ class ServerArgs(DisaggServerArgsMixin):
             ),
         )
         parser.add_argument(
+            "--batching-memory-reserve-fraction",
+            type=float,
+            default=ServerArgs.batching_memory_reserve_fraction,
+            help=(
+                "Fraction of total device memory held back from memory-aware "
+                "diffusion batching as allocator/workspace slack. Default: 0.02."
+            ),
+        )
+        parser.add_argument(
             "--enable-batching-metrics",
             action="store_true",
             default=ServerArgs.enable_batching_metrics,
@@ -1999,6 +2009,8 @@ class ServerArgs(DisaggServerArgsMixin):
             raise ValueError("batching_max_size must be >= 1")
         if self.batching_delay_ms < 0:
             raise ValueError("batching_delay_ms must be >= 0")
+        if not 0.0 <= self.batching_memory_reserve_fraction < 1.0:
+            raise ValueError("batching_memory_reserve_fraction must be in [0, 1)")
 
     def _set_default_attention_backend(self) -> None:
         """Configure ROCm defaults when users do not specify an attention backend."""

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -255,6 +255,7 @@ class ServerArgs(DisaggServerArgsMixin):
     batching_max_size: int = 1
     batching_delay_ms: float = 0.0
     batching_config: str | None = None
+    batching_memory_profile_cache: str | None = None
     enable_batching_metrics: bool = False
 
     # Strict port mode: fail if requested port is unavailable instead of auto-selecting
@@ -1441,6 +1442,15 @@ class ServerArgs(DisaggServerArgsMixin):
                 "Optional JSON file with {'schema_version': 1, 'rules': [...]} "
                 "batching admission rules that can cap model/resolution shapes "
                 "below --batching-max-size."
+            ),
+        )
+        parser.add_argument(
+            "--batching-memory-profile-cache",
+            type=str,
+            default=ServerArgs.batching_memory_profile_cache,
+            help=(
+                "Path or directory for the diffusion batching memory profile cache. "
+                "Use 'none' to disable persistence."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
+++ b/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -39,6 +41,14 @@ class CalibrationRecord:
     peak_allocated_memory_mb: float
     duration_s: float
     errors: list[str]
+
+
+@dataclass
+class CalibrationProfileRecord:
+    key_hash: str
+    observation_count: int
+    batch_sizes: list[int]
+    peak_memory_mb: list[float]
 
 
 def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
@@ -87,6 +97,12 @@ def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
         "model_path": args.model_path,
         "profile_cache": args.batching_memory_profile_cache,
         "records": [asdict(record) for record in records],
+        "profiles": [
+            asdict(record)
+            for record in _read_profile_cache_summary(
+                args.batching_memory_profile_cache
+            )
+        ],
     }
     if args.output_json:
         with open(args.output_json, "w", encoding="utf-8") as f:
@@ -208,6 +224,67 @@ def _add_geometric_ramp(batch_sizes: list[int]) -> list[int]:
             current = min(target, current * 2)
             expanded.add(current)
     return sorted(expanded)
+
+
+def _read_profile_cache_summary(
+    cache_path: str | None,
+) -> list[CalibrationProfileRecord]:
+    if not cache_path:
+        return []
+
+    path = cache_path
+    if not path.endswith(".json"):
+        try:
+            files = [
+                os.path.join(path, name)
+                for name in os.listdir(path)
+                if name.endswith(".json")
+            ]
+        except OSError:
+            return []
+        if not files:
+            return []
+        path = max(files, key=os.path.getmtime)
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            payload = json.load(f)
+    except Exception:
+        return []
+
+    records = []
+    for item in payload.get("profiles", []):
+        profile = item.get("profile", {}) if isinstance(item, dict) else {}
+        key = item.get("key") if isinstance(item, dict) else None
+        successes = profile.get("successes", [])
+        if not isinstance(successes, list):
+            continue
+        batch_sizes = sorted(
+            {
+                int(obs.get("batch_size", 1))
+                for obs in successes
+                if isinstance(obs, dict)
+            }
+        )
+        peaks = [
+            float(obs.get("peak_memory_mb", 0.0))
+            for obs in successes
+            if isinstance(obs, dict)
+        ]
+        records.append(
+            CalibrationProfileRecord(
+                key_hash=_short_json_hash(key),
+                observation_count=len(successes),
+                batch_sizes=batch_sizes,
+                peak_memory_mb=peaks,
+            )
+        )
+    return records
+
+
+def _short_json_hash(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
 
 
 def build_arg_parser() -> argparse.ArgumentParser:

--- a/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
+++ b/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Calibrate diffusion batching memory profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import zmq
+
+from sglang.multimodal_gen.configs.sample.sampling_params import (
+    SamplingParams,
+    generate_request_id,
+)
+from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator
+from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.scheduler_client import SchedulerClient
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class CalibrationRecord:
+    width: int
+    height: int
+    num_frames: int
+    batch_size: int
+    success_count: int
+    oom_count: int
+    error_count: int
+    peak_memory_mb: float
+    peak_allocated_memory_mb: float
+    duration_s: float
+    errors: list[str]
+
+
+def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
+    shapes = _parse_calibration_shapes(args.shapes)
+    requested_batch_sizes = _parse_calibration_batch_sizes(args.batch_sizes)
+    batch_sizes = _add_geometric_ramp(requested_batch_sizes)
+
+    max_batch_size = max(batch_sizes)
+    server_args = ServerArgs.from_kwargs(
+        model_path=args.model_path,
+        batching_max_size=max_batch_size,
+        batching_delay_ms=args.batching_delay_ms,
+        batching_memory_profile_cache=args.batching_memory_profile_cache,
+        warmup=args.warmup,
+    )
+
+    records: list[CalibrationRecord] = []
+    with DiffGenerator.from_server_args(server_args, local_mode=True) as _generator:
+        for width, height, num_frames in shapes:
+            for batch_size in batch_sizes:
+                logger.info(
+                    "Calibrating shape=%dx%dx%d batch_size=%d",
+                    width,
+                    height,
+                    num_frames,
+                    batch_size,
+                )
+                record = _run_calibration_batch(
+                    server_args=server_args,
+                    prompt=args.prompt,
+                    width=width,
+                    height=height,
+                    num_frames=num_frames,
+                    num_inference_steps=args.num_inference_steps,
+                    batch_size=batch_size,
+                    timeout_s=args.per_batch_timeout_s,
+                )
+                records.append(record)
+                if args.stop_on_oom and record.oom_count:
+                    break
+                if args.stop_on_error and record.error_count and not record.oom_count:
+                    break
+
+    summary = {
+        "schema_version": 1,
+        "model_path": args.model_path,
+        "profile_cache": args.batching_memory_profile_cache,
+        "records": [asdict(record) for record in records],
+    }
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+            f.write("\n")
+    return summary
+
+
+def _run_calibration_batch(
+    *,
+    server_args: ServerArgs,
+    prompt: str,
+    width: int,
+    height: int,
+    num_frames: int,
+    num_inference_steps: int | None,
+    batch_size: int,
+    timeout_s: float,
+) -> CalibrationRecord:
+    start = time.monotonic()
+    barrier = threading.Barrier(batch_size)
+
+    def send_one(idx: int):
+        sampling_params = SamplingParams.from_user_sampling_params_args(
+            server_args.model_path,
+            server_args=server_args,
+            prompt=prompt,
+            width=width,
+            height=height,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            request_id=f"batch-memory-calibration-{generate_request_id()}-{idx}",
+            save_output=False,
+            suppress_logs=True,
+        )
+        req = prepare_request(server_args=server_args, sampling_params=sampling_params)
+        client = SchedulerClient()
+        client.initialize(server_args)
+        client.scheduler_socket.setsockopt(zmq.RCVTIMEO, int(timeout_s * 1000))
+        try:
+            barrier.wait(timeout=timeout_s)
+            return client.forward([req])
+        finally:
+            client.close()
+
+    outputs = []
+    errors = []
+    with ThreadPoolExecutor(max_workers=batch_size) as executor:
+        futures = [executor.submit(send_one, idx) for idx in range(batch_size)]
+        for future in as_completed(futures, timeout=timeout_s * max(1, batch_size)):
+            try:
+                outputs.append(future.result(timeout=timeout_s))
+            except Exception as exc:
+                errors.append(str(exc))
+
+    output_errors = [out.error for out in outputs if getattr(out, "error", None)]
+    errors.extend(str(error) for error in output_errors)
+    oom_count = sum(1 for out in outputs if getattr(out, "is_oom", False))
+    success_count = sum(
+        1
+        for out in outputs
+        if getattr(out, "error", None) is None and not getattr(out, "is_oom", False)
+    )
+    return CalibrationRecord(
+        width=width,
+        height=height,
+        num_frames=num_frames,
+        batch_size=batch_size,
+        success_count=success_count,
+        oom_count=oom_count,
+        error_count=len(errors) - oom_count,
+        peak_memory_mb=max(
+            (getattr(out, "peak_memory_mb", 0.0) for out in outputs), default=0.0
+        ),
+        peak_allocated_memory_mb=max(
+            (getattr(out, "peak_allocated_memory_mb", 0.0) for out in outputs),
+            default=0.0,
+        ),
+        duration_s=time.monotonic() - start,
+        errors=errors,
+    )
+
+
+def _parse_calibration_shapes(raw: str) -> list[tuple[int, int, int]]:
+    shapes = []
+    for item in raw.split(","):
+        item = item.strip().lower()
+        if not item:
+            continue
+        parts = item.replace(":", "x").split("x")
+        if len(parts) == 2:
+            width, height = (int(parts[0]), int(parts[1]))
+            num_frames = 1
+        elif len(parts) == 3:
+            width, height, num_frames = (int(parts[0]), int(parts[1]), int(parts[2]))
+        else:
+            raise ValueError(
+                f"invalid shape {item!r}; expected WIDTHxHEIGHT or WIDTHxHEIGHTxFRAMES"
+            )
+        shapes.append((width, height, num_frames))
+    if not shapes:
+        raise ValueError("at least one shape is required")
+    return shapes
+
+
+def _parse_calibration_batch_sizes(raw: str) -> list[int]:
+    values = sorted({int(item.strip()) for item in raw.split(",") if item.strip()})
+    if not values or values[0] < 1:
+        raise ValueError("batch sizes must be positive integers")
+    return values
+
+
+def _add_geometric_ramp(batch_sizes: list[int]) -> list[int]:
+    expanded = set(batch_sizes)
+    for target in batch_sizes:
+        current = 1
+        expanded.add(current)
+        while current < target:
+            current = min(target, current * 2)
+            expanded.add(current)
+    return sorted(expanded)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Calibrate diffusion dynamic batching memory profiles."
+    )
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--prompt", default="a cinematic landscape")
+    parser.add_argument(
+        "--shapes",
+        required=True,
+        help="Comma-separated WIDTHxHEIGHT or WIDTHxHEIGHTxFRAMES entries.",
+    )
+    parser.add_argument("--batch-sizes", default="1,2,4,8")
+    parser.add_argument("--num-inference-steps", type=int, default=None)
+    parser.add_argument("--batching-delay-ms", type=float, default=25.0)
+    parser.add_argument("--batching-memory-profile-cache", default=None)
+    parser.add_argument("--per-batch-timeout-s", type=float, default=600.0)
+    parser.add_argument(
+        "--output-json", default="batch_memory_calibration_summary.json"
+    )
+    parser.add_argument("--stop-on-oom", action="store_true")
+    parser.add_argument("--stop-on-error", action="store_true")
+    parser.add_argument("--warmup", action="store_true")
+    return parser
+
+
+def main() -> None:
+    run_calibration(build_arg_parser().parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
+++ b/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
@@ -9,7 +9,8 @@ import json
 import os
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -27,6 +28,8 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
+_CACHE_ENV = "SGLANG_DIFFUSION_BATCH_MEMORY_CACHE"
+
 
 @dataclass
 class CalibrationRecord:
@@ -40,6 +43,9 @@ class CalibrationRecord:
     peak_memory_mb: float
     peak_allocated_memory_mb: float
     duration_s: float
+    realized_batch_sizes: list[int]
+    realized_stop_reasons: list[str | None]
+    fully_realized: bool
     errors: list[str]
 
 
@@ -55,6 +61,7 @@ def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
     shapes = _parse_calibration_shapes(args.shapes)
     requested_batch_sizes = _parse_calibration_batch_sizes(args.batch_sizes)
     batch_sizes = _add_geometric_ramp(requested_batch_sizes)
+    profile_cache = _get_profile_cache_source(args.batching_memory_profile_cache)
 
     max_batch_size = max(batch_sizes)
     server_args = ServerArgs.from_kwargs(
@@ -86,6 +93,13 @@ def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
                     batch_size=batch_size,
                     timeout_s=args.per_batch_timeout_s,
                 )
+                if record.success_count and not record.fully_realized:
+                    logger.warning(
+                        "Requested calibration batch_size=%d but observed scheduler dispatch sizes=%s stop_reasons=%s",
+                        batch_size,
+                        record.realized_batch_sizes or ["unknown"],
+                        record.realized_stop_reasons or ["unknown"],
+                    )
                 records.append(record)
                 if args.stop_on_oom and record.oom_count:
                     break
@@ -95,13 +109,12 @@ def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
     summary = {
         "schema_version": 1,
         "model_path": args.model_path,
-        "profile_cache": args.batching_memory_profile_cache,
+        "profile_cache": profile_cache,
+        "requested_batch_sizes": requested_batch_sizes,
+        "executed_batch_sizes": batch_sizes,
         "records": [asdict(record) for record in records],
         "profiles": [
-            asdict(record)
-            for record in _read_profile_cache_summary(
-                args.batching_memory_profile_cache
-            )
+            asdict(record) for record in _read_profile_cache_summary(profile_cache)
         ],
     }
     if args.output_json:
@@ -152,20 +165,32 @@ def _run_calibration_batch(
     errors = []
     with ThreadPoolExecutor(max_workers=batch_size) as executor:
         futures = [executor.submit(send_one, idx) for idx in range(batch_size)]
-        for future in as_completed(futures, timeout=timeout_s * max(1, batch_size)):
-            try:
-                outputs.append(future.result(timeout=timeout_s))
-            except Exception as exc:
-                errors.append(str(exc))
+        try:
+            for future in as_completed(futures, timeout=timeout_s * max(1, batch_size)):
+                try:
+                    outputs.append(future.result(timeout=timeout_s))
+                except Exception as exc:
+                    errors.append(str(exc))
+        except TimeoutError as exc:
+            errors.append(f"timeout waiting for calibration batch: {exc}")
+            for future in futures:
+                future.cancel()
 
     output_errors = [out.error for out in outputs if getattr(out, "error", None)]
     errors.extend(str(error) for error in output_errors)
-    oom_count = sum(1 for out in outputs if getattr(out, "is_oom", False))
+    typed_oom_count = sum(1 for out in outputs if getattr(out, "is_oom", False))
+    oom_count = max(
+        typed_oom_count,
+        sum(1 for error in errors if _is_oom_error_message(error)),
+    )
     success_count = sum(
         1
         for out in outputs
         if getattr(out, "error", None) is None and not getattr(out, "is_oom", False)
     )
+    realized_batches = _get_realized_batches(outputs)
+    realized_batch_sizes = [item[0] for item in realized_batches]
+    realized_stop_reasons = [item[1] for item in realized_batches]
     return CalibrationRecord(
         width=width,
         height=height,
@@ -173,7 +198,7 @@ def _run_calibration_batch(
         batch_size=batch_size,
         success_count=success_count,
         oom_count=oom_count,
-        error_count=len(errors) - oom_count,
+        error_count=max(0, len(errors) - oom_count),
         peak_memory_mb=max(
             (getattr(out, "peak_memory_mb", 0.0) for out in outputs), default=0.0
         ),
@@ -182,6 +207,9 @@ def _run_calibration_batch(
             default=0.0,
         ),
         duration_s=time.monotonic() - start,
+        realized_batch_sizes=realized_batch_sizes,
+        realized_stop_reasons=realized_stop_reasons,
+        fully_realized=realized_batch_sizes == [batch_size],
         errors=errors,
     )
 
@@ -224,6 +252,40 @@ def _add_geometric_ramp(batch_sizes: list[int]) -> list[int]:
             current = min(target, current * 2)
             expanded.add(current)
     return sorted(expanded)
+
+
+def _get_realized_batches(outputs: list[Any]) -> list[tuple[int, str | None]]:
+    counts: Counter[tuple[int, str | None]] = Counter(
+        (
+            max(1, int(getattr(out, "dynamic_batch_size", 1) or 1)),
+            getattr(out, "dynamic_batch_stop_reason", None),
+        )
+        for out in outputs
+    )
+    realized = []
+    for (batch_size, stop_reason), output_count in counts.items():
+        dispatch_count = output_count // batch_size if output_count else 0
+        realized.extend([(batch_size, stop_reason)] * max(1, dispatch_count))
+    return sorted(realized, key=lambda item: (item[0], item[1] or ""))
+
+
+def _is_oom_error_message(error: str) -> bool:
+    lowered = error.lower()
+    return "out of memory" in lowered or "cuda oom" in lowered or "hip oom" in lowered
+
+
+def _get_profile_cache_source(configured: str | None) -> str | None:
+    path = configured or os.getenv(_CACHE_ENV)
+    if path is None:
+        path = os.path.join(
+            os.path.expanduser("~"),
+            ".cache",
+            "sglang",
+            "diffusion_batch_memory",
+        )
+    if str(path).lower() in ("", "none", "off", "false"):
+        return None
+    return os.path.expanduser(path)
 
 
 def _read_profile_cache_summary(

--- a/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
+++ b/python/sglang/multimodal_gen/tools/calibrate_batch_memory.py
@@ -69,6 +69,7 @@ def run_calibration(args: argparse.Namespace) -> dict[str, Any]:
         batching_max_size=max_batch_size,
         batching_delay_ms=args.batching_delay_ms,
         batching_memory_profile_cache=args.batching_memory_profile_cache,
+        batching_memory_reserve_fraction=args.batching_memory_reserve_fraction,
         warmup=args.warmup,
     )
 
@@ -364,6 +365,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--num-inference-steps", type=int, default=None)
     parser.add_argument("--batching-delay-ms", type=float, default=25.0)
     parser.add_argument("--batching-memory-profile-cache", default=None)
+    parser.add_argument(
+        "--batching-memory-reserve-fraction",
+        type=float,
+        default=0.02,
+        help=(
+            "Fraction of total device memory held back from memory-aware "
+            "batching during calibration. Default: 0.02."
+        ),
+    )
     parser.add_argument("--per-batch-timeout-s", type=float, default=600.0)
     parser.add_argument(
         "--output-json", default="batch_memory_calibration_summary.json"


### PR DESCRIPTION
 ## Motivation

 Dynamic batching for SGLang-Diffusion is useful only if admission can pick a batch size that is safe for the current model, resolution, hardware, precision, backend, etc etc etc. 

Instead of trying to derive exact tensor bytes for every diffusion pipeline, my pr learns from measured peak gpu mem for the runtime and request shape, then uses those profiles to admit larger batches when safe.

The goal is to make batching less dependent on hand-tuned caps

  ## Modifications

- Records peak GPU memory and builds memory profiles.
- Uses cold-start ramping, measured peak prediction, and OOM boundaries to avoid unsafe batches.
- Persists profiles and adds an offline calibration tool so production can start with prefilled memory data.
  The memory budget is refreshed once per scheduler batch-selection pass and accounts for device memory, configured reserve fraction, and external GPU usage.

When a batch runs across multiple distributed workers/GPUs, each worker reports its peak GPU memory, and admission uses the maximum value. This makes the profile reflect the most memory-heavy worker

I also added a new flag `--batching-memory-reserve-fraction` which controls how much GPU memory should be left unused for safety. The default 0.02 reserves 2% of total device memory

## Design Summary

[ref](https://docs.google.com/document/d/1KXS4JzRLuBUZMFM5f9KBAmIWWjRNWpZEdEAMzZNiBC4/edit?tab=t.0#heading=h.fk6cndjjavt8)  

The admission flow is:

  1. Respect --batching-max-size.
  2. Apply static config caps if provided.
  3. Use cold-start calibration for shapes that have not been seen.
  4. Use rough memory estimation while the profile is still under-sampled.
  5. Use measured profile prediction once enough successful observations exist.
  6. Reject the candidate if predicted peak memory exceeds the safe budget.

Diffusion memory depends on many factors so byte-level prediction is quite hard (unlike LLMs, there is no single kv-cache pool to account for)

## Speed Tests and Profiling

1xh200
```
sglang serve \
    --model-path Qwen/Qwen-Image-2512 \
    --model-type diffusion \
    --host 127.0.0.1 \
    --port 30000 \
    --batching-mode dynamic \
    --batching-max-size 12 \
    --batching-delay-ms 25 \
    --batching-memory-profile-cache /tmp/diffusion_batch_memory_qwen1024 \
    --enable-batching-metrics \
    --prompt "A cinematic studio photo of a red glass teapot on a white marble table, sharp details, softbox lighting" \
    --width 1024 \
    --height 1024 \
    --steps 4 \
    --seed 42 \
    --total-requests 96 \
    --concurrency 24 \
```

The behaviour I was looking for here is that the system starts safe, learns, and then admits larger batches.

| Case | Cap | Concurrency | Profile | Avg Batch | QPS | P95 | Peak Reserved | OOMs |
  |---|---:|---:|---|---:|---:|---:|---:|---:|
  | Baseline | 1 | 16 | none | 1.00 | 0.648 | 26.60s | 49,432 MB | 0 |
  | Empty profile | 8 | 16 | empty | 5.82 | 0.775 | 26.11s | 116,702 MB | 0 |
  | Calibrated 16c | 8 | 16 | loaded | 8.00 | 0.786 | 26.82s | 116,702 MB | 0 |
  | Calibrated 24c | 8 | 24 | loaded | 8.00 | 0.790 | 35.50s | 116,702 MB | 0 |
  | Calibrated 24c (warm) | 12 | 24 | loaded | 12.00 | 0.827 | 35.35s | 133,770 MB | 0 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27396493023](https://github.com/sgl-project/sglang/actions/runs/27396493023)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27396492924](https://github.com/sgl-project/sglang/actions/runs/27396492924)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->