### PR TITLE
[CI] Lower mem-fraction-static for GLM-5.1 FP8 8-GPU test to 0.85

### DIFF
--- a/test/registered/8-gpu-models/test_glm_51_fp8.py
+++ b/test/registered/8-gpu-models/test_glm_51_fp8.py
@@ -15,7 +15,7 @@ COMMON_ARGS = [
     "--trust-remote-code",
     "--reasoning-parser=glm45",
     "--tool-call-parser=glm47",
-    "--mem-fraction-static=0.9",
+    "--mem-fraction-static=0.85",
     "--enable-metrics",
 ]
 


### PR DESCRIPTION
## Motivation

`test/registered/8-gpu-models/test_glm_51_fp8.py::test_glm51_fp8` has been failing on **every** B200 nightly since the test was added in #22399 (2026-04-09, ~37 days, 0 passes on B200). The `TP8+DP8` variant OOMs at scheduler init; `TP8` and `TP8+DP8+MTP` are fine. The same test passes on H200 in the same scheduled runs.

Example failure: [run 25835354140 / job 75909128349](https://github.com/sgl-project/sglang/actions/runs/25835354140/job/75909128349).

`--mem-fraction-static=0.9` on B200 (178 GiB/GPU) leaves only ~3 GiB free after the DP-attention workspaces and cuda-graph capture intermediates land; the next 6.38 GiB cuda-graph alloc OOMs. Not a code regression — the B200 runner has ~5 GiB higher baseline residency than H200 for this model.

## Modifications

```diff
-    "--mem-fraction-static=0.9",
+    "--mem-fraction-static=0.85",
```

`0.85` is already used by `test_minimax_m25.py` for the same 8-GPU + DP-attention shape; every other 8-GPU + DP-attention test in this dir uses 0.85 or lower. GB300 tests keep 0.9 (different runner, 288 GiB/GPU).

## Verification (8x B200, local repro)

| Variant | 0.9 (current) | 0.85 (this PR) |
|---|---|---|
| `TP8`         | PASS, gsm8k 0.966 | PASS, gsm8k 0.967 |
| `TP8+DP8`     | **FAIL: 6.38 GiB OOM, scheduler died** | PASS, gsm8k 0.967 |
| `TP8+DP8+MTP` | PASS | PASS, gsm8k 0.965 |
| Overall       | **FAILED** | **ALL TESTS PASSED** |

Local OOM signature at 0.9 matches CI exactly (6.38 GiB request, ~3.3 GiB free, 170.07 GiB resident).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
