### PR TITLE
Sandbox: reproduce test_swa_radix_cache_kl failure on latest main

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ Long-term active SGLang contributors are eligible for coding agent sponsorship, 
 
 ## Acknowledgment
 We learned the design and reused code from the following projects: [Guidance](https://github.com/guidance-ai/guidance), [vLLM](https://github.com/vllm-project/vllm), [LightLLM](https://github.com/ModelTC/lightllm), [FlashInfer](https://github.com/flashinfer-ai/flashinfer), [Outlines](https://github.com/outlines-dev/outlines), and [LMQL](https://github.com/eth-sri/lmql).
+


### PR DESCRIPTION
Context: was checking whether my long pr chain make ci pass on main

(all below are generated by agent not me)

---


Sandbox PR to reproduce the `test_swa_radix_cache_kl.py` failure observed on main: https://github.com/sgl-project/sglang/actions/runs/25949547821/job/76300295350 and https://github.com/sgl-project/sglang/actions/runs/25949547821/job/76285130348

Triggering via `/rerun-test test/registered/radix_cache/test_swa_radix_cache_kl.py`. Do not merge.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->