### PR TITLE
Fix V2 trace filename collisions when DP/PP/EP enabled

### DIFF
--- a/python/sglang/srt/utils/profile_utils.py
+++ b/python/sglang/srt/utils/profile_utils.py
@@ -293,12 +293,12 @@ class _ProfilerTorch(_ProfilerConcreteBase):
             filename_parts = [self.profile_id, f"TP-{self.ps.tp_rank}"]
 
             # Only add other ranks if parallelism is enabled (size > 1)
-            if getattr(self, "dp_size", 1) > 1:
-                filename_parts.append(f"DP-{getattr(self, 'dp_rank', 0)}")
-            if getattr(self, "pp_size", 1) > 1:
-                filename_parts.append(f"PP-{getattr(self, 'pp_rank', 0)}")
-            if getattr(self, "moe_ep_size", 1) > 1:
-                filename_parts.append(f"EP-{getattr(self, 'moe_ep_rank', 0)}")
+            if self.ps.dp_size > 1:
+                filename_parts.append(f"DP-{self.ps.dp_rank}")
+            if self.ps.pp_size > 1:
+                filename_parts.append(f"PP-{self.ps.pp_rank}")
+            if self.ps.moe_ep_size > 1:
+                filename_parts.append(f"EP-{self.ps.moe_ep_rank}")
 
             filename = (
                 (self.output_prefix + "-" if self.output_prefix else "")


### PR DESCRIPTION
In `_ProfilerTorch.stop_with_meta`, the trace filename was
constructed by reading parallelism size/rank fields off `self` with
`getattr` defaults:

    if getattr(self, "dp_size", 1) > 1:
        filename_parts.append(f"DP-{getattr(self, 'dp_rank', 0)}")
    # same pattern for pp_*, moe_ep_*

The bug: `_ProfilerTorch` never had `dp_size`, `dp_rank`, `pp_size`,
`pp_rank`, `moe_ep_size`, or `moe_ep_rank` as attributes — only
`tp_rank`. Every getattr call hit the default branch — `dp_size`
read as 1 (DP suffix suppressed), `pp_size` as 1 (PP suppressed),
`moe_ep_size` as 1 (EP suppressed). When any of DP / PP / EP was
actually enabled, every rank wrote to a filename like
`<id>-TP-<n>.trace.json` with no rank-disambiguating suffix — so
multi-rank runs overwrote each other's traces, losing all but one
rank's profile.

After `inject-parallel-state-profiler` made `self.ps` available on
the profiler, this commit replaces all six `getattr(...)` calls
with direct `self.ps.<field>` reads. Now:

- Size predicates (`self.ps.dp_size > 1`, etc.) correctly fire when
  the dimension is enabled.
- Rank suffixes (`f"DP-{self.ps.dp_rank}"`, etc.) are appended with
  the true rank value, not 0.
- Files no longer collide.

Refactor chain ID: fix-trace-filename-collision

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->