### PR TITLE
Replace single-line defensive getattrs with direct access

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -75,7 +75,7 @@ class SchedulerOutputProcessorMixin:
                 "host": req.cached_tokens_host,
             }
             # Only include storage fields if L3 storage is enabled
-            if getattr(self, "enable_hicache_storage", False):
+            if self.enable_hicache_storage:
                 details["storage"] = req.cached_tokens_storage
                 details["storage_backend"] = self._get_storage_backend_type()
             return details

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -717,7 +717,7 @@ class SchedulerPPMixin:
         ):
             return None
 
-        max_chunk_size = getattr(self, "max_prefill_tokens", None)
+        max_chunk_size = self.max_prefill_tokens
         predicted_size = self.length_predictor.predict_next_chunk_size(
             history_len=history_len,
             base_chunk_size=self.chunked_prefill_size,

--- a/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_manager_score_mixin.py
@@ -261,7 +261,7 @@ class TokenizerManagerScoreMixin:
         has_phs = False
         prompt_tokens = 0
 
-        is_generation = getattr(self, "is_generation", True)
+        is_generation = self.is_generation
         if is_generation:
             for result in results:
                 # For single-item scoring, logprobs are in output_token_ids_logprobs
@@ -563,7 +563,7 @@ class TokenizerManagerScoreMixin:
                     return_pooled_hidden_states=True and the model supports it;
                     None otherwise.
         """
-        is_generation = getattr(self, "is_generation", True)
+        is_generation = self.is_generation
 
         if is_generation and label_token_ids is None:
             raise ValueError(
@@ -676,7 +676,7 @@ class TokenizerManagerScoreMixin:
                     "It requires a model with a task-specific head "
                     "(e.g. SequenceClassification or RewardModel)."
                 )
-            model_config = getattr(self, "model_config", None)
+            model_config = self.model_config
             if model_config is not None:
                 archs = getattr(model_config.hf_config, "architectures", []) or []
                 if is_cross_encoding_pooler_model(archs):


### PR DESCRIPTION
Drop `getattr(self, "<attr>", <default>)` at call sites where the
attribute is always present at runtime:

- managers/tokenizer_manager_score_mixin.py: `self.model_config`
- managers/tokenizer_manager_score_mixin.py: `self.is_generation`
- managers/scheduler_pp_mixin.py: `self.max_prefill_tokens`
- managers/scheduler_output_processor_mixin.py: `self.enable_hicache_storage`

These follow the same pattern — the attribute is unconditionally
set on the owning manager's `__init__`, so the `getattr(..., default)`
fallback was dead defensive code that only served to hide future
bugs. Direct access raises AttributeError immediately if a future
refactor drops the field, instead of silently returning the default
and letting downstream code branch on the wrong value.

Refactor chain ID: direct-trivial-getattrs

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->