### PR TITLE
[CI] Show distinct run-name per event in pr-test workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,4 +1,11 @@
 name: PR Test Base
+run-name: >-
+  ${{
+    github.event_name == 'schedule' && 'Scheduled CI Base'
+    || github.event_name == 'workflow_dispatch' && format('Manual run by {0}', github.actor)
+    || github.event_name == 'pull_request' && format('PR #{0} - {1}', github.event.pull_request.number, github.event.pull_request.title)
+    || 'PR Test Base'
+  }}
 
 on:
   schedule:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,7 +1,7 @@
 name: PR Test Base
 run-name: >-
   ${{
-    github.event_name == 'schedule' && 'Scheduled CI Base'
+    github.event_name == 'schedule' && 'Scheduled Full Run'
     || github.event_name == 'workflow_dispatch' && format('Manual run by {0}', github.actor)
     || github.event_name == 'pull_request' && format('PR #{0} - {1}', github.event.pull_request.number, github.event.pull_request.title)
     || 'PR Test Base'


### PR DESCRIPTION
Set `run-name` so the bold title of each PR Test Base run on the Actions page reflects what triggered it (scheduled / manual / PR), instead of all showing 'PR Test Base'.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->