### PR TITLE
Remove fields that are never used in spec/engine/disagg

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -119,9 +119,6 @@ class EventPublisher(ABC):
     - This allows consumers to distinguish events from different DP ranks
     """
 
-    def __init__(self, attn_dp_rank: int = 0):
-        self._attn_dp_rank = attn_dp_rank
-
     @abstractmethod
     def publish(self, events: EventBatch) -> None:
         """Emit events in order.
@@ -183,7 +180,6 @@ class ZmqEventPublisher(EventPublisher):
         topic: str = "",
     ) -> None:
         # Storage
-        super().__init__(attn_dp_rank)
         self._event_queue = Queue[Optional[EventBatch]](maxsize=max_queue_size)
         self._buffer = deque[tuple[int, bytes]](maxlen=buffer_steps)
 

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -245,11 +245,6 @@ class Engine(EngineScoreMixin, EngineBase):
         if tokenizer_manager is not None:
             tokenizer_manager._subprocess_watchdog = subprocess_watchdog
         self.port_args = port_args
-        # Access transfer engine info if bootstrap server is started.
-        if scheduler_init_result.engine_info_bootstrap_server is not None:
-            self.remote_instance_transfer_engine_info = (
-                scheduler_init_result.engine_info_bootstrap_server.transfer_engine_info
-            )
 
         # Initialize ZMQ sockets
         context = zmq.Context(2)

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -112,8 +112,6 @@ class AdaptiveSpeculativeParams:
             len(self.candidate_steps) >= 2
         ), "candidate_steps must have at least 2 distinct values"
 
-        self.min_steps = self.candidate_steps[0]
-        self.max_steps = self.candidate_steps[-1]
         self.ema_alpha = cfg.get("ema_alpha", 0.2)
         self.update_interval = cfg.get("update_interval", 5)
         self.warmup_batches = cfg.get("warmup_batches", 10)

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -34,7 +34,6 @@ class NgramCorpus:
             external_sam_budget=external_sam_budget,
             external_corpus_max_tokens=external_corpus_max_tokens,
         )
-        self.default_mask = np.ones((1, 1), dtype=np.int64)
         self.draft_token_num = draft_token_num
         self.external_corpus_max_tokens = external_corpus_max_tokens
         self._req_id_to_state_id: Dict[str, int] = {}

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -240,7 +240,6 @@ class EagleDraftWorker(BaseDraftWorker):
     def init_attention_backend(self):
         # Create multi-step attn backends and cuda graph runners
 
-        self.has_prefill_wrapper_verify = False
         self.draft_extend_attn_backend = None
 
         draft_backend_factory = DraftBackendFactory(


### PR DESCRIPTION
Drop dead state writes / instance attributes that are never read,
covering speculative decoding, disaggregation event publisher, and
the top-level Engine entry point.

Affected files:

- entrypoints/engine.py: drop unused Engine fields
- disaggregation/kv_events.py: drop unused EventPublisher field
- speculative/adaptive_spec_params.py: drop unused AdaptiveSpeculativeParams fields
- speculative/cpp_ngram/ngram_corpus.py: drop unused NgramCorpus field
- speculative/eagle_worker_v2.py: drop unused EagleDraftWorker field

Refactor chain ID: drop-unused-spec-engine-fields

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->