### PR TITLE
fix(piecewise-cuda-graph): pass dummy lora_ids to ForwardBatch during PCG capture (fixes #25307)

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -602,7 +602,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)


### PR DESCRIPTION
## Summary

Fixes #25307. When `--enable-lora` is combined with forced piecewise CUDA graph, the server crashes during startup with `TypeError: object of type 'NoneType' has no len()` inside `prepare_lora_batch`.

## Root cause

`PiecewiseCudaGraphRunner.capture_one_batch_size()` builds a dummy `lora_ids = [None] * bs` exactly for the graph-capture path, then **discards it** when constructing the `ForwardBatch`:

```python
if self.model_runner.server_args.enable_lora:
    lora_ids = [None] * bs       # dummy IDs for graph capture
else:
    lora_ids = None

with torch.device(self.device):
    forward_batch = ForwardBatch(
        ...
        lora_ids=None,           # <-- bug: hard-coded, dummy IDs dropped here
        ...
    )

if lora_ids is not None:
    self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
    #         forward_batch.lora_ids is None
    #         -> len(None) -> TypeError
```

The intent on the dummy-id branch (per the in-line comment) is to let LoRA kernels launch on the capture path with a no-op input. The cuda graph capture itself in the non-piecewise `CudaGraphRunner` already wires `lora_ids=lora_ids` through to `ForwardBatch` (`cuda_graph_runner.py:1059`); this PR aligns the piecewise capture path with that pattern.

## Fix

```diff
-                lora_ids=None,
+                lora_ids=lora_ids,
```

Single-line change in `python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py`. The local guard `if lora_ids is not None:` immediately below remains correct: when `enable_lora=True` the local `lora_ids` is `[None] * bs` (truthy, `is not None`), so `prepare_lora_batch` still runs; when `enable_lora=False` the local `lora_ids` is `None` and `prepare_lora_batch` is still skipped.

## Reproduction (from #25307)

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3-0.6B \
  --enable-lora \
  --lora-paths lora0=AIPlans/Qwen3-0.6B-DPO \
  --max-loras-per-batch 2 \
  --lora-backend torch_native \
  --enforce-piecewise-cuda-graph \
  --piecewise-cuda-graph-tokens 4 \
  --mem-fraction-static 0.70
```

Without the patch, startup fails with the `NoneType` `len()` traceback at `lora_manager.py:315`. With the patch, the immediate `prepare_lora_batch` crash clears.

## Out of scope (intentional)

1. The same `lora_ids=None` pattern exists at line 432 in `warmup_compile()` of the same file. That path does not invoke `prepare_lora_batch`, so it does not produce the crash reported in #25307. Leaving it to a separate change to keep this PR scoped to the reported bug.
2. `breakable_cuda_graph_runner.py:299` has an analogous `lora_ids=None` literal in a different runner. Out of scope for this PR.
3. The reporter notes that after this immediate crash is resolved, a separate `torch_native` LoRA dynamo graph break appears later in the capture path (`sgemm_lora_a_fwd` data-dependent branching). That is a distinct LoRA + PCG compatibility issue and is also out of scope here.

## Related

- Adjacent recent LoRA/`prepare_lora_batch` fix: #21974
- Reporter's own end-to-end repro and the `local_lora_ids=[None] forward_batch.lora_ids=None` debug print are quoted in #25307.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->