### PR TITLE
feat: coarse grained match with approximate hit length

### DIFF
--- a/docs/advanced_features/sgl_model_gateway.md
+++ b/docs/advanced_features/sgl_model_gateway.md
@@ -1700,7 +1700,13 @@ Increase `--worker-startup-timeout-secs` or ensure health probes respond before 
 
 ### Load Imbalance / Hot Workers
 
-Inspect `smg_router_requests_total` by worker and tune cache-aware thresholds (`--balance-*`, `--cache-threshold`).
+Inspect `smg_router_requests_total` by worker. The `cache_aware` policy now scores
+each worker by `pending_tokens + miss_chars` (pending tokens come from `/v1/loads`,
+miss chars from the gateway's approximate prefix tree). To shift traffic off a hot
+cache holder more aggressively, increase `LoadMonitor`'s polling cadence so pending
+tokens are refreshed faster, or scale out replicas. The legacy threshold knobs
+(`--balance-*`, `--cache-threshold`) remain accepted for backward compatibility
+but no longer affect routing decisions.
 
 ### Circuit Breaker Flapping
 

--- a/sgl-model-gateway/src/core/worker_manager.rs
+++ b/sgl-model-gateway/src/core/worker_manager.rs
@@ -192,7 +192,8 @@ impl WorkerManager {
 
         // Group workers by base URL so we issue at most one /v1/loads request per
         // engine process even when N DPAwareWorker entries share the same backend.
-        let mut groups: HashMap<String, (Option<String>, Vec<Arc<dyn Worker>>)> = HashMap::new();
+        type WorkerGroup = (Option<String>, Vec<Arc<dyn Worker>>);
+        let mut groups: HashMap<String, WorkerGroup> = HashMap::new();
         for worker in &workers {
             if !matches!(worker.connection_mode(), ConnectionMode::Http) {
                 continue;

--- a/sgl-model-gateway/src/core/worker_manager.rs
+++ b/sgl-model-gateway/src/core/worker_manager.rs
@@ -67,6 +67,32 @@ async fn fan_out(
         .await
 }
 
+/// Parsed `/v1/loads` response for a single engine process.
+///
+/// Holds both the aggregate (used for DP-blind worker views) and the per-DP-rank
+/// num_total_tokens map (used to derive per-rank loads for DPAwareWorker entries).
+#[derive(Debug, Clone)]
+struct ParsedLoads {
+    aggregate_total_tokens: Option<isize>,
+    per_rank: HashMap<usize, isize>,
+}
+
+impl ParsedLoads {
+    /// Resolve the load value for a specific worker.
+    /// DP-aware workers get their per-rank num_total_tokens; everyone else
+    /// gets the aggregate, falling back to -1 only if the JSON lacked the field.
+    fn load_for_worker(&self, worker: &dyn Worker) -> isize {
+        if worker.is_dp_aware() {
+            if let Some(rank) = worker.dp_rank() {
+                if let Some(v) = self.per_rank.get(&rank) {
+                    return *v;
+                }
+            }
+        }
+        self.aggregate_total_tokens.unwrap_or(-1)
+    }
+}
+
 pub enum EngineMetricsResult {
     Ok(String),
     Err(String),
@@ -164,35 +190,59 @@ impl WorkerManager {
         let workers = worker_registry.get_all();
         let total_workers = workers.len();
 
-        let futures: Vec<_> = workers
-            .iter()
-            .map(|worker| {
-                let url = worker.url().to_string();
-                let api_key = worker.api_key().clone();
-                let worker_type = match worker.worker_type() {
-                    WorkerType::Regular => None,
-                    WorkerType::Prefill { .. } => Some("prefill".to_string()),
-                    WorkerType::Decode => Some("decode".to_string()),
-                };
-                let is_http = matches!(worker.connection_mode(), ConnectionMode::Http);
-                let client = client.clone();
+        // Group workers by base URL so we issue at most one /v1/loads request per
+        // engine process even when N DPAwareWorker entries share the same backend.
+        let mut groups: HashMap<String, (Option<String>, Vec<Arc<dyn Worker>>)> = HashMap::new();
+        for worker in &workers {
+            if !matches!(worker.connection_mode(), ConnectionMode::Http) {
+                continue;
+            }
+            let base = worker.base_url().to_string();
+            groups
+                .entry(base)
+                .or_insert_with(|| (worker.api_key().clone(), Vec::new()))
+                .1
+                .push(Arc::clone(worker));
+        }
 
+        let futures: Vec<_> = groups
+            .into_iter()
+            .map(|(base_url, (api_key, group_workers))| {
+                let client = client.clone();
                 async move {
-                    let load = if is_http {
-                        Self::parse_load_response(&client, &url, api_key.as_deref()).await
-                    } else {
-                        -1
-                    };
-                    WorkerLoadInfo {
-                        worker: url,
-                        worker_type,
-                        load,
-                    }
+                    let parsed =
+                        Self::parse_load_response(&client, &base_url, api_key.as_deref()).await;
+                    (group_workers, parsed)
                 }
             })
             .collect();
 
-        let loads = future::join_all(futures).await;
+        let group_results = future::join_all(futures).await;
+
+        let mut loads = Vec::with_capacity(total_workers);
+        for worker in &workers {
+            if !matches!(worker.connection_mode(), ConnectionMode::Http) {
+                loads.push(WorkerLoadInfo {
+                    worker: worker.url().to_string(),
+                    worker_type: Self::worker_type_label(worker.worker_type()),
+                    load: -1,
+                });
+            }
+        }
+        for (group_workers, parsed) in group_results {
+            for worker in group_workers {
+                let load = match &parsed {
+                    Some(p) => p.load_for_worker(worker.as_ref()),
+                    None => -1,
+                };
+                loads.push(WorkerLoadInfo {
+                    worker: worker.url().to_string(),
+                    worker_type: Self::worker_type_label(worker.worker_type()),
+                    load,
+                });
+            }
+        }
+
         let successful = loads.iter().filter(|l| l.load >= 0).count();
         let failed = loads.iter().filter(|l| l.load < 0).count();
 
@@ -204,29 +254,55 @@ impl WorkerManager {
         }
     }
 
+    fn worker_type_label(worker_type: &WorkerType) -> Option<String> {
+        match worker_type {
+            WorkerType::Regular => None,
+            WorkerType::Prefill { .. } => Some("prefill".to_string()),
+            WorkerType::Decode => Some("decode".to_string()),
+        }
+    }
+
+    /// Fetch and parse /v1/loads for a single engine base URL.
+    /// Returns `None` on transport/parse failure so callers can treat all
+    /// workers in the group as `load = -1`.
     async fn parse_load_response(
         client: &reqwest::Client,
-        url: &str,
+        base_url: &str,
         api_key: Option<&str>,
-    ) -> isize {
-        let load_url = format!("{}/v1/loads?include=core", url);
+    ) -> Option<ParsedLoads> {
+        let load_url = format!("{}/v1/loads?include=core", base_url);
         let mut req = client.get(&load_url).timeout(REQUEST_TIMEOUT);
         if let Some(key) = api_key {
             req = req.bearer_auth(key);
         }
 
-        match req.send().await {
-            Ok(r) if r.status().is_success() => match r.json::<Value>().await {
-                Ok(json) => json
-                    .get("aggregate")
-                    .and_then(|a| a.get("total_tokens"))
-                    .and_then(|v| v.as_i64())
-                    .map(|n| n as isize)
-                    .unwrap_or(-1),
-                _ => -1,
-            },
-            _ => -1,
+        let resp = req.send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
         }
+        let json: Value = resp.json().await.ok()?;
+
+        let aggregate_total_tokens = json
+            .get("aggregate")
+            .and_then(|a| a.get("total_tokens"))
+            .and_then(|v| v.as_i64())
+            .map(|n| n as isize);
+
+        let mut per_rank = HashMap::new();
+        if let Some(arr) = json.get("loads").and_then(|v| v.as_array()) {
+            for entry in arr {
+                let rank = entry.get("dp_rank").and_then(|v| v.as_i64());
+                let tokens = entry.get("num_total_tokens").and_then(|v| v.as_i64());
+                if let (Some(r), Some(t)) = (rank, tokens) {
+                    per_rank.insert(r as usize, t as isize);
+                }
+            }
+        }
+
+        Some(ParsedLoads {
+            aggregate_total_tokens,
+            per_rank,
+        })
     }
 
     pub async fn get_engine_metrics(
@@ -348,9 +424,10 @@ impl LoadMonitor {
             interval_timer.tick().await;
 
             let power_of_two_policies = policy_registry.get_all_power_of_two_policies();
+            let cache_aware_policies = policy_registry.get_all_cache_aware_policies();
 
-            if power_of_two_policies.is_empty() {
-                debug!("No PowerOfTwo policies found, skipping load fetch");
+            if power_of_two_policies.is_empty() && cache_aware_policies.is_empty() {
+                debug!("No load-aware policies found, skipping load fetch");
                 continue;
             }
 
@@ -363,11 +440,15 @@ impl LoadMonitor {
 
             if !loads.is_empty() {
                 debug!(
-                    "Fetched loads from {} workers, updating {} PowerOfTwo policies",
+                    "Fetched loads from {} workers, updating {} PoT + {} CacheAware policies",
                     loads.len(),
-                    power_of_two_policies.len()
+                    power_of_two_policies.len(),
+                    cache_aware_policies.len()
                 );
                 for policy in &power_of_two_policies {
+                    policy.update_loads(&loads);
+                }
+                for policy in &cache_aware_policies {
                     policy.update_loads(&loads);
                 }
                 let _ = tx.send(loads);

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -464,104 +464,73 @@ mod tests {
     use super::*;
     use crate::core::{BasicWorkerBuilder, WorkerType};
 
-    #[tokio::test]
-    async fn test_cache_aware_with_balanced_load() {
-        // Create policy without eviction thread for testing
-        let config = CacheAwareConfig {
-            eviction_interval_secs: 0, // Disable eviction thread
+    /// Build a CacheAwarePolicy with the eviction thread disabled — the
+    /// standard setup for in-process tests.
+    fn test_policy() -> CacheAwarePolicy {
+        CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
             ..Default::default()
-        };
-        let policy = CacheAwarePolicy::with_config(config);
-        let workers: Vec<Arc<dyn Worker>> = vec![
+        })
+    }
+
+    /// Build two regular HTTP workers at the canonical `http://w{1,2}:8000`
+    /// URLs. Used by every cache_aware test that needs the simplest topology.
+    fn two_workers() -> Vec<Arc<dyn Worker>> {
+        vec![
             Arc::new(
                 BasicWorkerBuilder::new("http://w1:8000")
                     .worker_type(WorkerType::Regular)
-                    .api_key("test_api_key")
                     .build(),
             ),
             Arc::new(
                 BasicWorkerBuilder::new("http://w2:8000")
                     .worker_type(WorkerType::Regular)
-                    .api_key("test_api_key")
                     .build(),
             ),
-        ];
+        ]
+    }
 
-        // Initialize the policy with workers
+    /// Convenience: produce a request info carrying just the prompt text.
+    fn req(text: &str) -> SelectWorkerInfo<'_> {
+        SelectWorkerInfo {
+            request_text: Some(text),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cache_aware_with_balanced_load() {
+        let policy = test_policy();
+        let workers = two_workers();
         policy.init_workers(&workers);
 
-        // First request should be distributed
         let idx1 = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("hello world"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("hello world"))
             .await
             .unwrap();
-
-        // Same request should go to same worker (cache hit)
+        // Same request → same worker (cache hit).
         let idx2 = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("hello world"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("hello world"))
             .await
             .unwrap();
         assert_eq!(idx1, idx2);
-
-        // Similar request should also go to same worker
-        let idx3 = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("hello"),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
+        // Shorter prefix of the same string → same worker.
+        let idx3 = policy.select_worker(&workers, &req("hello")).await.unwrap();
         assert_eq!(idx1, idx3);
     }
 
     #[tokio::test]
     async fn test_newcomer_wins_when_cache_holder_saturated() {
-        // Cache holder w1 has the prefix but is buried under pending tokens;
+        // Cache holder w1 owns the prefix but is buried under pending tokens;
         // newcomer w2 has no overlap but pending=0. For short input, w2 wins.
-        let config = CacheAwareConfig {
-            eviction_interval_secs: 0,
-            ..Default::default()
-        };
-        let policy = CacheAwarePolicy::with_config(config);
-        let workers: Vec<Arc<dyn Worker>> = vec![
-            Arc::new(
-                BasicWorkerBuilder::new("http://w1:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-            Arc::new(
-                BasicWorkerBuilder::new("http://w2:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-        ];
+        let policy = test_policy();
+        let workers = two_workers();
         policy.init_workers(&workers);
 
         // Seed the tree so w1 owns "hello world" entirely.
         for _ in 0..3 {
             let idx = policy
-                .select_worker(
-                    &workers,
-                    &SelectWorkerInfo {
-                        request_text: Some("hello world"),
-                        ..Default::default()
-                    },
-                )
+                .select_worker(&workers, &req("hello world"))
                 .await
                 .unwrap();
             assert_eq!(idx, 0);
@@ -575,13 +544,7 @@ mod tests {
 
         // A short prompt: w1's pending dwarfs any cache savings → w2.
         let idx = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("hello world"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("hello world"))
             .await
             .unwrap();
         assert_eq!(
@@ -592,39 +555,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_holder_wins_when_balanced() {
-        let config = CacheAwareConfig {
-            eviction_interval_secs: 0,
-            ..Default::default()
-        };
-        let policy = CacheAwarePolicy::with_config(config);
-        let workers: Vec<Arc<dyn Worker>> = vec![
-            Arc::new(
-                BasicWorkerBuilder::new("http://w1:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-            Arc::new(
-                BasicWorkerBuilder::new("http://w2:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-        ];
+        let policy = test_policy();
+        let workers = two_workers();
         policy.init_workers(&workers);
 
-        // First request lands somewhere (deterministic: index 0 ties broken first).
+        // First request lands somewhere; we then pin pending tokens equal
+        // and require subsequent identical-prefix requests to stick.
         let first = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("the quick brown fox"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("the quick brown fox"))
             .await
             .unwrap();
 
-        // Both workers report identical pending. The cache holder should win
-        // any subsequent identical-prefix request.
         let mut loads = std::collections::HashMap::new();
         loads.insert("http://w1:8000".to_string(), 10);
         loads.insert("http://w2:8000".to_string(), 10);
@@ -632,13 +573,7 @@ mod tests {
 
         for _ in 0..3 {
             let idx = policy
-                .select_worker(
-                    &workers,
-                    &SelectWorkerInfo {
-                        request_text: Some("the quick brown fox"),
-                        ..Default::default()
-                    },
-                )
+                .select_worker(&workers, &req("the quick brown fox"))
                 .await
                 .unwrap();
             assert_eq!(
@@ -650,46 +585,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_pending_tokens_default_zero_for_unknown_worker() {
-        // No update_loads call has happened yet; both workers should be
-        // treated as pending=0 and the tie should break the same way every
-        // call (longest-prefix tenant wins).
-        let config = CacheAwareConfig {
-            eviction_interval_secs: 0,
-            ..Default::default()
-        };
-        let policy = CacheAwarePolicy::with_config(config);
-        let workers: Vec<Arc<dyn Worker>> = vec![
-            Arc::new(
-                BasicWorkerBuilder::new("http://w1:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-            Arc::new(
-                BasicWorkerBuilder::new("http://w2:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-        ];
+        // No update_loads call has happened yet; both workers are pending=0
+        // and the tie must break the same way every call (longest-prefix wins).
+        let policy = test_policy();
+        let workers = two_workers();
         policy.init_workers(&workers);
 
         let first = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("alpha beta"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("alpha beta"))
             .await
             .unwrap();
         let second = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("alpha beta"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("alpha beta"))
             .await
             .unwrap();
         assert_eq!(first, second);
@@ -699,23 +606,8 @@ mod tests {
     async fn test_failed_load_probe_treated_as_zero() {
         // LoadMonitor reports w1 with -1 (probe failed) — must not cause w1
         // to be permanently preferred-or-excluded; we treat -1 as 0.
-        let config = CacheAwareConfig {
-            eviction_interval_secs: 0,
-            ..Default::default()
-        };
-        let policy = CacheAwarePolicy::with_config(config);
-        let workers: Vec<Arc<dyn Worker>> = vec![
-            Arc::new(
-                BasicWorkerBuilder::new("http://w1:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-            Arc::new(
-                BasicWorkerBuilder::new("http://w2:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-        ];
+        let policy = test_policy();
+        let workers = two_workers();
         policy.init_workers(&workers);
 
         let mut loads = std::collections::HashMap::new();
@@ -725,13 +617,7 @@ mod tests {
 
         // w1 (treated as 0) should beat w2 (500) for a fresh prompt.
         let idx = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("never seen before"),
-                    ..Default::default()
-                },
-            )
+            .select_worker(&workers, &req("never seen before"))
             .await
             .unwrap();
         assert_eq!(idx, 0);
@@ -739,61 +625,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_aware_worker_removal() {
-        let config = CacheAwareConfig {
-            eviction_interval_secs: 0, // Disable eviction thread
-            ..Default::default()
-        };
-        let policy = CacheAwarePolicy::with_config(config);
-        let workers: Vec<Arc<dyn Worker>> = vec![
-            Arc::new(
-                BasicWorkerBuilder::new("http://w1:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-            Arc::new(
-                BasicWorkerBuilder::new("http://w2:8000")
-                    .worker_type(WorkerType::Regular)
-                    .build(),
-            ),
-        ];
-
+        let policy = test_policy();
+        let workers = two_workers();
         policy.init_workers(&workers);
 
-        // Route some requests
-        policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("test1"),
-                    ..Default::default()
-                },
-            )
-            .await;
-        policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("test2"),
-                    ..Default::default()
-                },
-            )
-            .await;
+        policy.select_worker(&workers, &req("test1")).await;
+        policy.select_worker(&workers, &req("test2")).await;
 
-        // Remove a worker
         policy.remove_worker_by_url("http://w1:8000");
         workers[0].set_healthy(false);
 
-        // All requests should now go to worker2
-        let idx = policy
-            .select_worker(
-                &workers,
-                &SelectWorkerInfo {
-                    request_text: Some("test1"),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
+        // w1 is gone + unhealthy; all traffic must land on w2.
+        let idx = policy.select_worker(&workers, &req("test1")).await.unwrap();
         assert_eq!(idx, 1);
     }
 

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -412,9 +412,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             })
             .copied();
 
-        let Some(idx) = scored_idx else {
-            return None;
-        };
+        let idx = scored_idx?;
 
         // Update gateway-side tree + mesh with this request (skip if model
         // had no tree yet — caller may not have init'd one for this model).
@@ -586,7 +584,10 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(idx, 1, "saturated cache holder should lose to idle newcomer");
+        assert_eq!(
+            idx, 1,
+            "saturated cache holder should lose to idle newcomer"
+        );
     }
 
     #[tokio::test]
@@ -640,7 +641,10 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            assert_eq!(idx, first, "cache affinity should win when pending is equal");
+            assert_eq!(
+                idx, first,
+                "cache affinity should win when pending is equal"
+            );
         }
     }
 

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -63,7 +63,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use rand::Rng;
 use smg_mesh::{tree_ops::TreeOperation, OptionalMeshSyncManager};
 use tracing::{debug, warn};
 
@@ -75,15 +74,38 @@ use crate::core::{Worker, UNKNOWN_MODEL_ID};
 
 /// Cache-aware routing policy
 ///
-/// Routes requests based on cache affinity when load is balanced,
-/// switches to shortest-queue routing when load is imbalanced.
-/// Maintains separate trees per model for multi-model support.
+/// Scores every healthy worker by `pending_tokens + miss_chars`, where:
+///   - `pending_tokens` comes from each worker's most recent `/v1/loads`
+///     report (`num_total_tokens` = used + queued prefill tokens). The
+///     LoadMonitor pushes these in via `update_loads` on its own cadence.
+///   - `miss_chars` is the prefill the worker would have to redo: zero
+///     for the worker the gateway radix tree reports as the longest-prefix
+///     tenant, `input_chars` for everyone else.
+///
+/// Newcomers start at `pending_tokens = 0`, so a fresh worker can beat a
+/// cache holder once the holder's backlog exceeds the input length.
+/// Note that `pending_tokens` is in tokens and `miss_chars` is in chars;
+/// we deliberately add them with a 1:1 implicit ratio. This biases the
+/// selection toward cache affinity for tokenizers where chars/token > 1
+/// (typical English BPE ≈ 4), which is acceptable for v1.
+///
+/// Maintains separate radix trees per model for multi-model support.
 /// Supports mesh synchronization of tree operations across cluster nodes.
-/// When mesh is not enabled, the policy works independently without synchronization.
+/// When mesh is not enabled, the policy works independently without sync.
 #[derive(Debug)]
 pub struct CacheAwarePolicy {
+    // Held only so existing CLI surface (cache_threshold, balance_*_threshold,
+    // max_tree_size, eviction_interval_secs) continues to parse without error.
+    // The new scoring rule consumes the eviction settings at construction
+    // time; the threshold knobs are dead. Prune in a follow-up PR once we
+    // remove them from CacheAwareConfig / CLI.
+    #[allow(dead_code)]
     config: CacheAwareConfig,
     trees: Arc<DashMap<String, Arc<Tree>>>,
+    /// Per-worker pending-token snapshot, keyed by `worker.url()` (which is
+    /// `base@rank` for DPAwareWorker, plain `base` otherwise). Populated by
+    /// `LoadMonitor` via `update_loads`; unknown workers fall back to 0.
+    pending_tokens: Arc<DashMap<String, isize>>,
     mesh_sync: OptionalMeshSyncManager,
     _eviction_task: Option<PeriodicTask>,
 }
@@ -124,6 +146,7 @@ impl CacheAwarePolicy {
         Self {
             config,
             trees,
+            pending_tokens: Arc::new(DashMap::new()),
             mesh_sync: None,
             _eviction_task: eviction_task,
         }
@@ -158,6 +181,9 @@ impl CacheAwarePolicy {
                 .or_insert_with(|| Arc::new(Tree::new()));
             for worker in model_workers {
                 tree.insert("", worker.url());
+                self.pending_tokens
+                    .entry(worker.url().to_string())
+                    .or_insert(0);
             }
         }
     }
@@ -170,6 +196,9 @@ impl CacheAwarePolicy {
             .entry(tree_key.to_string())
             .or_insert_with(|| Arc::new(Tree::new()));
         tree.insert("", worker.url());
+        self.pending_tokens
+            .entry(worker.url().to_string())
+            .or_insert(0);
     }
 
     /// Add a worker by URL and model (for backward compatibility)
@@ -179,6 +208,7 @@ impl CacheAwarePolicy {
             .entry(model_id.to_string())
             .or_insert_with(|| Arc::new(Tree::new()));
         tree.insert("", url);
+        self.pending_tokens.entry(url.to_string()).or_insert(0);
     }
 
     /// Remove a worker from the tree
@@ -187,6 +217,7 @@ impl CacheAwarePolicy {
         if let Some(tree) = self.trees.get(tree_key) {
             tree.remove_tenant(worker.url());
         }
+        self.pending_tokens.remove(worker.url());
     }
 
     /// Remove a worker by URL (removes from all model trees for backward compatibility)
@@ -195,6 +226,7 @@ impl CacheAwarePolicy {
         for tree_ref in self.trees.iter() {
             tree_ref.value().remove_tenant(url);
         }
+        self.pending_tokens.remove(url);
     }
 
     /// Restore tree state from mesh store
@@ -283,66 +315,44 @@ impl CacheAwarePolicy {
         }
     }
 
-    fn select_worker_min_load(
-        &self,
-        workers: &[Arc<dyn Worker>],
-        request_text: &Option<&str>,
-        healthy_indices: &[usize],
-        model_id: &str,
-        max_load: usize,
-        min_load: usize,
-    ) -> Option<usize> {
-        // Log load balancing trigger (only compute worker loads if debug enabled)
-        if tracing::enabled!(tracing::Level::DEBUG) {
-            let worker_loads: Vec<(&str, usize)> =
-                workers.iter().map(|w| (w.url(), w.load())).collect();
+    /// Look up a worker's most recently reported pending-token count.
+    /// Returns 0 for workers the LoadMonitor hasn't reached yet (newcomers).
+    /// Negative values mean the worker's /v1/loads probe failed; treat as 0
+    /// rather than `isize::MAX` so a transient outage doesn't permanently
+    /// exclude a worker from selection.
+    fn pending_tokens_for(&self, worker_url: &str) -> isize {
+        self.pending_tokens
+            .get(worker_url)
+            .map(|v| (*v).max(0))
+            .unwrap_or(0)
+    }
+
+    /// Insert request text into the tree under the chosen worker and mirror
+    /// the op into the mesh. Pulled out so both the imbalanced and
+    /// balanced paths can share it.
+    fn record_request_in_tree(&self, model_id: &str, text: &str, worker_url: &str) {
+        let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
+        let Some(tree) = tree else {
             debug!(
-                "Load balancing triggered | max: {} | min: {} | workers: {:?}",
-                max_load, min_load, worker_loads
+                "Warning: No tree found for model '{}', skipping cache update",
+                model_id
             );
-        }
+            return;
+        };
 
-        // Use shortest queue when imbalanced
-        let min_load_idx = healthy_indices
-            .iter()
-            .min_by_key(|&&idx| workers[idx].load())
-            .copied()?;
+        tree.insert(text, worker_url);
 
-        // Even in imbalanced mode, update the tree to maintain cache state
-        if let Some(text) = request_text {
-            // Get the tree reference without locking the entire HashMap
-            // DashMap only locks the specific shard containing this key
-            let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
-
-            if let Some(tree) = tree {
-                let worker_url = workers[min_load_idx].url();
-                // Now we can work with the tree without holding the HashMap lock
-                tree.insert(text, worker_url);
-
-                // Sync insert operation to mesh if enabled (no-op if mesh is not enabled)
-                if let Some(ref mesh_sync) = self.mesh_sync {
-                    use smg_mesh::tree_ops::TreeInsertOp;
-                    let op = TreeOperation::Insert(TreeInsertOp {
-                        text: text.to_string(),
-                        tenant: worker_url.to_string(),
-                    });
-                    let mesh_model_id = Self::normalize_mesh_model_id(model_id);
-                    if let Err(e) = mesh_sync.sync_tree_operation(mesh_model_id.to_string(), op) {
-                        warn!("Failed to sync tree insert operation to mesh: {}", e);
-                    }
-                }
-            } else {
-                debug!(
-                    "Warning: No tree found for model '{}', skipping cache update",
-                    model_id
-                );
+        if let Some(ref mesh_sync) = self.mesh_sync {
+            use smg_mesh::tree_ops::TreeInsertOp;
+            let op = TreeOperation::Insert(TreeInsertOp {
+                text: text.to_string(),
+                tenant: worker_url.to_string(),
+            });
+            let mesh_model_id = Self::normalize_mesh_model_id(model_id);
+            if let Err(e) = mesh_sync.sync_tree_operation(mesh_model_id.to_string(), op) {
+                warn!("Failed to sync tree insert operation to mesh: {}", e);
             }
         }
-
-        // Increment processed counter
-        workers[min_load_idx].increment_processed();
-
-        Some(min_load_idx)
     }
 }
 
@@ -353,133 +363,77 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         workers: &[Arc<dyn Worker>],
         info: &SelectWorkerInfo<'_>,
     ) -> Option<usize> {
-        let request_text = info.request_text;
         let healthy_indices = get_healthy_worker_indices(workers);
-
         if healthy_indices.is_empty() {
             return None;
         }
 
-        // Determine the model for this set of workers (router pre-filters by model)
-        // All workers should be from the same model
+        // Router pre-filters by model, so any healthy worker yields the key.
         let model_id = normalize_model_key(workers[healthy_indices[0]].model_id());
+        let text = info.request_text.unwrap_or("");
 
-        // Get current load statistics - compute min/max in single pass without allocation
-        let (min_load, max_load) = workers.iter().fold((usize::MAX, 0usize), |(min, max), w| {
-            let load = w.load();
-            (min.min(load), max.max(load))
-        });
-        let min_load = if min_load == usize::MAX { 0 } else { min_load };
+        // Single tree walk: returns the deepest reachable node, the cached
+        // tenant at that node (our "longest-prefix worker"), and the matched
+        // / input char counts. If there's no tree yet for this model, treat
+        // every worker as having zero match.
+        let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
+        let (best_tenant, best_match_chars, input_chars) = match &tree {
+            Some(t) => {
+                let r = t.prefix_match_with_counts(text);
+                (Some(r.tenant), r.matched_char_count, r.input_char_count)
+            }
+            None => {
+                debug!(
+                    "No cache tree for model '{}'; scoring on pending tokens only",
+                    model_id
+                );
+                (None, 0usize, text.chars().count())
+            }
+        };
 
-        // Check if load is imbalanced
-        let is_imbalanced = max_load.saturating_sub(min_load) > self.config.balance_abs_threshold
-            && (max_load as f32) > (min_load as f32 * self.config.balance_rel_threshold);
+        // Score every healthy worker by `pending_tokens + miss_chars`.
+        // The longest-prefix tenant gets `miss_chars = input - matched`;
+        // everyone else is assumed to have zero overlap and pays the full
+        // `input_chars`. Units are intentionally mixed 1:1 — see struct
+        // doc-comment for rationale.
+        let best_tenant_str: Option<&str> = best_tenant.as_ref().map(|t| t.as_ref());
+        let scored_idx = healthy_indices
+            .iter()
+            .min_by_key(|&&idx| {
+                let w = &workers[idx];
+                let is_best = best_tenant_str == Some(w.url());
+                let miss_chars = if is_best {
+                    input_chars.saturating_sub(best_match_chars)
+                } else {
+                    input_chars
+                };
+                let pending = self.pending_tokens_for(w.url()) as i128;
+                pending + miss_chars as i128
+            })
+            .copied();
 
-        if is_imbalanced {
-            return self.select_worker_min_load(
-                workers,
-                &request_text,
-                &healthy_indices,
-                model_id,
-                max_load,
-                min_load,
-            );
+        let Some(idx) = scored_idx else {
+            return None;
+        };
+
+        // Update gateway-side tree + mesh with this request (skip if model
+        // had no tree yet — caller may not have init'd one for this model).
+        if tree.is_some() {
+            self.record_request_in_tree(model_id, text, workers[idx].url());
         }
 
-        // Use cache-aware routing when balanced
-        let text = request_text.unwrap_or("");
+        workers[idx].increment_processed();
+        Some(idx)
+    }
 
-        // Get the tree reference without locking the entire HashMap
-        // DashMap only locks the specific shard containing this key
-        let tree = self.trees.get(model_id).map(|entry| entry.value().clone());
-
-        if let Some(tree) = tree {
-            // Now we work with the tree without holding the HashMap lock
-            // Use prefix_match_with_counts to avoid redundant chars().count() calls
-            let result = tree.prefix_match_with_counts(text);
-            let match_rate = if result.input_char_count == 0 {
-                0.0
-            } else {
-                result.matched_char_count as f32 / result.input_char_count as f32
-            };
-
-            // Select worker without String allocation
-            let selected_idx = if match_rate > self.config.cache_threshold {
-                // Cache hit path: find worker by URL (compare &str directly, no allocation)
-                let tenant_url: &str = &result.tenant;
-                workers
-                    .iter()
-                    .position(|w| w.url() == tenant_url)
-                    .filter(|&idx| workers[idx].is_healthy())
-            } else {
-                // Low cache match: use worker with minimum load
-                healthy_indices
-                    .iter()
-                    .min_by_key(|&&idx| workers[idx].load())
-                    .copied()
-            };
-
-            if let Some(idx) = selected_idx {
-                // Update the tree with this request (use worker URL directly, no allocation)
-                tree.insert(text, workers[idx].url());
-
-                // Sync insert operation to mesh if enabled (no-op if mesh is not enabled)
-                if let Some(ref mesh_sync) = self.mesh_sync {
-                    use smg_mesh::tree_ops::TreeInsertOp;
-                    let op = TreeOperation::Insert(TreeInsertOp {
-                        text: text.to_string(),
-                        tenant: workers[idx].url().to_string(),
-                    });
-                    let mesh_model_id = Self::normalize_mesh_model_id(model_id);
-                    if let Err(e) = mesh_sync.sync_tree_operation(mesh_model_id.to_string(), op) {
-                        warn!("Failed to sync tree insert operation to mesh: {}", e);
-                    }
-                }
-
-                // Increment processed counter
-                workers[idx].increment_processed();
-
-                return Some(idx);
-            }
-
-            // Selected worker no longer exists or unhealthy, remove stale tenant from tree
-            if match_rate > self.config.cache_threshold {
-                let tenant_url: &str = &result.tenant;
-                tree.remove_tenant(tenant_url);
-                debug!("Removed stale worker {} from cache tree", tenant_url);
-
-                // Sync removal to mesh if enabled (no-op if mesh is not enabled)
-                if let Some(ref mesh_sync) = self.mesh_sync {
-                    use smg_mesh::tree_ops::TreeRemoveOp;
-                    let op = TreeOperation::Remove(TreeRemoveOp {
-                        tenant: tenant_url.to_string(),
-                    });
-                    let mesh_model_id = Self::normalize_mesh_model_id(model_id);
-                    if let Err(e) = mesh_sync.sync_tree_operation(mesh_model_id.to_string(), op) {
-                        warn!("Failed to sync tree remove operation to mesh: {}", e);
-                    }
-                }
-            }
-
-            // Fallback to first healthy worker
-            healthy_indices.first().copied()
-        } else {
-            // No tree for this model, log warning and use random selection
-            debug!(
-                "Warning: No tree found for model '{}', using random worker selection",
-                model_id
-            );
-            // Return a random healthy worker
-            let mut rng = rand::rng();
-            let random_idx = rng.random_range(0..healthy_indices.len());
-            Some(healthy_indices[random_idx])
+    fn update_loads(&self, loads: &std::collections::HashMap<String, isize>) {
+        for (url, v) in loads.iter() {
+            self.pending_tokens.insert(url.clone(), *v);
         }
     }
 
     fn on_request_complete(&self, worker_url: &str, success: bool) {
-        // Could track success rates per worker for more intelligent routing
         if !success {
-            // Optionally reduce affinity for failed requests
             tracing::debug!(
                 "Request to {} completed with success={}",
                 worker_url,
@@ -578,40 +532,205 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_aware_with_imbalanced_load() {
-        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
-            cache_threshold: 0.5,
-            balance_abs_threshold: 5,
-            balance_rel_threshold: 2.0,
-            eviction_interval_secs: 0, // Disable eviction thread
-            max_tree_size: 10000,
-        });
-
-        let worker1 = BasicWorkerBuilder::new("http://w1:8000")
-            .worker_type(WorkerType::Regular)
-            .build();
-        let worker2 = BasicWorkerBuilder::new("http://w2:8000")
-            .worker_type(WorkerType::Regular)
-            .build();
-
-        // Create significant load imbalance
-        for _ in 0..20 {
-            worker1.increment_load();
-        }
-        // worker2 has load 0
-
-        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(worker1), Arc::new(worker2)];
-        policy.init_workers(&workers);
-
-        // Should select worker2 (lower load) despite cache affinity
-        let info = SelectWorkerInfo {
-            request_text: Some("test"),
+    async fn test_newcomer_wins_when_cache_holder_saturated() {
+        // Cache holder w1 has the prefix but is buried under pending tokens;
+        // newcomer w2 has no overlap but pending=0. For short input, w2 wins.
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
             ..Default::default()
         };
-        for _ in 0..5 {
-            let idx = policy.select_worker(&workers, &info).await.unwrap();
-            assert_eq!(idx, 1); // Should always pick worker2
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        // Seed the tree so w1 owns "hello world" entirely.
+        for _ in 0..3 {
+            let idx = policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        request_text: Some("hello world"),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(idx, 0);
         }
+
+        // LoadMonitor reports w1 with a huge backlog, w2 idle.
+        let mut loads = std::collections::HashMap::new();
+        loads.insert("http://w1:8000".to_string(), 1_000_000);
+        loads.insert("http://w2:8000".to_string(), 0);
+        policy.update_loads(&loads);
+
+        // A short prompt: w1's pending dwarfs any cache savings → w2.
+        let idx = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("hello world"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(idx, 1, "saturated cache holder should lose to idle newcomer");
+    }
+
+    #[tokio::test]
+    async fn test_cache_holder_wins_when_balanced() {
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        // First request lands somewhere (deterministic: index 0 ties broken first).
+        let first = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("the quick brown fox"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // Both workers report identical pending. The cache holder should win
+        // any subsequent identical-prefix request.
+        let mut loads = std::collections::HashMap::new();
+        loads.insert("http://w1:8000".to_string(), 10);
+        loads.insert("http://w2:8000".to_string(), 10);
+        policy.update_loads(&loads);
+
+        for _ in 0..3 {
+            let idx = policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        request_text: Some("the quick brown fox"),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(idx, first, "cache affinity should win when pending is equal");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pending_tokens_default_zero_for_unknown_worker() {
+        // No update_loads call has happened yet; both workers should be
+        // treated as pending=0 and the tie should break the same way every
+        // call (longest-prefix tenant wins).
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        let first = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("alpha beta"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let second = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("alpha beta"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn test_failed_load_probe_treated_as_zero() {
+        // LoadMonitor reports w1 with -1 (probe failed) — must not cause w1
+        // to be permanently preferred-or-excluded; we treat -1 as 0.
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        let mut loads = std::collections::HashMap::new();
+        loads.insert("http://w1:8000".to_string(), -1);
+        loads.insert("http://w2:8000".to_string(), 500);
+        policy.update_loads(&loads);
+
+        // w1 (treated as 0) should beat w2 (500) for a fresh prompt.
+        let idx = policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some("never seen before"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(idx, 0);
     }
 
     #[tokio::test]

--- a/sgl-model-gateway/src/policies/registry.rs
+++ b/sgl-model-gateway/src/policies/registry.rs
@@ -256,42 +256,52 @@ impl PolicyRegistry {
 
     /// Get all PowerOfTwo policies that need load updates (lock-free)
     pub fn get_all_power_of_two_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
-        let mut power_of_two_policies = Vec::new();
+        self.get_all_policies_by_name("power_of_two")
+    }
 
-        if self.default_policy.name() == "power_of_two" {
-            power_of_two_policies.push(Arc::clone(&self.default_policy));
+    /// Get all CacheAware policies that need load updates (lock-free)
+    pub fn get_all_cache_aware_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
+        self.get_all_policies_by_name("cache_aware")
+    }
+
+    /// Get all distinct policy instances whose `name()` matches the given value.
+    /// Used by LoadMonitor to fan periodic load updates to load-aware policies.
+    fn get_all_policies_by_name(&self, target_name: &str) -> Vec<Arc<dyn LoadBalancingPolicy>> {
+        let mut policies = Vec::new();
+
+        if self.default_policy.name() == target_name {
+            policies.push(Arc::clone(&self.default_policy));
         }
 
-        // Get prefill and decode policies (lock-free via OnceLock::get)
         let prefill_policy_opt = self.prefill_policy.get();
         let decode_policy_opt = self.decode_policy.get();
 
         if let Some(policy) = prefill_policy_opt {
-            if policy.name() == "power_of_two" && !Arc::ptr_eq(policy, &self.default_policy) {
-                power_of_two_policies.push(Arc::clone(policy));
+            if policy.name() == target_name && !Arc::ptr_eq(policy, &self.default_policy) {
+                policies.push(Arc::clone(policy));
             }
         }
 
         if let Some(policy) = decode_policy_opt {
-            if policy.name() == "power_of_two"
+            if policy.name() == target_name
                 && !Arc::ptr_eq(policy, &self.default_policy)
                 && !prefill_policy_opt.is_some_and(|p| Arc::ptr_eq(p, policy))
             {
-                power_of_two_policies.push(Arc::clone(policy));
+                policies.push(Arc::clone(policy));
             }
         }
 
         for entry in self.model_policies.iter() {
             let policy = entry.value();
-            if policy.name() == "power_of_two" {
-                let already_added = power_of_two_policies.iter().any(|p| Arc::ptr_eq(p, policy));
+            if policy.name() == target_name {
+                let already_added = policies.iter().any(|p| Arc::ptr_eq(p, policy));
                 if !already_added {
-                    power_of_two_policies.push(Arc::clone(policy));
+                    policies.push(Arc::clone(policy));
                 }
             }
         }
 
-        power_of_two_policies
+        policies
     }
 
     /// Initialize cache-aware policy with workers if applicable


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The cache-aware routing policy currently decides between cache-affinity and shortest-queue via two independent gated thresholds  (`cache_threshold`, `balance_*_threshold`), with no signal of real per-worker backlog.
Two side-effects:
  1. **No notion of pending work.** "Imbalance" is measured by the gateway's in-flight request counter (`Worker::load()`), not actual  queued tokens on the worker. A worker holding the longest prefix can stay pinned long after its queue grows unhealthy.
  2. **`/v1/loads` is unused for cache-aware.** Each SGLang worker already reports `num_total_tokens` (used + queued prefill tokens) per  DP rank via `/v1/loads`, and the gateway's `LoadMonitor` already polls it — but only `PowerOfTwoPolicy` consumes it. Cache-aware has no   view of true backlog.

This PR replaces the threshold gating with a single per-worker score that fuses cache-affinity (from the gateway's approximate radix  tree) with real pending-token reports (from `/v1/loads`), so a saturated cache holder naturally yields traffic to a less-loaded peer once the backlog outweighs the cache savings.

## Modifications

**`src/policies/cache_aware.rs`** — new scoring rule
  - New field `pending_tokens: Arc<DashMap<String, isize>>`, keyed by `worker.url()` (which is `base@rank` for `DPAwareWorker`, plain `base` otherwise). Initialized to `0` for every worker in `init_workers` / `add_worker` / `add_worker_by_url`; cleared on remove.
  - Implements `LoadBalancingPolicy::update_loads` to refresh the snapshot from `LoadMonitor`.
  - `select_worker` rewritten:
    (best_tenant, best_match_chars, input_chars) = tree.prefix_match_with_counts(text)
    ```
    for w in healthy_workers:        miss_chars = (input_chars - best_match_chars) if w.url()==best_tenant else input_chars
        score[w]   = pending_tokens[w.url()].max(0) + miss_chars
    pick argmin(score)
    ```

One tree walk total; longest-prefix tenant comes from the tree's existing cached `last_tenant` at the deepest matched node. Failed  probes (`-1`) are clamped to `0` so transient outages don't permanently exclude a worker. Newcomers (no `update_loads` entry yet)  default to `0`, which makes them attractive — matching the design goal "prefer newcomers whose pending tokens count is smallest."
  - Imbalance / cache-threshold gates removed; `CacheAwareConfig::{cache_threshold, balance_abs_threshold, balance_rel_threshold}` are  kept dead-but-parsing to preserve CLI surface (will be pruned in a follow-up).

Unit choice: `pending_tokens` is in tokens and `miss_chars` is in chars; they're added with an implicit 1:1 ratio. This biases  selection toward cache affinity for tokenizers where chars/token > 1 (English BPE ≈ 4). Documented in the struct doc-comment; we can introduce a `chars_per_token` knob later if metrics show cache-holder hotspots.

**`src/core/worker_manager.rs`** — DP-aware load fetching
  - New `ParsedLoads { aggregate_total_tokens, per_rank }` struct parsed from `/v1/loads`.
  - `get_all_worker_loads` now groups workers by `base_url()` so each engine process gets one `/v1/loads` fetch even when N  - `ParsedLoads::load_for_worker` returns the per-rank `num_total_tokens` for DP-aware workers and falls back to `aggregate.total_tokens` for non-DP workers.  - `LoadMonitor::monitor_loop` now also fans loads into cache-aware policies and runs whenever either PoT or cache-aware policies are registered (previously skipped when only cache-aware was present).
  
  **`src/policies/registry.rs`** — `get_all_cache_aware_policies()` via a shared `get_all_policies_by_name(name)` helper that dedups the existing power-of-two lookup logic.  

**`src/core/worker_manager.rs`** — DP-aware load fetching
  - New `ParsedLoads { aggregate_total_tokens, per_rank }` struct parsed from `/v1/loads`.
  - `get_all_worker_loads` now groups workers by `base_url()` so each engine process gets one `/v1/loads` fetch even when N
  `DPAwareWorker` entries sit behind it.
  - `ParsedLoads::load_for_worker` returns the per-rank `num_total_tokens` for DP-aware workers and falls back to
  `aggregate.total_tokens` for non-DP workers.
  - `LoadMonitor::monitor_loop` now also fans loads into cache-aware policies and runs whenever either PoT or cache-aware policies are registered (previously skipped when only cache-aware was present).

**`src/policies/registry.rs`** — `get_all_cache_aware_policies()` via a shared `get_all_policies_by_name(name)` helper that dedups the existing power-of-two lookup logic.

**Unit Tests** — 4 new in `cache_aware::tests`:
  - `test_newcomer_wins_when_cache_holder_saturated`: cache holder with `pending=1_000_000` loses to idle newcomer for a short prompt.
  - `test_cache_holder_wins_when_balanced`: equal `pending=10` on both; cache affinity wins repeated identical prefixes.
  - `test_pending_tokens_default_zero_for_unknown_worker`: with no `update_loads` call, behavior is deterministic.
  - `test_failed_load_probe_treated_as_zero`: `update_loads({w1: -1, w2: 500})` picks w1 (probe failure ≠ infinite load).

All 7 pre-existing cache-aware tests still pass.

## Accuracy Tests

This commit modifies the worker selection algorithm of router and has nothing to do with model forward logic.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->