### PR TITLE
Fix LoRA pool not appearing in /v1/loads

### DIFF
--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -1042,7 +1042,7 @@ class SchedulerMetricsMixin:
 
         lora = None
         if include_all or "lora" in include:
-            if hasattr(self, "lora_scheduler") and self.lora_scheduler is not None:
+            if self.enable_lora:
                 lora = LoRAMetrics(
                     slots_used=self.stats.lora_pool_slots_used,
                     slots_total=self.stats.lora_pool_slots_total,


### PR DESCRIPTION
Change the `/v1/loads` LoRA branch from

    if hasattr(self, "lora_scheduler") and self.lora_scheduler is not None:

to

    if self.enable_lora:

The `hasattr` form was wrong: `lora_scheduler` is a phantom name
that does not exist anywhere in the codebase — it was a typo
introduced in #16976 ("Add /v1/loads endpoint for load metrics")
and has been dead ever since. The actual LoRA owner is
`ModelRunner.lora_manager`, accessed via
`self.tp_worker.model_runner.lora_manager`. Because `lora_scheduler`
was never set on anything, the `hasattr` always returned False on
a Scheduler instance, and the LoRA stats block was silently skipped
on every `/v1/loads` request — the endpoint returned the LoRA pool
as missing even when LoRA was active.

`self.enable_lora` is the actual server-args flag set on Scheduler.
Using it as the guard:

- Correctly fires when LoRA is enabled.
- Matches the same predicate Scheduler uses elsewhere to gate
  LoRA-pool-related work.

Refactor chain ID: fix-lora-loads

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->