### PR TITLE
[CI] Enable weight loader prefetch in CI

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3564,6 +3564,9 @@ class ServerArgs:
                 )
                 self.load_format = "auto"
 
+        if self.load_format == "auto" and is_in_ci():
+            self.weight_loader_prefetch_checkpoints = True
+
         # Check whether TransferEngine can be used when users want to start seed service that supports TransferEngine backend.
         if self.remote_instance_weight_loader_start_seed_via_transfer_engine:
             self.remote_instance_weight_loader_start_seed_via_transfer_engine = (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3564,7 +3564,7 @@ class ServerArgs:
                 )
                 self.load_format = "auto"
 
-        if self.load_format == "auto" and is_in_ci():
+        if self.load_format in ["auto", "mistral"] and is_in_ci():
             self.weight_loader_prefetch_checkpoints = True
 
         # Check whether TransferEngine can be used when users want to start seed service that supports TransferEngine backend.


### PR DESCRIPTION
Enable weight loader prefetching in CI when load_format is auto.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Weight loading is a non-trivial fraction of CI wall time on bandwidth-bottlenecked runners (notably the 8-GPU H200 box where model checkpoints come off network storage). The existing `weight_loader_prefetch_checkpoints` path (`weight_utils.py:_prefetch_all_checkpoints`) warms the OS page cache from a background thread while `mmap`-based loading runs in the foreground, with each local rank sharding `1/local_world_size` of the shards. Turning it on for CI when `load_format ∈ {auto, mistral}` should be a free speedup on slow-storage runners with negligible cost elsewhere.

## Modifications

`server_args.py:_handle_load_format`: set `weight_loader_prefetch_checkpoints=True` when `is_in_ci()` and `load_format ∈ {auto, mistral}`. 3-line change, no other behavior touched.

## Accuracy Tests

No model-output changes; this only affects when checkpoint bytes are pulled into the page cache.

## Speed Tests and Profiling

Compared `Load weight end. elapsed=` lines (`model_runner.py:1554`) between this PR's CI run (`runs/25976567086`) and the 2026-05-17 scheduled main run (`runs/25978269530`), with a second main run (`runs/25932256364`) used to gauge per-runner variance.

### Per-runner per-model load times

| Runner / job | Model | PR (prefetch) | Main (no prefetch) | Verdict |
|---|---|---|---|---|
| `base-c-test-8-gpu-h200 (0)` | MiniMaxM2 27GB | 20.4–21.1s | **110.8–111.0s** | **~5.4× faster** (8 sequential loads tight-clustered → bandwidth-bound) |
| `base-c-test-8-gpu-h200 (0)` | Qwen3Next 37GB | 24.4–26.4s | 98.5–99.0s | **~3.9× faster** |
| `base-c-test-8-gpu-h200 (0)` | DeepseekV4 68GB | 39.7–42.7s | 58.2–64.9s | ~33% faster |
| `base-c-test-dsv4-8-gpu-h200 (0)` | DSv4 38–46GB | 50–79s | 33–65s | PR slightly worse (cache state) |
| `base-c-test-8-gpu-h20 (0)` | DSv3 / Llama small | 1.1–4.3s | 1.1–4.4s | neutral |
| `base-c-test-4-gpu-h100 (0)` | Qwen3 / GptOss | 3.3–6.9s | 2.3–5.8s | PR ~1s slower per load |
| `base-b-test-4-gpu-b200 (0)` | DSv3 94GB | 186–199s | 44–49s | apparent ~4× regression — see note below |
| `base-b-test-1-gpu-small/large` | Llama / Qwen2.5 | 0.5–6.4s | 0.5–3.3s | PR up to ~1s slower per load |

### The B200 "regression" is runner-cache variance, not the PR

A separate scheduled main run from 2026-05-15 (`runs/25932256364`) shows the same `4-gpu-b200` job loading DSv3 94GB in **174–204s** — matching this PR's 186–199s — and job wall time **1365s** vs the PR's 1370s. The 2026-05-17 main run was simply the lucky case (warm page cache, 44s loads, 857s wall time). PR ≈ cold main; recent main is the outlier. The same caveat applies to the H100 4-GPU wall-time bump.

### Aggregate job-time impact (PR vs 2026-05-17 main)

| Job | PR dur | Main dur | Δ |
|---|---|---|---|
| `base-b-test-1-gpu-small (0)` | 1299s | 1328s | **−29s** |
| `base-b-test-1-gpu-small (1)` | 1498s | 1516s | **−18s** |
| `base-b-test-1-gpu-large (0)` | 1283s | 1433s | **−150s** |
| `base-b-test-4-gpu-b200 (0)` | 1370s | 857s | +513s (cache artifact) |
| `base-c-test-4-gpu-h100 (0)` | 1441s | 1207s | +234s (cache artifact) |
| `base-c-test-8-gpu-h200 (0)` | 1185s | 1326s | **−141s** |
| `base-c-test-dsv4-8-gpu-h200 (0)` | 1163s | 1250s | **−87s** |
| `base-c-test-8-gpu-h20 (0)` | 1424s | 1431s | −7s |

Net across these 8 jobs: ~4 minutes saved against the warm-cache main reference; the H200-8-GPU job alone reclaims ~12 minutes of MiniMaxM2 load time per run (90s × 8 sequential loads collapse to ~20s each).

### Conclusion

Worst credible cost is ~0.5–1s of extra latency per load on fast-disk runners (H100/H20/CPU box), which is inside per-runner variance noise. Wins on bandwidth-bound H200 storage are 3–5×, dominating the cost. The change is confined to CI via `is_in_ci()` and trivially revertable. A possible follow-up if more selectivity is wanted: gate on an env var (e.g. `SGLANG_CI_PREFETCH_WEIGHTS`) set only on the H200 runners where the gain is largest.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.














<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25976567086](https://github.com/sgl-project/sglang/actions/runs/25976567086)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->[Run #25976567046](https://github.com/sgl-project/sglang/actions/runs/25976567046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
