### PR TITLE
lora: native loading for PEFT 0.18+ batched-MoE adapters; add LFM2 / LFM2-MoE LoRA

### DIFF
--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -198,6 +198,10 @@ class LoRAAdapter(nn.Module):
 
     def _normalize_weights(self):
         for layer in self.layers:
+            # Convert PEFT 0.18+ ParamWrapper batched-MoE-expert LoRAs into
+            # SGLang's 3D-per-expert layout (must run before the others so
+            # downstream normalizers see the canonical `experts.<leaf>` names).
+            self._normalize_peft_paramwrapper_moe(layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_qkv_proj(weight_names, layer.weights)
             self._rename_expert_w_to_proj(layer.weights)
@@ -205,10 +209,132 @@ class LoRAAdapter(nn.Module):
             self._normalize_in_proj(layer.weights)
             # Stack in_proj_q + in_proj_k + in_proj_v + in_proj_z → in_proj_qkvz for GDN layers
             self._normalize_in_proj_qkvz(layer.weights)
+            self._replicate_merged_in_proj_lora_a(layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_gate_up_proj(weight_names, layer.weights)
             weight_names = list(layer.weights.keys())
             self.normalize_fused_qkv_a_proj(weight_names, layer.weights)
+
+    # PEFT 0.18+ `target_parameters` save paths for batched-MoE-expert LoRA:
+    #   <parent>.experts.lora_<A|B>(.<adapter>).weight              (outer wrap)
+    #   <parent>.experts.base_layer.lora_<A|B>(.<adapter>).weight   (inner wrap)
+    # `<parent>` varies by model (LFM2 → `feed_forward`, DeepSeek → `mlp`,
+    # Mixtral → `block_sparse_moe`) so we don't anchor on it. Mixtral-style
+    # adapters that save per-expert (`...experts.<N>.<module>.lora_*`) don't
+    # match here and take SGLang's existing per-expert load path.
+    _PEFT_EXPERTS_PARAMWRAPPER_RE = re.compile(
+        r"(?P<prefix>.+?)\.experts(?P<base_layer>\.base_layer)?\.lora_(?P<ab>[AB])"
+        r"(?:\.[^.]+)?\.weight$"
+    )
+
+    # Stacked-shard count per target — for fused targets like gate_up_proj
+    # SGLang stores LoRA A with rank tiled c× along the rank dim.
+    _PEFT_LORA_STACKED_MULTIPLY = {"gate_up_proj": 2, "down_proj": 1}
+
+    def _normalize_peft_paramwrapper_moe(self, weights: Dict[str, torch.Tensor]):
+        """Rewrite PEFT 0.18+ batched-MoE-expert LoRAs into SGLang's 3D-per-expert form.
+
+        PEFT 0.18 added ``target_parameters`` for LoRA-training arbitrary
+        ``nn.Parameter`` tensors — including the batched 3D MoE expert weights
+        used by HF transformers >= 5.8 (Mixtral, DeepSeek-V2, LFM2-MoE via
+        ``@use_experts_implementation``). PEFT saves these via ``ParamWrapper``
+        as flat 2D tensors (A: ``(E*r, in)`` with experts outer; B:
+        ``(out, r*E)`` with experts inner) under names that don't match the
+        standard ``experts.<leaf>.lora_*`` convention SGLang's MoE-LoRA path
+        expects.
+
+        With two ``target_parameters``, PEFT nests the wrappers, so the first
+        listed param lands at the inner ``base_layer`` slot and the second at
+        the outer slot. We use ``adapter_config.target_parameters`` to map
+        each slot back to a leaf module name, reshape A to
+        ``(E, c*r, in)`` (c-tiled for stacked targets like ``gate_up_proj``)
+        and B to ``(E, out, r)``, and rename the key to
+        ``...experts.<leaf>.lora_*.weight`` so the existing 3D MoE load path
+        picks it up natively.
+        """
+        target_parameters = self.config.hf_config.get("target_parameters") or []
+        if not target_parameters:
+            return
+        if len(target_parameters) > 2:
+            raise ValueError(
+                "PEFT ParamWrapper compatibility supports at most 2 "
+                f"target_parameters per parent module, got: {target_parameters}"
+            )
+
+        cfg = self.base_hf_config
+        if hasattr(cfg, "get_text_config"):
+            cfg = cfg.get_text_config()
+        num_experts = (
+            getattr(cfg, "num_experts", None)
+            or getattr(cfg, "num_local_experts", None)
+            or getattr(cfg, "n_routed_experts", None)
+        )
+        if num_experts is None:
+            raise ValueError(
+                "Cannot determine num_experts from base model config; needed to "
+                "reshape PEFT ParamWrapper MoE LoRA weights."
+            )
+        rank = self.config.r
+
+        for name in list(weights.keys()):
+            m = self._PEFT_EXPERTS_PARAMWRAPPER_RE.match(name)
+            if m is None:
+                continue
+            is_inner = bool(m.group("base_layer"))
+            if is_inner:
+                target_param = target_parameters[0]
+            elif len(target_parameters) >= 2:
+                target_param = target_parameters[-1]
+            else:
+                # Outer-slot weight present but only one target_parameter listed
+                # — ambiguous, leave for the loader to flag.
+                continue
+            leaf = target_param.rsplit(".", 1)[-1]
+            is_lora_A = m.group("ab") == "A"
+
+            w = weights.pop(name)
+            if is_lora_A:
+                # PEFT layout (E*r, in_features) → (E, r, in)
+                in_features = w.shape[1]
+                w = w.reshape(num_experts, rank, in_features).contiguous()
+                c = self._PEFT_LORA_STACKED_MULTIPLY.get(leaf, 1)
+                if c > 1:
+                    # SGLang's stacked-LoRA A holds [shard_0; shard_1; ...].
+                    # PEFT's fused-parameter LoRA is equivalent to stacked-LoRA
+                    # with identical A across shards — tile along the rank dim.
+                    w = w.repeat(1, c, 1).contiguous()
+            else:
+                # PEFT layout (out_features, r*E) → (E, out, r)
+                out_features = w.shape[0]
+                w = (
+                    w.reshape(out_features, rank, num_experts)
+                    .permute(2, 0, 1)
+                    .contiguous()
+                )
+            new_name = f"{m.group('prefix')}.experts.{leaf}.lora_{m.group('ab')}.weight"
+            weights[new_name] = w
+
+    def _replicate_merged_in_proj_lora_a(self, weights: Dict[str, torch.Tensor]):
+        """Tile lora_A for adapters trained against a single in_proj that the
+        base model exposes as a 3-partition ``MergedColumnParallelLinear``.
+
+        When the base model packs three equal-width projections into one
+        ``in_proj`` (e.g. a B/C/x ShortConv gate stack), the LoRA buffer
+        expects three stacked rank-r slices: A is ``(3r, hidden)``, B is
+        ``(3*hidden, r)``. Adapters trained against the merged in_proj as a
+        single Linear instead carry one shared rank-r LoRA whose B is already
+        full-width ``(3*hidden, r)`` but whose A is just ``(r, hidden)``.
+        Replicating A three times along the rank dim makes the stacked-LoRA
+        computation ``(x@A)·B`` produce an identical contribution per slice.
+        """
+        for weight_name in list(weights.keys()):
+            if ".conv.in_proj." not in weight_name or "lora_A" not in weight_name:
+                continue
+            tensor = weights[weight_name]
+            ndim = tensor.dim()
+            repeat_dims = [1] * ndim
+            repeat_dims[ndim - 2] = 3
+            weights[weight_name] = tensor.repeat(*repeat_dims)
 
     def normalize_qkv_proj(
         self, weight_names: List[str], weights: Dict[str, torch.Tensor]

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -474,9 +474,19 @@ class LoRAMemoryPool:
             if hasattr(cfg, "get_text_config"):
                 cfg = cfg.get_text_config()
             has_shared_experts = (
-                hasattr(cfg, "shared_expert_intermediate_size")
-                and cfg.shared_expert_intermediate_size > 0
-            ) or (getattr(cfg, "n_shared_experts", 0) or 0) > 0
+                # DeepSeek-style shared experts.
+                (
+                    hasattr(cfg, "shared_expert_intermediate_size")
+                    and cfg.shared_expert_intermediate_size > 0
+                )
+                or (getattr(cfg, "n_shared_experts", 0) or 0) > 0
+                # Hybrid-layer MoE models (e.g. LFM2-MoE `num_dense_layers`,
+                # DeepSeek `first_k_dense_replace`) use the standard
+                # `gate_up_proj` / `down_proj` names on their dense MLP layers,
+                # so they also need a non-MoE 3D buffer in addition to `*_moe`.
+                or (getattr(cfg, "num_dense_layers", 0) or 0) > 0
+                or (getattr(cfg, "first_k_dense_replace", 0) or 0) > 0
+            )
             has_moe = self._has_moe_module(base_model)
 
             # Shape functions automatically handle both 3D (standard) and 4D (MoE)

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -209,6 +209,9 @@ def get_normalized_target_modules(
         "unembed_tokens": "lm_head",
         "q_a_proj": "fused_qkv_a_proj_with_mqa",
         "kv_a_proj_with_mqa": "fused_qkv_a_proj_with_mqa",
+        "w1": "gate_up_proj",
+        "w3": "gate_up_proj",
+        "w2": "down_proj",
     }
 
     result = set()
@@ -288,6 +291,7 @@ _KNOWN_LORA_TARGET_MODULES = frozenset(
         "fused_qkv_a_proj_with_mqa",
         "q_b_proj",
         "kv_b_proj",
+        "gate",
     }
 )
 

--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -15,18 +15,17 @@ import logging
 from typing import Iterable, Optional, Set, Tuple
 
 import torch
-import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.configs.lfm2 import Lfm2Config
 from sglang.srt.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.attention.mamba.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
-    ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
@@ -72,32 +71,28 @@ class Lfm2MLP(nn.Module):
                     // config.block_multiple_of
                 )
 
