### PR TITLE
[Test] Set default temperature to 0.0 in kl_test_utils

### DIFF
--- a/python/sglang/test/kl_test_utils.py
+++ b/python/sglang/test/kl_test_utils.py
@@ -133,7 +133,7 @@ def _generate(
     max_new_tokens,
     return_logprob=False,
     logprob_start_len=-1,
-    temperature=1,
+    temperature=0.0,
 ):
     """Send generate request and return results."""
     json_data = {
@@ -156,7 +156,7 @@ def _generate(
     return response.json()
 
 
-def _get_input_logprobs(base_url, new_input_ids, output_logprobs, temperature=1):
+def _get_input_logprobs(base_url, new_input_ids, output_logprobs, temperature=0.0):
     """Run prefill to get input logprobs matching output logprobs."""
     _flush_cache(base_url)
     results = _generate(


### PR DESCRIPTION
## Summary
- Change default temperature from 1 to 0.0 in `_generate` and `_get_input_logprobs` functions in `kl_test_utils.py` for deterministic test results.

## Original commits
- `b39aad59e`

## Test plan
- Existing KL tests should pass with the updated default temperature.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->