### PR TITLE
Remove dead self.adder/can_run_list/running_bs writes in Scheduler._get_new_batch_prefill_raw

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2802,11 +2802,6 @@ class Scheduler(
         if self.chunked_req is not None:
             self.chunked_req.is_chunked += 1
 
-        # Record for logging prefill stats after forward
-        self.adder = adder
-        self.can_run_list = can_run_list
-        self.running_bs = len(self.running_batch.reqs)
-
         set_time_batch(can_run_list, "set_forward_entry_time")
 
         # Create a new batch


### PR DESCRIPTION
Drop three writes to `self.X` near the end of
`Scheduler._get_new_batch_prefill_raw` that capture the local
prefill-builder state for use by some other reader:

    self.adder = adder
    self.can_run_list = can_run_list
    self.running_bs = len(self.running_batch.reqs)

Grepping the entire codebase, no reader of `self.adder` /
`self.can_run_list` / `self.running_bs` exists anywhere — these
were legacy scratch slots from when prefill stats were emitted by a
separate post-forward path on the Scheduler. That path has since
migrated to attaching `prefill_stats` directly to the batch object
via `new_batch.prefill_stats = PrefillStats.from_adder(adder, ...)`
a few lines below, which consumes the LOCAL variables `adder` and
`can_run_list` (and computes `running_bs` from `self.running_batch`
on demand). The local variables in this function are still in use;
only the writes to `self.X` are dead.

Refactor chain ID: drop-dead-prefill-locals

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->