### PR TITLE
Convert local-only self.X attributes to locals

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -445,7 +445,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.disaggregation_mode = DisaggregationMode(
             self.server_args.disaggregation_mode
         )
-        self.bootstrap_server = start_disagg_service(self.server_args)
+        start_disagg_service(self.server_args)
         # Single-source counter for auto-assigning fake bootstrap_room.
         self.fake_bootstrap_room_counter = 0
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1500,8 +1500,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Register model for layerwise NVTX profiling if enabled
         if self.server_args.enable_layerwise_nvtx_marker:
-            self.pyt_hooks = PytHooks()
-            self.pyt_hooks.register_hooks(self.model, module_prefix="model")
+            pyt_hooks = PytHooks()
+            pyt_hooks.register_hooks(self.model, module_prefix="model")
 
         if self.server_args.kv_cache_dtype == "fp8_e4m3":
             if self.server_args.quantization_param_path is not None:
@@ -2080,8 +2080,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
 
         # We need to get device after patch otherwise the device would be wrong
-        self.device_module = torch.get_device_module(self.device)
-        infered_device = self.device_module.current_device()
+        device_module = torch.get_device_module(self.device)
+        infered_device = device_module.current_device()
 
         named_tensors = [
             (name, _unwrap_tensor(tensor, tp_rank=self.tp_rank, device=infered_device))


### PR DESCRIPTION
Three writes of the form `self.X = expr` on TokenizerManager and
ModelRunner where the resulting attribute has no reader anywhere in
the codebase. Converting to function-scope locals makes the lifetime
explicit and prevents future "is this attribute available?" guards
from spreading.

- managers/tokenizer_manager.py: `self.bootstrap_server = start_disagg_service(...)`
  → `start_disagg_service(...)`. The return value has no consumer;
  the side effect (starting the disagg bootstrap server thread) is
  what mattered.

- model_executor/model_runner.py: `self.pyt_hooks = PytHooks();
  self.pyt_hooks.register_hooks(...)` → `pyt_hooks = PytHooks();
  pyt_hooks.register_hooks(...)`. The hooks remain registered on the
  model's module dicts; no later code reads `self.pyt_hooks` for
  teardown or inspection.

- model_executor/model_runner.py: `self.device_module = torch.get_device_module(self.device)`
  in `update_weights_from_distributed` → `device_module = ...`. The
  surrounding usage is purely local. Scheduler has its own
  independent `self.device_module` set elsewhere; the two are not
  related.

Refactor chain ID: convert-self-x-to-locals

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->