### PR TITLE
Remove managers' unused fields

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -149,13 +149,9 @@ class TransferBuffer:
     Overlapping buffer preparation and transfer operations to improve throughput.
     """
 
-    def __init__(
-        self, stop_event, buffer_count: int = 3, max_buffer_size: int = 1024
-    ) -> None:
+    def __init__(self, stop_event, buffer_count: int = 3) -> None:
         self.stop_event = stop_event
         self.buffers = Queue(maxsize=buffer_count)
-        # todo: adjust the buffer size based on throughput profile of the system
-        self.max_buffer_size = max_buffer_size
 
     def full(self) -> bool:
         return self.buffers.full()
@@ -322,9 +318,7 @@ class HiCacheController:
 
         self.stop_event = threading.Event()
         self.write_buffer = TransferBuffer(self.stop_event)
-        self.load_buffer = TransferBuffer(
-            self.stop_event, buffer_count=10, max_buffer_size=100
-        )
+        self.load_buffer = TransferBuffer(self.stop_event, buffer_count=10)
 
         self.write_stream = device_module.Stream()
         self.load_stream = device_module.Stream()

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -135,9 +135,6 @@ class DataParallelController:
         )
         self.run_scheduler_process_func = run_scheduler_process_func
 
-        # For DP balance
-        self.global_balance_id = 0
-
         # Init inter-process communication
         self.context = zmq.Context(1 + server_args.dp_size)
         if server_args.node_rank == 0:

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1560,7 +1560,6 @@ class ShmPointerMMData:
         self.shm_name = state["shm_name"]
         self.shape = state["shape"]
         self.dtype = state["dtype"]
-        self.shm = None
         self._shm_handle = shared_memory.SharedMemory(name=self.shm_name)
         # Zero-copy view into shared memory (no clone, no unlink)
         self.tensor = torch.frombuffer(self._shm_handle.buf, dtype=self.dtype).reshape(

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -37,7 +37,6 @@ import zmq
 import zmq.asyncio
 
 from sglang.srt.disaggregation.utils import DisaggregationMode, TransferBackend
-from sglang.srt.managers.communicator import FanOutCommunicator
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.io_struct import (
     BaseBatchReq,
@@ -557,10 +556,6 @@ class TokenizerWorker(TokenizerManager):
         )
         self.disaggregation_transfer_backend = TransferBackend(
             self.server_args.disaggregation_transfer_backend
-        )
-        # Communicator
-        self.register_multi_tokenizer_communicator = FanOutCommunicator(
-            self.send_to_scheduler, 2
         )
 
         # Register this worker with the router for pause/continue broadcasting

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -130,9 +130,6 @@ def _compute_pad_value(hash: int) -> int:
 
 
 class BaseFinishReason:
-    def __init__(self, is_error: bool = False):
-        self.is_error = is_error
-
     def to_json(self):
         raise NotImplementedError()
 
@@ -187,7 +184,7 @@ class FINISH_LENGTH(BaseFinishReason):
 
 class FINISH_ABORT(BaseFinishReason):
     def __init__(self, message=None, status_code=None, err_type=None):
-        super().__init__(is_error=True)
+        super().__init__()
         self.message = message or "Aborted"
         self.status_code = status_code
         self.err_type = err_type
@@ -623,7 +620,6 @@ class Req(ReqDllmMixin):
     ):
         # Input and output info
         self.rid = rid
-        self.origin_input_text = origin_input_text
         self.origin_input_ids_unpadded = (
             origin_input_ids_unpadded
             if origin_input_ids_unpadded
@@ -777,8 +773,6 @@ class Req(ReqDllmMixin):
         self.logprob_start_len = 0
         self.top_logprobs_num = top_logprobs_num
         self.token_ids_logprob = token_ids_logprob
-        self.temp_scaled_logprobs = False
-        self.top_p_normalized_logprobs = False
 
         # Logprobs (return values)
         # True means the input logprob has been already sent to detokenizer.

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -398,7 +398,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.dump_request_list: List[Tuple] = []
         self.crash_dump_request_list: deque[Tuple] = deque()
         self.crash_dump_performed = False  # Flag to ensure dump is only called once
-        self.straggler_request_list: List[Tuple] = []
 
         # Initialize performance metrics loggers with proper skip names
         _, obj_skip_names, out_skip_names = self.request_logger.metadata


### PR DESCRIPTION
Drop dead state writes / instance attributes that are never read on
the corresponding code paths. All changes are localized to
`python/sglang/srt/managers/`.

Affected files:

- cache_controller.py: drop unused fields in the cache controller
- data_parallel_controller.py: drop unused fields
- mm_utils.py: drop unused field
- multi_tokenizer_mixin.py: drop unused state writes
- schedule_batch.py: drop unused Req-level fields
- tokenizer_manager.py: drop unused TokenizerManager field

Refactor chain ID: drop-unused-mgr-fields

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->