### PR TITLE
[1/4][LoRA] Add NVFP4 Cutlass MoE LoRA runner

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -62,6 +62,17 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer TRT-LLM only supports fused path
         elif runner_backend.is_flashinfer_cutedsl():
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
+        elif runner_backend.is_flashinfer_cutlass():
+            if lora_enabled:
+                from sglang.srt.lora.lora_moe_runner_cutlass_fp4 import (
+                    CutlassFp4LoraRunnerCore,
+                )
+
+                self.runner_core = CutlassFp4LoraRunnerCore(config)
+            else:
+                # Non-LoRA flashinfer_cutlass bypasses MoeRunner: calls
+                # ``flashinfer_cutlass_fused_moe`` directly from quant ``apply``.
+                self.runner_core = None
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 
@@ -121,8 +132,9 @@ class MoeRunner:
                 )
             return None
 
-        # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore)
-        # bypass the pre-permute step and do their own alignment internally.
+        # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore,
+        # CutlassFp4LoraRunnerCore) bypass the pre-permute step and do their
+        # own alignment internally.
         if hasattr(self.runner_core, "run_from_dispatch"):
             hooks = _maybe_build_lora_hooks(dispatch_output)
             return self.runner_core.run_from_dispatch(

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -163,6 +163,7 @@ TBO_TOKEN_DISTRIBUTION_THRESHOLD: Optional[float] = None
 DEEPEP_CONFIG: Optional[str] = None
 DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER: Optional[bool] = None
 MOE_QUANTIZATION: Optional[str] = None
+ENABLE_LORA: Optional[bool] = None
 
 
 def initialize_moe_config(server_args: ServerArgs):
@@ -177,6 +178,7 @@ def initialize_moe_config(server_args: ServerArgs):
     global TBO_TOKEN_DISTRIBUTION_THRESHOLD
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     global MOE_QUANTIZATION
+    global ENABLE_LORA
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
@@ -199,6 +201,7 @@ def initialize_moe_config(server_args: ServerArgs):
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     )
     MOE_QUANTIZATION = server_args.quantization
+    ENABLE_LORA = server_args.enable_lora
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:
@@ -303,9 +306,14 @@ def filter_moe_weight_param_global_expert(name, x, num_local_experts):
 def should_use_flashinfer_cutlass_moe_fp4_allgather():
     """
     Perform FP4 quantize before all-gather for flashinfer cutlass moe to reduce communication cost for high-throughput serving.
+
+    Disabled for LoRA because the current Cutlass FP4 LoRA runner expects
+    bf16/float16 hidden states and local LoRA routing metadata, not the
+    dispatcher's pre-packed all-gathered FP4 payload.
     """
     return (
         not DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
+        and not ENABLE_LORA
         and get_moe_a2a_backend().is_none()
         and get_moe_runner_backend().is_flashinfer_cutlass()
         and is_dp_attention_enabled()

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1781,6 +1781,29 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             (1 / w2_input_scale).to(torch.float32),
         )
 