-        self.w1 = ColumnParallelLinear(
+        # w1 (gate) + w3 (up) are merged into gate_up_proj so the LoRA system
+        # can wrap them with a single MergedColumnParallelLinearWithLoRA.
+        self.gate_up_proj = MergedColumnParallelLinear(
             config.hidden_size,
-            intermediate_size,
+            [intermediate_size] * 2,
             bias=False,
             quant_config=quant_config,
-            prefix=add_prefix("w1", prefix),
+            prefix=add_prefix("gate_up_proj", prefix),
         )
-        self.w3 = ColumnParallelLinear(
-            config.hidden_size,
-            intermediate_size,
-            bias=False,
-            quant_config=quant_config,
-            prefix=add_prefix("w3", prefix),
-        )
-        self.w2 = RowParallelLinear(
+        self.down_proj = RowParallelLinear(
             intermediate_size,
             config.hidden_size,
             bias=False,
             quant_config=quant_config,
-            prefix=add_prefix("w2", prefix),
+            prefix=add_prefix("down_proj", prefix),
         )
+        self.act_fn = SiluAndMul()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate, _ = self.w1(x)
-        up, _ = self.w3(x)
-        out, _ = self.w2(F.silu(gate) * up)
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        out, _ = self.down_proj(x)
         return out
 
 
@@ -453,6 +448,14 @@ class Lfm2ForCausalLM(nn.Module):
 
     fall_back_to_pt_during_load = False
 
+    supported_lora_modules = [
+        "qkv_proj",
+        "out_proj",
+        "gate_up_proj",
+        "down_proj",
+        "in_proj",
+    ]
+
     def __init__(
         self,
         config: Lfm2Config,
@@ -482,6 +485,60 @@ class Lfm2ForCausalLM(nn.Module):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.model.embed_tokens
 
+    def get_hidden_dim(self, module_name: str, layer_idx: int) -> Tuple[int, int]:
+        """Return (input_dim, output_dim) for each LoRA-supported module.
+
+        Used by SGLang's LoRA system to size the per-rank GPU buffers.
+        Mirrors the dim logic in Lfm2MLP / Lfm2Attention / Lfm2ShortConv.
+        """
+        config = self.config
+        hidden_size = config.hidden_size
+        head_dim = getattr(config, "head_dim", None) or (
+            hidden_size // config.num_attention_heads
+        )
+
+        intermediate_size = config.intermediate_size
+        if config.block_auto_adjust_ff_dim:
+            intermediate_size = int(2 * intermediate_size / 3)
+            if config.block_ffn_dim_multiplier is not None:
+                intermediate_size = int(
+                    config.block_ffn_dim_multiplier * intermediate_size
+                )
+                intermediate_size = config.block_multiple_of * (
+                    (intermediate_size + config.block_multiple_of - 1)
+                    // config.block_multiple_of
+                )
+
+        if module_name == "qkv_proj":
+            q_dim = head_dim * config.num_attention_heads
+            kv_dim = head_dim * config.num_key_value_heads
+            return hidden_size, q_dim + 2 * kv_dim
+        elif module_name == "out_proj":
+            # Same shape for attention out_proj and ShortConv out_proj.
+            return hidden_size, hidden_size
+        elif module_name == "gate_up_proj":
+            return hidden_size, 2 * intermediate_size
+        elif module_name == "down_proj":
+            return intermediate_size, hidden_size
+        elif module_name == "in_proj":
+            # ShortConv in_proj: hidden -> 3*hidden (B, C, x gates stacked).
+            return hidden_size, 3 * hidden_size
+        else:
+            raise NotImplementedError(
+                f"get_hidden_dim not implemented for {module_name}"
+            )
+
+    def get_stacked_multiply(self, module_name: str) -> int:
+        """Override the global stacked_rank for LFM2-specific module shapes."""
+        if module_name == "in_proj":
+            # ShortConv in_proj packs 3 sub-projections (B, C, x). The
+            # adapter's B matrix is full-width (3*hidden); its single A
+            # gets replicated 3× by lora.py's _replicate_merged_in_proj_lora_a.
+            return 3
+        from sglang.srt.lora.utils import get_stacked_multiply
+
+        return get_stacked_multiply(module_name)
+
     @torch.no_grad()
     def forward(
         self,
@@ -503,6 +560,9 @@ class Lfm2ForCausalLM(nn.Module):
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
+            # MLP w1/w3 -> merged gate_up_proj (shard 0 = gate, 1 = up).
+            ("gate_up_proj", "w1", 0),
+            ("gate_up_proj", "w3", 1),
         ]
 
         params_dict = dict(self.named_parameters())
@@ -523,7 +583,11 @@ class Lfm2ForCausalLM(nn.Module):
             if ".conv.conv.bias" in name:
                 name = name.replace(".conv.conv.bias", ".conv.conv_bias")
 
-            # Handle QKV stacking
+            # Rename HF down projection (w2) to down_proj (our merged MLP convention).
+            if ".feed_forward.w2." in name:
+                name = name.replace(".feed_forward.w2.", ".feed_forward.down_proj.")
+
+            # Handle QKV + gate_up stacking
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -525,6 +525,19 @@ class Lfm2MoeForCausalLM(nn.Module):
 
     fall_back_to_pt_during_load = False
 
+    # LoRA targets covered: attention, leading dense MLP layers, ShortConv,
+    # and the MoE router. FusedMoE expert weights are auto-wrapped via
+    # FusedMoEWithLoRA when gate_up_proj + down_proj are in target_modules
+    # (the LoRA system maps them to gate_up_proj_moe / down_proj_moe buffers).
+    supported_lora_modules = [
+        "qkv_proj",
+        "out_proj",
+        "gate_up_proj",
+        "down_proj",
+        "in_proj",
+        "gate",
+    ]
+
     def __init__(
         self,
         config: Lfm2MoeConfig,
@@ -552,6 +565,54 @@ class Lfm2MoeForCausalLM(nn.Module):
 
     def get_num_kv_cache_layers(self) -> int:
         return self.num_attention_layers
+
+    def get_hidden_dim(self, module_name: str, layer_idx: int) -> Tuple[int, int]:
+        """Return (input_dim, output_dim) for each LoRA-supported module.
+
+        Covers attention, the leading dense MLP layers (Lfm2MoeMLP), and
+        ShortConv. Does NOT cover FusedMoE experts.
+        """
+        config = self.config
+        hidden_size = config.hidden_size
+        head_dim = hidden_size // config.num_attention_heads
+        intermediate_size = config.intermediate_size
+
+        if module_name == "qkv_proj":
+            q_dim = head_dim * config.num_attention_heads
+            kv_dim = head_dim * config.num_key_value_heads
+            return hidden_size, q_dim + 2 * kv_dim
+        elif module_name == "out_proj":
+            # Same shape for attention out_proj and ShortConv out_proj.
+            return hidden_size, hidden_size
+        elif module_name == "gate_up_proj":
+            return hidden_size, 2 * intermediate_size
+        elif module_name == "down_proj":
+            return intermediate_size, hidden_size
+        elif module_name == "gate_up_proj_moe":
+            return hidden_size, 2 * config.moe_intermediate_size
+        elif module_name == "down_proj_moe":
+            return config.moe_intermediate_size, hidden_size
+        elif module_name == "in_proj":
+            # ShortConv in_proj: hidden -> 3*hidden (B, C, x gates stacked).
+            return hidden_size, 3 * hidden_size
+        elif module_name == "gate":
+            # MoE router (ReplicatedLinear): hidden -> num_experts.
+            return hidden_size, config.num_experts
+        else:
+            raise NotImplementedError(
+                f"get_hidden_dim not implemented for {module_name}"
+            )
+
+    def get_stacked_multiply(self, module_name: str) -> int:
+        """Override the global stacked_rank for LFM2-MoE-specific shapes."""
+        if module_name == "in_proj":
+            # ShortConv in_proj packs 3 sub-projections (B, C, x). The
+            # adapter's B matrix is full-width (3*hidden); its single A
+            # gets replicated 3× by lora.py's _replicate_merged_in_proj_lora_a.
+            return 3
+        from sglang.srt.lora.utils import get_stacked_multiply
+
+        return get_stacked_multiply(module_name)
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3568,6 +3568,12 @@ SUPPORTED_LORA_TARGET_MODULES = [
     "gate_up_proj",
     "embed_tokens",
     "lm_head",
+    "w1",
+    "w2",
+    "w3",
+    "in_proj",
+    "out_proj",
+    "gate",
 ]
 
 LORA_TARGET_ALL_MODULES = "all"

--- a/test/registered/lora/test_lora_lfm2_moe.py
+++ b/test/registered/lora/test_lora_lfm2_moe.py
@@ -1,0 +1,84 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Smoke test for LFM2-MoE LoRA support.
+
+Loads the published PEFT 0.18+ smoltalk adapter (which targets the batched
+3D MoE expert weights via `target_parameters`) into SGLang and asserts the
+LoRA-on output differs from the base output. Exercises the full
+`Lfm2MoeForCausalLM` LoRA path end-to-end: attention, ShortConv, dense MLP,
+MoE router, and the FusedMoEWithLoRA expert codepath.
+
+Usage:
+    python test/registered/lora/test_lora_lfm2_moe.py
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=120, suite="stage-b-test-1-gpu-small")
+
+import sglang as sgl
+
+BASE_MODEL = "LiquidAI/LFM2-8B-A1B"
+LORA_REPO = "LiquidAI/LFM2-8B-A1B-smoltalk-LoRA"
+LORA_NAME = "smoltalk"
+LORA_TARGET_MODULES = [
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "out_proj",
+    "w1",
+    "w2",
+    "w3",
+    "in_proj",
+    "gate",
+    "gate_up_proj",
+    "down_proj",
+]
+PROMPT = (
+    "What are some ideas for a good short story about a city not on a planet, "
+    "but rather a generation ship, or on the moon of a gas giant, "
+    "or somewhere else unusual?"
+)
+SAMPLING = {"max_new_tokens": 32, "temperature": 0.0}
+
+
+class TestLFM2MoELoRA(CustomTestCase):
+    def test_lora_changes_outputs(self):
+        engine = sgl.Engine(
+            model_path=BASE_MODEL,
+            enable_lora=True,
+            max_lora_rank=8,
+            lora_paths=[f"{LORA_NAME}={LORA_REPO}"],
+            lora_target_modules=LORA_TARGET_MODULES,
+        )
+        try:
+            base = engine.generate(PROMPT, sampling_params=SAMPLING)["text"]
+            lora = engine.generate(
+                PROMPT, sampling_params=SAMPLING, lora_path=LORA_NAME
+            )["text"]
+        finally:
+            engine.shutdown()
+        self.assertNotEqual(
+            base,
+            lora,
+            "LoRA-on and base outputs should differ; if they're identical, the adapter "
+            "isn't reaching the forward path.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
+++ b/test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
@@ -1,0 +1,217 @@
+"""Unit tests for ``LoRAAdapter._normalize_peft_paramwrapper_moe``.
+
+Covers PEFT 0.18+ ``target_parameters`` (``ParamWrapper``) → SGLang 3D-per-expert
+rewrite: name resolution (inner/outer slot → first/last listed param), reshape
+semantics (c=1 and c=2 stacking, B-axis layout per PEFT source), gating against
+non-PEFT-ParamWrapper adapters.
+
+Usage:
+    python test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
+"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+# CPU-only unit test; no CUDA needed.
+register_cuda_ci(est_time=5, suite="stage-b-test-1-gpu-small")
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.lora.lora import LoRAAdapter
+
+
+# Standard LFM2-MoE-style adapter_config target_parameters (in user order).
+_TPARAMS = ["experts.gate_up_proj", "experts.down_proj"]
+
+
+def _make_adapter(
+    target_parameters,
+    *,
+    rank: int = 8,
+    num_experts: int = 32,
+):
+    """Build a bare LoRAAdapter-like stub with just the fields the normalizer reads.
+
+    We bypass ``__init__`` so the test doesn't need to stand up a base model
+    or a real LoRAConfig instance — both are heavy. The normalizer only reads
+    ``self.config.hf_config["target_parameters"]``, ``self.config.r``, and
+    ``self.base_hf_config.num_experts``.
+    """
+    adapter = LoRAAdapter.__new__(LoRAAdapter)
+    adapter.config = types.SimpleNamespace(
+        hf_config={"target_parameters": target_parameters},
+        r=rank,
+    )
+    adapter.base_hf_config = types.SimpleNamespace(num_experts=num_experts)
+    return adapter
+
+
+class TestPeftParamWrapperRename(unittest.TestCase):
+    """Name resolution: inner/outer slot → first/last listed target_parameter."""
+
+    def test_inner_base_layer_maps_to_first_target(self):
+        adapter = _make_adapter(_TPARAMS)
+        name = (
+            "base_model.model.model.layers.5.feed_forward.experts.base_layer"
+            ".lora_A.default.weight"
+        )
+        weights = {name: torch.zeros(32 * 8, 2048, dtype=torch.bfloat16)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        new_keys = list(weights.keys())
+        self.assertEqual(len(new_keys), 1)
+        self.assertTrue(new_keys[0].endswith(".experts.gate_up_proj.lora_A.weight"))
+
+    def test_outer_no_base_layer_maps_to_last_target(self):
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.layers.5.mlp.experts.lora_B.default.weight"
+        weights = {name: torch.zeros(2048, 8 * 32, dtype=torch.bfloat16)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        new_keys = list(weights.keys())
+        self.assertEqual(len(new_keys), 1)
+        self.assertTrue(new_keys[0].endswith(".experts.down_proj.lora_B.weight"))
+
+    def test_user_supplied_order_is_honored(self):
+        """If the user lists target_parameters reversed, the slot mapping flips."""
+        adapter = _make_adapter(list(reversed(_TPARAMS)))
+        inner = "x.experts.base_layer.lora_A.default.weight"
+        outer = "x.experts.lora_A.default.weight"
+        weights = {
+            inner: torch.zeros(32 * 8, 1792, dtype=torch.bfloat16),
+            outer: torch.zeros(32 * 8, 2048, dtype=torch.bfloat16),
+        }
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        keys = set(weights.keys())
+        self.assertIn("x.experts.down_proj.lora_A.weight", keys)
+        self.assertIn("x.experts.gate_up_proj.lora_A.weight", keys)
+
+
+class TestPeftParamWrapperReshape(unittest.TestCase):
+    """Reshape semantics — flat 2D → 3D-per-expert with c-tiling for stacked targets."""
+
+    NUM_EXPERTS = 32
+    RANK = 8
+    HIDDEN = 2048
+    MOE_INTERMEDIATE = 1792
+
+    def test_gate_up_proj_lora_A_tiles_for_stacked_c2(self):
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.experts.base_layer.lora_A.default.weight"
+        weights = {
+            name: torch.randn(
+                self.NUM_EXPERTS * self.RANK, self.HIDDEN, dtype=torch.bfloat16
+            )
+        }
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        out = next(iter(weights.values()))
+        # c=2 → rank dim doubled; the two halves identical (PEFT's
+        # fused-parameter LoRA shared across gate/up shards).
+        self.assertEqual(
+            tuple(out.shape), (self.NUM_EXPERTS, 2 * self.RANK, self.HIDDEN)
+        )
+        self.assertTrue(torch.equal(out[:, : self.RANK, :], out[:, self.RANK :, :]))
+
+    def test_down_proj_lora_A_unchanged_for_c1(self):
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.experts.lora_A.default.weight"
+        weights = {
+            name: torch.randn(
+                self.NUM_EXPERTS * self.RANK,
+                self.MOE_INTERMEDIATE,
+                dtype=torch.bfloat16,
+            )
+        }
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        out = next(iter(weights.values()))
+        self.assertEqual(
+            tuple(out.shape),
+            (self.NUM_EXPERTS, self.RANK, self.MOE_INTERMEDIATE),
+        )
+
+    def test_lora_B_reshape_and_permute_preserves_per_expert(self):
+        """Round-trip B: build PEFT's layout (experts FAST-varying inside r*E
+        per ``B.reshape(out, rank, num_experts)`` in peft/tuners/lora/layer.py)
+        then verify the reshape recovers each expert's per-expert ``(out, r)``.
+        """
+        adapter = _make_adapter(_TPARAMS, rank=4, num_experts=5)
+        out_dim, rank, E = 64, 4, 5
+        per_expert = [
+            torch.full((out_dim, rank), float(i + 1), dtype=torch.bfloat16)
+            for i in range(E)
+        ]
+        # Experts FAST-varying — matches PEFT's saved layout.
+        flat = torch.stack(per_expert, dim=2).reshape(out_dim, rank * E)
+        name = "x.experts.lora_B.default.weight"
+        weights = {name: flat}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        out = next(iter(weights.values()))
+        self.assertEqual(tuple(out.shape), (E, out_dim, rank))
+        for i in range(E):
+            self.assertTrue(torch.equal(out[i], per_expert[i]))
+
+
+class TestPeftParamWrapperGating(unittest.TestCase):
+    """The normalizer must be inert for non-PEFT-ParamWrapper adapters."""
+
+    def test_no_target_parameters_is_noop(self):
+        adapter = _make_adapter([])
+        weights = {
+            "x.q_proj.lora_A.weight": torch.zeros(8, 2048),
+            "x.experts.0.gate_proj.lora_A.weight": torch.zeros(8, 2048),
+        }
+        snap = {k: v.clone() for k, v in weights.items()}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertEqual(set(weights.keys()), set(snap.keys()))
+        for k, v in snap.items():
+            self.assertTrue(torch.equal(weights[k], v))
+
+    def test_target_parameters_none_is_noop(self):
+        """Older PEFT writes ``"target_parameters": null`` — should be a no-op."""
+        adapter = LoRAAdapter.__new__(LoRAAdapter)
+        adapter.config = types.SimpleNamespace(
+            hf_config={"target_parameters": None}, r=8
+        )
+        adapter.base_hf_config = types.SimpleNamespace(num_experts=32)
+        weights = {"x.q_proj.lora_A.weight": torch.zeros(8, 2048)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn("x.q_proj.lora_A.weight", weights)
+
+    def test_per_expert_names_not_renamed(self):
+        """Mixtral-classic per-expert names (``experts.0.gate_proj.lora_A.weight``)
+        must NOT match the regex — they take SGLang's existing per-expert path."""
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.layers.5.block_sparse_moe.experts.0.gate_proj.lora_A.weight"
+        weights = {name: torch.zeros(8, 2048)}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn(name, weights)
+
+    def test_already_converted_3d_names_not_renamed(self):
+        """Already-converted names (``experts.gate_up_proj.lora_A.weight``)
+        must NOT match (no ``base_layer`` slot, and a leaf module between
+        ``experts.`` and ``lora_``)."""
+        adapter = _make_adapter(_TPARAMS)
+        name = "x.experts.gate_up_proj.lora_A.weight"
+        weights = {name: torch.zeros(32, 8, 2048)}  # already 3D
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertIn(name, weights)
+
+    def test_non_moe_names_untouched(self):
+        adapter = _make_adapter(_TPARAMS)
+        weights = {
+            "x.q_proj.lora_A.weight": torch.zeros(8, 2048),
+            "x.gate_up_proj.lora_B.weight": torch.zeros(2048, 8),
+        }
+        snap = {k: v.clone() for k, v in weights.items()}
+        adapter._normalize_peft_paramwrapper_moe(weights)
+        self.assertEqual(set(weights.keys()), set(snap.keys()))
+
+    def test_more_than_two_target_parameters_rejected(self):
+        adapter = _make_adapter(_TPARAMS + ["experts.gate"])
+        weights = {"x.experts.base_layer.lora_A.weight": torch.zeros(32 * 8, 2048)}
+        with self.assertRaises(ValueError):
+            adapter._normalize_peft_paramwrapper_moe(weights)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
+++ b/test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py
@@ -21,7 +21,6 @@ import torch
 
 from sglang.srt.lora.lora import LoRAAdapter
 
-
 # Standard LFM2-MoE-style adapter_config target_parameters (in user order).
 _TPARAMS = ["experts.gate_up_proj", "experts.down_proj"]
 


### PR DESCRIPTION
PEFT 0.18+'s `target_parameters` is the only way to LoRA-train batched MoE experts (HF transformers ≥ 5.8 stores them as a single 3D `nn.Parameter` under `@use_experts_implementation` — Mixtral, DeepSeek-V2, LFM2-MoE). PEFT saves those expert LoRA tensors under names SGLang's current loader doesn't recognize, so adapters trained this way silently fail to apply on the expert path. This PR bridges the format.

## Summary

**Primary change** — generic loader fix in `lora/lora.py::_normalize_peft_paramwrapper_moe`, invoked at the top of `LoRAAdapter._normalize_weights` before the existing per-format normalizers. Rewrites PEFT 0.18+ `ParamWrapper` save paths (`...experts.base_layer.lora_*`, `...experts.lora_*`, flat 2D `(E·r, in)` / `(out, r·E)`) into SGLang's existing 3D-per-expert layout (`...experts.<leaf>.lora_*`, A: `(E, c·r, in)`, B: `(E, out, r)`). Gated on `adapter_config.target_parameters` being non-empty — inert for any pre-0.18 / `target_modules`-only / per-expert MoE adapter.

**Integration consumer** — LFM2 / LFM2-MoE model-side LoRA wiring in `models/lfm2.py` / `models/lfm2_moe.py` (attention, dense MLP with merged `gate_up_proj`, ShortConv with B/C/x `in_proj` packing, MoE router as a new `gate` target, `FusedMoE` experts via auto-wrap). Serves as the end-to-end integration test for the loader.

**Buffer allocation** — `lora/mem_pool.py::init_buffers`'s `has_shared_experts` check is extended with `num_dense_layers > 0` and `first_k_dense_replace > 0` so hybrid-layer MoE models (LFM2-MoE, DeepSeek with leading dense layers) get the standard 3D `gate_up_proj` buffer alongside the 4D `*_moe` one. *(Variable name retained for diff minimality; the condition semantically now means "requires non-MoE `gate_up_proj` LoRA buffer".)*

## Design

- **Normalizer call site.** Hooked into `LoRAAdapter._normalize_weights` as the first per-layer pass, before existing model-format normalizers (`_normalize_in_proj` Mamba, `_normalize_in_proj_qkvz` GDN, `_replicate_merged_in_proj_lora_a` ShortConv). Same pattern as those — model-format-specific weight-name normalization gated on regex.
- **Reject `>2 target_parameters` per parent.** PEFT's `ParamWrapper` nests at most two per parent module (inner `base_layer` + outer wrap); without exactly two slots, the slot→leaf mapping is ambiguous.
- **Tile `lora_A` for `gate_up_proj_moe` (c=2).** PEFT's fused-parameter LoRA produces one `A` shared across both shards — mathematically equivalent to stacked-LoRA with `A_shard_0 == A_shard_1`. `B` doesn't need tiling: PEFT's `out_features` already concatenates the shards.

## Reproduction

```bash
python -m sglang.launch_server \
  --model-path LiquidAI/LFM2-8B-A1B \
  --enable-lora --max-lora-rank 8 \
  --lora-paths "smoltalk=LiquidAI/LFM2-8B-A1B-smoltalk-LoRA" \
  --lora-target-modules q_proj k_proj v_proj out_proj w1 w2 w3 in_proj gate gate_up_proj down_proj
```

Call with LoRA (colon syntax) / without (base model):

```bash
curl -sS http://localhost:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "LiquidAI/LFM2-8B-A1B:smoltalk",
    "messages": [{"role": "user", "content": "What are some ideas for a good short story about a city not on a planet, but rather a generation ship, or on the moon of a gas giant, or somewhere else unusual?"}],
    "max_tokens": 64,
    "temperature": 0
  }'
```

## Tests

`test/registered/unit/lora/test_peft_paramwrapper_moe_unit.py` — 12 CPU-only unit tests for the normalizer (~60 ms total):

- **Name resolution** (3 tests): inner `base_layer` → first listed `target_parameter`; outer slot → last; user-reversed `target_parameters` order respected.
- **Reshape semantics** (3 tests): c=1 unchanged; c=2 tiling produces identical halves; B-axis layout per PEFT source (`B.reshape(out, rank, num_experts)`).
- **Gating against non-PEFT adapters** (5 tests): no-`target_parameters` is no-op; `target_parameters: null` is no-op; per-expert names (`...experts.0.gate_proj.lora_*`) untouched; already-converted names (`...experts.gate_up_proj.lora_*` 3D) untouched; non-MoE names untouched.
- **Error handling** (1 test): `>2 target_parameters` rejected with clear message.

`test/registered/lora/test_lora_lfm2_moe.py` — single-assertion end-to-end smoke: with `LiquidAI/LFM2-8B-A1B-smoltalk-LoRA` loaded, LoRA-on generated text differs from base. ~46 s on one H100. Exercises the full `Lfm2MoeForCausalLM` LoRA path (attention, ShortConv, dense MLP, MoE router, `FusedMoEWithLoRA` expert codepath).

Numerical parity vs `peft.PeftModel.from_pretrained` verified manually via teacher-forced top-k logprob comparison on both dense and MoE adapters:

- Dense: [`LiquidAI/LFM2.5-1.2B-Instruct-smoltalk-LoRA`](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-smoltalk-LoRA)
- MoE: [`LiquidAI/LFM2-8B-A1B-smoltalk-LoRA`](https://huggingface.co/LiquidAI/LFM2-8B-A1B-smoltalk-LoRA) (PEFT 0.18+ `target_parameters` — exercises the new loader path)
