### PR TITLE
Refactor and optimize Gemma4 attention QKV proj and norm

### DIFF
--- a/python/sglang/srt/layers/gemma4_fused_ops.py
+++ b/python/sglang/srt/layers/gemma4_fused_ops.py
@@ -4,11 +4,27 @@ Fuses standard RMSNorm + residual-add (+ optional scalar multiply) into
 a single kernel pass to reduce kernel launch overhead.
 """
 
+from enum import Enum
 from typing import Optional
 
 import torch
 import triton
 import triton.language as tl
+
+
+class ProjAndNormMode(Enum):
+    """Projection + RMSNorm layout for a Gemma4 attention layer.
+
+    Q_ONLY    KV-sharing layer; only Q is projected and normalised.
+    QK_ONLY   attention_k_eq_v layer; Q and a shared K/V are projected,
+              the fused norm derives K and V from one K projection.
+    QKV_FULL  Standard layer; Q, K, V are projected and normalised
+              independently.
+    """
+
+    Q_ONLY = "q"
+    QK_ONLY = "qk"
+    QKV_FULL = "qkv"
 
 
 @triton.jit
@@ -156,67 +172,113 @@ def _gemma_qkv_rmsnorm_store(
 
 
 @triton.jit
+def _gemma_qkv_rmsnorm_keqv_store(
+    KV_in_ptr,
+    K_out_ptr,
+    V_out_ptr,
+    K_w_ptr,
+    stride_kin_m,
+    stride_kout_m,
+    stride_vout_m,
+    m,
+    h,
+    cols,
+    mask,
+    HEAD_DIM: tl.constexpr,
+    eps,
+):
+    """K=V store for one (token, head): read shared KV once, write
+    ``K_out = norm(KV) * k_weight`` and ``V_out = norm(KV)`` (shared rrms).
+    """
+    in_off = m * stride_kin_m + h * HEAD_DIM + cols
+    x = tl.load(KV_in_ptr + in_off, mask=mask, other=0.0).to(tl.float32)
+    rrms = tl.rsqrt(tl.sum(x * x, axis=0) / HEAD_DIM + eps)
+    v_out = x * rrms
+    kw = tl.load(K_w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    k_out = v_out * kw
+    k_off = m * stride_kout_m + h * HEAD_DIM + cols
+    v_off = m * stride_vout_m + h * HEAD_DIM + cols
+    tl.store(K_out_ptr + k_off, k_out.to(K_out_ptr.dtype.element_ty), mask=mask)
+    tl.store(V_out_ptr + v_off, v_out.to(V_out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
 def _gemma_qkv_rmsnorm_kernel(
     Q_ptr,
-    K_ptr,
-    V_ptr,
+    K_in_ptr,
+    V_in_ptr,
+    K_out_ptr,
+    V_out_ptr,
     Q_w_ptr,
     K_w_ptr,
     stride_q_m,
-    stride_k_m,
-    stride_v_m,
+    stride_kin_m,
+    stride_vin_m,
+    stride_kout_m,
+    stride_vout_m,
     NUM_Q_HEADS: tl.constexpr,
     NUM_KV_HEADS: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     eps,
     HAS_KV: tl.constexpr,
+    K_EQ_V: tl.constexpr,
     BY_HEAD: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """Fused per-head RMSNorm for Q, K, V.
+    """Fused per-head RMSNorm: Q (q_w), K (k_w), V (weight=ones, so the
+    multiply-by-weight is omitted).
 
-    The same kernel supports two launch shapes:
-    - BY_HEAD=True: grid is (M, total_heads), one program per token/head.
-    - BY_HEAD=False: grid is (M,), one program per token looping over heads.
+    Modes (``HAS_KV`` / ``K_EQ_V``):
+    * Q-only (``HAS_KV=False``): norm Q in place; K/V pointers unused.
+    * QKV (``K_EQ_V=False``): norm Q, K, V in place (``*_in == *_out``).
+    * K=V (``K_EQ_V=True``, ``attention_k_eq_v``): norm Q in place; ``K_in``
+      is the shared K/V projection -> ``K_out = norm*k_w``, ``V_out = norm``.
 
-    Layout assumption: each tensor's last dim packs (num_heads, head_dim)
-    contiguously so per-head offset is `h * HEAD_DIM`. The token (M) stride is
-    taken from stride_*_m so the kernel works on strided views (e.g. slices of a
-    larger qkv buffer produced by `qkv.split`) without requiring `.contiguous()`
-    copies. V uses `weight=ones` semantics so the multiply-by-weight is omitted.
+    Launch shapes (``BY_HEAD``): ``(M,)`` one program per token (looping
+    heads), or ``(M, total_heads)`` one program per (token, head) for better
+    occupancy at M <= 256. The launcher sizes ``total_heads`` per mode
+    (Q: ``NUM_Q_HEADS``; K=V: ``+ NUM_KV_HEADS``; QKV: ``+ 2 * NUM_KV_HEADS``).
+
+    Each tensor's last dim packs (num_heads, head_dim) contiguously, so the
+    per-head offset is ``h * HEAD_DIM`` and the M stride is read from
+    ``stride_*_m`` -- strided views (e.g. ``qkv.split`` slices) need no copy.
     """
     m = tl.program_id(0)
     cols = tl.arange(0, BLOCK)
     mask = cols < HEAD_DIM
 
     if BY_HEAD:
+        # One program per (token, head).
         h_all = tl.program_id(1)
         if h_all < NUM_Q_HEADS:
+            # Q head.
             _gemma_qkv_rmsnorm_store(
                 Q_ptr, Q_w_ptr, stride_q_m, m, h_all, cols, mask, HEAD_DIM, eps, True
             )
