### PR TITLE
[AMD] greedy LM-head AG+argmax shortcut with EAGLE compatibility

### DIFF
--- a/benchmark/kernels/all_gather/benchmark_ag_argmax_shortcut.py
+++ b/benchmark/kernels/all_gather/benchmark_ag_argmax_shortcut.py
@@ -33,7 +33,6 @@ import sys
 import torch
 import torch.distributed as dist
 
-
 # Dense M sweep to locate the eager→graph crossover precisely.
 M_SWEEP = [1, 2, 4, 6, 8, 10, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256]
 # V_local for Qwen3.5 FP8 LM-head on TP=8 (vocab 248320 / 8).
@@ -175,8 +174,10 @@ def main():
             f"{'base_eager (ms)':>16}  {'short_eager (ms)':>17}  {'spdup_eager':>11}  "
             f"{'base_graph (ms)':>16}  {'short_graph (ms)':>17}  {'spdup_graph':>11}"
         )
-        print(f"\nShape: V_local={V_LOCAL}  V_total={V_LOCAL * world_size}  "
-              f"dtype={DTYPE}  TP={world_size}\n")
+        print(
+            f"\nShape: V_local={V_LOCAL}  V_total={V_LOCAL * world_size}  "
+            f"dtype={DTYPE}  TP={world_size}\n"
+        )
         print(hdr)
         print("-" * len(hdr))
         cutoff_eager = None

