### PR TITLE
fix: accept RPC kwargs in save_sharded_model/save_remote_model

### DIFF
--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -196,23 +196,45 @@ class SchedulerUpdateWeightsMixin:
             traceback.print_exc()
             return CheckWeightsReqOutput(success=False, message=f"{e}")
 
-    def save_remote_model(self: Scheduler, params):
-        url = params["url"]
+    def save_remote_model(
+        self: Scheduler, params=None, *, url=None, draft_url=None
+    ):
+        """Save model weights through the scheduler RPC path.
 
+        Accept both legacy ``params`` dict calls and the newer ``**kwargs`` RPC
+        dispatch used by ``Scheduler.handle_rpc_request``.
+        """
+        if params is not None:
+            url = params["url"] if url is None else url
+            draft_url = params.get("draft_url", draft_url)
+
+        assert url is not None, "url must be provided"
         self.tp_worker.model_runner.save_remote_model(url)
 
         if self.draft_worker is not None:
-            draft_url = params.get("draft_url", None)
             assert (
                 draft_url is not None
             ), "draft_url must be provided when draft model is enabled"
             self.draft_worker.model_runner.save_remote_model(draft_url)
 
-    def save_sharded_model(self: Scheduler, params):
+    def save_sharded_model(
+        self: Scheduler, params=None, *, path=None, pattern=None, max_size=None
+    ):
+        """Save sharded model weights through the scheduler RPC path.
+
+        Accept both legacy ``params`` dict calls and the newer ``**kwargs`` RPC
+        dispatch used by ``Scheduler.handle_rpc_request``.
+        """
+        if params is not None:
+            path = params["path"] if path is None else path
+            pattern = params.get("pattern", pattern)
+            max_size = params.get("max_size", max_size)
+
+        assert path is not None, "path must be provided"
         self.tp_worker.model_runner.save_sharded_model(
-            path=params["path"],
-            pattern=params["pattern"],
-            max_size=params["max_size"],
+            path=path,
+            pattern=pattern,
+            max_size=max_size,
         )
 
 

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -203,8 +203,8 @@ class SchedulerUpdateWeightsMixin:
         dispatch used by ``Scheduler.handle_rpc_request``.
         """
         if params is not None:
-            url = params["url"] if url is None else url
-            draft_url = params.get("draft_url", draft_url)
+            url = url if url is not None else params.get("url")
+            draft_url = draft_url if draft_url is not None else params.get("draft_url")
 
         assert url is not None, "url must be provided"
         self.tp_worker.model_runner.save_remote_model(url)
@@ -224,9 +224,9 @@ class SchedulerUpdateWeightsMixin:
         dispatch used by ``Scheduler.handle_rpc_request``.
         """
         if params is not None:
