### PR TITLE
[DeepSeek-V4] Add experimental SM89/L40S FP8 support slice

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -123,6 +123,31 @@ We provide two different options for running DeepSeek-V4 models on Hopper device
 - Original FP4 checkpoints: To run original FP4 checkpoints, apply the w4a16 MoE kernels (marlin) as in interactive command generator. For this option we only support TP method. Complete Pro model can be run on a single H200 node with this option.
 - Converted FP8 checkpoints: We also provide pre-converted FP8 checkpoints (`sgl-project/DeepSeek-V4-Flash-FP8`, `sgl-project/DeepSeek-V4-Pro-FP8`), which support more parallelism and features.
 
+**L40S (SM89) experimental note**
+
+L40S does not support the Hopper/Blackwell-only DeepGEMM or FP4 fast paths used by the primary DeepSeek-V4 recipes. For L40S, use the converted FP8 Flash checkpoint with Triton backends and the DSV4 PyTorch top-k transform fallback:
+
+```bash Command
+export SGLANG_TOPK_TRANSFORM_512_TORCH=1
+export SGLANG_OPT_USE_FUSED_HASH_TOPK=0
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=0
+export SGLANG_NSA_FUSE_TOPK=0
+
+sglang serve sgl-project/DeepSeek-V4-Flash-FP8 \
+  --served-model-name deepseek-ai/DeepSeek-V4-Flash \
+  --tp-size 8 \
+  --attention-backend dsv4 \
+  --fp8-gemm-backend triton \
+  --moe-runner-backend triton \
+  --sampling-backend pytorch \
+  --cuda-graph-max-bs 32 \
+  --cuda-graph-bs 1 2 4 8 16 32 \
+  --reasoning-parser deepseek-v4 \
+  --tool-call-parser deepseekv4
+```
+
+The L40S path is optimized for compatibility and single-node availability rather than matching the H200/B200 throughput recipes. It relies on L40S-specific FP8 W8A8 and Triton MoE tuning configs when available.
+
 PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=-1`
 (or `--device /dev/infiniband:/dev/infiniband --cap-add IPC_LOCK`) so mooncake
 can discover the IB HCAs; without IB exposure mooncake silently falls back to

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -108,10 +108,8 @@ def topk_transform_512_pytorch_vectorized(
     page_bits = (page_size - 1).bit_length() if page_size > 1 else 0
     page_mask = page_size - 1
 
-    sequential_indices = (
-        torch.arange(TOPK, device=device, dtype=torch.int32)
-        .unsqueeze(0)
-        .expand(batch_size, -1)
+    sequential_indices = torch.arange(TOPK, device=device, dtype=torch.int32).unsqueeze(
+        0
     )
     sequential_valid = sequential_indices < seq_lens.unsqueeze(1)
     negative_indices = torch.full_like(sequential_indices, -1)
@@ -122,9 +120,7 @@ def topk_transform_512_pytorch_vectorized(
         )
         valid_topk = sequential_valid
     else:
-        positions = (
-            torch.arange(max_seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
-        )
+        positions = torch.arange(max_seq_len, device=device).unsqueeze(0)
         valid_mask = positions < seq_lens.unsqueeze(1)
 
         masked_scores = scores.masked_fill(~valid_mask, float("-inf"))
@@ -133,15 +129,11 @@ def topk_transform_512_pytorch_vectorized(
         )
         raw_indices = raw_indices.to(torch.int32)
 
-        batch_indices = (
-            torch.arange(batch_size, device=device).unsqueeze(1).expand(-1, TOPK)
-        )
-        gathered_scores = scores[
-            batch_indices.flatten(), raw_indices.clamp(min=0).flatten()
-        ].view(batch_size, TOPK)
+        batch_indices = torch.arange(batch_size, device=device).unsqueeze(1)
+        gathered_scores = scores[batch_indices, raw_indices]
 
         valid_topk = gathered_scores != float("-inf")
-        needs_sequential = (seq_lens <= TOPK).unsqueeze(1).expand(-1, TOPK)
+        needs_sequential = (seq_lens <= TOPK).unsqueeze(1)
         raw_indices = torch.where(
             needs_sequential,
             torch.where(sequential_valid, sequential_indices, negative_indices),

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -60,7 +60,7 @@ def fp8_paged_mqa_logits_torch(
     assert weight.shape == (batch_size, num_heads)
     assert seq_lens.shape == (batch_size,)
     assert page_table.shape[0] == batch_size
-    assert clean_logits == False
+    assert not clean_logits
 
     logits = page_table.new_empty((batch_size, max_seq_len), dtype=torch.float32)
     for i in range(batch_size):
@@ -108,59 +108,46 @@ def topk_transform_512_pytorch_vectorized(
     page_bits = (page_size - 1).bit_length() if page_size > 1 else 0
     page_mask = page_size - 1
 
-    positions = (
-        torch.arange(max_seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+    sequential_indices = (
+        torch.arange(TOPK, device=device, dtype=torch.int32)
+        .unsqueeze(0)
+        .expand(batch_size, -1)
     )
-    valid_mask = positions < seq_lens.unsqueeze(1)
+    sequential_valid = sequential_indices < seq_lens.unsqueeze(1)
+    negative_indices = torch.full_like(sequential_indices, -1)
 
-    masked_scores = scores.clone()
-    masked_scores[~valid_mask] = float("-inf")
-
-    actual_k = min(TOPK, max_seq_len)
-    _, raw_indices = torch.topk(
-        masked_scores, k=actual_k, dim=1, largest=True, sorted=False
-    )
-    raw_indices = raw_indices.to(torch.int32)
-
-    if actual_k < TOPK:
-        padding = torch.zeros(
-            (batch_size, TOPK - actual_k), dtype=torch.int32, device=device
-        )
-        raw_indices = torch.cat([raw_indices, padding], dim=1)
-
-    batch_indices = (
-        torch.arange(batch_size, device=device).unsqueeze(1).expand(-1, TOPK)
-    )
-    gathered_scores = scores[
-        batch_indices.flatten(), raw_indices.clamp(min=0).flatten()
-    ].view(batch_size, TOPK)
-
-    valid_topk = gathered_scores != float("-inf")
-    if actual_k < TOPK:
-        pad_mask = torch.arange(TOPK, device=device).unsqueeze(0) >= actual_k
-        valid_topk = valid_topk & ~pad_mask
-
-    needs_sequential = seq_lens <= TOPK
-    if needs_sequential.any():
-        sequential_indices = (
-            torch.arange(TOPK, device=device, dtype=torch.int32)
-            .unsqueeze(0)
-            .expand(batch_size, -1)
-        )
-        sequential_valid = sequential_indices < seq_lens.unsqueeze(1)
-
+    if max_seq_len <= TOPK:
         raw_indices = torch.where(
-            needs_sequential.unsqueeze(1).expand(-1, TOPK),
-            torch.where(
-                sequential_valid,
-                sequential_indices,
-                torch.tensor(-1, device=device, dtype=torch.int32),
-            ),
+            sequential_valid, sequential_indices, negative_indices
+        )
+        valid_topk = sequential_valid
+    else:
+        positions = (
+            torch.arange(max_seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+        )
+        valid_mask = positions < seq_lens.unsqueeze(1)
+
+        masked_scores = scores.masked_fill(~valid_mask, float("-inf"))
+        _, raw_indices = torch.topk(
+            masked_scores, k=TOPK, dim=1, largest=True, sorted=False
+        )
+        raw_indices = raw_indices.to(torch.int32)
+
+        batch_indices = (
+            torch.arange(batch_size, device=device).unsqueeze(1).expand(-1, TOPK)
+        )
+        gathered_scores = scores[
+            batch_indices.flatten(), raw_indices.clamp(min=0).flatten()
+        ].view(batch_size, TOPK)
+
+        valid_topk = gathered_scores != float("-inf")
+        needs_sequential = (seq_lens <= TOPK).unsqueeze(1).expand(-1, TOPK)
+        raw_indices = torch.where(
+            needs_sequential,
+            torch.where(sequential_valid, sequential_indices, negative_indices),
             raw_indices,
         )
-        valid_topk = torch.where(
-            needs_sequential.unsqueeze(1).expand(-1, TOPK), sequential_valid, valid_topk
-        )
+        valid_topk = torch.where(needs_sequential, sequential_valid, valid_topk)
 
     page_idx = raw_indices >> page_bits
     offset_in_page = raw_indices & page_mask
@@ -171,16 +158,12 @@ def topk_transform_512_pytorch_vectorized(
     page_indices = (physical_pages << page_bits) | offset_in_page
     page_indices = page_indices.to(torch.int32)
 
-    page_indices = torch.where(
-        valid_topk, page_indices, torch.tensor(-1, device=device, dtype=torch.int32)
-    )
+    page_indices = torch.where(valid_topk, page_indices, negative_indices)
 
     out_page_indices.copy_(page_indices)
 
     if out_raw_indices is not None:
-        raw_indices = torch.where(
-            valid_topk, raw_indices, torch.tensor(-1, device=device, dtype=torch.int32)
-        )
+        raw_indices = torch.where(valid_topk, raw_indices, negative_indices)
         out_raw_indices.copy_(raw_indices)
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=256,N=256,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=256,N=256,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=256,N=256,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=256,N=256,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=1024,K=4096,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=1024,K=4096,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=4096,K=1024,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=4096,K=1024,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=4096,K=256,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=4096,K=256,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=512,K=4096,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=512,K=4096,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/quantization/configs/N=8192,K=1024,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/quantization/configs/N=8192,K=1024,device_name=NVIDIA_L40S,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,10 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    }
+}

--- a/test/registered/unit/layers/test_dsv4_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_indexer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.indexer import (
+    topk_transform_512_pytorch_vectorized,
+)
+
+
+def _run_topk_transform(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: torch.Tensor,
+    page_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out_page_indices = torch.empty(
+        (scores.shape[0], 512), device=scores.device, dtype=torch.int32
+    )
+    out_raw_indices = torch.empty_like(out_page_indices)
+
+    topk_transform_512_pytorch_vectorized(
+        scores,
+        seq_lens,
+        page_tables,
+        out_page_indices,
+        page_size,
+        out_raw_indices,
+    )
+
+    return out_page_indices, out_raw_indices
+
+
+def test_topk_transform_512_uses_sequential_indices_for_short_sequences():
+    page_size = 4
+    seq_lens = torch.tensor([3, 6], dtype=torch.int32)
+    page_tables = torch.tensor(
+        [
+            [10, 11],
+            [20, 21],
+        ],
+        dtype=torch.int32,
+    )
+    scores = torch.arange(12, dtype=torch.float32).reshape(2, 6)
+
+    out_page_indices, out_raw_indices = _run_topk_transform(
+        scores, seq_lens, page_tables, page_size
+    )
+
+    assert out_raw_indices[0, :5].tolist() == [0, 1, 2, -1, -1]
+    assert out_page_indices[0, :5].tolist() == [40, 41, 42, -1, -1]
+
+    assert out_raw_indices[1, :8].tolist() == [0, 1, 2, 3, 4, 5, -1, -1]
+    assert out_page_indices[1, :8].tolist() == [80, 81, 82, 83, 84, 85, -1, -1]
+
+
+def test_topk_transform_512_handles_mixed_short_and_topk_rows():
+    page_size = 8
+    max_seq_len = 640
+    seq_lens = torch.tensor([9, 600], dtype=torch.int32)
+    page_tables = torch.arange(200, dtype=torch.int32).reshape(2, 100)
+    scores = torch.zeros((2, max_seq_len), dtype=torch.float32)
+    scores[1] = -10000
+    scores[1, 88:600] = torch.arange(512, dtype=torch.float32)
+
+    out_page_indices, out_raw_indices = _run_topk_transform(
+        scores, seq_lens, page_tables, page_size
+    )
+
+    assert out_raw_indices[0, :12].tolist() == list(range(9)) + [-1, -1, -1]
+    assert out_page_indices[0, :12].tolist() == list(range(9)) + [-1, -1, -1]
+
+    assert (out_raw_indices[1] >= 88).all()
+    assert (out_raw_indices[1] < 600).all()
+    assert (out_page_indices[1] >= 0).all()
+    assert out_raw_indices[1].unique().numel() == 512

--- a/test/registered/unit/layers/test_dsv4_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_indexer.py
@@ -5,6 +5,9 @@ import torch
 from sglang.srt.layers.attention.dsv4.indexer import (
     topk_transform_512_pytorch_vectorized,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 def _run_topk_transform(


### PR DESCRIPTION
# DeepSeek-V4 Flash SM89/L40S support slice

## Summary

- Make the DeepSeek-V4 torch top-k fallback CUDA-graph safe by replacing Python `.any()` control flow with tensor-only masking.
- Add L40S FP8 W8A8 and Triton MoE tuned config assets for the DeepSeek-V4-Flash FP8 path.
- Document the L40S/SM89 recipe as an experimental FP8 + Triton fallback path.

Related: #23602

## Motivation

DeepSeek-V4 Flash can run on 8x L40S with the FP8 checkpoint, but the current SM89 path needs two upstreamable fixes before it can be maintained cleanly:

- the torch top-k fallback must not branch on CUDA tensors during graph capture;
- L40S tuned kernel configs should live in the normal SGLang config asset directories instead of being injected out of tree.

This PR intentionally keeps the scope small. It does not attempt to upstream the whole external sparse decode fallback or the local deployment wrapper.

## Modifications

1. `python/sglang/srt/layers/attention/dsv4/indexer.py`
   - Rewrites `topk_transform_512_pytorch_vectorized` so short-sequence handling is expressed with tensor operations.
   - Keeps the short-row padding semantics while avoiding `.any()` on CUDA tensors.

2. `test/registered/unit/layers/test_dsv4_indexer.py`
   - Covers all-short rows.
   - Covers mixed short/top-k rows.

3. L40S config assets
   - Adds observed L40S W8A8 FP8 configs for DeepSeek-V4-Flash FP8 shapes.
   - Adds Triton 3.5.1 MoE configs for `E=256,N=256`, including the `_down` variant.

4. Docs
   - Adds an experimental L40S note to the DeepSeek-V4 cookbook.

## Accuracy Tests

Local checks:

```text
git diff --check origin/main..HEAD
python3 -m py_compile \
  python/sglang/srt/layers/attention/dsv4/indexer.py \
  test/registered/unit/layers/test_dsv4_indexer.py