--- a/benchmark/kernels/all_gather/benchmark_ag_argmax_shortcut.py
+++ b/benchmark/kernels/all_gather/benchmark_ag_argmax_shortcut.py
@@ -1,0 +1,206 @@
+"""
+Microbenchmark: greedy AG+argmax shortcut vs. baseline (full-vocab AG + full-vocab argmax).
+
+Measures BOTH regimes:
+  * eager  — standalone kernel launches (upper-bound on launch overhead)
+  * graph  — captured HIP/CUDA graph + replay (matches production decode regime,
+             where every kernel launch in the decode step is absorbed into the
+             model graph)
+
+Why graph mode matters:
+  The shortcut issues 4–5 small kernels (max, stack, tiny-AG, transpose, argmax).
+  In eager, each launch costs ~20 µs on ROCm, giving the shortcut a ~90 µs floor
+  that hides its asymptotic win. Under graph replay those launches are free, so
+  the comparison reflects what production actually sees.
+
+Baseline:
+    full = tensor_model_parallel_all_gather(local_logits, dim=-1)   # [M, V]
+    ids  = torch.argmax(full, dim=-1)                                # [M]
+
+Shortcut:
+    _fused_greedy_argmax_across_tp(local_logits) -> [M]              # local argmax
+                                                                       + small AG(val,idx)
+                                                                       + global pick
+
+Launch (MI355X × 8, Qwen3.5 FP8 LM-head shape included):
+    torchrun --nproc_per_node=8 --master_port=29510 \
+        benchmark/kernels/all_gather/benchmark_ag_argmax_shortcut.py
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+
+# Dense M sweep to locate the eager→graph crossover precisely.
+M_SWEEP = [1, 2, 4, 6, 8, 10, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256]
+# V_local for Qwen3.5 FP8 LM-head on TP=8 (vocab 248320 / 8).
+V_LOCAL = 31040
+DTYPE = torch.bfloat16
+
+
+def time_eager(fn, iters, warmup, device):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize(device=device)
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize(device=device)
+    return start.elapsed_time(end) / iters  # ms/call
+
+
+def time_graph(fn, iters, warmup, device):
+    """Capture `fn` into a HIP graph under SGLang's graph-capture context,
+    which routes aiter AG through the graph-safe `all_gather_reg` path and
+    suppresses the RCCL watchdog collision with HIP stream capture.
+    """
+    from sglang.srt.distributed import graph_capture
+
+    with graph_capture() as gc:
+        stream = gc.stream
+        # Warm up on the capture stream so NCCL/aiter metadata is initialized.
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                fn()
+        torch.cuda.synchronize(device=device)
+
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g, stream=stream):
+            fn()
+
+    # Exit graph_capture before replaying so the watchdog can run normally.
+    for _ in range(warmup):
+        g.replay()
+    torch.cuda.synchronize(device=device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        g.replay()
+    end.record()
+    torch.cuda.synchronize(device=device)
+    return start.elapsed_time(end) / iters  # ms/call
+
+
+def main():
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    dist.init_process_group(
+        backend="cpu:gloo,cuda:nccl", rank=rank, world_size=world_size
+    )
+
+    import sglang.srt.distributed.parallel_state as ps
+
+    ps.init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method="env://",
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    ps.initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    from sglang.srt.distributed import tensor_model_parallel_all_gather
+    from sglang.srt.layers.logits_processor import _fused_greedy_argmax_across_tp
+
+    rows = []
+
+    for M in M_SWEEP:
+        torch.manual_seed(1234 + rank * 37 + M)
+        # Pre-allocated input — in production this is the LM-head matmul output.
+        local = torch.randn(M, V_LOCAL, dtype=DTYPE, device=device)
+
+        # --- Correctness (eager reference) ---
+        ref_full = tensor_model_parallel_all_gather(local, dim=-1)
+        ref_ids = torch.argmax(ref_full, dim=-1).to(torch.int64)
+        got_ids = _fused_greedy_argmax_across_tp(local).to(torch.int64)
+        assert torch.equal(ref_ids, got_ids), f"eager mismatch at M={M}"
+
+        # --- Closures under test ---
+        # NOTE: these must not keep Python-side references that the graph capture
+        # can't reuse. Allocations inside the closure are captured into the
+        # graph's private memory pool on first capture.
+        def baseline():
+            full = tensor_model_parallel_all_gather(local, dim=-1)
+            _ = torch.argmax(full, dim=-1)
+
+        def shortcut():
+            _ = _fused_greedy_argmax_across_tp(local)
+
+        # --- Eager timing ---
+        base_eager = time_eager(baseline, iters=200, warmup=20, device=device)
+        short_eager = time_eager(shortcut, iters=200, warmup=20, device=device)
+
+        # --- Graph timing (the regime that matches production) ---
+        try:
+            base_graph = time_graph(baseline, iters=200, warmup=20, device=device)
+        except Exception as exc:
+            base_graph = float("nan")
+            if rank == 0:
+                print(f"[M={M}] baseline graph capture failed: {exc}", flush=True)
+        try:
+            short_graph = time_graph(shortcut, iters=200, warmup=20, device=device)
+        except Exception as exc:
+            short_graph = float("nan")
+            if rank == 0:
+                print(f"[M={M}] shortcut graph capture failed: {exc}", flush=True)
+
+        # Rank-avg to smooth per-rank jitter.
+        buf = torch.tensor(
+            [base_eager, short_eager, base_graph, short_graph], device=device
+        )
+        # all_reduce(AVG) doesn't handle NaN well; mask them first.
+        nan_mask = torch.isnan(buf)
+        buf = torch.where(nan_mask, torch.zeros_like(buf), buf)
+        dist.all_reduce(buf, op=dist.ReduceOp.AVG)
+        be, se, bg, sg = buf.tolist()
+
+        rows.append((M, be, se, bg, sg))
+
+    if rank == 0:
+        hdr = (
+            f"{'M':>4}  "
+            f"{'base_eager (ms)':>16}  {'short_eager (ms)':>17}  {'spdup_eager':>11}  "
+            f"{'base_graph (ms)':>16}  {'short_graph (ms)':>17}  {'spdup_graph':>11}"
+        )
+        print(f"\nShape: V_local={V_LOCAL}  V_total={V_LOCAL * world_size}  "
+              f"dtype={DTYPE}  TP={world_size}\n")
+        print(hdr)
+        print("-" * len(hdr))
+        cutoff_eager = None
+        cutoff_graph = None
+        for M, be, se, bg, sg in rows:
+            sp_e = be / se if se > 0 else float("inf")
+            sp_g = bg / sg if sg > 0 else float("inf")
+            if cutoff_eager is None and sp_e >= 1.0:
+                cutoff_eager = M
+            if cutoff_graph is None and sp_g >= 1.0:
+                cutoff_graph = M
+            print(
+                f"{M:>4}  "
+                f"{be:>16.4f}  {se:>17.4f}  {sp_e:>10.2f}x  "
+                f"{bg:>16.4f}  {sg:>17.4f}  {sp_g:>10.2f}x"
+            )
+        print()
+        print(f"Crossover (eager, baseline/shortcut ≥ 1.0×): M ≈ {cutoff_eager}")
+        print(f"Crossover (graph, baseline/shortcut ≥ 1.0×): M ≈ {cutoff_graph}")
+
+    dist.barrier()
+    dist.destroy_process_group()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/all_gather/benchmark_aiter.py
+++ b/benchmark/kernels/all_gather/benchmark_aiter.py
@@ -1,0 +1,431 @@
+"""
+Benchmark baseline NCCL all-gather vs Aiter custom all-gather across message sizes.
+
+Aiter exposes ``CustomAllreduce.custom_all_gather(inp, dim=0)`` (see
+``aiter/aiter/dist/device_communicators/custom_all_reduce.py``), which dispatches
+to ``all_gather_reg`` / ``all_gather_unreg`` based on whether the current stream
+is capturing. This script measures per-rank time vs. the default
+``torch.distributed.all_gather_into_tensor`` (RCCL) path for apples-to-apples
+comparison, mirroring the structure of the all-reduce benchmark.
+
+Usage:
+    torchrun --nproc_per_node=2 benchmark_aiter.py
+    torchrun --nproc_per_node=4 benchmark_aiter.py
+    torchrun --nproc_per_node=8 benchmark_aiter.py
+"""
+
+import argparse
+import os
+import sys
+import time
+from typing import List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark NCCL vs Aiter custom all-gather across message sizes."
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="cpu:gloo,cuda:nccl",
+        help=(
+            "Process group backend. Default routes CPU collectives through gloo "
+            "and CUDA collectives through NCCL (RCCL on ROCm), giving a real "
+            "RCCL baseline for all-gather while still letting Aiter's "
+            "CustomAllreduce use the gloo sub-PG it requires."
+        ),
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=5,
+        help="Warmup iterations per size per implementation.",
+    )
+    parser.add_argument(
+        "--iters-small",
+        type=int,
+        default=50,
+        help="Benchmark iterations for sizes <= 1MB (per-rank input bytes).",
+    )
+    parser.add_argument(
+        "--iters-large",
+        type=int,
+        default=20,
+        help="Benchmark iterations for sizes > 1MB (per-rank input bytes).",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="float16",
+        choices=["float16", "bfloat16"],
+        help="Element dtype (2 bytes).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print per-iteration timings on rank 0 for debugging.",
+    )
+    return parser.parse_args()
+
+
+def get_env_rank_world() -> Tuple[int, int, int]:
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", str(rank)))
+    return rank, world_size, local_rank
+
+
+def init_dist(backend: str):
+    rank, world_size, _ = get_env_rank_world()
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend=backend,
+            init_method="env://",
+            rank=rank,
+            world_size=world_size,
+        )
+
+
+def get_device(local_rank: int) -> torch.device:
+    torch.cuda.set_device(local_rank)
+    return torch.device(f"cuda:{local_rank}")
+
+
+def human_size(num_bytes: int) -> str:
+    units = [("B", 1), ("K", 1024), ("M", 1024 * 1024), ("G", 1024 * 1024 * 1024)]
+    for suf, base in reversed(units):
+        if num_bytes % base == 0 and num_bytes >= base:
+            val = num_bytes // base
+            return f"{val}{suf}"
+    return f"{num_bytes}B"
+
+
+def get_message_sizes() -> List[int]:
+    """Per-rank input sizes in bytes.
+
+    For all-gather, total on-the-wire traffic per step is roughly
+    ``world_size * size`` bytes (each rank receives world_size-1 shards).
+    """
+    return [
+        32 * 1024,
+        64 * 1024,
+        128 * 1024,
+        256 * 1024,
+        512 * 1024,
+        1 * 1024 * 1024,
+        2 * 1024 * 1024,
+        4 * 1024 * 1024,
+        8 * 1024 * 1024,
+        16 * 1024 * 1024,
+        32 * 1024 * 1024,
+        64 * 1024 * 1024,
+    ]
+
+
+@torch.inference_mode()
+def nccl_all_gather(
+    inp: torch.Tensor, out: torch.Tensor, group: Optional[dist.ProcessGroup]
+) -> torch.Tensor:
+    dist.all_gather_into_tensor(out, inp, group=group)
+    return out
+
+
+@torch.inference_mode()
+def aiter_all_gather(comm, inp: torch.Tensor) -> Optional[torch.Tensor]:
+    """Call Aiter's custom all-gather along dim=0 (out is allocated internally)."""
+    if hasattr(comm, "custom_all_gather"):
+        return comm.custom_all_gather(inp, dim=0)
+    raise RuntimeError("Aiter communicator does not expose custom_all_gather.")
+
+
+def _should_custom_ag(comm, inp: torch.Tensor) -> bool:
+    """Replicate Aiter's ``should_custom_ag`` gate without importing the
+    private attribute if missing; fall back to ``True`` and let the kernel
+    raise (we still skip if the comm is disabled)."""
+    if comm is None or getattr(comm, "disabled", True):
+        return False
+    fn = getattr(comm, "should_custom_ag", None)
+    if fn is None:
+        return True
+    return bool(fn(inp))
+
+
+@torch.inference_mode()
+def bench_nccl(
+    sizes: List[int],
+    device: torch.device,
+    dtype: torch.dtype,
+    warmup: int,
+    iters_small: int,
+    iters_large: int,
+    verbose: bool,
+    pg: Optional[dist.ProcessGroup] = None,
+) -> List[Tuple[int, Optional[float]]]:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    results: List[Tuple[int, Optional[float]]] = []
+
+    for size_bytes in sizes:
+        elems = size_bytes // torch.tensor([], dtype=dtype).element_size()
+        inp = torch.empty(elems, dtype=dtype, device=device)
+        inp.uniform_(0, 1) if dtype != torch.bfloat16 else inp.fill_(1.0)
+        out = torch.empty(elems * world_size, dtype=dtype, device=device)
+
+        dist.barrier(group=pg)
+        for _ in range(warmup):
+            nccl_all_gather(inp, out, pg)
+        torch.cuda.synchronize()
+        dist.barrier(group=pg)
+
+        num_iters = iters_small if size_bytes <= (1 * 1024 * 1024) else iters_large
+        times_ms: List[float] = []
+        for it in range(num_iters):
+            dist.barrier(group=pg)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            nccl_all_gather(inp, out, pg)
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            dist.barrier(group=pg)
+            dt_ms = (t1 - t0) * 1000.0
+            times_ms.append(dt_ms)
+            if verbose and rank == 0:
+                print(
+                    f"[NCCL] size={human_size(size_bytes)} iter={it} time={dt_ms:.3f} ms"
+                )
+
+        avg_ms_local = sum(times_ms) / len(times_ms)
+        avg_tensor = torch.tensor([avg_ms_local], dtype=torch.float64, device=device)
+        gather_list = [torch.zeros_like(avg_tensor) for _ in range(world_size)]
+        dist.all_gather(gather_list, avg_tensor, group=pg)
+        if rank == 0:
+            avg_ms = float(torch.stack(gather_list).mean().item())
+            print(f"[NCCL] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)")
+            results.append((size_bytes, avg_ms))
+        else:
+            results.append((size_bytes, None))
+
+    return results
+
+
+@torch.inference_mode()
+def bench_aiter(
+    comm,
+    sizes: List[int],
+    device: torch.device,
+    dtype: torch.dtype,
+    warmup: int,
+    iters_small: int,
+    iters_large: int,
+    verbose: bool,
+    pg: Optional[dist.ProcessGroup] = None,
+) -> List[Tuple[int, Optional[float]]]:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    results: List[Tuple[int, Optional[float]]] = []
+
+    for size_bytes in sizes:
+        elems = size_bytes // torch.tensor([], dtype=dtype).element_size()
+        inp = torch.empty(elems, dtype=dtype, device=device)
+        inp.uniform_(0, 1) if dtype != torch.bfloat16 else inp.fill_(1.0)
+
+        # Aiter's custom all-gather requires 16B alignment of the per-rank
+        # byte size AND the per-rank input to fit in max_size / (world_size*2).
+        if not _should_custom_ag(comm, inp):
+            if rank == 0:
+                print(f"[Aiter] {human_size(size_bytes)}: skipped (should_custom_ag=False)")
+            results.append((size_bytes, None))
+            continue
+
+        disabled = False
+        dist.barrier(group=pg)
+        for _ in range(warmup):
+            torch.cuda.synchronize()
+            out = aiter_all_gather(comm, inp)
+            torch.cuda.synchronize()
+            if out is None:
+                disabled = True
+                break
+        dist.barrier(group=pg)
+
+        if disabled:
+            if rank == 0:
+                print(f"[Aiter] {human_size(size_bytes)}: custom AG disabled (skipped)")
+            results.append((size_bytes, None))
+            continue
+
+        # One-shot correctness check vs. NCCL reference on this size.
+        ref = torch.empty(elems * world_size, dtype=dtype, device=device)
+        dist.all_gather_into_tensor(ref, inp, group=pg)
+        aiter_out = aiter_all_gather(comm, inp)
+        if aiter_out is None or aiter_out.shape != ref.shape:
+            if rank == 0:
+                print(
+                    f"[Aiter] {human_size(size_bytes)}: correctness skipped "
+                    f"(out={None if aiter_out is None else tuple(aiter_out.shape)} "
+                    f"ref={tuple(ref.shape)})"
+                )
+        else:
+            mismatch = not torch.equal(aiter_out, ref)
+            if mismatch and rank == 0:
+                print(
+                    f"[Aiter] {human_size(size_bytes)}: WARNING output differs from NCCL reference"
+                )
+
+        num_iters = iters_small if size_bytes <= (1 * 1024 * 1024) else iters_large
+        times_ms: List[float] = []
+        for it in range(num_iters):
+            dist.barrier(group=pg)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            out = aiter_all_gather(comm, inp)
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            dist.barrier(group=pg)
+            if out is None:
+                disabled = True
+                break
+            dt_ms = (t1 - t0) * 1000.0
+            times_ms.append(dt_ms)
+            if verbose and rank == 0:
+                print(
+                    f"[Aiter] size={human_size(size_bytes)} iter={it} time={dt_ms:.3f} ms"
+                )
+
+        if disabled or not times_ms:
+            if rank == 0:
+                print(f"[Aiter] {human_size(size_bytes)}: custom AG disabled (no timings)")
+            results.append((size_bytes, None))
+            continue
+
+        avg_ms_local = sum(times_ms) / len(times_ms)
+        avg_tensor = torch.tensor([avg_ms_local], dtype=torch.float64, device=device)
+        gather_list = [torch.zeros_like(avg_tensor) for _ in range(world_size)]
+        dist.all_gather(gather_list, avg_tensor, group=pg)
+        if rank == 0:
+            avg_ms = float(torch.stack(gather_list).mean().item())
+            print(f"[Aiter] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)")
+            results.append((size_bytes, avg_ms))
+        else:
+            results.append((size_bytes, None))
+
+    return results
+
+
+def main():
+    args = parse_args()
+    rank, world_size, local_rank = get_env_rank_world()
+
+    if world_size not in (2, 4, 6, 8):
+        print(
+            f"[rank {rank}] WARNING: world_size={world_size} not in supported set (2,4,6,8). "
+            "Aiter custom AG may disable itself.",
+            file=sys.stderr,
+        )
+
+    init_dist(args.backend)
+    device = get_device(local_rank)
+    dtype = torch.float16 if args.dtype == "float16" else torch.bfloat16
+
+    aiter_comm = None
+    HAVE_AITER = False
+    try:
+        from aiter.dist.device_communicators.custom_all_reduce import (
+            CustomAllreduce as AiterCustomAllreduce,
+        )
+
+        HAVE_AITER = True
+    except Exception as e:
+        if rank == 0:
+            print(f"Aiter CustomAllreduce import failed: {e}", file=sys.stderr)
+
+    if rank == 0:
+        print(f"Initialized PG backend={args.backend} world_size={world_size}")
+        print(f"Device: {device.type}:{device.index} dtype={dtype}")
+        print(f"Aiter available: {HAVE_AITER}")
+
+    pg = dist.group.WORLD
+    sizes = get_message_sizes()
+    max_size = max(sizes) if sizes else (64 * 1024 * 1024)
+
+    # Aiter's CustomAllreduce refuses an NCCL-backed PG (it needs a pure TCP
+    # store for IPC handle exchange). SGLang creates a separate gloo group for
+    # the same reason; replicate that here.
+    ranks = list(range(world_size))
+    gloo_group = dist.new_group(ranks=ranks, backend="gloo")
+
+    if HAVE_AITER:
+        try:
+            aiter_comm = AiterCustomAllreduce(
+                group=gloo_group, device=device, max_size=max_size
+            )
+        except Exception as e:
+            if rank == 0:
+                print(f"Failed to construct Aiter CustomAllreduce: {e}", file=sys.stderr)
+            aiter_comm = None
+
+    nccl_results = bench_nccl(
+        sizes=sizes,
+        device=device,
+        dtype=dtype,
+        warmup=args.warmup,
+        iters_small=args.iters_small,
+        iters_large=args.iters_large,
+        verbose=args.verbose,
+        pg=pg,
+    )
+
+    aiter_results: List[Tuple[int, Optional[float]]] = []
+    if aiter_comm is not None:
+        aiter_results = bench_aiter(
+            comm=aiter_comm,
+            sizes=sizes,
+            device=device,
+            dtype=dtype,
+            warmup=args.warmup,
+            iters_small=args.iters_small,
+            iters_large=args.iters_large,
+            verbose=args.verbose,
+            pg=pg,
+        )
+
+    if aiter_comm is not None and hasattr(aiter_comm, "close"):
+        try:
+            aiter_comm.close()
+        except Exception:
+            pass
+
+    if dist.get_rank() == 0:
+        print("\nResults (avg ms across ranks; None = disabled/unavailable):")
+        header = f"{'Size':>8}  {'NCCL(ms)':>11}  {'Aiter(ms)':>11}  {'Speedup':>8}"
+        print(header)
+        print("-" * len(header))
+
+        nccl_map = {s: v for s, v in nccl_results if v is not None}
+        aiter_map = {s: v for s, v in aiter_results if v is not None}
+
+        for s in sizes:
+            nccl_ms = nccl_map.get(s, None)
+            aiter_ms = aiter_map.get(s, None)
+            speedup = (
+                f"{nccl_ms / aiter_ms:.2f}x"
+                if (nccl_ms is not None and aiter_ms is not None and aiter_ms > 0)
+                else "-"
+            )
+            print(
+                f"{human_size(s):>8}  "
+                f"{('%.3f' % nccl_ms) if nccl_ms is not None else 'None':>11}  "
+                f"{('%.3f' % aiter_ms) if aiter_ms is not None else 'None':>11}  "
+                f"{speedup:>8}"
+            )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/all_gather/benchmark_aiter.py
+++ b/benchmark/kernels/all_gather/benchmark_aiter.py
@@ -204,7 +204,9 @@ def bench_nccl(
         dist.all_gather(gather_list, avg_tensor, group=pg)
         if rank == 0:
             avg_ms = float(torch.stack(gather_list).mean().item())
-            print(f"[NCCL] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)")
+            print(
+                f"[NCCL] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)"
+            )
             results.append((size_bytes, avg_ms))
         else:
             results.append((size_bytes, None))
@@ -237,7 +239,9 @@ def bench_aiter(
         # byte size AND the per-rank input to fit in max_size / (world_size*2).
         if not _should_custom_ag(comm, inp):
             if rank == 0:
-                print(f"[Aiter] {human_size(size_bytes)}: skipped (should_custom_ag=False)")
+                print(
+                    f"[Aiter] {human_size(size_bytes)}: skipped (should_custom_ag=False)"
+                )
             results.append((size_bytes, None))
             continue
 
@@ -298,7 +302,9 @@ def bench_aiter(
 
         if disabled or not times_ms:
             if rank == 0:
-                print(f"[Aiter] {human_size(size_bytes)}: custom AG disabled (no timings)")
+                print(
+                    f"[Aiter] {human_size(size_bytes)}: custom AG disabled (no timings)"
+                )
             results.append((size_bytes, None))
             continue
 
@@ -308,7 +314,9 @@ def bench_aiter(
         dist.all_gather(gather_list, avg_tensor, group=pg)
         if rank == 0:
             avg_ms = float(torch.stack(gather_list).mean().item())
-            print(f"[Aiter] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)")
+            print(
+                f"[Aiter] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)"
+            )
             results.append((size_bytes, avg_ms))
         else:
             results.append((size_bytes, None))
@@ -365,7 +373,9 @@ def main():
             )
         except Exception as e:
             if rank == 0:
-                print(f"Failed to construct Aiter CustomAllreduce: {e}", file=sys.stderr)
+                print(
+                    f"Failed to construct Aiter CustomAllreduce: {e}", file=sys.stderr
+                )
             aiter_comm = None
 
     nccl_results = bench_nccl(

--- a/greedy_shortcut_draft_pr.md
+++ b/greedy_shortcut_draft_pr.md
@@ -1,0 +1,201 @@
+# Draft PR: AMD greedy LM-head AG+argmax shortcut with EAGLE compatibility
+
+## Summary
+
+This PR adds an AMD/HIP-only fast path for greedy decode when the LM head is tensor-parallel sharded. Instead of materializing full-vocab logits via TP
+all-gather and then running `torch.argmax`, each rank computes its local `max/argmax`, all-gathers only `(max_value, local_index)` pairs, and reconstructs the global token id.
+
+The route is opt-in via:
+
+```bash
+SGLANG_AITER_AG_ARGMAX_SHORTCUT=1
+SGLANG_AITER_AG_ARGMAX_SHORTCUT_MIN_M=2
+```
+
+Non-HIP platforms are explicitly gated out and continue using the existing full-logits path.
+
+## What changed
+
+- Added `_fused_greedy_argmax_across_tp(local_logits)` in the logits processor.
+- Added `next_token_ids_shortcut` to `LogitsProcessorOutput`.
+- Added sampler support for consuming precomputed greedy token ids.
+- Preserved CUDA graph replay plumbing for `next_token_ids_shortcut`.
+- Made EAGLE compatible:
+  - Draft inputs keep full logits because draft generation needs `softmax`.
+  - AMD/HIP target verification can consume `next_token_ids_shortcut` for greedy verification.
+  - Non-HIP EAGLE paths keep the old full-logits assumptions.
+- Added a torchrun-able correctness and benchmark test:
+  - `test/srt/test_greedy_argmax_shortcut.py`
+
+## Serving results
+
+Server command:
+
+```bash
+SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1 \
+  SGLANG_ENABLE_SPEC_V2=1 \
+  ROCM_QUICK_REDUCE_QUANTIZATION=NONE \
+  SGLANG_AITER_FP8_PREFILL_ATTN=1 \
+  SGLANG_AITER_MLA_PERSIST=1 \
+  AITER_MXFP4_MOE_SF=1 \
+  SGLANG_USE_AITER=1 \
+  SGLANG_INT4_WEIGHT=0 \
+  SGLANG_MOE_PADDING=1 \
+  SGLANG_SET_CPU_AFFINITY=1 \
+  SGLANG_ROCM_FUSED_DECODE_MLA=1 \
+  SGLANG_USE_ROCM700A=1 \
+  SGLANG_DISABLE_FUSED_AR_MXFP4_QUANT=false \
+  python3 -m sglang.launch_server \
+    --model-path amd/DeepSeek-R1-MXFP4 \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --mem-fraction-static 0.9 \
+    --chunked-prefill-size 131072 \
+    --attention-backend aiter \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --max-running-requests 32 \
+    --context-length 200000 \
+    --kv-cache-dtype fp8_e4m3 \
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'
+```
+## Correctness gates
+
+GSM8K on `amd/DeepSeek-R1-MXFP4`, TP=4, EAGLE enabled, AITER route:
+```bash
+python3 benchmark/gsm8k/bench_sglang.py \
+  --num-questions 1319 \
+  --parallel 1319 \
+  --num-shots 5 \
+  --port 8000
+```
+Baseline:
+
+```text
+run 1: 0.952
+run 2: 0.943
+run 3: 0.937
+```
+
+Optimized:
+
+```text
+run 1: 0.948
+run 2: 0.945
+run 3: 0.944
+```
+
+
+### `max-concurrency=2`
+
+Workload:
+
+```text
+random-input-len=70000
+random-output-len=500
+num-prompts=16
+max-concurrency=2
+```
+
+Result:
+
+```text
+total token throughput: 12252.08 tok/s vs baseline 11280.16 tok/s (+8.6%)
+median TPOT:            14.04 ms vs baseline 15.80 ms
+```
+
+### `max-concurrency=4`
+
+Workload:
+
+```text
+random-input-len=70000
+random-output-len=200
+num-prompts=32
+max-concurrency=4
+```
+
+Result:
+
+```text
+total token throughput: 24363.59 tok/s vs baseline 23657.53 tok/s (+3.0%)
+median TPOT:            32.21 ms vs baseline 30.37 ms
+```
+
+The `mc4` throughput improved while median TPOT regressed slightly; this should be called out as a tradeoff in review.
+
+## Shared-prefix cache bench
+
+Quick sweep using `benchmark/hicache/bench_warm_cache.py`:
+
+```text
+pcts=0,60,90,99
+total_tokens=70000
+output_len=500
+num_prompts=16
+max_concurrency=2
+```
+
+Artifacts:
+
+```text
+benchmark/hicache/bench_warm_cache.py
+```
+
+Headline:
+
+```text
+0% shared prefix:  TPM/GPU -1.80%, median TPOT -0.46%
+60% shared prefix: TPM/GPU +1.84%, median TPOT +11.71%
+90% shared prefix: TPM/GPU +2.71%, median TPOT +0.24%
+99% shared prefix: TPM/GPU +0.98%, median TPOT +0.32%
+```
+
+## Unit/benchmark test
+
+Correctness only:
+
+```bash
+SGLANG_AITER_AG_ARGMAX_SHORTCUT=1 \
+PYTHONPATH=/sgl-workspace/sglang/python \
+torchrun --nproc_per_node=4 --master_port=29510 \
+  test/srt/test_greedy_argmax_shortcut.py
+```
+
+Correctness plus benchmark:
+
+```bash
+SGLANG_AITER_AG_ARGMAX_SHORTCUT=1 \
+PYTHONPATH=/sgl-workspace/sglang/python \
+torchrun --nproc_per_node=4 --master_port=29510 \
+  test/srt/test_greedy_argmax_shortcut.py \
+  --benchmark \
+  --m-values 1,2,8,16,32,64,128 \
+  --v-local 31040 \
+  --csv-out /tmp/greedy_argmax_shortcut_bench.csv
+```
+```
+PASS correctness: M=[1, 2, 8, 16, 32, 64, 128], V_local=31040, TP=4, dtype=torch.bfloat16
+     M   base_eager     shortcut   eager_x   base_graph   shortcut_g   graph_x
+     1       0.0624       0.1043     0.60x       0.0520       0.0431     1.21x
+     2       0.0722       0.1045     0.69x       0.0651       0.0434     1.50x
+     8       0.0785       0.1050     0.75x       0.0715       0.0433     1.65x
+    16       0.0898       0.1049     0.86x       0.0829       0.0442     1.87x
+    32       0.1146       0.1151     1.00x       0.1073       0.0438     2.45x
+    64       0.1563       0.1031     1.52x       0.1508       0.0449     3.36x
+   128       0.2400       0.1021     2.35x       0.2340       0.0454     5.16x
+```
+
+The test skips shortcut execution on non-HIP devices so other hardware routes remain untouched.
+
+## Risk and review notes
+
+- This is AMD/HIP-only and opt-in.
+- Draft-side EAGLE still requires full logits for `softmax`; the shortcut is gated off for speculative draft inputs.
+- Target-side EAGLE greedy verification can consume `next_token_ids_shortcut`.
+- Non-HIP EAGLE and sampler paths keep the original full-logits behavior.
+- The route intentionally falls back for logprobs, full logits, logit bias, vocab masks, grammars, custom logit processors, penalties, softcapping, LoRA/AMX wrapping, DP-attention gather, and attention-TP-group gather.

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -47,6 +47,7 @@ from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cud
 from sglang.srt.distributed.utils import set_global_tcp_store
 from sglang.srt.environ import envs
 from sglang.srt.utils import (
+    get_bool_env_var,
     get_current_device_stream_fast,
     get_int_env_var,
     is_cpu,
@@ -801,6 +802,32 @@ class GroupCoordinator:
             return output
 
     def _all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
+        # Aiter custom all-gather (ROCm). Gated by SGLANG_USE_AITER_AG (default OFF)
+        # and by Aiter's own should_custom_ag (16B alignment, weak-contiguous,
+        # world==2 or fully-connected, per-rank size <= max_size/(world*2)).
+        # On a hit, writes directly into the caller's pre-allocated `output` via
+        # all_gather_reg during CUDA-graph capture and all_gather_unreg otherwise.
+        ca_comm = self.ca_comm
+        if (
+            is_hip()
+            and get_bool_env_var("SGLANG_USE_AITER_AG", default="false")
+            and ca_comm is not None
+            and not getattr(ca_comm, "disabled", True)
+            and hasattr(ca_comm, "should_custom_ag")
+            and hasattr(ca_comm, "all_gather_reg")
+            and hasattr(ca_comm, "all_gather_unreg")
+            and input.is_contiguous()
+            and output.is_contiguous()
+            and ca_comm.should_custom_ag(input)
+        ):
+            if getattr(ca_comm, "_IS_CAPTURING", False):
+                if torch.cuda.is_current_stream_capturing():
+                    ca_comm.all_gather_reg(input, out=output, dim=0)
+                    return
+            else:
+                ca_comm.all_gather_unreg(input, out=output, dim=0)
+                return
+
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is not None and (
             not pynccl_comm.disabled or self.is_symmetric_memory_enabled()

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -248,6 +248,7 @@ class LogitsMetadata:
     # import on SamplingBatchInfo here; only attribute accesses are used.
     sampling_info: Optional[Any] = None
     sampler_return_logprob: bool = False
+    spec_info: Optional[Any] = None
 
     @classmethod
     def from_forward_batch(cls, forward_batch: ForwardBatch):
@@ -302,6 +303,7 @@ class LogitsMetadata:
             mm_input_embeds=forward_batch.mm_input_embeds,
             sampling_info=forward_batch.sampling_info,
             sampler_return_logprob=forward_batch.return_logprob,
+            spec_info=forward_batch.spec_info,
         )
 
     def compute_dp_attention_metadata(self):
@@ -1043,7 +1045,16 @@ class LogitsProcessor(nn.Module):
             return None
         if sample_indices is not None:
             return None
-        if not logits_metadata.forward_mode.is_decode_or_idle():
+        if not (
+            logits_metadata.forward_mode.is_decode_or_idle()
+            or logits_metadata.forward_mode.is_target_verify()
+        ):
+            return None
+        spec_info = logits_metadata.spec_info
+        if (
+            spec_info is not None
+            and getattr(spec_info, "is_draft_input", lambda: False)()
+        ):
             return None
         if logits_metadata.mm_input_embeds is not None:
             return None

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -15,6 +15,7 @@
 
 import dataclasses
 import logging
+import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -25,6 +26,7 @@ from triton.language.extra import libdevice
 
 from sglang.srt.distributed import (
     get_tensor_model_parallel_world_size,
+    get_tp_group,
     tensor_model_parallel_all_gather,
 )
 from sglang.srt.environ import envs
@@ -56,11 +58,93 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
 )
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils.common import is_npu, use_intel_amx_backend
+from sglang.srt.utils.common import (
+    get_bool_env_var,
+    is_hip,
+    is_npu,
+    use_intel_amx_backend,
+)
 
 logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
+_is_hip = is_hip()
+
+# Greedy AG+argmax shortcut (opt-in, AMD/ROCm only). Replaces the full-vocab
+# LM-head all-gather + full-vocab torch.argmax with a per-rank local argmax
+# followed by a tiny all-gather of (max_value, local_index) pairs and a global
+# pick. Validated and measured only on AMD MI355X under HIP graph replay; the
+# runtime gate in `_try_greedy_argmax_shortcut` short-circuits on non-HIP
+# platforms to preserve existing CUDA/NPU/CPU behavior bit-for-bit.
+SGLANG_AITER_AG_ARGMAX_SHORTCUT = get_bool_env_var(
+    "SGLANG_AITER_AG_ARGMAX_SHORTCUT", default="false"
+)
+# Minimum batch size (M = pruned_states.shape[0]) at which the shortcut is
+# taken. Below this the baseline AG+argmax is cheaper than the shortcut's
+# constant ~40 µs floor under HIP graph replay. Default 2 matches the
+# measured crossover on MI355X / TP=8 / Qwen3.5 FP8 LM-head shape; override
+# per-deployment if a different model/TP shifts the curve.
+SGLANG_AITER_AG_ARGMAX_SHORTCUT_MIN_M = int(
+    os.environ.get("SGLANG_AITER_AG_ARGMAX_SHORTCUT_MIN_M", "2")
+)
+
+
+def _fused_greedy_argmax_across_tp(local_logits: torch.Tensor) -> torch.Tensor:
+    """
+    Compute ``torch.argmax(tensor_model_parallel_all_gather(local_logits), dim=-1)``
+    without materializing the full-vocab logits on any rank.
+
+    Each rank computes its local (max_value, argmax_index_in_shard) and participates
+    in a single all-gather of a [M, 2] int32 tensor (fp32 max-value reinterpreted as
+    int32 bits in column 0, int32 argmax index in column 1). All ranks then pick the
+    global winner locally.
+
+    Tie-break matches ``torch.argmax`` semantics on the concatenation
+    ``[rank0_shard | rank1_shard | ...]``: the smallest flat index wins on ties,
+    because (1) ``torch.max``/``torch.argmax`` return the first occurrence inside a
+    shard, and (2) ``torch.argmax`` over [M, TP] picks the smallest rank on ties.
+
+    Args:
+        local_logits: [M, V_local] on the current rank. ``V_local`` must equal
+            ``vocab_size // tp_world_size`` (no intra-shard padding); callers must
+            gate on that condition before invoking this helper.
+
+    Returns:
+        [M] int64 tensor of global token ids, matching ``torch.argmax`` output.
+    """
+    tp_group = get_tp_group()
+    tp_world = tp_group.world_size
+    v_local = local_logits.shape[-1]
+    m = local_logits.shape[0]
+
+    local_max_val, local_arg = local_logits.max(dim=-1)
+
+    # Pack (max_value_fp32, local_arg_int32-as-fp32-bits) into one [M, 2] fp32
+    # tensor. We keep the AG payload dtype as fp32 so that the aiter custom
+    # all-gather (which only accepts fp16/bf16/fp32) can handle it; bit-copy
+    # semantics make reinterpret safe on both ends.
+    val_f32 = local_max_val.to(torch.float32)
+    idx_i32 = local_arg.to(torch.int32)
+    local_pair = torch.stack(
+        [val_f32, idx_i32.view(torch.float32)], dim=-1
+    ).contiguous()
+
+    gathered = torch.empty(
+        (tp_world, m, 2), dtype=torch.float32, device=local_logits.device
+    )
+    tp_group.all_gather_into_tensor(gathered.view(tp_world * m, 2), local_pair)
+
+    vals_f32 = gathered[..., 0]
+    idxs_i32 = gathered[..., 1].view(torch.int32)
+    vals_f32 = vals_f32.transpose(0, 1).contiguous()
+    idxs_i32 = idxs_i32.transpose(0, 1).contiguous()
+
+    winner_rank = vals_f32.argmax(dim=-1)
+    winner_local_idx = idxs_i32.gather(1, winner_rank.unsqueeze(-1)).squeeze(-1)
+    global_idx = winner_rank.to(torch.int64) * v_local + winner_local_idx.to(
+        torch.int64
+    )
+    return global_idx
 
 
 @dataclasses.dataclass
@@ -107,6 +191,13 @@ class LogitsProcessorOutput:
 
     mm_input_embeds: Optional[torch.Tensor] = None
 
+    ## Part 6: Greedy AG+argmax shortcut (opt-in via SGLANG_AITER_AG_ARGMAX_SHORTCUT).
+    # When set, `next_token_logits` is None and the Sampler should use these
+    # precomputed greedy-argmax token ids directly, skipping the full-vocab AG
+    # + full-vocab argmax that would otherwise run on the gathered logits.
+    # Shape: [num_seqs], dtype int64 (matches torch.argmax semantics).
+    next_token_ids_shortcut: Optional[torch.Tensor] = None
+
 
 @dataclasses.dataclass
 class LogitsMetadata:
@@ -150,6 +241,13 @@ class LogitsMetadata:
     is_prefill_only: bool = False
 
     mm_input_embeds: Optional[torch.Tensor] = None
+
+    # Sampling/logprob info peeked from ForwardBatch; used to gate the
+    # greedy AG+argmax shortcut inside LogitsProcessor.forward (opt-in via
+    # SGLANG_AITER_AG_ARGMAX_SHORTCUT). Kept as `Any` to avoid a circular
+    # import on SamplingBatchInfo here; only attribute accesses are used.
+    sampling_info: Optional[Any] = None
+    sampler_return_logprob: bool = False
 
     @classmethod
     def from_forward_batch(cls, forward_batch: ForwardBatch):
@@ -202,6 +300,8 @@ class LogitsMetadata:
             global_num_tokens_for_logprob_gpu=forward_batch.global_num_tokens_for_logprob_gpu,
             dp_padding_mode=DpPaddingMode.SUM_LEN,
             mm_input_embeds=forward_batch.mm_input_embeds,
+            sampling_info=forward_batch.sampling_info,
+            sampler_return_logprob=forward_batch.return_logprob,
         )
 
     def compute_dp_attention_metadata(self):
@@ -339,6 +439,23 @@ class LogitsProcessor(nn.Module):
         del hidden_states
 
         if not logits_metadata.extend_return_logprob:
+            # Greedy AG+argmax shortcut: when the batch is all-greedy, we can
+            # skip both the full-vocab LM-head all-gather and the full-vocab
+            # torch.argmax in the Sampler, and instead do a per-rank local
+            # argmax plus a tiny all-gather of (max_val, local_idx) pairs.
+            # Returns precomputed token ids on the output; Sampler picks them
+            # up and skips its own argmax path.
+            shortcut_ids = self._try_greedy_argmax_shortcut(
+                pruned_states, lm_head, logits_metadata, sample_indices
+            )
+            if shortcut_ids is not None:
+                return LogitsProcessorOutput(
+                    next_token_logits=None,
+                    hidden_states=hidden_states_to_store,
+                    mm_input_embeds=logits_metadata.mm_input_embeds,
+                    next_token_ids_shortcut=shortcut_ids,
+                )
+
             # Compute logits for both input and sampled tokens.
             logits = self._get_logits(pruned_states, lm_head, logits_metadata)
             sampled_logits = (
@@ -883,6 +1000,120 @@ class LogitsProcessor(nn.Module):
                 )
 
         return logits
+
+    def _try_greedy_argmax_shortcut(
+        self,
+        pruned_states: torch.Tensor,
+        lm_head: VocabParallelEmbedding,
+        logits_metadata: LogitsMetadata,
+        sample_indices: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        """Fast path for decode when all requests use greedy sampling.
+
+        Skips the full-vocab LM-head all-gather and the full-vocab
+        ``torch.argmax`` in the Sampler, replacing them with a per-rank local
+        argmax + a tiny all-gather of (val, idx) pairs. Returns the chosen
+        token ids (shape ``[num_seqs]`` int64) on success, or ``None`` if any
+        eligibility check fails (callers must then fall back to the standard
+        AG path). See ``_fused_greedy_argmax_across_tp`` for details.
+        """
+        if not SGLANG_AITER_AG_ARGMAX_SHORTCUT:
+            return None
+        # AMD/ROCm only — validated on MI355X; other platforms fall through to
+        # the standard AG+argmax path so behavior is bitwise-unchanged.
+        if not _is_hip:
+            return None
+        if not self.do_tensor_parallel_all_gather:
+            return None
+        if self.use_attn_tp_group or self.do_tensor_parallel_all_gather_dp_attn:
+            return None
+        # Batch-size guard. The shortcut has a constant ~40 µs floor under HIP
+        # graph replay (measured on MI355X / TP=8 / Qwen3.5 FP8 LM-head shape,
+        # see benchmark/kernels/all_gather/benchmark_ag_argmax_shortcut.py).
+        # The baseline AG+argmax is cheaper than that floor only at M=1 (~22 µs
+        # under graph), so we fall back for single-row batches. For M>=2 the
+        # shortcut is strictly faster (2.3x at M=2 up to 11x at M=256).
+        # Note: at graph capture time M is the captured/padded batch size, so
+        # this gate specializes captured graphs for bs>=2 only.
+        if pruned_states.shape[0] < SGLANG_AITER_AG_ARGMAX_SHORTCUT_MIN_M:
+            return None
+        if self.final_logit_softcapping is not None:
+            return None
+        if self.return_full_logits or self.use_fp32_lm_head:
+            return None
+        if sample_indices is not None:
+            return None
+        if not logits_metadata.forward_mode.is_decode_or_idle():
+            return None
+        if logits_metadata.mm_input_embeds is not None:
+            return None
+        # `next_token_logits_buffer` is always allocated under CUDA-graph
+        # capture; we just leave it unused when the shortcut fires.
+        if logits_metadata.sampler_return_logprob:
+            return None
+
+        # Capture-time override: under CUDA-graph capture we don't have a real
+        # SamplingBatchInfo (the capture ForwardBatch leaves sampling_info
+        # unset). The env flag is an explicit opt-in that asserts "serve this
+        # engine in all-greedy mode"; in that case we bake the shortcut into
+        # the captured graph and skip the runtime sampling-info checks below.
+        # At replay the graph always runs the shortcut regardless of the live
+        # sampling mode, so callers must not enable the flag for servers that
+        # also serve top-p / temperature / grammar workloads on captured shapes.
+        is_capturing = (
+            torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+        )
+        if not is_capturing:
+            sampling_info = logits_metadata.sampling_info
+            if sampling_info is None or not getattr(
+                sampling_info, "is_all_greedy", False
+            ):
+                return None
+            if getattr(sampling_info, "logit_bias", None) is not None:
+                return None
+            if getattr(sampling_info, "vocab_mask", None) is not None:
+                return None
+            if getattr(sampling_info, "grammars", None):
+                return None
+            if getattr(sampling_info, "has_custom_logit_processor", False):
+                return None
+            penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
+            if penalizer is not None and getattr(penalizer, "is_required", False):
+                return None
+
+        # lm_head must be a plain column-parallel linear without LoRA/AMX/GGUF
+        # paths, because we bypass `_compute_lm_head`'s special cases here.
+        if hasattr(lm_head, "set_lora") and hasattr(lm_head, "apply_lora"):
+            return None
+        if not hasattr(lm_head, "weight"):
+            return None
+        if use_intel_amx_backend(lm_head):
+            return None
+        if get_global_server_args().rl_on_policy_target is not None:
+            return None
+
+        tp_world = get_tensor_model_parallel_world_size()
+        # Require exact divisibility so that local shard indices are global
+        # indices modulo V_local, with no intra-shard padding to mask. This
+        # holds for Qwen3.5 FP8 (vocab 248320, TP=8 → V_local 31040) and is a
+        # strict gate; non-divisible vocabs fall back to the standard path.
+        if tp_world <= 1 or self.vocab_size % tp_world != 0:
+            return None
+        v_local = self.vocab_size // tp_world
+        if lm_head.weight.shape[0] != v_local:
+            # Padded lm_head (V_padded > V_actual / TP): the trailing rows on
+            # the last rank may produce winning argmax values. Skip.
+            return None
+
+        local_logits = torch.matmul(
+            pruned_states.to(lm_head.weight.dtype), lm_head.weight.T
+        )
+        if self.logit_scale is not None:
+            # argmax is invariant under positive scaling; still apply for
+            # bitwise equivalence with the baseline when logit_scale != 1.
+            local_logits.mul_(self.logit_scale)
+
+        return _fused_greedy_argmax_across_tp(local_logits)
 
     def _compute_lm_head(
         self,

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -113,6 +113,18 @@ class Sampler(nn.Module):
             positions: The positions of the tokens in the sequence. Used for deterministic sampling
                 to get the unique seed for each position.
         """
+        # Greedy AG+argmax shortcut: LogitsProcessor has already computed the
+        # greedy token ids via a per-rank local argmax + tiny AG of (val, idx)
+        # pairs, skipping the full-vocab AG + full-vocab argmax. Eligibility is
+        # enforced in LogitsProcessor._try_greedy_argmax_shortcut (decode-only,
+        # all_greedy, no logprobs, no penalties/masks/bias, no softcap, no DP
+        # attn / attn-TP-group gather). All we need here is to consume the ids
+        # and still run the cross-TP sync that the normal greedy path runs.
+        if logits_output.next_token_ids_shortcut is not None:
+            batch_next_token_ids = logits_output.next_token_ids_shortcut
+            self._sync_token_ids_across_tp(batch_next_token_ids, sampling_info)
+            return batch_next_token_ids
+
         logits = logits_output.next_token_logits
 
         # Preprocess logits (custom processors and NaN handling)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1372,6 +1372,11 @@ class CudaGraphRunner:
                     else None
                 ),
                 customized_info=output.customized_info,
+                next_token_ids_shortcut=(
+                    output.next_token_ids_shortcut[: self.raw_num_token]
+                    if output.next_token_ids_shortcut is not None
+                    else None
+                ),
             )
         else:
             assert isinstance(output, PPProxyTensors)

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -849,15 +849,22 @@ class PiecewiseCudaGraphRunner:
                     ):
                         mm_input_embeds = output.mm_input_embeds[: self.raw_num_tokens]
                     return LogitsProcessorOutput(
-                        next_token_logits=output.next_token_logits[
-                            : self.raw_num_tokens
-                        ],
+                        next_token_logits=(
+                            output.next_token_logits[: self.raw_num_tokens]
+                            if output.next_token_logits is not None
+                            else None
+                        ),
                         hidden_states=(
                             output.hidden_states[: self.raw_num_tokens]
                             if output.hidden_states is not None
                             else None
                         ),
                         mm_input_embeds=mm_input_embeds,
+                        next_token_ids_shortcut=(
+                            output.next_token_ids_shortcut[: self.raw_num_tokens]
+                            if output.next_token_ids_shortcut is not None
+                            else None
+                        ),
                     )
                 elif isinstance(output, EmbeddingPoolerOutput):
                     return output

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -44,7 +44,9 @@ from sglang.srt.speculative.spec_utils import (
     get_src_tgt_cache_loc,
     get_target_cache_loc,
 )
-from sglang.srt.utils import is_cuda, is_musa, next_power_of_2
+from sglang.srt.utils import is_cuda, is_hip, is_musa, next_power_of_2
+
+_is_hip = is_hip()
 
 if is_cuda() or is_musa():
     from sgl_kernel import (
@@ -272,7 +274,12 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
         sampling_info = batch.sampling_info
 
-        predict_shape = list(logits_output.next_token_logits.shape)[:-1]
+        shortcut_ids = logits_output.next_token_ids_shortcut if _is_hip else None
+        if shortcut_ids is not None:
+            target_predict = shortcut_ids.reshape(bs, self.draft_token_num)
+            predict_shape = list(target_predict.shape)
+        else:
+            predict_shape = list(logits_output.next_token_logits.shape)[:-1]
         predict_shape[-1] += 1
         predict = torch.empty(predict_shape, dtype=torch.int32, device=batch.device)
         accept_index = torch.full(
@@ -288,7 +295,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             )
 
         # Apply the custom logit processors if registered in the sampling info.
-        if sampling_info.has_custom_logit_processor:
+        if shortcut_ids is None and sampling_info.has_custom_logit_processor:
             apply_custom_logit_processor(
                 logits_output.next_token_logits,
                 sampling_info,
@@ -296,7 +303,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             )
 
         # Apply penalty
-        if (
+        if shortcut_ids is None and (
             sampling_info.penalizer_orchestrator.is_required
             or sampling_info.logit_bias is not None
         ):
@@ -312,7 +319,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 )
 
         # Apply grammar mask
-        if vocab_mask is not None:
+        if shortcut_ids is None and vocab_mask is not None:
             assert self.grammar is not None
             self.grammar.apply_vocab_mask(
                 logits=logits_output.next_token_logits, vocab_mask=vocab_mask
@@ -326,9 +333,10 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 "Falling back to greedy verification."
             )
 
-        if is_all_greedy or not TREE_SPEC_KERNEL_AVAILABLE:
-            target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
-            target_predict = target_predict.reshape(bs, self.draft_token_num)
+        if shortcut_ids is not None or is_all_greedy or not TREE_SPEC_KERNEL_AVAILABLE:
+            if shortcut_ids is None:
+                target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
+                target_predict = target_predict.reshape(bs, self.draft_token_num)
             predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
                 predicts=predict,  # mutable
                 accept_index=accept_index,  # mutable

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -352,40 +352,49 @@ class EagleVerifyInputV2Mixin:
 
         bs = len(batch.seq_lens)
         sampling_info = batch.sampling_info
-        next_token_logits = logits_output.next_token_logits
         device = batch.input_ids.device
+        shortcut_ids = logits_output.next_token_ids_shortcut if _is_hip else None
 
-        # Apply penalty
-        # This is a relaxed version of penalties for speculative decoding.
-        if sampling_info.acc_additive_penalties is not None:
-            next_token_logits.add_(
-                torch.repeat_interleave(
-                    sampling_info.acc_additive_penalties, self.draft_token_num, dim=0
-                )
-            )
-        if sampling_info.acc_scaling_penalties is not None:
-            apply_scaling_penalties(
-                next_token_logits,
-                torch.repeat_interleave(
-                    sampling_info.acc_scaling_penalties, self.draft_token_num, dim=0
-                ),
-            )
-        if sampling_info.logit_bias is not None:
-            next_token_logits.add_(
-                torch.repeat_interleave(
-                    sampling_info.logit_bias, self.draft_token_num, dim=0
-                )
-            )
+        if shortcut_ids is None:
+            next_token_logits = logits_output.next_token_logits
 
-        # Apply grammar mask if provided
-        if vocab_mask is not None:
-            assert self.grammar is not None
-            self.grammar.apply_vocab_mask(
-                logits=next_token_logits, vocab_mask=vocab_mask
-            )
+            # Apply penalty
+            # This is a relaxed version of penalties for speculative decoding.
+            if sampling_info.acc_additive_penalties is not None:
+                next_token_logits.add_(
+                    torch.repeat_interleave(
+                        sampling_info.acc_additive_penalties,
+                        self.draft_token_num,
+                        dim=0,
+                    )
+                )
+            if sampling_info.acc_scaling_penalties is not None:
+                apply_scaling_penalties(
+                    next_token_logits,
+                    torch.repeat_interleave(
+                        sampling_info.acc_scaling_penalties, self.draft_token_num, dim=0
+                    ),
+                )
+            if sampling_info.logit_bias is not None:
+                next_token_logits.add_(
+                    torch.repeat_interleave(
+                        sampling_info.logit_bias, self.draft_token_num, dim=0
+                    )
+                )
+
+            # Apply grammar mask if provided
+            if vocab_mask is not None:
+                assert self.grammar is not None
+                self.grammar.apply_vocab_mask(
+                    logits=next_token_logits, vocab_mask=vocab_mask
+                )
 
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
-        predict_shape = list(next_token_logits.shape)[:-1]
+        if shortcut_ids is not None:
+            target_predict = shortcut_ids.reshape(bs, self.draft_token_num)
+            predict_shape = list(target_predict.shape)
+        else:
+            predict_shape = list(next_token_logits.shape)[:-1]
         predict = torch.zeros(predict_shape, dtype=torch.int32, device=device).flatten()
         accept_index = torch.full(
             (bs, self.spec_steps + 1), -1, dtype=torch.int32, device=device
@@ -393,9 +402,15 @@ class EagleVerifyInputV2Mixin:
         num_correct_drafts = torch.empty((bs,), dtype=torch.int32, device=device)
 
         # Sample tokens
-        if sampling_info.is_all_greedy or _is_npu or _is_hip:
-            target_predict = torch.argmax(next_token_logits, dim=-1)
-            target_predict = target_predict.reshape(bs, self.draft_token_num)
+        if (
+            shortcut_ids is not None
+            or sampling_info.is_all_greedy
+            or _is_npu
+            or _is_hip
+        ):
+            if shortcut_ids is None:
+                target_predict = torch.argmax(next_token_logits, dim=-1)
+                target_predict = target_predict.reshape(bs, self.draft_token_num)
             predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
                 predicts=predict,  # mutable
                 accept_index=accept_index,  # mutable

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -72,6 +72,7 @@ from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
     is_cuda,
+    is_hip,
     is_musa,
     is_npu,
     log_info_on_rank0,
@@ -81,6 +82,7 @@ from sglang.srt.utils.patch_torch import monkey_patch_torch_reductions
 
 _is_npu = is_npu()
 _is_musa = is_musa()
+_is_hip = is_hip()
 
 if is_cuda():
     from sgl_kernel import segment_packbits  # noqa: F401
@@ -985,7 +987,10 @@ class EAGLEWorker(TpModelWorker):
                 # and will be applied to produce wrong results
                 batch.sampling_info.vocab_mask = None
 
-        maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
+        if not _is_hip or logits_output.next_token_logits is not None:
+            maybe_detect_nan(
+                logits_output.next_token_logits, "verify: target model logits"
+            )
 
         spec_info.hidden_states = logits_output.hidden_states
         res: EagleVerifyOutput = spec_info.verify(
@@ -998,9 +1003,10 @@ class EAGLEWorker(TpModelWorker):
 
         # Post process based on verified outputs.
         # Pick indices that we care (accepted)
-        logits_output.next_token_logits = logits_output.next_token_logits[
-            res.accept_indices
-        ]
+        if not _is_hip or logits_output.next_token_logits is not None:
+            logits_output.next_token_logits = logits_output.next_token_logits[
+                res.accept_indices
+            ]
         if logits_output.hidden_states is not None:
             logits_output.hidden_states = logits_output.hidden_states[
                 res.accept_indices

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1066,7 +1066,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 batch.sampling_info.vocab_mask = None
 
         # Sample
-        maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
+        if not _is_hip or logits_output.next_token_logits is not None:
+            maybe_detect_nan(
+                logits_output.next_token_logits, "verify: target model logits"
+            )
         (
             predict,
             accept_lens,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -57,7 +57,15 @@ from sglang.srt.speculative.spec_utils import (
     maybe_detect_nan,
     select_top_k_tokens,
 )
-from sglang.srt.utils import empty_context, get_available_gpu_memory, is_cuda, is_npu
+from sglang.srt.utils import (
+    empty_context,
+    get_available_gpu_memory,
+    is_cuda,
+    is_hip,
+    is_npu,
+)
+
+_is_hip = is_hip()
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
@@ -587,7 +595,10 @@ class MultiLayerEagleWorker(TpModelWorker):
                 # and will be applied to produce wrong results
                 batch.sampling_info.vocab_mask = None
 
-        maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
+        if not _is_hip or logits_output.next_token_logits is not None:
+            maybe_detect_nan(
+                logits_output.next_token_logits, "verify: target model logits"
+            )
 
         spec_info.hidden_states = logits_output.hidden_states
         res: EagleVerifyOutput = spec_info.verify(
@@ -600,9 +611,10 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         # Post process based on verified outputs.
         # Pick indices that we care (accepted)
-        logits_output.next_token_logits = logits_output.next_token_logits[
-            res.accept_indices
-        ]
+        if not _is_hip or logits_output.next_token_logits is not None:
+            logits_output.next_token_logits = logits_output.next_token_logits[
+                res.accept_indices
+            ]
         logits_output.hidden_states = logits_output.hidden_states[res.accept_indices]
 
         if self.target_worker.model_runner.hybrid_gdn_config is not None:

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -52,7 +52,9 @@ from sglang.srt.speculative.spec_utils import (
     maybe_detect_oob,
     select_top_k_tokens,
 )
-from sglang.srt.utils.common import empty_context, fast_topk
+from sglang.srt.utils.common import empty_context, fast_topk, is_hip
+
+_is_hip = is_hip()
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner, ModelRunnerOutput
@@ -768,7 +770,10 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         logits_output = forward_batch_output.logits_output
 
         # Sample
-        maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")
+        if not _is_hip or logits_output.next_token_logits is not None:
+            maybe_detect_nan(
+                logits_output.next_token_logits, "verify: target model logits"
+            )
         (
             predict,
             accept_lens,

--- a/test/srt/test_greedy_argmax_shortcut.py
+++ b/test/srt/test_greedy_argmax_shortcut.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Correctness and benchmark test for the greedy TP AG+argmax shortcut.
+
+Run on AMD/ROCm with tensor parallel ranks, for example:
+
+    SGLANG_AITER_AG_ARGMAX_SHORTCUT=1 \
+    PYTHONPATH=/sgl-workspace/sglang/python \
+    torchrun --nproc_per_node=4 --master_port=29510 \
+      test/srt/test_greedy_argmax_shortcut.py --benchmark
+
+The correctness test compares the shortcut against the baseline
+`tensor_model_parallel_all_gather(local_logits, dim=-1).argmax(dim=-1)`,
+including deterministic cross-rank tie cases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+
+
+def _init_dist() -> tuple[int, int, int, torch.device]:
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if not torch.cuda.is_available():
+        raise RuntimeError("This test requires a CUDA/HIP-visible device.")
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="cpu:gloo,cuda:nccl", rank=rank, world_size=world_size
+        )
+
+    import sglang.srt.distributed.parallel_state as ps
+
+    ps.init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method="env://",
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    ps.initialize_model_parallel(tensor_model_parallel_size=world_size)
+    return rank, world_size, local_rank, device
+
+
+def _time_eager(fn: Callable[[], None], iters: int, warmup: int, device: torch.device) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize(device=device)
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize(device=device)
+    return start.elapsed_time(end) / iters
+
+
+def _time_graph(fn: Callable[[], None], iters: int, warmup: int, device: torch.device) -> float:
+    from sglang.srt.distributed import graph_capture
+
+    with graph_capture() as gc:
+        stream = gc.stream
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                fn()
+        torch.cuda.synchronize(device=device)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            fn()
+
+    for _ in range(warmup):
+        graph.replay()
+    torch.cuda.synchronize(device=device)
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        graph.replay()
+    end.record()
+    torch.cuda.synchronize(device=device)
+    return start.elapsed_time(end) / iters
+
+
+def _check_correctness(
+    m_values: list[int],
+    v_local: int,
+    dtype: torch.dtype,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+) -> None:
+    from sglang.srt.distributed import tensor_model_parallel_all_gather
+    from sglang.srt.layers.logits_processor import _fused_greedy_argmax_across_tp
+    from sglang.srt.utils import is_hip
+
+    if not is_hip():
+        if rank == 0:
+            print("SKIP: greedy shortcut is AMD/HIP-only; non-HIP routes are untouched.")
+        return
+
+    for m in m_values:
+        torch.manual_seed(20260515 + rank * 17 + m)
+        local = torch.randn(m, v_local, dtype=dtype, device=device)
+        ref_full = tensor_model_parallel_all_gather(local, dim=-1)
+        ref_ids = torch.argmax(ref_full, dim=-1).to(torch.int64)
+        got_ids = _fused_greedy_argmax_across_tp(local).to(torch.int64)
+        assert torch.equal(ref_ids, got_ids), (
+            f"random correctness mismatch: M={m}, rank={rank}, "
+            f"ref={ref_ids[:8]}, got={got_ids[:8]}"
+        )
+
+        # Tie case: every rank has the same winning value at local index 0.
+        # torch.argmax over concatenated shards should pick rank 0, index 0.
+        tied = torch.zeros(m, v_local, dtype=dtype, device=device)
+        tied[:, 0] = 1.0
+        ref_full = tensor_model_parallel_all_gather(tied, dim=-1)
+        ref_ids = torch.argmax(ref_full, dim=-1).to(torch.int64)
+        got_ids = _fused_greedy_argmax_across_tp(tied).to(torch.int64)
+        expected = torch.zeros(m, dtype=torch.int64, device=device)
+        assert torch.equal(ref_ids, expected)
+        assert torch.equal(got_ids, expected), (
+            f"tie-break mismatch: M={m}, rank={rank}, got={got_ids[:8]}"
+        )
+
+    if rank == 0:
+        print(
+            f"PASS correctness: M={m_values}, V_local={v_local}, "
+            f"TP={world_size}, dtype={dtype}"
+        )
+
+
+def _run_benchmark(
+    m_values: list[int],
+    v_local: int,
+    dtype: torch.dtype,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    iters: int,
+    warmup: int,
+    csv_out: str | None,
+    graph: bool,
+) -> None:
+    from sglang.srt.distributed import tensor_model_parallel_all_gather
+    from sglang.srt.layers.logits_processor import _fused_greedy_argmax_across_tp
+    from sglang.srt.utils import is_hip
+
+    if not is_hip():
+        if rank == 0:
+            print("SKIP benchmark: greedy shortcut is AMD/HIP-only.")
+        return
+
+    rows = []
+    for m in m_values:
+        torch.manual_seed(4242 + rank * 31 + m)
+        local = torch.randn(m, v_local, dtype=dtype, device=device)
+
+        def baseline() -> None:
+            full = tensor_model_parallel_all_gather(local, dim=-1)
+            _ = torch.argmax(full, dim=-1)
+
+        def shortcut() -> None:
+            _ = _fused_greedy_argmax_across_tp(local)
+
+        base_eager = _time_eager(baseline, iters, warmup, device)
+        short_eager = _time_eager(shortcut, iters, warmup, device)
+        base_graph = short_graph = float("nan")
+        if graph:
+            base_graph = _time_graph(baseline, iters, warmup, device)
+            short_graph = _time_graph(shortcut, iters, warmup, device)
+
+        stat = torch.tensor(
+            [base_eager, short_eager, base_graph, short_graph],
+            dtype=torch.float32,
+            device=device,
+        )
+        dist.all_reduce(stat, op=dist.ReduceOp.AVG)
+        be, se, bg, sg = stat.tolist()
+        rows.append(
+            {
+                "M": m,
+                "V_local": v_local,
+                "TP": world_size,
+                "dtype": str(dtype).replace("torch.", ""),
+                "base_eager_ms": be,
+                "shortcut_eager_ms": se,
+                "eager_speedup": be / se if se > 0 else float("inf"),
+                "base_graph_ms": bg,
+                "shortcut_graph_ms": sg,
+                "graph_speedup": bg / sg if graph and sg > 0 else float("nan"),
+            }
+        )
+
+    if rank == 0:
+        print(
+            f"{'M':>6} {'base_eager':>12} {'shortcut':>12} {'eager_x':>9} "
+            f"{'base_graph':>12} {'shortcut_g':>12} {'graph_x':>9}"
+        )
+        for row in rows:
+            print(
+                f"{row['M']:>6} "
+                f"{row['base_eager_ms']:>12.4f} {row['shortcut_eager_ms']:>12.4f} "
+                f"{row['eager_speedup']:>8.2f}x "
+                f"{row['base_graph_ms']:>12.4f} {row['shortcut_graph_ms']:>12.4f} "
+                f"{row['graph_speedup']:>8.2f}x"
+            )
+        if csv_out:
+            out = Path(csv_out)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            with out.open("w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(rows)
+            print(f"Wrote benchmark CSV: {out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m-values", default="1,2,8,16,32,64,128")
+    parser.add_argument("--v-local", type=int, default=31040)
+    parser.add_argument("--dtype", choices=["bf16", "fp16", "fp32"], default="bf16")
+    parser.add_argument("--benchmark", action="store_true")
+    parser.add_argument("--no-graph", action="store_true")
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--csv-out", default="")
+    args = parser.parse_args()
+
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
+        args.dtype
+    ]
+    m_values = [int(v) for v in args.m_values.split(",") if v.strip()]
+
+    rank, world_size, _, device = _init_dist()
+    try:
+        _check_correctness(m_values, args.v_local, dtype, rank, world_size, device)
+        if args.benchmark:
+            _run_benchmark(
+                m_values=m_values,
+                v_local=args.v_local,
+                dtype=dtype,
+                rank=rank,
+                world_size=world_size,
+                device=device,
+                iters=args.iters,
+                warmup=args.warmup,
+                csv_out=args.csv_out or None,
+                graph=not args.no_graph,
+            )
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

This PR adds an AMD/HIP-only fast path for greedy decode when the LM head is tensor-parallel sharded. Instead of materializing full-vocab logits via TP all-gather and then running `torch.argmax`, each rank computes its local `max/argmax`, all-gathers only `(max_value, local_index)` pairs, and reconstructs the global token id.

The route is opt-in via:

```bash
SGLANG_AITER_AG_ARGMAX_SHORTCUT=1
SGLANG_AITER_AG_ARGMAX_SHORTCUT_MIN_M=2
```

Non-HIP platforms are explicitly gated out and continue using the existing full-logits path.

## What changed

- Added `_fused_greedy_argmax_across_tp(local_logits)` in the logits processor.
- Added `next_token_ids_shortcut` to `LogitsProcessorOutput`.
- Added sampler support for consuming precomputed greedy token ids.
- Preserved CUDA graph replay plumbing for `next_token_ids_shortcut`.
- Made EAGLE compatible:
  - Draft inputs keep full logits because draft generation needs `softmax`.
  - AMD/HIP target verification can consume `next_token_ids_shortcut` for greedy verification.
  - Non-HIP EAGLE paths keep the old full-logits assumptions.
- Added a torchrun-able correctness and benchmark test:
  - `test/srt/test_greedy_argmax_shortcut.py`

## Serving results

Server command:

```bash
SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1 \
  SGLANG_ENABLE_SPEC_V2=1 \
  ROCM_QUICK_REDUCE_QUANTIZATION=NONE \
  SGLANG_AITER_FP8_PREFILL_ATTN=1 \
  SGLANG_AITER_MLA_PERSIST=1 \
  AITER_MXFP4_MOE_SF=1 \
  SGLANG_USE_AITER=1 \
  SGLANG_INT4_WEIGHT=0 \
  SGLANG_MOE_PADDING=1 \
  SGLANG_SET_CPU_AFFINITY=1 \
  SGLANG_ROCM_FUSED_DECODE_MLA=1 \
  SGLANG_USE_ROCM700A=1 \
  SGLANG_DISABLE_FUSED_AR_MXFP4_QUANT=false \
  python3 -m sglang.launch_server \
    --model-path amd/DeepSeek-R1-MXFP4 \
    --tensor-parallel-size 4 \
    --trust-remote-code \
    --host 0.0.0.0 \
    --port 8000 \
    --mem-fraction-static 0.9 \
    --chunked-prefill-size 131072 \
    --attention-backend aiter \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --max-running-requests 32 \
    --context-length 200000 \
    --kv-cache-dtype fp8_e4m3 \
    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'
```
## Correctness gates

GSM8K on `amd/DeepSeek-R1-MXFP4`, TP=4, EAGLE enabled, AITER route:
```bash
python3 benchmark/gsm8k/bench_sglang.py \
  --num-questions 1319 \
  --parallel 1319 \
  --num-shots 5 \
  --port 8000
```
| Run | Baseline accuracy | Optimized accuracy | Optimized delta | Read |
|---:|---:|---:|---:|---|
| 1 | 0.952 | 0.948 | -0.004 | Within expected variance; passes gate |
| 2 | 0.943 | 0.945 | +0.002 | Slightly higher; passes gate |
| 3 | 0.937 | 0.944 | +0.007 | Higher; passes gate |

All optimized runs pass the required `accuracy > 0.936` gate. The optimized route is accuracy-neutral within run-to-run variance.


### `max-concurrency=2`

```bash
python3 -m sglang.bench_serving \
  --host 0.0.0.0 --port 8000 \
  --model /data/DeepSeek-R1-MXFP4-Preview/ \
  --dataset-name random \
  --random-input-len 70000 \
  --random-output-len 500 \
  --random-range-ratio 1.0 \
  --num-prompts 16 \
  --max-concurrency 2
```

Result:

```text
total token throughput: 12252.08 tok/s vs baseline 11280.16 tok/s (+8.6%)
median TPOT:            14.04 ms vs baseline 15.80 ms
```

### `max-concurrency=4`

```bash
python3 -m sglang.bench_serving \
  --host 0.0.0.0 --port 8000 \
  --model /data/DeepSeek-R1-MXFP4-Preview/ \
  --dataset-name random \
  --random-input-len 70000 \
  --random-output-len 200 \
  --random-range-ratio 1.0 \
  --num-prompts 32 \
  --max-concurrency 4
```

Result:

```text
total token throughput: 24363.59 tok/s vs baseline 23657.53 tok/s (+3.0%)
median TPOT:            32.21 ms vs baseline 30.37 ms
```

The `mc4` throughput improved while median TPOT regressed slightly; this should be called out as a tradeoff in review.

## Shared-prefix cache bench

Quick sweep using `benchmark/hicache/bench_warm_cache.py`:

```text
pcts=0,60,90,99
total_tokens=70000
output_len=500
num_prompts=16
max_concurrency=2
```

Artifacts:

```text
benchmark/hicache/bench_warm_cache.py
```

Headline deltas below are optimized versus baseline. For `TPM/GPU`, positive is an improvement because higher is better. For `median TPOT`, positive is an improvement because it means optimized is lower than baseline.

| Shared prefix | TPM/GPU delta | TPM/GPU read | Median TPOT delta | Median TPOT read |
|---:|---:|---|---:|---|
| 0% | -1.80% | Regression | -0.46% | Regression |
| 60% | +1.84% | Improvement | +11.71% | Improvement |
| 90% | +2.71% | Improvement | +0.24% | Roughly neutral / slight improvement |
| 99% | +0.98% | Improvement | +0.32% | Roughly neutral / slight improvement |

Takeaway: the shortcut is neutral-to-negative with no prefix reuse, but improves throughput once shared-prefix reuse is present. The clearest latency win is at 60% shared prefix, where median TPOT improves by 11.71%.

## Unit/benchmark test

Correctness only:

```bash
SGLANG_AITER_AG_ARGMAX_SHORTCUT=1 \
PYTHONPATH=/sgl-workspace/sglang/python \
torchrun --nproc_per_node=4 --master_port=29510 \
  test/srt/test_greedy_argmax_shortcut.py
```

Correctness plus benchmark:

```bash
SGLANG_AITER_AG_ARGMAX_SHORTCUT=1 \
PYTHONPATH=/sgl-workspace/sglang/python \
torchrun --nproc_per_node=4 --master_port=29510 \
  test/srt/test_greedy_argmax_shortcut.py \
  --benchmark \
  --m-values 1,2,8,16,32,64,128 \
  --v-local 31040 \
  --csv-out /tmp/greedy_argmax_shortcut_bench.csv
```
```
PASS correctness: M=[1, 2, 8, 16, 32, 64, 128], V_local=31040, TP=4, dtype=torch.bfloat16
     M   base_eager     shortcut   eager_x   base_graph   shortcut_g   graph_x
     1       0.0624       0.1043     0.60x       0.0520       0.0431     1.21x
     2       0.0722       0.1045     0.69x       0.0651       0.0434     1.50x
     8       0.0785       0.1050     0.75x       0.0715       0.0433     1.65x
    16       0.0898       0.1049     0.86x       0.0829       0.0442     1.87x
    32       0.1146       0.1151     1.00x       0.1073       0.0438     2.45x
    64       0.1563       0.1031     1.52x       0.1508       0.0449     3.36x
   128       0.2400       0.1021     2.35x       0.2340       0.0454     5.16x
```

The test skips shortcut execution on non-HIP devices so other hardware routes remain untouched.

## Risk and review notes

- This is AMD/HIP-only and opt-in.
- Draft-side EAGLE still requires full logits for `softmax`; the shortcut is gated off for speculative draft inputs.
- Target-side EAGLE greedy verification can consume `next_token_ids_shortcut`.
- Non-HIP EAGLE and sampler paths keep the original full-logits behavior.
- The route intentionally falls back for logprobs, full logits, logit bias, vocab masks, grammars, custom logit processors, penalties, softcapping, LoRA/AMX wrapping, DP-attention gather, and attention-TP-group gather.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->[Run #25947574729](https://github.com/sgl-project/sglang/actions/runs/25947574729)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->