### PR TITLE
[Benchmark] Improve MMMU harness with mulit-image, prompt config, and per-request pixel resolution

### DIFF
--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -218,6 +218,8 @@ async def eval_mmmu(args) -> None:
         )
 
     if args.concurrency == 1:
+        # For concurrency == 1, run in sequential mode to ensure consistent order
+        # this is mainly for profiling
         for sample in tqdm(samples):
             _, response = await process_sample(
                 client,

--- a/benchmark/mmmu/bench_sglang.py
+++ b/benchmark/mmmu/bench_sglang.py
@@ -36,6 +36,7 @@ from tqdm import tqdm
 from sglang.test.test_utils import add_common_sglang_args_and_parse
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
+IMAGE_TAG_RE = re.compile(r"<image\s*\d*>")
 
 
 @dataclass
@@ -69,11 +70,32 @@ async def async_request_profile(api_url: str) -> RequestFuncOutput:
     return output
 
 
-def _get_prefix_suffix(prompt: str) -> Tuple[str, str]:
-    """Split the prompt into prefix and suffix."""
-    prefix = prompt.split("<")[0]
-    suffix = prompt.split(">", 1)[1]
-    return prefix, suffix
+def _strip_think_tags(response: Optional[str]) -> Optional[str]:
+    """Strip <think>...</think> tags from model response."""
+    if response and "</think>" in response:
+        return response.split("</think>")[-1].strip()
+    return response
+
+
+def _split_prompt_on_images(prompt: str) -> List[str]:
+    """Split prompt on <image>, <image 1>, <image 2>, etc. tags.
+
+    Returns a list of text segments (one more than the number of image tags).
+    For a prompt with no image tags, returns [prompt].
+    """
+    parts = IMAGE_TAG_RE.split(prompt)
+    return parts
+
+
+def _encode_image_path(image_path: str) -> str:
+    """Convert a local image path to a base64 data URL, or pass through remote URLs."""
+    if image_path and not image_path.startswith(("http://", "https://", "data:")):
+        p = Path(image_path)
+        mime = mimetypes.guess_type(str(p))[0] or "image/png"
+        with open(p, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode()
+        return f"data:{mime};base64,{b64}"
+    return image_path
 
 
 async def process_sample(
@@ -83,45 +105,46 @@ async def process_sample(
     model: str,
     reasoning_effort: Optional[str] = None,
     lora_path: Optional[str] = None,
+    min_pixels: Optional[int] = None,
+    max_pixels: Optional[int] = None,
 ) -> Tuple[dict, str]:
     """Send a single sample to the LLM and return (sample, response)."""
     prompt = sample["final_input_prompt"]
-    prefix, suffix = _get_prefix_suffix(prompt)
-    image = sample["image"]
-    assert image is not None
-    image_path = sample["image_path"]
-    if image_path and not image_path.startswith(("http://", "https://", "data:")):
-        p = Path(image_path)
-        mime = mimetypes.guess_type(str(p))[0] or "image/png"
-        with open(p, "rb") as f:
-            b64 = base64.b64encode(f.read()).decode()
-        image_url = f"data:{mime};base64,{b64}"
-    else:
-        image_url = image_path
-    extra_body = {"lora_path": lora_path} if lora_path else None
+    text_parts = _split_prompt_on_images(prompt)
+    image_paths = sample["image_paths"]
+
+    content = []
+    for i, text in enumerate(text_parts):
+        if text:
+            content.append({"type": "text", "text": text})
+        if i < len(image_paths):
+            image_url = _encode_image_path(image_paths[i])
+            image_part = {"url": image_url}
+            if min_pixels is not None:
+                image_part["min_pixels"] = min_pixels
+            if max_pixels is not None:
+                image_part["max_pixels"] = max_pixels
+            content.append({"type": "image_url", "image_url": image_part})
+
+    params = {k: v for k, v in sampling_params.items() if k != "extra_body"}
+    extra_body = dict(sampling_params.get("extra_body") or {})
+    if lora_path:
+        extra_body["lora_path"] = lora_path
     payload = {
         "model": model,
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": prefix},
-                    {"type": "image_url", "image_url": {"url": image_url}},
-                    {"type": "text", "text": suffix},
-                ],
-            }
-        ],
-        "extra_body": extra_body,
-        **sampling_params,
+        "messages": [{"role": "user", "content": content}],
+        **params,
     }
+    if extra_body:
+        payload["extra_body"] = extra_body
     if reasoning_effort:
         payload["reasoning_effort"] = reasoning_effort
     response = await client.chat.completions.create(**payload)
     msg = response.choices[0].message
