### PR TITLE
[DSv4] Route large-q prefill through flash_mla_sparse_fwd

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -68,6 +68,18 @@ SWA_WINDOW = 128
 C4_TOPK = 512
 PAGE_INDEX_ALIGNED_SIZE = 64
 
+# Largest ``b`` for FlashMLA's sparse_decode ``get_decoding_sched_meta``
+# kernel before its dynamic shared memory allocation exceeds the per-arch
+# opt-in cap. The kernel allocates ``sizeof(int) * (b * 5 + 1)`` bytes
+# (see ``csrc/smxx/decode/get_decoding_sched_meta/get_decoding_sched_meta.cu``).
+# Both SM 9.0 (Hopper: H100/H800/H20) and SM 10.0 (Blackwell datacenter:
+# B100/B200/GB200) have the same 228 KB opt-in cap per CUDA Programming
+# Guide Table 16 and the Blackwell whitepaper. flash_mla itself only
+# supports SM90a + SM100f (``csrc/api/sparse_fwd.h::sparse_attn_prefill_interface``
+# TORCH_CHECKs this), so we don't need to handle other arches.
+#   b_max = (228 * 1024 - sizeof(int)) // (5 * sizeof(int)) = 11673
+_FLASHMLA_SMEM_MAX_B = 11673
+
 
 T = TypeVar("T", bound=Optional[torch.Tensor])
 
