### PR TITLE
[codex] Fix FLUX.1 NVFP4 CUDNN scale layout

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
@@ -554,8 +554,13 @@ class ModelOptFp4LinearMethod(LinearMethodBase):
         padded_scales[:B, :M, :K] = scales
 
         _, flashinfer_backend = _get_fp4_gemm_op()
-        if flashinfer_backend is None:
-            # CUTLASS (sgl_kernel) path: blockwise interleave to TMA layout
+        uses_flux1_scale_layout = not getattr(
+            self.quant_config, "checkpoint_uses_packed_qkv", False
+        ) and getattr(layer, "prefix", "").startswith(
+            ("transformer_blocks.", "single_transformer_blocks.")
+        )
+        if flashinfer_backend is None or uses_flux1_scale_layout:
+            # CUTLASS and FLUX.1 CUDNN paths need the TMA scale layout.
             padded_scales = padded_scales.reshape(
                 B, M_padded // 128, 4, 32, K_padded // 4, 4
             )


### PR DESCRIPTION
## Summary

- Restore the TMA weight-scale layout for FLUX.1 ModelOpt NVFP4 layers when using the FlashInfer CUDNN FP4 GEMM backend.
- Keep the existing FlashInfer CUDNN layout for packed-QKV checkpoints such as the official FLUX.2 NVFP4 export.
- Limit the change to the runtime quantization path; no test files are changed.

## Root Cause

PR #23625 stopped applying the CUTLASS/TMA scale interleave for all FlashInfer backends. That is correct for packed-QKV FLUX.2 exports, but the FLUX.1 ModelOpt NVFP4 transformer keeps the non-packed FLUX.1 layer layout and still needs the interleaved scale layout under CUDNN. Without it, the CI smoke run can complete but the rendered image is noise.

## Validation

- `python3 -m py_compile python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py`
- B200 FLUX.1 NVFP4 CUDNN smoke: `black-forest-labs/FLUX.1-dev` + `lmsys/flux1-dev-modelopt-nvfp4-sglang-transformer`, 768x768, 12 steps, seed 0. Output hash: `ed65162cb7f8f4bada6256a5eb806445478dfa350bdbc60fe4975a0911130a05`.
- B200 FLUX.2 official NVFP4 CUDNN smoke: `black-forest-labs/FLUX.2-dev` + `black-forest-labs/FLUX.2-dev-NVFP4`, 768x768, 12 steps, seed 0. Output hash: `895467b60cc3444ffa40264e3434829de1b1af7a91e72893d13bf7cf4d83edf0`; visually inspected as coherent.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->