### PR TITLE
Lift running_batch / running_mbs access — direct + PP-explicit

### DIFF
--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -925,14 +925,14 @@ class SchedulerMetricsMixin:
             active_lora_ids = set()
 
             # For PP mode, check all running micro batches
-            if hasattr(self, "running_mbs") and self.running_mbs:
+            if self.server_args.pp_size > 1:
                 for batch in self.running_mbs:
                     if batch and hasattr(batch, "reqs"):
                         for req in batch.reqs:
                             if hasattr(req, "lora_id") and req.lora_id is not None:
                                 active_lora_ids.add(req.lora_id)
             # For normal mode, check running_batch
-            elif hasattr(self, "running_batch") and self.running_batch:
+            elif self.running_batch:
                 if hasattr(self.running_batch, "reqs"):
                     for req in self.running_batch.reqs:
                         if hasattr(req, "lora_id") and req.lora_id is not None:


### PR DESCRIPTION
Two related cleanups in `Scheduler.__init__` and `SchedulerMetricsMixin`:

- `running_batch`: always created in `Scheduler.__init__`; drop the
  redundant `hasattr(self, "running_batch")` guard at the read site
  and use direct access.

- `running_mbs`: PP-mode-only state, initialized inside
  `init_pp_loop_state` (the first action of every PP event loop).
  Rewrite the `hasattr(self, "running_mbs") and self.running_mbs`
  read-site guard as `if self.server_args.pp_size > 1` — making the
  intent explicit: the `hasattr` check was a proxy for "are we in
  PP mode", and `init_pp_loop_state` guarantees `running_mbs` is
  populated before any reader runs in PP mode.

Refactor chain ID: lift-running-batch-mbs

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->