### PR TITLE
Lift forward_ct/cur_batch and use direct access in watchdog

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -349,6 +349,9 @@ class Scheduler(
         dp_rank: Optional[int],
     ):
         self.is_initializing = True
+        # init_soft_watchdog starts a daemon thread that reads these on its first tick.
+        self.forward_ct: int = 0
+        self.cur_batch: Optional[ScheduleBatch] = None
         self.init_soft_watchdog(server_args)
 
         # Parse args

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -594,9 +594,8 @@ def create_scheduler_watchdog(
 
     return WatchdogRaw(
         debug_name="Scheduler",
-        get_counter=lambda: getattr(scheduler, "forward_ct", 0),
-        is_active=lambda: scheduler.is_initializing
-        or getattr(scheduler, "cur_batch", None) is not None,
+        get_counter=lambda: scheduler.forward_ct,
+        is_active=lambda: scheduler.is_initializing or scheduler.cur_batch is not None,
         watchdog_timeout=watchdog_timeout,
         soft=soft,
         dump_info=dump_info,


### PR DESCRIPTION
Two related cleanups that together remove the defensive `getattr(...)`
calls in `create_scheduler_watchdog`:

- managers/scheduler.py: lift `self.forward_ct: int = 0` and
  `self.cur_batch: Optional[ScheduleBatch] = None` to the very top of
  `Scheduler.__init__`, BEFORE `init_soft_watchdog()` is called.
  The watchdog launches a daemon thread that reads these on its
  first tick — if the ctor hadn't set them yet, the watchdog had to
  fall back to `getattr(scheduler, "forward_ct", 0)` etc. Lifting
  the attrs to the earliest possible point makes their existence at
  watchdog-read time an invariant of `__init__` rather than a
  defensive convention spread across two files.

- managers/scheduler_runtime_checker_mixin.py: in
  `create_scheduler_watchdog`, replace
  `getattr(scheduler, "forward_ct", 0)` and
  `getattr(scheduler, "cur_batch", None) is not None` with direct
  attribute access. The defensive forms were only necessary because
  the attrs weren't set early enough; with the lift above, direct
  access is safe.

Refactor chain ID: direct-watchdog-defenses

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->