### PR TITLE
[Fix] Probe speculative draft config via sglang get_config

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -324,9 +324,9 @@ def _resolve_speculative_algorithm_alias(
 
     is_gemma4_draft = False
     if speculative_draft_model_path:
-        from transformers import AutoConfig
+        from sglang.srt.utils.hf_transformers_utils import get_config
 
-        cfg = AutoConfig.from_pretrained(
+        cfg = get_config(
             speculative_draft_model_path, trust_remote_code=trust_remote_code
         )
         is_gemma4_draft = "Gemma4AssistantForCausalLM" in (


### PR DESCRIPTION
## Motivation

Mistral-native EAGLE drafts (e.g. `mistralai/Mistral-Large-3-675B-Instruct-2512-Eagle`, which ships `params.json` not `config.json`) crash startup in `_resolve_speculative_algorithm_alias()`:

```
ValueError: Unrecognized model in mistralai/Mistral-Large-3-675B-Instruct-2512-Eagle.
Should have a `model_type` key in its config.json...
```

The probe is only there to detect `Gemma4AssistantForCausalLM` and promote `NEXTN`/`EAGLE` → `FROZEN_KV_MTP`. `transformers.AutoConfig` can't parse Mistral-native checkpoints.

## Modifications

Swap the probe loader to sglang's `get_config`, which routes Mistral-native checkpoints through the Mistral parser:

```diff
-        from transformers import AutoConfig
+        from sglang.srt.utils.hf_transformers_utils import get_config

-        cfg = AutoConfig.from_pretrained(
+        cfg = get_config(
             speculative_draft_model_path, trust_remote_code=trust_remote_code
         )
```

All existing alias semantics (Gemma4 promotion, EAGLE3 rejection, non-Gemma4 passthrough) are unchanged.

## Accuracy Tests

8× B200, `test_mistral_large3.py` (gsm8k, baseline 0.85):

| Variant | gsm8k |
|---|---:|
| TP8 | 0.952 |
| **TP8+MTP** (regression target) | **0.957** |
| NVFP4 | 0.954 |

Gemma4 regression coverage:

| Test | Result |
|---|---|
| `unit/server_args/test_server_args.py` | 51/51 OK |
| `core/test_gemma4_moe_deterministic.py` (TP=2) | 180/180 OK |
| `models/test_gemma4_fp8_per_expert_loading.py` (TP=4) | 3/3 OK, gsm8k 0.95 |

## Speed Tests and Profiling

Probe is one-shot at startup, off the request path — no inference-perf impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
