### PR TITLE
[4/4][LoRA] Add NVFP4 Cutlass LoRA virtual experts

### DIFF
--- a/python/sglang/jit_kernel/activation.py
+++ b/python/sglang/jit_kernel/activation.py
@@ -32,7 +32,7 @@ def _fast_math_flags() -> list[str]:
 def _jit_activation_module(dtype: torch.dtype) -> Module:
     args = make_cpp_args(dtype, is_arch_support_pdl())
     return load_jit(
-        "activation",
+        "activation_swap_halves",
         *args,
         cuda_files=["elementwise/activation.cuh"],
         extra_cuda_cflags=_fast_math_flags(),
@@ -51,13 +51,13 @@ SUPPORTED_ACTIVATIONS = {"silu", "gelu", "gelu_tanh"}
 
 @register_custom_op(mutates_args=["out"])
 def _run_activation_inplace(
-    op_name: str, input: torch.Tensor, out: torch.Tensor
+    op_name: str, input: torch.Tensor, out: torch.Tensor, swap_halves: bool
 ) -> None:
     hidden_size = input.shape[-1] // 2
     module = _jit_activation_module(input.dtype)
     input_2d = input.view(-1, hidden_size * 2)
     out_2d = out.view(-1, hidden_size)
-    module.run_activation(input_2d, out_2d, op_name)
+    module.run_activation(input_2d, out_2d, op_name, swap_halves)
 
 
 @register_custom_op(mutates_args=["out"])
@@ -67,12 +67,15 @@ def _run_activation_filtered_inplace(
     out: torch.Tensor,
     expert_ids: torch.Tensor,
     expert_step: int,
+    swap_halves: bool,
 ) -> None:
     hidden_size = input.shape[-1] // 2
     module = _jit_activation_module(input.dtype)
     input_2d = input.view(-1, hidden_size * 2)
     out_2d = out.view(-1, hidden_size)
-    module.run_activation_filtered(input_2d, out_2d, expert_ids, expert_step, op_name)
+    module.run_activation_filtered(
+        input_2d, out_2d, expert_ids, expert_step, op_name, swap_halves
+    )
 
 
 def run_activation(
@@ -81,8 +84,14 @@ def run_activation(
     out: Optional[torch.Tensor],
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
     """Apply ``op_name`` activation followed by element-wise multiplication.
+
+    ``swap_halves`` controls which half feeds the activation. ``False`` (default)
+    computes ``act(first) * second`` — the standard ``[Gate | Up]`` convention.
+    ``True`` computes ``act(second) * first`` — for ``[Up | Gate]`` layouts
+    (e.g. Kimi-K2.5 on FlashInfer-CUTLASS NVFP4 MoE).
 
     When ``expert_ids`` is provided, output rows are skipped for tokens whose
     routed expert id is ``-1``. ``expert_step`` is 1 for per-token routing and
@@ -94,9 +103,11 @@ def run_activation(
     if out is None:
         out = input.new_empty(*input.shape[:-1], hidden_size)
     if expert_ids is None:
-        _run_activation_inplace(op_name, input, out)
+        _run_activation_inplace(op_name, input, out, swap_halves)
     else:
-        _run_activation_filtered_inplace(op_name, input, out, expert_ids, expert_step)
+        _run_activation_filtered_inplace(
+            op_name, input, out, expert_ids, expert_step, swap_halves
+        )
     return out
 
 
@@ -105,8 +116,9 @@ def silu_and_mul(
     out: Optional[torch.Tensor] = None,
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
-    return run_activation("silu", input, out, expert_ids, expert_step)
+    return run_activation("silu", input, out, expert_ids, expert_step, swap_halves)
 
 
 def gelu_and_mul(
@@ -114,8 +126,9 @@ def gelu_and_mul(
     out: Optional[torch.Tensor] = None,
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
-    return run_activation("gelu", input, out, expert_ids, expert_step)
+    return run_activation("gelu", input, out, expert_ids, expert_step, swap_halves)
 
 
 def gelu_tanh_and_mul(
@@ -123,5 +136,6 @@ def gelu_tanh_and_mul(
     out: Optional[torch.Tensor] = None,
     expert_ids: Optional[torch.Tensor] = None,
     expert_step: int = 1,
+    swap_halves: bool = False,
 ) -> torch.Tensor:
-    return run_activation("gelu_tanh", input, out, expert_ids, expert_step)
+    return run_activation("gelu_tanh", input, out, expert_ids, expert_step, swap_halves)

--- a/python/sglang/jit_kernel/activation.py
+++ b/python/sglang/jit_kernel/activation.py
@@ -88,15 +88,12 @@ def run_activation(
 ) -> torch.Tensor:
     """Apply ``op_name`` activation followed by element-wise multiplication.
 
-    ``swap_halves`` controls which half feeds the activation. ``False`` (default)
-    computes ``act(first) * second`` — the standard ``[Gate | Up]`` convention.
-    ``True`` computes ``act(second) * first`` — for ``[Up | Gate]`` layouts
-    (e.g. Kimi-K2.5 on FlashInfer-CUTLASS NVFP4 MoE).
+    ``swap_halves=False`` (default) computes ``act(first) * second`` ([Gate|Up]);
+    ``True`` computes ``act(second) * first`` ([Up|Gate]).
 
     When ``expert_ids`` is provided, output rows are skipped for tokens whose
-    routed expert id is ``-1``. ``expert_step`` is 1 for per-token routing and
-    ``BLOCK_SIZE_M`` for sorted/TMA routing — i.e. ``expert_ids[token_id //
-    expert_step]`` is consulted before computing each row.
+    routed expert id is ``-1``. ``expert_ids[token_id // expert_step]`` is
+    consulted before computing each row.
     """
     assert op_name in SUPPORTED_ACTIVATIONS, f"Unsupported activation: {op_name}"
     hidden_size = input.shape[-1] // 2

--- a/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
@@ -51,7 +51,13 @@ struct ActivationParams {
   uint32_t expert_step;
 };
 
-template <typename T, ActivationKind kAct, bool kUsePDL, bool kFilterExpert>
+// kSwapHalves selects which half of the [first | second] input feeds the
+// activation. kSwapHalves=false computes act(first) * second (the stock
+// [Gate | Up] convention). kSwapHalves=true computes act(second) * first
+// (the [Up | Gate] convention used by FlashInfer-CUTLASS NVFP4 MoE, e.g.
+// Kimi-K2.5). The flag is a template constexpr, so the existing call path
+// compiles to byte-identical SASS.
+template <typename T, ActivationKind kAct, bool kUsePDL, bool kFilterExpert, bool kSwapHalves>
 __global__ void act_and_mul_kernel(const __grid_constant__ ActivationParams params) {
   using namespace device;
   constexpr auto kVecSize = kMaxVecBytes / sizeof(T);
@@ -68,13 +74,15 @@ __global__ void act_and_mul_kernel(const __grid_constant__ ActivationParams para
   const auto input_offset = token_id * (num_vecs * 2) + offset;
   const auto output_offset = tid;
   PDLWaitPrimary<kUsePDL>();
-  const auto gate = device::load_as<vec_t>(params.input, input_offset);
-  const auto up = device::load_as<vec_t>(params.input, input_offset + num_vecs);
+  const auto first = device::load_as<vec_t>(params.input, input_offset);
+  const auto second = device::load_as<vec_t>(params.input, input_offset + num_vecs);
   vec_t out;
 #pragma unroll
   for (int i = 0; i < kVecSize; ++i) {
-    const float gate_f32 = device::cast<fp32_t>(gate[i]);
-    const float up_f32 = device::cast<fp32_t>(up[i]);
+    const float first_f32 = device::cast<fp32_t>(first[i]);
+    const float second_f32 = device::cast<fp32_t>(second[i]);
+    const float gate_f32 = kSwapHalves ? second_f32 : first_f32;
+    const float up_f32 = kSwapHalves ? first_f32 : second_f32;
     out[i] = device::cast<T>(apply_activation_f32<kAct>(gate_f32) * up_f32);
   }
   device::store_as<vec_t>(params.out, out, output_offset);
@@ -86,21 +94,21 @@ struct ActivationKernel {
   static constexpr auto kVecSize = device::kMaxVecBytes / sizeof(T);
   static constexpr auto kBlockSize = 256u;
 
-  template <ActivationKind kAct, bool kFilterExpert>
-  static constexpr auto activation_kernel = act_and_mul_kernel<T, kAct, kUsePDL, kFilterExpert>;
+  template <ActivationKind kAct, bool kFilterExpert, bool kSwapHalves>
+  static constexpr auto activation_kernel = act_and_mul_kernel<T, kAct, kUsePDL, kFilterExpert, kSwapHalves>;
 
   static_assert(device::kMaxVecBytes % sizeof(T) == 0, "unsupported data type");
 
-  template <bool kFilterExpert>
+  template <bool kFilterExpert, bool kSwapHalves>
   static auto select_kernel(const std::string& type)
-      -> decltype(activation_kernel<ActivationKind::kSiLU, kFilterExpert>) {
+      -> decltype(activation_kernel<ActivationKind::kSiLU, kFilterExpert, kSwapHalves>) {
     using namespace host;
     if (type == "silu") {
-      return activation_kernel<ActivationKind::kSiLU, kFilterExpert>;
+      return activation_kernel<ActivationKind::kSiLU, kFilterExpert, kSwapHalves>;
     } else if (type == "gelu") {
-      return activation_kernel<ActivationKind::kGELU, kFilterExpert>;
+      return activation_kernel<ActivationKind::kGELU, kFilterExpert, kSwapHalves>;
     } else if (type == "gelu_tanh") {
-      return activation_kernel<ActivationKind::kGELUTanh, kFilterExpert>;
+      return activation_kernel<ActivationKind::kGELUTanh, kFilterExpert, kSwapHalves>;
     } else {
       Panic("unsupported activation type: ", type);
     }
@@ -112,7 +120,8 @@ struct ActivationKernel {
       const tvm::ffi::TensorView& out,
       const std::string& type,
       const int32_t* expert_ids,
-      uint32_t expert_step) {
+      uint32_t expert_step,
+      bool swap_halves) {
     using namespace host;
 
     auto N = SymbolicSize{"num_tokens"};
@@ -150,16 +159,27 @@ struct ActivationKernel {
     };
     if (expert_ids != nullptr) {
       RuntimeCheck(expert_step > 0, "expert_step must be positive");
-      const auto kernel = select_kernel<true>(type);
-      LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      if (swap_halves) {
+        const auto kernel = select_kernel<true, true>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      } else {
+        const auto kernel = select_kernel<true, false>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      }
     } else {
-      const auto kernel = select_kernel<false>(type);
-      LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      if (swap_halves) {
+        const auto kernel = select_kernel<false, true>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      } else {
+        const auto kernel = select_kernel<false, false>(type);
+        LaunchKernel(num_blocks, kBlockSize, device).enable_pdl(kUsePDL)(kernel, params);
+      }
     }
   }
 
-  static void run_activation(const tvm::ffi::TensorView input, const tvm::ffi::TensorView out, std::string type) {
-    launch(input, out, type, /*expert_ids=*/nullptr, /*expert_step=*/1);
+  static void
+  run_activation(const tvm::ffi::TensorView input, const tvm::ffi::TensorView out, std::string type, bool swap_halves) {
+    launch(input, out, type, /*expert_ids=*/nullptr, /*expert_step=*/1, swap_halves);
   }
 
   static void run_activation_filtered(
@@ -167,11 +187,18 @@ struct ActivationKernel {
       const tvm::ffi::TensorView out,
       const tvm::ffi::TensorView expert_ids,
       int64_t expert_step,
-      std::string type) {
+      std::string type,
+      bool swap_halves) {
     using namespace host;
     RuntimeCheck(is_type<int32_t>(expert_ids.dtype()), "expert_ids must have dtype int32");
     RuntimeCheck(expert_step >= 1, "expert_step must be positive");
-    launch(input, out, type, static_cast<const int32_t*>(expert_ids.data_ptr()), static_cast<uint32_t>(expert_step));
+    launch(
+        input,
+        out,
+        type,
+        static_cast<const int32_t*>(expert_ids.data_ptr()),
+        static_cast<uint32_t>(expert_step),
+        swap_halves);
   }
 };
 

--- a/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
+++ b/python/sglang/jit_kernel/csrc/elementwise/activation.cuh
@@ -51,12 +51,8 @@ struct ActivationParams {
   uint32_t expert_step;
 };
 
-// kSwapHalves selects which half of the [first | second] input feeds the
-// activation. kSwapHalves=false computes act(first) * second (the stock
-// [Gate | Up] convention). kSwapHalves=true computes act(second) * first
-// (the [Up | Gate] convention used by FlashInfer-CUTLASS NVFP4 MoE, e.g.
-// Kimi-K2.5). The flag is a template constexpr, so the existing call path
-// compiles to byte-identical SASS.
+// kSwapHalves=false: act(first) * second  ([Gate | Up], default).
+// kSwapHalves=true : act(second) * first  ([Up | Gate], FlashInfer-CUTLASS NVFP4).
 template <typename T, ActivationKind kAct, bool kUsePDL, bool kFilterExpert, bool kSwapHalves>
 __global__ void act_and_mul_kernel(const __grid_constant__ ActivationParams params) {
   using namespace device;

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -396,8 +396,8 @@ def cutlass_moe_fp4(
     c_strides_13: [e] dtype: int64 [Gemm 1: Output Strides]
     c_strides_2: [e] dtype: int64 [Gemm 1: Output Strides]
 
-    topk_weights: [m, topk] dtype: float8
-    topk_ids: [m, topk] dtype: float8
+    topk_weights: [m, topk] dtype: float32
+    topk_ids: [m, topk] dtype: int32
 
     m, n, k: Unquantized weight shapes, dtype: int
     e: number of experts for the current rank, dtype: int
@@ -431,6 +431,8 @@ def cutlass_moe_fp4(
     assert a.dtype in [torch.half, torch.bfloat16], "Invalid input dtype"
 
     out_dtype = a.dtype
+    topk_ids = topk_ids.to(torch.int32)
+    topk_weights = topk_weights.to(torch.float32)
     num_topk = topk_ids.shape[1]
     device = a.device
     a_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
@@ -490,8 +492,11 @@ def cutlass_moe_fp4(
         params.to_gemm2_args(),
     )
     del int_fp4, int_blockscale
-    c2 = shuffle_rows(c2, c_map, (m_a * num_topk, params.hidden_size))
-    c2 = c2.view(m_a, num_topk, params.hidden_size)
-    if not apply_router_weight_on_input:
-        c2 = c2 * topk_weights.view(m_a, num_topk, 1).to(out_dtype)
-    return c2.sum(dim=1).to(out_dtype)
+    output = torch.empty((m_a, params.hidden_size), device=device, dtype=out_dtype)
+    apply_shuffle_mul_sum(
+        c2,
+        output,
+        c_map,
+        None if apply_router_weight_on_input else topk_weights.reshape(-1),
+    )
+    return output

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -62,6 +62,17 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer TRT-LLM only supports fused path
         elif runner_backend.is_flashinfer_cutedsl():
             self.runner_core = None  # FlashInfer CuteDSL only supports fused path
+        elif runner_backend.is_flashinfer_cutlass():
+            if lora_enabled:
+                from sglang.srt.lora.lora_moe_runner_cutlass_fp4 import (
+                    CutlassFp4LoraRunnerCore,
+                )
+
+                self.runner_core = CutlassFp4LoraRunnerCore(config)
+            else:
+                # Non-LoRA flashinfer_cutlass bypasses MoeRunner: calls
+                # ``flashinfer_cutlass_fused_moe`` directly from quant ``apply``.
+                self.runner_core = None
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 
@@ -121,8 +132,9 @@ class MoeRunner:
                 )
             return None
 
-        # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore)
-        # bypass the pre-permute step and do their own alignment internally.
+        # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore,
+        # CutlassFp4LoraRunnerCore) bypass the pre-permute step and do their
+        # own alignment internally.
         if hasattr(self.runner_core, "run_from_dispatch"):
             hooks = _maybe_build_lora_hooks(dispatch_output)
             return self.runner_core.run_from_dispatch(

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -134,11 +134,17 @@ class MoeRunner:
 
         # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore,
         # CutlassFp4LoraRunnerCore) bypass the pre-permute step and do their
-        # own alignment internally.
+        # own alignment internally. ``lora_info`` is also passed so the runner
+        # can opt into sorted-layout LoRA hooks by mutating fields like
+        # ``c_map`` / ``sorted_layout`` before the hook closures fire.
         if hasattr(self.runner_core, "run_from_dispatch"):
             hooks = _maybe_build_lora_hooks(dispatch_output)
             return self.runner_core.run_from_dispatch(
-                dispatch_output, quant_info, self.config, hooks=hooks
+                dispatch_output,
+                quant_info,
+                self.config,
+                hooks=hooks,
+                lora_info=lora_info,
             )
 
         dispatch_format = dispatch_output.format.value

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_kernels.py
@@ -336,6 +336,7 @@ def fused_moe_kernel(
     expert_ids_ptr,
     num_tokens_post_padded_ptr,
     add_mask_ptr,
+    c_map_ptr,
     # Matrix dimensions
     N,
     K,
@@ -381,6 +382,7 @@ def fused_moe_kernel(
     FUSE_ADD_TO_OUTPUT: tl.constexpr,
     FUSE_SUM_ALL_REDUCE: tl.constexpr,
     ROUTER_TOPK: tl.constexpr,
+    USE_C_MAP_OUTPUT: tl.constexpr,
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -612,7 +614,13 @@ def fused_moe_kernel(
         # Accumulate into existing output with per-token mask.
         offs_token_out = offs_token // ROUTER_TOPK
         add_mask = tl.load(add_mask_ptr + offs_token_out, mask=token_mask, other=False)
-        c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        if USE_C_MAP_OUTPUT:
+            c_row = tl.load(c_map_ptr + offs_token, mask=token_mask, other=0).to(
+                tl.int64
+            )
+        else:
+            c_row = offs_token
+        c_ptrs = c_ptr + stride_cm * c_row[:, None] + stride_cn * offs_cn[None, :]
         c_mask = token_mask[:, None] & add_mask[:, None] & (offs_cn[None, :] < N)
         existing = tl.load(c_ptrs, mask=c_mask, other=0.0)
         tl.store(c_ptrs, existing + accumulator, mask=c_mask)
@@ -731,6 +739,7 @@ def invoke_fused_moe_kernel(
     router_topk: int = 1,
     fuse_add_to_output: bool = False,
     add_output_mask: Optional[torch.Tensor] = None,
+    c_map: Optional[torch.Tensor] = None,
 ) -> None:
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
@@ -807,6 +816,16 @@ def invoke_fused_moe_kernel(
         assert (
             add_output_mask is not None
         ), "add_output_mask required when fuse_add_to_output=True"
+    if c_map is not None:
+        assert (
+            fuse_add_to_output
+        ), "c_map output remap is only supported with fuse_add_to_output"
+        assert not c_sorted, "c_map output remap and c_sorted are mutually exclusive"
+        assert not (
+            use_int8_w8a16 or use_int4_w4a16
+        ), "c_map output remap is not supported for GPTQ/AWQ kernels"
+        assert c_map.dtype == torch.int32
+        assert c_map.stride(0) == 1
 
     if (
         (use_int8_w8a16 or use_int4_w4a16)
@@ -892,6 +911,7 @@ def invoke_fused_moe_kernel(
             expert_ids,
             num_tokens_post_padded,
             add_output_mask,
+            c_map,
             B.shape[1],
             B.shape[2] - padded_size,
             sorted_token_ids.shape[0],
@@ -926,6 +946,7 @@ def invoke_fused_moe_kernel(
             FUSE_ADD_TO_OUTPUT=fuse_add_to_output,
             FUSE_SUM_ALL_REDUCE=fuse_sum_all_reduce,
             ROUTER_TOPK=router_topk,
+            USE_C_MAP_OUTPUT=c_map is not None,
             **config,
         )
 

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -163,6 +163,7 @@ TBO_TOKEN_DISTRIBUTION_THRESHOLD: Optional[float] = None
 DEEPEP_CONFIG: Optional[str] = None
 DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER: Optional[bool] = None
 MOE_QUANTIZATION: Optional[str] = None
+ENABLE_LORA: Optional[bool] = None
 
 
 def initialize_moe_config(server_args: ServerArgs):
@@ -177,6 +178,7 @@ def initialize_moe_config(server_args: ServerArgs):
     global TBO_TOKEN_DISTRIBUTION_THRESHOLD
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     global MOE_QUANTIZATION
+    global ENABLE_LORA
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
@@ -199,6 +201,7 @@ def initialize_moe_config(server_args: ServerArgs):
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     )
     MOE_QUANTIZATION = server_args.quantization
+    ENABLE_LORA = server_args.enable_lora
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:
@@ -303,9 +306,14 @@ def filter_moe_weight_param_global_expert(name, x, num_local_experts):
 def should_use_flashinfer_cutlass_moe_fp4_allgather():
     """
     Perform FP4 quantize before all-gather for flashinfer cutlass moe to reduce communication cost for high-throughput serving.
+
+    Disabled for LoRA because the current Cutlass FP4 LoRA runner expects
+    bf16/float16 hidden states and local LoRA routing metadata, not the
+    dispatcher's pre-packed all-gathered FP4 payload.
     """
     return (
         not DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
+        and not ENABLE_LORA
         and get_moe_a2a_backend().is_none()
         and get_moe_runner_backend().is_flashinfer_cutlass()
         and is_dp_attention_enabled()

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1781,6 +1781,29 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             (1 / w2_input_scale).to(torch.float32),
         )
 
+        # ``[E]``-expanded fp32 view consumed by ``CutlassFp4LoraRunnerCore``.
+        # The source may be scalar (FlashInfer paths reduce all experts to a
+        # single max above) or already ``[E]``-shaped; expand once at load
+        # time so the hot path can hand it directly to the FP4 quant kernel.
+        E = layer.num_local_experts
+
+        def _to_per_expert(src: torch.Tensor) -> torch.Tensor:
+            flat = src.view(-1).to(torch.float32)
+            if flat.shape[0] == E:
+                return flat.contiguous()
+            return flat.expand(E).contiguous()
+
+        copy_or_rebind_param(
+            layer,
+            "w13_input_scale_quant_per_expert",
+            _to_per_expert(layer.w13_input_scale_quant),
+        )
+        copy_or_rebind_param(
+            layer,
+            "w2_input_scale_quant_per_expert",
+            _to_per_expert(layer.w2_input_scale_quant),
+        )
+
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         layer.dispatcher.set_quant_config(
             {
@@ -1984,6 +2007,30 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             self.enable_flashinfer_cutlass_moe or self._is_cutedsl_v2_standard
         )
 
+    def get_cutlass_fp4_quant_info(self, layer: torch.nn.Module):
+        """Build the LoRA-aware NVFP4 quant payload for ``CutlassFp4LoraRunnerCore``."""
+        from sglang.srt.lora.lora_moe_runner_cutlass_fp4 import (
+            CutlassFp4MoeQuantInfo,
+        )
+
+        return CutlassFp4MoeQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_blockscale_swizzled=layer.w13_blockscale_swizzled,
+            w2_blockscale_swizzled=layer.w2_blockscale_swizzled,
+            g1_alphas=layer.g1_alphas,
+            g2_alphas=layer.g2_alphas,
+            w13_input_scale_expanded=layer.w13_input_scale_quant_per_expert,
+            w2_input_scale_expanded=layer.w2_input_scale_quant_per_expert,
+            cutlass_moe_params=layer.cutlass_moe_params,
+            num_local_experts=layer.num_local_experts,
+            hidden_size=layer.hidden_size,
+            intermediate_size_per_partition=layer.intermediate_size_per_partition,
+            moe_ep_rank=layer.moe_ep_rank,
+            moe_ep_size=layer.moe_ep_size,
+            w13_swap_halves=self.load_up_proj_weight_first,
+        )
+
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
@@ -2160,7 +2207,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             topk_ids=topk_ids,
             params=layer.cutlass_moe_params,
             apply_router_weight_on_input=moe_runner_config.apply_router_weight_on_input,
-        ).to(x.dtype)
+        )
         # Scale by routed_scaling_factor is fused into select_experts.
         return StandardCombineInput(hidden_states=output)
 

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2027,7 +2027,6 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             hidden_size=layer.hidden_size,
             intermediate_size_per_partition=layer.intermediate_size_per_partition,
             moe_ep_rank=layer.moe_ep_rank,
-            moe_ep_size=layer.moe_ep_size,
             w13_swap_halves=self.load_up_proj_weight_first,
         )
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -879,6 +879,12 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.experts_shared_outer_loras: bool = False
         self.lora_use_virtual_experts: bool = False
         self.quant_method = base_layer.quant_method
+        self.moe_runner_config = base_layer.moe_runner_config
+        self.dispatcher = base_layer.dispatcher
+        self.num_local_experts = base_layer.num_local_experts
+        self.should_fuse_routed_scaling_factor_in_topk = (
+            base_layer.should_fuse_routed_scaling_factor_in_topk
+        )
 
         self.tp_size = getattr(base_layer, "moe_tp_size", 1)
         self.tp_rank = getattr(base_layer, "moe_tp_rank", 0)
@@ -927,6 +933,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         elif runner_backend.is_triton():
             assert base_layer.quant_method is not None, "Quant method must be set"
             self._quant_info = base_layer.quant_method.get_triton_quant_info(base_layer)
+        elif runner_backend.is_flashinfer_cutlass():
+            assert base_layer.quant_method is not None, "Quant method must be set"
+            self._quant_info = base_layer.quant_method.get_cutlass_fp4_quant_info(
+                base_layer
+            )
         else:
             raise NotImplementedError(
                 f"LoRA MoE not supported for backend {runner_backend}"
@@ -972,6 +983,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 len(lora_ranks), dtype=torch.int32, device=lora_ranks.device
             )
             adapter_enabled.index_fill_(0, wi.long(), 1)
+        rank_enabled = (lora_ranks > 0).to(
+            device=adapter_enabled.device, dtype=adapter_enabled.dtype
+        )
+        adapter_enabled.mul_(rank_enabled)
 
         seg_indptr = (
             batch_info.req_seg_indptr
@@ -1032,10 +1047,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             hidden_states=hidden_states, topk_output=topk_output
         )
 
-        # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
 
-        # Run the only lora moe runner (Triton)
         combine_input = self._lora_runner.run(
             dispatch_output, quant_info, lora_info=lora_info
         )

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -1,0 +1,228 @@
+"""FlashInfer-CUTLASS NVFP4 MoE runner core with LoRA support.
+
+Breaks open the upstream ``flashinfer_cutlass_fused_moe`` (a single black-box
+kernel called from ``ModelOptNvFp4FusedMoEMethod.apply``) into its FP4 group
+GEMMs so we can inject the standard ``after_gate_up`` / ``after_down`` LoRA
+hooks between w13 and w2, mirroring ``MarlinLoraRunnerCore``.
+
+Layout bridge: ``cutlass_fp4_group_mm`` writes expert-sorted ``[M*topk, *]``,
+the hooks expect token-major ``[M, topk, *]``. We round-trip via
+``shuffle_rows(.., c_map)`` (un-sort) and ``shuffle_rows(.., inv_c_map)``
+(re-sort) around ``after_gate_up``; for ``after_down`` the un-sort doubles
+as the combine permutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+)
+from sglang.srt.utils import is_cuda, is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+    from sglang.srt.lora.lora_moe_runners import LoRAHooks
+
+
+_is_cuda = is_cuda()
+_is_hip = is_hip()
+
+if _is_cuda:
+    from sgl_kernel import silu_and_mul
+elif _is_hip:
+    from vllm._custom_ops import silu_and_mul
+
+
+@dataclass
+class CutlassFp4MoeQuantInfo(MoeQuantInfo):
+    """Quantization payload consumed by ``CutlassFp4LoraRunnerCore``."""
+
+    w13_weight: torch.Tensor  # [E, 2 * N, K // 2] uint8
+    w2_weight: torch.Tensor  # [E, K, N // 2]     uint8
+    w13_blockscale_swizzled: torch.Tensor
+    w2_blockscale_swizzled: torch.Tensor
+    g1_alphas: torch.Tensor  # [E] fp32
+    g2_alphas: torch.Tensor  # [E] fp32
+    # ``[E]``-expanded once at load time so the hot path never has to expand.
+    w13_input_scale_expanded: torch.Tensor  # [E] fp32
+    w2_input_scale_expanded: torch.Tensor  # [E] fp32
+    cutlass_moe_params: object
+    num_local_experts: int
+    hidden_size: int
+    intermediate_size_per_partition: int
+    moe_ep_rank: int
+    moe_ep_size: int
+    # FlashInfer-CUTLASS loads w13 as ``[up | gate]`` (Kimi-K2.5).
+    w13_swap_halves: bool
+
+
+class CutlassFp4LoraRunnerCore:
+    """LoRA-aware NVFP4 MoE forward on the FlashInfer-CUTLASS GEMM primitives.
+
+    Pipeline: EP local-id remap → FP4 GEMM 1 → un-sort → ``after_gate_up`` →
+    re-sort → silu_and_mul → FP4 GEMM 2 → un-sort → ``after_down`` → combine.
+    """
+
+    def __init__(self, config: MoeRunnerConfig):
+        self.config = config
+
+    def run_from_dispatch(
+        self,
+        dispatch_output: "StandardDispatchOutput",
+        quant_info: CutlassFp4MoeQuantInfo,
+        runner_config: MoeRunnerConfig,
+        hooks: Optional["LoRAHooks"] = None,
+    ) -> "StandardCombineInput":
+        from sgl_kernel import prepare_moe_input
+
+        from sglang.srt.layers.moe.cutlass_moe import (
+            cutlass_fp4_group_mm,
+            scaled_fp4_experts_quant,
+            shuffle_rows,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.standard import (
+            StandardCombineInput,
+        )
+
+        hidden_states = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+        topk_weights = topk_output.topk_weights
+        topk_ids = topk_output.topk_ids
+
+        m_a = hidden_states.shape[0]
+        num_topk = topk_ids.shape[1]
+        out_dtype = hidden_states.dtype
+        device = hidden_states.device
+        E = quant_info.num_local_experts
+        K = quant_info.hidden_size
+        inter = quant_info.intermediate_size_per_partition
+        # This LoRA runner injects between the gate/up projection and the
+        # SwiGLU activation, so it only supports gated MoE weights.
+        N = quant_info.w13_weight.shape[1]
+        if N != inter * 2:
+            raise NotImplementedError(
+                "CutlassFp4LoraRunnerCore expects gated NVFP4 MoE weights with "
+                f"w13 output dim {inter * 2}, but got {N}."
+            )
+        params = quant_info.cutlass_moe_params
+        offsets = params.expert_offsets
+        total_tokens = m_a * num_topk
+
+        # StandardDispatcher hands flashinfer_cutlass global topk_ids; remap
+        # to local for the per-rank GEMM. Non-local tokens go to local expert
+        # 0 with weight 0 — they pay GEMM cost but contribute nothing.
+        local_offset = quant_info.moe_ep_rank * E
+        local_ids = topk_ids.to(torch.int32) - local_offset
+        non_local = (local_ids < 0) | (local_ids >= E)
+        local_ids = local_ids.masked_fill(non_local, 0)
+        local_weights = topk_weights.masked_fill(non_local, 0.0)
+
+        a_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        c_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
+        prepare_moe_input(
+            local_ids,
+            offsets,
+            params.problem_sizes1,
+            params.problem_sizes2,
+            a_map,
+            c_map,
+            E,
+            inter,
+            K,
+            params.blockscale_offsets,
+        )
+
+        # ---- GEMM 1 (w13)
+        rep_a_fp4, rep_a_blockscale = scaled_fp4_experts_quant(
+            hidden_states,
+            quant_info.w13_input_scale_expanded,
+            offsets,
+            params.blockscale_offsets,
+            num_topk,
+            expert_map=a_map,
+        )
+        gateup_flat = cutlass_fp4_group_mm(
+            rep_a_fp4,
+            quant_info.w13_weight,
+            rep_a_blockscale,
+            quant_info.w13_blockscale_swizzled,
+            quant_info.g1_alphas,
+            out_dtype,
+            params.to_gemm1_args(),
+        )
+
+        # ---- LoRA w13 delta
+        # Un-sort to token-major with ``c_map`` (pair-index permutation), run
+        # the hook, then re-sort with ``inv_c_map``. ``a_map`` is an M-index
+        # and is NOT a valid inverse for the pair-index ``[M*topk, *]`` tensor
+        # — using it silently corrupts every (token, k>0) row.
+        if hooks is not None and hooks.after_gate_up is not None:
+            inv_c_map = torch.empty_like(c_map)
+            inv_c_map[c_map.long()] = torch.arange(
+                total_tokens, device=c_map.device, dtype=c_map.dtype
+            )
+            gateup_token_major = shuffle_rows(gateup_flat, c_map, (total_tokens, N))
+            gateup_3d = gateup_token_major.view(m_a, num_topk, N)
+            hooks.after_gate_up(hidden_states, gateup_3d, topk_weights, topk_ids)
+            gateup_flat = shuffle_rows(
+                gateup_token_major.view(total_tokens, N),
+                inv_c_map,
+                (total_tokens, N),
+            )
+
+        # ---- silu + mul
+        if quant_info.w13_swap_halves:
+            # ``[up | gate]`` layout: silu(gate) * up = silu(second) * first.
+            intermediate = (
+                torch.nn.functional.silu(gateup_flat[:, N // 2 :].float())
+                * gateup_flat[:, : N // 2].float()
+            ).to(out_dtype)
+        else:
+            intermediate = torch.empty(
+                total_tokens, N // 2, dtype=out_dtype, device=device
+            )
+            silu_and_mul(gateup_flat, intermediate)
+
+        # ---- GEMM 2 (w2)
+        int_fp4, int_blockscale = scaled_fp4_experts_quant(
+            intermediate,
+            quant_info.w2_input_scale_expanded,
+            offsets,
+            params.blockscale_offsets,
+            num_topk,
+        )
+        out_flat = cutlass_fp4_group_mm(
+            int_fp4,
+            quant_info.w2_weight,
+            int_blockscale,
+            quant_info.w2_blockscale_swizzled,
+            quant_info.g2_alphas,
+            out_dtype,
+            params.to_gemm2_args(),
+        )
+
+        # Un-sort to token-major; needed by ``after_down`` and by the combine.
+        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
+
+        # Standard hook contract: the down hook adds a router-weighted delta
+        # into an already-router-weighted per-expert output.
+        if not runner_config.apply_router_weight_on_input:
+            out_3d = out_3d * local_weights.view(m_a, num_topk, 1).to(out_dtype)
+
+        # ---- LoRA w2 delta
+        if hooks is not None and hooks.after_down is not None:
+            intermediate_token_major = shuffle_rows(
+                intermediate, c_map, (total_tokens, N // 2)
+            )
+            hooks.after_down(intermediate_token_major, out_3d, local_weights, topk_ids)
+
+        return StandardCombineInput(hidden_states=out_3d.sum(dim=1))

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -37,8 +37,15 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 
 if _is_cuda:
-    from sgl_kernel import silu_and_mul
+    # In-tree JIT variant (carries the ``swap_halves`` flag added for the
+    # ``[Up | Gate]`` Kimi-K2.5 W13 loader layout). The sgl_kernel AOT
+    # build doesn't expose ``swap_halves`` yet; the JIT path is the only
+    # caller of swap_halves and is loaded on demand on first use.
+    from sglang.jit_kernel.activation import silu_and_mul
 elif _is_hip:
+    # HIP path doesn't reach the cutlass FP4 LoRA runner (SM100+ only).
+    # Keep the existing import for code-symmetry; if it's ever called with
+    # swap_halves=True it will raise.
     from vllm._custom_ops import silu_and_mul
 
 
@@ -81,6 +88,7 @@ class CutlassFp4LoraRunnerCore:
         quant_info: CutlassFp4MoeQuantInfo,
         runner_config: MoeRunnerConfig,
         hooks: Optional["LoRAHooks"] = None,
+        lora_info=None,
     ) -> "StandardCombineInput":
         from sgl_kernel import prepare_moe_input
 
@@ -97,6 +105,15 @@ class CutlassFp4LoraRunnerCore:
         topk_output = dispatch_output.topk_output
         topk_weights = topk_output.topk_weights
         topk_ids = topk_output.topk_ids
+
+        if (
+            lora_info is not None
+            and lora_info.lora_use_virtual_experts
+            and lora_info.has_active_lora
+        ):
+            raise NotImplementedError(
+                "Cutlass FP4 LoRA virtual experts are added in the virtual-experts PR."
+            )
 
         m_a = hidden_states.shape[0]
         num_topk = topk_ids.shape[1]
@@ -160,37 +177,31 @@ class CutlassFp4LoraRunnerCore:
             params.to_gemm1_args(),
         )
 
+        # Hand the LoRA hook builder the c_map so its kernel calls read/write
+        # against the expert-sorted base GEMM buffers directly, skipping the
+        # 3× ``shuffle_rows`` layout bridge the token-major contract would
+        # otherwise need (un-sort gateup, re-sort gateup, un-sort intermediate).
+        # ``sorted_layout=True`` also tells ``_add_lora_down_delta`` to leave
+        # the router weighting to the runner — see the post-W2 multiply below.
+        # The hook closures captured ``lora_info`` from ``build_lora_hooks`` so
+        # these mutations are visible at hook-call time.
+        if lora_info is not None:
+            lora_info.c_map = c_map
+            lora_info.sorted_layout = True
+
         # ---- LoRA w13 delta
-        # Un-sort to token-major with ``c_map`` (pair-index permutation), run
-        # the hook, then re-sort with ``inv_c_map``. ``a_map`` is an M-index
-        # and is NOT a valid inverse for the pair-index ``[M*topk, *]`` tensor
-        # — using it silently corrupts every (token, k>0) row.
+        # Output buffer is ``gateup_flat`` interpreted as ``[M, topk, 2N]``;
+        # the kernel uses c_map indirection to write the delta at the
+        # expert-sorted row matching the base GEMM output.
         if hooks is not None and hooks.after_gate_up is not None:
-            inv_c_map = torch.empty_like(c_map)
-            inv_c_map[c_map.long()] = torch.arange(
-                total_tokens, device=c_map.device, dtype=c_map.dtype
-            )
-            gateup_token_major = shuffle_rows(gateup_flat, c_map, (total_tokens, N))
-            gateup_3d = gateup_token_major.view(m_a, num_topk, N)
+            gateup_3d = gateup_flat.view(m_a, num_topk, N)
             hooks.after_gate_up(hidden_states, gateup_3d, topk_weights, topk_ids)
-            gateup_flat = shuffle_rows(
-                gateup_token_major.view(total_tokens, N),
-                inv_c_map,
-                (total_tokens, N),
-            )
 
         # ---- silu + mul
-        if quant_info.w13_swap_halves:
-            # ``[up | gate]`` layout: silu(gate) * up = silu(second) * first.
-            intermediate = (
-                torch.nn.functional.silu(gateup_flat[:, N // 2 :].float())
-                * gateup_flat[:, : N // 2].float()
-            ).to(out_dtype)
-        else:
-            intermediate = torch.empty(
-                total_tokens, N // 2, dtype=out_dtype, device=device
-            )
-            silu_and_mul(gateup_flat, intermediate)
+        # ``w13_swap_halves=True`` selects the ``[up | gate]`` convention
+        # (silu(second) * first) for FlashInfer-CUTLASS NVFP4 W13 loaders.
+        intermediate = torch.empty(total_tokens, N // 2, dtype=out_dtype, device=device)
+        silu_and_mul(gateup_flat, intermediate, swap_halves=quant_info.w13_swap_halves)
 
         # ---- GEMM 2 (w2)
         int_fp4, int_blockscale = scaled_fp4_experts_quant(
@@ -210,19 +221,18 @@ class CutlassFp4LoraRunnerCore:
             params.to_gemm2_args(),
         )
 
-        # Un-sort to token-major; needed by ``after_down`` and by the combine.
-        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
+        # ---- LoRA w2 delta
+        # Input ``intermediate`` is already expert-sorted (W13->silu output);
+        # the down kernel uses c_map indirection on BOTH input and output, so
+        # we don't materialize a token-major copy. ``mul_routed_weight=False``
+        # is set inside ``_add_lora_down_delta`` for sorted layout — the
+        # router weighting happens once below, over ``base + unweighted_delta``.
+        if hooks is not None and hooks.after_down is not None:
+            out_3d_sorted_view = out_flat.view(m_a, num_topk, K)
+            hooks.after_down(intermediate, out_3d_sorted_view, local_weights, topk_ids)
 
-        # Standard hook contract: the down hook adds a router-weighted delta
-        # into an already-router-weighted per-expert output.
+        # ---- combine: un-sort once, weight (base + delta) once, sum.
+        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
         if not runner_config.apply_router_weight_on_input:
             out_3d = out_3d * local_weights.view(m_a, num_topk, 1).to(out_dtype)
-
-        # ---- LoRA w2 delta
-        if hooks is not None and hooks.after_down is not None:
-            intermediate_token_major = shuffle_rows(
-                intermediate, c_map, (total_tokens, N // 2)
-            )
-            hooks.after_down(intermediate_token_major, out_3d, local_weights, topk_ids)
-
         return StandardCombineInput(hidden_states=out_3d.sum(dim=1))

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -1,16 +1,5 @@
-"""FlashInfer-CUTLASS NVFP4 MoE runner core with LoRA support.
-
-Breaks open the upstream ``flashinfer_cutlass_fused_moe`` (a single black-box
-kernel called from ``ModelOptNvFp4FusedMoEMethod.apply``) into its FP4 group
-GEMMs so we can inject the standard ``after_gate_up`` / ``after_down`` LoRA
-hooks between w13 and w2, mirroring ``MarlinLoraRunnerCore``.
-
-Layout bridge: ``cutlass_fp4_group_mm`` writes expert-sorted ``[M*topk, *]``,
-the hooks expect token-major ``[M, topk, *]``. We round-trip via
-``shuffle_rows(.., c_map)`` (un-sort) and ``shuffle_rows(.., inv_c_map)``
-(re-sort) around ``after_gate_up``; for ``after_down`` the un-sort doubles
-as the combine permutation.
-"""
+"""NVFP4 MoE runner that exposes ``after_gate_up`` / ``after_down`` LoRA hooks
+between the W13 and W2 group GEMMs of FlashInfer-CUTLASS."""
 
 from __future__ import annotations
 
@@ -36,30 +25,24 @@ if TYPE_CHECKING:
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 
+# Use the JIT silu_and_mul: it carries the ``swap_halves`` flag (the AOT
+# sgl_kernel build doesn't expose it yet) for Kimi-K2.5's ``[Up|Gate]`` W13.
 if _is_cuda:
-    # In-tree JIT variant (carries the ``swap_halves`` flag added for the
-    # ``[Up | Gate]`` Kimi-K2.5 W13 loader layout). The sgl_kernel AOT
-    # build doesn't expose ``swap_halves`` yet; the JIT path is the only
-    # caller of swap_halves and is loaded on demand on first use.
     from sglang.jit_kernel.activation import silu_and_mul
 elif _is_hip:
-    # HIP path doesn't reach the cutlass FP4 LoRA runner (SM100+ only).
-    # Keep the existing import for code-symmetry; if it's ever called with
-    # swap_halves=True it will raise.
+    # SM100+ only; this import is here for symmetry and should never run.
     from vllm._custom_ops import silu_and_mul
 
 
 @dataclass
 class CutlassFp4MoeQuantInfo(MoeQuantInfo):
-    """Quantization payload consumed by ``CutlassFp4LoraRunnerCore``."""
-
-    w13_weight: torch.Tensor  # [E, 2 * N, K // 2] uint8
-    w2_weight: torch.Tensor  # [E, K, N // 2]     uint8
+    w13_weight: torch.Tensor  # [E, 2*N, K // 2] uint8
+    w2_weight: torch.Tensor  # [E, K, N // 2]   uint8
     w13_blockscale_swizzled: torch.Tensor
     w2_blockscale_swizzled: torch.Tensor
     g1_alphas: torch.Tensor  # [E] fp32
     g2_alphas: torch.Tensor  # [E] fp32
-    # ``[E]``-expanded once at load time so the hot path never has to expand.
+    # [E]-expanded once at load time so the hot path doesn't broadcast.
     w13_input_scale_expanded: torch.Tensor  # [E] fp32
     w2_input_scale_expanded: torch.Tensor  # [E] fp32
     cutlass_moe_params: object
@@ -67,20 +50,16 @@ class CutlassFp4MoeQuantInfo(MoeQuantInfo):
     hidden_size: int
     intermediate_size_per_partition: int
     moe_ep_rank: int
-    moe_ep_size: int
-    # FlashInfer-CUTLASS loads w13 as ``[up | gate]`` (Kimi-K2.5).
+    # ``[Up|Gate]`` W13 layout (Kimi-K2.5): silu the second half, multiply the first.
     w13_swap_halves: bool
 
 
 class CutlassFp4LoraRunnerCore:
-    """LoRA-aware NVFP4 MoE forward on the FlashInfer-CUTLASS GEMM primitives.
-
-    Pipeline: EP local-id remap → FP4 GEMM 1 → un-sort → ``after_gate_up`` →
-    re-sort → silu_and_mul → FP4 GEMM 2 → un-sort → ``after_down`` → combine.
-    """
+    """LoRA-aware NVFP4 MoE forward on the FlashInfer-CUTLASS GEMM primitives."""
 
     def __init__(self, config: MoeRunnerConfig):
-        self.config = config
+        # config is unused today; runner_config is passed per-call.
+        pass
 
     def run_from_dispatch(
         self,
@@ -100,19 +79,18 @@ class CutlassFp4LoraRunnerCore:
             StandardCombineInput,
         )
 
+        # FP4 all-gather dispatch (gated by should_use_flashinfer_cutlass_moe_fp4_allgather)
+        # delivers pre-packed FP4 input; this runner re-quantizes bf16 only.
+        if getattr(dispatch_output, "hidden_states_scale", None) is not None:
+            raise NotImplementedError(
+                "CutlassFp4LoraRunnerCore does not support the FP4 all-gather "
+                "dispatch path; disable it for LoRA configurations."
+            )
+
         hidden_states = dispatch_output.hidden_states
         topk_output = dispatch_output.topk_output
         topk_weights = topk_output.topk_weights
         topk_ids = topk_output.topk_ids
-
-        if (
-            lora_info is not None
-            and lora_info.lora_use_virtual_experts
-            and lora_info.has_active_lora
-        ):
-            raise NotImplementedError(
-                "Cutlass FP4 LoRA virtual experts are added in the virtual-experts PR."
-            )
 
         m_a = hidden_states.shape[0]
         num_topk = topk_ids.shape[1]
@@ -134,8 +112,7 @@ class CutlassFp4LoraRunnerCore:
         total_tokens = m_a * num_topk
 
         # StandardDispatcher hands flashinfer_cutlass global topk_ids; remap
-        # to local for the per-rank GEMM. Non-local tokens go to local expert
-        # 0 with weight 0 — they pay GEMM cost but contribute nothing.
+        # to local. Non-local tokens go to local expert 0 with weight 0.
         local_offset = quant_info.moe_ep_rank * E
         local_ids = topk_ids.to(torch.int32) - local_offset
         non_local = (local_ids < 0) | (local_ids >= E)
@@ -176,22 +153,13 @@ class CutlassFp4LoraRunnerCore:
             params.to_gemm1_args(),
         )
 
-        # Hand the LoRA hook builder the c_map so its kernel calls read/write
-        # against the expert-sorted base GEMM buffers directly, skipping the
-        # 3× ``shuffle_rows`` layout bridge the token-major contract would
-        # otherwise need (un-sort gateup, re-sort gateup, un-sort intermediate).
-        # ``sorted_layout=True`` also tells ``_add_lora_down_delta`` to leave
-        # the router weighting to the runner — see the post-W2 multiply below.
-        # The hook closures captured ``lora_info`` from ``build_lora_hooks`` so
-        # these mutations are visible at hook-call time.
+        # Hand the LoRA hooks the c_map so their kernels read/write expert-sorted
+        # rows directly, skipping the token-major round-trips.
         if lora_info is not None:
             lora_info.c_map = c_map
             lora_info.sorted_layout = True
 
         # ---- LoRA w13 delta
-        # Output buffer is ``gateup_flat`` interpreted as ``[M, topk, 2N]``;
-        # the kernel uses c_map indirection to write the delta at the
-        # expert-sorted row matching the base GEMM output.
         if hooks is not None and hooks.after_gate_up is not None:
             gateup_3d = gateup_flat.view(m_a, num_topk, N)
             hooks.after_gate_up(hidden_states, gateup_3d, topk_weights, topk_ids)
@@ -220,19 +188,14 @@ class CutlassFp4LoraRunnerCore:
             params.to_gemm2_args(),
         )
 
-        # ---- LoRA w2 delta
-        # Input ``intermediate`` is already expert-sorted (W13->silu output);
-        # the down kernel uses c_map indirection on BOTH input and output, so
-        # we don't materialize a token-major copy. ``mul_routed_weight=False``
-        # is set inside ``_add_lora_down_delta`` for sorted layout — the
-        # router weighting happens once below, over ``base + unweighted_delta``.
+        # ---- LoRA w2 delta. Sorted-layout: hook writes unweighted delta into
+        # out_flat; router weighting happens once in the combine below.
         if hooks is not None and hooks.after_down is not None:
             out_3d_sorted_view = out_flat.view(m_a, num_topk, K)
             hooks.after_down(intermediate, out_3d_sorted_view, local_weights, topk_ids)
 
-        # ---- combine: un-sort once, weight (base + delta) once, sum. Keep
-        # router weights in fp32 to match FlashInfer-CUTLASS fused MoE's final
-        # accumulation; the kernel stores the final result as ``out_dtype``.
+        # ---- combine: un-sort, weight (base + delta), sum. Router weights stay
+        # fp32 to match FlashInfer-CUTLASS fused MoE's final accumulation.
         output = torch.empty((m_a, K), dtype=out_dtype, device=device)
         apply_shuffle_mul_sum(
             out_flat,

--- a/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
+++ b/python/sglang/srt/lora/lora_moe_runner_cutlass_fp4.py
@@ -90,12 +90,11 @@ class CutlassFp4LoraRunnerCore:
         hooks: Optional["LoRAHooks"] = None,
         lora_info=None,
     ) -> "StandardCombineInput":
-        from sgl_kernel import prepare_moe_input
+        from sgl_kernel import apply_shuffle_mul_sum, prepare_moe_input
 
         from sglang.srt.layers.moe.cutlass_moe import (
             cutlass_fp4_group_mm,
             scaled_fp4_experts_quant,
-            shuffle_rows,
         )
         from sglang.srt.layers.moe.token_dispatcher.standard import (
             StandardCombineInput,
@@ -141,7 +140,7 @@ class CutlassFp4LoraRunnerCore:
         local_ids = topk_ids.to(torch.int32) - local_offset
         non_local = (local_ids < 0) | (local_ids >= E)
         local_ids = local_ids.masked_fill(non_local, 0)
-        local_weights = topk_weights.masked_fill(non_local, 0.0)
+        local_weights = topk_weights.to(torch.float32).masked_fill(non_local, 0.0)
 
         a_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
         c_map = torch.empty(total_tokens, dtype=torch.int32, device=device)
@@ -231,8 +230,18 @@ class CutlassFp4LoraRunnerCore:
             out_3d_sorted_view = out_flat.view(m_a, num_topk, K)
             hooks.after_down(intermediate, out_3d_sorted_view, local_weights, topk_ids)
 
-        # ---- combine: un-sort once, weight (base + delta) once, sum.
-        out_3d = shuffle_rows(out_flat, c_map, (total_tokens, K)).view(m_a, num_topk, K)
-        if not runner_config.apply_router_weight_on_input:
-            out_3d = out_3d * local_weights.view(m_a, num_topk, 1).to(out_dtype)
-        return StandardCombineInput(hidden_states=out_3d.sum(dim=1))
+        # ---- combine: un-sort once, weight (base + delta) once, sum. Keep
+        # router weights in fp32 to match FlashInfer-CUTLASS fused MoE's final
+        # accumulation; the kernel stores the final result as ``out_dtype``.
+        output = torch.empty((m_a, K), dtype=out_dtype, device=device)
+        apply_shuffle_mul_sum(
+            out_flat,
+            output,
+            c_map,
+            (
+                None
+                if runner_config.apply_router_weight_on_input
+                else local_weights.reshape(-1)
+            ),
+        )
+        return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/lora/lora_moe_runner_marlin.py
+++ b/python/sglang/srt/lora/lora_moe_runner_marlin.py
@@ -63,6 +63,7 @@ class MarlinLoraRunnerCore:
         quant_info: MarlinMoeQuantInfo,
         runner_config: MoeRunnerConfig,
         hooks=None,
+        lora_info=None,  # accepted for interface uniformity; Marlin uses hooks directly
     ) -> StandardCombineInput:
         global _MARLIN_WORKSPACE
         from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -175,7 +175,7 @@ class LoRAInfo:
 
     # LoRA config per adapter
     lora_ranks: torch.Tensor  # [num_loras]
-    adapter_enabled: torch.Tensor  # [num_loras] - which adapters are enabled
+    adapter_enabled: torch.Tensor  # [num_loras] - requested adapters with rank > 0
     max_lora_rank: int  # Maximum LoRA rank across all adapters
 
     num_experts: int
@@ -214,7 +214,11 @@ def _compute_token_lora_mapping(
         token_positions,
         right=True,
     )
-    return lora_info.req_to_lora.to(torch.int32)[req_indices]
+    mapping = lora_info.req_to_lora.to(torch.int32)[req_indices]
+    valid = mapping >= 0
+    safe_mapping = mapping.clamp_min(0).long()
+    active = lora_info.adapter_enabled[safe_mapping] > 0
+    return torch.where(valid & active, mapping, torch.full_like(mapping, -1))
 
 
 def _compute_lora_alignment(

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -195,6 +195,7 @@ class LoRAInfo:
     c_map: torch.Tensor | None = None
     sorted_layout: bool = False
 
+
 @dataclass
 class LoRAHooks:
     """Hook callbacks for injecting LoRA deltas into the MoE pipeline."""
@@ -326,6 +327,10 @@ def _compute_lora_alignment(
     )
 
 
+def _sorted_layout_active(lora_info: LoRAInfo) -> bool:
+    return lora_info.sorted_layout and lora_info.c_map is not None
+
+
 def _add_lora_gate_up_delta(
     hidden_states: torch.Tensor,
     intermediate_cache: torch.Tensor,
@@ -388,6 +393,8 @@ def _add_lora_gate_up_delta(
         lora_b_stacked = [gate_up_b]
 
     if lora_info.lora_use_virtual_experts:
+        sorted_layout_active = _sorted_layout_active(lora_info)
+
         merged_experts_fused_moe_lora_add(
             output=intermediate_cache,
             hidden_states=hidden_states,
@@ -400,6 +407,9 @@ def _add_lora_gate_up_delta(
             experts_shared_outer_loras_a=lora_info.experts_shared_outer_loras,
             experts_shared_outer_loras_b=False,
             routing_cache=routing_cache,
+            c_map=lora_info.c_map if sorted_layout_active else None,
+            input_is_sorted=False,
+            output_is_sorted=sorted_layout_active,
         )
     else:
         blk = _get_moe_lora_block_config(r)
@@ -471,6 +481,7 @@ def _add_lora_down_delta(
         offset = 0
 
     if lora_info.lora_use_virtual_experts:
+        sorted_layout_active = _sorted_layout_active(lora_info)
         merged_experts_fused_moe_lora_add(
             output=intermediate_cache,
             hidden_states=intermediate_input,
@@ -479,18 +490,19 @@ def _add_lora_down_delta(
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             token_lora_mapping=token_lora_mapping,
-            mul_routed_weight=True,
+            mul_routed_weight=not sorted_layout_active,
             experts_shared_outer_loras_a=False,
             experts_shared_outer_loras_b=lora_info.experts_shared_outer_loras,
             routing_cache=routing_cache,
+            c_map=lora_info.c_map if sorted_layout_active else None,
+            input_is_sorted=sorted_layout_active,
+            output_is_sorted=sorted_layout_active,
         )
     else:
         blk = _get_moe_lora_block_config(lora_info.max_lora_rank)
-        # Sorted-layout callers apply router weights *after* the LoRA delta is
-        # accumulated into the expert-sorted output; running mul_routed_weight
-        # inside the kernel here would double-weight (Bug 4 reborn under the
-        # new layout). Token-major callers keep the existing single-weighting.
-        kernel_mul_routed_weight = not lora_info.sorted_layout
+        # Sorted-layout callers apply router weights themselves over base+delta;
+        # don't let the kernel pre-weight or we double-weight.
+        kernel_mul_routed_weight = not _sorted_layout_active(lora_info)
         fused_moe_lora(
             output=intermediate_cache,
             qcurr_hidden_states=intermediate_input,

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -188,6 +188,12 @@ class LoRAInfo:
     hidden_size: int = 0
     lora_use_virtual_experts: bool = False
 
+    # Set by the runner when its GEMM outputs are in expert-sorted layout.
+    # When ``sorted_layout`` is True and ``c_map`` is set, hook kernels
+    # address rows via ``c_map[pair_idx]`` and the runner applies router
+    # weights once over (base + delta) instead of the kernel doing it.
+    c_map: torch.Tensor | None = None
+    sorted_layout: bool = False
 
 @dataclass
 class LoRAHooks:
@@ -425,6 +431,7 @@ def _add_lora_gate_up_delta(
             expand_num_stages=2,
             expand_split_k=1,
             fully_sharded=lora_info.fully_sharded,
+            c_map=lora_info.c_map,
         )
 
 
@@ -479,6 +486,11 @@ def _add_lora_down_delta(
         )
     else:
         blk = _get_moe_lora_block_config(lora_info.max_lora_rank)
+        # Sorted-layout callers apply router weights *after* the LoRA delta is
+        # accumulated into the expert-sorted output; running mul_routed_weight
+        # inside the kernel here would double-weight (Bug 4 reborn under the
+        # new layout). Token-major callers keep the existing single-weighting.
+        kernel_mul_routed_weight = not lora_info.sorted_layout
         fused_moe_lora(
             output=intermediate_cache,
             qcurr_hidden_states=intermediate_input,
@@ -506,9 +518,10 @@ def _add_lora_down_delta(
             expand_num_warps=4,
             expand_num_stages=2,
             expand_split_k=1,
-            mul_routed_weight=True,
+            mul_routed_weight=kernel_mul_routed_weight,
             fully_sharded=lora_info.fully_sharded,
             offset=offset,
+            c_map=lora_info.c_map,
         )
 
 

--- a/python/sglang/srt/lora/triton_ops/fused_moe_lora_kernel.py
+++ b/python/sglang/srt/lora/triton_ops/fused_moe_lora_kernel.py
@@ -55,6 +55,7 @@ def _fused_moe_lora_kernel(
     sorted_token_ids_ptr,
     expert_ids_ptr,
     num_tokens_post_padded_ptr,
+    c_map_ptr,  # NULL unless USE_C_MAP_INPUT or USE_C_MAP_OUTPUT
     # Matrix dimensions
     N,
     K,
@@ -92,6 +93,15 @@ def _fused_moe_lora_kernel(
     USE_GDC: tl.constexpr,
     launch_pdl: tl.constexpr,
     IS_PRIMARY: tl.constexpr,
+    # c_map indirection — when set, the kernel reads/writes via
+    # ``c_map[offs_token]`` instead of ``offs_token``. Lets the caller keep
+    # tensors in expert-sorted layout and skip explicit ``shuffle_rows`` round
+    # trips. ``USE_C_MAP_INPUT`` applies when the input row is per-pair
+    # (down path: input is already expert-sorted intermediate);
+    # ``USE_C_MAP_OUTPUT`` applies when the output accumulator buffer is
+    # expert-sorted. Both default off so existing callers compile identically.
+    USE_C_MAP_INPUT: tl.constexpr,
+    USE_C_MAP_OUTPUT: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     slice_id = tl.program_id(axis=1)
@@ -146,12 +156,29 @@ def _fused_moe_lora_kernel(
     )
     token_mask = offs_token < num_valid_tokens
 
+    # c_map[offs_token] maps a token-major pair index back to the expert-sorted
+    # position used by ``cutlass_fp4_group_mm`` outputs. Only read if at least
+    # one side asks for the remap; constexpr-False keeps the load out of the
+    # SASS for existing callers.
+    if USE_C_MAP_INPUT or USE_C_MAP_OUTPUT:
+        offs_token_sorted = tl.load(
+            c_map_ptr + offs_token, mask=token_mask, other=0
+        ).to(tl.int64)
+
     # ================================================================= secure
 
     # get a_ptrs,b_ptrs
-    a_ptrs = cur_a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-    )
+    if USE_C_MAP_INPUT:
+        # Input is already expert-sorted (down path with sorted intermediate):
+        # read row at sorted_pos = c_map[pair_idx].
+        a_row = offs_token_sorted
+    else:
+        # Existing behavior: ``offs_token // top_k`` gives the M-index for
+        # the gate_up path (where ``a`` is token-major hidden_states), or
+        # ``offs_token`` itself when ``top_k == 1`` (down path with
+        # token-major intermediate, the existing default).
+        a_row = offs_token // top_k
+    a_ptrs = cur_a_ptr + (a_row[:, None] * stride_am + offs_k[None, :] * stride_ak)
 
     b_ptrs = (
         cur_b_ptr
@@ -195,9 +222,15 @@ def _fused_moe_lora_kernel(
         moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
         accumulator = accumulator * moe_weight[:, None]
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
-    # Write back the block of the output
+    # Write back the block of the output. For the sorted-layout path we land
+    # the delta at the expert-sorted row (sorted_pos), matching where the
+    # base GEMM output lives in the caller's buffer.
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = cur_c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    if USE_C_MAP_OUTPUT:
+        c_row = offs_token_sorted
+    else:
+        c_row = offs_token
+    c_ptrs = cur_c_ptr + stride_cm * c_row[:, None] + stride_cn * offs_cn[None, :]
     c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
 
     if SPLIT_K == 1:
@@ -239,6 +272,8 @@ def _fused_moe_lora_shrink(
     split_k: int,
     top_k_divisor: int = None,
     mul_routed_weight: bool = False,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
 ) -> None:
     w1_lora_a_stacked = lora_a_stacked[0]
 
@@ -272,6 +307,7 @@ def _fused_moe_lora_shrink(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
+        c_map,
         N,
         K,
         EM,
@@ -300,6 +336,11 @@ def _fused_moe_lora_shrink(
         ),
         MUL_ROUTED_WEIGHT=False,
         IS_PRIMARY=True,
+        # Shrink reads input via c_map only when caller marks the input as
+        # already expert-sorted (down path); the scratch ``a_intermediate``
+        # stays token-major regardless.
+        USE_C_MAP_INPUT=bool(input_is_sorted),
+        USE_C_MAP_OUTPUT=False,
         **shrink_config,
     )
 
@@ -339,6 +380,7 @@ def _fused_moe_lora_expand(
     split_k: int,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
 
     b_ptr = _get_ptr(lora_b_stacked, device)
@@ -377,6 +419,7 @@ def _fused_moe_lora_expand(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
+        c_map,
         N,
         K,
         EM,
@@ -401,6 +444,13 @@ def _fused_moe_lora_expand(
         top_k=1,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         IS_PRIMARY=False,
+        # Expand writes ``b_intermediate_cache1`` at expert-sorted positions
+        # via c_map iff the caller hands a c_map. The downstream Python
+        # accumulate (``output += b_intermediate_cache1``) then lands the
+        # delta on the matching expert-sorted row of ``output``. Caller is
+        # responsible for interpreting ``output`` in the expected layout.
+        USE_C_MAP_INPUT=False,
+        USE_C_MAP_OUTPUT=c_map is not None,
         **expand_config,
     )
     for i in range(num_slices):
@@ -442,6 +492,7 @@ def _fused_moe_lora(
     mul_routed_weight: bool = False,
     fully_sharded: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
     assert len(lora_a_stacked) == len(lora_b_stacked) > 0
     assert (
@@ -486,6 +537,11 @@ def _fused_moe_lora(
         device=device,
     )
 
+    # When the caller marks the layout sorted (``c_map is not None``) AND the
+    # input row is per-pair (``input_is_expanded``), the shrink reads its
+    # input via c_map. Gate-up path keeps M-index addressing regardless,
+    # because hidden_states is always token-major.
+    shrink_input_is_sorted = c_map is not None and input_is_expanded
     _fused_moe_lora_shrink(
         a_intermediate_cache1,
         qcurr_hidden_states,
@@ -515,6 +571,8 @@ def _fused_moe_lora(
         shrink_split_k,
         top_k_divisor=shrink_top_k_divisor,
         mul_routed_weight=False,
+        c_map=c_map,
+        input_is_sorted=shrink_input_is_sorted,
     )
 
     if fully_sharded:
@@ -562,6 +620,7 @@ def _fused_moe_lora(
         expand_split_k,
         mul_routed_weight,
         offset,
+        c_map=c_map,
     )
 
 
@@ -595,6 +654,7 @@ def _fused_moe_lora_fake(
     mul_routed_weight: bool = False,
     fully_sharded: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
     return
 
@@ -625,7 +685,10 @@ def _fused_moe_lora_shrink_fake(
     num_warps: int,
     num_stages: int,
     split_k: int,
+    top_k_divisor: int = None,
     mul_routed_weight: bool = False,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
 ) -> None:
     return
 
@@ -661,6 +724,7 @@ def _fused_moe_lora_expand_fake(
     split_k: int,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    c_map: torch.Tensor | None = None,
 ) -> None:
     return
 

--- a/python/sglang/srt/lora/triton_ops/fused_moe_lora_kernel.py
+++ b/python/sglang/srt/lora/triton_ops/fused_moe_lora_kernel.py
@@ -93,13 +93,8 @@ def _fused_moe_lora_kernel(
     USE_GDC: tl.constexpr,
     launch_pdl: tl.constexpr,
     IS_PRIMARY: tl.constexpr,
-    # c_map indirection — when set, the kernel reads/writes via
-    # ``c_map[offs_token]`` instead of ``offs_token``. Lets the caller keep
-    # tensors in expert-sorted layout and skip explicit ``shuffle_rows`` round
-    # trips. ``USE_C_MAP_INPUT`` applies when the input row is per-pair
-    # (down path: input is already expert-sorted intermediate);
-    # ``USE_C_MAP_OUTPUT`` applies when the output accumulator buffer is
-    # expert-sorted. Both default off so existing callers compile identically.
+    # c_map: when set, the kernel reads/writes ``c_map[offs_token]`` instead of
+    # ``offs_token`` to address expert-sorted layout without a shuffle_rows pass.
     USE_C_MAP_INPUT: tl.constexpr,
     USE_C_MAP_OUTPUT: tl.constexpr,
 ):
@@ -156,10 +151,6 @@ def _fused_moe_lora_kernel(
     )
     token_mask = offs_token < num_valid_tokens
 
-    # c_map[offs_token] maps a token-major pair index back to the expert-sorted
-    # position used by ``cutlass_fp4_group_mm`` outputs. Only read if at least
-    # one side asks for the remap; constexpr-False keeps the load out of the
-    # SASS for existing callers.
     if USE_C_MAP_INPUT or USE_C_MAP_OUTPUT:
         offs_token_sorted = tl.load(
             c_map_ptr + offs_token, mask=token_mask, other=0
@@ -169,14 +160,9 @@ def _fused_moe_lora_kernel(
 
     # get a_ptrs,b_ptrs
     if USE_C_MAP_INPUT:
-        # Input is already expert-sorted (down path with sorted intermediate):
-        # read row at sorted_pos = c_map[pair_idx].
         a_row = offs_token_sorted
     else:
-        # Existing behavior: ``offs_token // top_k`` gives the M-index for
-        # the gate_up path (where ``a`` is token-major hidden_states), or
-        # ``offs_token`` itself when ``top_k == 1`` (down path with
-        # token-major intermediate, the existing default).
+        # gate_up reads source token (pair // top_k); down with top_k==1 reads pair.
         a_row = offs_token // top_k
     a_ptrs = cur_a_ptr + (a_row[:, None] * stride_am + offs_k[None, :] * stride_ak)
 
@@ -222,9 +208,6 @@ def _fused_moe_lora_kernel(
         moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
         accumulator = accumulator * moe_weight[:, None]
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
-    # Write back the block of the output. For the sorted-layout path we land
-    # the delta at the expert-sorted row (sorted_pos), matching where the
-    # base GEMM output lives in the caller's buffer.
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     if USE_C_MAP_OUTPUT:
         c_row = offs_token_sorted
@@ -336,9 +319,6 @@ def _fused_moe_lora_shrink(
         ),
         MUL_ROUTED_WEIGHT=False,
         IS_PRIMARY=True,
-        # Shrink reads input via c_map only when caller marks the input as
-        # already expert-sorted (down path); the scratch ``a_intermediate``
-        # stays token-major regardless.
         USE_C_MAP_INPUT=bool(input_is_sorted),
         USE_C_MAP_OUTPUT=False,
         **shrink_config,
@@ -444,11 +424,6 @@ def _fused_moe_lora_expand(
         top_k=1,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         IS_PRIMARY=False,
-        # Expand writes ``b_intermediate_cache1`` at expert-sorted positions
-        # via c_map iff the caller hands a c_map. The downstream Python
-        # accumulate (``output += b_intermediate_cache1``) then lands the
-        # delta on the matching expert-sorted row of ``output``. Caller is
-        # responsible for interpreting ``output`` in the expected layout.
         USE_C_MAP_INPUT=False,
         USE_C_MAP_OUTPUT=c_map is not None,
         **expand_config,
@@ -537,10 +512,8 @@ def _fused_moe_lora(
         device=device,
     )
 
-    # When the caller marks the layout sorted (``c_map is not None``) AND the
-    # input row is per-pair (``input_is_expanded``), the shrink reads its
-    # input via c_map. Gate-up path keeps M-index addressing regardless,
-    # because hidden_states is always token-major.
+    # Down path with a sorted-layout caller: shrink reads input via c_map.
+    # Gate-up keeps M-index addressing (hidden_states is always token-major).
     shrink_input_is_sorted = c_map is not None and input_is_expanded
     _fused_moe_lora_shrink(
         a_intermediate_cache1,

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -156,6 +156,7 @@ def _moe_lora_shrink_splitk_kernel(
     sorted_token_ids_ptr,  # type: ignore
     expert_ids_ptr,  # type: ignore
     num_tokens_post_padded_ptr,  # type: ignore
+    c_map_ptr,  # type: ignore  # NULL unless USE_C_MAP_INPUT
     # Dimensions
     N,  # type: ignore
     K,  # type: ignore
@@ -170,6 +171,7 @@ def _moe_lora_shrink_splitk_kernel(
     stride_cn,  # type: ignore
     # Constexprs
     top_k: tl.constexpr,
+    USE_C_MAP_INPUT: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
@@ -208,9 +210,14 @@ def _moe_lora_shrink_splitk_kernel(
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
     offs_k = pid_sk * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
 
-    a_ptrs = a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-    )
+    if USE_C_MAP_INPUT:
+        # Sorted-layout input: c_map[pair_idx] -> physical row.
+        a_row = tl.load(c_map_ptr + offs_token, mask=token_mask, other=0).to(tl.int64)
+    else:
+        # Token-major: gate_up reads source token; down with top_k==1 reads pair.
+        a_row = offs_token // top_k
+
+    a_ptrs = a_ptr + (a_row[:, None] * stride_am + offs_k[None, :] * stride_ak)
     b_ptrs = (
         b_ptr
         + off_expert * stride_be
@@ -255,6 +262,8 @@ def _invoke_moe_lora_shrink_splitk(
     num_tokens_post_padded: torch.Tensor,
     top_k: int,
     config: dict[str, Any],
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
 ) -> None:
     """Launch split-K shrink kernel for LoRA A with few virtual experts."""
     N = weight.shape[1]
@@ -279,6 +288,7 @@ def _invoke_moe_lora_shrink_splitk(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
+        c_map,
         N,
         K,
         topk_ids.numel(),
@@ -290,6 +300,7 @@ def _invoke_moe_lora_shrink_splitk(
         output.stride(0),
         output.stride(1),
         top_k=top_k,
+        USE_C_MAP_INPUT=input_is_sorted,
         BLOCK_SIZE_M=BLOCK_SIZE_M,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
@@ -507,6 +518,9 @@ def _merged_experts_fused_moe_lora_add_fake(
     mul_routed_weight: bool,
     experts_shared_outer_loras_a: bool,
     experts_shared_outer_loras_b: bool,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
+    output_is_sorted: bool = False,
 ) -> None:
     return
 
@@ -523,13 +537,19 @@ def _merged_experts_fused_moe_lora_add_impl(
     experts_shared_outer_loras_a: bool,
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
+    output_is_sorted: bool = False,
 ) -> None:
     """
     1. Prepare virtual expert routing metadata from topk_ids + token_lora_mapping * num_experts.
     2. Flatten LoRA weights from [max_loras, num_experts, ...] to [max_loras * num_experts, ...].
-    3. Run regular SGLang fused-MoE kernels for LoRA A and LoRA B.
+    3. Run LoRA A shrink, then LoRA B expand/add with optional c_map layout.
     4. Mask out tokens with token_lora_mapping == -1 on the add path.
     """
+    if (input_is_sorted or output_is_sorted) and c_map is None:
+        raise ValueError("c_map is required when sorted virtual-expert layout is used")
+
     max_loras, _, max_lora_rank, _ = lora_a.shape
     input_top_k = 1 if hidden_states.shape[0] == topk_ids.numel() else topk_ids.shape[1]
 
@@ -637,10 +657,6 @@ def _merged_experts_fused_moe_lora_add_impl(
 
         return result
 
-    from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels import (
-        invoke_fused_moe_kernel,
-    )
-
     lora_a_virtual = _merge_lora_expert_weight(lora_a)
     lora_b_virtual = _merge_lora_expert_weight(lora_b)
     num_experts_a = lora_a.shape[1]
@@ -676,6 +692,8 @@ def _merged_experts_fused_moe_lora_add_impl(
         num_tokens_post_padded,
         input_top_k,
         a_stage_config,
+        c_map=c_map,
+        input_is_sorted=input_is_sorted,
     )
 
     b_stage_config = _get_stage_config(lora_b_virtual, 1)
@@ -692,33 +710,59 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    invoke_fused_moe_kernel(
-        intermediate.view(-1, max_lora_rank),
-        lora_b_virtual,
-        None,
-        output,
-        None,
-        None,
-        None,
-        topk_weights,
-        topk_ids,
-        sorted_token_ids,
-        expert_ids,
-        num_tokens_post_padded,
-        mul_routed_weight,
-        1,
-        b_stage_config,
-        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-        False,
-        False,
-        False,
-        False,
-        False,
-        None,
-        fuse_add_to_output=True,
-        add_output_mask=token_lora_mask,
-        router_topk=topk_ids.shape[1],
+    # Gated MLP: lora_a stacks [gate|up] along rank (=2r), lora_b keeps rank=r
+    # but stacks gate/up along the output dim. Run expand twice with matching
+    # A and B slices so the up rank slice isn't dropped.
+    expand_rank = lora_b_virtual.shape[-1]
+    is_gated_expand = max_lora_rank > expand_rank
+    intermediate_2d = intermediate.view(-1, max_lora_rank)
+    out_dim = lora_b_virtual.shape[1]
+
+    from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels import (
+        invoke_fused_moe_kernel,
     )
+
+    def _do_expand(a_slice_2d, b_slice_3d, out_slice):
+        invoke_fused_moe_kernel(
+            a_slice_2d,
+            b_slice_3d,
+            None,
+            out_slice,
+            None,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            1,
+            b_stage_config,
+            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+            fuse_add_to_output=True,
+            add_output_mask=token_lora_mask,
+            router_topk=topk_ids.shape[1],
+            c_map=c_map if output_is_sorted else None,
+        )
+
+    if is_gated_expand:
+        n_half = out_dim // 2
+        output_full_2d = output.view(-1, out_dim)
+        for s in range(2):
+            _do_expand(
+                intermediate_2d[:, s * expand_rank : (s + 1) * expand_rank],
+                lora_b_virtual[:, s * n_half : (s + 1) * n_half, :],
+                output_full_2d[:, s * n_half : (s + 1) * n_half],
+            )
+    else:
+        _do_expand(intermediate_2d, lora_b_virtual, output)
 
 
 def _merged_experts_fused_moe_lora_add_op(
@@ -732,6 +776,9 @@ def _merged_experts_fused_moe_lora_add_op(
     mul_routed_weight: bool,
     experts_shared_outer_loras_a: bool,
     experts_shared_outer_loras_b: bool,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
+    output_is_sorted: bool = False,
 ) -> None:
     _merged_experts_fused_moe_lora_add_impl(
         output,
@@ -744,6 +791,9 @@ def _merged_experts_fused_moe_lora_add_op(
         mul_routed_weight,
         experts_shared_outer_loras_a,
         experts_shared_outer_loras_b,
+        c_map=c_map,
+        input_is_sorted=input_is_sorted,
+        output_is_sorted=output_is_sorted,
     )
 
 
@@ -769,6 +819,9 @@ def merged_experts_fused_moe_lora_add(
     experts_shared_outer_loras_a: bool,
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
+    c_map: torch.Tensor | None = None,
+    input_is_sorted: bool = False,
+    output_is_sorted: bool = False,
 ) -> None:
     """Public API: wraps the registered op with routing_cache support."""
     _merged_experts_fused_moe_lora_add_impl(
@@ -783,4 +836,7 @@ def merged_experts_fused_moe_lora_add(
         experts_shared_outer_loras_a,
         experts_shared_outer_loras_b,
         routing_cache,
+        c_map=c_map,
+        input_is_sorted=input_is_sorted,
+        output_is_sorted=output_is_sorted,
     )

--- a/sgl-kernel/csrc/moe/prepare_moe_input.cu
+++ b/sgl-kernel/csrc/moe/prepare_moe_input.cu
@@ -255,7 +255,7 @@ void shuffle_rows(const torch::Tensor& input_tensor, const torch::Tensor& dst2sr
   return;
 }
 
-template <typename scalar_t>
+template <typename scalar_t, typename factor_t>
 __global__ void apply_shuffle_mul_sum_kernel(
     const scalar_t* __restrict__ input_tensor,  // [m * topk, k] (expert-major layout)
     scalar_t* __restrict__ output_tensor,       // [m, k] (token-major layout)
@@ -263,7 +263,7 @@ __global__ void apply_shuffle_mul_sum_kernel(
     int m,
     int topk,
     int row_stride,
-    const scalar_t* __restrict__ factors)  // [m * topk] (topk_weights, token-major layout)
+    const factor_t* __restrict__ factors)  // [m * topk] (topk_weights, token-major layout)
 {
   int i = blockIdx.x;
   if (i >= m) {
@@ -290,7 +290,7 @@ __global__ void apply_shuffle_mul_sum_kernel(
 
       t factor = 1.0;
       if (factors != nullptr) {
-        factor = factors[token_major_idx];
+        factor = static_cast<t>(factors[token_major_idx]);
       }
 
 #pragma unroll
@@ -312,7 +312,7 @@ __global__ void apply_shuffle_mul_sum_kernel(
 
       t factor = 1.0;
       if (factors != nullptr) {
-        factor = factors[token_major_idx];
+        factor = static_cast<t>(factors[token_major_idx]);
       }
       sum_val += factor * val;
     }
@@ -324,7 +324,7 @@ void get_apply_shuffle_mul_sum_caller(
     const torch::Tensor& input_tensor,                // [m * topk, row_stride], bf16/f16
     torch::Tensor& output_tensor,                     // [m, row_stride], bf16/f16
     const torch::Tensor& permutation,                 // [m * topk], int32
-    const std::optional<torch::Tensor>& factors_opt)  // optional [m * topk], bf16/f16
+    const std::optional<torch::Tensor>& factors_opt)  // optional [m * topk], bf16/f16/fp32
 {
   TORCH_CHECK(input_tensor.dim() == 2, "input_tensor must be 2D [m * topk, row_stride]");
   TORCH_CHECK(output_tensor.dim() == 2, "output_tensor must be 2D [m, row_stride]");
@@ -347,21 +347,36 @@ void get_apply_shuffle_mul_sum_caller(
   const int32_t* perm_ptr = permutation.data_ptr<int32_t>();
 
   void* factors_ptr = nullptr;
+  bool factors_are_fp32 = false;
   if (factors_opt.has_value()) {
-    TORCH_CHECK(factors_opt->dtype() == output_tensor.dtype(), "Factors must match output dtype");
+    TORCH_CHECK(
+        factors_opt->dtype() == output_tensor.dtype() || factors_opt->dtype() == torch::kFloat32,
+        "Factors must match output dtype or be float32");
     TORCH_CHECK(factors_opt->numel() == m * topk, "Factors must have shape [m * topk]");
+    factors_are_fp32 = factors_opt->dtype() == torch::kFloat32;
     factors_ptr = factors_opt->data_ptr();
   }
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(output_tensor.scalar_type(), scalar_t, [&] {
-    apply_shuffle_mul_sum_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        static_cast<const scalar_t*>(input_tensor.data_ptr()),
-        static_cast<scalar_t*>(output_tensor.data_ptr()),
-        perm_ptr,
-        m,
-        topk,
-        row_stride,
-        static_cast<const scalar_t*>(factors_ptr));
+    if (factors_are_fp32) {
+      apply_shuffle_mul_sum_kernel<scalar_t, float><<<grid, block, 0, stream>>>(
+          static_cast<const scalar_t*>(input_tensor.data_ptr()),
+          static_cast<scalar_t*>(output_tensor.data_ptr()),
+          perm_ptr,
+          m,
+          topk,
+          row_stride,
+          static_cast<const float*>(factors_ptr));
+    } else {
+      apply_shuffle_mul_sum_kernel<scalar_t, scalar_t><<<grid, block, 0, stream>>>(
+          static_cast<const scalar_t*>(input_tensor.data_ptr()),
+          static_cast<scalar_t*>(output_tensor.data_ptr()),
+          perm_ptr,
+          m,
+          topk,
+          row_stride,
+          static_cast<const scalar_t*>(factors_ptr));
+    }
     return true;
   });
 }
@@ -371,7 +386,7 @@ void get_apply_shuffle_mul_sum_caller(
  *
  * This function performs the equivalent of the following PyTorch expression:
  *
- *     (c2[c_map].view(m, topk, k) * topk_weights.view(m, topk, 1).to(out_dtype)).sum(dim=1)
+ *     (c2[c_map].view(m, topk, k) * topk_weights.view(m, topk, 1)).sum(dim=1).to(out_dtype)
  *
  * Specifically:
  * - `input` is shuffled using the `permutation` tensor.
@@ -382,6 +397,7 @@ void get_apply_shuffle_mul_sum_caller(
  * @param output       Output tensor of shape (m, k), where the final reduced results are stored.
  * @param permutation  Index tensor (e.g., c_map) that maps positions in `input` to shuffled layout.
  * @param factors      Optional scaling factors (e.g., top-k weights), shape (m * topk) or (m, topk).
+ *                     May match output dtype or be float32.
  */
 void apply_shuffle_mul_sum(
     const torch::Tensor& input,


### PR DESCRIPTION
Reference: split from the overall PR [sgl-project/sglang#25202](https://github.com/sgl-project/sglang/pull/25202).

## Motivation

The non-virtual expert LoRA path works after PR1-PR3, but the virtual-expert path needs matching sorted-layout support. Without it, enabling virtual experts either needs layout bridges or can write/read the LoRA delta in the wrong row layout. There is also a gated-MLP correctness issue where the virtual-expert expand stage can drop the up half.

## Approach

This PR extends the virtual-expert LoRA kernels and the fused MoE expand-add helper with `c_map` output remapping, then wires that through the standard MoE LoRA hooks. It also fixes the gated expand stage by expanding both gate and up slices.

Virtual experts are enabled with the server flag `--lora-use-virtual-experts`.

## Key Changes

- Add sorted-layout `c_map` support to `merged_experts_fused_moe_lora_add`.
- Extend `invoke_fused_moe_kernel` with a `c_map` output remap for `fuse_add_to_output=True`.
- Fix gated virtual-expert expand by running the expand over both gate and up slices instead of only the first rank slice.
- Remove the temporary virtual-experts guard from `CutlassFp4LoraRunnerCore`.
- Keep non-VE C behavior aligned with PR3.

## Accuracy

Same two-node TP=8 setup as PR1. Accuracy captures use the 1809-token sequence from [`compare_sample_train_data.pt`](https://huggingface.co/datasets/yushengsu/lora-diff-Kimi-K2.5/blob/main/compare_sample_train_data.pt), request `max_new_tokens=0`, return input-token logprobs, and compare 1808 positions.

Dataset input-logprob diff:

| Pair | mean abs | max abs | half squared mean | identical |
|---|---:|---:|---:|---|
| B vs PR4 C-nolora | 0.000000 | 0.000000 | 0.000000 | true |
| PR3 C-lora vs PR4 C-lora | 0.000000 | 0.000000 | 0.000000 | true |
| PR4 C-lora vs PR4 C-VE-lora | 0.000000 | 0.000000 | 0.000000 | true |

The VE path matches the non-VE active-LoRA path exactly on the dataset capture, and PR4 does not move the PR3 non-VE behavior.

## Performance

`bs=32`, `input_len=1024`, `output_len=2048`.

| Variant | prefill time (s) | prefill tok/s | decode time (s) | decode tok/s | total latency (s) | overall tok/s |
|---|---:|---:|---:|---:|---:|---:|
| PR3 C-nolora | 1.10 | 29767 | 421.17 | 155.61 | 422.27 | 232.80 |
| PR3 C-lora | 1.72 | 19080 | 411.27 | 159.35 | 412.99 | 238.03 |
| PR4 C-nolora | 1.05 | 31314 | 420.85 | 155.72 | 421.90 | 233.01 |
| PR4 C-lora | 1.72 | 19026 | 411.29 | 159.34 | 413.01 | 238.02 |
| PR4 C-VE-lora | 1.53 | 21380 | 380.20 | 172.37 | 381.73 | 257.52 |

The VE path is faster than the non-VE active path in this single-shape run, while the normal C-lora path is unchanged from PR3.

## Validation

- `python -m py_compile` on the touched Python files.
- `git diff --check`.
- Two-node C and C-VE server launches on `mnnvl-yanbin-0/1`.
- Dataset-based accuracy capture for C-nolora, C-lora, and C-VE-lora.
- Active C-VE perf with `--lora-use-virtual-experts`, not `SGLANG_USE_VIRTUAL_EXPERTS`.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->