### PR TITLE
Convert discarded-value ternary to a plain if statement

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -636,11 +636,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
         self.expert_location_updater = ExpertLocationUpdater()
 
-        (
+        if self.server_args.elastic_ep_backend:
             ElasticEPStateManager.init(self.server_args)
-            if self.server_args.elastic_ep_backend
-            else None
-        )
         # Load the model
         self.sampler = create_sampler()
         self.load_model()


### PR DESCRIPTION
Rewrite the `ElasticEPStateManager.init` call site from a ternary
expression used as a statement to an `if` statement.

Before:
    (
        ElasticEPStateManager.init(self.server_args)
        if self.server_args.elastic_ep_backend
        else None
    )

After:
    if self.server_args.elastic_ep_backend:
        ElasticEPStateManager.init(self.server_args)

The original form is a `<call> if <cond> else None` ternary whose value
is immediately discarded, so the `else None` branch is meaningless —
`None` is computed and thrown away when the condition is false.
Idiomatic Python uses an `if` statement for conditional side effects;
the ternary form here adds three lines of syntactic noise without any
semantic difference.

The visually similar block immediately above (lines 634-638) is
deliberately *not* changed: `self.eplb_manager = (... if ... else
None)` actually uses the `None` branch to assign a default to
`eplb_manager`, so the ternary carries real semantic load there.

Refactor chain ID: ternary-to-if-elastic-ep











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->