### PR TITLE
[PoC][Spec] introduce DraftExecutor / SpecCoordinator ABCs; unify draft_runner naming

### DIFF
--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -1,20 +1,60 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from sglang.srt.managers.tp_worker import TpModelWorker
+    from sglang.srt.model_executor.model_runner import ModelRunner
+    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
-class BaseDraftWorker(ABC):
+class DraftExecutor(ABC):
+    """Contract for the draft-execution layer of speculative decoding.
+
+    Implementations either run the draft model on `self` (V1 monolithic
+    `EAGLEWorker(TpModelWorker, DraftExecutor)`) or wrap an inner draft
+    `TpModelWorker` (V2 `EagleDraftWorker`). `draft_runner` is the canonical
+    accessor; shape classmethods on `EagleDraftInput` / `EagleDraftExtendInput`
+    read it directly.
+    """
+
+    @property
     @abstractmethod
-    def draft():
-        pass
+    def draft_runner(self) -> Optional["ModelRunner"]:
+        """Primary draft `ModelRunner`. `None` for algorithms with no draft model
+        (e.g. NGRAM); for multi-layer algorithms, points to layer 0."""
+
+    @property
+    @abstractmethod
+    def target_worker(self) -> "TpModelWorker": ...
+
+    @property
+    @abstractmethod
+    def speculative_algorithm(self) -> "SpeculativeAlgorithm": ...
+
+    @property
+    @abstractmethod
+    def eagle_use_aux_hidden_state(self) -> bool:
+        """Whether the draft model consumes EAGLE3 auxiliary hidden states.
+        Always False outside EAGLE3 (e.g. Frozen-KV MTP, standalone)."""
 
     @abstractmethod
-    def draft_extend():
-        pass
+    def init_attention_backend(self) -> None: ...
+
+    @abstractmethod
+    def init_cuda_graphs(self) -> None: ...
+
+    # NOTE: V2 draft executors (`EagleDraftWorker`, `MultiLayerEagleDraftWorker`)
+    # additionally expose `draft(...)` and `draft_extend(...)` as their per-phase
+    # entry points. V1 monolithic workers (`EAGLEWorker` & subclasses) drive both
+    # phases internally from `forward_batch_generation`; they do not expose those
+    # methods. Formalizing the per-phase signature is left to a later step where
+    # V1 is split into coordinator + executor.
+
+
+# Backward-compat alias; existing V2 subclasses continue to inherit through this name.
+BaseDraftWorker = DraftExecutor
 
 
 class BaseSpecWorker(ABC):
@@ -25,7 +65,7 @@ class BaseSpecWorker(ABC):
 
     @property
     @abstractmethod
-    def draft_worker(self) -> BaseDraftWorker:
+    def draft_worker(self) -> DraftExecutor:
         pass
 
     @abstractmethod
@@ -37,6 +77,6 @@ class BaseSpecWorker(ABC):
         """Hook called after verify finishes and accept counts are on CPU.
 
         Default no-op. Adaptive-aware workers override this to feed the
-        controller without forcing a GPU→CPU sync in the worker hot path.
+        controller without forcing a GPU -> CPU sync in the worker hot path.
         """
         pass

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -53,25 +53,75 @@ class DraftExecutor(ABC):
     # V1 is split into coordinator + executor.
 
 
+class NullDraftExecutor(DraftExecutor):
+    """Concrete no-op `DraftExecutor` for algorithms that derive draft tokens
+    without running a draft model (e.g. `NGRAM` corpus lookup).
+
+    The host `SpecCoordinator` keeps a reference to a `NullDraftExecutor` so the
+    coordinator/executor type contract holds uniformly across all spec
+    algorithms — the draft side is simply absent rather than duck-typed.
+    """
+
+    def __init__(
+        self,
+        target_worker: "TpModelWorker",
+        speculative_algorithm: "SpeculativeAlgorithm",
+    ):
+        self._target_worker = target_worker
+        self._speculative_algorithm = speculative_algorithm
+
+    @property
+    def draft_runner(self) -> None:
+        return None
+
+    @property
+    def target_worker(self) -> "TpModelWorker":
+        return self._target_worker
+
+    @property
+    def speculative_algorithm(self) -> "SpeculativeAlgorithm":
+        return self._speculative_algorithm
+
+    @property
+    def eagle_use_aux_hidden_state(self) -> bool:
+        return False
+
+    def init_attention_backend(self) -> None:
+        pass
+
+    def init_cuda_graphs(self) -> None:
+        pass
+
+
 # Backward-compat alias; existing V2 subclasses continue to inherit through this name.
 BaseDraftWorker = DraftExecutor
 
 
-class BaseSpecWorker(ABC):
-    @property
-    @abstractmethod
-    def target_worker(self) -> TpModelWorker:
-        pass
+class SpecCoordinator(ABC):
+    """Contract for the spec-pipeline-coordinating layer.
+
+    A `SpecCoordinator` drives the draft / verify / extend pipeline. It holds a
+    `target_worker` (target model) and a `draft_worker` (a `DraftExecutor`,
+    possibly `self` for V1 monolithic workers, or `NullDraftExecutor` for
+    no-draft-model algorithms).
+    """
 
     @property
     @abstractmethod
-    def draft_worker(self) -> DraftExecutor:
-        pass
+    def target_worker(self) -> "TpModelWorker": ...
+
+    @property
+    @abstractmethod
+    def draft_worker(self) -> DraftExecutor: ...
+
+    @property
+    @abstractmethod
+    def speculative_algorithm(self) -> "SpeculativeAlgorithm": ...
 
     @abstractmethod
-    def clear_cache_pool(self):
+    def clear_cache_pool(self) -> None:
         # TODO: move this abstract method to BaseTpWorker and call through self.model_runner
-        pass
+        ...
 
     def on_verify_complete_cpu(self, num_correct_drafts_per_req: list[int]) -> None:
         """Hook called after verify finishes and accept counts are on CPU.
@@ -80,3 +130,12 @@ class BaseSpecWorker(ABC):
         controller without forcing a GPU -> CPU sync in the worker hot path.
         """
         pass
+
+    # NOTE: `forward_batch_generation(...)` is the pipeline entry point but its
+    # signature is split (`ScheduleBatch` on V1 / `NGRAM`, `ModelWorkerBatch` on
+    # V2 / DFlash). Formalizing it as abstract is left to a later step that
+    # unifies the input type.
+
+
+# Backward-compat alias; pre-existing call sites keep working.
+BaseSpecWorker = SpecCoordinator

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -17,27 +17,25 @@ class DraftExecutor(ABC):
     `TpModelWorker` (V2 `EagleDraftWorker`). `draft_runner` is the canonical
     accessor; shape classmethods on `EagleDraftInput` / `EagleDraftExtendInput`
     read it directly.
+
+    The fields below (`target_worker`, `speculative_algorithm`,
+    `eagle_use_aux_hidden_state`) are declared as type annotations rather than
+    `@abstractmethod` properties because subclasses set them as instance attrs
+    in `__init__`; Python ABC would reject instance attrs as a valid override
+    of a strict abstract property.
     """
+
+    target_worker: "TpModelWorker"
+    speculative_algorithm: "SpeculativeAlgorithm"
+    # Whether the draft model consumes EAGLE3 auxiliary hidden states. Always
+    # False outside EAGLE3 (e.g. Frozen-KV MTP, standalone).
+    eagle_use_aux_hidden_state: bool
 
     @property
     @abstractmethod
     def draft_runner(self) -> Optional["ModelRunner"]:
         """Primary draft `ModelRunner`. `None` for algorithms with no draft model
         (e.g. NGRAM); for multi-layer algorithms, points to layer 0."""
-
-    @property
-    @abstractmethod
-    def target_worker(self) -> "TpModelWorker": ...
-
-    @property
-    @abstractmethod
-    def speculative_algorithm(self) -> "SpeculativeAlgorithm": ...
-
-    @property
-    @abstractmethod
-    def eagle_use_aux_hidden_state(self) -> bool:
-        """Whether the draft model consumes EAGLE3 auxiliary hidden states.
-        Always False outside EAGLE3 (e.g. Frozen-KV MTP, standalone)."""
 
     @abstractmethod
     def init_attention_backend(self) -> None: ...
@@ -104,19 +102,17 @@ class SpecCoordinator(ABC):
     `target_worker` (target model) and a `draft_worker` (a `DraftExecutor`,
     possibly `self` for V1 monolithic workers, or `NullDraftExecutor` for
     no-draft-model algorithms).
+
+    `target_worker` and `speculative_algorithm` are declared as type annotations
+    rather than abstract properties — see `DraftExecutor` for the same rationale.
     """
 
