### PR TITLE
pr-states: workflow_dispatch refresh on slash cmds

### DIFF
--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -36,8 +36,11 @@ jobs:
             // Event-agnostic PR lookup.
             // - pull_request_target: PR is in the payload.
             // - workflow_run: pull_requests[] is populated for same-repo PRs;
-            //   for fork PRs it's empty and we must reverse-lookup by head_sha.
-            //   Bail out cleanly if no open PR matches (e.g. push to main).
+            //   for fork PRs it's empty and we reverse-lookup by head ref
+            //   ("forkOwner:branch"), which is the GH-documented fork-PR query
+            //   pattern and avoids the "commit must be in default branch" caveat
+            //   of listPullRequestsAssociatedWithCommit. Bail cleanly when no
+            //   open PR matches (e.g. workflow run from a push to main).
             let prNumber;
             if (context.payload.pull_request) {
               prNumber = context.payload.pull_request.number;
@@ -45,18 +48,25 @@ jobs:
               const wr = context.payload.workflow_run;
               if (wr.pull_requests && wr.pull_requests.length > 0) {
                 prNumber = wr.pull_requests[0].number;
-              } else {
-                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              } else if (wr.head_repository && wr.head_branch) {
+                const headSpec = `${wr.head_repository.owner.login}:${wr.head_branch}`;
+                const { data: prs } = await github.rest.pulls.list({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  commit_sha: wr.head_sha,
+                  state: 'open',
+                  head: headSpec,
                 });
-                const openPr = prs.find(p => p.state === 'open');
-                if (!openPr) {
-                  core.info(`No open PR for head_sha=${wr.head_sha}; skipping.`);
+                // Multiple PRs could share a head ref if a branch was reused;
+                // match by head_sha to pick the right one.
+                const match = prs.find(p => p.head.sha === wr.head_sha) || prs[0];
+                if (!match) {
+                  core.info(`No open PR for head=${headSpec}; skipping.`);
                   return;
                 }
-                prNumber = openPr.number;
+                prNumber = match.number;
+              } else {
+                core.info(`workflow_run has no PR linkage; skipping.`);
+                return;
               }
             }
             const { data: pr } = await github.rest.pulls.get({

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -7,13 +7,19 @@ name: PR States
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to refresh
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
   actions: read
 
 concurrency:
-  group: pr-states-${{ github.event.pull_request.number }}
+  group: pr-states-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -24,8 +30,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = context.payload.pull_request.head.sha;
-            const labels = context.payload.pull_request.labels.map(l => l.name);
+            // Event-agnostic PR lookup. pull_request_target carries the PR
+            // in the payload; workflow_dispatch passes only pr_number and we
+            // fetch fresh metadata via the API. The latter path is used by
+            // the slash-command-handler so a `/tag-and-rerun-ci` (which adds
+            // labels and reruns workflows via GITHUB_TOKEN — neither of which
+            // refires pull_request_target) still refreshes the body.
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : Number(context.payload.inputs.pr_number);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const sha = pr.head.sha;
+            const labels = pr.labels.map(l => l.name);
             const hasCI = labels.includes('run-ci');
             const hasExtra = labels.includes('run-ci-extra');
 
@@ -90,11 +110,6 @@ jobs:
               outerEnd,
             ].join('\n');
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
             const body = pr.body || '';
 
             const blockRe = new RegExp(`(?:\\n+---\\n+)?${outerStart}[\\s\\S]*?${outerEnd}`);
@@ -112,7 +127,7 @@ jobs:
               await github.rest.pulls.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.issue.number,
+                pull_number: prNumber,
                 body: newBody,
               });
             }

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -7,19 +7,22 @@ name: PR States
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: PR number to refresh
-        required: true
-        type: string
+  workflow_run:
+    # Listen to pr-test* lifecycle so reruns initiated by slash commands
+    # (run.rerun / run.rerun_failed_jobs via GITHUB_TOKEN) — which don't
+    # refire pull_request_target — still refresh the CI-states block.
+    workflows: ["PR Test", "PR Test Extra"]
+    types: [requested, completed]
 
 permissions:
   pull-requests: write
   actions: read
 
 concurrency:
-  group: pr-states-${{ github.event.pull_request.number || inputs.pr_number }}
+  # Dedupe per commit SHA across both event sources so simultaneous
+  # synchronize + workflow_run firings on the same push queue instead
+  # of racing on the body PATCH.
+  group: pr-states-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
 jobs:
