### PR TITLE
Annotate dead max_running_requests_under_SLO

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -784,6 +784,7 @@ class Scheduler(
         if self.enable_metrics:
             self.metrics_collector.emit_constants(
                 max_total_num_tokens=self.max_total_num_tokens,
+                # TODO: max_running_requests_under_SLO has no setter — dead chain.
                 max_running_requests_under_SLO=getattr(
                     self, "max_running_requests_under_SLO", None
                 ),

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -954,6 +954,7 @@ class SchedulerMetricsMixin:
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.stats.utilization = -1
         else:
+            # TODO: max_running_requests_under_SLO has no setter — sglang:utilization stuck at 0 (regressed #22713).
             max_under_slo = getattr(self, "max_running_requests_under_SLO", None)
             if max_under_slo is not None and max_under_slo > 0:
                 self.stats.utilization = max(


### PR DESCRIPTION
Add `# TODO` comments at the two read sites of
`max_running_requests_under_SLO` flagging that the attribute has no
setter anywhere in the codebase — it was orphaned during the
regression introduced by #22713.

The two sites:

- managers/scheduler.py: emitted as a constant to the metrics
  collector. Always falls back to `None` (the getattr default).

- observability/scheduler_metrics_mixin.py: read to compute
  `sglang:utilization`. Falls back to `None` → the predicate
  `if max_under_slo is not None and max_under_slo > 0` is always
  False → `self.stats.utilization` is stuck at 0.

This commit does NOT remove the dead reads — fixing the regression
(re-adding the setter so the SLO-aware utilization metric works
again) belongs in a separate non-mechanical commit. The TODOs make
the dead chain visible to the next maintainer without changing
runtime behavior.

Refactor chain ID: annotate-dead-slo-field

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->