-    @property
-    @abstractmethod
-    def target_worker(self) -> "TpModelWorker": ...
+    target_worker: "TpModelWorker"
+    speculative_algorithm: "SpeculativeAlgorithm"
 
     @property
     @abstractmethod
     def draft_worker(self) -> DraftExecutor: ...
-
-    @property
-    @abstractmethod
-    def speculative_algorithm(self) -> "SpeculativeAlgorithm": ...
 
     @abstractmethod
     def clear_cache_pool(self) -> None:

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -156,10 +156,10 @@ class DFlashWorker:
             memory_pool_config=target_worker.model_runner.memory_pool_config,
         )
         set_global_server_args_for_scheduler(saved_server_args)
-        self.draft_model_runner = self.draft_worker.model_runner
-        self.draft_model = self.draft_model_runner.model
+        self.draft_runner = self.draft_worker.model_runner
+        self.draft_model = self.draft_runner.model
         draft_config = parse_dflash_draft_config(
-            draft_hf_config=self.draft_model_runner.model_config.hf_config
+            draft_hf_config=self.draft_runner.model_config.hf_config
         )
         if server_args.speculative_num_draft_tokens is None:
             # Should not happen (ServerArgs should have inferred it), but keep a fallback.
@@ -597,7 +597,7 @@ class DFlashWorker:
 
         seq_lens_cpu = self._draft_seq_lens_cpu_buf[:bs]
         seq_lens_cpu.copy_(draft_prefix_lens.to(device="cpu", dtype=torch.int32))
-        allocator = self.draft_model_runner.token_to_kv_pool_allocator
+        allocator = self.draft_runner.token_to_kv_pool_allocator
         token_to_kv_pool_state_backup = allocator.backup_state()
         try:
             if self.page_size == 1:
@@ -605,7 +605,7 @@ class DFlashWorker:
             else:
                 block_end_cpu = seq_lens_cpu + int(self.block_size)
                 last_loc = get_last_loc(
-                    self.draft_model_runner.req_to_token_pool.req_to_token,
+                    self.draft_runner.req_to_token_pool.req_to_token,
                     batch.req_pool_indices,
                     block_start,
                 )
@@ -624,7 +624,7 @@ class DFlashWorker:
 
             assign_req_to_token_pool_func(
                 batch.req_pool_indices,
-                self.draft_model_runner.req_to_token_pool.req_to_token,
+                self.draft_runner.req_to_token_pool.req_to_token,
                 block_start,
                 block_end,
                 block_cache_loc,
@@ -647,9 +647,9 @@ class DFlashWorker:
                 seq_lens_sum=seq_lens_sum,
                 seq_lens_cpu=seq_lens_cpu,
                 positions=positions,
-                req_to_token_pool=self.draft_model_runner.req_to_token_pool,
-                token_to_kv_pool=self.draft_model_runner.token_to_kv_pool,
-                attn_backend=self.draft_model_runner.attn_backend,
+                req_to_token_pool=self.draft_runner.req_to_token_pool,
+                token_to_kv_pool=self.draft_runner.token_to_kv_pool,
+                attn_backend=self.draft_runner.attn_backend,
                 input_embeds=input_embeds,
                 spec_algorithm=SpeculativeAlgorithm.DFLASH,
                 spec_info=draft_spec_info,
@@ -657,7 +657,7 @@ class DFlashWorker:
             )
 
             with torch.inference_mode():