+        # ``[E]``-expanded fp32 view consumed by ``CutlassFp4LoraRunnerCore``.
+        # The source may be scalar (FlashInfer paths reduce all experts to a
+        # single max above) or already ``[E]``-shaped; expand once at load
+        # time so the hot path can hand it directly to the FP4 quant kernel.
+        E = layer.num_local_experts
+
+        def _to_per_expert(src: torch.Tensor) -> torch.Tensor:
+            flat = src.view(-1).to(torch.float32)
+            if flat.shape[0] == E:
+                return flat.contiguous()
+            return flat.expand(E).contiguous()
+
+        copy_or_rebind_param(
+            layer,
+            "w13_input_scale_quant_per_expert",
+            _to_per_expert(layer.w13_input_scale_quant),
+        )
+        copy_or_rebind_param(
+            layer,
+            "w2_input_scale_quant_per_expert",
+            _to_per_expert(layer.w2_input_scale_quant),
+        )
+
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         layer.dispatcher.set_quant_config(
             {
@@ -1984,6 +2007,30 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             self.enable_flashinfer_cutlass_moe or self._is_cutedsl_v2_standard
         )
 
+    def get_cutlass_fp4_quant_info(self, layer: torch.nn.Module):
+        """Build the LoRA-aware NVFP4 quant payload for ``CutlassFp4LoraRunnerCore``."""
+        from sglang.srt.lora.lora_moe_runner_cutlass_fp4 import (
+            CutlassFp4MoeQuantInfo,
+        )
+
+        return CutlassFp4MoeQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_blockscale_swizzled=layer.w13_blockscale_swizzled,
+            w2_blockscale_swizzled=layer.w2_blockscale_swizzled,
+            g1_alphas=layer.g1_alphas,
+            g2_alphas=layer.g2_alphas,
+            w13_input_scale_expanded=layer.w13_input_scale_quant_per_expert,
+            w2_input_scale_expanded=layer.w2_input_scale_quant_per_expert,
+            cutlass_moe_params=layer.cutlass_moe_params,
+            num_local_experts=layer.num_local_experts,
+            hidden_size=layer.hidden_size,
+            intermediate_size_per_partition=layer.intermediate_size_per_partition,
+            moe_ep_rank=layer.moe_ep_rank,
+            moe_ep_size=layer.moe_ep_size,
+            w13_swap_halves=self.load_up_proj_weight_first,
+        )
+
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
@@ -2160,7 +2207,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             topk_ids=topk_ids,
             params=layer.cutlass_moe_params,
             apply_router_weight_on_input=moe_runner_config.apply_router_weight_on_input,
-        ).to(x.dtype)
+        )
         # Scale by routed_scaling_factor is fused into select_experts.
         return StandardCombineInput(hidden_states=output)
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -879,6 +879,12 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.experts_shared_outer_loras: bool = False
         self.lora_use_virtual_experts: bool = False
         self.quant_method = base_layer.quant_method
+        self.moe_runner_config = base_layer.moe_runner_config
+        self.dispatcher = base_layer.dispatcher
+        self.num_local_experts = base_layer.num_local_experts
+        self.should_fuse_routed_scaling_factor_in_topk = (
+            base_layer.should_fuse_routed_scaling_factor_in_topk
+        )
 
         self.tp_size = getattr(base_layer, "moe_tp_size", 1)
         self.tp_rank = getattr(base_layer, "moe_tp_rank", 0)
@@ -927,6 +933,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         elif runner_backend.is_triton():
             assert base_layer.quant_method is not None, "Quant method must be set"
             self._quant_info = base_layer.quant_method.get_triton_quant_info(base_layer)
+        elif runner_backend.is_flashinfer_cutlass():
+            assert base_layer.quant_method is not None, "Quant method must be set"
+            self._quant_info = base_layer.quant_method.get_cutlass_fp4_quant_info(
+                base_layer
+            )
         else:
             raise NotImplementedError(
                 f"LoRA MoE not supported for backend {runner_backend}"
@@ -972,6 +983,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 len(lora_ranks), dtype=torch.int32, device=lora_ranks.device
             )
             adapter_enabled.index_fill_(0, wi.long(), 1)
+        rank_enabled = (lora_ranks > 0).to(
+            device=adapter_enabled.device, dtype=adapter_enabled.dtype
+        )
+        adapter_enabled.mul_(rank_enabled)
 
         seg_indptr = (
             batch_info.req_seg_indptr
@@ -1032,10 +1047,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             hidden_states=hidden_states, topk_output=topk_output
         )
 
-        # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
 