@@ -30,15 +33,32 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Event-agnostic PR lookup. pull_request_target carries the PR
-            // in the payload; workflow_dispatch passes only pr_number and we
-            // fetch fresh metadata via the API. The latter path is used by
-            // the slash-command-handler so a `/tag-and-rerun-ci` (which adds
-            // labels and reruns workflows via GITHUB_TOKEN — neither of which
-            // refires pull_request_target) still refreshes the body.
-            const prNumber = context.payload.pull_request
-              ? context.payload.pull_request.number
-              : Number(context.payload.inputs.pr_number);
+            // Event-agnostic PR lookup.
+            // - pull_request_target: PR is in the payload.
+            // - workflow_run: pull_requests[] is populated for same-repo PRs;
+            //   for fork PRs it's empty and we must reverse-lookup by head_sha.
+            //   Bail out cleanly if no open PR matches (e.g. push to main).
+            let prNumber;
+            if (context.payload.pull_request) {
+              prNumber = context.payload.pull_request.number;
+            } else {
+              const wr = context.payload.workflow_run;
+              if (wr.pull_requests && wr.pull_requests.length > 0) {
+                prNumber = wr.pull_requests[0].number;
+              } else {
+                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: wr.head_sha,
+                });
+                const openPr = prs.find(p => p.state === 'open');
+                if (!openPr) {
+                  core.info(`No open PR for head_sha=${wr.head_sha}; skipping.`);
+                  return;
+                }
+                prNumber = openPr.number;
+              }
+            }
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -282,6 +282,22 @@ def has_sgl_kernel_changes(pr):
         return False
 
 
+def _dispatch_pr_states_refresh(gh_repo, pr):
+    """
+    Trigger pr-states.yml via workflow_dispatch so the CI-states block in
+    the PR body is refreshed after the slash command changed something it
+    cares about (labels or pr-test* run status). Neither label changes via
+    GITHUB_TOKEN nor `run.rerun()` refires pull_request_target, so the
+    workflow_dispatch route is the only way pr-states learns the change.
+    """
+    try:
+        workflow = gh_repo.get_workflow("pr-states.yml")
+        workflow.create_dispatch(ref="main", inputs={"pr_number": str(pr.number)})
+        print(f"Dispatched pr-states.yml refresh for PR #{pr.number}.")
+    except Exception as e:
+        print(f"Failed to dispatch pr-states refresh: {e}")
+
+
 def handle_tag_run_ci(gh_repo, pr, comment, user_perms, react_on_success=True):
     """
     Handles the /tag-run-ci-label command.
@@ -293,6 +309,7 @@ def handle_tag_run_ci(gh_repo, pr, comment, user_perms, react_on_success=True):
 
     print("Permission granted. Adding 'run-ci' label.")
     pr.add_to_labels("run-ci")
+    _dispatch_pr_states_refresh(gh_repo, pr)
 
     if react_on_success:
         comment.create_reaction("+1")
@@ -395,6 +412,7 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
 
     if rerun_count > 0:
         print(f"Triggered rerun for {rerun_count} workflows.")
+        _dispatch_pr_states_refresh(gh_repo, pr)
         if react_on_success:
             comment.create_reaction("+1")
         return True

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -282,22 +282,6 @@ def has_sgl_kernel_changes(pr):
         return False
 
 
-def _dispatch_pr_states_refresh(gh_repo, pr):
-    """
-    Trigger pr-states.yml via workflow_dispatch so the CI-states block in
-    the PR body is refreshed after the slash command changed something it
-    cares about (labels or pr-test* run status). Neither label changes via
-    GITHUB_TOKEN nor `run.rerun()` refires pull_request_target, so the
-    workflow_dispatch route is the only way pr-states learns the change.
-    """
-    try:
-        workflow = gh_repo.get_workflow("pr-states.yml")
-        workflow.create_dispatch(ref="main", inputs={"pr_number": str(pr.number)})
-        print(f"Dispatched pr-states.yml refresh for PR #{pr.number}.")
-    except Exception as e:
-        print(f"Failed to dispatch pr-states refresh: {e}")
-
-
 def handle_tag_run_ci(gh_repo, pr, comment, user_perms, react_on_success=True):
     """
     Handles the /tag-run-ci-label command.
@@ -309,7 +293,6 @@ def handle_tag_run_ci(gh_repo, pr, comment, user_perms, react_on_success=True):
 
     print("Permission granted. Adding 'run-ci' label.")
     pr.add_to_labels("run-ci")
-    _dispatch_pr_states_refresh(gh_repo, pr)
 
     if react_on_success:
         comment.create_reaction("+1")
@@ -412,7 +395,6 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
 
     if rerun_count > 0:
         print(f"Triggered rerun for {rerun_count} workflows.")
-        _dispatch_pr_states_refresh(gh_repo, pr)
         if react_on_success:
             comment.create_reaction("+1")
         return True


### PR DESCRIPTION
Make pr-states.yml refreshable via workflow_dispatch so /tag-and-rerun-ci and /rerun-failed-ci refresh the CI states block in PR body.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->