### PR TITLE
Drop dead hasattr guards (hisparse_coordinator, metrics_collector)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -781,7 +781,7 @@ class Scheduler(
                 f"{'available_cpu_mem' if self.device == 'cpu' else 'available_gpu_mem'}={avail_mem:.2f} GB"
             )
 
-        if self.enable_metrics and hasattr(self, "metrics_collector"):
+        if self.enable_metrics:
             self.metrics_collector.emit_constants(
                 max_total_num_tokens=self.max_total_num_tokens,
                 max_running_requests_under_SLO=getattr(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -568,9 +568,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self._model_update_group = {}
         self._weights_send_group = {}
 
-        if not hasattr(self, "hisparse_coordinator"):
-            self.hisparse_coordinator = None
-
     def _build_model_config(
         self, server_args, model_path=None, model_revision=None, is_draft_model=False
     ):


### PR DESCRIPTION
Drop two redundant runtime guards on attributes that are always set
on their owners by the time the read site executes:

- model_executor/model_runner.py: `if not hasattr(self, "hisparse_coordinator"): self.hisparse_coordinator = None`.
  `ModelRunner.__init__` already sets `self.hisparse_coordinator = None`
  unconditionally earlier in the ctor, so this fallback block was dead
  — `hasattr` always returned True and the assignment never fired.

- managers/scheduler.py: `if self.enable_metrics and hasattr(self, "metrics_collector"):`.
  `Scheduler.__init__` creates `self.metrics_collector` inside
  `if self.enable_metrics:`, so by the time the read site runs (also
  guarded by `enable_metrics`), the attribute is guaranteed to exist.
  The `hasattr` was a paranoia check that hid the real invariant.

Removing both guards surfaces the invariant at the source line — a
future refactor that drops either attribute now raises AttributeError
at the call site instead of silently skipping the metrics emit or
leaving the hisparse coordinator slot in an inconsistent state.

Refactor chain ID: drop-hisparse-guard

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->