-                draft_logits_output = self.draft_model_runner.forward(
+                draft_logits_output = self.draft_runner.forward(
                     forward_batch
                 ).logits_output
         finally:
@@ -907,7 +907,7 @@ class DFlashWorker:
             return
 
         target_req_to_token = batch.req_to_token_pool.req_to_token
-        draft_req_to_token = self.draft_model_runner.req_to_token_pool.req_to_token
+        draft_req_to_token = self.draft_runner.req_to_token_pool.req_to_token
 
         req_pool_indices = batch.req_pool_indices
         if req_pool_indices.dtype != torch.int64:
@@ -1025,7 +1025,7 @@ class DFlashWorker:
             k = attn.apply_k_rope(ctx_positions, k)
             k = k.view(-1, attn.num_kv_heads, attn.head_dim)
             v = v.view(-1, attn.num_kv_heads, attn.head_dim)
-            self.draft_model_runner.token_to_kv_pool.set_kv_buffer(
+            self.draft_runner.token_to_kv_pool.set_kv_buffer(
                 attn.attn,
                 ctx_cache_loc,
                 k,
@@ -1041,7 +1041,7 @@ class DFlashWorker:
         ctx_cache_loc: torch.Tensor,
     ) -> None:
         """Fused KV materialization using batched projection + Triton kernel."""
-        token_to_kv_pool = self.draft_model_runner.token_to_kv_pool
+        token_to_kv_pool = self.draft_runner.token_to_kv_pool
         layers = self.draft_model.layers
 
         def _write_layer_kv(

--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -20,6 +20,7 @@ from sglang.srt.server_args import (
     get_global_server_args,
     set_global_server_args_for_scheduler,
 )
+from sglang.srt.speculative.base_spec_worker import DraftExecutor, SpecCoordinator
 from sglang.srt.speculative.dflash_info import DFlashDraftInput, DFlashVerifyInput
 from sglang.srt.speculative.dflash_utils import (
     can_dflash_use_fused_qkv_proj,
@@ -47,7 +48,50 @@ def _get_fused_kv_materialize_helper():
     return _FusedKVMaterializeHelper
 
 
-class DFlashWorker:
+class DFlashDraftExecutor(DraftExecutor):
+    """DraftExecutor wrapping the inner draft `TpModelWorker` used by DFlash.
+
+    Holds a reference to the inner draft TpModelWorker; exposes the canonical
+    `draft_runner` accessor expected by spec-info shape classmethods. DFlash's
+    attention-backend / cuda-graph setup remains driven by the coordinator (it
+    is intertwined with the verify pipeline), so this executor's
+    `init_*` methods are no-ops.
+    """
+
+    def __init__(
+        self,
+        inner_tp: TpModelWorker,
+        target_worker: TpModelWorker,
+        speculative_algorithm: SpeculativeAlgorithm,
+    ):
+        self._inner_tp = inner_tp
+        self._target_worker = target_worker
+        self._speculative_algorithm = speculative_algorithm
+
+    @property
+    def draft_runner(self):
+        return self._inner_tp.model_runner
+
+    @property
+    def target_worker(self) -> TpModelWorker:
+        return self._target_worker
+
+    @property
+    def speculative_algorithm(self) -> SpeculativeAlgorithm:
+        return self._speculative_algorithm
+
+    @property
+    def eagle_use_aux_hidden_state(self) -> bool:
+        return False
+
+    def init_attention_backend(self) -> None:
+        pass
+
+    def init_cuda_graphs(self) -> None:
+        pass
+
+
+class DFlashSpecCoordinator(SpecCoordinator):
     """DFlash speculative decoding worker (spec-v1, tp>=1/pp=1)."""
 
     def __init__(
@@ -72,6 +116,9 @@ class DFlashWorker:
         self.nccl_port = nccl_port
         self.target_worker = target_worker
         self.model_runner = target_worker.model_runner
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
         self.page_size = server_args.page_size
         self.draft_window_size: Optional[int] = (
             int(server_args.speculative_draft_window_size)
@@ -140,7 +187,7 @@ class DFlashWorker:
             target_worker.model_runner.model_config.context_len
         )
         saved_server_args = get_global_server_args()
-        self.draft_worker = TpModelWorker(
+        self._inner_tp = TpModelWorker(
             server_args=draft_server_args,
             gpu_id=gpu_id,
             tp_rank=tp_rank,
@@ -156,7 +203,10 @@ class DFlashWorker:
             memory_pool_config=target_worker.model_runner.memory_pool_config,
         )
         set_global_server_args_for_scheduler(saved_server_args)
-        self.draft_runner = self.draft_worker.model_runner
+        self.draft_runner = self._inner_tp.model_runner
+        self._draft_executor: DraftExecutor = DFlashDraftExecutor(
+            self._inner_tp, target_worker, self.speculative_algorithm
+        )
         self.draft_model = self.draft_runner.model
         draft_config = parse_dflash_draft_config(
             draft_hf_config=self.draft_runner.model_config.hf_config
@@ -342,6 +392,10 @@ class DFlashWorker:
     def __getattr__(self, name):
         # Delegate anything not implemented yet to the target worker.
         return getattr(self.target_worker, name)
+
+    @property
+    def draft_worker(self) -> DraftExecutor:
+        return self._draft_executor
 
     def clear_cache_pool(self):
         # The target worker owns the shared KV allocator/cache. For the compact
@@ -1254,3 +1308,7 @@ class DFlashWorker:
             num_correct_drafts_per_req_cpu=num_correct_drafts_per_req_cpu,
             can_run_cuda_graph=can_run_cuda_graph,
         )
+
+
+# Pre-rename alias; existing call sites keep importing `DFlashWorker`.
+DFlashWorker = DFlashSpecCoordinator

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -10,12 +10,12 @@ class DraftBackendFactory:
     def __init__(
         self,
         server_args: ServerArgs,
-        draft_model_runner,
+        draft_runner,
         topk: int,
         speculative_num_steps: int,
     ):
         self.server_args = server_args
-        self.draft_model_runner = draft_model_runner
+        self.draft_runner = draft_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.draft_attn_backend = server_args.speculative_draft_attention_backend
@@ -103,13 +103,13 @@ class DraftBackendFactory:
         )
 
         return NativeSparseAttnMultiStepBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_nsa_prefill_backend(self):
         from sglang.srt.layers.attention.nsa_backend import NativeSparseAttnBackend
 
-        return NativeSparseAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return NativeSparseAttnBackend(self.draft_runner, skip_prefill=False)
 
     def _create_flashinfer_decode_backend(self):
         if not get_global_server_args().use_mla_backend:
@@ -118,7 +118,7 @@ class DraftBackendFactory:
             )
 
             return FlashInferMultiStepDraftBackend(
-                self.draft_model_runner, self.topk, self.speculative_num_steps
+                self.draft_runner, self.topk, self.speculative_num_steps
             )
         else:
             from sglang.srt.layers.attention.flashinfer_mla_backend import (
@@ -126,7 +126,7 @@ class DraftBackendFactory:
             )
 
             return FlashInferMLAMultiStepDraftBackend(
-                self.draft_model_runner, self.topk, self.speculative_num_steps
+                self.draft_runner, self.topk, self.speculative_num_steps
             )
 
     def _create_triton_decode_backend(self):
@@ -135,14 +135,14 @@ class DraftBackendFactory:
         )
 
         return TritonMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_aiter_decode_backend(self):
         from sglang.srt.layers.attention.aiter_backend import AiterMultiStepDraftBackend
 
         return AiterMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_fa_decode_backend(self, fa_impl_ver: int = 3):
@@ -156,7 +156,7 @@ class DraftBackendFactory:
             )
 
         return FlashAttentionMultiStepBackend(
-            self.draft_model_runner,
+            self.draft_runner,
             self.topk,
             self.speculative_num_steps,
             fa_impl_ver=fa_impl_ver,
@@ -174,7 +174,7 @@ class DraftBackendFactory:
         )
 
         return FlashMLAMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_trtllm_mha_decode_backend(self):
@@ -183,7 +183,7 @@ class DraftBackendFactory:
         )
 
         return TRTLLMHAAttnMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_trtllm_mla_decode_backend(self):
@@ -197,7 +197,7 @@ class DraftBackendFactory:
         )
 
         return TRTLLMMLAMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_tokenspeed_mla_decode_backend(self):
@@ -211,7 +211,7 @@ class DraftBackendFactory:
         )
 
         return TokenspeedMLAMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_ascend_decode_backend(self):
@@ -220,7 +220,7 @@ class DraftBackendFactory:
         )
 
         return AscendAttnMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_dsv4_decode_backend(self):
@@ -229,7 +229,7 @@ class DraftBackendFactory:
         )
 
         return DeepseekV4MultiStepBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+            self.draft_runner, self.topk, self.speculative_num_steps
         )
 
     def _create_flashinfer_prefill_backend(self):
@@ -238,23 +238,23 @@ class DraftBackendFactory:
                 FlashInferAttnBackend,
             )
 
-            return FlashInferAttnBackend(self.draft_model_runner, skip_prefill=False)
+            return FlashInferAttnBackend(self.draft_runner, skip_prefill=False)
         else:
             from sglang.srt.layers.attention.flashinfer_mla_backend import (
                 FlashInferMLAAttnBackend,
             )
 
-            return FlashInferMLAAttnBackend(self.draft_model_runner, skip_prefill=False)
+            return FlashInferMLAAttnBackend(self.draft_runner, skip_prefill=False)
 
     def _create_triton_prefill_backend(self):
         from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 
-        return TritonAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return TritonAttnBackend(self.draft_runner, skip_prefill=False)
 
     def _create_aiter_prefill_backend(self):
         from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
 
-        return AiterAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return AiterAttnBackend(self.draft_runner, skip_prefill=False)
 
     def _create_fa_prefill_backend(self, fa_impl_ver: int = 3):
         if not is_musa():
@@ -266,7 +266,7 @@ class DraftBackendFactory:
                 MusaFlashAttentionBackend as FlashAttentionBackend,
             )
         return FlashAttentionBackend(
-            self.draft_model_runner, skip_prefill=False, fa_impl_ver=fa_impl_ver
+            self.draft_runner, skip_prefill=False, fa_impl_ver=fa_impl_ver
         )
 
     def _create_fa3_prefill_backend(self):
@@ -278,7 +278,7 @@ class DraftBackendFactory:
     def _create_trtllm_mha_prefill_backend(self):
         from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
 
-        return TRTLLMHAAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return TRTLLMHAAttnBackend(self.draft_runner, skip_prefill=False)
 
     def _create_trtllm_mla_prefill_backend(self):
         if not get_global_server_args().use_mla_backend:
@@ -288,7 +288,7 @@ class DraftBackendFactory:
 
         from sglang.srt.layers.attention.trtllm_mla_backend import TRTLLMMLABackend
 
-        return TRTLLMMLABackend(self.draft_model_runner, skip_prefill=False)
+        return TRTLLMMLABackend(self.draft_runner, skip_prefill=False)
 
     def _create_tokenspeed_mla_prefill_backend(self):
         if not get_global_server_args().use_mla_backend:
@@ -300,14 +300,14 @@ class DraftBackendFactory:
             TokenspeedMLABackend,
         )
 
-        return TokenspeedMLABackend(self.draft_model_runner, skip_prefill=False)
+        return TokenspeedMLABackend(self.draft_runner, skip_prefill=False)
 
     def _create_ascend_prefill_backend(self):
         from sglang.srt.hardware_backend.npu.attention.ascend_backend import (
             AscendAttnBackend,
         )
 
