### PR TITLE
Cache _linear_attn_registry_cache with sentinel

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -29,7 +29,7 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -289,6 +289,8 @@ UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data proces
 
 logger = logging.getLogger(__name__)
 
+_UNSET: Any = object()
+
 
 def resolve_language_model(model: nn.Module) -> nn.Module:
     model_cls_name = model.__class__.__name__
@@ -530,6 +532,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # For hisparse (must be set before initialize() so CUDA graph capture can see it)
         self.hisparse_coordinator = None
+
+        self._linear_attn_registry_cache: Any = _UNSET
 
         # Initialize the model runner
         self.initialize(pre_model_load_memory)
@@ -2313,7 +2317,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         return None
 
     def _get_linear_attn_registry_result(self):
-        if not hasattr(self, "_linear_attn_registry_cache"):
+        if self._linear_attn_registry_cache is _UNSET:
             self._linear_attn_registry_cache = get_linear_attn_config(
                 self.model_config.hf_config
             )


### PR DESCRIPTION
Replace the lazy-init pattern based on `hasattr` with an explicit
`_UNSET` sentinel set in `ModelRunner.__init__`.

Before:

    def _get_linear_attn_registry_result(self):
        if not hasattr(self, "_linear_attn_registry_cache"):
            self._linear_attn_registry_cache = get_linear_attn_config(...)
        return self._linear_attn_registry_cache

After:

    # in __init__:
    self._linear_attn_registry_cache: Any = _UNSET

    def _get_linear_attn_registry_result(self):
        if self._linear_attn_registry_cache is _UNSET:
            self._linear_attn_registry_cache = get_linear_attn_config(...)
        return self._linear_attn_registry_cache

Why a sentinel and not `None`: the cached value can legitimately be
`None` (`get_linear_attn_config` returns None for non-linear-attn
models). A simple `if self._cache is None` check can't distinguish
"not yet computed" from "computed, result was None". The `_UNSET`
sentinel — analogous to Rust's `OnceCell<Option<T>>` — gives both
states distinct representations.

The previous `hasattr` form worked but defended against a non-existent
threat (attribute always exists by `__init__` invariant) and hid the
real cache-state distinction. The sentinel form makes both lifecycle
and cache-hit branch explicit.

Refactor chain ID: cache-linear-attn-registry

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->