### PR TITLE
fix(pd): tolerate kv pools without end_layer (Qwen3-Next disagg)

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -56,7 +56,7 @@ class KVArgs:
     # reconstruct PP sub-ranges when kv_data_ptrs does not use a flat
     # layer-indexed layout (e.g. DeepSeek V4's buffer-type-organized flat
     # list).
-    prefill_end_layer: int
+    prefill_end_layer: Optional[int]
     # For DeepSeek V4 (and other compressed-MLA) memory pools only.
     # Full-model compression ratio per layer (entries are 0/4/128). Used by
     # the connection layer to slice the buffer-type-organized flat list in a

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -147,7 +147,7 @@ class PrefillBootstrapQueue:
         kv_args.pp_rank = self.pp_rank
         kv_args.system_dp_rank = self.scheduler.ps.dp_rank
         kv_args.prefill_start_layer = self.token_to_kv_pool.start_layer
-        kv_args.prefill_end_layer = self.token_to_kv_pool.end_layer
+        kv_args.prefill_end_layer = getattr(self.token_to_kv_pool, "end_layer", None)
         kv_args.mla_compression_ratios = None
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()


### PR DESCRIPTION
PR #24704 unconditionally reads self.token_to_kv_pool.end_layer in PrefillBootstrap._init_kv_manager, but HybridLinearKVPool (used by Qwen3-Next) only defines start_layer, causing:

    AttributeError: 'HybridLinearKVPool' object has no attribute 'end_layer'

prefill_end_layer is only meaningful for compressed-MLA pools (DeepSeek-V4); the downstream consumer in common/conn.py already uses getattr(..., None). Make the source side equally tolerant and mark KVArgsRegisterInfo.prefill_end_layer as Optional[int].

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Fix https://github.com/sgl-project/sglang/pull/24896



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->