-        return AscendAttnBackend(self.draft_model_runner)
+        return AscendAttnBackend(self.draft_runner)
 
     def _create_flashmla_prefill_backend(self):
         logger.warning(
@@ -320,4 +320,4 @@ class DraftBackendFactory:
             DeepseekV4AttnBackend,
         )
 
-        return DeepseekV4AttnBackend(self.draft_model_runner, skip_prefill=False)
+        return DeepseekV4AttnBackend(self.draft_runner, skip_prefill=False)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -68,11 +68,7 @@ class EAGLEDraftCudaGraphRunner:
     ):
         # Parse args
         self.eagle_worker = eagle_worker
-        if not hasattr(eagle_worker, "model_runner"):
-            # V2: EagleDraftWorker
-            self.model_runner = model_runner = eagle_worker.draft_runner
-        else:
-            self.model_runner = model_runner = eagle_worker.model_runner
+        self.model_runner = model_runner = eagle_worker.draft_runner
         self.graphs = {}
         self.output_buffers = {}
         self.enable_torch_compile = model_runner.server_args.enable_torch_compile

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -67,13 +67,14 @@ class EAGLEDraftExtendCudaGraphRunner:
     ):
         # Parse args
         self.eagle_worker = eagle_worker
-        if not hasattr(eagle_worker, "model_runner"):
-            # V2: EagleDraftWorker
-            self.model_runner = model_runner = eagle_worker.draft_runner
-            self.forward_mode = ForwardMode.DRAFT_EXTEND_V2
-        else:
-            self.model_runner = model_runner = eagle_worker.model_runner
+        self.model_runner = model_runner = eagle_worker.draft_runner
+        # V1 `EAGLEWorker(TpModelWorker)` has `.model_runner`; V2 `EagleDraftWorker`
+        # wraps an inner `TpModelWorker` and does not. Used here only to pick the
+        # correct ForwardMode for draft extend.
+        if hasattr(eagle_worker, "model_runner"):
             self.forward_mode = ForwardMode.DRAFT_EXTEND