-    content = msg.content
-    if content is None:
-        content = getattr(msg, "reasoning_content", None)
-    return sample, content
+    result = msg.content
+    if result is None:
+        result = getattr(msg, "reasoning_content", None)
+    return sample, result
 
 
 async def process_sample_with_semaphore(
@@ -132,11 +155,20 @@ async def process_sample_with_semaphore(
     model: str,
     reasoning_effort: Optional[str] = None,
     lora_path: Optional[str] = None,
+    min_pixels: Optional[int] = None,
+    max_pixels: Optional[int] = None,
 ) -> Tuple[dict, str]:
     """Wrap process_sample with a semaphore for concurrency control."""
     async with semaphore:
         return await process_sample(
-            client, sample, sampling_params, model, reasoning_effort, lora_path
+            client,
+            sample,
+            sampling_params,
+            model,
+            reasoning_effort,
+            lora_path,
+            min_pixels,
+            max_pixels,
         )
 
 
@@ -148,6 +180,8 @@ async def eval_mmmu(args) -> None:
     model = args.model
     reasoning_effort = eval_args.reasoning_effort
     lora_path = eval_args.lora_path
+    min_pixels = eval_args.min_pixels
+    max_pixels = eval_args.max_pixels
     answer_dict = {}
     out_samples = {}
     client = openai.AsyncOpenAI(
@@ -168,25 +202,34 @@ async def eval_mmmu(args) -> None:
 
         samples = samples[: args.profile_number]
 
+    def _handle_response(sample, response):
+        sample["original_response"] = response
+        response = _strip_think_tags(response)
+        answer = (
+            re.search(args.response_answer_regex, response)
+            if response is not None
+            else None
+        )
+        process_result(
+            answer.group(1).strip() if answer else response,
+            sample,
+            answer_dict,
+            out_samples,
+        )
+
     if args.concurrency == 1:
-        # For concurrency == 1, run in sequential mode to ensure consistent order
-        # this is mainly for profiling
         for sample in tqdm(samples):
             _, response = await process_sample(
-                client, sample, sampling_params, model, reasoning_effort, lora_path
-            )
-            sample["original_response"] = response
-            answer = (
-                re.search(args.response_answer_regex, response)
-                if response is not None
-                else None
-            )
-            process_result(
-                answer.group(1).strip() if answer else response,
+                client,
                 sample,
-                answer_dict,
-                out_samples,
+                sampling_params,
+                model,
+                reasoning_effort,
+                lora_path,
+                min_pixels,
+                max_pixels,
             )
+            _handle_response(sample, response)
     else:
         semaphore = asyncio.Semaphore(args.concurrency)
         tasks = [
@@ -198,24 +241,15 @@ async def eval_mmmu(args) -> None:
                 model,
                 reasoning_effort,
                 lora_path,
+                min_pixels,
+                max_pixels,
             )
             for sample in samples
         ]
 
         for coro in tqdm(asyncio.as_completed(tasks), total=len(tasks)):
             sample, response = await coro
-            sample["original_response"] = response
-            answer = (
-                re.search(args.response_answer_regex, response)
-                if response is not None
-                else None
-            )
-            process_result(
-                answer.group(1).strip() if answer else response,
-                sample,
-                answer_dict,
-                out_samples,
-            )
+            _handle_response(sample, response)
 
     if args.profile:
         print("Stopping profiler...")

--- a/benchmark/mmmu/data_utils.py
+++ b/benchmark/mmmu/data_utils.py
@@ -6,6 +6,9 @@ import re
 
 import yaml
 
+# MMMU dataset has image_1 through image_7 columns
+MAX_IMAGES_PER_SAMPLE = 7
+
 DOMAIN_CAT2SUB_CAT = {
     "Art and Design": ["Art", "Art_Theory", "Design", "Music"],
     "Business": ["Accounting", "Economics", "Finance", "Manage", "Marketing"],
@@ -106,7 +109,7 @@ def parse_img_path(text):
     return matches
 
 
-def process_single_sample(data):
+def process_single_sample(data, multi_images=False):
     question = data["question"]
     o_imgs_paths = []
     for option in data["options"]:
@@ -114,30 +117,41 @@ def process_single_sample(data):
         for img_path in current_o_imgs_paths:
             o_imgs_paths.append(img_path)
 
-    if len(o_imgs_paths) > 1:  # multiple images in options, used for random selection
+    if len(o_imgs_paths) > 1:  # multiple images in options, not supported
         return {
             "id": data["id"],
             "question": question,
             "options": data["options"],
             "answer": data["answer"],
-            "image": None,
+            "images": [],
             "question_type": data["question_type"],
         }
+
+    images = []
+    if multi_images:
+        for i in range(1, MAX_IMAGES_PER_SAMPLE + 1):
+            key = f"image_{i}"
+            if key in data and data[key] is not None:
+                images.append(data[key])
     else:
-        return {
-            "id": data["id"],
-            "question": question,
-            "options": data["options"],
-            "answer": data["answer"],
-            "image": data["image_1"],
-            "question_type": data["question_type"],
-        }
+        if data.get("image_1") is not None:
+            images.append(data["image_1"])
+    return {
+        "id": data["id"],
+        "question": question,
+        "options": data["options"],
+        "answer": data["answer"],
+        "images": images,
+        "question_type": data["question_type"],
+    }
 
 
 # DATA SAVING
 def save_json(filename, ds):
     print(f"answers saved to: {filename}")
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    dirname = os.path.dirname(filename)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
     with open(filename, "w") as f:
         json.dump(ds, f, indent=4)
 
@@ -174,13 +188,17 @@ def construct_prompt(sample, config):
     question = sample["question"]
     options = eval(sample["options"])
     example = ""
+    option_fmt = config["option_format"]
     if sample["question_type"] == "multiple-choice":
         start_chr = "A"
         prediction_range = []
         index2ans = {}
         for option in options:
             prediction_range.append(start_chr)
-            example += f"({start_chr}) {option}\n"
+            if option_fmt == "dot":
+                example += f"{start_chr}. {option}\n"
+            else:
+                example += f"({start_chr}) {option}\n"
             index2ans[start_chr] = option
             start_chr = chr(ord(start_chr) + 1)
         empty_prompt_sample_structure = config["multi_choice_example_format"]

--- a/benchmark/mmmu/data_utils.py
+++ b/benchmark/mmmu/data_utils.py
@@ -117,7 +117,7 @@ def process_single_sample(data, multi_images=False):
         for img_path in current_o_imgs_paths:
             o_imgs_paths.append(img_path)
 
-    if len(o_imgs_paths) > 1:  # multiple images in options, not supported
+    if len(o_imgs_paths) > 1:  # multiple images in options
         return {
             "id": data["id"],
             "question": question,

--- a/benchmark/mmmu/eval_utils.py
+++ b/benchmark/mmmu/eval_utils.py
@@ -29,7 +29,7 @@ class EvalArgs:
     seed: int = 42
     split: str = "validation"
     image_pixels_limit: int = -1
-    result_filename: str = f"./val_sglang.json"
+    result_filename: str = "./val_sglang.json"
     prompt_format_file: str = "prompt_format.yaml"
     dataset_path: str = "MMMU/MMMU"
     extra_request_body: Optional[str] = None
@@ -38,9 +38,16 @@ class EvalArgs:
     concurrency: int = 1
     max_new_tokens: Optional[int] = None
     temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    presence_penalty: Optional[float] = None
+    repetition_penalty: Optional[float] = None
     response_answer_regex: str = "(?s)(.*)"
     lora_path: Optional[str] = None
     reasoning_effort: Optional[str] = None
+    min_pixels: Optional[int] = None
+    max_pixels: Optional[int] = None
+    multi_images: bool = False
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
@@ -110,6 +117,30 @@ class EvalArgs:
             help="Sampling temperature for generation.",
         )
         parser.add_argument(
+            "--top-p",
+            type=float,
+            default=EvalArgs.top_p,
+            help="Top-p (nucleus) sampling parameter.",
+        )
+        parser.add_argument(
+            "--top-k",
+            type=int,
+            default=EvalArgs.top_k,
+            help="Top-k sampling parameter.",
+        )
+        parser.add_argument(
+            "--presence-penalty",
+            type=float,
+            default=EvalArgs.presence_penalty,
+            help="Presence penalty for generation (penalizes tokens that have appeared).",
+        )
+        parser.add_argument(
+            "--repetition-penalty",
+            type=float,
+            default=EvalArgs.repetition_penalty,
+            help="Repetition penalty for generation.",
+        )
+        parser.add_argument(
             "--response-answer-regex",
             type=str,
             default=EvalArgs.response_answer_regex,
@@ -127,6 +158,24 @@ class EvalArgs:
             default=EvalArgs.reasoning_effort,
             choices=["none", "high"],
             help="Reasoning effort for the model (none or high).",
+        )
+        parser.add_argument(
+            "--min-pixels",
+            type=int,
+            default=EvalArgs.min_pixels,
+            help="Minimum pixel count for image resizing (e.g., 1003520 for Qwen3-VL).",
+        )
+        parser.add_argument(
+            "--max-pixels",
+            type=int,
+            default=EvalArgs.max_pixels,
+            help="Maximum pixel count for image resizing (e.g., 4014080 for Qwen3-VL).",
+        )
+        parser.add_argument(
+            "--multi-images",
+            action="store_true",
+            default=EvalArgs.multi_images,
+            help="Use all images per sample instead of only the first.",
         )
 
     @classmethod
@@ -215,17 +264,23 @@ def prepare_samples(eval_args: EvalArgs):
     skip_count = 0
 
     def process_sample(i, sample):
-        sample = process_single_sample(sample)
+        sample = process_single_sample(sample, multi_images=eval_args.multi_images)
         sample = construct_prompt(sample, eval_args.config)
-        image = sample["image"]
-        width, height = image.size
+        images = sample.get("images", [])
+        if not images:
+            return None, True
+        first_image = images[0]
+        width, height = first_image.size
         if 0 < eval_args.image_pixels_limit <= width * height:
             return None, True
-        # Use a unique identifier for the image path to avoid potential collisions if indices reset
-        image_path = f"{images_path}/image_{sample['id']}.png"
-        if not os.path.exists(image_path):
-            image.save(image_path)
-        sample["image_path"] = image_path
+        image_paths = []
+        for idx, img in enumerate(images):
+            suffix = f"_{idx}" if len(images) > 1 else ""
+            image_path = f"{images_path}/image_{sample['id']}{suffix}.png"
+            if not os.path.exists(image_path):
+                img.save(image_path)
+            image_paths.append(image_path)
+        sample["image_paths"] = image_paths
         return sample, False
 
     print("Processing samples...")
@@ -264,10 +319,25 @@ def get_sampling_params(eval_args):
     }
 
     if eval_args.max_new_tokens is not None and eval_args.max_new_tokens > 0:
-        sampling_params.update({"max_completion_tokens": eval_args.max_new_tokens})
+        sampling_params["max_completion_tokens"] = eval_args.max_new_tokens
 
     if eval_args.temperature is not None:
-        sampling_params.update({"temperature": eval_args.temperature})
+        sampling_params["temperature"] = eval_args.temperature
+
+    if eval_args.top_p is not None:
+        sampling_params["top_p"] = eval_args.top_p
+
+    if eval_args.presence_penalty is not None:
+        sampling_params["presence_penalty"] = eval_args.presence_penalty
+
+    # top_k and repetition_penalty are SGLang extensions, not standard OpenAI fields
+    extra_body = sampling_params.pop("extra_body", {})
+    if eval_args.top_k is not None:
+        extra_body["top_k"] = eval_args.top_k
+    if eval_args.repetition_penalty is not None:
+        extra_body["repetition_penalty"] = eval_args.repetition_penalty
+    if extra_body:
+        sampling_params["extra_body"] = extra_body
 
     return sampling_params
 
@@ -286,6 +356,8 @@ _EXPLICIT_ANSWER_PATTERNS = (
     r"\\boxed\{\s*\*{0,2}\s*\(?([A-Z])\)?\s*\*{0,2}\s*\}",
     # "(the) answer is X" / "(the) correct answer is X"
     r"\b(?:the\s+)?answer\s+is\s*\*{0,2}\s*\(?([A-Z])\)?\s*\*{0,2}(?![A-Za-z])",
+    # "X." at the very start (model echoes the option letter)
+    r"^\s*\(?([A-Z])\)?\s*\.",
 )
 
 
@@ -333,8 +405,19 @@ def parse_multi_choice_response(response, all_choices, index2ans):
                 candidates.append(index)
                 index_ans = False  # it's content ans.
 
-    if len(candidates) == 0:  # still not get answer, randomly choose one.
-        pred_index = random.choice(all_choices)
+    if len(candidates) == 0:
+        stripped = response
+        for ch in ".()[],:;!*#{}\"'":
+            stripped = stripped.replace(ch, " ")
+        tokens = [t.strip() for t in stripped.split() if t.strip()]
+        found = [c for c in all_choices if c in tokens]
+        if len(found) == 1:
+            pred_index = found[0]
+        elif len(found) > 1:
+            first_pos = {c: tokens.index(c) for c in found}
+            pred_index = min(first_pos, key=first_pos.get)
+        else:
+            pred_index = random.choice(all_choices)
     elif len(candidates) > 1:
         start_indexes = []
         if index_ans:
@@ -531,20 +614,25 @@ def eval_open(gold_i, pred_i):
     """
     correct = False
     if isinstance(gold_i, list):
-        # use float to avoid trivial matches
         norm_answers = []
+        raw_answers = [str(a).strip().lower() for a in gold_i]
         for answer in gold_i:
             norm_answers.extend(normalize_str(answer))
     else:
         norm_answers = normalize_str(gold_i)
-    for pred in pred_i:  # pred is already normalized in parse response phase
-        if isinstance(pred, str):  # if it's a string, then find if ans in the pred_i
+        raw_answers = [str(gold_i).strip().lower()]
+    for pred in pred_i:
+        if isinstance(pred, str):
             for norm_ans in norm_answers:
-                # only see if the string answer in the string pred
                 if isinstance(norm_ans, str) and norm_ans in pred:
                     if not correct:
                         correct = True
                     break
+            if not correct:
+                for raw_ans in raw_answers:
+                    if raw_ans in pred:
+                        correct = True
+                        break
         else:  # it's a float number
             if pred in norm_answers:
                 if not correct:
@@ -622,7 +710,6 @@ def eval_result(model_answer_path, answer_dict, eval_output_path=None):
         eval_output_path = model_answer_path
     print("Evaluating...")
     output_dict = json.load(open(model_answer_path))
-    # answer_dict = json.load(open(answer_path))
 
     # group by category
     output_dict_w_cat = {}
@@ -662,12 +749,9 @@ def eval_result(model_answer_path, answer_dict, eval_output_path=None):
         for data_id, parsed_pred in cat_outputs.items():
             question_type = cat_answers[data_id]["question_type"]
             if question_type != "multiple-choice":
-                parsed_pred = parse_open_response(
-                    parsed_pred
-                )  # mainly for type consistency (make it number, etc.)
-            else:
-                parsed_pred = parsed_pred
-
+                raw_response = parsed_pred
+                parsed_pred = parse_open_response(raw_response)
+                parsed_pred.append(raw_response.lower())
             exampels_to_eval.append(
                 {
                     "id": data_id,

--- a/benchmark/mmmu/eval_utils.py
+++ b/benchmark/mmmu/eval_utils.py
@@ -276,6 +276,7 @@ def prepare_samples(eval_args: EvalArgs):
         image_paths = []
         for idx, img in enumerate(images):
             suffix = f"_{idx}" if len(images) > 1 else ""
+            # Use a unique identifier for the image path to avoid potential collisions if indices reset
             image_path = f"{images_path}/image_{sample['id']}{suffix}.png"
             if not os.path.exists(image_path):
                 img.save(image_path)
@@ -416,7 +417,7 @@ def parse_multi_choice_response(response, all_choices, index2ans):
         elif len(found) > 1:
             first_pos = {c: tokens.index(c) for c in found}
             pred_index = min(first_pos, key=first_pos.get)
-        else:
+        else:  # still not get answer, randomly choose one.
             pred_index = random.choice(all_choices)
     elif len(candidates) > 1:
         start_indexes = []
@@ -614,6 +615,7 @@ def eval_open(gold_i, pred_i):
     """
     correct = False
     if isinstance(gold_i, list):
+        # use float to avoid trivial matches
         norm_answers = []
         raw_answers = [str(a).strip().lower() for a in gold_i]
         for answer in gold_i:
@@ -621,9 +623,10 @@ def eval_open(gold_i, pred_i):
     else:
         norm_answers = normalize_str(gold_i)
         raw_answers = [str(gold_i).strip().lower()]
-    for pred in pred_i:
-        if isinstance(pred, str):
+    for pred in pred_i:  # pred is already normalized in parse response phase
+        if isinstance(pred, str):  # if it's a string, then find if ans in the pred_i
             for norm_ans in norm_answers:
+                # only see if the string answer in the string pred
                 if isinstance(norm_ans, str) and norm_ans in pred:
                     if not correct:
                         correct = True
@@ -750,7 +753,9 @@ def eval_result(model_answer_path, answer_dict, eval_output_path=None):
             question_type = cat_answers[data_id]["question_type"]
             if question_type != "multiple-choice":
                 raw_response = parsed_pred
-                parsed_pred = parse_open_response(raw_response)
+                parsed_pred = parse_open_response(
+                    raw_response
+                )  # mainly for type consistency (make it number, etc.)
                 parsed_pred.append(raw_response.lower())
             exampels_to_eval.append(
                 {

--- a/benchmark/mmmu/prompt_format.yaml
+++ b/benchmark/mmmu/prompt_format.yaml
@@ -11,5 +11,7 @@ short_ans_example_format:
 - "{}
 
 Answer the question using a single word or phrase."
+option_format:
+- "paren"
 temperature:
 - 0

--- a/benchmark/mmmu/prompt_format_qwen3vl.yaml
+++ b/benchmark/mmmu/prompt_format_qwen3vl.yaml
@@ -1,0 +1,12 @@
+task_instructions:
+- ""
+multi_choice_example_format:
+- "Question: {}
+Options:
+{}Please select the correct answer from the options above."
+short_ans_example_format:
+- "Question: {}"
+option_format:
+- "dot"
+temperature:
+- 0

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -438,6 +438,8 @@ class ChatCompletionMessageContentImageURL(BaseModel):
     detail: Optional[Literal["auto", "low", "high"]] = "auto"
     max_dynamic_patch: Optional[int] = None
     min_dynamic_patch: Optional[int] = None
+    min_pixels: Optional[int] = None
+    max_pixels: Optional[int] = None
 
 
 class ChatCompletionMessageContentVideoURL(BaseModel):

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -401,8 +401,13 @@ class BaseMultimodalProcessor(ABC):
         """
         if images:
             kwargs["images"] = images
+            per_request_images_kwargs = kwargs.pop("images_kwargs", {})
+            merged_images_kwargs = {}
             if self.image_config:
-                kwargs.setdefault("images_kwargs", {}).update(self.image_config)
+                merged_images_kwargs.update(self.image_config)
+            merged_images_kwargs.update(per_request_images_kwargs)
+            if merged_images_kwargs:
+                kwargs["images_kwargs"] = merged_images_kwargs
         if videos:
             kwargs["videos"] = videos
             if self.video_config:
@@ -1214,7 +1219,6 @@ class BaseMultimodalProcessor(ABC):
                     isinstance(item.precomputed_embeddings, torch.Tensor)
                     and item.precomputed_embeddings.is_cuda
                 ):
-
                     sync_flag, available_slice, byte_offset = (
                         self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(
                             item.precomputed_embeddings

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -33,6 +33,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
+from sglang.srt.utils.common import ImageData
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 
@@ -515,6 +516,13 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         load_time = time.perf_counter()
         rid = getattr(request_obj, "rid", "anonymous_rid")
 
+        per_request_images_kwargs = {}
+        if image_data:
+            for img_item in image_data:
+                if isinstance(img_item, ImageData) and img_item.preprocess_kwargs:
+                    per_request_images_kwargs.update(img_item.preprocess_kwargs)
+                    break
+
         video_metadata = None
         if base_output.videos:
             videos_processed = [
@@ -524,6 +532,10 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             base_output.videos, video_metadata = map(list, zip(*videos_processed))
 
         preprocess_time = time.perf_counter()
+
+        extra_kwargs = {}
+        if per_request_images_kwargs:
+            extra_kwargs["images_kwargs"] = per_request_images_kwargs
 
         # NOTE: for qwen3-vl, video_meta need to be passed in, since do_sample_frames is already done in preprocess_video
         if self.hf_config.model_type in (
@@ -538,10 +550,11 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 self.mm_tokens,
                 video_metadata=video_metadata,
                 do_sample_frames=False,
+                **extra_kwargs,
             )
         else:
             mm_items, input_ids, ret = self.process_and_combine_mm_data(
-                base_output, self.mm_tokens
+                base_output, self.mm_tokens, **extra_kwargs
             )
 
         audio_feature_lengths = None

--- a/python/sglang/srt/parser/jinja_template_utils.py
+++ b/python/sglang/srt/parser/jinja_template_utils.py
@@ -160,12 +160,17 @@ def process_content_for_template_format(
                 if chunk_type == "image_url":
                     image_obj = chunk.get("image_url") or {}
                     mdp = image_obj.get("max_dynamic_patch", None)
-                    # Also allow flat style: chunk["max_dynamic_patch"]
+                    preprocess_kwargs = {}
+                    if image_obj.get("min_pixels") is not None:
+                        preprocess_kwargs["min_pixels"] = image_obj["min_pixels"]
+                    if image_obj.get("max_pixels") is not None:
+                        preprocess_kwargs["max_pixels"] = image_obj["max_pixels"]
                     image_data.append(
                         ImageData(
                             url=image_obj["url"],
                             detail=image_obj.get("detail", "auto"),
                             max_dynamic_patch=mdp,
+                            preprocess_kwargs=preprocess_kwargs or None,
                         )
                     )
 

--- a/test/registered/core/test_mm_process_config.py
+++ b/test/registered/core/test_mm_process_config.py
@@ -179,6 +179,33 @@ class TestProcessMmDataKwargs(unittest.TestCase):
             call_kwargs.kwargs.get("videos_kwargs"), {"max_pixels": 602112}
         )
 
+    def test_per_request_images_kwargs_overrides_server_config(self):
+        """Per-request images_kwargs should override server-level image_config."""
+        config = {"image": {"max_pixels": 1000000, "min_pixels": 100}}
+        proc, mock_proc, _ = self._make_base_processor(config)
+
+        proc.process_mm_data(
+            "test", images=["img1"], images_kwargs={"max_pixels": 500000}
+        )
+
+        call_kwargs = mock_proc.__call__.call_args
+        images_kw = call_kwargs.kwargs.get("images_kwargs", {})
+        self.assertEqual(images_kw["max_pixels"], 500000)
+        self.assertEqual(images_kw["min_pixels"], 100)
+
+    def test_per_request_images_kwargs_without_server_config(self):
+        """Per-request images_kwargs works even with empty server config."""
+        proc, mock_proc, _ = self._make_base_processor({})
+
+        proc.process_mm_data(
+            "test", images=["img1"], images_kwargs={"max_pixels": 500000}
+        )
+
+        call_kwargs = mock_proc.__call__.call_args
+        self.assertEqual(
+            call_kwargs.kwargs.get("images_kwargs"), {"max_pixels": 500000}
+        )
+
     def test_empty_config_no_kwargs_injected(self):
         proc, mock_proc, _ = self._make_base_processor({})
 

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field, ValidationError
 
 from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionMessageContentImageURL,
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
@@ -436,6 +437,46 @@ class TestFunctionDeferLoading(unittest.TestCase):
         self.assertEqual(parts[0].type, "tool_reference")
         self.assertEqual(parts[0].name, "search_db")
         self.assertEqual(parts[1].type, "text")
+
+
+class TestImageURLPixelFields(unittest.TestCase):
+    """Test min_pixels / max_pixels on ChatCompletionMessageContentImageURL."""
+
+    def test_defaults_to_none(self):
+        obj = ChatCompletionMessageContentImageURL(url="http://example.com/img.jpg")
+        self.assertIsNone(obj.min_pixels)
+        self.assertIsNone(obj.max_pixels)
+
+    def test_accepts_and_roundtrips(self):
+        obj = ChatCompletionMessageContentImageURL(
+            url="http://example.com/img.jpg", min_pixels=256, max_pixels=1048576
+        )
+        self.assertEqual(obj.min_pixels, 256)
+        self.assertEqual(obj.max_pixels, 1048576)
+        data = obj.model_dump()
+        self.assertEqual(data["min_pixels"], 256)
+        self.assertEqual(data["max_pixels"], 1048576)
+
+    def test_chat_request_with_pixel_fields(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "http://example.com/img.jpg",
+                            "min_pixels": 128,
+                            "max_pixels": 512000,
+                        },
+                    }
+                ],
+            }
+        ]
+        request = ChatCompletionRequest(model="test-model", messages=messages)
+        img_part = request.messages[0].content[0]
+        self.assertEqual(img_part.image_url.min_pixels, 128)
+        self.assertEqual(img_part.image_url.max_pixels, 512000)
 
 
 class TestValidationEdgeCases(unittest.TestCase):

--- a/test/registered/unit/parser/test_jinja_template_utils.py
+++ b/test/registered/unit/parser/test_jinja_template_utils.py
@@ -468,6 +468,64 @@ class TestTemplateContentFormatDetection(CustomTestCase):
         result = detect_jinja_template_content_format(template)
         self.assertEqual(result, "string")
 
+    def test_process_content_image_with_min_max_pixels(self):
+        """Test that min_pixels/max_pixels are extracted into ImageData.preprocess_kwargs."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "http://example.com/img.jpg",
+                        "min_pixels": 256,
+                        "max_pixels": 1048576,
+                    },
+                }
+            ],
+        }
+        image_data = []
+        result = process_content_for_template_format(
+            msg_dict, "openai", image_data, [], [], []
+        )
+        self.assertEqual(len(image_data), 1)
+        self.assertEqual(
+            image_data[0].preprocess_kwargs,
+            {"min_pixels": 256, "max_pixels": 1048576},
+        )
+
+    def test_process_content_image_without_pixels_has_no_preprocess_kwargs(self):
+        """preprocess_kwargs should be None when no pixel fields are provided."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "http://example.com/img.jpg"},
+                }
+            ],
+        }
+        image_data = []
+        process_content_for_template_format(msg_dict, "openai", image_data, [], [], [])
+        self.assertIsNone(image_data[0].preprocess_kwargs)
+
+    def test_process_content_image_with_only_min_pixels(self):
+        """Only min_pixels provided — max_pixels should not appear in preprocess_kwargs."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "http://example.com/img.jpg",
+                        "min_pixels": 128,
+                    },
+                }
+            ],
+        }
+        image_data = []
+        process_content_for_template_format(msg_dict, "openai", image_data, [], [], [])
+        self.assertEqual(image_data[0].preprocess_kwargs, {"min_pixels": 128})
+
     def test_detect_msg_content_without_multimodal_keywords(self):
         """Test AST detection of 'for item in msg.content' without keyword shortcut.
         Templates that contain 'image'/'video'/'audio'/'vision' take a shortcut.


### PR DESCRIPTION
## Motivation

The MMMU benchmark harness in SGLang had limited support for Qwen3-VL models: single-image only, limited prompt format, and missing important sampling parameters. This resulted in a ~6pp accuracy gap compared to the Qwen3-VL-30B-A3B-Instruct official reference results.

This PR minimizes that gap to ~1-2pp accuracy by improving the benchmark harness and adding per-request image resolution support in the serving engine.

Qwen3-VL MMMU evaluation reference: https://github.com/QwenLM/Qwen3-VL/tree/main/evaluation/mmmu
Related discussion: https://github.com/sgl-project/sglang-omni/issues/434#issuecomment-4446352972

## Modifications

### Benchmark harness (`benchmark/mmmu/`)

- **Multi-image support**: Replace the brittle `_get_prefix_suffix()` single-image split with regex-based `_split_prompt_on_images()` that handles arbitrary `<image N>` tags. New `--multi-images` flag sends all images per sample (default: first image only for backward compatibility).
- **Configurable option format**: Add `option_format` field to YAML prompt configs (`paren` for `(A)` style, `dot` for `A.` style). Existing `prompt_format.yaml` defaults to `paren`; a separate `prompt_format_qwen3vl.yaml` uses `dot` for Qwen3-VL alignment.
- **Think tag stripping**: Add `_strip_think_tags()` to remove `<think>...</think>` blocks before answer extraction.
- **Better answer extraction**: Add explicit patterns for `\boxed{X}`, "the answer is X", and leading `X.` letter echo. Add tokenized fallback that strips punctuation and finds unique choice letters before falling back to random. For open-ended questions, also match the raw (unnormalized) answer.
- **New sampling CLI args**: `--top-p`, `--top-k`, `--presence-penalty`, `--repetition-penalty` (the first two are SGLang extensions passed via `extra_body`). Also add `--min-pixels`, `--max-pixels` for per-request image resolution, and `--multi-images` for multi-image support.
- **Code quality**: Extract `_handle_response()` to deduplicate sequential/concurrent response handling. Extract `_encode_image_path()` for base64 encoding. Fix `save_json` crash when filename has no directory component.

### Per-request image resolution (`python/sglang/srt/`)

- Add `min_pixels` and `max_pixels` fields to `ChatCompletionMessageContentImageURL` in the OpenAI-compatible protocol.
- Extract per-request pixel values in `jinja_template_utils.py` into `ImageData.preprocess_kwargs`.
- In `qwen_vl.py`, read `preprocess_kwargs` from `ImageData` items and forward as `images_kwargs` to the HF processor.
- In `base_processor.py`, change `images_kwargs` merging so per-request values override server-level `--mm-process-config` (previously server config could clobber per-request values). Non-overridden server config keys are preserved.

## Accuracy Tests

**Model:** Qwen3-VL-30B-A3B-Instruct (TP=2, H200 SXM)
**Dataset:** MMMU validation (900 samples, 30 subjects)

### Best configuration (Qwen3-VL sampling + Qwen3-VL prompt + pixel config ON)
```bash
# Server
python -m sglang.launch_server \
  --model Qwen/Qwen3-VL-30B-A3B-Instruct --tp 2 \
  --mm-process-config '{"image": {"min_pixels": 1003520, "max_pixels": 4014080}}'

# Benchmark
python benchmark/mmmu/bench_sglang.py \
  --prompt-format-file benchmark/mmmu/prompt_format_qwen3vl.yaml \
  --multi-images --reasoning-effort none --max-new-tokens 32768 \
  --temperature 0.7 --top-p 0.8 --top-k 20 --presence-penalty 1.5
```

| Run | Accuracy |
|-----|----------|
| 1 | 71.8% |
| 2 | 70.3% |
| 3 | 73.3% |
| 4 | 70.9% |
| **Mean** | **71.6%** |
| Qwen3-VL-30B-A3B-Instruct [reference](https://arxiv.org/pdf/2511.21631) (see table 3)  | 74.2% |

Variance across 4 runs: 70.3%–73.3% (stddev ~1.1pp).

### Baseline (original setup in `benchmark/mmmu/bench_sglang.py`)
```bash
# Server
python -m sglang.launch_server \
  --model Qwen/Qwen3-VL-30B-A3B-Instruct --tp 2

# Benchmark
python benchmark/mmmu/bench_sglang.py \
  --prompt-format-file benchmark/mmmu/prompt_format.yaml \
  --reasoning-effort none --max-new-tokens 32768
```
Accuracy: ~67.1%


## Speed Tests and Profiling

Not applicable. The benchmark harness changes do not affect inference speed. The per-request `min_pixels`/`max_pixels` adds no overhead when not used (fields default to `None`, existing code path unchanged).

## Unit Tests

Added 8 test methods across 3 existing test files covering the per-request pixel pipeline:

- **`test/registered/unit/entrypoints/openai/test_protocol.py`** — `TestImageURLPixelFields`: verifies `min_pixels`/`max_pixels` fields default to `None`, accept integers with roundtrip serialization, and parse correctly inside a full `ChatCompletionRequest`.
- **`test/registered/unit/parser/test_jinja_template_utils.py`** — 3 tests: verifies `process_content_for_template_format` extracts pixel fields into `ImageData.preprocess_kwargs` (both present, neither present, only one present).
- **`test/registered/core/test_mm_process_config.py`** — 2 tests in `TestProcessMmDataKwargs`: verifies per-request `images_kwargs` overrides server-level `image_config` while preserving non-overridden keys, and works with empty server config.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->