@@ -1033,27 +1045,191 @@ class DeepseekV4AttnBackend(
 
             import flash_mla
 
-            o = flash_mla.flash_mla_with_kvcache(
-                q=q,
-                k_cache=swa_k_cache,
-                head_dim_v=self.head_dim_v,
-                block_table=None,
-                cache_seqlens=None,
-                tile_scheduler_metadata=flashmla_metadata,
-                softmax_scale=self.softmax_scale,
-                is_fp8_kvcache=True,
-                indices=swa_page_indices,
-                topk_length=swa_topk_lengths,
-                attn_sink=attn_sink,
-                extra_k_cache=extra_k_cache,
-                extra_indices_in_kvcache=extra_indices,
-                extra_topk_length=extra_topk_lengths,
-            )[0]
+            # FlashMLA's sparse_decode ``get_decoding_sched_meta`` kernel
+            # allocates ``4 * (b*5 + 1)`` bytes of dynamic shared memory.
+            # ``cudaFuncSetAttribute(..., MaxDynamicSharedMemorySize, smem)``
+            # returns "invalid argument" when ``smem`` exceeds the SM90/SM100
+            # opt-in cap of 228 KB, i.e. when ``b > _FLASHMLA_SMEM_MAX_B``.
+            # For decode ``b`` is the number of active sequences (always
+            # small); for DSv4 prefill-extend SGLang reshapes q so
+            # ``b == num tokens in the chunk``, and any sufficiently large
+            # ``chunked_prefill_size`` crashes the decode path.
+            #
+            # Above the cap we route through the dedicated prefill kernel
+            # ``flash_mla.flash_mla_sparse_fwd``. flash_mla provides two
+            # distinct sparse attention paths and both are supported on SM90a
+            # and SM100f (see ``csrc/api/sparse_fwd.h::sparse_attn_prefill_interface``):
+            #
+            #   flash_mla_with_kvcache  -> sparse_decode kernel
+            #                              FP8 paged KV, smem-limited schedule
+            #                              kernel.
+            #   flash_mla_sparse_fwd    -> sparse_prefill kernel
+            #                              BF16 flat KV, no schedule kernel,
+            #                              tile shapes tuned for prefill.
+            #
+            # The two-path pattern mirrors SGLang's NSA backend for DSv3.2
+            # (``nsa_backend.py::NSAAttnBackend._forward_flashmla_sparse`` for
+            # prefill, ``_forward_flashmla_kv`` for decode).
+            if q.shape[0] <= _FLASHMLA_SMEM_MAX_B:
+                # Fast path: original decode kernel, smem fits, zero overhead.
+                o = flash_mla.flash_mla_with_kvcache(
+                    q=q,
+                    k_cache=swa_k_cache,
+                    head_dim_v=self.head_dim_v,
+                    block_table=None,
+                    cache_seqlens=None,
+                    tile_scheduler_metadata=flashmla_metadata,
+                    softmax_scale=self.softmax_scale,
+                    is_fp8_kvcache=True,
+                    indices=swa_page_indices,
+                    topk_length=swa_topk_lengths,
+                    attn_sink=attn_sink,
+                    extra_k_cache=extra_k_cache,
+                    extra_indices_in_kvcache=extra_indices,
+                    extra_topk_length=extra_topk_lengths,
+                )[0]
+            else:
+                # Stage 2: dedicated prefill kernel. Handles all
+                # compress_ratio values (0 / 4 / 128) by dequant + concat +
+                # index combine.
+                o = self._forward_prefill_sparse_fwd(
+                    q=q,
+                    swa_k_cache=swa_k_cache,
+                    swa_page_indices=swa_page_indices,
+                    swa_topk_lengths=swa_topk_lengths,
+                    extra_k_cache=extra_k_cache,
+                    extra_indices=extra_indices,
+                    extra_topk_lengths=extra_topk_lengths,
+                    attn_sink=attn_sink,
+                )
 
             o = o.squeeze(1)
             return o
 
         raise NotImplementedError("ragged attention")
+
+    def _forward_prefill_sparse_fwd(
+        self,
+        q: torch.Tensor,
+        swa_k_cache: torch.Tensor,
+        swa_page_indices: torch.Tensor,
+        swa_topk_lengths: Optional[torch.Tensor],
+        extra_k_cache: Optional[torch.Tensor],
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_lengths: Optional[torch.Tensor],
+        attn_sink: torch.Tensor,
+    ) -> torch.Tensor:
+        """Stage 2 prefill path for all DSv4 layer types.
+
+        Routes prefill through ``flash_mla.flash_mla_sparse_fwd`` (the
+        dedicated prefill kernel) instead of ``flash_mla_with_kvcache``
+        (the decode kernel). The decode kernel has an SM90 smem cap on
+        ``b == q.shape[0]``; the prefill kernel does not.
+
+        For ``compress_ratio == 0`` the layer only has the SWA cache, so
+        we just dequantize it and call sparse_fwd directly. For
+        ``compress_ratio in {4, 128}`` the layer additionally has a
+        compressed ``extra_k_cache``; we dequantize both, concatenate them
+        along the kv-token axis (``kv = [swa_bf16; extra_bf16]``), and
+        merge the per-token swa/extra topk indices into one flat array via
+        :func:`combine_swa_extra_indices` (which shifts extra indices by
+        ``s_kv_swa`` so they point into the extra region of the
+        concatenated buffer).
+
+        Args:
+            q:                  ``[num_tokens, 1, h_q, d_qk]`` bf16.
+            swa_k_cache:        ``[num_blocks, block_size, 1,
+                                bytes_per_token]`` uint8 (DSv4-Flash
+                                layout, 584 bytes/token).
+            swa_page_indices:   ``[num_tokens, 1, topk_swa]`` int32. Global
+                                indices into the flattened swa view.
+            swa_topk_lengths:   ``[num_tokens]`` int32. Per-token valid
+                                count in ``swa_page_indices``.
+            extra_k_cache:      Same layout as ``swa_k_cache``, or ``None``
+                                for ``compress_ratio == 0``.
+            extra_indices:      ``[num_tokens, 1, topk_extra]`` int32 or
+                                ``None``. Global indices into the
+                                flattened extra view.
+            extra_topk_lengths: ``[num_tokens]`` int32 or ``None``.
+            attn_sink:          ``[h_q]`` float32.
+
+        Returns:
+            ``[num_tokens, 1, h_q, d_v]`` bf16. The ``s_q`` dim is kept so
+            the caller's ``o.squeeze(1)`` matches the decode path's output
+            shape.
+
+        Performance notes:
+        * Dequantizes the FULL ``swa_k_cache`` (and ``extra_k_cache`` when
+          present) to BF16 per call. With expandable_segments allocator
+          mode this is fine but allocates ~2x the FP8 cache size in
+          transient BF16 storage per call. A follow-up can replace this
+          with a fused gather+dequant kernel that only materializes the
+          tokens actually referenced by the topk indices.
+        """
+        import flash_mla
+
+        from sglang.srt.layers.attention.dsv4.dequant_k_cache import (
+            dequant_k_cache_dsv4_flash,
+        )
+        from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+            combine_swa_extra_indices,
+        )
+
+        # Dequantize SWA cache: uint8 page-SOA [num_blocks, block_size, 1, 584]
+        # -> BF16 [num_blocks, block_size, 1, 512] (448 nope dequant + 64 rope).
+        swa_kv_bf16 = dequant_k_cache_dsv4_flash(swa_k_cache)
+        num_swa_blocks, swa_block_size, h_kv, d_qk = swa_kv_bf16.shape
+        assert h_kv == 1, f"DSv4 expects h_kv=1, got {h_kv}"
+        s_kv_swa = num_swa_blocks * swa_block_size
+        swa_kv_flat = swa_kv_bf16.view(s_kv_swa, h_kv, d_qk)
+
+        if extra_k_cache is None:
+            # compress_ratio == 0: SWA only.
+            kv_flat = swa_kv_flat
+            indices = swa_page_indices
+            topk_lengths = swa_topk_lengths
+        else:
+            # compress_ratio in {4, 128}: dequantize the extra cache and
+            # concatenate. Indices into the concatenated buffer:
+            #   [0, s_kv_swa)         -> swa region
+            #   [s_kv_swa, s_kv_swa + s_kv_extra) -> extra region
+            assert extra_indices is not None and extra_topk_lengths is not None
+            assert (
+                swa_topk_lengths is not None
+            ), "swa_topk_lengths is required when combining with extra cache"
+
+            extra_kv_bf16 = dequant_k_cache_dsv4_flash(extra_k_cache)
+            num_extra_blocks, extra_block_size, _, _ = extra_kv_bf16.shape
+            s_kv_extra = num_extra_blocks * extra_block_size
+            extra_kv_flat = extra_kv_bf16.view(s_kv_extra, h_kv, d_qk)
+
+            kv_flat = torch.cat([swa_kv_flat, extra_kv_flat], dim=0)
+
+            indices, topk_lengths = combine_swa_extra_indices(
+                swa_indices=swa_page_indices,
+                swa_topk_lens=swa_topk_lengths,
+                extra_indices=extra_indices,
+                extra_topk_lens=extra_topk_lengths,
+                s_kv_swa=s_kv_swa,
+            )
+
+        # sparse_fwd takes q as [s_q, h_q, d_qk] (no batch dim). The
+        # caller earlier unsqueezed q to [num_tokens, 1, h_q, d_qk] for
+        # the decode-style API; undo that here.
+        q_flat = q.squeeze(1)
+
+        out, _, _ = flash_mla.flash_mla_sparse_fwd(
+            q=q_flat,
+            kv=kv_flat,
+            indices=indices,
+            sm_scale=self.softmax_scale,
+            d_v=self.head_dim_v,
+            attn_sink=attn_sink,
+            topk_length=topk_lengths,
+        )
+        # out: [num_tokens, h_q, d_v=512]. Restore the s_q dim so the
+        # caller's o.squeeze(1) gives the same shape as the decode path.
+        return out.unsqueeze(1)
 
     def expand_prefill_casually(
         self,

--- a/python/sglang/srt/layers/attention/dsv4/dequant_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsv4/dequant_k_cache.py
@@ -1,0 +1,214 @@
+"""Dequantize the DSV4-Flash K cache (MXFP8 + page-SOA layout) to BF16.
+
+The DSV4-Flash K cache stores each token as 584 bytes laid out per-page in
+SOA form (NOT per-token AOS like DSV3.2's 656-byte FP8 cache)::
+
+    Per page (page_size = 256 tokens, total 149504 bytes):
+      [token_0 nope (448B FP8) | token_0 rope (128B BF16)]
+      [token_1 nope                  | token_1 rope        ]
+      ...
+      [token_255 nope                | token_255 rope      ]   <- data region ends at 147456B
+      [token_0 scale (7 ue8m0 + 1 pad = 8B)]
+      [token_1 scale 8B]
+      ...
+      [token_255 scale 8B]                                     <- scale region 2048B
+
+Per-token decode:
+* nope: 448 FP8 e4m3, scaled by 7 ue8m0 group scales (group_size = 64).
+* rope: 64 BF16, copied through unchanged.
+* output: 512 BF16 (= 448 dequantized nope ++ 64 rope).
+
+Counterpart writer is `dsv4/index_buf_accessor.py::_set_k_and_s_triton_kernel`
+and the per-token quant kernel is `dsv4/quant_k_cache.py::_quant_k_cache_fused_kernel`.
+
+This module is needed for prefill paths that pass a BF16 KV tensor into
+`flash_mla.flash_mla_sparse_fwd` (the existing `nsa/dequant_k_cache.py`
+assumes the 656-byte DSV3.2 per-token AOS layout and is not compatible).
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+# Layout constants (mirror the writer side in dsv4/index_buf_accessor.py).
+DIM_NOPE_FP8: int = 448
+DIM_ROPE_BF16: int = 64
+HEAD_DIM_BF16: int = DIM_NOPE_FP8 + DIM_ROPE_BF16  # 512
+GROUP_SIZE: int = 64
+NUM_NOPE_TILES: int = DIM_NOPE_FP8 // GROUP_SIZE  # 7
+PADDED_SCALE_BYTES: int = 8  # 7 ue8m0 + 1 byte alignment pad
+NOPE_ROPE_BYTES_PER_TOKEN: int = DIM_NOPE_FP8 + DIM_ROPE_BF16 * 2  # 576
+HEAD_BYTES: int = NOPE_ROPE_BYTES_PER_TOKEN + PADDED_SCALE_BYTES  # 584
+
+
+@triton.jit
+def _dequant_kernel(
+    out_ptr,
+    nope_fp8_ptr,
+    rope_bf16_ptr,
+    scale_u8_ptr,
+    out_stride_token,
+    nope_stride_token,
+    rope_stride_token,
+    scale_stride_token,
+    NUM_TILES: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    DIM_NOPE: tl.constexpr,
+    DIM_ROPE: tl.constexpr,
+    PADDED_NUM_TILES: tl.constexpr,
+):
+    """One program per token. Loads nope as a 2D ``(PADDED_NUM_TILES,
+    GROUP_SIZE)`` block in one shot, loads scales as a 1D vector once,
+    broadcasts the scale row across the tile dimension, and writes the
+    dequantized nope in one fat store. The padded dimension is masked to
+    ``NUM_TILES`` valid lanes (next-power-of-2 padding is required by
+    Triton's ``tl.arange``).
+
+    Optimizations vs the original tile-serial version:
+    * One ``NUM_TILES × GROUP_SIZE`` nope load + one ``PADDED_NUM_TILES``
+      scale load per token (vs ``NUM_TILES`` × small loads under
+      ``tl.static_range``).
+    * ue8m0 → bf16 scale via ``(s << 7).bitcast<bf16>`` (one shift), vs
+      ``tl.exp2`` (transcendental).
+    """
+    token_id = tl.program_id(0)
+
+    # ----- rope: pure copy (BF16 in, BF16 out) -----
+    rope_offs = tl.arange(0, GROUP_SIZE)
+    rope_mask = rope_offs < DIM_ROPE
+    rope = tl.load(
+        rope_bf16_ptr + token_id * rope_stride_token + rope_offs,
+        mask=rope_mask,
+        other=0.0,
+    )
+    tl.store(
+        out_ptr + token_id * out_stride_token + DIM_NOPE + rope_offs,
+        rope,
+        mask=rope_mask,
+    )
+
+    # ----- nope: 2D fused load + multiply + store -----
+    tile_off = tl.arange(0, PADDED_NUM_TILES)  # (P,), P = next_pow2(NUM_TILES)
+    elem_off = tl.arange(0, GROUP_SIZE)  # (G,)
+    tile_mask = tile_off < NUM_TILES  # (P,)
+
+    # Load the scale row (one load, NUM_TILES valid bytes padded to P).
+    scales_u8 = tl.load(
+        scale_u8_ptr + token_id * scale_stride_token + tile_off,
+        mask=tile_mask,
+        other=127,  # 2^0 = 1.0 for padded lanes
+    )
+    # ue8m0 → bf16: bit pattern (s << 7) is exactly the bf16 encoding of
+    # 2^(s-127) (sign=0, exp=s, mantissa=0).
+    scales_bf16 = (scales_u8.to(tl.uint16) << 7).to(tl.bfloat16, bitcast=True)
+
+    # 2D nope load: offs[tile, elem] = tile * GROUP_SIZE + elem.
+    nope_offs_2d = tile_off[:, None] * GROUP_SIZE + elem_off[None, :]  # (P, G)
+    nope_mask_2d = tile_mask[:, None]  # broadcasts to (P, G)
+    nope_fp8 = tl.load(
+        nope_fp8_ptr + token_id * nope_stride_token + nope_offs_2d,
+        mask=nope_mask_2d,
+        other=0.0,
+    )
+
+    # Broadcast scale across G; do FP32 multiply for full mantissa.
+    nope_fp32 = nope_fp8.to(tl.float32) * scales_bf16[:, None].to(tl.float32)
+
+    # Store back into the contiguous output row.
+    tl.store(
+        out_ptr + token_id * out_stride_token + nope_offs_2d,
+        nope_fp32.to(tl.bfloat16),
+        mask=nope_mask_2d,
+    )
+
+
+def dequant_k_cache_dsv4_flash(quant_k_cache: torch.Tensor) -> torch.Tensor:
+    """Dequantize a DSV4-Flash K cache view to per-token BF16.
+
+    Args:
+        quant_k_cache: ``[num_pages, page_size, 1, 584]`` uint8 view over the
+            raw page-SOA byte buffer. ``page_size`` must equal the K-cache
+            pool's ``page_size`` (typically 256). The trailing dim is the
+            head_bytes (584) for shape bookkeeping only — the actual bytes
+            are page-SOA, not AOS, so this dim is **not** a real per-token
+            slice and must be re-derived via byte offsets.
+
+    Returns:
+        ``[num_pages, page_size, 1, 512]`` bfloat16.
+    """
+    assert (
+        quant_k_cache.is_cuda
+    ), f"expected CUDA tensor, got device={quant_k_cache.device}"
+    assert (
+        quant_k_cache.dtype == torch.uint8
+    ), f"expected uint8 raw cache, got {quant_k_cache.dtype}"
+    assert quant_k_cache.ndim == 4, f"expected 4D view, got {quant_k_cache.shape}"
+    num_pages, page_size, h_kv, head_bytes = quant_k_cache.shape
+    assert h_kv == 1, f"expected h_kv=1, got {h_kv}"
+    assert head_bytes == HEAD_BYTES, (
+        f"expected head_bytes={HEAD_BYTES}, got {head_bytes}. "
+        f"DSV4-Flash page-SOA cache must be 584 bytes/token."
+    )
+    # The caller's view may be a non-contiguous slice of a larger pool
+    # buffer (e.g. swa_k_cache[:, : swa_window_size * head_bytes].view(...)).
+    # Materialize a contiguous copy so the byte-region splits below are
+    # well-defined.
+    quant_k_cache = quant_k_cache.contiguous()
+
+    page_bytes = page_size * head_bytes
+    data_bytes = page_size * NOPE_ROPE_BYTES_PER_TOKEN
+    scale_bytes = page_size * PADDED_SCALE_BYTES
+    assert (
+        page_bytes == data_bytes + scale_bytes
+    ), f"page_bytes mismatch: {page_bytes} vs {data_bytes}+{scale_bytes}"
+
+    # Flatten per-page bytes and split into the SOA data + scale regions.
+    # The non-contig slice forces ``.reshape`` to copy into a packed
+    # ``(num_pages, page_size, *)`` buffer; the resulting tensors are
+    # already contiguous so no explicit ``.contiguous()`` is needed.
+    buf_flat = quant_k_cache.view(num_pages, page_bytes)
+    data_region = buf_flat[:, :data_bytes].reshape(
+        num_pages, page_size, NOPE_ROPE_BYTES_PER_TOKEN
+    )
+    scale_region = buf_flat[:, data_bytes:].reshape(
+        num_pages, page_size, PADDED_SCALE_BYTES
+    )
+
+    num_tokens = num_pages * page_size
+    nope_fp8 = (
+        data_region[:, :, :DIM_NOPE_FP8]
+        .reshape(num_tokens, DIM_NOPE_FP8)
+        .view(torch.float8_e4m3fn)
+    )
+    rope_bf16 = (
+        data_region[:, :, DIM_NOPE_FP8:]
+        .reshape(num_tokens, DIM_ROPE_BF16 * 2)
+        .view(torch.bfloat16)
+    )
+    scale_u8 = scale_region.reshape(num_tokens, PADDED_SCALE_BYTES)
+
+    out = torch.empty(
+        (num_tokens, HEAD_DIM_BF16),
+        dtype=torch.bfloat16,
+        device=quant_k_cache.device,
+    )
+
+    _dequant_kernel[(num_tokens,)](
+        out,
+        nope_fp8,
+        rope_bf16,
+        scale_u8,
+        out.stride(0),
+        nope_fp8.stride(0),
+        rope_bf16.stride(0),
+        scale_u8.stride(0),
+        NUM_TILES=NUM_NOPE_TILES,
+        GROUP_SIZE=GROUP_SIZE,
+        DIM_NOPE=DIM_NOPE_FP8,
+        DIM_ROPE=DIM_ROPE_BF16,
+        PADDED_NUM_TILES=triton.next_power_of_2(NUM_NOPE_TILES),
+    )
+
+    return out.view(num_pages, page_size, 1, HEAD_DIM_BF16)

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -108,7 +108,18 @@ class PagedIndexerMetadata:
         else:
             import deep_gemm
 
-            if envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get():
+            # deep_gemm.get_paged_mqa_logits_metadata crashes with
+            # CUDA_ERROR_INVALID_VALUE on SM90 when the per-query batch
+            # exceeds the FlashMLA decode SMEM cap (observed at
+            # chunked_prefill_size >= 16384). The vendored JIT kernel does
+            # not have this limit. Auto-route to JIT for those shapes; an
+            # explicit env opt-in still forces JIT for all shapes.
+            _LARGE_INDEXER_QUERY_THRESHOLD = 11673
+            use_jit_indexer = (
+                envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get()
+                or self.c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
+            )
+            if use_jit_indexer:
                 from sglang.jit_kernel.deepseek_v4 import get_paged_mqa_logits_metadata
             else:
                 from deep_gemm import get_paged_mqa_logits_metadata

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -1,0 +1,184 @@
+"""Helper kernels for the DSv4 sparse-prefill path that routes through
+``flash_mla.flash_mla_sparse_fwd``.
+
+The sparse-decode kernel (``flash_mla_with_kvcache``) takes the SWA cache and
+the optional extra compressed cache as separate paged tensors. The sparse-
+prefill kernel takes a *single* flat KV tensor. To use it for layers with
+``compress_ratio in {4, 128}`` we need to:
+
+  1. Dequantize both caches to BF16 and concatenate them along the kv-token
+     axis: ``kv = [swa_bf16; extra_bf16]``. The extra region starts at
+     offset ``s_kv_swa = num_swa_blocks * swa_block_size``.
+
+  2. Merge each query token's swa and extra topk indices into one flat index
+     array, shifting the extra indices by ``s_kv_swa`` so they point into the
+     concatenated buffer. Per-token valid lengths are summed.
+
+``combine_swa_extra_indices`` implements step 2. The dequant+concat in step 1
+is plain PyTorch and lives in the caller.
+"""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+# Alignment required by ``flash_mla_sparse_fwd`` along the topk dimension.
+# Covers both ``h_q=64`` (B_TOPK=64) and ``h_q=128`` (B_TOPK=128) kernel
+# variants; FlashMLA decode asserts ``extra_topk % B_TOPK == 0`` so the
+# combined topk must be a multiple of 128 to be safe across head counts.
+_TOPK_ALIGNMENT = 128
+
+
+@triton.jit
+def _combine_swa_extra_indices_kernel(
+    combined_ptr,
+    combined_stride_token,
+    combined_lens_ptr,
+    swa_indices_ptr,
+    swa_stride_token,
+    extra_indices_ptr,
+    extra_stride_token,
+    swa_topk_len_ptr,
+    extra_topk_len_ptr,
+    s_kv_swa,
+    TOPK_SWA: tl.constexpr,
+    TOPK_EXTRA: tl.constexpr,
+    COMBINED_TOPK: tl.constexpr,
+):
+    """One program per query token.
+
+    Reads ``swa_indices[token_idx, 0, :]`` and ``extra_indices[token_idx, 0, :]``
+    along with their per-token valid lengths, then writes a packed layout
+    ``[swa_valid; extra_valid + s_kv_swa; -1 padding]`` into
+    ``combined[token_idx, 0, :]``.
+
+    The output buffer is assumed to be pre-initialized to -1, so the kernel
+    only needs to fill the valid prefix.
+    """
+    token_idx = tl.program_id(0)
+
+    swa_len = tl.load(swa_topk_len_ptr + token_idx)
+    extra_len = tl.load(extra_topk_len_ptr + token_idx)
+
+    # --- Copy swa valid prefix unchanged ---
+    swa_off = tl.arange(0, TOPK_SWA)
+    swa_mask = swa_off < swa_len
+    swa_vals = tl.load(
+        swa_indices_ptr + token_idx * swa_stride_token + swa_off,
+        mask=swa_mask,
+        other=-1,
+    )
+    tl.store(
+        combined_ptr + token_idx * combined_stride_token + swa_off,
+        swa_vals,
+        mask=swa_mask,
+    )
+
+    # --- Copy extra valid prefix shifted by s_kv_swa, written after swa ---
+    extra_off = tl.arange(0, TOPK_EXTRA)
+    extra_mask = extra_off < extra_len
+    extra_vals = tl.load(
+        extra_indices_ptr + token_idx * extra_stride_token + extra_off,
+        mask=extra_mask,
+        other=-1,
+    )
+    extra_vals = extra_vals + s_kv_swa
+
+    write_pos = swa_len + extra_off
+    write_mask = extra_mask & (write_pos < COMBINED_TOPK)
+    tl.store(
+        combined_ptr + token_idx * combined_stride_token + write_pos,
+        extra_vals,
+        mask=write_mask,
+    )
+
+    tl.store(combined_lens_ptr + token_idx, swa_len + extra_len)
+
+
+def combine_swa_extra_indices(
+    swa_indices: torch.Tensor,
+    swa_topk_lens: torch.Tensor,
+    extra_indices: torch.Tensor,
+    extra_topk_lens: torch.Tensor,
+    s_kv_swa: int,
+    alignment: int = _TOPK_ALIGNMENT,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Combine per-token swa and extra topk indices into a single fixed-size
+    index tensor suitable for ``flash_mla_sparse_fwd``.
+
+    Args:
+        swa_indices:        ``[num_tokens, 1, topk_swa]`` int32. Global indices
+                            into the flat swa KV view.
+        swa_topk_lens:      ``[num_tokens]`` int32. Per-token count of valid
+                            entries in the swa prefix.
+        extra_indices:      ``[num_tokens, 1, topk_extra]`` int32. Global
+                            indices into the flat extra KV view (will be
+                            shifted by ``s_kv_swa`` so they index into the
+                            concatenated buffer).
+        extra_topk_lens:    ``[num_tokens]`` int32. Per-token valid count.
+        s_kv_swa:           ``num_swa_blocks * swa_block_size``. The size of
+                            the swa region in the concatenated KV buffer;
+                            added to every extra index.
+        alignment:          The topk dim of the output is padded up to a
+                            multiple of this value (default 128, matching
+                            sparse_fwd's kernel B_TOPK).
+
+    Returns:
+        combined_indices: ``[num_tokens, 1, combined_topk]`` int32. Padded
+                          with -1 on the right.
+        combined_lens:    ``[num_tokens]`` int32. ``swa_len + extra_len`` per
+                          token.
+    """
+    assert (
+        swa_indices.dim() == 3 and swa_indices.shape[1] == 1
+    ), f"swa_indices must be [num_tokens, 1, topk_swa]; got {swa_indices.shape}"
+    assert (
+        extra_indices.dim() == 3 and extra_indices.shape[1] == 1
+    ), f"extra_indices must be [num_tokens, 1, topk_extra]; got {extra_indices.shape}"
+    assert swa_indices.shape[0] == extra_indices.shape[0], (
+        f"swa and extra token counts must match: "
+        f"{swa_indices.shape[0]} vs {extra_indices.shape[0]}"
+    )
+    assert swa_topk_lens.shape[0] == extra_topk_lens.shape[0] == swa_indices.shape[0]
+    assert swa_indices.dtype == torch.int32 and extra_indices.dtype == torch.int32
+    assert swa_indices.is_contiguous() and extra_indices.is_contiguous()
+
+    num_tokens = swa_indices.shape[0]
+    topk_swa = swa_indices.shape[-1]
+    topk_extra = extra_indices.shape[-1]
+
+    raw_combined = topk_swa + topk_extra
+    combined_topk = (raw_combined + alignment - 1) // alignment * alignment
+
+    combined_indices = torch.full(
+        (num_tokens, 1, combined_topk),
+        fill_value=-1,
+        dtype=torch.int32,
+        device=swa_indices.device,
+    )
+    combined_lens = torch.empty(
+        num_tokens, dtype=torch.int32, device=swa_indices.device
+    )
+
+    # Triton requires the per-program tl.arange size to be a power of 2.
+    # topk_{swa,extra} are typically multiples of 64 (asserted in the
+    # backend), which are already power of 2 for the values we see
+    # (512, 1024, 2048, ...). next_power_of_2 here is a safety net.
+    _combine_swa_extra_indices_kernel[(num_tokens,)](
+        combined_indices,
+        combined_indices.stride(0),
+        combined_lens,
+        swa_indices,
+        swa_indices.stride(0),
+        extra_indices,
+        extra_indices.stride(0),
+        swa_topk_lens,
+        extra_topk_lens,
+        s_kv_swa,
+        TOPK_SWA=triton.next_power_of_2(topk_swa),
+        TOPK_EXTRA=triton.next_power_of_2(topk_extra),
+        COMBINED_TOPK=combined_topk,
+    )
+    return combined_indices, combined_lens

--- a/test/registered/kernels/test_combine_swa_extra_indices.py
+++ b/test/registered/kernels/test_combine_swa_extra_indices.py
@@ -1,0 +1,261 @@
+"""Unit tests for the ``combine_swa_extra_indices`` Triton kernel used by
+the DSv4 sparse-prefill path (``flash_mla.flash_mla_sparse_fwd``).
+
+The kernel merges per-token SWA and extra (compressed) topk indices into a
+single fixed-size buffer suitable for ``flash_mla_sparse_fwd``:
+
+    combined[i, 0, :swa_len]                    = swa_indices[i, 0, :swa_len]
+    combined[i, 0, swa_len:swa_len+extra_len]   = extra_indices[i, 0, :extra_len] + s_kv_swa
+    combined[i, 0, swa_len+extra_len:]          = -1  (padding)
+    combined_lens[i]                            = swa_len + extra_len
+
+Tests compare the kernel output against a straightforward PyTorch
+reference implementation across a few shape/length regimes (typical
+prefill, the large-q regime that motivated the kernel, full lengths, and
+the all-zero-length edge case).
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+
+def _reference_combine_swa_extra_indices(
+    swa_indices: torch.Tensor,
+    swa_topk_lens: torch.Tensor,
+    extra_indices: torch.Tensor,
+    extra_topk_lens: torch.Tensor,
+    s_kv_swa: int,
+    alignment: int = 128,
+):
+    """Plain-PyTorch reference implementation for cross-checking the
+    Triton kernel.
+
+    Same contract as :func:`combine_swa_extra_indices`; uses a small Python
+    loop over tokens, which is fine for unit-test scale.
+    """
+    num_tokens, _, topk_swa = swa_indices.shape
+    _, _, topk_extra = extra_indices.shape
+    raw_combined = topk_swa + topk_extra
+    combined_topk = (raw_combined + alignment - 1) // alignment * alignment
+
+    combined = torch.full(
+        (num_tokens, 1, combined_topk),
+        -1,
+        dtype=torch.int32,
+        device=swa_indices.device,
+    )
+    combined_lens = (swa_topk_lens + extra_topk_lens).to(torch.int32)
+
+    for i in range(num_tokens):
+        sl = int(swa_topk_lens[i].item())
+        el = int(extra_topk_lens[i].item())
+        if sl > 0:
+            combined[i, 0, :sl] = swa_indices[i, 0, :sl]
+        if el > 0:
+            combined[i, 0, sl : sl + el] = extra_indices[i, 0, :el] + s_kv_swa
+
+    return combined, combined_lens
+
+
+class TestCombineSwaExtraIndices(CustomTestCase):
+    """Verify ``combine_swa_extra_indices`` matches the Python reference
+    across representative input shapes and length distributions."""
+
+    def setUp(self):
+        # Lazy import: the module pulls in triton which requires CUDA.
+        from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+            combine_swa_extra_indices,
+        )
+
+        self.combine = combine_swa_extra_indices
+
+    def _make_inputs(
+        self,
+        *,
+        num_tokens: int,
+        topk_swa: int,
+        topk_extra: int,
+        s_kv_swa: int,
+        s_kv_extra: int,
+        variable_lengths: bool,
+        seed: int,
+        device: str = "cuda",
+    ):
+        gen = torch.Generator(device=device).manual_seed(seed)
+        swa_indices = torch.randint(
+            0,
+            max(s_kv_swa, 1),
+            (num_tokens, 1, topk_swa),
+            generator=gen,
+            dtype=torch.int32,
+            device=device,
+        )
+        extra_indices = torch.randint(
+            0,
+            max(s_kv_extra, 1),
+            (num_tokens, 1, topk_extra),
+            generator=gen,
+            dtype=torch.int32,
+            device=device,
+        )
+        if variable_lengths:
+            # Random valid prefix length in [0, topk_*]. Hits both extremes.
+            swa_lens = torch.randint(
+                0,
+                topk_swa + 1,
+                (num_tokens,),
+                generator=gen,
+                dtype=torch.int32,
+                device=device,
+            )
+            extra_lens = torch.randint(
+                0,
+                topk_extra + 1,
+                (num_tokens,),
+                generator=gen,
+                dtype=torch.int32,
+                device=device,
+            )
+        else:
+            swa_lens = torch.full(
+                (num_tokens,), topk_swa, dtype=torch.int32, device=device
+            )
+            extra_lens = torch.full(
+                (num_tokens,), topk_extra, dtype=torch.int32, device=device
+            )
+
+        # Stamp -1 past the valid prefix to assert the kernel doesn't peek
+        # past the declared length. Use a simple mask construction so we
+        # stay vectorised.
+        swa_pos = torch.arange(topk_swa, device=device, dtype=torch.int32)
+        extra_pos = torch.arange(topk_extra, device=device, dtype=torch.int32)
+        swa_mask = swa_pos.unsqueeze(0) < swa_lens.unsqueeze(1)
+        extra_mask = extra_pos.unsqueeze(0) < extra_lens.unsqueeze(1)
+        swa_indices.masked_fill_(~swa_mask.unsqueeze(1), -1)
+        extra_indices.masked_fill_(~extra_mask.unsqueeze(1), -1)
+
+        return swa_indices, swa_lens, extra_indices, extra_lens
+
+    def _run_case(
+        self,
+        *,
+        num_tokens: int,
+        topk_swa: int,
+        topk_extra: int,
+        s_kv_swa: int = 200_000,
+        s_kv_extra: int = 100_000,
+        variable_lengths: bool = True,
+        seed: int = 0,
+    ):
+        swa, swa_lens, extra, extra_lens = self._make_inputs(
+            num_tokens=num_tokens,
+            topk_swa=topk_swa,
+            topk_extra=topk_extra,
+            s_kv_swa=s_kv_swa,
+            s_kv_extra=s_kv_extra,
+            variable_lengths=variable_lengths,
+            seed=seed,
+        )
+
+        out_combined, out_lens = self.combine(
+            swa_indices=swa,
+            swa_topk_lens=swa_lens,
+            extra_indices=extra,
+            extra_topk_lens=extra_lens,
+            s_kv_swa=s_kv_swa,
+        )
+        ref_combined, ref_lens = _reference_combine_swa_extra_indices(
+            swa, swa_lens, extra, extra_lens, s_kv_swa
+        )
+
+        # Exact match expected -- the kernel only does loads/stores and an
+        # integer add for the extra offset.
+        torch.testing.assert_close(out_lens, ref_lens, rtol=0, atol=0)
+        torch.testing.assert_close(out_combined, ref_combined, rtol=0, atol=0)
+
+    def test_small_inputs(self):
+        """Tiny sanity check (covers Python-side path)."""
+        self._run_case(num_tokens=4, topk_swa=64, topk_extra=128, seed=0)
+
+    def test_typical_dsv4_sizes(self):
+        """Shapes representative of DSv4-Flash compress_ratio=4 prefill."""
+        self._run_case(num_tokens=1024, topk_swa=512, topk_extra=2048, seed=1)
+
+    def test_large_q_above_smem_cap(self):
+        """The regime that motivated the kernel: ``b == num_tokens`` past
+        the FlashMLA sparse_decode smem cap (11673), so the decode kernel
+        would crash and we fall back to ``sparse_fwd``."""
+        self._run_case(num_tokens=16384, topk_swa=512, topk_extra=2048, seed=2)
+
+    def test_uniform_full_lengths(self):
+        """All tokens at the max valid count -- exercises the upper-bound
+        of the ``swa_len + extra_off`` write position."""
+        self._run_case(
+            num_tokens=128,
+            topk_swa=512,
+            topk_extra=512,
+            variable_lengths=False,
+            seed=3,
+        )
+
+    def test_zero_lengths(self):
+        """All-zero-length edge case: no valid entries on either side, so
+        the entire combined buffer should remain at the -1 fill and lens
+        should be 0."""
+        device = "cuda"
+        num_tokens = 16
+        topk_swa, topk_extra = 64, 64
+        swa = torch.full(
+            (num_tokens, 1, topk_swa), -1, dtype=torch.int32, device=device
+        )
+        extra = torch.full(
+            (num_tokens, 1, topk_extra), -1, dtype=torch.int32, device=device
+        )
+        swa_lens = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+        extra_lens = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+
+        out_combined, out_lens = self.combine(
+            swa_indices=swa,
+            swa_topk_lens=swa_lens,
+            extra_indices=extra,
+            extra_topk_lens=extra_lens,
+            s_kv_swa=100,
+        )
+        self.assertTrue(torch.all(out_lens == 0))
+        self.assertTrue(torch.all(out_combined == -1))
+
+    def test_extra_offset_is_added(self):
+        """Verifies that ``extra_indices`` are actually shifted by
+        ``s_kv_swa`` in the combined buffer (the kernel's one real
+        arithmetic op, easy to break)."""
+        device = "cuda"
+        # One token, swa_len=0 so the combined buffer's prefix is entirely
+        # populated from extra. extra entry 7 should land at position 0
+        # of combined and have value (7 + s_kv_swa).
+        swa = torch.full((1, 1, 64), -1, dtype=torch.int32, device=device)
+        extra = torch.zeros((1, 1, 64), dtype=torch.int32, device=device)
+        extra[0, 0, 0] = 7
+        swa_lens = torch.zeros(1, dtype=torch.int32, device=device)
+        extra_lens = torch.ones(1, dtype=torch.int32, device=device)
+
+        s_kv_swa = 5_000
+        out_combined, out_lens = self.combine(
+            swa_indices=swa,
+            swa_topk_lens=swa_lens,
+            extra_indices=extra,
+            extra_topk_lens=extra_lens,
+            s_kv_swa=s_kv_swa,
+        )
+        self.assertEqual(int(out_lens[0].item()), 1)
+        self.assertEqual(int(out_combined[0, 0, 0].item()), 7 + s_kv_swa)
+        self.assertTrue(torch.all(out_combined[0, 0, 1:] == -1))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

To fix crash in large --chunked-prefill-size.

DSv3 uses **dense** MLA: every query attends to all KV, no per-token
routing. The corresponding FlashMLA path is `dense_decode.h`, which takes
`q` in shape `[num_seq, seq_len, h, d]`. Here `b == num_seq`, capped by
`max_running_requests` (typically a few tens), so the per-`b` SMEM
allocation inside `get_decoding_sched_meta` stays in the single-digit KB
range and never trips the opt-in cap.

DSv4 introduces **sparse** attention with per-token top-k routing
(`sparse_decode.h`). The current SGLang DSv4 backend reuses the existing
DSv3 dense-decode infrastructure (same FlashMLA entrypoint, same
schedule kernel, same SMEM accounting), and only patches the `q` layout
to carry per-token routing. Concretely, since each token now needs its
own top-k indices, `q` is reshaped to `[num_tokens, 1, h, d]` before
dispatch — the kernel's `b` flips from "number of active sequences" to
"number of query tokens in the chunk", a 100–1000× jump. With
`get_decoding_sched_meta` still allocating `4 * (b * 5 + 1)` bytes of
dynamic shared memory and the SM90/SM100 opt-in SMEM cap at 228 KB,
anything above `b > 11673` (= ⌊(228 × 1024 / 4 − 1) / 5⌋) makes
`cudaFuncSetAttribute` return `invalid argument` and the scheduler
crashes:

```
csrc/smxx/decode/get_decoding_sched_meta/get_decoding_sched_meta.cu:111
Assertion error: smem_size <= SM90ArchSpec::smem_capacity
```

Concretely, any `chunked_prefill_size > 11673` crashes the DSv4 backend on
the very first long-prompt request. This PR adds the plumbing required to
run DSv4-Flash safely at larger chunk sizes — specifically the
`--chunked-prefill-size 32768` configuration we want for long-context
prefill throughput.
## Modifications

The fix is split across three concerns. All three must land together:
removing any one makes the long-prompt request crash before the next can even be triggered.

### 1. Route large-`q` prefill through `flash_mla_sparse_fwd`

When `q.shape[0] > 11673` the attention call now dispatches to
`flash_mla.flash_mla_sparse_fwd` (the dedicated prefill kernel — BF16 flat
KV, no schedule kernel, tile shapes tuned for prefill) instead of
`flash_mla_with_kvcache` (the decode kernel — FP8 paged KV, SMEM-limited
schedule kernel). FlashMLA exposes both kernels on SM90a and SM100f, so the
runtime dispatch happens inside FlashMLA and no Python-side arch branching
is required. The two-path pattern (sparse-decode for decode, sparse-fwd for
prefill) mirrors the NSA backend for DSv3.2.

For layers with `compress_ratio in {4, 128}` the sparse-fwd path additionally
needs to attend over `[swa_kv; extra_kv]` as a single flat KV tensor.
`combine_swa_extra_indices` handles index merging — it shifts each extra
index by `s_kv_swa` so the same flat-index assumption holds for both halves
of the concatenated buffer. Unit tests cover the SWA-only, both-halves
populated, and asymmetric per-token-length cases.

Files: `deepseek_v4_backend.py` (the branch + plumbing),
`dsv4/sparse_prefill_utils.py` (helper kernel + Python wrapper),
`test/registered/kernels/test_combine_swa_extra_indices.py` (UT).

### 2. DSv4-Flash MXFP8 page-SOA dequantizer

`flash_mla_sparse_fwd` requires a BF16 KV tensor, so the sparse-fwd branch
needs to dequantize the FP8 K cache before calling it. NSA already has a
`dequantize_k_cache` helper, but it was written for the **DSv3.2** layout
(656 bytes per token, per-token AOS: 512 nope FP8 + 16 fp32 scales +
128 BF16 rope) and reusing it for DSv4-Flash trips an assertion:

```
swa_kv_bf16 = dequantize_k_cache(swa_k_cache)   # _forward_prefill_sparse_fwd
  → assert dim_quant == 656                     # AssertionError
```

DSv4-Flash uses an entirely different layout:

| field | DSv3.2 (656) | DSv4-Flash (584) |
|---|---|---|
| nope element | 512 dim FP8 e4m3 = 512 B | 448 dim FP8 e4m3 = 448 B |
| nope scale | 4 × fp32 = 16 B | 7 × ue8m0 = 7 B (+1 pad) |
| rope element | 64 dim BF16 = 128 B | 64 dim BF16 = 128 B |
| per-token total | 656 B (AOS) | 584 B |
| per-page arrangement | per-token AOS | **page-SOA** (data region 256×576 B then scale region 256×8 B) |

NSA's helper doesn't understand either the new byte count or the per-page
SOA split — re-using it produces garbage data and trips the dim assertion.

A new module `sglang/srt/layers/attention/dsv4/dequant_k_cache.py` mirrors
the writer side in `dsv4/index_buf_accessor.py` and
`dsv4/quant_k_cache.py`. One Triton kernel program per token; 2D fused load
of the `(NUM_TILES, GROUP_SIZE)` nope block; single-load scale row;
single-shift bitcast for ue8m0 → BF16 (`(s << 7).bitcast<bf16>` is exactly
`2^(s-127)` for non-degenerate exponents); FP32 multiply for full mantissa.
The function is called from both compress_ratio paths in
`_forward_prefill_sparse_fwd`. Verified by a writer → reader roundtrip
with max relative error 5.9% (within FP8 e4m3 precision).

### 3. Auto-route the DeepGEMM indexer for large query batches

Before attention ever runs, the DSv4 indexer builds a metadata tensor via
`deep_gemm.get_paged_mqa_logits_metadata`. On SM90 this call raises
`CUDA_ERROR_INVALID_VALUE` once the per-query batch grows past roughly the
FlashMLA SMEM cap (observed at `chunked_prefill_size >= 16384`):

```
File ".../sglang/srt/layers/attention/dsv4/metadata.py", line 119, in __post_init__
    self.deep_gemm_metadata = get_paged_mqa_logits_metadata(...)
tvm.error.InternalError: CUDA driver error
  (/deepgemm/csrc/apis/../jit_kernels/impls/../../jit/handle.hpp:178):
  1 (CUDA_ERROR_INVALID_VALUE, invalid argument)
```

This happens *before* the sparse-fwd path is even reached, so without
auto-routing this concern, large-`q` requests crash in the indexer and
items 1–2 never get exercised. The same call has a working alternative in
`sglang/jit_kernel/deepseek_v4.py::get_paged_mqa_logits_metadata` (vendored
Triton kernel, no SMEM cap), gated today by
`SGLANG_OPT_USE_JIT_INDEXER_METADATA`.

**Change:** `metadata.py` now also picks the JIT kernel when
`c4_seq_lens.numel() > 11673`. An explicit
`SGLANG_OPT_USE_JIT_INDEXER_METADATA=1` still wins for users who want JIT
everywhere.

A note on the threshold: `11673` is the FlashMLA decode-kernel SMEM cap
(`4 * (b*5+1) ≤ 228 KB ⇒ b ≤ 11673`) that the prefill branch above uses to
gate `_forward_prefill_sparse_fwd`. It is **not** the indexer's observed
crash point — the indexer was seen to crash at
`chunked_prefill_size ≥ 16384`, so its true ceiling lives somewhere in
`(11673, 16384]`. Reusing the same constant ties the two switches together
(whenever attention falls back to sparse-fwd, the indexer falls back to JIT
in lockstep), keeps the code reader from juggling two thresholds, and
stays comfortably below the observed indexer ceiling. The two metadata
kernels are equivalent in cost, so over-routing in the `(11673, 16384]`
band has no measurable impact.

## Files

| file | size | purpose |
|---|---|---|
| `python/sglang/srt/layers/attention/deepseek_v4_backend.py` | +207 −0 | sparse-fwd routing branch, `_forward_prefill_sparse_fwd`, two callsites to new dequant |
| `python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py` | +187 (new) | `combine_swa_extra_indices` Triton kernel + wrapper |
| `python/sglang/srt/layers/attention/dsv4/dequant_k_cache.py` | +214 (new) | DSv4-Flash MXFP8 page-SOA dequant Triton kernel |
| `python/sglang/srt/layers/attention/dsv4/metadata.py` | +13 −1 | auto-route to JIT indexer at `c4_seq_lens.numel() > 11673` |
| `test/registered/kernels/test_combine_swa_extra_indices.py` | +265 (new) | unit test for index-merge helper |

## Verification

Tested on H20-3e × 8 (TP=8) with DeepSeek-V4-Flash, EAGLE-3 spec decoding,
393 216-token context, `--moe-runner-backend flashinfer_mxfp4`.

* **Correctness**: chat-formatted long-prompt requests (~27 500 tokens)
  produce coherent output via the sparse-fwd path. Short prompts
  (`q.shape[0] ≤ 11673`) are unchanged — they still go through
  `flash_mla_with_kvcache` and match the pre-PR output character for
  character.
* **Performance** (single-request prefill latency, `temperature=0.0`,
  `max_tokens=8`):

  | prompt tokens | chunked=8192 (decode-kernel path) | chunked=32768 (sparse-fwd path, this PR) |
  |---|---|---|
  | 5 602  | 0.66 s | 0.67 s (both branches hit the decode kernel)|
  | 13 302 | 1.36 s | 1.55 s (sparse-fwd ~15% slower at medium chunks) |
  | 30 352 | 3.11 s | 3.27 s (within 5%; sparse-fwd matches decode-kernel) |

  The 15% regression at the 13 K point is a known characteristic of
  `flash_mla_sparse_fwd`: its per-call setup overhead doesn't amortize as
  well as the decode kernel on medium-sized prefills. The 30 K point — the
  primary motivation for the larger chunk size — already matches.

* **Backwards compat**: `SGLANG_OPT_USE_JIT_INDEXER_METADATA=1` continues
  to force JIT for all shapes (the new auto-route is OR-ed in, not
  overridden); `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1` still bypasses
  deep_gemm entirely.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25982140150](https://github.com/sgl-project/sglang/actions/runs/25982140150)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->