+        else:
+            self.forward_mode = ForwardMode.DRAFT_EXTEND_V2
 
         self.graphs = {}
         self.output_buffers = {}

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -26,6 +26,7 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.server_args import get_global_server_args
+from sglang.srt.speculative.base_spec_worker import DraftExecutor
 from sglang.srt.speculative.eagle_info_v2 import (
     EagleDraftExtendInputV2Mixin,
     EagleDraftInputV2Mixin,
@@ -715,7 +716,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             pt += extend_len
 
     @classmethod
-    def hidden_size_for(cls, worker) -> Optional[int]:
+    def hidden_size_for(cls, worker: DraftExecutor) -> Optional[int]:
         """Decode-phase `hidden_states` width: draft self-chain output
         (draft model writes its own last hidden back via `capture_for_decode`
         and the draft loop). Returns None when the draft architecture doesn't
@@ -725,7 +726,7 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
         return worker.draft_runner.model_config.spec_hidden_size
 
     @classmethod
-    def dtype_for(cls, worker) -> Optional[torch.dtype]:
+    def dtype_for(cls, worker: DraftExecutor) -> Optional[torch.dtype]:
         if worker.speculative_algorithm.is_standalone():
             return None
         return worker.draft_runner.model_config.dtype
@@ -864,7 +865,7 @@ class EagleDraftExtendInput(SpecInput, EagleDraftExtendInputV2Mixin):
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
     @classmethod
-    def hidden_size_for(cls, worker) -> Optional[int]:
+    def hidden_size_for(cls, worker: DraftExecutor) -> Optional[int]:
         """Extend-phase `hidden_states` width: target's `spec_hidden_size`,
         widened to `num_aux * target_hidden` for EAGLE-3 aux mode. Returns
         None when the draft architecture doesn't consume the field
@@ -891,7 +892,7 @@ class EagleDraftExtendInput(SpecInput, EagleDraftExtendInputV2Mixin):
         return target_hidden * num_aux
 
     @classmethod
-    def dtype_for(cls, worker) -> Optional[torch.dtype]:
+    def dtype_for(cls, worker: DraftExecutor) -> Optional[torch.dtype]:
         if worker.speculative_algorithm.is_standalone():
             return None
         return worker.target_worker.model_runner.model_config.dtype

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -57,18 +57,6 @@ if is_cuda() or is_musa():
 logger = logging.getLogger(__name__)
 
 
-def _draft_runner_of(worker):
-    """Draft model_runner accessor that handles v1 / v2 worker naming.
-
-    v1 (`EAGLEWorker` and subclasses) exposes the draft model_runner as
-    `model_runner` (the worker itself runs the draft model);
-    v2 (`EagleDraftWorker` and subclasses) exposes it as `draft_runner`.
-    """
-    return (
-        worker.draft_runner if hasattr(worker, "draft_runner") else worker.model_runner
-    )
-
-
 @dataclass
 class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
     draft_token: torch.Tensor
@@ -734,13 +722,13 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
         consume the field (e.g., STANDALONE)."""
         if worker.speculative_algorithm.is_standalone():
             return None
-        return _draft_runner_of(worker).model_config.spec_hidden_size
+        return worker.draft_runner.model_config.spec_hidden_size
 
     @classmethod
     def dtype_for(cls, worker) -> Optional[torch.dtype]:
         if worker.speculative_algorithm.is_standalone():
             return None
-        return _draft_runner_of(worker).model_config.dtype
+        return worker.draft_runner.model_config.dtype
 
     @classmethod
     def create_idle_input(

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -184,7 +184,7 @@ class EagleDraftInputV2Mixin:
         req_to_token_pool: ReqToTokenPool,
         batch: ModelWorkerBatch,
         cuda_graph_runner: EAGLEDraftCudaGraphRunner,
-        draft_model_runner: ModelRunner,
+        draft_runner: ModelRunner,
         topk: int,
         num_steps: int,
     ):
@@ -213,12 +213,12 @@ class EagleDraftInputV2Mixin:
         self.num_tokens_for_logprob_per_req = topk
         capture_mode = (
             CaptureHiddenMode.NULL
-            if draft_model_runner.spec_algorithm.is_standalone()
+            if draft_runner.spec_algorithm.is_standalone()
             else CaptureHiddenMode.LAST
         )
         batch.capture_hidden_mode = capture_mode
         self.positions = batch.seq_lens.repeat_interleave(topk, dim=0)
-        forward_batch = ForwardBatch.init_new(batch, draft_model_runner)
+        forward_batch = ForwardBatch.init_new(batch, draft_runner)
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         return forward_batch, can_cuda_graph
 
@@ -230,7 +230,7 @@ class EagleDraftExtendInputV2Mixin:
         batch: ModelWorkerBatch,
         predict: torch.Tensor,
         num_draft_tokens: int,
-        draft_model_runner: Any,
+        draft_runner: Any,
         cuda_graph_runner: Any,
     ):
         # Caller is responsible for `batch.spec_info = self` before calling.
@@ -247,7 +247,7 @@ class EagleDraftExtendInputV2Mixin:
         batch.extend_num_tokens = extend_num_tokens
         capture_mode = (
             CaptureHiddenMode.NULL
-            if draft_model_runner.spec_algorithm.is_standalone()
+            if draft_runner.spec_algorithm.is_standalone()
             else CaptureHiddenMode.FULL
         )
         batch.capture_hidden_mode = capture_mode
@@ -256,10 +256,10 @@ class EagleDraftExtendInputV2Mixin:
             if batch.forward_mode.is_idle()
             else ForwardMode.DRAFT_EXTEND_V2
         )
-        forward_batch = ForwardBatch.init_new(batch, draft_model_runner)
+        forward_batch = ForwardBatch.init_new(batch, draft_runner)
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:
-            draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
+            draft_runner.attn_backend.init_forward_metadata(forward_batch)
         return forward_batch
 
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -37,6 +37,7 @@ from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
     SpecRuntimeState,
 )
+from sglang.srt.speculative.base_spec_worker import DraftExecutor
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
@@ -87,7 +88,7 @@ if is_cuda():
 logger = logging.getLogger(__name__)
 
 
-class EAGLEWorker(TpModelWorker):
+class EAGLEWorker(TpModelWorker, DraftExecutor):
 
     def __init__(
         self,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -179,16 +179,16 @@ class EAGLEWorker(TpModelWorker):
             # most cases EAGLE3 models don't share lm_head
             # but some models (e.g. nvidia/gpt-oss-120b-Eagle3) shares
             if (
-                hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
-                and self.draft_model_runner.model.load_lm_head_from_target
+                hasattr(self.draft_runner.model, "load_lm_head_from_target")
+                and self.draft_runner.model.load_lm_head_from_target
             ):
-                self.draft_model_runner.model.set_embed_and_head(embed, head)
+                self.draft_runner.model.set_embed_and_head(embed, head)
             else:
-                self.draft_model_runner.model.set_embed(embed)
+                self.draft_runner.model.set_embed(embed)
 
             # grab hot token ids
-            if self.draft_model_runner.model.hot_token_id is not None:
-                self.hot_token_id = self.draft_model_runner.model.hot_token_id.to(
+            if self.draft_runner.model.hot_token_id is not None:
+                self.hot_token_id = self.draft_runner.model.hot_token_id.to(
                     embed.device
                 )
 
@@ -199,12 +199,10 @@ class EAGLEWorker(TpModelWorker):
                 head.data = head.data[self.hot_token_id]
 
             # Share the embedding and lm_head
-            self.draft_model_runner.model.set_embed_and_head(embed, head)
+            self.draft_runner.model.set_embed_and_head(embed, head)
 
         # Init attention backend and cuda graphs
-        self.draft_model_runner.server_args.disable_cuda_graph = (
-            backup_disable_cuda_graph
-        )
+        self.draft_runner.server_args.disable_cuda_graph = backup_disable_cuda_graph
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
@@ -212,13 +210,13 @@ class EAGLEWorker(TpModelWorker):
         if self.speculative_algorithm.is_eagle3():
             self.eagle_use_aux_hidden_state = True
             eagle_config = getattr(
-                self.draft_model_runner.model_config.hf_config, "eagle_config", {}
+                self.draft_runner.model_config.hf_config, "eagle_config", {}
             )
             self.eagle_use_aux_hidden_state = eagle_config.get(
                 "use_aux_hidden_state", True
             )
         with (
-            self.draft_tp_context(self.draft_model_runner.tp_group),
+            self.draft_tp_context(self.draft_runner.tp_group),
             speculative_moe_backend_context(),
             speculative_moe_a2a_backend_context(),
         ):
@@ -249,7 +247,7 @@ class EAGLEWorker(TpModelWorker):
         # Create multi-step attn backends and cuda graph runners
         draft_backend_factory = DraftBackendFactory(
             self.server_args,
-            self.draft_model_runner,
+            self.draft_runner,
             self.topk,
             self.speculative_num_steps,
         )
@@ -262,7 +260,7 @@ class EAGLEWorker(TpModelWorker):
             draft_backend_factory.create_draft_extend_backend()
         )
 
-        self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
+        self.draft_runner.draft_attn_backend = self.draft_attn_backend
 
     def init_cuda_graphs(self):
         """Capture cuda graphs."""
@@ -328,7 +326,7 @@ class EAGLEWorker(TpModelWorker):
         self.speculative_num_draft_tokens = state.speculative_num_draft_tokens
         # Draft stage
         self.draft_attn_backend = state.draft_attn_backend
-        self.draft_model_runner.draft_attn_backend = state.draft_attn_backend
+        self.draft_runner.draft_attn_backend = state.draft_attn_backend
         self.cuda_graph_runner = state.cuda_graph_runner
         # Verify stage
         self.target_worker.model_runner.attn_backend = state.target_attn_backend
@@ -412,7 +410,7 @@ class EAGLEWorker(TpModelWorker):
             self.speculative_num_draft_tokens,
             self.draft_attn_backend,
             self.draft_extend_attn_backend,
-            self.draft_model_runner.draft_attn_backend,
+            self.draft_runner.draft_attn_backend,
             self.cuda_graph_runner,
             self.cuda_graph_runner_for_draft_extend,
             sa.speculative_num_steps,
@@ -430,7 +428,7 @@ class EAGLEWorker(TpModelWorker):
                 self.speculative_num_draft_tokens,
                 self.draft_attn_backend,
                 self.draft_extend_attn_backend,
-                self.draft_model_runner.draft_attn_backend,
+                self.draft_runner.draft_attn_backend,
                 self.cuda_graph_runner,
                 self.cuda_graph_runner_for_draft_extend,
                 sa.speculative_num_steps,
@@ -438,7 +436,7 @@ class EAGLEWorker(TpModelWorker):
             ) = backup
 
     @property
-    def draft_model_runner(self):
+    def draft_runner(self):
         return self.model_runner
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
@@ -461,7 +459,7 @@ class EAGLEWorker(TpModelWorker):
                 can_run_cuda_graph,
             ) = self.forward_target_extend(batch)
             with (
-                self.draft_tp_context(self.draft_model_runner.tp_group),
+                self.draft_tp_context(self.draft_runner.tp_group),
                 speculative_moe_backend_context(),
                 speculative_moe_a2a_backend_context(),
             ):
@@ -483,7 +481,7 @@ class EAGLEWorker(TpModelWorker):
             set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
 
             with (
-                self.draft_tp_context(self.draft_model_runner.tp_group),
+                self.draft_tp_context(self.draft_runner.tp_group),
                 speculative_moe_backend_context(),
                 speculative_moe_a2a_backend_context(),
             ):
@@ -510,7 +508,7 @@ class EAGLEWorker(TpModelWorker):
             )
 
             with (
-                self.draft_tp_context(self.draft_model_runner.tp_group),
+                self.draft_tp_context(self.draft_runner.tp_group),
                 speculative_moe_backend_context(),
                 speculative_moe_a2a_backend_context(),
             ):
@@ -736,7 +734,7 @@ class EAGLEWorker(TpModelWorker):
 
         if self.page_size > 1 and self.topk > 1:
             if duplicate_cache_len > 0:
-                self.draft_model_runner.token_to_kv_pool.move_kv_cache(
+                self.draft_runner.token_to_kv_pool.move_kv_cache(
                     target_cache_loc, source_cache_loc
                 )
             # Remove padded slots
@@ -788,9 +786,7 @@ class EAGLEWorker(TpModelWorker):
         # Get forward batch
         model_worker_batch = batch.get_model_worker_batch()
         assert model_worker_batch.capture_hidden_mode == draft_capture_mode
-        forward_batch = ForwardBatch.init_new(
-            model_worker_batch, self.draft_model_runner
-        )
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_runner)
         can_cuda_graph = self.cuda_graph_runner and self.cuda_graph_runner.can_run(
             forward_batch
         )
@@ -915,7 +911,7 @@ class EAGLEWorker(TpModelWorker):
             spec_info.hidden_states = hidden_states
 
             # Run forward
-            logits_output = self.draft_model_runner.forward(
+            logits_output = self.draft_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
@@ -1155,13 +1151,11 @@ class EAGLEWorker(TpModelWorker):
             model_worker_batch = batch.get_model_worker_batch(
                 seq_lens_cpu_cache=seq_lens_cpu
             )
-            forward_batch = ForwardBatch.init_new(
-                model_worker_batch, self.draft_model_runner
-            )
+            forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_runner)
             forward_batch.return_logprob = False
             if mm_input_embeds is not None:
                 forward_batch.mm_input_embeds = mm_input_embeds
-            logits_output = self.draft_model_runner.forward(forward_batch).logits_output
+            logits_output = self.draft_runner.forward(forward_batch).logits_output
             maybe_detect_nan(
                 logits_output.next_token_logits, "draft_extend_for_prefill"
             )
@@ -1214,9 +1208,7 @@ class EAGLEWorker(TpModelWorker):
         draft_extend_input.capture_hidden_mode = draft_extend_capture_mode
         model_worker_batch = batch.get_model_worker_batch()
         assert model_worker_batch.capture_hidden_mode == draft_extend_capture_mode
-        forward_batch = ForwardBatch.init_new(
-            model_worker_batch, self.draft_model_runner
-        )
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_runner)
         if forward_batch.seq_lens_cpu is not None:
             forward_batch.seq_lens_sum = forward_batch.seq_lens_cpu.sum().item()
         else:
@@ -1239,12 +1231,11 @@ class EAGLEWorker(TpModelWorker):
             forward_batch.can_run_dp_cuda_graph = False
             if not forward_batch.forward_mode.is_idle():
                 attn_backend = (
-                    self.draft_extend_attn_backend
-                    or self.draft_model_runner.attn_backend
+                    self.draft_extend_attn_backend or self.draft_runner.attn_backend
                 )
                 attn_backend.init_forward_metadata(forward_batch)
                 forward_batch.attn_backend = attn_backend
-            logits_output = self.draft_model_runner.forward(
+            logits_output = self.draft_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             ).logits_output
             # Non-cuda-graph path: compute topk_p / topk_index inline.

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -37,7 +37,7 @@ from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
     SpecRuntimeState,
 )
-from sglang.srt.speculative.base_spec_worker import DraftExecutor
+from sglang.srt.speculative.base_spec_worker import DraftExecutor, SpecCoordinator
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
@@ -88,7 +88,7 @@ if is_cuda():
 logger = logging.getLogger(__name__)
 
 
-class EAGLEWorker(TpModelWorker, DraftExecutor):
+class EAGLEWorker(TpModelWorker, DraftExecutor, SpecCoordinator):
 
     def __init__(
         self,
@@ -439,6 +439,11 @@ class EAGLEWorker(TpModelWorker, DraftExecutor):
     @property
     def draft_runner(self):
         return self.model_runner
+
+    @property
+    def draft_worker(self) -> DraftExecutor:
+        # V1 monolithic: this worker is both coordinator and draft executor.
+        return self
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
         """Run speculative decoding forward.

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -168,8 +168,9 @@ class EagleDraftWorker(BaseDraftWorker):
                 memory_pool_config=target_worker.model_runner.memory_pool_config,
             )
 
