### PR TITLE
[NPU] Fix qwen3vl deepstack

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -25,6 +25,7 @@ from sglang.srt.batch_invariant_ops import (
     rms_norm_batch_invariant,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
@@ -185,6 +186,8 @@ class RMSNorm(MultiPlatformOp):
         override_orig_dtype: Optional = None,
     ) -> None:
         super().__init__()
+        self.attn_tp_size = get_attention_tp_size()
+        self.attn_tp_rank = get_attention_tp_rank()
         self.has_weight = has_weight
         self.cast_x_before_out_mul = cast_x_before_out_mul
         self.fp32_residual = fp32_residual
@@ -271,6 +274,8 @@ class RMSNorm(MultiPlatformOp):
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         if residual is not None:
             if post_residual_addition is not None:
+                if post_residual_addition.shape[0] != residual.shape[0]:
+                    post_residual_addition = post_residual_addition.chunk(self.attn_tp_size)[self.attn_tp_ranks]
                 residual = residual + post_residual_addition
             out, _, residual_out = torch_npu.npu_add_rms_norm(
                 residual, x, self.weight.data, self.variance_epsilon

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -25,7 +25,6 @@ from sglang.srt.batch_invariant_ops import (
     rms_norm_batch_invariant,
 )
 from sglang.srt.environ import envs
-from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
@@ -186,8 +185,6 @@ class RMSNorm(MultiPlatformOp):
         override_orig_dtype: Optional = None,
     ) -> None:
         super().__init__()
-        self.attn_tp_size = get_attention_tp_size()
-        self.attn_tp_rank = get_attention_tp_rank()
         self.has_weight = has_weight
         self.cast_x_before_out_mul = cast_x_before_out_mul
         self.fp32_residual = fp32_residual
@@ -274,10 +271,6 @@ class RMSNorm(MultiPlatformOp):
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         if residual is not None:
             if post_residual_addition is not None:
