### PR TITLE
Avoid nonzero sync in selected tensor paths

### DIFF
--- a/python/sglang/srt/configs/janus_pro.py
+++ b/python/sglang/srt/configs/janus_pro.py
@@ -471,12 +471,15 @@ class VLChatProcessor(ProcessorMixin):
 
         sft_format = prompt
         # tokenize
-        input_ids = self.tokenizer.encode(sft_format)
-        input_ids = torch.LongTensor(input_ids)
+        token_ids = self.tokenizer.encode(sft_format)
+        image_indices = [
+            index
+            for index, token_id in enumerate(token_ids)
+            if token_id == self.image_id
+        ]
+        input_ids = torch.LongTensor(token_ids)
 
         # add image tokens to the input_ids
-        image_token_mask: torch.Tensor = (input_ids == self.image_id).to(torch.bool)
-        image_indices = image_token_mask.nonzero()
         input_ids, num_image_tokens = self.add_image_token(
             image_indices=image_indices,
             input_ids=input_ids,

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -63,6 +63,20 @@ logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 
 
+def _get_chunk_logprob_indices(
+    input_logprob_indices: torch.Tensor, start_idx: int, end_idx: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Select sorted logprob indices for a chunk without materializing a bool mask."""
+    chunk_start = torch.searchsorted(input_logprob_indices, start_idx)
+    chunk_end = torch.searchsorted(input_logprob_indices, end_idx)
+    mask_indices = torch.arange(
+        chunk_start, chunk_end, device=input_logprob_indices.device
+    )
+    global_indices = input_logprob_indices[mask_indices]
+    chunk_indices = global_indices - start_idx
+    return mask_indices, global_indices, chunk_indices
+
+
 @dataclasses.dataclass
 class LogitsProcessorOutput:
     ## Part 1: This part will be assigned in python/sglang/srt/layers/logits_processor.py::LogitsProcessor
@@ -716,14 +730,15 @@ class LogitsProcessor(nn.Module):
                 lm_head.set_lm_head_pass(i)
 
             # Get indices for this chunk
-            chunk_mask = (input_logprob_indices >= start_idx) & (
-                input_logprob_indices < end_idx
+            (
+                mask_indices,
+                global_indices,
+                chunk_indices,
+            ) = _get_chunk_logprob_indices(
+                input_logprob_indices,
+                start_idx,
+                end_idx,
             )
-            global_indices = input_logprob_indices[chunk_mask]
-            chunk_indices = global_indices - start_idx
-            # Get the positions in the original array where chunk_mask is True
-            # This is needed to correctly index into extend_input_logprob_token_ids_gpu
-            mask_indices = torch.nonzero(chunk_mask, as_tuple=True)[0]
 
             # Get the logits for this chunk
             chunk_states = pruned_states[start_idx:end_idx]

--- a/python/sglang/srt/models/phi4mm_utils.py
+++ b/python/sglang/srt/models/phi4mm_utils.py
@@ -71,22 +71,24 @@ def adaptive_enc_mask(x_len, chunk_start_idx, left_window=0, right_window=0):
                     [False., True., True., False.],
                     [False., False., True., True.]])
     """
-    chunk_start_idx = torch.Tensor(
-        chunk_start_idx
-    ).long()  # first idx of each chunk, such as [0,18,36,48].
+    chunk_start_idx = torch.as_tensor(
+        chunk_start_idx, dtype=torch.long
+    )  # first idx of each chunk, such as [0,18,36,48].
     start_pad = torch.nn.functional.pad(
         chunk_start_idx, (1, 0)
     )  # append 0 to the beginning, so it becomes [0, 0, 18, 36, 48]
     end_pad = torch.nn.functional.pad(
         chunk_start_idx, (0, 1), value=x_len
     )  # append x_len to the end, so it becomes [0,18,36,48, x_len]
-    seq_range = torch.arange(0, x_len).unsqueeze(-1)  # seq_range size: [x_len, 1]
-    idx = ((seq_range < end_pad) & (seq_range >= start_pad)).nonzero()[
-        :, 1
-    ]  # idx size: [x_len]
+    seq_range = torch.arange(
+        0, x_len, device=chunk_start_idx.device
+    )  # seq_range size: [x_len]
+    idx = torch.bucketize(seq_range, chunk_start_idx, right=True)  # idx size: [x_len]
     # boundary = end_pad[idx]  # boundary size: [x_len]
     seq_range_expand = (
-        torch.arange(0, x_len).unsqueeze(0).expand(x_len, -1)
+        torch.arange(0, x_len, device=chunk_start_idx.device)
+        .unsqueeze(0)
+        .expand(x_len, -1)
     )  # seq_range_expand size [x_len, x_len]
     idx_left = idx - left_window
     idx_left[idx_left < 0] = 0

--- a/test/registered/unit/configs/test_janus_pro.py
+++ b/test/registered/unit/configs/test_janus_pro.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.configs.janus_pro import VLChatProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def test_add_image_token_accepts_python_indices_with_special_token():
+    processor = SimpleNamespace(
+        add_special_token=True,
+        image_start_id=101,
+        image_id=99,
+        image_end_id=102,
+        num_image_tokens=2,
+    )
+
+    input_ids, num_image_tokens = VLChatProcessor.add_image_token(
+        processor, [1, 3], torch.tensor([1, 99, 2, 99, 3], dtype=torch.long)
+    )
+
+    assert input_ids.tolist() == [1, 99, 101, 99, 99, 102, 2, 99, 101, 99, 99, 102, 3]
+    assert num_image_tokens.tolist() == [2, 2]
+
+
+def test_add_image_token_accepts_python_indices_without_special_token():
+    processor = SimpleNamespace(
+        add_special_token=False,
+        image_start_id=101,
+        image_id=99,
+        image_end_id=102,
+        num_image_tokens=2,
+    )
+
+    input_ids, num_image_tokens = VLChatProcessor.add_image_token(
+        processor, [1, 3], torch.tensor([1, 99, 2, 99, 3], dtype=torch.long)
+    )
+
+    assert input_ids.tolist() == [1, 101, 99, 99, 102, 2, 101, 99, 99, 102, 3]
+    assert num_image_tokens.tolist() == [2, 2]

--- a/test/registered/unit/layers/test_logits_processor.py
+++ b/test/registered/unit/layers/test_logits_processor.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+
+from sglang.srt.layers.logits_processor import _get_chunk_logprob_indices
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize(
+    (
+        "input_logprob_indices",
+        "start_idx",
+        "end_idx",
+        "expected_mask",
+        "expected_chunk",
+    ),
+    [
+        ([0, 1, 2, 3, 5, 6, 7], 0, 3, [0, 1, 2], [0, 1, 2]),
+        ([0, 1, 2, 3, 5, 6, 7], 3, 6, [3, 4], [0, 2]),
+        ([0, 1, 2, 3, 5, 6, 7], 6, 9, [5, 6], [0, 1]),
+        ([0, 2, 5], 3, 5, [], []),
+        ([], 0, 4, [], []),
+    ],
+)
+def test_get_chunk_logprob_indices_matches_nonzero_selection(
+    input_logprob_indices, start_idx, end_idx, expected_mask, expected_chunk
+):
+    input_logprob_indices = torch.tensor(input_logprob_indices, dtype=torch.int64)
+
+    mask_indices, global_indices, chunk_indices = _get_chunk_logprob_indices(
+        input_logprob_indices, start_idx, end_idx
+    )
+
+    assert mask_indices.tolist() == expected_mask
+    assert global_indices.tolist() == [
+        input_logprob_indices[index].item() for index in expected_mask
+    ]
+    assert chunk_indices.tolist() == expected_chunk
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_get_chunk_logprob_indices_preserves_cuda_device():
+    input_logprob_indices = torch.tensor(
+        [0, 1, 2, 3, 5, 6, 7], dtype=torch.int64, device="cuda"
+    )
+
+    mask_indices, global_indices, chunk_indices = _get_chunk_logprob_indices(
+        input_logprob_indices, 3, 6
+    )
+
+    assert mask_indices.device.type == "cuda"
+    assert global_indices.device.type == "cuda"
+    assert chunk_indices.device.type == "cuda"
+    assert mask_indices.cpu().tolist() == [3, 4]
+    assert global_indices.cpu().tolist() == [3, 5]
+    assert chunk_indices.cpu().tolist() == [0, 2]

--- a/test/registered/unit/models/test_phi4mm_utils.py
+++ b/test/registered/unit/models/test_phi4mm_utils.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+from sglang.srt.models.phi4mm_utils import adaptive_enc_mask
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _expected_adaptive_enc_mask(
+    x_len: int, chunk_start_idx: list[int], left_window: int, right_window: int
+):
+    start_pad = [0] + chunk_start_idx
+    end_pad = chunk_start_idx + [x_len]
+    expected = []
+
+    for token_idx in range(x_len):
+        chunk_idx = 0
+        for idx, start in enumerate(chunk_start_idx, start=1):
+            if token_idx >= start:
+                chunk_idx = idx
+
+        left_idx = max(chunk_idx - left_window, 0)
+        right_idx = min(chunk_idx + right_window, len(chunk_start_idx))
+        row_start = start_pad[left_idx]
+        row_end = end_pad[right_idx]
+        expected.append(
+            [row_start <= attend_idx < row_end for attend_idx in range(x_len)]
+        )
+
+    return torch.tensor(expected, dtype=torch.bool)
+
+
+@pytest.mark.parametrize(
+    ("x_len", "chunk_start_idx", "left_window", "right_window"),
+    [
+        (8, [0, 3, 6], 0, 0),
+        (8, [0, 3, 6], 1, 0),
+        (8, [0, 3, 6], 0, 1),
+        (8, [0, 3, 6], 2, 2),
+        (5, [], 0, 0),
+        (7, [2, 5], 1, 1),
+    ],
+)
+def test_adaptive_enc_mask_matches_chunk_windows(
+    x_len, chunk_start_idx, left_window, right_window
+):
+    result = adaptive_enc_mask(x_len, chunk_start_idx, left_window, right_window)
+
+    assert result.dtype == torch.bool
+    assert torch.equal(
+        result,
+        _expected_adaptive_enc_mask(x_len, chunk_start_idx, left_window, right_window),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_adaptive_enc_mask_preserves_tensor_device_on_cuda():
+    chunk_start_idx = torch.tensor([0, 3, 6], device="cuda")
+
+    result = adaptive_enc_mask(8, chunk_start_idx, left_window=1, right_window=1)
+
+    assert result.device.type == "cuda"
+    assert torch.equal(result.cpu(), _expected_adaptive_enc_mask(8, [0, 3, 6], 1, 1))


### PR DESCRIPTION
## Summary
- avoid `nonzero()` in Janus image-token index discovery by collecting indices from the tokenizer output before tensorization
- replace Phi4 `adaptive_enc_mask` chunk lookup with `torch.bucketize`, avoiding the dense interval mask + `nonzero()` path
- replace chunked logprob GPU bool-mask + `torch.nonzero()` selection with a `torch.searchsorted` helper over sorted logprob indices

Refs #9889.

## Tests
- `PYTHONPATH=python .venv/bin/python -m pytest -q test/registered/unit/configs/test_janus_pro.py test/registered/unit/models/test_phi4mm_utils.py test/registered/unit/layers/test_logits_processor.py` -> 15 passed
- `PYTHONPATH=python .venv/bin/python -m pytest -q test/registered/unit/sampling/test_custom_logit_processor.py test/registered/unit/sampling/test_sampling_batch_info.py` -> 73 passed
- `.venv/bin/python scripts/ci/check_registered_tests.py`
- `git diff --check`

## B200 microbenchmark
On NVIDIA B200 with Torch 2.11.0+cu130, comparing the old chunked logprob bool-mask + `nonzero()` path to the new `searchsorted` helper:

- old: 0.0735 ms/iter
- new: 0.0459 ms/iter
- speedup: 1.60x











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->