```

`pytest` collection on my local macOS Python is blocked by a missing optional runtime dependency (`orjson`), not by the test itself.

Previous remote/container checks from this experiment:

```text
PYTHONPATH=python pytest -q test/registered/unit/layers/test_dsv4_indexer.py
2 passed, 6 warnings in 7.80s
```

```text
loader smoke ok
```

## Speed Tests and Profiling

8x L40S deployment evidence using this config slice plus local follow-up runtime work:

```text
512-word prompt / 512 output x3:
decode_tps.mean=140.132

4K input / 1K output:
decode_tps.mean=131.299
```

## Non-goals

- No claim of complete DeepSeek official API parity.
- No DeepGEMM/DeepEP enablement on SM89.
- No upstreaming of the local SGLang Docker wrapper, auth proxy, or web test page.
- No upstreaming of the external sparse decode fallback in this PR.
- No model-alias compatibility layer for `deepseek-chat` / `deepseek-reasoner` in this PR.

## Follow-ups

- Package and review the SM89 sparse decode fallback as a separate PR.
- Decide whether the local `hash_topk` PDL guard should be upstreamed; the WIP patch is saved outside the PR-ready branch.
- Build a compatibility shim if this deployment must behave exactly like DeepSeek's public API, including official model aliases, `thinking` object normalization, Beta prefix/FIM routes, and context-cache observability.

## Checklist

- [x] The change is scoped to an SM89/L40S support slice.
- [x] Unit coverage added for the torch top-k fallback.
- [x] Config assets live in the standard SGLang config directories.
- [x] Cookbook note added for the experimental L40S path.
- [x] Registered the new unit test with the CI registry.
- [x] `git diff --check origin/main..HEAD` passes.
- [x] Python syntax check passes for the changed Python files.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->