-        elif HAS_KV and h_all < NUM_Q_HEADS + NUM_KV_HEADS:
-            h = h_all - NUM_Q_HEADS
-            _gemma_qkv_rmsnorm_store(
-                K_ptr, K_w_ptr, stride_k_m, m, h, cols, mask, HEAD_DIM, eps, True
-            )
         elif HAS_KV:
-            h = h_all - NUM_Q_HEADS - NUM_KV_HEADS
-            _gemma_qkv_rmsnorm_store(
-                V_ptr, Q_w_ptr, stride_v_m, m, h, cols, mask, HEAD_DIM, eps, False
-            )
-    else:
-        for h in tl.static_range(NUM_Q_HEADS):
-            _gemma_qkv_rmsnorm_store(
-                Q_ptr, Q_w_ptr, stride_q_m, m, h, cols, mask, HEAD_DIM, eps, True
-            )
-
-        if HAS_KV:
-            for h in tl.static_range(NUM_KV_HEADS):
-                _gemma_qkv_rmsnorm_store(
-                    K_ptr,
+            h = h_all - NUM_Q_HEADS
+            if K_EQ_V:
+                _gemma_qkv_rmsnorm_keqv_store(
+                    K_in_ptr,
+                    K_out_ptr,
+                    V_out_ptr,
                     K_w_ptr,
-                    stride_k_m,
+                    stride_kin_m,
+                    stride_kout_m,
+                    stride_vout_m,
+                    m,
+                    h,
+                    cols,
+                    mask,
+                    HEAD_DIM,
+                    eps,
+                )
+            elif h < NUM_KV_HEADS:
+                # K head.
+                _gemma_qkv_rmsnorm_store(
+                    K_in_ptr,
+                    K_w_ptr,
+                    stride_kin_m,
                     m,
                     h,
                     cols,
@@ -225,20 +287,74 @@ def _gemma_qkv_rmsnorm_kernel(
                     eps,
                     True,
                 )
-
-            for h in tl.static_range(NUM_KV_HEADS):
+            else:
+                # V head (no scale).
+                hv = h - NUM_KV_HEADS
                 _gemma_qkv_rmsnorm_store(
-                    V_ptr,
+                    V_in_ptr,
                     Q_w_ptr,
-                    stride_v_m,
+                    stride_vin_m,
                     m,
-                    h,
+                    hv,
                     cols,
                     mask,
                     HEAD_DIM,
                     eps,
                     False,
                 )
+    else:
+        # One program per token, looping over heads.
+        for h in tl.static_range(NUM_Q_HEADS):  # Q heads
+            _gemma_qkv_rmsnorm_store(
+                Q_ptr, Q_w_ptr, stride_q_m, m, h, cols, mask, HEAD_DIM, eps, True
+            )
+
+        if HAS_KV:
+            if K_EQ_V:
+                for h in tl.static_range(NUM_KV_HEADS):
+                    _gemma_qkv_rmsnorm_keqv_store(
+                        K_in_ptr,
+                        K_out_ptr,
+                        V_out_ptr,
+                        K_w_ptr,
+                        stride_kin_m,
+                        stride_kout_m,
+                        stride_vout_m,
+                        m,
+                        h,
+                        cols,
+                        mask,
+                        HEAD_DIM,
+                        eps,
+                    )
+            else:
+                for h in tl.static_range(NUM_KV_HEADS):  # K heads
+                    _gemma_qkv_rmsnorm_store(
+                        K_in_ptr,
+                        K_w_ptr,
+                        stride_kin_m,
+                        m,
+                        h,
+                        cols,
+                        mask,
+                        HEAD_DIM,
+                        eps,
+                        True,
+                    )
+
+                for h in tl.static_range(NUM_KV_HEADS):  # V heads (no scale)
+                    _gemma_qkv_rmsnorm_store(
+                        V_in_ptr,
+                        Q_w_ptr,
+                        stride_vin_m,
+                        m,
+                        h,
+                        cols,
+                        mask,
+                        HEAD_DIM,
+                        eps,
+                        False,
+                    )
 
 
 def gemma_qkv_rmsnorm(
@@ -251,19 +367,23 @@ def gemma_qkv_rmsnorm(
     num_kv_heads: int,
     head_dim: int,
     eps: float = 1e-6,
-) -> None:
-    """In-place fused RMSNorm on Q, K, V for Gemma4 attention.
+    *,
+    mode: ProjAndNormMode = ProjAndNormMode.QKV_FULL,
+) -> Optional[tuple[torch.Tensor, torch.Tensor]]:
+    """Fused per-head RMSNorm on Q, K, V (or any subset) for Gemma4.
 
-    All three norms compute `x * rsqrt(mean(x^2) + eps)` independently per head.
-    Q is scaled by `q_weight`, K by `k_weight`, V by 1 (Gemma4's V-norm has
-    `with_scale=False`).
+    Each head computes ``x * rsqrt(mean(x^2) + eps)``: Q scaled by q_weight,
+    K by k_weight, V by 1 (Gemma4 V-norm uses with_scale=False). Inputs may be
+    2D ``(M, num_heads * head_dim)`` or strided ``qkv.split`` slices; the
+    actual ``stride(0)`` is used so no ``.contiguous()`` copy is needed (the
+    last dim must stay contiguous). The caller picks the layout via ``mode``:
 
-    Inputs may be 2D `(M, num_heads * head_dim)` or strided views of a larger
-    buffer (such as q/k/v slices from `qkv.split`). The kernel uses the actual
-    `stride(0)` so no `.contiguous()` copy is required. Within a token, the
-    last dim must be contiguous so heads pack as `h * head_dim` offsets.
-
-    If k and v are both None (KV-shared layer), only Q is normalized.
+    Q_ONLY    k=None, v=None. Q normalised in place. Returns None.
+    QKV_FULL  k and v non-None. Q, K, V normalised in place. Returns
+              None.
+    QK_ONLY   k is the shared K/V projection, v=None. Q normalised in
+              place; fresh K and V tensors are allocated. Returns
+              (k_out, v_out).
     """
     assert q.is_cuda or q.is_xpu
     assert q.stride(-1) == 1, "Q's last dim must be contiguous"
@@ -271,50 +391,93 @@ def gemma_qkv_rmsnorm(
     M = q.shape[0] if q.dim() >= 2 else 1
     BLOCK = triton.next_power_of_2(head_dim)
 
-    has_kv = k is not None and v is not None
-    if has_kv:
+    # Resolve the mode + allocate outputs if needed.
+    if mode is ProjAndNormMode.QK_ONLY:
+        assert (
+            k is not None and v is None
+        ), "QK_ONLY expects k=<shared KV input>, v=None"
+        assert k.is_cuda and k.stride(-1) == 1
+        assert k_weight is not None and k_weight.shape[-1] == head_dim
+        assert (
+            q.shape[0] == k.shape[0]
+        ), f"M mismatch: q.shape[0]={q.shape[0]} vs kv.shape[0]={k.shape[0]}"
+        has_kv = True
+        k_eq_v = True
+        k_in = k
+        v_in = q  # unused; valid pointer for triton.
+        k_out = torch.empty_like(k)
+        v_out = torch.empty_like(k)
+        stride_kin_m = k.stride(0)
+        stride_vin_m = 0
+        stride_kout_m = k_out.stride(0)
+        stride_vout_m = v_out.stride(0)
+    elif mode is ProjAndNormMode.QKV_FULL:
+        assert k is not None and v is not None, "QKV_FULL expects non-None k and v"
         assert (k.is_cuda and v.is_cuda) or (k.is_xpu and v.is_xpu)
         assert k.stride(-1) == 1 and v.stride(-1) == 1
         assert k_weight is not None and k_weight.shape[-1] == head_dim
+        has_kv = True
+        k_eq_v = False
+        k_in = k
+        v_in = v
+        # In-place: outputs == inputs.
+        k_out = k
+        v_out = v
+        stride_kin_m = k.stride(0)
+        stride_vin_m = v.stride(0)
+        stride_kout_m = k.stride(0)
+        stride_vout_m = v.stride(0)
+    else:
+        assert mode is ProjAndNormMode.Q_ONLY
+        assert k is None and v is None, "Q_ONLY requires both k and v to be None"
+        has_kv = False
+        k_eq_v = False
+        # Unused pointers; pass q for safety.
+        k_in = v_in = k_out = v_out = q
+        stride_kin_m = stride_vin_m = stride_kout_m = stride_vout_m = 0
 
-    if M <= 256:
-        total_heads = num_q_heads + (2 * num_kv_heads if has_kv else 0)
-        _gemma_qkv_rmsnorm_kernel[(M, total_heads)](
-            q,
-            k if has_kv else q,
-            v if has_kv else q,
-            q_weight,
-            k_weight if has_kv else q_weight,
-            q.stride(0),
-            k.stride(0) if has_kv else 0,
-            v.stride(0) if has_kv else 0,
-            NUM_Q_HEADS=num_q_heads,
-            NUM_KV_HEADS=num_kv_heads if has_kv else 0,
-            HEAD_DIM=head_dim,
-            eps=eps,
-            HAS_KV=has_kv,
-            BY_HEAD=True,
-            BLOCK=BLOCK,
-        )
-        return
+    kv_heads = num_kv_heads if has_kv else 0
 
-    _gemma_qkv_rmsnorm_kernel[(M,)](
+    # BY_HEAD for M <= 256: one program per (token, head) for better
+    # occupancy. K=V uses one KV program per head; QKV uses two (K and V).
+    by_head = M <= 256
+    if by_head:
+        if not has_kv:
+            total_heads = num_q_heads
+        elif k_eq_v:
+            total_heads = num_q_heads + kv_heads
+        else:
+            total_heads = num_q_heads + 2 * kv_heads
+        grid = (M, total_heads)
+    else:
+        grid = (M,)
+
+    _gemma_qkv_rmsnorm_kernel[grid](
         q,
-        k if has_kv else q,
-        v if has_kv else q,
+        k_in,
+        v_in,
+        k_out,
+        v_out,
         q_weight,
         k_weight if has_kv else q_weight,
         q.stride(0),
-        k.stride(0) if has_kv else 0,
-        v.stride(0) if has_kv else 0,
+        stride_kin_m,
+        stride_vin_m,
+        stride_kout_m,
+        stride_vout_m,
         NUM_Q_HEADS=num_q_heads,
-        NUM_KV_HEADS=num_kv_heads if has_kv else 0,
+        NUM_KV_HEADS=kv_heads,
         HEAD_DIM=head_dim,
         eps=eps,
         HAS_KV=has_kv,
-        BY_HEAD=False,
+        K_EQ_V=k_eq_v,
+        BY_HEAD=by_head,
         BLOCK=BLOCK,
     )
+
+    if mode is ProjAndNormMode.QK_ONLY:
+        return k_out, v_out
+    return None
 
 
 @triton.jit

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -30,6 +30,7 @@ from sglang.srt.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from sglang.srt.layers.gemma4_fused_ops import (
+    ProjAndNormMode,
     gemma4_fused_routing,
     gemma_dual_rmsnorm_residual_scalar,
     gemma_qkv_rmsnorm,
@@ -38,6 +39,8 @@ from sglang.srt.layers.gemma4_fused_ops import (
 )
 from sglang.srt.layers.layernorm import Gemma4RMSNorm, RMSNorm
 from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
@@ -127,6 +130,32 @@ def pp_filter_load_weight(
         return True
 
     return False
+
+
+def get_k_eq_v_layers(text_config) -> Set[int]:
+    """Return set of layer indices where attention_k_eq_v applies (full-attention layers)."""
+    if not getattr(text_config, "attention_k_eq_v", False):
+        return set()
+    return {i for i, lt in enumerate(text_config.layer_types) if lt == "full_attention"}
+
+
+def _resolve_proj_mode(
+    layer_id: int,
+    *,
+    k_eq_v_layers: Set[int],
+    kv_shared_layers: Set[int],
+) -> ProjAndNormMode:
+    """Pick the projection + norm layout for one decoder layer.
+
+    Q-only wins over QK-only when a layer appears in both sets (KV
+    sharing borrows another layer's K/V cache, so the K projection
+    would be dead weight).
+    """
+    if layer_id in kv_shared_layers:
+        return ProjAndNormMode.Q_ONLY
+    if layer_id in k_eq_v_layers:
+        return ProjAndNormMode.QK_ONLY
+    return ProjAndNormMode.QKV_FULL
 
 
 class Gemma4Router(nn.Module):
@@ -286,6 +315,7 @@ class Gemma4Attention(nn.Module):
         max_position_embeddings: int,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        proj_mode: ProjAndNormMode = ProjAndNormMode.QKV_FULL,
     ) -> None:
         super().__init__()
 
@@ -322,15 +352,48 @@ class Gemma4Attention(nn.Module):
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
 
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size,
-            self.head_dim,
-            self.total_num_heads,
-            self.total_num_kv_heads,
-            bias=config.attention_bias,
-            quant_config=quant_config,
-            prefix=add_prefix("qkv_proj", prefix),
-        )
+        # Single source of truth for this layer's projection + norm
+        # layout. See ProjAndNormMode.
+        self.proj_mode = proj_mode
+
+        # Build exactly the projection layer this layout needs.
+        self.q_proj = None
+        self.qk_proj = None
+        self.qkv_proj = None
+        if proj_mode is ProjAndNormMode.Q_ONLY:
+            # KV-sharing: K/V come from another layer's cache.
+            self.q_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_heads * self.head_dim,
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=add_prefix("q_proj", prefix),
+            )
+        elif proj_mode is ProjAndNormMode.QK_ONLY:
+            # attention_k_eq_v: Q (shard 0) and K (shard 1) merged into
+            # one Linear; V is derived from K at runtime via the fused
+            # QK_ONLY norm kernel.
+            self.qk_proj = MergedColumnParallelLinear(
+                hidden_size,
+                [
+                    self.total_num_heads * self.head_dim,  # Q
+                    self.total_num_kv_heads * self.head_dim,  # K
+                ],
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=add_prefix("qk_proj", prefix),
+            )
+        else:
+            assert proj_mode is ProjAndNormMode.QKV_FULL
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=add_prefix("qkv_proj", prefix),
+            )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
@@ -339,17 +402,21 @@ class Gemma4Attention(nn.Module):
             prefix=add_prefix("o_proj", prefix),
         )
 
-        self.q_norm = Gemma4RMSNorm(
-            self.head_dim,
-            eps=config.rms_norm_eps,
-        )
-        self.k_norm = Gemma4RMSNorm(
-            self.head_dim,
-            eps=config.rms_norm_eps,
-        )
-        self.v_norm = Gemma4RMSNorm(
-            self.head_dim, eps=config.rms_norm_eps, scale_shift=0.0, with_scale=False
-        )
+        # Norms: Q-only layers have only q_norm in the checkpoint, so
+        # don't allocate k_norm / v_norm (they'd silently stay zero-init
+        # and waste memory).
+        self.q_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        if proj_mode is ProjAndNormMode.Q_ONLY:
+            self.k_norm = None
+            self.v_norm = None
+        else:
+            self.k_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.v_norm = Gemma4RMSNorm(
+                self.head_dim,
+                eps=config.rms_norm_eps,
+                scale_shift=0.0,
+                with_scale=False,
+            )
 
         if layer_type in config.rope_parameters:
             rope_parameters = dict(config.rope_parameters[layer_type])
@@ -359,12 +426,12 @@ class Gemma4Attention(nn.Module):
                 rope_theta=10000.0,
             )
 
-        # KV sharing logic
+        # KV sharing: proj_mode == Q_ONLY is the single source of truth.
+        # The caller (e.g. assistant MTP) may force this even when the
+        # config wouldn't.
         num_kv_shared_layers = getattr(config, "num_kv_shared_layers", 0)
         first_kv_shared_layer_idx = config.num_hidden_layers - num_kv_shared_layers
-        self.is_kv_shared_layer = (
-            layer_id >= first_kv_shared_layer_idx and num_kv_shared_layers > 0
-        )
+        self.is_kv_shared_layer = proj_mode is ProjAndNormMode.Q_ONLY
 
         self.kv_shared_layer_index = None
         if num_kv_shared_layers > 0 and self.layer_id >= first_kv_shared_layer_idx:
@@ -411,71 +478,11 @@ class Gemma4Attention(nn.Module):
         forward_batch: ForwardBatch,
         **kwargs,
     ):
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-
-        # Fused Q/K/V RMSNorm: replaces three separate norm kernels with one.
-        # Preconditions for the fused path: tensors on CUDA or XPU (the kernel
-        # is pure Triton and lowers to both backends), q_norm/k_norm use the
-        # standard norm*weight (scale_shift==0) and v_norm has weight=ones
-        # (with_scale=False) — the canonical Gemma4 attention configuration.
-        is_kv_shared = (
-            self.is_kv_shared_layer and self.kv_shared_layer_index is not None
-        )
-        can_fuse_qkv_norm = (
-            (q.is_cuda or q.is_xpu)
-            and self.q_norm.scale_shift == 0.0
-            and self.k_norm.scale_shift == 0.0
-            and not self.v_norm.with_scale
-        )
-        if can_fuse_qkv_norm:
-            if is_kv_shared:
-                gemma_qkv_rmsnorm(
-                    q,
-                    None,
-                    None,
-                    self.q_norm.weight.data,
-                    None,
-                    num_q_heads=self.num_heads,
-                    num_kv_heads=self.num_kv_heads,
-                    head_dim=self.head_dim,
-                    eps=self.q_norm.eps,
-                )
-                k = None
-                v = None
-            else:
-                gemma_qkv_rmsnorm(
-                    q,
-                    k,
-                    v,
-                    self.q_norm.weight.data,
-                    self.k_norm.weight.data,
-                    num_q_heads=self.num_heads,
-                    num_kv_heads=self.num_kv_heads,
-                    head_dim=self.head_dim,
-                    eps=self.q_norm.eps,
-                )
-                # Match the original norm path's output shapes: q stays 2D,
-                # k/v become 3D so the subsequent `.flatten(-2, -1)` works.
-                # Use reshape (not view) since k/v are strided slice views of
-                # the qkv buffer and may not satisfy view's contiguity rules.
-                k = k.reshape(-1, self.num_kv_heads, self.head_dim)
-                v = v.reshape(-1, self.num_kv_heads, self.head_dim)
-        else:
-            q = q.unflatten(-1, (self.num_heads, self.head_dim))
-            q = self.q_norm(q)
-            q = q.flatten(-2, -1)
-            if is_kv_shared:
-                k = None
-                v = None
-            else:
-                k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
-                k = self.k_norm(k)
-                v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
-                v = self.v_norm(v)
-
-        # Apply rotary embedding
+        q, k, v = self._project_and_norm(hidden_states)
         use_fused_kv = False
+
+        # Apply rotary embedding. K is None for Q-only layers (KV-shared);
+        # rotary needs a key input so we pass a zero stand-in.
         if k is not None:
             k = k.flatten(-2, -1)
             # Fuse RoPE + KV-cache write for non-SWA layers with bf16 cache
@@ -493,7 +500,6 @@ class Gemma4Attention(nn.Module):
             q, k = self.rotary_emb(positions, q, k, fused_set_kv_buffer_arg=fused_arg)
             k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
         else:
-            # Rotary embedding requires a key input; use zeros since KV is shared from another layer
             dummy_k = torch.zeros_like(q[:, : self.kv_size])
             q, _ = self.rotary_emb(positions, q, dummy_k)
 
@@ -508,8 +514,118 @@ class Gemma4Attention(nn.Module):
         if attn_output.dim() == 3:
             attn_output = attn_output.flatten(-2, -1)
         output, _ = self.o_proj(attn_output)
-
         return output
+
+    def _can_use_fused_norm(self, q: torch.Tensor) -> bool:
+        """The fused kernel assumes the canonical Gemma4 norm settings:
+        Q/K use the standard ``x * rrms * w`` form and V has unit scale.
+        Anything else falls back to per-tensor Gemma4RMSNorm modules."""
+        return (
+            q.is_cuda
+            and self.q_norm.scale_shift == 0.0
+            and (self.k_norm is None or self.k_norm.scale_shift == 0.0)
+            and (self.v_norm is None or not self.v_norm.with_scale)
+        )
+
+    def _project_and_norm(self, hidden_states: torch.Tensor):
+        """Return (q, k, v) ready for rotary + attention."""
+        if self.proj_mode is ProjAndNormMode.Q_ONLY:
+            return self._project_and_norm_q_only(hidden_states)
+        if self.proj_mode is ProjAndNormMode.QK_ONLY:
+            return self._project_and_norm_qk(hidden_states)
+        return self._project_and_norm_qkv(hidden_states)
+
+    def _project_and_norm_q_only(self, hidden_states: torch.Tensor):
+        """Q only project.
+
+        KV is read from another layer's cache; only Q is
+        projected and normalised. K/V are returned as ``None`` so the
+        downstream rotary code uses a dummy and the attention call
+        reads KV from cache.
+        """
+        q, _ = self.q_proj(hidden_states)
+        if self._can_use_fused_norm(q):
+            gemma_qkv_rmsnorm(
+                q,
+                None,
+                None,
+                self.q_norm.weight.data,
+                None,
+                num_q_heads=self.num_heads,
+                num_kv_heads=0,
+                head_dim=self.head_dim,
+                eps=self.q_norm.eps,
+                mode=ProjAndNormMode.Q_ONLY,
+            )
+        else:
+            q = q.unflatten(-1, (self.num_heads, self.head_dim))
+            q = self.q_norm(q)
+            q = q.flatten(-2, -1)
+        return q, None, None
+
+    def _project_and_norm_qk(self, hidden_states: torch.Tensor):
+        """Q + K projection (V derived from K).
+
+        Uses the K_EQ_V mode of the fused norm kernel: K and V are allocated out-of-place from a single shared K input read.
+        """
+        qk, _ = self.qk_proj(hidden_states)
+        q, k = qk.split([self.q_size, self.kv_size], dim=-1)
+        if self._can_use_fused_norm(q):
+            # K is a strided slice of the qk buffer; the kernel respects
+            # stride(0) so no .contiguous() copy is needed.
+            k_out, v_out = gemma_qkv_rmsnorm(
+                q,
+                k,
+                None,
+                self.q_norm.weight.data,
+                self.k_norm.weight.data,
+                num_q_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim=self.head_dim,
+                eps=self.q_norm.eps,
+                mode=ProjAndNormMode.QK_ONLY,
+            )
+            k = k_out.reshape(-1, self.num_kv_heads, self.head_dim)
+            v = v_out.reshape(-1, self.num_kv_heads, self.head_dim)
+        else:
+            q = q.unflatten(-1, (self.num_heads, self.head_dim))
+            q = self.q_norm(q)
+            q = q.flatten(-2, -1)
+            k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            v = self.v_norm(k)
+            k = self.k_norm(k)
+        return q, k, v
+
+    def _project_and_norm_qkv(self, hidden_states: torch.Tensor):
+        """Standard QKV projection with three independent shards."""
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if self._can_use_fused_norm(q):
+            gemma_qkv_rmsnorm(
+                q,
+                k,
+                v,
+                self.q_norm.weight.data,
+                self.k_norm.weight.data,
+                num_q_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim=self.head_dim,
+                eps=self.q_norm.eps,
+                mode=ProjAndNormMode.QKV_FULL,
+            )
+            # Use reshape (not view) since k/v are strided slice views of
+            # the qkv buffer and may not satisfy view's contiguity rules.
+            k = k.reshape(-1, self.num_kv_heads, self.head_dim)
+            v = v.reshape(-1, self.num_kv_heads, self.head_dim)
+        else:
+            q = q.unflatten(-1, (self.num_heads, self.head_dim))
+            q = self.q_norm(q)
+            q = q.flatten(-2, -1)
+            k = k.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            k = self.k_norm(k)
+            v = v.unflatten(-1, (self.num_kv_heads, self.head_dim))
+            v = self.v_norm(v)
+        return q, k, v
 
 
 class Gemma4DecoderLayer(nn.Module):
@@ -519,6 +635,7 @@ class Gemma4DecoderLayer(nn.Module):
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        proj_mode: ProjAndNormMode = ProjAndNormMode.QKV_FULL,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -543,6 +660,7 @@ class Gemma4DecoderLayer(nn.Module):
             head_dim=head_dim,
             quant_config=quant_config,
             prefix=add_prefix("self_attn", prefix),
+            proj_mode=proj_mode,
         )
 
         first_kv_shared_layer_idx = config.num_hidden_layers - getattr(
@@ -759,6 +877,7 @@ class Gemma4TextModel(PreTrainedModel):
         config: Gemma4TextConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        kv_shared_layer_indices: Optional[Set[int]] = None,
     ) -> None:
         super().__init__(config=config)
         self.config = config
@@ -846,6 +965,21 @@ class Gemma4TextModel(PreTrainedModel):
             self.per_layer_input_scale = None
             self.per_layer_projection_scale = None
 
+        # Resolve per-layer projection / norm layout.  The caller may
+        # override the config-derived KV-sharing set via
+        # kv_shared_layer_indices (MTP assistant passes every layer to
+        # read from the target's cache).
+        k_eq_v_layers = get_k_eq_v_layers(config)
+        if kv_shared_layer_indices is None:
+            n_shared = getattr(config, "num_kv_shared_layers", 0)
+            kv_shared_layer_indices = (
+                set(
+                    range(config.num_hidden_layers - n_shared, config.num_hidden_layers)
+                )
+                if n_shared > 0
+                else set()
+            )
+
         self.layers, self.start_layer, self.end_layer = make_layers(
             config.num_hidden_layers,
             lambda idx, prefix: Gemma4DecoderLayer(
@@ -853,6 +987,11 @@ class Gemma4TextModel(PreTrainedModel):
                 config=config,
                 quant_config=quant_config,
                 prefix=prefix,
+                proj_mode=_resolve_proj_mode(
+                    idx,
+                    k_eq_v_layers=k_eq_v_layers,
+                    kv_shared_layers=kv_shared_layer_indices,
+                ),
             ),
             pp_rank=self.pp_group.rank_in_group,
             pp_size=self.pp_group.world_size,
@@ -1159,13 +1298,9 @@ class Gemma4ForCausalLM(PreTrainedModel):
             input_ids, hidden_states, self.lm_head, forward_batch, aux_hidden_states
         )
 
-    def _get_k_eq_v_layers(self) -> set:
+    def _get_k_eq_v_layers(self) -> Set[int]:
         """Return set of layer indices where attention_k_eq_v applies (full-attention layers)."""
-        if not getattr(self.config, "attention_k_eq_v", False):
-            return set()
-        return {
-            i for i, lt in enumerate(self.config.layer_types) if lt == "full_attention"
-        }
+        return get_k_eq_v_layers(self.config)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
@@ -1173,6 +1308,19 @@ class Gemma4ForCausalLM(PreTrainedModel):
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        # k_eq_v layers use MergedColumnParallelLinear (qk_proj) instead
+        # of QKVParallelLinear (qkv_proj).  Map checkpoint q_proj / k_proj
+        # to integer shard ids 0 and 1 respectively.  V is derived from K
+        # at runtime via the K_EQ_V fused norm, so there is no v shard
+        # and no v_proj weight in the checkpoint for these layers.
+        k_eq_v_stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qk_proj", "q_proj", 0),
+            ("qk_proj", "k_proj", 1),
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
         ]
@@ -1246,16 +1394,12 @@ class Gemma4ForCausalLM(PreTrainedModel):
             ):
                 continue
 
-            # attention_k_eq_v: full-attention layers have no v_proj in the
-            # checkpoint (K and V share weights).  When we see a k_proj weight
-            # for one of these layers, load it into both the "k" and "v" shards
-            # of the fused QKV so the forward produces v_raw == k_raw.
-            should_dup_k_to_v = (
-                ".k_proj." in name
-                and k_eq_v_layers
-                and (m := re.search(r"layers\.(\d+)\.", name)) is not None
-                and int(m.group(1)) in k_eq_v_layers
-            )
+            # Determine whether this weight belongs to a k_eq_v layer.
+            is_k_eq_v_layer = False
+            if k_eq_v_layers:
+                m = re.search(r"layers\.(\d+)\.", name)
+                if m is not None:
+                    is_k_eq_v_layer = int(m.group(1)) in k_eq_v_layers
 
             # MoE expert weights checked first (gate_up_proj contains "up_proj"
             # which would false-match the stacked dense MLP mapping).
@@ -1310,7 +1454,17 @@ class Gemma4ForCausalLM(PreTrainedModel):
                     loaded_params.add(name)
                     break
                 else:
-                    for param_name, weight_name, shard_id in stacked_params_mapping:
+                    # 3) Stacked dense projection weights.  k_eq_v layers
+                    #    pack only Q+K into qk_proj (V is derived at
+                    #    runtime from K via the K_EQ_V fused norm), so
+                    #    they need a different mapping than the standard
+                    #    qkv_proj layers.
+                    mapping = (
+                        k_eq_v_stacked_params_mapping
+                        if is_k_eq_v_layer
+                        else stacked_params_mapping
+                    )
+                    for param_name, weight_name, shard_id in mapping:
                         name = orig_name
                         if weight_name not in name:
                             continue
@@ -1320,8 +1474,6 @@ class Gemma4ForCausalLM(PreTrainedModel):
                         param = params_dict[name]
                         weight_loader = param.weight_loader
                         weight_loader(param, loaded_weight, shard_id)
-                        if should_dup_k_to_v:
-                            weight_loader(param, loaded_weight, "v")
                         loaded_params.add(name)
                         break
                     else:

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -59,7 +59,11 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.models.gemma4_audio import Gemma4AudioEncoder
-from sglang.srt.models.gemma4_causal import Gemma4TextModel, pp_filter_load_weight
+from sglang.srt.models.gemma4_causal import (
+    Gemma4TextModel,
+    get_k_eq_v_layers,
+    pp_filter_load_weight,
+)
 from sglang.srt.models.gemma4_vision import Gemma4VisionEncoder
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_processor
@@ -689,6 +693,17 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         (".gate_up_proj", ".gate_proj", 0),
     ]
 
+    # k_eq_v layers use MergedColumnParallelLinear (qk_proj) instead of
+    # QKVParallelLinear (qkv_proj).  Map checkpoint q_proj / k_proj to
+    # integer shard ids 0 and 1 respectively.
+    k_eq_v_stacked_params_mapping = [
+        # (param_name, shard_name, shard_id)
+        (".qk_proj", ".q_proj", 0),
+        (".qk_proj", ".k_proj", 1),
+        (".gate_up_proj", ".up_proj", 1),
+        (".gate_up_proj", ".gate_proj", 0),
+    ]
+
     # Regex for fused QKV in vision/audio towers.
     # Vision: *.self_attn.{q,k,v}_proj.*  Audio: *.attn.{q,k,v}_proj.*
     _RE_TOWER_QKV = re.compile(
@@ -802,14 +817,9 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
 
         return name
 
-    def _get_k_eq_v_layers(self) -> set:
+    def _get_k_eq_v_layers(self) -> Set[int]:
         """Return set of layer indices where attention_k_eq_v applies (full-attention layers)."""
-        text_config = self.config.text_config
-        if not getattr(text_config, "attention_k_eq_v", False):
-            return set()
-        return {
-            i for i, lt in enumerate(text_config.layer_types) if lt == "full_attention"
-        }
+        return get_k_eq_v_layers(self.config.text_config)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         k_eq_v_layers = self._get_k_eq_v_layers()
@@ -904,17 +914,12 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             if "vision_tower." in name or "audio_tower." in name:
                 name = self._remap_tower_name(name, params_dict)
 
-            # attention_k_eq_v: full-attention layers have no v_proj in the
-            # checkpoint (K and V share weights).  When we see a k_proj weight
-            # for one of these layers, load it into both the "k" and "v" shards
-            # of the fused QKV so the forward produces v_raw == k_raw.
-            should_dup_k_to_v = (
-                ".k_proj." in name
-                and k_eq_v_layers
-                and "language_model." in name
-                and (m := re.search(r"layers\.(\d+)\.", name)) is not None
-                and int(m.group(1)) in k_eq_v_layers
-            )
+            # Determine whether this weight belongs to a k_eq_v layer.
+            is_k_eq_v_layer = False
+            if k_eq_v_layers and "language_model." in name:
+                m_layer = re.search(r"layers\.(\d+)\.", name)
+                if m_layer is not None:
+                    is_k_eq_v_layer = int(m_layer.group(1)) in k_eq_v_layers
 
             # MoE expert weights checked first (gate_up_proj contains "up_proj"
             # which would false-match the stacked dense MLP mapping).
@@ -969,11 +974,21 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                     loaded_params.add(name)
                     break
                 else:
+                    # 3) Stacked dense projection weights.  k_eq_v layers
+                    #    pack only Q+K into qk_proj (V is derived at
+                    #    runtime from K via the K_EQ_V fused norm), so
+                    #    they need a different mapping than the standard
+                    #    qkv_proj layers.
+                    mapping = (
+                        self.k_eq_v_stacked_params_mapping
+                        if is_k_eq_v_layer
+                        else self.stacked_params_mapping
+                    )
                     for (
                         param_name,
                         weight_name,
                         shard_id,
-                    ) in self.stacked_params_mapping:
+                    ) in mapping:
                         name = orig_name
                         if weight_name not in name:
                             continue
@@ -983,8 +998,6 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                         param = params_dict[name]
                         weight_loader = param.weight_loader
                         weight_loader(param, loaded_weight, shard_id)
-                        if should_dup_k_to_v:
-                            weight_loader(param, loaded_weight, "v")
                         loaded_params.add(name)
                         break
                     else:

--- a/python/sglang/srt/models/gemma4_mtp.py
+++ b/python/sglang/srt/models/gemma4_mtp.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Dict, Iterable, Optional, Set, Tuple
 
 import torch
 from torch import nn
@@ -74,6 +74,8 @@ class Gemma4AssistantForCausalLM(Gemma4ForCausalLM):
         self.config = text_config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
+        n_layers = text_config.num_hidden_layers
+        self._assistant_kv_shared_layers: Set[int] = set(range(n_layers))
 
         self.vocab_size = text_config.vocab_size
         self.hidden_size = text_config.hidden_size
@@ -98,6 +100,7 @@ class Gemma4AssistantForCausalLM(Gemma4ForCausalLM):
             config=text_config,
             quant_config=quant_config,
             prefix=add_prefix("model", prefix),
+            kv_shared_layer_indices=self._assistant_kv_shared_layers,
         )
         self.post_projection = ReplicatedLinear(
             self.hidden_size,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Fuse kernel for layers when k=v.
- The largest gain come from trtllm_mha kernel. This PR also try to validate trtllm_mha
- Note trtllm_mha kernel only supports 314. Larger spec setup will cause a missing cubin error.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python -m sglang.launch_server     --host 0.0.0.0     --port 18000     --model-path google/gemma-4-31B-it     --tp 1     --enable-metrics     --decode-log-interval 1     --enable-cache-report     --model-loader-extra-config '{"enable_multithread_load":true,"num_threads":64}'     --revision main     --served-model-name google/gemma-4-31B-it     --context-length 65536     --mem-fraction-static 0.85     --chunked-prefill-size 8192     --max-prefill-tokens 8192     --cuda-graph-max-bs 32     --max-running-requests 32     --speculative-algorithm NEXTN     --speculative-draft-model-path google/gemma-4-31B-it-assistant     --speculative-num-steps 3     --speculative-num-draft-tokens 4     --speculative-eagle-topk 1  [--attention-backend=trtllm_mha]
```

MMLU - 31B

- Baseline before this PR: `Average accuracy: 0.709`
- This PR with triton attn backend: `Average accuracy: 0.709`
- This PR with trtllm_mha: `Average accuracy: 0.711`

MMLU - E4B

- Before: Average accuracy: 0.588
- After: Average accuracy: 0.587

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

```
============ Serving Benchmark Result ============                                                                                                                                                                            
Backend:                                 vllm-chat                                                                                                                                                                            
Traffic request rate:                    1.0                                                                                                                                                                                  
Max request concurrency:                 256                                                                   
Successful requests:                     64                                                                    
Benchmark duration (s):                  62.15                                                                                                                                                                                
Total input tokens:                      752156                                                                                                                                                                               
Total input text tokens:                 752156                                                                                                                                                                               
Total generated tokens:                  51200                                                                                                                                                                                
Total generated tokens (retokenized):    51197                                                                                                                                                                                
Request throughput (req/s):              1.03                                                                                                                                                                                 
Input token throughput (tok/s):          12101.35                                                                                                                                                                             
Output token throughput (tok/s):         823.75                                                                                                                                                                               
Peak output token throughput (tok/s):    656.00                                                                                                                                                                               
Peak concurrent requests:                20                                                                                                                                                                                   
Total token throughput (tok/s):          12925.10                                                                                                                                                                             
Concurrency:                             9.42                                                                  
----------------End-to-End Latency----------------                                                             
Mean E2E Latency (ms):                   9148.54                                                                                                                                                                              
Median E2E Latency (ms):                 9541.21                                                                                                                                                                              
P90 E2E Latency (ms):                    11752.22                                                                                                                                                                             
P99 E2E Latency (ms):                    12821.44                                                              
---------------Time to First Token----------------                                                                                                                                                                            
Mean TTFT (ms):                          835.47                                                                                                                                                                               
Median TTFT (ms):                        498.64                                                                
P99 TTFT (ms):                           3355.32                                                               
-----Time per Output Token (excl. 1st token)------                                                             
Mean TPOT (ms):                          10.40                                                                 
Median TPOT (ms):                        10.53                                                                 
P99 TPOT (ms):                           15.11     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           36.81                                                                 
Median ITL (ms):                         22.28     
P95 ITL (ms):                            27.47     
P99 ITL (ms):                            651.13                                                                
Max ITL (ms):                            3059.00                                                               
==================================================
```


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27076435053](https://github.com/sgl-project/sglang/actions/runs/27076435053)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27076434999](https://github.com/sgl-project/sglang/actions/runs/27076434999)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->