### PR TITLE
Convert forward_pass_device_timer to None-init

### DIFF
--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -162,6 +162,8 @@ class SchedulerMetricsMixin:
 
         self.fwd_occupancy = float("nan")
 
+        self.forward_pass_device_timer: Optional[DeviceTimer] = None
+
         if ENABLE_METRICS_DEVICE_TIMER:
             self._device_timer_window_batch_count = 0
             self._device_timer_window_gpu_time = 0.0
@@ -185,7 +187,7 @@ class SchedulerMetricsMixin:
         )
 
     def install_device_timer_on_runners(self: Scheduler):
-        if not hasattr(self, "forward_pass_device_timer"):
+        if self.forward_pass_device_timer is None:
             return
         timer = self.forward_pass_device_timer
         self.tp_worker.model_runner.device_timer = timer
@@ -237,7 +239,7 @@ class SchedulerMetricsMixin:
             def _fpm_device_timer_reporter(t, **_kwargs):
                 self._fpm_gpu_time_acc += t
 
-            if hasattr(self, "forward_pass_device_timer"):
+            if self.forward_pass_device_timer is not None:
                 self.forward_pass_device_timer.add_reporter(_fpm_device_timer_reporter)
             else:
                 self.forward_pass_device_timer = DeviceTimer(


### PR DESCRIPTION
Add `self.forward_pass_device_timer: Optional[DeviceTimer] = None`
unconditionally in `SchedulerMetricsMixin.__init__`, and change the
read-site guard from `if not hasattr(self, "forward_pass_device_timer"): return`
to `if self.forward_pass_device_timer is None: return`.

The attribute was previously conditionally assigned only when device
timer metrics were enabled (`if ENABLE_METRICS_DEVICE_TIMER:`),
forcing the read site (`install_device_timer_on_runners`) to defend
against the attribute simply not existing. By initializing to None
unconditionally and gating the read on `is None`, the real invariant
("forward_pass_device_timer is the timer when device timer metrics
are enabled, else None") is encoded directly in the type
(`Optional[DeviceTimer]`) rather than relying on hasattr as a proxy.

Refactor chain ID: init-forward-pass-timer

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->