-        # Run the only lora moe runner (Triton)
         combine_input = self._lora_runner.run(
             dispatch_output, quant_info, lora_info=lora_info
         )

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -1,0 +1,228 @@
+"""FlashInfer-CUTLASS NVFP4 MoE runner core with LoRA support.
+
+Breaks open the upstream ``flashinfer_cutlass_fused_moe`` (a single black-box
+kernel called from ``ModelOptNvFp4FusedMoEMethod.apply``) into its FP4 group
+GEMMs so we can inject the standard ``after_gate_up`` / ``after_down`` LoRA
+hooks between w13 and w2, mirroring ``MarlinLoraRunnerCore``.
+
+Layout bridge: ``cutlass_fp4_group_mm`` writes expert-sorted ``[M*topk, *]``,
+the hooks expect token-major ``[M, topk, *]``. We round-trip via
+``shuffle_rows(.., c_map)`` (un-sort) and ``shuffle_rows(.., inv_c_map)``
+(re-sort) around ``after_gate_up``; for ``after_down`` the un-sort doubles
+as the combine permutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+)
+from sglang.srt.utils import is_cuda, is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+    from sglang.srt.lora.lora_moe_runners import LoRAHooks
+
+
+_is_cuda = is_cuda()
+_is_hip = is_hip()
+
+if _is_cuda:
+    from sgl_kernel import silu_and_mul
+elif _is_hip:
+    from vllm._custom_ops import silu_and_mul
+
+
+@dataclass
+class CutlassFp4MoeQuantInfo(MoeQuantInfo):
+    """Quantization payload consumed by ``CutlassFp4LoraRunnerCore``."""
+
+    w13_weight: torch.Tensor  # [E, 2 * N, K // 2] uint8
+    w2_weight: torch.Tensor  # [E, K, N // 2]     uint8
+    w13_blockscale_swizzled: torch.Tensor
+    w2_blockscale_swizzled: torch.Tensor
+    g1_alphas: torch.Tensor  # [E] fp32
+    g2_alphas: torch.Tensor  # [E] fp32
+    # ``[E]``-expanded once at load time so the hot path never has to expand.
+    w13_input_scale_expanded: torch.Tensor  # [E] fp32
+    w2_input_scale_expanded: torch.Tensor  # [E] fp32
+    cutlass_moe_params: object
+    num_local_experts: int
+    hidden_size: int
+    intermediate_size_per_partition: int
+    moe_ep_rank: int
+    moe_ep_size: int
+    # FlashInfer-CUTLASS loads w13 as ``[up | gate]`` (Kimi-K2.5).
+    w13_swap_halves: bool
+
+
+class CutlassFp4LoraRunnerCore:
+    """LoRA-aware NVFP4 MoE forward on the FlashInfer-CUTLASS GEMM primitives.
+
+    Pipeline: EP local-id remap → FP4 GEMM 1 → un-sort → ``after_gate_up`` →
+    re-sort → silu_and_mul → FP4 GEMM 2 → un-sort → ``after_down`` → combine.
+    """
+
+    def __init__(self, config: MoeRunnerConfig):
+        self.config = config
+
+    def run_from_dispatch(
+        self,
+        dispatch_output: "StandardDispatchOutput",
+        quant_info: CutlassFp4MoeQuantInfo,
+        runner_config: MoeRunnerConfig,
+        hooks: Optional["LoRAHooks"] = None,
+    ) -> "StandardCombineInput":
+        from sgl_kernel import prepare_moe_input
+
+        from sglang.srt.layers.moe.cutlass_moe import (
+            cutlass_fp4_group_mm,
+            scaled_fp4_experts_quant,
+            shuffle_rows,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardCombineInput,
+        )
+
+        hidden_states = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+        topk_weights = topk_output.topk_weights
+        topk_ids = topk_output.topk_ids
+
+        m_a = hidden_states.shape[0]
+        num_topk = topk_ids.shape[1]
+        out_dtype = hidden_states.dtype
+        device = hidden_states.device
+        E = quant_info.num_local_experts
+        K = quant_info.hidden_size
+        inter = quant_info.intermediate_size_per_partition
+        # This LoRA runner injects between the gate/up projection and the
+        # SwiGLU activation, so it only supports gated MoE weights.
+        N = quant_info.w13_weight.shape[1]
+        if N != inter * 2:
+            raise NotImplementedError(
+                "CutlassFp4LoraRunnerCore expects gated NVFP4 MoE weights with "
+                f"w13 output dim {inter * 2}, but got {N}."
+            )
+        params = quant_info.cutlass_moe_params
+        offsets = params.expert_offsets
+        total_tokens = m_a * num_topk
+
+        # StandardDispatcher hands flashinfer_cutlass global topk_ids; remap
+        # to local for the per-rank GEMM. Non-local tokens go to local expert
+        # 0 with weight 0 — they pay GEMM cost but contribute nothing.
+        local_offset = quant_info.moe_ep_rank * E
+        local_ids = topk_ids.to(torch.int32) - local_offset
+        non_local = (local_ids < 0) | (local_ids >= E)
+        local_ids = local_ids.masked_fill(non_local, 0)
+        local_weights = topk_weights.masked_fill(non_local, 0.0)
+
+        a_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        c_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        prepare_moe_input(
+            local_ids,
+            offsets,
+            params.problem_sizes1,
+            params.problem_sizes2,
+            a_map,
+            c_map,
+            E,
+            inter,
+            K,
+            params.blockscale_offsets,
+        )
+
+        # ---- GEMM 1 (w13)
+        rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
+            hidden_states,
+            quant_info.w13_input_scale_expanded,
+            offsets,
+            params.blockscale_offsets,
+            num_topk,
+            expert_map=a_map,
+        )
+        gateup_flat = cutlass_fp4_group_mm(
+            rep_a_fp4,
+            quant_info.w13_weight,
+            rep_a_blockscale,
+            quant_info.w13_blockscale_swizzled,
+            quant_info.g1_alphas,
+            out_dtype,
+            params.to_gemm1_args(),
+        )
+
+        # ---- LoRA w13 delta
+        # Un-sort to token-major with ``c_map`` (pair-index permutation), run
+        # the hook, then re-sort with ``inv_c_map``. ``a_map`` is an M-index
+        # and is NOT a valid inverse for the pair-index ``[M*topk, *]`` tensor
+        # — using it silently corrupts every (token, k>0) row.
+        if hooks is not None and hooks.after_gate_up is not None:
+            inv_c_map = torch.empty_like(c_map)
+            inv_c_map[c_map.long()] = torch.arange(
+                total_tokens, device=c_map.device, dtype=c_map.dtype
+            )
+            gateup_token_major = shuffle_rows(gateup_flat, c_map, (total_tokens, N))
+            gateup_3d = gateup_token_major.view(m_a, num_topk, N)
+            hooks.after_gate_up(hidden_states, gateup_3d, topk_weights, topk_ids)
+            gateup_flat = shuffle_rows(
+                gateup_token_major.view(total_tokens, N),
+                inv_c_map,
+                (total_tokens, N),
+            )
+
+        # ---- silu + mul
+        if quant_info.w13_swap_halves:
+            # ``[up | gate]`` layout: silu(gate) * up = silu(second) * first.
+            intermediate = (
+                torch.nn.functional.silu(gateup_flat[:, N // 2 :].float())
+                * gateup_flat[:, : N // 2].float()
+            ).to(out_dtype)
+        else:
+            intermediate = torch.empty(
+                total_tokens, N // 2, dtype=out_dtype, device=device
+            )
+            silu_and_mul(gateup_flat, intermediate)
+
+        # ---- GEMM 2 (w2)
+        int_fp4, int_blockscale = scaled_fp4_experts_quant(
+            intermediate,
+            quant_info.w2_input_scale_expanded,
+            offsets,
+            params.blockscale_offsets,
+            num_topk,
+        )
+        out_flat = cutlass_fp4_group_mm(
+            int_fp4,
+            quant_info.w2_weight,
+            int_blockscale,
+            quant_info.w2_blockscale_swizzled,
+            quant_info.g2_alphas,
+            out_dtype,
+            params.to_gemm2_args(),
+        )
+
+        # Un-sort to token-major; needed by ``after_down`` and by the combine.
+        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
+
+        # Standard hook contract: the down hook adds a router-weighted delta
+        # into an already-router-weighted per-expert output.
+        if not runner_config.apply_router_weight_on_input:
+            out_3d = out_3d * local_weights.view(m_a, num_topk, 1).to(out_dtype)
+
+        # ---- LoRA w2 delta
+        if hooks is not None and hooks.after_down is not None:
+            intermediate_token_major = shuffle_rows(
+                intermediate, c_map, (total_tokens, N // 2)
+            )
+            hooks.after_down(intermediate_token_major, out_3d, local_weights, topk_ids)
+
+        return StandardCombineInput(hidden_states=out_3d.sum(dim=1))

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -175,7 +175,7 @@ class LoRAInfo:
 
     # LoRA config per adapter
     lora_ranks: torch.Tensor  # [num_loras]
-    adapter_enabled: torch.Tensor  # [num_loras] - which adapters are enabled
+    adapter_enabled: torch.Tensor  # [num_loras] - requested adapters with rank > 0
     max_lora_rank: int  # Maximum LoRA rank across all adapters
 
     num_experts: int
@@ -214,7 +214,11 @@ def _compute_token_lora_mapping(
         token_positions,
         right=True,
     )
-    return lora_info.req_to_lora.to(torch.int32)[req_indices]
+    mapping = lora_info.req_to_lora.to(torch.int32)[req_indices]
+    valid = mapping >= 0
+    safe_mapping = mapping.clamp_min(0).long()
+    active = lora_info.adapter_enabled[safe_mapping] > 0
+    return torch.where(valid & active, mapping, torch.full_like(mapping, -1))
 
 
 def _compute_lora_alignment(


### PR DESCRIPTION
Reference: split from the overall PR [sgl-project/sglang#25202](https://github.com/sgl-project/sglang/pull/25202).

## Motivation

`flashinfer_cutlass` calls the NVFP4 MoE as one fused kernel, so there is no point between W13 and W2 where the existing LoRA hooks can add the adapter delta. Enabling LoRA with this backend therefore needs a runner that exposes the same `after_gate_up` and `after_down` hook points used by the existing MoE LoRA runners.

## Approach

This PR adds `CutlassFp4LoraRunnerCore`, an unfused NVFP4 Cutlass MoE pipeline used only when `--enable-lora` is active with `--moe-runner-backend flashinfer_cutlass`. Non-LoRA `flashinfer_cutlass` serving continues to use the existing fused backend.

The runner performs EP-local expert remap, FP4 input quantization, Cutlass FP4 group GEMM for W13, standard LoRA gate/up hook, activation, FP4 intermediate quantization, Cutlass FP4 group GEMM for W2, standard LoRA down hook, and final combine.

## Key Changes

- Add `python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py`.
- Wire the runner from the MoE runner factory for `flashinfer_cutlass + lora_enabled`.
- Build and pass NVFP4 Cutlass quantization metadata through `modelopt_quant.py`.
- Add `LoRAInfo.has_active_lora` and skip eager zero-LoRA hook launches.
- Disable the FP4 all-gather dispatch path for LoRA configurations because this runner expects bf16 hidden states and re-quantizes locally.

## Accuracy

Tested on `mnnvl-yanbin-0/1` with two-node TP=8, `Kimi-K2.5-NVFP4`, and the rank-16 `alpha` adapter. Accuracy captures use the 1809-token sequence from [`compare_sample_train_data.pt`](https://huggingface.co/datasets/yushengsu/lora-diff-Kimi-K2.5/blob/main/compare_sample_train_data.pt), request `max_new_tokens=0`, return input-token logprobs, and compare the 1808 positions after dropping the first token.

Baselines:

- A: `flashinfer_trtllm`, no LoRA.
- B: `flashinfer_cutlass`, fused, no LoRA.
- C: `flashinfer_cutlass --enable-lora`, request without `lora_path`.

| Pair | mean abs | max abs | half squared mean | identical |
|---|---:|---:|---:|---|
| A vs B | 0.101421 | 3.921772 | 0.065445 | false |
| B vs PR1 C-nolora | 0.102540 | 3.790158 | 0.053243 | false |

PR1 proves the path runs, and a separate active-LoRA capture with `lora_path=alpha` completed on the same dataset. The no-LoRA passthrough is not yet identical to fused Cutlass; PR3 addresses that combine-precision gap.

## Performance

Two-node TP=8, `bs=32`, `input_len=1024`, `output_len=2048`, FA4 prefill, FlashInfer decode. Values are the measured JSONL pass from `bench_one_batch_server`.

| Variant | prefill time (s) | prefill tok/s | decode time (s) | decode tok/s | total latency (s) | overall tok/s |
|---|---:|---:|---:|---:|---:|---:|
| A trtllm | 0.95 | 34329 | 428.72 | 152.87 | 429.67 | 228.79 |
| B cutlass fused | 0.85 | 38332 | 441.72 | 148.37 | 442.57 | 222.12 |
| PR1 C-nolora | 1.41 | 23221 | 425.36 | 154.07 | 426.77 | 230.35 |
| PR1 C-lora | 2.11 | 15516 | 415.83 | 157.60 | 417.94 | 235.21 |

## Validation

- `python -m py_compile` on the touched Python files.
- `git diff --check`.
- Two-node server launch, dataset-based accuracy capture, no-LoRA perf, and active-LoRA perf on `mnnvl-yanbin-0/1`.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->