### PR TITLE
Replace defensive getattr in pool_configurator with direct access

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -110,7 +110,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 scale_kv_cell_size_per_token_for_dflash,
             )
 
-            draft_num_layers = getattr(mr, "dflash_draft_num_layers", None)
+            draft_num_layers = mr.dflash_draft_num_layers
             if (
                 draft_num_layers is not None
                 and int(draft_num_layers) > 0


### PR DESCRIPTION
Drop `getattr(mr, "dflash_draft_num_layers", None)` in
DefaultPoolConfigurator and use direct attribute access — the fallback
is dead code in preflight, and a silent-failure trap once downstream
chains swap `mr`'s type.

Why the defensive form is dead in preflight:
In preflight, `mr` is always a `ModelRunner` whose ctor unconditionally
sets `self.dflash_draft_num_layers = None` (model_runner.py:419), then
overwrites with an int only when DFLASH is enabled
(model_runner.py:485). The attribute is therefore guaranteed to exist
on every code path, and the `getattr(..., None)` default can never
fire. The form looks protective but has no load-bearing semantic.

Why it becomes a silent bug downstream:
Downstream chain `mech_model_runner` replaces `mr` with a
`frozen=True, slots=True, kw_only=True` dataclass
(`KVCacheConfigurator`). If a future refactor forgets to declare
`dflash_draft_num_layers` on that dataclass, the `getattr(..., None)`
silently swallows the AttributeError, returns None, and DFLASH scaling
is skipped — the target KV pool overshoots by ~1 GB and crashes cuda
graph capture with OOM on 32 GB GPUs. The OOM trace points at
flashinfer workspace allocation, completely unrelated to KV pool
sizing, making the root cause expensive to localize. This actually
happened during `kvc-introduce-skeleton` and took several debug
rounds to track down.

After this commit:
- Preflight behavior is byte-equivalent — `ModelRunner.dflash_draft_num_layers`
  always exists (None or int), so direct access never raises.
- The slots=True contract of any future KVCacheConfigurator dataclass
  is enforced at the call site: a missing field becomes a loud,
  immediate AttributeError instead of a silent pool overallocation.

Refactor chain ID: direct-dflash-draft-num-layers

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->