### PR TITLE
test: verify B200 CI stability

### DIFF
--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_b200.py
@@ -132,3 +132,4 @@ class TestDSV4FlashFP4B200Balanced(ServerSanityMixin, CustomTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+# test B200 CI


### PR DESCRIPTION
Trivial change to test B200 CI runner stability.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->