### PR TITLE
fix(overlap): skip empty future interval for dp attention idle ranks

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -163,6 +163,9 @@ class FutureMap:
     ):
         if self.spec_algo.is_none():
             intv = future_indices.interval
+            if self.is_empty_slice(intv):
+                # idle indices in dp attention do not need store info
+                return
             self.token_ids_buf[intv] = batch_result.next_token_ids
         else:
             draft_input: EagleDraftInput = batch_result.next_draft_input


### PR DESCRIPTION
Mirror the empty-slice guard from `store_to_map_for_new_batch` into `store_to_map`'s `spec_algo.is_none()` branch — idle ranks in DP attention have empty future interval and don't need to store anything.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->