-                if post_residual_addition.shape[0] != residual.shape[0]:
-                    post_residual_addition = post_residual_addition.tensor_split(
-                        self.attn_tp_size
-                    )[self.attn_tp_rank]
                 residual = residual + post_residual_addition
             out, _, residual_out = torch_npu.npu_add_rms_norm(
                 residual, x, self.weight.data, self.variance_epsilon

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -275,7 +275,7 @@ class RMSNorm(MultiPlatformOp):
         if residual is not None:
             if post_residual_addition is not None:
                 if post_residual_addition.shape[0] != residual.shape[0]:
-                    post_residual_addition = post_residual_addition.chunk(self.attn_tp_size)[self.attn_tp_ranks]
+                    post_residual_addition = post_residual_addition.chunk(self.attn_tp_size)[self.attn_tp_rank]
                 residual = residual + post_residual_addition
             out, _, residual_out = torch_npu.npu_add_rms_norm(
                 residual, x, self.weight.data, self.variance_epsilon

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -275,7 +275,9 @@ class RMSNorm(MultiPlatformOp):
         if residual is not None:
             if post_residual_addition is not None:
                 if post_residual_addition.shape[0] != residual.shape[0]:
-                    post_residual_addition = post_residual_addition.chunk(self.attn_tp_size)[self.attn_tp_rank]
+                    post_residual_addition = post_residual_addition.tensor_split(
+                        self.attn_tp_size
+                    )[self.attn_tp_rank]
                 residual = residual + post_residual_addition
             out, _, residual_out = torch_npu.npu_add_rms_norm(
                 residual, x, self.weight.data, self.variance_epsilon

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -25,8 +25,8 @@ import torch.nn as nn
 from sglang.srt.configs.qwen3_vl import Qwen3VLMoeConfig, Qwen3VLMoeTextConfig
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
-from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.utils import get_layer_id
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
@@ -117,8 +117,12 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                 layer_idx - 1, input_deepstack_embeds
             )
             a2a_backend = get_moe_a2a_backend()
-            if deepstack_embeds is not None and a2a_backend.is_deepep() and post_residual_addition.shape[0] != residual.shape[0]:
-                post_residual_addition = post_residual_addition.tensor_split(
+            if (
+                deepstack_embeds is not None
+                and a2a_backend.is_deepep()
+                and deepstack_embeds.shape[0] != residual.shape[0]
+            ):
+                deepstack_embeds = deepstack_embeds.tensor_split(
                     self.attn_tp_size
                 )[self.attn_tp_rank]
             hidden_states, residual = layer(

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -122,9 +122,9 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                 and a2a_backend.is_deepep()
                 and deepstack_embeds.shape[0] != residual.shape[0]
             ):
-                deepstack_embeds = deepstack_embeds.tensor_split(
-                    self.attn_tp_size
-                )[self.attn_tp_rank]
+                deepstack_embeds = deepstack_embeds.tensor_split(self.attn_tp_size)[
+                    self.attn_tp_rank
+                ]
             hidden_states, residual = layer(
                 positions,
                 hidden_states,

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -24,6 +24,8 @@ import torch.nn as nn
 
 from sglang.srt.configs.qwen3_vl import Qwen3VLMoeConfig, Qwen3VLMoeTextConfig
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.utils import get_layer_id
@@ -53,6 +55,8 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
             prefix=prefix,
             decoder_layer_type=decoder_layer_type,
         )
+        self.attn_tp_size = get_attention_tp_size()
+        self.attn_tp_rank = get_attention_tp_rank()
         self.hidden_size = config.hidden_size
         # Currently, we use 3 as len(config.vision_config.deepstack_visual_indexes) is not directly accessible here.
         # This approach follows the original implementation.
@@ -112,6 +116,11 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
             deepstack_embeds = self.get_deepstack_embeds(
                 layer_idx - 1, input_deepstack_embeds
             )
+            a2a_backend = get_moe_a2a_backend()
+            if deepstack_embeds is not None and a2a_backend.is_deepep() and post_residual_addition.shape[0] != residual.shape[0]:
+                post_residual_addition = post_residual_addition.tensor_split(
+                    self.attn_tp_size
+                )[self.attn_tp_rank]
             hidden_states, residual = layer(
                 positions,
                 hidden_states,

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -117,10 +117,11 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                 layer_idx - 1, input_deepstack_embeds
             )
             a2a_backend = get_moe_a2a_backend()
+            # When deepep is enabled, the scatter mode of deepstack_embeds is set to TP_ATTN_FULL, whereas that of residual is SCATTERED.
+            # Therefore, deepstack_embeds must be split in this scenario.
             if (
                 deepstack_embeds is not None
                 and a2a_backend.is_deepep()
-                and deepstack_embeds.shape[0] != residual.shape[0]
             ):
                 deepstack_embeds = deepstack_embeds.tensor_split(self.attn_tp_size)[
                     self.attn_tp_rank

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -119,10 +119,7 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
             a2a_backend = get_moe_a2a_backend()
             # When deepep is enabled, the scatter mode of deepstack_embeds is set to TP_ATTN_FULL, whereas that of residual is SCATTERED.
             # Therefore, deepstack_embeds must be split in this scenario.
-            if (
-                deepstack_embeds is not None
-                and a2a_backend.is_deepep()
-            ):
+            if deepstack_embeds is not None and a2a_backend.is_deepep():
                 deepstack_embeds = deepstack_embeds.tensor_split(self.attn_tp_size)[
                     self.attn_tp_rank
                 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
When DeepEP is enabled for the Qwen3-VL MoE model, residual is split across tp ranks, but deepstack embedding is not, leading to a shape mismatch error. This pr fixes the issue.
## Modifications
Split deepstack embedding when residual and deepstack embedding shape mismatch.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
 python -m sglang.launch_server \
   --device npu \
   --attention-backend ascend \
   --trust-remote-code \
   --tp-size 2 \
   --mm-attention-backend ascend_attn \
   --disable-radix-cache \
   --disable-overlap-schedule \
   --dtype bfloat16 \
   --port 8024 \
   --moe-a2a-backend deepep \
   --deepep-mode auto \
   --enable-multimodal \
   --sampling-backend ascend \
   --model-path Qwen3-VL-30B-A3B-Instruct \
   --mem-fraction-static 0.5 
```
import requests

url = f"http://localhost:8024/v1/chat/completions"

data = {
    "model": "Qwen/Qwen3-VL-30B-A3B-Instruct",
    "messages": [
        {
            "role": "user",
            "content": [
             {
                "type": "image",
                "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
             },
             {"type": "text", "text": "Describe this image."},
        ],
        }
    ],
    "max_tokens": 1000,
}

response = requests.post(url, json=data)
print(response.text)
```
NPU

- before this PR:
RuntimeError:
File "/sglang/python/sglang/srt/models/qwen3_moe.py", line 817, in forward
    self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
  File "/sglang/python/sglang/srt/layers/communicator.py", line 485, in prepare_attn_and_capture_last_layer_outputs
    hidden_states, residual = self.prepare_attn(
                              ^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/layers/communicator.py", line 632, in prepare_attn
    hidden_states, residual = self.input_layernorm(
                              ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/layers/utils/multi_platform.py", line 83, in forward
    return self._forward_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/layers/layernorm.py", line 274, in forward_npu
    residual = residual + post_residual_addition
               ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
RuntimeError: The size of tensor a (39) must match the size of tensor b (78) at non-singleton dimension 0
- after this PR:
_Of course, here is a detailed description of the image.\n\nThis is a heartwarming and serene photograph capturing a tender moment between a woman and her dog on a beach during what appears to be sunrise or sunset.\n\n- **Main Subjects and Interaction:** The central focus is a woman and a large, light-colored dog, likely a yellow Labrador Retriever, sitting on the sand. The dog is sitting upright and is extending its right paw to meet the woman's hand in a \"high-five\" gesture. The woman, who is sitting cross-legged, is smiling warmly and looking at the dog, reciprocating the high-five. This interaction conveys a strong sense of companionship, trust, and joy.\n\n- **Setting and Atmosphere:** The scene is set on a sandy beach. In the background, the ocean is visible with gentle waves rolling in. The lighting is the most prominent feature, with a warm, golden glow emanating from the right side of the frame, suggesting the sun is low on the horizon. This creates a soft, hazy, and peaceful atmosphere. The light illuminates the woman's hair and the dog's fur, creating a beautiful rim light effect.\n\n- **Details and Composition:**\n    - The woman has long, dark hair and is wearing a blue and white plaid shirt over dark pants. She is barefoot, with her feet in the sand.\n    - The dog is wearing a dark blue harness with a colorful pattern of small, possibly paw-print-like, designs. A red leash is visible on the sand near the dog.\n    - The composition places the subjects slightly off-center, with the vast expanse of the ocean and sky filling the background, which emphasizes the peacefulness of the moment.\n    - The overall mood is one of happiness, tranquility, and the deep bond between a person and their pet._

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26281388401](https://github.com/sgl-project/sglang/actions/runs/26281388401)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26281388196](https://github.com/sgl-project/sglang/actions/runs/26281388196)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->