### PR TITLE
[Fix] Skip None entries in HiCache DSV4 layer_mapping iteration

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -294,6 +294,8 @@ def build_deepseek_v4_hicache_stack(
     c4_state_global_layers = []
     c128_state_global_layers = []
     for layer_id, layer_item in enumerate(kvcache.layer_mapping):
+        if layer_item is None:
+            continue
         if layer_item.compress_ratio == 4:
             c4_layer_mapping[layer_id] = layer_item.compress_layer_id
             c4_state_global_layers.append(layer_id)


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'NoneType' object has no attribute 'compress_ratio'` crash when starting DeepSeek-V4-Flash with `--enable-hierarchical-cache`
- #24704 changed `layer_mapping` from a compact list to a sparse array with `None` for out-of-stage layers, but `build_deepseek_v4_hicache_stack` was not updated to handle `None` entries
- DeepSeek-V4-Flash has `len(compress_ratios)=44 > num_hidden_layers=43`, so `layer_mapping[43]` is always `None` and causes the crash

Fixes the nightly CI failure: https://github.com/sgl-project/sglang/actions/runs/25957207185/job/76305916663



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->