-        # Alias for better readability
-        self.draft_runner = self.draft_worker.model_runner
+        # Alias for better readability. Backed by `_draft_runner` because
+        # `DraftExecutor` declares `draft_runner` as an abstract @property.
+        self._draft_runner = self.draft_worker.model_runner
         self.eagle_use_aux_hidden_state = False
         if self.speculative_algorithm.is_eagle3():
             eagle_config = getattr(
@@ -197,6 +198,10 @@ class EagleDraftWorker(BaseDraftWorker):
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
 
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)
+
+    @property
+    def draft_runner(self):
+        return self._draft_runner
 
     def init_token_map(self):
         # Load hot token ids

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -55,7 +55,7 @@ class FrozenKVMTPCudaGraphRunner:
 
     def __init__(self, frozen_kv_mtp_worker: FrozenKVMTPWorker):
         self.frozen_kv_mtp_worker = frozen_kv_mtp_worker
-        self.model_runner = model_runner = frozen_kv_mtp_worker.draft_model_runner
+        self.model_runner = model_runner = frozen_kv_mtp_worker.draft_runner
         self.graphs = {}
         self.output_buffers = {}
         self.enable_torch_compile = model_runner.server_args.enable_torch_compile

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -154,40 +154,38 @@ class FrozenKVMTPWorker(TpModelWorker):
             )
 
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()
-        if hasattr(self.draft_model_runner.model, "set_embed_and_head"):
-            self.draft_model_runner.model.set_embed_and_head(embed, head)
+        if hasattr(self.draft_runner.model, "set_embed_and_head"):
+            self.draft_runner.model.set_embed_and_head(embed, head)
         else:
             logger.debug(
                 "Draft model %s does not implement set_embed_and_head; "
                 "skipping target-embedding bind in Frozen-KV MTP skeleton.",
-                type(self.draft_model_runner.model).__name__,
+                type(self.draft_runner.model).__name__,
             )
 
         self.kv_context: Optional["FrozenKVMTPContext"] = None
-        if hasattr(self.draft_model_runner.model, "bind_frozen_kv_context"):
+        if hasattr(self.draft_runner.model, "bind_frozen_kv_context"):
             self._bind_kv_context()
 
-        self.draft_model_runner.server_args.disable_cuda_graph = (
-            backup_disable_cuda_graph
-        )
+        self.draft_runner.server_args.disable_cuda_graph = backup_disable_cuda_graph
 
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
 
         self.draft_attn_backend = self._init_draft_attn_backend()
-        self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
+        self.draft_runner.draft_attn_backend = self.draft_attn_backend
         self.cuda_graph_runner = None
 
         with (
-            self.draft_tp_context(self.draft_model_runner.tp_group),
+            self.draft_tp_context(self.draft_runner.tp_group),
             speculative_moe_backend_context(),
             speculative_moe_a2a_backend_context(),
         ):
             self.init_cuda_graphs()
 
     @property
-    def draft_model_runner(self):
+    def draft_runner(self):
         return self.model_runner
 
     def get_attn_backend(self):  # pragma: no cover - exposed for adaptive
@@ -205,7 +203,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
     def _init_draft_attn_backend(self):
         if self.topk == 1:
-            return self.draft_model_runner.attn_backend
+            return self.draft_runner.attn_backend
 
         backend_type = self._resolve_draft_backend_type()
         if backend_type != "triton":
@@ -220,16 +218,16 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         max_bs = self.req_to_token_pool.size * self.topk
         kv_indptr_buf = torch.zeros(
-            (max_bs + 1,), dtype=torch.int32, device=self.draft_model_runner.device
+            (max_bs + 1,), dtype=torch.int32, device=self.draft_runner.device
         )
         return TritonAttnBackend(
-            self.draft_model_runner,
+            self.draft_runner,
             skip_prefill=True,
             kv_indptr_buf=kv_indptr_buf,
         )
 
     def _bind_kv_context(self) -> None:
-        draft_model = self.draft_model_runner.model
+        draft_model = self.draft_runner.model
         if not hasattr(draft_model, "build_frozen_kv_mtp_context") or not hasattr(
             draft_model, "bind_frozen_kv_context"
         ):
@@ -264,7 +262,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
     @property
     def _recurrent_hidden_size(self) -> int:
-        return int(self.draft_model_runner.model.backbone_hidden_size)
+        return int(self.draft_runner.model.backbone_hidden_size)
 
     def _init_frozen_kv_metadata(self, forward_batch: ForwardBatch) -> None:
         if forward_batch.forward_mode.is_idle():
@@ -396,16 +394,14 @@ class FrozenKVMTPWorker(TpModelWorker):
             model_worker_batch = batch.get_model_worker_batch(
                 seq_lens_cpu_cache=seq_lens_cpu
             )
-            forward_batch = ForwardBatch.init_new(
-                model_worker_batch, self.draft_model_runner
-            )
+            forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_runner)
             forward_batch.return_logprob = False
             if mm_input_embeds is not None:
                 forward_batch.mm_input_embeds = mm_input_embeds
             self._set_positions(forward_batch)
             self._init_frozen_kv_metadata(forward_batch)
             with self._target_kv_pool_view(forward_batch):
-                logits_output = self.draft_model_runner.forward(
+                logits_output = self.draft_runner.forward(
                     forward_batch, skip_attn_backend_init=True
                 ).logits_output
             maybe_detect_nan(logits_output.next_token_logits, "frozen_kv_mtp_seed")
@@ -428,7 +424,7 @@ class FrozenKVMTPWorker(TpModelWorker):
                 can_run_cuda_graph,
             ) = self.forward_target_extend(batch)
             with (
-                self.draft_tp_context(self.draft_model_runner.tp_group),
+                self.draft_tp_context(self.draft_runner.tp_group),
                 speculative_moe_backend_context(),
                 speculative_moe_a2a_backend_context(),
             ):
