### PR TITLE
unify page allocation estimation to kv_allocated_len

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -70,6 +70,7 @@ from sglang.srt.mem_cache.common import (
     alloc_for_decode,
     alloc_for_extend,
     evict_from_tree_cache,
+    new_tokens_for_alloc,
     release_kv_cache,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -2144,9 +2145,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         total = 0
         for r in requests:
             x = max(0, r.kv_committed_len + 2 * alloc_len - r.kv_allocated_len)
-            cur = r.kv_allocated_len
-            nxt = cur + x
-            total += ceil_align(nxt, page_size) - ceil_align(cur, page_size)
+            total += new_tokens_for_alloc(r.kv_allocated_len, x, page_size)
         return total
 
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.utils.common import ceil_align, is_pin_memory_available
+from sglang.srt.utils.common import is_pin_memory_available
 
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2120,22 +2120,31 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if self.is_spec_v2:
             return self._new_tokens_required_next_decode_spec_v2(requests, page_size)
 
+        return self._new_tokens_required_next_decode_spec_v1(requests, page_size)
+
+    def _new_tokens_required_next_decode_spec_v1(self, requests, page_size):
+        """Per-req exact estimate matching eagle_worker.draft alloc shape.
+
+        Topk > 1 branches each take their own page-aligned chunk
+        (ceil((last_page + len_per_topk) / ps) pages); verify phase allocs
+        one contiguous spec_tokens block. Budget reserves max of the two.
+        """
         server_args = get_global_server_args()
         len_per_topk = server_args.speculative_num_steps or 1
         spec_topk = server_args.speculative_eagle_topk or 1
         spec_tokens = server_args.speculative_num_draft_tokens
 
-        if page_size > 1 and spec_topk > 1:
-            # last partial page and ceil alignment
-            len_per_topk = ceil_align(len_per_topk + page_size, page_size)
-            spec_tokens = ceil_align(spec_tokens, page_size)
-        elif page_size > 1:
-            # only page alignment
-            len_per_topk = ceil_align(len_per_topk, page_size)
-            spec_tokens = ceil_align(spec_tokens, page_size)
-
-        num_tokens = max(len_per_topk * spec_topk, spec_tokens) * len(requests)
-        return num_tokens
+        total = 0
+        for r in requests:
+            if page_size > 1 and spec_topk > 1:
+                last_page = r.kv_allocated_len % page_size
+                branch_pages = (last_page + len_per_topk + page_size - 1) // page_size
+                n_topk = spec_topk * branch_pages * page_size - last_page
+            else:
+                n_topk = len_per_topk * spec_topk
+            n = max(n_topk, spec_tokens)
+            total += new_tokens_for_alloc(r.kv_allocated_len, n, page_size)
+        return total
 
     def _new_tokens_required_next_decode_spec_v2(self, requests, page_size):
         """Tight estimate matching eagle_info_v2.prepare_for_decode allocation."""

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -720,7 +720,7 @@ class PrefillAdder:
                 self.tree_cache.dec_lock_ref(last_node)
 
     def add_one_req_ignore_eos(self, req: Req):
-        paged_input = self.ceil_paged_tokens(req.extend_input_len)
+        paged_input = new_tokens_for_alloc(0, req.extend_input_len, self.page_size)
         if paged_input > min(self.cur_rem_tokens, self.rem_total_tokens):
             return AddReqResult.NO_TOKEN
         if self.is_hybrid_swa:
@@ -763,8 +763,8 @@ class PrefillAdder:
         if not self.is_hybrid_swa:
             # Skip this logic for swa. The SWA has different memory management, and
             # this mechanism is underestimating the memory usage.
-            cur_rem_tokens = self.cur_rem_tokens - self.ceil_paged_tokens(
-                req.extend_input_len
+            cur_rem_tokens = self.cur_rem_tokens - new_tokens_for_alloc(
+                0, req.extend_input_len, self.page_size
             )
             tokens_freed = 0
             for i, (tokens_left, tokens_occupied) in enumerate(self.req_states):

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -841,21 +841,16 @@ class PrefillAdder:
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
             return self.add_one_req_ignore_eos(req)
 
-        # Reserve page_size for page-alignment overhead. The paged allocator
-        # may consume up to one extra page per request (see alloc_extend), and
-        # _update_prefill_budget already accounts for this in the deduction.
-        # Without this, admission is more optimistic than the actual budget
-        # deduction, allowing over-admission when the pool is nearly full.
         max_new = min(
             max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
             CLIP_MAX_NEW_TOKENS,
         )
-        total_tokens = req.extend_input_len + max_new + self.page_size
-
-        # adjusting the input_tokens based on host_hit_length and page_size
-        real_input_tokens = req.extend_input_len - req.host_hit_length
-        real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
+        total_tokens = new_tokens_for_alloc(
+            prefix_len, req.extend_input_len + max_new, self.page_size
+        )
+
+        real_input_tokens = req.extend_input_len - req.host_hit_length
 
         if total_tokens >= self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
@@ -891,7 +886,7 @@ class PrefillAdder:
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
 
-            input_tokens = self.ceil_paged_tokens(req.extend_input_len)
+            input_tokens = req.extend_input_len
 
             if input_tokens >= self.rem_input_tokens and len(self.can_run_list) != 0:
                 return AddReqResult.OTHER

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -687,7 +687,7 @@ class PrefillAdder:
         req.fill_ids = req.fill_ids[: len(req.prefix_indices) + req.extend_input_len]
         self.can_run_list.append(req)
         self._update_prefill_budget(
-            0,
+            req.kv_committed_len,
             req.extend_input_len,
             (
                 min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -44,6 +44,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     zero_match_result,
 )
+from sglang.srt.mem_cache.common import new_tokens_for_alloc
 from sglang.srt.mem_cache.hisparse_memory_pool import (
     DeepSeekV4HiSparseTokenToKVPoolAllocator,
 )
@@ -584,13 +585,14 @@ class PrefillAdder:
     def _update_prefill_budget(
         self, prefix_len: int, extend_input_len: int, max_new_tokens: int
     ):
-        # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
-        extend_input_len = self.ceil_paged_tokens(extend_input_len)
-
-        # alloc_extend reserves an extra page_size per request to make sure the budget doesn't over-commit
-        page_overhead = self.page_size
-        self.rem_total_token_offset += extend_input_len + max_new_tokens + page_overhead
-        self.cur_rem_token_offset += extend_input_len + page_overhead
+        new_extend_tokens = new_tokens_for_alloc(
+            prefix_len, extend_input_len, self.page_size
+        )
+        new_full_tokens = new_tokens_for_alloc(
+            prefix_len, extend_input_len + max_new_tokens, self.page_size
+        )
+        self.rem_total_token_offset += new_full_tokens
+        self.cur_rem_token_offset += new_extend_tokens
         self.rem_input_tokens -= extend_input_len
 
         if self.is_hybrid_swa:

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -560,9 +560,6 @@ class PrefillAdder:
             alloc = extend_input_len
         return max(alloc, self.tree_cache.sliding_window_size) + self.page_size
 
-    def ceil_paged_tokens(self, tokens: int) -> int:
-        return -(-tokens // self.page_size) * self.page_size
-
     def budget_state(self):
         no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0
         if not no_token and self.is_hybrid_swa:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1880,11 +1880,11 @@ class Scheduler(
     def init_req_max_new_tokens(self, req):
         input_len = len(req.origin_input_ids)
         # Keep this bound consistent with PrefillAdder's admission budget:
-        # ceil_page(input_len) + max_new_tokens + page_size must be strictly
-        # smaller than max_total_num_tokens. Otherwise a request can be accepted
-        # into the waiting queue but can never be scheduled, blocking the queue
-        # and eventually making health checks fail.
-        paged_input_len = -(-input_len // self.page_size) * self.page_size
+        # new_tokens_for_alloc(prefix=0, input_len + max_new_tokens, page_size)
+        # <= input_len + max_new_tokens + page_size - 1 must be strictly smaller
+        # than max_total_num_tokens. Otherwise a request can be accepted into
+        # the waiting queue but can never be scheduled, blocking the queue and
+        # eventually making health checks fail.
         req.sampling_params.max_new_tokens = max(
             0,
             min(
@@ -1894,7 +1894,7 @@ class Scheduler(
                     else 1 << 30
                 ),
                 self.max_req_len - input_len - 1,
-                self.max_total_num_tokens - paged_input_len - self.page_size - 1,
+                self.max_total_num_tokens - input_len - self.page_size,
             ),
         )
 

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -43,6 +43,27 @@ def page_align_floor(length: int, page_size: int) -> int:
     return (length // page_size) * page_size
 
 
+def new_pages_for_alloc(allocated_len: int, next_alloc_len: int, page_size: int) -> int:
+    # Exact physical page count for allocating next_alloc_len more tokens on top
+    # of allocated_len. Mirrors the kernel formula in alloc_extend_kernel.
+    if page_size == 1:
+        return next_alloc_len
+    return (
+        ceil_align(allocated_len + next_alloc_len, page_size)
+        - ceil_align(allocated_len, page_size)
+    ) // page_size
+
+
+def new_tokens_for_alloc(
+    allocated_len: int, next_alloc_len: int, page_size: int
+) -> int:
+    if page_size == 1:
+        return next_alloc_len
+    return ceil_align(allocated_len + next_alloc_len, page_size) - ceil_align(
+        allocated_len, page_size
+    )
+
+
 def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
     if getattr(req, "skip_radix_cache_insert", False):
         return

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -528,8 +528,25 @@ def alloc_paged_token_slots_decode(
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
-    # Over estimate the number of tokens: assume each request needs a new page.
-    num_tokens = len(seq_lens) * allocator.page_size
+    if token_per_req == 1:
+        num_tokens = (
+            get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=allocator.page_size,
+                decode=True,
+            )
+            * allocator.page_size
+        )
+    else:
+        prefix_lens_cpu = seq_lens_cpu - token_per_req
+        num_tokens = (
+            get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=allocator.page_size,
+                prefix_lens=prefix_lens_cpu,
+            )
+            * allocator.page_size
+        )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     out_cache_loc = allocator.alloc_decode(seq_lens, seq_lens_cpu, last_loc)

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -13,7 +13,7 @@ from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPoo
 from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_hip, support_triton
-from sglang.srt.utils.common import ceil_align
+from sglang.srt.utils.common import ceil_align, get_num_new_pages
 
 _is_hip = is_hip()
 
@@ -384,9 +384,15 @@ def alloc_paged_token_slots_extend(
     extend_num_tokens: int,
     backup_state: bool = False,
 ):
-    # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
-    num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
+    num_tokens = (
+        get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=allocator.page_size,
+            prefix_lens=prefix_lens_cpu,
+        )
+        * allocator.page_size
+    )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     state = None


### PR DESCRIPTION
PoC: replace ceil_paged + page_size estimation with exact new_tokens_for_alloc helper across admission / budget / eviction.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25977165372](https://github.com/sgl-project/sglang/actions/runs/25977165372)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->[Run #25977165342](https://github.com/sgl-project/sglang/actions/runs/25977165342)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->