### PR TITLE
fix(function_call): handle stripped functions{name}{index} tool call IDs

### DIFF
--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -47,6 +47,11 @@ class KimiK2Detector(BaseFormatDetector):
     <|tool_call_begin|>{counter}<|tool_call_argument_begin|>{json_args}<|tool_call_end|>
     ```
 
+    Format Structure (stripped functions — client sanitized "." and ":" in history):
+    ```
+    <|tool_call_begin|>functions{name}{index}<|tool_call_argument_begin|>{json_args}<|tool_call_end|>
+    ```
+
     Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
     """
 
@@ -81,14 +86,25 @@ class KimiK2Detector(BaseFormatDetector):
         )
         # Bare call counter: "0", "3" (model uses auto-incrementing counter)
         self.tool_call_id_counter_regex = re.compile(r"^\d+$")
+        # Client-stripped functions ID: "functionsread3" when a client
+        # sanitized "." and ":" from the canonical "functions.read:3" form
+        # and round-tripped that ID through chat history, training the model
+        # to emit the stripped variant in subsequent turns. Lazy name match
+        # so trailing digits route to index.
+        self.tool_call_id_stripped_regex = re.compile(
+            r"^functions(?P<name>.+?)(?P<index>\d+)$"
+        )
 
     def _parse_tool_call_id(
         self, function_id: str, tools: List[Tool], function_args: str = None
     ):
         """Parse a tool call ID into (function_name, call_index).
 
-        Standard format: "functions.ReadFile:0" → ("ReadFile", 0)
-        Bare counter:    "3" → call_index=3, infer name from arguments.
+        Standard format:    "functions.ReadFile:0" → ("ReadFile", 0)
+        Bare counter:       "3" → call_index=3, infer name from arguments.
+        Stripped functions: "functionsread3" → ("read", 3); occurs when a
+            client sanitized "." and ":" from canonical IDs and the format
+            round-tripped through chat history.
 
         The bare counter is a conversation-level auto-increment, NOT an index
         into the tools list. The function name is inferred by matching argument
@@ -104,6 +120,10 @@ class KimiK2Detector(BaseFormatDetector):
             if name:
                 return name, call_index
             return None, call_index
+
+        m = self.tool_call_id_stripped_regex.match(function_id)
+        if m:
+            return m.group("name"), int(m.group("index"))
 
         logger.warning("Unexpected tool_call_id format: %s", function_id)
         return None, 0

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1172,6 +1172,59 @@ class TestKimiK2Detector(unittest.TestCase):
         self.assertEqual(tool_calls[0]["name"], "get_weather")
         self.assertEqual(tool_calls[0]["parameters"], '{"city": "Paris"')
 
+    def test_stripped_functions_tool_call_detect_and_parse(self):
+        """Test parsing tool calls with stripped functions{name}{index} IDs.
+
+        Occurs when a client (e.g. a BFF that requires alphanumeric IDs)
+        sanitized "." and ":" out of the canonical "functions.read:0" ID and
+        round-tripped that ID through chat history. The model then mirrors the
+        sanitized format ("functionsread0", "functionsread1", ...) in
+        subsequent turns, even though sglang itself always emits the canonical
+        form. Without this fallback the calls were silently dropped.
+        """
+        text = '<|tool_calls_section_begin|><|tool_call_begin|>functionsget_weather3<|tool_call_argument_begin|>{"city": "Paris"}<|tool_call_end|><|tool_call_begin|>functionsget_weather4<|tool_call_argument_begin|>{"city": "London"}<|tool_call_end|><|tool_calls_section_end|>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[0].tool_index, 3)
+        self.assertEqual(result.calls[0].parameters, '{"city": "Paris"}')
+        self.assertEqual(result.calls[1].name, "get_weather")
+        self.assertEqual(result.calls[1].tool_index, 4)
+        self.assertEqual(result.calls[1].parameters, '{"city": "London"}')
+
+    def test_stripped_functions_tool_call_streaming(self):
+        """Test streaming parsing of stripped functions{name}{index} IDs."""
+        self.detector = KimiK2Detector()
+
+        chunks = [
+            "<|tool_calls_section_begin|><|tool_call_begin|>functionsget_weather3<|tool_call_argument_begin|>{",
+            '"city": "Paris"',
+            "}<|tool_call_end|>",
+            "<|tool_call_begin|>functionsget_weather4<|tool_call_argument_begin|>{",
+            '"city": "London"',
+            "}<|tool_call_end|>",
+            "<|tool_calls_section_end|>",
+        ]
+
+        tool_calls = []
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            for tool_call_chunk in result.calls:
+                if tool_call_chunk.tool_index is not None:
+                    while len(tool_calls) <= tool_call_chunk.tool_index:
+                        tool_calls.append({"name": "", "parameters": ""})
+                    tc = tool_calls[tool_call_chunk.tool_index]
+                    if tool_call_chunk.name:
+                        tc["name"] += tool_call_chunk.name
+                    if tool_call_chunk.parameters:
+                        tc["parameters"] += tool_call_chunk.parameters
+
+        self.assertEqual(len(tool_calls), 2)
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+        self.assertEqual(tool_calls[0]["parameters"], '{"city": "Paris"}')
+        self.assertEqual(tool_calls[1]["name"], "get_weather")
+        self.assertEqual(tool_calls[1]["parameters"], '{"city": "London"}')
+
 
 class TestDeepSeekV3Detector(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION

Related to #25358 / #25362 — same root-cause family (client-side `tool_call_id` round-trip pollution through the Kimi K2 chat history), different sanitization shape. Complementary, not overlapping, with PR #25362.

## Motivation

When a downstream client sanitizes `.` and `:` out of the canonical `functions.read:0` `tool_call_id` before persisting it to chat history, the sanitized form (`functionsread0`, `functionsread1`, …) gets round-tripped back through `chat_template.jinja` on the next turn and the model mirrors that format in its outputs. Without an explicit fallback, `_parse_tool_call_id` returns `(None, 0)`, `detect_and_parse` silently drops the call, and the response comes back with `finish_reason: stop`, no content, and no `tool_calls` — multi-turn agent loops break with the user seeing only `<think>...</think>` and an empty assistant turn.

This is the same class of bug as #25358 (`call00003` prefixed counter format addressed by #25362), but triggered by a different client sanitization pattern. The two fixes touch adjacent branches in the same `_parse_tool_call_id` cascade and are complementary; merge order does not matter.

**Production trace from one captured session (Kimi-K2.6 + sglang v0.5.11):**

| tool_call_id emitted by model | count |
|---|---|
| `functionsread0` | 5 |
| `functionsread1` | 4 |
| `functionsread2` | 4 |
| `functionsread3` | 1 |
| `functions.read:0` | 2 |
| `functions.read:1` | 1 |
| `functions.read:2` | 1 |

14 of 18 calls in the stripped form. The prompt fed back into Kimi for the next turn contained `"id": "functionsread0"` directly in chat history JSON, confirming the round-trip path.

## Modifications

- `python/sglang/srt/function_call/kimik2_detector.py`:
  - New `tool_call_id_stripped_regex = r"^functions(?P<name>.+?)(?P<index>\d+)$"`. Lazy quantifier on `name` so trailing digits route to `index`.
  - New final fallback branch in `_parse_tool_call_id`. Function name comes directly from the regex group, so no `_infer_tool_name` lookup is needed for this case.
  - Docstring + class-level format reference updated.
- `test/registered/unit/function_call/test_function_call_parser.py`:
  - `test_stripped_functions_tool_call_detect_and_parse`
  - `test_stripped_functions_tool_call_streaming`

Cascade order after this PR (and #25362 if both land):
1. standard `functions.{name}:{index}` — wins first
2. bare numeric counter `\d+`
3. `call\d+` prefixed counter (#25362)
4. `functions{name}{index}` stripped (this PR)

Canonical IDs are unaffected by every step below the first.

## Accuracy Tests

N/A — bug fix in a parser fallback path; no change to model forward or kernel code. Covered by the two new unit tests in `test/registered/unit/function_call/test_function_call_parser.py`, plus a regression check that the standard `functions.{name}:{index}` form still parses through the original branch (verified in development; not committed since it is already covered by existing `test_single_tool_call` / `test_multiple_tool_calls`).

Field-validated on Kimi-K2.6 (compressed-tensors INT4, 16×A800, PP=2×TP=8):
- 66 real-traffic tool calls in the stripped format → **0** `Unexpected tool_call_id` warnings after the patch
- End-to-end `curl` with a multi-turn request whose history contained `"id": "functionsread0"` → response returns `finish_reason: tool_calls` with `tool_calls[0].id = "functions.read:2"` (sglang's canonical ID regenerated by `_process_tool_call_id`)

## Speed Tests and Profiling

N/A — the change adds at most one extra `re.match()` call per tool-call ID, only when the prior cascade branches all miss. No hot-path impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A, internal parser fallback.
- [ ] Provide accuracy and speed benchmark results — N/A (see above sections).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

cc @CatherineSue @JustinTong0323 — same area as #23950 / #25196 / #25362; this is the smallest possible extension of the cascade pattern #23950 introduced.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->