### PR TITLE
[2/4][LoRA] Avoid NVFP4 Cutlass LoRA layout bridges

### DIFF
--- a/python/sglang/jit_kernel/activation.py
+++ b/python/sglang/jit_kernel/activation.py
@@ -32,7 +32,7 @@ def _fast_math_flags() -> list[str]:
 def _jit_activation_module(dtype: torch.dtype) -> Module:
     args = make_cpp_args(dtype, is_arch_support_pdl())
     return load_jit(
-        "activation",
+        "activation_swap_halves",
         *args,
         cuda_files=["elementwise/activation.cuh"],
         extra_cuda_cflags=_fast_math_flags(),
@@ -51,13 +51,13 @@ SUPPORTED_ACTIVATIONS = {"silu", "gelu", "gelu_tanh"}
 
 @register_custom_op(mutates_args=["out"])
 def _run_activation_inplace(
-    op_name: str, input: torch.Tensor, out: torch.Tensor
+    op_name: str, input: torch.Tensor, out: torch.Tensor, swap_halves: bool
 ) -> None:
     hidden_size = input.shape[-1] // 2
     module = _jit_activation_module(input.dtype)
     input_2d = input.view(-1, hidden_size * 2)
     out_2d = out.view(-1, hidden_size)
-    module.run_activation(input_2d, out_2d, op_name)
+    module.run_activation(input_2d, out_2d, op_name, swap_halves)
 
 
 @register_custom_op(mutates_args=["out"])
@@ -67,12 +67,15 @@ def _run_activation_filtered_inplace(
     out: torch.Tensor,
     expert_ids: torch.Tensor,
     expert_step: int,
+    swap_halves: bool,
 ) -> None:
     hidden_size = input.shape[-1] // 2
     module = _jit_activation_module(input.dtype)
     input_2d = input.view(-1, hidden_size * 2)
     out_2d = out.view(-1, hidden_size)
-    module.run_activation_filtered(input_2d, out_2d, expert_ids, expert_step, op_name)
+    module.run_activation_filtered(
+        input_2d, out_2d, expert_ids, expert_step, op_name, swap_halves
+    )
 
 
 def run_activation(
@@ -81,8 +84,14 @@ def run_activation(
     out: Optional[torch.Tensor],
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
     """Apply ``op_name`` activation followed by element-wise multiplication.
+
+    ``swap_halves`` controls which half feeds the activation. ``False`` (default)
+    computes ``act(first) * second`` — the standard ``[Gate | Up]`` convention.
+    ``True`` computes ``act(second) * first`` — for ``[Up | Gate]`` layouts
+    (e.g. Kimi-K2.5 on FlashInfer-CUTLASS NVFP4 MoE).
 
     When ``expert_ids`` is provided, output rows are skipped for tokens whose
     routed expert id is ``-1``. ``expert_step`` is 1 for per-token routing and
@@ -94,9 +103,11 @@ def run_activation(
     if out is None:
         out = input.new_empty(*input.shape[:-1], hidden_size)
     if expert_ids is None:
-        _run_activation_inplace(op_name, input, out)
+        _run_activation_inplace(op_name, input, out, swap_halves)
     else:
-        _run_activation_filtered_inplace(op_name, input, out, expert_ids, expert_step)
+        _run_activation_filtered_inplace(
+            op_name, input, out, expert_ids, expert_step, swap_halves
+        )
     return out
 
 
@@ -105,8 +116,9 @@ def silu_and_mul(
     out: Optional[torch.Tensor] = None,
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
-    return run_activation("silu", input, out, expert_ids, expert_step)
+    return run_activation("silu", input, out, expert_ids, expert_step, swap_halves)
 
 
 def gelu_and_mul(
@@ -114,8 +126,9 @@ def gelu_and_mul(
     out: Optional[torch.Tensor] = None,
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
-    return run_activation("gelu", input, out, expert_ids, expert_step)
+    return run_activation("gelu", input, out, expert_ids, expert_step, swap_halves)
 
 
 def gelu_tanh_and_mul(
@@ -123,5 +136,6 @@ def gelu_tanh_and_mul(
     out: Optional[torch.Tensor] = None,
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
-    return run_activation("gelu_tanh", input, out, expert_ids, expert_step)
+    return run_activation("gelu_tanh", input, out, expert_ids, expert_step, swap_halves)

--- a/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
@@ -51,7 +51,13 @@ struct ActivationParams {
   uint32_t expert_step;
 };
 
-template <typename T, ActivationKind kAct, bool kUsePDL, bool kFilterExpert>
+// kSwapHalves selects which half of the [first | second] input feeds the
+// activation. kSwapHalves=false computes act(first) * second (the stock
+// [Gate | Up] convention). kSwapHalves=true computes act(second) * first
+// (the [Up | Gate] convention used by FlashInfer-CUTLASS NVFP4 MoE, e.g.
+// Kimi-K2.5). The flag is a template constexpr, so the existing call path
+// compiles to byte-identical SASS.
+template <typename T, ActivationKind kAct, bool kUsePDL, bool kFilterExpert, bool kSwapHalves>
 __global__ void act_and_mul_kernel(const __grid_constant__ ActivationParams params) {
   using namespace device;
   constexpr auto kVecSize = kMaxVecBytes / sizeof(T);
@@ -68,13 +74,15 @@ __global__ void act_and_mul_kernel(const __grid_constant__ ActivationParams para
   const auto input_offset = token_id * (num_vecs * 2) + offset;
   const auto output_offset = tid;
   PDLWaitPrimary<kUsePDL>();
-  const auto gate = device::load_as<vec_t>(params.input, input_offset);
-  const auto up = device::load_as<vec_t>(params.input, input_offset + num_vecs);
+  const auto first = device::load_as<vec_t>(params.input, input_offset);
+  const auto second = device::load_as<vec_t>(params.input, input_offset + num_vecs);
   vec_t out;
 #pragma unroll
   for (int i = 0; i < kVecSize; ++i) {
-    const float gate_f32 = device::cast<fp32_t>(gate[i]);
-    const float up_f32 = device::cast<fp32_t>(up[i]);
+    const float first_f32 = device::cast<fp32_t>(first[i]);
+    const float second_f32 = device::cast<fp32_t>(second[i]);
+    const float gate_f32 = kSwapHalves ? second_f32 : first_f32;
+    const float up_f32 = kSwapHalves ? first_f32 : second_f32;
     out[i] = device::cast<T>(apply_activation_f32<kAct>(gate_f32) * up_f32);
   }
   device::store_as<vec_t>(params.out, out, output_offset);
@@ -86,21 +94,21 @@ struct ActivationKernel {
   static constexpr auto kVecSize = device::kMaxVecBytes / sizeof(T);
   static constexpr auto kBlockSize = 256u;
 
-  template <ActivationKind kAct, bool kFilterExpert>
-  static constexpr auto activation_kernel = act_and_mul_kernel<T, kAct, kUsePDL, kFilterExpert>;
+  template <ActivationKind kAct, bool kFilterExpert, bool kSwapHalves>
+  static constexpr auto activation_kernel = act_and_mul_kernel<T, kAct, kUsePDL, kFilterExpert, kSwapHalves>;
 
   static_assert(device::kMaxVecBytes % sizeof(T) == 0, "unsupported data type");
 
-  template <bool kFilterExpert>
+  template <bool kFilterExpert, bool kSwapHalves>
   static auto select_kernel(const std::string& type)
-      -> decltype(activation_kernel<ActivationKind::kSiLU, kFilterExpert>) {
+      -> decltype(activation_kernel<ActivationKind::kSiLU, kFilterExpert, kSwapHalves>) {
     using namespace host;
     if (type == "silu") {
-      return activation_kernel<ActivationKind::kSiLU, kFilterExpert>;
+      return activation_kernel<ActivationKind::kSiLU, kFilterExpert, kSwapHalves>;
     } else if (type == "gelu") {
-      return activation_kernel<ActivationKind::kGELU, kFilterExpert>;
+      return activation_kernel<ActivationKind::kGELU, kFilterExpert, kSwapHalves>;
     } else if (type == "gelu_tanh") {
-      return activation_kernel<ActivationKind::kGELUTanh, kFilterExpert>;
+      return activation_kernel<ActivationKind::kGELUTanh, kFilterExpert, kSwapHalves>;
     } else {
       Panic("unsupported activation type: ", type);
     }
@@ -112,7 +120,8 @@ struct ActivationKernel {
       const tvm::ffi::TensorView& out,
       const std::string& type,
       const int32_t* expert_ids,
-      uint32_t expert_step) {
+      uint32_t expert_step,
+      bool swap_halves) {
     using namespace host;
 
     auto N = SymbolicSize{"num_tokens"};
@@ -150,16 +159,27 @@ struct ActivationKernel {
     };
     if (expert_ids != nullptr) {
       RuntimeCheck(expert_step > 0, "expert_step must be positive");
-      const auto kernel = select_kernel<true>(type);
-      LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      if (swap_halves) {
+        const auto kernel = select_kernel<true, true>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      } else {
+        const auto kernel = select_kernel<true, false>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      }
     } else {
-      const auto kernel = select_kernel<false>(type);
-      LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      if (swap_halves) {
+        const auto kernel = select_kernel<false, true>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      } else {
+        const auto kernel = select_kernel<false, false>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      }
     }
   }
 
-  static void run_activation(const tvm::ffi::TensorView input, const tvm::ffi::TensorView out, std::string type) {
-    launch(input, out, type, /*expert_ids=*/nullptr, /*expert_step=*/1);
+  static void
+  run_activation(const tvm::ffi::TensorView input, const tvm::ffi::TensorView out, std::string type, bool swap_halves) {
+    launch(input, out, type, /*expert_ids=*/nullptr, /*expert_step=*/1, swap_halves);
   }
 
   static void run_activation_filtered(
@@ -167,11 +187,18 @@ struct ActivationKernel {
       const tvm::ffi::TensorView out,
       const tvm::ffi::TensorView expert_ids,
       int64_t expert_step,
-      std::string type) {
+      std::string type,
+      bool swap_halves) {
     using namespace host;
     RuntimeCheck(is_type<int32_t>(expert_ids.dtype()), "expert_ids must have dtype int32");
     RuntimeCheck(expert_step >= 1, "expert_step must be positive");
-    launch(input, out, type, static_cast<const int32_t*>(expert_ids.data_ptr()), static_cast<uint32_t>(expert_step));
+    launch(
+        input,
+        out,
+        type,
+        static_cast<const int32_t*>(expert_ids.data_ptr()),
+        static_cast<uint32_t>(expert_step),
+        swap_halves);
   }
 };
 

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -62,6 +62,17 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer TRT-LLM only supports fused path
         elif runner_backend.is_flashinfer_cutedsl():
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
+        elif runner_backend.is_flashinfer_cutlass():
+            if lora_enabled:
+                from sglang.srt.lora.lora_moe_runner_cutlass_fp4 import (
+                    CutlassFp4LoraRunnerCore,
+                )
+
+                self.runner_core = CutlassFp4LoraRunnerCore(config)
+            else:
+                # Non-LoRA flashinfer_cutlass bypasses MoeRunner: calls
+                # ``flashinfer_cutlass_fused_moe`` directly from quant ``apply``.
+                self.runner_core = None
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 
@@ -121,8 +132,9 @@ class MoeRunner:
                 )
             return None
 
-        # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore)
-        # bypass the pre-permute step and do their own alignment internally.
+        # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore,
+        # CutlassFp4LoraRunnerCore) bypass the pre-permute step and do their
+        # own alignment internally.
         if hasattr(self.runner_core, "run_from_dispatch"):
             hooks = _maybe_build_lora_hooks(dispatch_output)
             return self.runner_core.run_from_dispatch(

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -134,11 +134,17 @@ class MoeRunner:
 
         # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore,
         # CutlassFp4LoraRunnerCore) bypass the pre-permute step and do their
-        # own alignment internally.
+        # own alignment internally. ``lora_info`` is also passed so the runner
+        # can opt into sorted-layout LoRA hooks by mutating fields like
+        # ``c_map`` / ``sorted_layout`` before the hook closures fire.
         if hasattr(self.runner_core, "run_from_dispatch"):
             hooks = _maybe_build_lora_hooks(dispatch_output)
             return self.runner_core.run_from_dispatch(
-                dispatch_output, quant_info, self.config, hooks=hooks
+                dispatch_output,
+                quant_info,
+                self.config,
+                hooks=hooks,
+                lora_info=lora_info,
             )
 
         dispatch_format = dispatch_output.format.value

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -163,6 +163,7 @@ TBO_TOKEN_DISTRIBUTION_THRESHOLD: Optional[float] = None
 DEEPEP_CONFIG: Optional[str] = None
 DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER: Optional[bool] = None
 MOE_QUANTIZATION: Optional[str] = None
+ENABLE_LORA: Optional[bool] = None
 
 
 def initialize_moe_config(server_args: ServerArgs):
@@ -177,6 +178,7 @@ def initialize_moe_config(server_args: ServerArgs):
     global TBO_TOKEN_DISTRIBUTION_THRESHOLD
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     global MOE_QUANTIZATION
+    global ENABLE_LORA
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
@@ -199,6 +201,7 @@ def initialize_moe_config(server_args: ServerArgs):
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     )
     MOE_QUANTIZATION = server_args.quantization
+    ENABLE_LORA = server_args.enable_lora
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:
@@ -303,9 +306,14 @@ def filter_moe_weight_param_global_expert(name, x, num_local_experts):
 def should_use_flashinfer_cutlass_moe_fp4_allgather():
     """
     Perform FP4 quantize before all-gather for flashinfer cutlass moe to reduce communication cost for high-throughput serving.
+
+    Disabled for LoRA because the current Cutlass FP4 LoRA runner expects
+    bf16/float16 hidden states and local LoRA routing metadata, not the
+    dispatcher's pre-packed all-gathered FP4 payload.
     """
     return (
         not DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
+        and not ENABLE_LORA
         and get_moe_a2a_backend().is_none()
         and get_moe_runner_backend().is_flashinfer_cutlass()
         and is_dp_attention_enabled()

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1781,6 +1781,29 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             (1 / w2_input_scale).to(torch.float32),
         )
 
+        # ``[E]``-expanded fp32 view consumed by ``CutlassFp4LoraRunnerCore``.
+        # The source may be scalar (FlashInfer paths reduce all experts to a
+        # single max above) or already ``[E]``-shaped; expand once at load
+        # time so the hot path can hand it directly to the FP4 quant kernel.
+        E = layer.num_local_experts
+
+        def _to_per_expert(src: torch.Tensor) -> torch.Tensor:
+            flat = src.view(-1).to(torch.float32)
+            if flat.shape[0] == E:
+                return flat.contiguous()
+            return flat.expand(E).contiguous()
+
+        copy_or_rebind_param(
+            layer,
+            "w13_input_scale_quant_per_expert",
+            _to_per_expert(layer.w13_input_scale_quant),
+        )
+        copy_or_rebind_param(
+            layer,
+            "w2_input_scale_quant_per_expert",
+            _to_per_expert(layer.w2_input_scale_quant),
+        )
+
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         layer.dispatcher.set_quant_config(
             {
@@ -1984,6 +2007,30 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             self.enable_flashinfer_cutlass_moe or self._is_cutedsl_v2_standard
         )
 
+    def get_cutlass_fp4_quant_info(self, layer: torch.nn.Module):
+        """Build the LoRA-aware NVFP4 quant payload for ``CutlassFp4LoraRunnerCore``."""
+        from sglang.srt.lora.lora_moe_runner_cutlass_fp4 import (
+            CutlassFp4MoeQuantInfo,
+        )
+
+        return CutlassFp4MoeQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_blockscale_swizzled=layer.w13_blockscale_swizzled,
+            w2_blockscale_swizzled=layer.w2_blockscale_swizzled,
+            g1_alphas=layer.g1_alphas,
+            g2_alphas=layer.g2_alphas,
+            w13_input_scale_expanded=layer.w13_input_scale_quant_per_expert,
+            w2_input_scale_expanded=layer.w2_input_scale_quant_per_expert,
+            cutlass_moe_params=layer.cutlass_moe_params,
+            num_local_experts=layer.num_local_experts,
+            hidden_size=layer.hidden_size,
+            intermediate_size_per_partition=layer.intermediate_size_per_partition,
+            moe_ep_rank=layer.moe_ep_rank,
+            moe_ep_size=layer.moe_ep_size,
+            w13_swap_halves=self.load_up_proj_weight_first,
+        )
+
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
@@ -2160,7 +2207,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             topk_ids=topk_ids,
             params=layer.cutlass_moe_params,
             apply_router_weight_on_input=moe_runner_config.apply_router_weight_on_input,
-        ).to(x.dtype)
+        )
         # Scale by routed_scaling_factor is fused into select_experts.
         return StandardCombineInput(hidden_states=output)
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -879,6 +879,12 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.experts_shared_outer_loras: bool = False
         self.lora_use_virtual_experts: bool = False
         self.quant_method = base_layer.quant_method
+        self.moe_runner_config = base_layer.moe_runner_config
+        self.dispatcher = base_layer.dispatcher
+        self.num_local_experts = base_layer.num_local_experts
+        self.should_fuse_routed_scaling_factor_in_topk = (
+            base_layer.should_fuse_routed_scaling_factor_in_topk
+        )
 
         self.tp_size = getattr(base_layer, "moe_tp_size", 1)
         self.tp_rank = getattr(base_layer, "moe_tp_rank", 0)
@@ -927,6 +933,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         elif runner_backend.is_triton():
             assert base_layer.quant_method is not None, "Quant method must be set"
             self._quant_info = base_layer.quant_method.get_triton_quant_info(base_layer)
+        elif runner_backend.is_flashinfer_cutlass():
+            assert base_layer.quant_method is not None, "Quant method must be set"
+            self._quant_info = base_layer.quant_method.get_cutlass_fp4_quant_info(
+                base_layer
+            )
         else:
             raise NotImplementedError(
                 f"LoRA MoE not supported for backend {runner_backend}"
@@ -972,6 +983,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 len(lora_ranks), dtype=torch.int32, device=lora_ranks.device
             )
             adapter_enabled.index_fill_(0, wi.long(), 1)
+        rank_enabled = (lora_ranks > 0).to(
+            device=adapter_enabled.device, dtype=adapter_enabled.dtype
+        )
+        adapter_enabled.mul_(rank_enabled)
 
         seg_indptr = (
             batch_info.req_seg_indptr
@@ -1032,10 +1047,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             hidden_states=hidden_states, topk_output=topk_output
         )
 
-        # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
 
-        # Run the only lora moe runner (Triton)
         combine_input = self._lora_runner.run(
             dispatch_output, quant_info, lora_info=lora_info
         )

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -1,0 +1,228 @@
+"""FlashInfer-CUTLASS NVFP4 MoE runner core with LoRA support.
+
+Breaks open the upstream ``flashinfer_cutlass_fused_moe`` (a single black-box
+kernel called from ``ModelOptNvFp4FusedMoEMethod.apply``) into its FP4 group
+GEMMs so we can inject the standard ``after_gate_up`` / ``after_down`` LoRA
+hooks between w13 and w2, mirroring ``MarlinLoraRunnerCore``.
+
+Layout bridge: ``cutlass_fp4_group_mm`` writes expert-sorted ``[M*topk, *]``,
+the hooks expect token-major ``[M, topk, *]``. We round-trip via
+``shuffle_rows(.., c_map)`` (un-sort) and ``shuffle_rows(.., inv_c_map)``
+(re-sort) around ``after_gate_up``; for ``after_down`` the un-sort doubles
+as the combine permutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+)
+from sglang.srt.utils import is_cuda, is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+    from sglang.srt.lora.lora_moe_runners import LoRAHooks
+
+
+_is_cuda = is_cuda()
+_is_hip = is_hip()
+
+if _is_cuda:
+    from sgl_kernel import silu_and_mul
+elif _is_hip:
+    from vllm._custom_ops import silu_and_mul
+
+
+@dataclass
+class CutlassFp4MoeQuantInfo(MoeQuantInfo):
+    """Quantization payload consumed by ``CutlassFp4LoraRunnerCore``."""
+
+    w13_weight: torch.Tensor  # [E, 2 * N, K // 2] uint8
+    w2_weight: torch.Tensor  # [E, K, N // 2]     uint8
+    w13_blockscale_swizzled: torch.Tensor
+    w2_blockscale_swizzled: torch.Tensor
+    g1_alphas: torch.Tensor  # [E] fp32
+    g2_alphas: torch.Tensor  # [E] fp32
+    # ``[E]``-expanded once at load time so the hot path never has to expand.
+    w13_input_scale_expanded: torch.Tensor  # [E] fp32
+    w2_input_scale_expanded: torch.Tensor  # [E] fp32
+    cutlass_moe_params: object
+    num_local_experts: int
+    hidden_size: int
+    intermediate_size_per_partition: int
+    moe_ep_rank: int
+    moe_ep_size: int
+    # FlashInfer-CUTLASS loads w13 as ``[up | gate]`` (Kimi-K2.5).
+    w13_swap_halves: bool
+
+
+class CutlassFp4LoraRunnerCore:
+    """LoRA-aware NVFP4 MoE forward on the FlashInfer-CUTLASS GEMM primitives.
+
+    Pipeline: EP local-id remap → FP4 GEMM 1 → un-sort → ``after_gate_up`` →
+    re-sort → silu_and_mul → FP4 GEMM 2 → un-sort → ``after_down`` → combine.
+    """
+
+    def __init__(self, config: MoeRunnerConfig):
+        self.config = config
+
+    def run_from_dispatch(
+        self,
+        dispatch_output: "StandardDispatchOutput",
+        quant_info: CutlassFp4MoeQuantInfo,
+        runner_config: MoeRunnerConfig,
+        hooks: Optional["LoRAHooks"] = None,
+    ) -> "StandardCombineInput":
+        from sgl_kernel import prepare_moe_input
+
+        from sglang.srt.layers.moe.cutlass_moe import (
+            cutlass_fp4_group_mm,
+            scaled_fp4_experts_quant,
+            shuffle_rows,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardCombineInput,
+        )
+
+        hidden_states = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+        topk_weights = topk_output.topk_weights
+        topk_ids = topk_output.topk_ids
+
+        m_a = hidden_states.shape[0]
+        num_topk = topk_ids.shape[1]
+        out_dtype = hidden_states.dtype
+        device = hidden_states.device
+        E = quant_info.num_local_experts
+        K = quant_info.hidden_size
+        inter = quant_info.intermediate_size_per_partition
+        # This LoRA runner injects between the gate/up projection and the
+        # SwiGLU activation, so it only supports gated MoE weights.
+        N = quant_info.w13_weight.shape[1]
+        if N != inter * 2:
+            raise NotImplementedError(
+                "CutlassFp4LoraRunnerCore expects gated NVFP4 MoE weights with "
+                f"w13 output dim {inter * 2}, but got {N}."
+            )
+        params = quant_info.cutlass_moe_params
+        offsets = params.expert_offsets
+        total_tokens = m_a * num_topk
+
+        # StandardDispatcher hands flashinfer_cutlass global topk_ids; remap
+        # to local for the per-rank GEMM. Non-local tokens go to local expert
+        # 0 with weight 0 — they pay GEMM cost but contribute nothing.
+        local_offset = quant_info.moe_ep_rank * E
+        local_ids = topk_ids.to(torch.int32) - local_offset
+        non_local = (local_ids < 0) | (local_ids >= E)
+        local_ids = local_ids.masked_fill(non_local, 0)
+        local_weights = topk_weights.masked_fill(non_local, 0.0)
+
+        a_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        c_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        prepare_moe_input(
+            local_ids,
+            offsets,
+            params.problem_sizes1,
+            params.problem_sizes2,
+            a_map,
+            c_map,
+            E,
+            inter,
+            K,
+            params.blockscale_offsets,
+        )
+
+        # ---- GEMM 1 (w13)
+        rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
+            hidden_states,
+            quant_info.w13_input_scale_expanded,
+            offsets,
+            params.blockscale_offsets,
+            num_topk,
+            expert_map=a_map,
+        )
+        gateup_flat = cutlass_fp4_group_mm(
+            rep_a_fp4,
+            quant_info.w13_weight,
+            rep_a_blockscale,
+            quant_info.w13_blockscale_swizzled,
+            quant_info.g1_alphas,
+            out_dtype,
+            params.to_gemm1_args(),
+        )
+
+        # ---- LoRA w13 delta
+        # Un-sort to token-major with ``c_map`` (pair-index permutation), run
+        # the hook, then re-sort with ``inv_c_map``. ``a_map`` is an M-index
+        # and is NOT a valid inverse for the pair-index ``[M*topk, *]`` tensor
+        # — using it silently corrupts every (token, k>0) row.
+        if hooks is not None and hooks.after_gate_up is not None:
+            inv_c_map = torch.empty_like(c_map)
+            inv_c_map[c_map.long()] = torch.arange(
+                total_tokens, device=c_map.device, dtype=c_map.dtype
+            )
+            gateup_token_major = shuffle_rows(gateup_flat, c_map, (total_tokens, N))
+            gateup_3d = gateup_token_major.view(m_a, num_topk, N)
+            hooks.after_gate_up(hidden_states, gateup_3d, topk_weights, topk_ids)
+            gateup_flat = shuffle_rows(
+                gateup_token_major.view(total_tokens, N),
+                inv_c_map,
+                (total_tokens, N),
+            )
+
+        # ---- silu + mul
+        if quant_info.w13_swap_halves:
+            # ``[up | gate]`` layout: silu(gate) * up = silu(second) * first.
+            intermediate = (
+                torch.nn.functional.silu(gateup_flat[:, N // 2 :].float())
+                * gateup_flat[:, : N // 2].float()
+            ).to(out_dtype)
+        else:
+            intermediate = torch.empty(
+                total_tokens, N // 2, dtype=out_dtype, device=device
+            )
+            silu_and_mul(gateup_flat, intermediate)
+
+        # ---- GEMM 2 (w2)
+        int_fp4, int_blockscale = scaled_fp4_experts_quant(
+            intermediate,
+            quant_info.w2_input_scale_expanded,
+            offsets,
+            params.blockscale_offsets,
+            num_topk,
+        )
+        out_flat = cutlass_fp4_group_mm(
+            int_fp4,
+            quant_info.w2_weight,
+            int_blockscale,
+            quant_info.w2_blockscale_swizzled,
+            quant_info.g2_alphas,
+            out_dtype,
+            params.to_gemm2_args(),
+        )
+
+        # Un-sort to token-major; needed by ``after_down`` and by the combine.
+        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
+
+        # Standard hook contract: the down hook adds a router-weighted delta
+        # into an already-router-weighted per-expert output.
+        if not runner_config.apply_router_weight_on_input:
+            out_3d = out_3d * local_weights.view(m_a, num_topk, 1).to(out_dtype)
+
+        # ---- LoRA w2 delta
+        if hooks is not None and hooks.after_down is not None:
+            intermediate_token_major = shuffle_rows(
+                intermediate, c_map, (total_tokens, N // 2)
+            )
+            hooks.after_down(intermediate_token_major, out_3d, local_weights, topk_ids)
+
+        return StandardCombineInput(hidden_states=out_3d.sum(dim=1))

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -37,8 +37,15 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 
 if _is_cuda:
-    from sgl_kernel import silu_and_mul
+    # In-tree JIT variant (carries the ``swap_halves`` flag added for the
+    # ``[Up | Gate]`` Kimi-K2.5 W13 loader layout). The sgl_kernel AOT
+    # build doesn't expose ``swap_halves`` yet; the JIT path is the only
+    # caller of swap_halves and is loaded on demand on first use.
+    from sglang.jit_kernel.activation import silu_and_mul
 elif _is_hip:
+    # HIP path doesn't reach the cutlass FP4 LoRA runner (SM100+ only).
+    # Keep the existing import for code-symmetry; if it's ever called with
+    # swap_halves=True it will raise.
     from vllm._custom_ops import silu_and_mul
 
 
@@ -81,6 +88,7 @@ class CutlassFp4LoraRunnerCore:
         quant_info: CutlassFp4MoeQuantInfo,
         runner_config: MoeRunnerConfig,
         hooks: Optional["LoRAHooks"] = None,
+        lora_info=None,
     ) -> "StandardCombineInput":
         from sgl_kernel import prepare_moe_input
 
@@ -97,6 +105,15 @@ class CutlassFp4LoraRunnerCore:
         topk_output = dispatch_output.topk_output
         topk_weights = topk_output.topk_weights
         topk_ids = topk_output.topk_ids
+
+        if (
+            lora_info is not None
+            and lora_info.lora_use_virtual_experts
+            and lora_info.has_active_lora
+        ):
+            raise NotImplementedError(
+                "Cutlass FP4 LoRA virtual experts are added in the virtual-experts PR."
+            )
 
         m_a = hidden_states.shape[0]
         num_topk = topk_ids.shape[1]
@@ -160,37 +177,31 @@ class CutlassFp4LoraRunnerCore:
             params.to_gemm1_args(),
         )
 
+        # Hand the LoRA hook builder the c_map so its kernel calls read/write
+        # against the expert-sorted base GEMM buffers directly, skipping the
+        # 3× ``shuffle_rows`` layout bridge the token-major contract would
+        # otherwise need (un-sort gateup, re-sort gateup, un-sort intermediate).
+        # ``sorted_layout=True`` also tells ``_add_lora_down_delta`` to leave
+        # the router weighting to the runner — see the post-W2 multiply below.
+        # The hook closures captured ``lora_info`` from ``build_lora_hooks`` so
+        # these mutations are visible at hook-call time.
+        if lora_info is not None:
+            lora_info.c_map = c_map
+            lora_info.sorted_layout = True
+
         # ---- LoRA w13 delta
-        # Un-sort to token-major with ``c_map`` (pair-index permutation), run
-        # the hook, then re-sort with ``inv_c_map``. ``a_map`` is an M-index
-        # and is NOT a valid inverse for the pair-index ``[M*topk, *]`` tensor
-        # — using it silently corrupts every (token, k>0) row.
+        # Output buffer is ``gateup_flat`` interpreted as ``[M, topk, 2N]``;
+        # the kernel uses c_map indirection to write the delta at the
+        # expert-sorted row matching the base GEMM output.
         if hooks is not None and hooks.after_gate_up is not None:
-            inv_c_map = torch.empty_like(c_map)
-            inv_c_map[c_map.long()] = torch.arange(
-                total_tokens, device=c_map.device, dtype=c_map.dtype
-            )
-            gateup_token_major = shuffle_rows(gateup_flat, c_map, (total_tokens, N))
-            gateup_3d = gateup_token_major.view(m_a, num_topk, N)
+            gateup_3d = gateup_flat.view(m_a, num_topk, N)
             hooks.after_gate_up(hidden_states, gateup_3d, topk_weights, topk_ids)
-            gateup_flat = shuffle_rows(
-                gateup_token_major.view(total_tokens, N),
-                inv_c_map,
-                (total_tokens, N),
-            )
 
         # ---- silu + mul
-        if quant_info.w13_swap_halves:
-            # ``[up | gate]`` layout: silu(gate) * up = silu(second) * first.
-            intermediate = (
-                torch.nn.functional.silu(gateup_flat[:, N // 2 :].float())
-                * gateup_flat[:, : N // 2].float()
-            ).to(out_dtype)
-        else:
-            intermediate = torch.empty(
-                total_tokens, N // 2, dtype=out_dtype, device=device
-            )
-            silu_and_mul(gateup_flat, intermediate)
+        # ``w13_swap_halves=True`` selects the ``[up | gate]`` convention
+        # (silu(second) * first) for FlashInfer-CUTLASS NVFP4 W13 loaders.
+        intermediate = torch.empty(total_tokens, N // 2, dtype=out_dtype, device=device)
+        silu_and_mul(gateup_flat, intermediate, swap_halves=quant_info.w13_swap_halves)
 
         # ---- GEMM 2 (w2)
         int_fp4, int_blockscale = scaled_fp4_experts_quant(
@@ -210,19 +221,18 @@ class CutlassFp4LoraRunnerCore:
             params.to_gemm2_args(),
         )
 
-        # Un-sort to token-major; needed by ``after_down`` and by the combine.
-        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
+        # ---- LoRA w2 delta
+        # Input ``intermediate`` is already expert-sorted (W13->silu output);
+        # the down kernel uses c_map indirection on BOTH input and output, so
+        # we don't materialize a token-major copy. ``mul_routed_weight=False``
+        # is set inside ``_add_lora_down_delta`` for sorted layout — the
+        # router weighting happens once below, over ``base + unweighted_delta``.
+        if hooks is not None and hooks.after_down is not None:
+            out_3d_sorted_view = out_flat.view(m_a, num_topk, K)
+            hooks.after_down(intermediate, out_3d_sorted_view, local_weights, topk_ids)
 
-        # Standard hook contract: the down hook adds a router-weighted delta
-        # into an already-router-weighted per-expert output.
+        # ---- combine: un-sort once, weight (base + delta) once, sum.
+        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
         if not runner_config.apply_router_weight_on_input:
             out_3d = out_3d * local_weights.view(m_a, num_topk, 1).to(out_dtype)
-
-        # ---- LoRA w2 delta
-        if hooks is not None and hooks.after_down is not None:
-            intermediate_token_major = shuffle_rows(
-                intermediate, c_map, (total_tokens, N // 2)
-            )
-            hooks.after_down(intermediate_token_major, out_3d, local_weights, topk_ids)
-
         return StandardCombineInput(hidden_states=out_3d.sum(dim=1))

--- a/python/sglang/srt/lora/lora_moe_runner_marlin.py
+++ b/python/sglang/srt/lora/lora_moe_runner_marlin.py
@@ -63,6 +63,7 @@ class MarlinLoraRunnerCore:
         quant_info: MarlinMoeQuantInfo,
         runner_config: MoeRunnerConfig,
         hooks=None,
+        lora_info=None,  # accepted for interface uniformity; Marlin uses hooks directly
     ) -> StandardCombineInput:
         global _MARLIN_WORKSPACE
         from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -175,7 +175,7 @@ class LoRAInfo:
 
     # LoRA config per adapter
     lora_ranks: torch.Tensor  # [num_loras]
-    adapter_enabled: torch.Tensor  # [num_loras] - which adapters are enabled
+    adapter_enabled: torch.Tensor  # [num_loras] - requested adapters with rank > 0
     max_lora_rank: int  # Maximum LoRA rank across all adapters
 
     num_experts: int
@@ -214,7 +214,11 @@ def _compute_token_lora_mapping(
         token_positions,
         right=True,
     )
-    return lora_info.req_to_lora.to(torch.int32)[req_indices]
+    mapping = lora_info.req_to_lora.to(torch.int32)[req_indices]
+    valid = mapping >= 0
+    safe_mapping = mapping.clamp_min(0).long()
+    active = lora_info.adapter_enabled[safe_mapping] > 0
+    return torch.where(valid & active, mapping, torch.full_like(mapping, -1))
 
 
 def _compute_lora_alignment(

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -188,6 +188,12 @@ class LoRAInfo:
     hidden_size: int = 0
     lora_use_virtual_experts: bool = False
 
+    # Set by the runner when its GEMM outputs are in expert-sorted layout.
+    # When ``sorted_layout`` is True and ``c_map`` is set, hook kernels
+    # address rows via ``c_map[pair_idx]`` and the runner applies router
+    # weights once over (base + delta) instead of the kernel doing it.
+    c_map: torch.Tensor | None = None
+    sorted_layout: bool = False
 
 @dataclass
 class LoRAHooks:
@@ -425,6 +431,7 @@ def _add_lora_gate_up_delta(
             expand_num_stages=2,
             expand_split_k=1,
             fully_sharded=lora_info.fully_sharded,
+            c_map=lora_info.c_map,
         )
 
 
@@ -479,6 +486,11 @@ def _add_lora_down_delta(
         )
     else:
         blk = _get_moe_lora_block_config(lora_info.max_lora_rank)
+        # Sorted-layout callers apply router weights *after* the LoRA delta is
+        # accumulated into the expert-sorted output; running mul_routed_weight
+        # inside the kernel here would double-weight (Bug 4 reborn under the
+        # new layout). Token-major callers keep the existing single-weighting.
+        kernel_mul_routed_weight = not lora_info.sorted_layout
         fused_moe_lora(
             output=intermediate_cache,
             qcurr_hidden_states=intermediate_input,
@@ -506,9 +518,10 @@ def _add_lora_down_delta(
             expand_num_warps=4,
             expand_num_stages=2,
             expand_split_k=1,
-            mul_routed_weight=True,
+            mul_routed_weight=kernel_mul_routed_weight,
             fully_sharded=lora_info.fully_sharded,
             offset=offset,
+            c_map=lora_info.c_map,
         )
 
 

--- a/python/sglang/srt/lora/triton_ops/fused_moe_lora_kernel.py
+++ b/python/sglang/srt/lora/triton_ops/fused_moe_lora_kernel.py
@@ -55,6 +55,7 @@ def _fused_moe_lora_kernel(
     sorted_token_ids_ptr,
     expert_ids_ptr,
     num_tokens_post_padded_ptr,
+    c_map_ptr,  # NULL unless USE_C_MAP_INPUT or USE_C_MAP_OUTPUT
     # Matrix dimensions
     N,
     K,
@@ -92,6 +93,15 @@ def _fused_moe_lora_kernel(
     USE_GDC: tl.constexpr,
     launch_pdl: tl.constexpr,
     IS_PRIMARY: tl.constexpr,
+    # c_map indirection — when set, the kernel reads/writes via
+    # ``c_map[offs_token]`` instead of ``offs_token``. Lets the caller keep
+    # tensors in expert-sorted layout and skip explicit ``shuffle_rows`` round
+    # trips. ``USE_C_MAP_INPUT`` applies when the input row is per-pair
+    # (down path: input is already expert-sorted intermediate);
+    # ``USE_C_MAP_OUTPUT`` applies when the output accumulator buffer is
+    # expert-sorted. Both default off so existing callers compile identically.
+    USE_C_MAP_INPUT: tl.constexpr,
+    USE_C_MAP_OUTPUT: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     slice_id = tl.program_id(axis=1)
@@ -146,12 +156,29 @@ def _fused_moe_lora_kernel(
     )
     token_mask = offs_token < num_valid_tokens
 
+    # c_map[offs_token] maps a token-major pair index back to the expert-sorted
+    # position used by ``cutlass_fp4_group_mm`` outputs. Only read if at least
+    # one side asks for the remap; constexpr-False keeps the load out of the
+    # SASS for existing callers.
+    if USE_C_MAP_INPUT or USE_C_MAP_OUTPUT:
+        offs_token_sorted = tl.load(
+            c_map_ptr + offs_token, mask=token_mask, other=0
+        ).to(tl.int64)
+
     # ================================================================= secure
 
     # get a_ptrs,b_ptrs
-    a_ptrs = cur_a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-    )
+    if USE_C_MAP_INPUT:
+        # Input is already expert-sorted (down path with sorted intermediate):
+        # read row at sorted_pos = c_map[pair_idx].
+        a_row = offs_token_sorted
+    else:
+        # Existing behavior: ``offs_token // top_k`` gives the M-index for
+        # the gate_up path (where ``a`` is token-major hidden_states), or
+        # ``offs_token`` itself when ``top_k == 1`` (down path with
+        # token-major intermediate, the existing default).
+        a_row = offs_token // top_k
+    a_ptrs = cur_a_ptr + (a_row[:, None] * stride_am + offs_k[None, :] * stride_ak)
 
     b_ptrs = (
         cur_b_ptr
@@ -195,9 +222,15 @@ def _fused_moe_lora_kernel(
         moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
         accumulator = accumulator * moe_weight[:, None]
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
-    # Write back the block of the output
+    # Write back the block of the output. For the sorted-layout path we land
+    # the delta at the expert-sorted row (sorted_pos), matching where the
+    # base GEMM output lives in the caller's buffer.
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = cur_c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    if USE_C_MAP_OUTPUT:
+        c_row = offs_token_sorted
+    else:
+        c_row = offs_token
+    c_ptrs = cur_c_ptr + stride_cm * c_row[:, None] + stride_cn * offs_cn[None, :]
     c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
 
     if SPLIT_K == 1:
@@ -239,6 +272,8 @@ def _fused_moe_lora_shrink(
     split_k: int,
     top_k_divisor: int = None,
     mul_routed_weight: bool = False,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
 ) -> None:
     w1_lora_a_stacked = lora_a_stacked[0]
 
@@ -272,6 +307,7 @@ def _fused_moe_lora_shrink(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
+        c_map,
         N,
         K,
         EM,
@@ -300,6 +336,11 @@ def _fused_moe_lora_shrink(
         ),
         MUL_ROUTED_WEIGHT=False,
         IS_PRIMARY=True,
+        # Shrink reads input via c_map only when caller marks the input as
+        # already expert-sorted (down path); the scratch ``a_intermediate``
+        # stays token-major regardless.
+        USE_C_MAP_INPUT=bool(input_is_sorted),
+        USE_C_MAP_OUTPUT=False,
         **shrink_config,
     )
 
@@ -339,6 +380,7 @@ def _fused_moe_lora_expand(
     split_k: int,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
 
     b_ptr = _get_ptr(lora_b_stacked, device)
@@ -377,6 +419,7 @@ def _fused_moe_lora_expand(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
+        c_map,
         N,
         K,
         EM,
@@ -401,6 +444,13 @@ def _fused_moe_lora_expand(
         top_k=1,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         IS_PRIMARY=False,
+        # Expand writes ``b_intermediate_cache1`` at expert-sorted positions
+        # via c_map iff the caller hands a c_map. The downstream Python
+        # accumulate (``output += b_intermediate_cache1``) then lands the
+        # delta on the matching expert-sorted row of ``output``. Caller is
+        # responsible for interpreting ``output`` in the expected layout.
+        USE_C_MAP_INPUT=False,
+        USE_C_MAP_OUTPUT=c_map is not None,
         **expand_config,
     )
     for i in range(num_slices):
@@ -442,6 +492,7 @@ def _fused_moe_lora(
     mul_routed_weight: bool = False,
     fully_sharded: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
     assert len(lora_a_stacked) == len(lora_b_stacked) > 0
     assert (
@@ -486,6 +537,11 @@ def _fused_moe_lora(
         device=device,
     )
 
+    # When the caller marks the layout sorted (``c_map is not None``) AND the
+    # input row is per-pair (``input_is_expanded``), the shrink reads its
+    # input via c_map. Gate-up path keeps M-index addressing regardless,
+    # because hidden_states is always token-major.
+    shrink_input_is_sorted = c_map is not None and input_is_expanded
     _fused_moe_lora_shrink(
         a_intermediate_cache1,
         qcurr_hidden_states,
@@ -515,6 +571,8 @@ def _fused_moe_lora(
         shrink_split_k,
         top_k_divisor=shrink_top_k_divisor,
         mul_routed_weight=False,
+        c_map=c_map,
+        input_is_sorted=shrink_input_is_sorted,
     )
 
     if fully_sharded:
@@ -562,6 +620,7 @@ def _fused_moe_lora(
         expand_split_k,
         mul_routed_weight,
         offset,
+        c_map=c_map,
     )
 
 
@@ -595,6 +654,7 @@ def _fused_moe_lora_fake(
     mul_routed_weight: bool = False,
     fully_sharded: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
     return
 
@@ -625,7 +685,10 @@ def _fused_moe_lora_shrink_fake(
     num_warps: int,
     num_stages: int,
     split_k: int,
+    top_k_divisor: int = None,
     mul_routed_weight: bool = False,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
 ) -> None:
     return
 
@@ -661,6 +724,7 @@ def _fused_moe_lora_expand_fake(
     split_k: int,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
     return
 


### PR DESCRIPTION
Reference: split from the overall PR [sgl-project/sglang#25202](https://github.com/sgl-project/sglang/pull/25202).

## Motivation

PR1 proves the LoRA hook integration but still has unnecessary layout traffic around the hooks. The Cutlass FP4 GEMMs naturally operate in expert-sorted pair layout, while the original hook contract expects token-major layout. Bridging those layouts with explicit shuffles costs extra memory bandwidth per MoE layer.

## Approach

This PR extends the MoE LoRA hook kernels with an optional `c_map` indirection so they can read and write expert-sorted buffers directly. It also adds a `swap_halves` mode to the JIT activation kernel for Kimi-K2.5's `[Up|Gate]` W13 layout.

## Key Changes

- Add `c_map` and `sorted_layout` propagation through `LoRAInfo`.
- Extend `fused_moe_lora` with `USE_C_MAP_INPUT` and `USE_C_MAP_OUTPUT` constexpr paths.
- Use the sorted-layout hook path in `CutlassFp4LoraRunnerCore`.
- Add `swap_halves` to the JIT `silu_and_mul` activation path.
- Bump the activation JIT module key to `activation_swap_halves` because the exported JIT function ABI now has the extra `swap_halves` argument; this avoids loading stale cached modules built with the old 3-argument ABI.
- Keep virtual experts guarded out of this PR; PR4 adds that support.

## Accuracy

Same two-node TP=8 setup as PR1. Accuracy captures use the 1809-token sequence from [`compare_sample_train_data.pt`](https://huggingface.co/datasets/yushengsu/lora-diff-Kimi-K2.5/blob/main/compare_sample_train_data.pt), request `max_new_tokens=0`, return input-token logprobs, and compare 1808 positions.

| Pair | mean abs | max abs | half squared mean | identical |
|---|---:|---:|---:|---|
| B vs PR2 C-nolora | 0.102540 | 3.790158 | 0.053243 | false |
| PR1 C-lora vs PR2 C-lora | 0.235814 | 2.668981 | 0.087248 | false |

This PR is primarily the sorted-layout/perf slice. The no-LoRA passthrough remains at the PR1 accuracy level; PR3 fixes the fused-Cutlass parity gap by keeping router factors in fp32 during the final combine.

## Performance

`bs=32`, `input_len=1024`, `output_len=2048`.

| Variant | prefill time (s) | prefill tok/s | decode time (s) | decode tok/s | total latency (s) | overall tok/s |
|---|---:|---:|---:|---:|---:|---:|
| PR1 C-nolora | 1.41 | 23221 | 425.36 | 154.07 | 426.77 | 230.35 |
| PR1 C-lora | 2.11 | 15516 | 415.83 | 157.60 | 417.94 | 235.21 |
| PR2 C-nolora | 1.39 | 23620 | 422.22 | 155.22 | 423.60 | 232.07 |
| PR2 C-lora | 2.02 | 16196 | 412.41 | 158.91 | 414.43 | 237.20 |

The sorted-layout path improves active-LoRA latency by 3.51s at this shape and also removes the stale JIT ABI failure observed when switching from PR1 to PR2 on a pod with an existing activation cache.

## Validation

- `python -m py_compile` on the touched Python files.
- `git diff --check`.
- Two-node C server launch after a PR1 run with an existing JIT cache, confirming the activation module key fix.
- Dataset-based accuracy capture, no-LoRA perf, and active-LoRA perf on `mnnvl-yanbin-0/1`.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->