-            path = params["path"] if path is None else path
-            pattern = params.get("pattern", pattern)
-            max_size = params.get("max_size", max_size)
+            path = path if path is not None else params.get("path")
+            pattern = pattern if pattern is not None else params.get("pattern")
+            max_size = max_size if max_size is not None else params.get("max_size")
 
         assert path is not None, "path must be provided"
         self.tp_worker.model_runner.save_sharded_model(

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -196,9 +196,7 @@ class SchedulerUpdateWeightsMixin:
             traceback.print_exc()
             return CheckWeightsReqOutput(success=False, message=f"{e}")
 
-    def save_remote_model(
-        self: Scheduler, params=None, *, url=None, draft_url=None
-    ):
+    def save_remote_model(self: Scheduler, params=None, *, url=None, draft_url=None):
         """Save model weights through the scheduler RPC path.
 
         Accept both legacy ``params`` dict calls and the newer ``**kwargs`` RPC

--- a/test/registered/unit/managers/test_scheduler_update_weights_mixin_rpc_save.py
+++ b/test/registered/unit/managers/test_scheduler_update_weights_mixin_rpc_save.py
@@ -1,0 +1,82 @@
+"""Unit tests for scheduler_update_weights_mixin RPC save helpers.
+
+Regression target: Scheduler.handle_rpc_request dispatches RPC parameters as
+``func(**recv_req.parameters)``. The mixin save helpers therefore must accept
+keyword arguments directly, not only a single ``params`` dict.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.scheduler_update_weights_mixin import (
+    SchedulerUpdateWeightsMixin,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSchedulerUpdateWeightsMixinRpcSave(CustomTestCase):
+    def setUp(self):
+        self.scheduler = SimpleNamespace(
+            tp_worker=SimpleNamespace(model_runner=MagicMock()),
+            draft_worker=None,
+        )
+
+    def test_save_sharded_model_accepts_rpc_kwargs(self):
+        SchedulerUpdateWeightsMixin.save_sharded_model(
+            self.scheduler,
+            path="/tmp/out",
+            pattern="model-rank{rank}.safetensors",
+            max_size=1024,
+        )
+
+        self.scheduler.tp_worker.model_runner.save_sharded_model.assert_called_once_with(
+            path="/tmp/out",
+            pattern="model-rank{rank}.safetensors",
+            max_size=1024,
+        )
+
+    def test_save_sharded_model_accepts_legacy_params_dict(self):
+        SchedulerUpdateWeightsMixin.save_sharded_model(
+            self.scheduler,
+            {"path": "/tmp/out", "pattern": None, "max_size": 2048},
+        )
+
+        self.scheduler.tp_worker.model_runner.save_sharded_model.assert_called_once_with(
+            path="/tmp/out",
+            pattern=None,
+            max_size=2048,
+        )
+
+    def test_save_remote_model_accepts_rpc_kwargs_for_tp_and_draft(self):
+        self.scheduler.draft_worker = SimpleNamespace(model_runner=MagicMock())
+
+        SchedulerUpdateWeightsMixin.save_remote_model(
+            self.scheduler,
+            url="s3://bucket/tp",
+            draft_url="s3://bucket/draft",
+        )
+
+        self.scheduler.tp_worker.model_runner.save_remote_model.assert_called_once_with(
+            "s3://bucket/tp"
+        )
+        self.scheduler.draft_worker.model_runner.save_remote_model.assert_called_once_with(
+            "s3://bucket/draft"
+        )
+
+    def test_save_remote_model_accepts_legacy_params_dict(self):
+        SchedulerUpdateWeightsMixin.save_remote_model(
+            self.scheduler,
+            {"url": "s3://bucket/tp"},
+        )
+
+        self.scheduler.tp_worker.model_runner.save_remote_model.assert_called_once_with(
+            "s3://bucket/tp"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_update_weights_mixin_rpc_save.py
+++ b/test/registered/unit/managers/test_scheduler_update_weights_mixin_rpc_save.py
@@ -77,6 +77,39 @@ class TestSchedulerUpdateWeightsMixinRpcSave(CustomTestCase):
             "s3://bucket/tp"
         )
 
+    def test_save_sharded_model_kwargs_take_priority_over_params_dict(self):
+        SchedulerUpdateWeightsMixin.save_sharded_model(
+            self.scheduler,
+            {"path": "/from-dict", "pattern": "from-dict", "max_size": 1},
+            path="/from-kwargs",
+            pattern="from-kwargs",
+            max_size=2,
+        )
+
+        self.scheduler.tp_worker.model_runner.save_sharded_model.assert_called_once_with(
+            path="/from-kwargs",
+            pattern="from-kwargs",
+            max_size=2,
+        )
+
+    def test_save_sharded_model_missing_path_raises_assertion_not_keyerror(self):
+        with self.assertRaises(AssertionError) as ctx:
+            SchedulerUpdateWeightsMixin.save_sharded_model(
+                self.scheduler,
+                {"pattern": "only-pattern"},
+            )
+
+        self.assertIn("path must be provided", str(ctx.exception))
+
+    def test_save_remote_model_missing_url_raises_assertion_not_keyerror(self):
+        with self.assertRaises(AssertionError) as ctx:
+            SchedulerUpdateWeightsMixin.save_remote_model(
+                self.scheduler,
+                {"draft_url": "s3://bucket/draft"},
+            )
+
+        self.assertIn("url must be provided", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Fix issue #25156.

`Engine.collective_rpc()` forwards RPC parameters as keyword arguments, and `Scheduler.handle_rpc_request()` dispatches them with `func(**recv_req.parameters)`. However, `SchedulerUpdateWeightsMixin.save_sharded_model()` and `save_remote_model()` still expected a single `params` dict, so RPC calls like the official `examples/runtime/engine/save_sharded_state.py` example failed before reaching the model runner.

## Modifications

- Updated `SchedulerUpdateWeightsMixin.save_sharded_model()` to accept both:
  - current RPC kwarg dispatch (`path=..., pattern=..., max_size=...`)
  - legacy dict-style calls (`params={...}`)
- Updated `SchedulerUpdateWeightsMixin.save_remote_model()` the same way, since it had the same RPC signature mismatch.
- Added a focused unit regression test covering:
  - kwarg RPC-style calls for both helpers
  - legacy dict compatibility for both helpers

## Accuracy Tests

N/A — this change only fixes scheduler RPC argument handling and does not change model math or outputs.

## Speed Tests and Profiling

N/A — no inference-path performance change.

## Validation

- `python3 -m py_compile` on the changed source and test files
- Reproduced the pre-fix failure on a clean checkout:
  - `save_sharded_model() got an unexpected keyword argument 'path'`
  - `save_remote_model() got an unexpected keyword argument 'url'`
- Verified the patched code accepts RPC kwargs and preserves legacy dict-style calls for both helpers

## Checklist

- [x] Add unit tests according to the run/add unit test guidance.
- [ ] Format code according to pre-commit guidance.
- [ ] Update documentation if needed (not needed for this fix).
- [ ] Provide accuracy / speed benchmarks if needed (not needed for this fix).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->