@@ -449,7 +445,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         set_time_batch(batch.reqs, "set_spec_draft_start_time", trace_only=True)
         with (
-            self.draft_tp_context(self.draft_model_runner.tp_group),
+            self.draft_tp_context(self.draft_runner.tp_group),
             speculative_moe_backend_context(),
             speculative_moe_a2a_backend_context(),
         ):
@@ -471,7 +467,7 @@ class FrozenKVMTPWorker(TpModelWorker):
         set_time_batch(batch.reqs, "set_spec_draft_extend_start_time", trace_only=True)
         next_draft_input = None
         with (
-            self.draft_tp_context(self.draft_model_runner.tp_group),
+            self.draft_tp_context(self.draft_runner.tp_group),
             speculative_moe_backend_context(),
             speculative_moe_a2a_backend_context(),
         ):
@@ -604,9 +600,7 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         model_worker_batch = batch.get_model_worker_batch()
         assert model_worker_batch.capture_hidden_mode == CaptureHiddenMode.LAST
-        forward_batch = ForwardBatch.init_new(
-            model_worker_batch, self.draft_model_runner
-        )
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_runner)
         self._set_positions(forward_batch)
         self._expand_for_topk_draft(forward_batch)
 
@@ -694,7 +688,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             self._set_positions(forward_batch)
 
             with self._target_kv_pool_view(forward_batch):
