### PR TITLE
[Fix] MiMo-V2 video+audio crash when audio shorter than video (#24602)

### DIFF
--- a/python/sglang/srt/multimodal/processors/mimo_v2.py
+++ b/python/sglang/srt/multimodal/processors/mimo_v2.py
@@ -968,16 +968,20 @@ class MiMoProcessor:
                 if i < len(grid_t_timestamps) - 1
                 else int(video_meta["segment_end_time"] * audio_token_per_second)
             )
-            segment_audio_token_len = (
-                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx
+            # Audio may end before the last video grid (e.g. silent tail).
+            # In that case `min(end, audio_token_len) - start` is <= 0; clamp
+            # to 0 so the grid still emits its video tokens with no audio
+            # placeholders, instead of asserting and dropping the request.
+            segment_audio_token_len = max(
+                0,
+                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx,
             )
-            assert segment_audio_token_len > 0
             segment_audio = (
                 processed_audio[
                     audio_start_token_idx : audio_start_token_idx
                     + segment_audio_token_len
                 ]
-                if is_tokenized
+                if is_tokenized and segment_audio_token_len > 0
                 else None
             )
             video_audio_units.append(

--- a/python/sglang/srt/multimodal/processors/mimo_v2.py
+++ b/python/sglang/srt/multimodal/processors/mimo_v2.py
@@ -1003,16 +1003,20 @@ class MiMoProcessor:
                 if i < len(grid_t_timestamps) - 1
                 else int(video_meta["segment_end_time"] * audio_token_per_second)
             )
-            segment_audio_token_len = (
-                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx
+            # Audio may end before the last video grid (e.g. silent tail).
+            # In that case `min(end, audio_token_len) - start` is <= 0; clamp
+            # to 0 so the grid still emits its video tokens with no audio
+            # placeholders, instead of asserting and dropping the request.
+            segment_audio_token_len = max(
+                0,
+                min(audio_end_token_idx, audio_token_len) - audio_start_token_idx,
             )
-            assert segment_audio_token_len > 0
             segment_audio = (
                 processed_audio[
                     audio_start_token_idx : audio_start_token_idx
                     + segment_audio_token_len
                 ]
-                if is_tokenized
+                if is_tokenized and segment_audio_token_len > 0
                 else None
             )
             units.append(

--- a/test/registered/unit/multimodal/processors/test_mimo_v2.py
+++ b/test/registered/unit/multimodal/processors/test_mimo_v2.py
@@ -1,0 +1,55 @@
+"""Unit tests for the MiMo-V2 multimodal processor."""
+
+import importlib
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestMiMoProcessor(CustomTestCase):
+    def test_video_units_allow_audio_to_end_before_video(self):
+        torchcodec = ModuleType("torchcodec")
+        torchcodec.__path__ = []
+        torchcodec_decoders = ModuleType("torchcodec.decoders")
+        torchcodec_decoders.AudioDecoder = object
+        torchcodec.decoders = torchcodec_decoders
+        with patch.dict(
+            sys.modules,
+            {
+                "torchcodec": torchcodec,
+                "torchcodec.decoders": torchcodec_decoders,
+            },
+        ):
+            mimo_v2 = importlib.import_module(
+                "sglang.srt.multimodal.processors.mimo_v2"
+            )
+
+        MiMoProcessor = mimo_v2.MiMoProcessor
+        processor = object.__new__(MiMoProcessor)
+        processor.temporal_patch_size = 1
+        processor.temporal_compression_ratio = 1
+        processor.use_video_timestamps = True
+        processor.audio_token_per_second = 1
+        processor.merge_size = 1
+
+        units = processor._build_video_audio_units(
+            thw_grid=(3, 1, 1),
+            timestamps=[0.0, 1.0, 2.0],
+            video_meta={"segment_end_time": 3.0},
+            processed_audio=[42],
+            is_tokenized=True,
+            audio_token_len=1,
+        )
+
+        self.assertEqual([unit["segment_audio_token_len"] for unit in units], [1, 0, 0])
+        self.assertEqual([unit["segment_audio"] for unit in units], [[42], None, None])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #24602.

MiMo-V2.5 crashes when a video's audio track ends before the final video grid. Later grids start at or beyond `audio_token_len`, so the previous calculation produced a zero or negative segment length and hit an assertion, returning HTTP 500 for the whole request.

## Modifications

The patch is rebased onto current `main`, where this logic now lives in `_build_video_audio_units`:

- Clamp each per-grid audio length at zero.
- Skip the audio slice for empty tail segments while preserving the video tokens.
- Add a registered CPU unit test covering positive, zero, and negative raw segment lengths.

Behavior is unchanged while audio is available. The only new path is for video grids after the audio has ended.

## Accuracy Tests

@yuweih205 independently reproduced the failure and verified the same fix on MiMo-V2.5 with 8xH200: the short-track case changed from 0/2 to 2/2, and the full six-case AV suite passed 12/12. See the verification in https://github.com/sgl-project/sglang/pull/25515#issuecomment-5455826388.

The new unit test is registered in `base-a-test-cpu`; Linux CI will execute it on this revision.

## Speed Tests and Profiling

Not run. The hot-path change replaces a subtraction plus assertion with `max(0, ...)` and avoids slicing empty audio segments.

## Checklist

- [x] Format code with pre-commit. Relevant hooks and registered-test validators pass.
- [x] Add unit tests. Added `test_video_units_allow_audio_to_end_before_video`.
- [x] Update documentation. Not needed for this internal bug fix.
- [x] Provide accuracy results. Independent real-model verification is linked above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33359800548](https://github.com/sgl-project/sglang/actions/runs/33359800548)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33359800304](https://github.com/sgl-project/sglang/actions/runs/33359800304)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33359800684](https://github.com/sgl-project/sglang/actions/runs/33359800684)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->