### PR TITLE
Fix invalid suite name in test_multi_detokenizer

### DIFF
--- a/test/registered/tokenizer/test_multi_detokenizer.py
+++ b/test/registered/tokenizer/test_multi_detokenizer.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=211, suite="stage-b-test-1-gpu-large")
+register_cuda_ci(est_time=211, suite="base-b-test-1-gpu-large")
 register_amd_ci(est_time=345, suite="stage-b-test-1-gpu-small-amd")
 
 


### PR DESCRIPTION
## Symptom

All PRs cherry-picked onto current main fail stage-a with:

    ValueError: Tests registered to invalid suites:
      test/registered/tokenizer/test_multi_detokenizer.py:
        backend=CUDA, suite='stage-b-test-1-gpu-large'

`validate_all_suites` rejects the registration, so every base-a CPU / 1-gpu-small job exits before tests even start.

## Cause

Almost certainly introduced by b7d62bd ([#25420] *[CI] Rename basic CI \`stage-a/b/c\` -> \`base-a/b/c\`*).

Timeline:

| Time (PDT) | Commit | What it did |
|---|---|---|
| 2026-05-15 17:26 | 5ba69f50fb (#24944) | Added \`test_multi_detokenizer.py\` registered with the old CUDA suite name \`stage-b-test-1-gpu-large\` |
| 2026-05-15 18:26 | b7d62bd (#25420) | Renamed CUDA suites \`stage-*\` -> \`base-*\` across the repo, but its diff did not include the file #24944 had just added an hour earlier |

After both merged, the file is the lone surviving \`stage-*\` CUDA registration and \`validate_all_suites\` (\`test/run_suite.py\`) flags it as invalid.

## Fix

One-line rename of the CUDA registration:

    -register_cuda_ci(est_time=211, suite=\"stage-b-test-1-gpu-large\")
    +register_cuda_ci(est_time=211, suite=\"base-b-test-1-gpu-large\")

The AMD line on the next row (\`stage-b-test-1-gpu-small-amd\`) is left untouched — #25420 only renamed CUDA suites; AMD suite names still use the \`stage-*\` prefix per \`test/run_suite.py\`.

[#25420]: https://github.com/sgl-project/sglang/pull/25420





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25949485582](https://github.com/sgl-project/sglang/actions/runs/25949485582)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->[Run #25949485495](https://github.com/sgl-project/sglang/actions/runs/25949485495)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->