-                logits_output = self.draft_model_runner.forward(
+                logits_output = self.draft_runner.forward(
                     forward_batch, skip_attn_backend_init=True
                 ).logits_output
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -43,6 +43,7 @@ from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.base_spec_worker import DraftExecutor
 from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     organize_draft_results,
@@ -78,7 +79,7 @@ from sglang.srt.utils import empty_context
 logger = logging.getLogger(__name__)
 
 
-class FrozenKVMTPWorker(TpModelWorker):
+class FrozenKVMTPWorker(TpModelWorker, DraftExecutor):
     """Frozen-KV MTP worker; same constructor shape as EAGLEWorker. Entry:
     :meth:`forward_batch_generation` (stubs for now).
     """
@@ -106,6 +107,8 @@ class FrozenKVMTPWorker(TpModelWorker):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+        # Frozen-KV MTP runs DSv4-style MTP, not EAGLE3; no aux hidden states.
+        self.eagle_use_aux_hidden_state = False
         assert self.speculative_algorithm.is_frozen_kv_mtp(), (
             "FrozenKVMTPWorker should only be instantiated for "
             "SpeculativeAlgorithm.FROZEN_KV_MTP, got "
@@ -173,8 +176,7 @@ class FrozenKVMTPWorker(TpModelWorker):
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
 
-        self.draft_attn_backend = self._init_draft_attn_backend()
-        self.draft_runner.draft_attn_backend = self.draft_attn_backend
+        self.init_attention_backend()
         self.cuda_graph_runner = None
 
         with (
@@ -201,17 +203,18 @@ class FrozenKVMTPWorker(TpModelWorker):
             or self.server_args.attention_backend
         )
 
-    def _init_draft_attn_backend(self):
+    def init_attention_backend(self):
         if self.topk == 1:
-            return self.draft_runner.attn_backend
-
-        backend_type = self._resolve_draft_backend_type()
-        if backend_type != "triton":
-            raise ValueError(
-                "Frozen-KV MTP topk > 1 currently supports only the triton "
-                f"attention backend, got {backend_type}."
-            )
-        return self._init_triton_draft_attn_backend()
+            self.draft_attn_backend = self.draft_runner.attn_backend
+        else:
+            backend_type = self._resolve_draft_backend_type()
+            if backend_type != "triton":
+                raise ValueError(
+                    "Frozen-KV MTP topk > 1 currently supports only the triton "
+                    f"attention backend, got {backend_type}."
+                )
+            self.draft_attn_backend = self._init_triton_draft_attn_backend()
+        self.draft_runner.draft_attn_backend = self.draft_attn_backend
 
     def _init_triton_draft_attn_backend(self):
         from sglang.srt.layers.attention.triton_backend import TritonAttnBackend

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -43,7 +43,7 @@ from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.speculative.base_spec_worker import DraftExecutor
+from sglang.srt.speculative.base_spec_worker import DraftExecutor, SpecCoordinator
 from sglang.srt.speculative.eagle_utils import (
     build_tree_kernel_efficient,
     organize_draft_results,
@@ -79,7 +79,7 @@ from sglang.srt.utils import empty_context
 logger = logging.getLogger(__name__)
 
 
-class FrozenKVMTPWorker(TpModelWorker, DraftExecutor):
+class FrozenKVMTPWorker(TpModelWorker, DraftExecutor, SpecCoordinator):
     """Frozen-KV MTP worker; same constructor shape as EAGLEWorker. Entry:
     :meth:`forward_batch_generation` (stubs for now).
     """
@@ -189,6 +189,11 @@ class FrozenKVMTPWorker(TpModelWorker, DraftExecutor):
     @property
     def draft_runner(self):
         return self.model_runner
+
+    @property
+    def draft_worker(self) -> DraftExecutor:
+        # V1 monolithic: this worker is both coordinator and draft executor.
+        return self
 
     def get_attn_backend(self):  # pragma: no cover - exposed for adaptive
         return self.draft_attn_backend

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -33,7 +33,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.speculative.base_spec_worker import DraftExecutor
+from sglang.srt.speculative.base_spec_worker import DraftExecutor, SpecCoordinator
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
@@ -70,7 +70,7 @@ if is_cuda():
 logger = logging.getLogger(__name__)
 
 
-class MultiLayerEagleWorker(TpModelWorker, DraftExecutor):
+class MultiLayerEagleWorker(TpModelWorker, DraftExecutor, SpecCoordinator):
 
     def __init__(
         self,
@@ -257,6 +257,11 @@ class MultiLayerEagleWorker(TpModelWorker, DraftExecutor):
     def draft_runner(self) -> ModelRunner:
         # Canonical "primary" runner expected by `EagleDraftInput` shape classmethods.
         return self.model_runner_list[0]
+
+    @property
+    def draft_worker(self) -> DraftExecutor:
+        # V1 monolithic: this worker is both coordinator and draft executor.
+        return self
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
         """Run speculative decoding forward.

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -163,16 +163,16 @@ class MultiLayerEagleWorker(TpModelWorker):
             # most cases EAGLE3 models don't share lm_head
             # but some models (e.g. nvidia/gpt-oss-120b-Eagle3) shares
             if (
-                hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
-                and self.draft_model_runner.model.load_lm_head_from_target
+                hasattr(self.mtp_model_runner(0).model, "load_lm_head_from_target")
+                and self.mtp_model_runner(0).model.load_lm_head_from_target
             ):
-                self.draft_model_runner.model.set_embed_and_head(embed, head)
+                self.mtp_model_runner(0).model.set_embed_and_head(embed, head)
             else:
-                self.draft_model_runner.model.set_embed(embed)
+                self.mtp_model_runner(0).model.set_embed(embed)
 
             # grab hot token ids
-            if self.draft_model_runner.model.hot_token_id is not None:
-                self.hot_token_id = self.draft_model_runner.model.hot_token_id.to(
+            if self.mtp_model_runner(0).model.hot_token_id is not None:
+                self.hot_token_id = self.mtp_model_runner(0).model.hot_token_id.to(
                     embed.device
                 )
 
@@ -247,6 +247,10 @@ class MultiLayerEagleWorker(TpModelWorker):
 
     def mtp_model_runner(self, layer_id: int) -> ModelRunner:
         return self.model_runner_list[layer_id]
+
+    @property
+    def draft_runner_list(self) -> List[ModelRunner]:
+        return self.model_runner_list
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
         """Run speculative decoding forward.

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -33,6 +33,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.base_spec_worker import DraftExecutor
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_info import (
     EagleDraftExtendInput,
@@ -69,7 +70,7 @@ if is_cuda():
 logger = logging.getLogger(__name__)
 
 
-class MultiLayerEagleWorker(TpModelWorker):
+class MultiLayerEagleWorker(TpModelWorker, DraftExecutor):
 
     def __init__(
         self,
@@ -251,6 +252,11 @@ class MultiLayerEagleWorker(TpModelWorker):
     @property
     def draft_runner_list(self) -> List[ModelRunner]:
         return self.model_runner_list
+
+    @property
+    def draft_runner(self) -> ModelRunner:
+        # Canonical "primary" runner expected by `EagleDraftInput` shape classmethods.
+        return self.model_runner_list[0]
 
     def forward_batch_generation(self, batch: ScheduleBatch) -> GenerationBatchResult:
         """Run speculative decoding forward.

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -147,8 +147,9 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         # Alias for better readability
         self.draft_runner_list: List[ModelRunner] = self.draft_worker.model_runner_list
         # `draft_runner` (single) is the canonical shape entry expected by the
-        # `EagleDraftInput` shape classmethods in eagle_info.py.
-        self.draft_runner: ModelRunner = self.draft_runner_list[0]
+        # `EagleDraftInput` shape classmethods in eagle_info.py. Backed by
+        # `_draft_runner` because `DraftExecutor` declares it as abstract @property.
+        self._draft_runner: ModelRunner = self.draft_runner_list[0]
 
         self.eagle_use_aux_hidden_state = False
         if self.speculative_algorithm.is_eagle3():
@@ -196,6 +197,10 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
 
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)
+
+    @property
+    def draft_runner(self) -> ModelRunner:
+        return self._draft_runner
 
     def mtp_model_runner(self, step: int):
         return self.draft_runner_list[step]

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -146,8 +146,8 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
 
         # Alias for better readability
         self.draft_runner_list: List[ModelRunner] = self.draft_worker.model_runner_list
-        # Match `EagleDraftWorker.draft_runner` so `_draft_runner_of(self)` works
-        # for the EagleDraftInput shape classmethods.
+        # `draft_runner` (single) is the canonical shape entry expected by the
+        # `EagleDraftInput` shape classmethods in eagle_info.py.
         self.draft_runner: ModelRunner = self.draft_runner_list[0]
 
         # Chain-style MTP: each step propagates its own output hidden states to the

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -150,6 +150,15 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         # `EagleDraftInput` shape classmethods in eagle_info.py.
         self.draft_runner: ModelRunner = self.draft_runner_list[0]
 
+        self.eagle_use_aux_hidden_state = False
+        if self.speculative_algorithm.is_eagle3():
+            eagle_config = getattr(
+                self.draft_runner.model_config.hf_config, "eagle_config", {}
+            )
+            self.eagle_use_aux_hidden_state = eagle_config.get(
+                "use_aux_hidden_state", True
+            )
+
         # Chain-style MTP: each step propagates its own output hidden states to the
         # next step.  Non-chain: each step uses the target model's hidden states.
         draft_arch = self.draft_worker.model_config.hf_config.architectures[0]

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -13,6 +13,11 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.observability.trace import get_global_tracing_enabled
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.base_spec_worker import (
+    DraftExecutor,
+    NullDraftExecutor,
+    SpecCoordinator,
+)
 from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -24,7 +29,15 @@ logger = logging.getLogger(__name__)
 USE_FULL_MASK = True
 
 
-class NGRAMWorker:
+class NgramSpecCoordinator(SpecCoordinator):
+    """Spec coordinator for the N-gram algorithm.
+
+    NGRAM derives draft tokens from a CPU-side n-gram corpus lookup rather than
+    a draft model. The draft side is exposed as a `NullDraftExecutor` so the
+    `SpecCoordinator + DraftExecutor` type contract holds uniformly across all
+    spec algorithms.
+    """
+
     def __init__(
         self,
         server_args: ServerArgs,
@@ -37,6 +50,7 @@ class NGRAMWorker:
         nccl_port: int,
         target_worker: TpModelWorker,
     ):
+        self.server_args = server_args
         self.target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = tp_rank
@@ -46,6 +60,15 @@ class NGRAMWorker:
 
         self.max_batch_size = target_worker.max_running_requests
         self.device = f"cuda:{gpu_id}" if gpu_id >= 0 else "cuda"
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        # NGRAM has no draft model — drafts come from `ngram_corpus.batch_get`.
+        # `NullDraftExecutor` makes the absence type-explicit.
+        self._draft_worker: DraftExecutor = NullDraftExecutor(
+            target_worker, self.speculative_algorithm
+        )
 
         self._init_preallocated_tensors()
 
@@ -79,6 +102,10 @@ class NGRAMWorker:
                 corpus_path,
                 loaded,
             )
+
+    @property
+    def draft_worker(self) -> DraftExecutor:
+        return self._draft_worker
 
     def clear_cache_pool(self):
         self.ngram_corpus.reset()
@@ -366,3 +393,7 @@ class NGRAMWorker:
             can_run_cuda_graph=can_run_cuda_graph,
             accept_lens=accept_lens,
         )
+
+
+# Pre-rename alias; existing call sites keep importing `NGRAMWorker`.
+NGRAMWorker = NgramSpecCoordinator

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from sglang.srt.managers.tp_worker import TpModelWorker
     from sglang.srt.server_args import ServerArgs
     from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
-    from sglang.srt.speculative.ngram_worker import NGRAMWorker
 
 
 class SpeculativeAlgorithm(Enum):
@@ -137,7 +136,7 @@ class SpeculativeAlgorithm(Enum):
 
     def create_worker(
         self, server_args: ServerArgs
-    ) -> Optional[Union[Type[BaseSpecWorker], Type[TpModelWorker], Type[NGRAMWorker]]]:
+    ) -> Optional[Union[Type[BaseSpecWorker], Type[TpModelWorker]]]:
         assert (
             not self.is_none()
         ), "Cannot create worker for NONE speculative algorithm."

--- a/python/sglang/srt/speculative/standalone_worker.py
+++ b/python/sglang/srt/speculative/standalone_worker.py
@@ -100,14 +100,12 @@ class StandaloneWorker(EAGLEWorker):
             )
 
         # Init attention backend and cuda graphs
-        self.draft_model_runner.server_args.disable_cuda_graph = (
-            backup_disable_cuda_graph
-        )
+        self.draft_runner.server_args.disable_cuda_graph = backup_disable_cuda_graph
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
         with (
-            self.draft_tp_context(self.draft_model_runner.tp_group),
+            self.draft_tp_context(self.draft_runner.tp_group),
             speculative_moe_backend_context(),
             speculative_moe_a2a_backend_context(),
         ):


### PR DESCRIPTION
PoC stacking on #24860 — not ready to merge. Posting for review of the type contract shape; final scope / split / commit history will be reshuffled after feedback.

- Unify draft `ModelRunner` exposure across V1/V2 spec workers to `draft_runner`; remove `_draft_runner_of` helper and the V1/V2 `hasattr` dispatch in the cuda-graph runners.
- Introduce `DraftExecutor` and `SpecCoordinator` ABCs in `base_spec_worker.py` (`BaseDraftWorker` / `BaseSpecWorker` kept as aliases).
- V1 workers multi-inherit `(TpModelWorker, DraftExecutor, SpecCoordinator)`; rename `NGRAMWorker` -> `NgramSpecCoordinator` (attaches a `NullDraftExecutor`) and `DFlashWorker` -> `DFlashSpecCoordinator` (extracts `DFlashDraftExecutor` wrapping the inner draft `TpModelWorker`). Pre-rename aliases kept for callers.
- Fix a latent multi-layer-V1 attribute bug surfaced while normalizing the EAGLE3 init path.





<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->