### PR TITLE
Inline the trivial _build_model_config wrapper

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -419,7 +419,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.dflash_draft_num_layers = None
         if self.spec_algorithm.is_eagle3() and not self.is_draft_worker:
             # load draft config
-            draft_model_config = self._build_model_config(
+            draft_model_config = ModelConfig.from_server_args(
                 server_args,
                 model_path=(server_args.speculative_draft_model_path),
                 model_revision=server_args.speculative_draft_model_revision,
@@ -448,7 +448,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
 
             # Select target layers to capture for building DFlash context features.
-            draft_model_config = self._build_model_config(
+            draft_model_config = ModelConfig.from_server_args(
                 server_args,
                 model_path=(server_args.speculative_draft_model_path),
                 model_revision=server_args.speculative_draft_model_revision,
@@ -567,16 +567,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # For weight updates
         self._model_update_group = {}
         self._weights_send_group = {}
-
-    def _build_model_config(
-        self, server_args, model_path=None, model_revision=None, is_draft_model=False
-    ):
-        return ModelConfig.from_server_args(
-            server_args,
-            model_path=model_path,
-            model_revision=model_revision,
-            is_draft_model=is_draft_model,
-        )
 
     def init_msprobe(self):
         # Init the msprobe


### PR DESCRIPTION
Drop `ModelRunner._build_model_config` and inline its body at the two
call sites (eagle3 + dflash draft-config loading). The wrapper does not
add any value beyond forwarding the same 4 args to
`ModelConfig.from_server_args`, with no extra logic, validation, side
effect, or default mutation.

Before:
    draft_model_config = self._build_model_config(
        server_args,
        model_path=...,
        model_revision=...,
        is_draft_model=True,
    )

After:
    draft_model_config = ModelConfig.from_server_args(
        server_args,
        model_path=...,
        model_revision=...,
        is_draft_model=True,
    )

`ModelConfig` is already imported at the top of the file, so no new
import is needed. Behavior is byte-equivalent at every call site.
Removing the indirection makes the call sites read more directly and
shrinks ModelRunner's surface area by one private helper.

Refactor chain ID: inline-build-model-config

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->