### PR TITLE
[Bug Fix] Fix DSv4 EAGLE draft CUDA graph replay metadata

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -805,7 +805,6 @@ class DeepseekV4AttnBackend(
             device = seq_lens.device
             seq_lens = torch.ones(bs, dtype=seq_lens.dtype, device=device)
             seq_lens_cpu = torch.ones(bs, dtype=torch.int64)
-            seq_lens_sum = bs
             req_pool_indices = torch.zeros(
                 bs, dtype=req_pool_indices.dtype, device=device
             )
@@ -823,6 +822,12 @@ class DeepseekV4AttnBackend(
         if bucket == _GraphBucket.DECODE_OR_IDLE:
             assert out_cache_loc is not None
             assert len(out_cache_loc.shape) == 1, f"{out_cache_loc.shape=}"
+            if len(out_cache_loc) > bs:
+                raise ValueError(
+                    "DSv4 decode replay metadata expects one out_cache_loc per "
+                    f"graph batch entry; got {len(out_cache_loc)} locations for "
+                    f"{bs=}. Multi-step EAGLE replay must pass a per-step slice."
+                )
             out_cache_loc_padded = torch.nn.functional.pad(
                 out_cache_loc,
                 pad=(0, bs - len(out_cache_loc)),
@@ -1227,26 +1232,63 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
         if self.speculative_num_steps == 1:
             return
 
-        self.attn_backends[0]._replay_forward_batch = forward_batch
-        self.attn_backends[0].init_forward_metadata_replay_cuda_graph(
-            bs=bs,
-            req_pool_indices=forward_batch.req_pool_indices,
-            seq_lens=forward_batch.seq_lens,
-            seq_lens_sum=forward_batch.seq_lens_sum,
-            encoder_lens=None,
-            forward_mode=ForwardMode.DECODE,
-            spec_info=forward_batch.spec_info,
-            seq_lens_cpu=forward_batch.seq_lens_cpu,
+        # EAGLE stores draft cache locations request-major, while each captured
+        # decode step consumes one step-major slice.
+        step_out_cache_locs = _split_eagle_draft_out_cache_loc_by_step(
+            forward_batch.out_cache_loc,
+            batch_size=bs,
+            topk=self.topk,
+            speculative_num_steps=self.speculative_num_steps,
         )
-        self.attn_backends[0]._replay_forward_batch = None
-        temp_metadata = self.attn_backends[0].forward_metadata
+        original_out_cache_loc = forward_batch.out_cache_loc
+        try:
+            for i in range(self.speculative_num_steps - 1):
+                backend = self.attn_backends[i]
+                forward_batch.out_cache_loc = step_out_cache_locs[i]
+                backend._replay_forward_batch = forward_batch
+                backend.init_forward_metadata_replay_cuda_graph(
+                    bs=bs,
+                    req_pool_indices=forward_batch.req_pool_indices,
+                    seq_lens=forward_batch.seq_lens,
+                    seq_lens_sum=forward_batch.seq_lens_sum,
+                    encoder_lens=None,
+                    forward_mode=ForwardMode.DECODE,
+                    spec_info=forward_batch.spec_info,
+                    seq_lens_cpu=forward_batch.seq_lens_cpu,
+                )
+                backend._replay_forward_batch = None
+        finally:
+            forward_batch.out_cache_loc = original_out_cache_loc
+            for backend in self.attn_backends:
+                backend._replay_forward_batch = None
 
-        for i in range(1, self.speculative_num_steps - 1):
-            self.attn_backends[i].replay_cuda_graph_metadata_from(
-                bs=bs,
-                temp_metadata=temp_metadata,
-                bucket=_GraphBucket.DECODE_OR_IDLE,
-            )
+
+def _split_eagle_draft_out_cache_loc_by_step(
+    out_cache_loc: torch.Tensor,
+    *,
+    batch_size: int,
+    topk: int,
+    speculative_num_steps: int,
+) -> torch.Tensor:
+    """Match the request-major EAGLE draft layout used by draft_forward.
+
+    Keep this in sync with the equivalent reshape/permute in eagle_worker.py
+    and eagle_worker_v2.py.
+    """
+    expected_num_locs = batch_size * topk * speculative_num_steps
+    if out_cache_loc.numel() != expected_num_locs:
+        raise ValueError(
+            "EAGLE draft out_cache_loc must be padded to the CUDA graph batch "
+            f"before DSv4 replay metadata is initialized: got {out_cache_loc.numel()} "
+            f"locations, expected {expected_num_locs} for {batch_size=} {topk=} "
+            f"{speculative_num_steps=}."
+        )
+
+    return (
+        out_cache_loc.reshape(batch_size, topk, speculative_num_steps)
+        .permute(2, 0, 1)
+        .reshape(speculative_num_steps, batch_size * topk)
+    )
 
 
 def _pad_tensor_to_size(tensor: torch.Tensor, size: int, *, value: int = 0):

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -398,6 +398,12 @@ class EAGLEDraftCudaGraphRunner:
 
         raw_bs = forward_batch.batch_size
         raw_num_token = raw_bs * self.num_tokens_per_bs
+        original_batch_size = forward_batch.batch_size
+        original_positions = forward_batch.positions
+        original_seq_lens = forward_batch.seq_lens
+        original_req_pool_indices = forward_batch.req_pool_indices
+        original_out_cache_loc = forward_batch.out_cache_loc
+        original_seq_lens_cpu = forward_batch.seq_lens_cpu
 
         # Pad
         if self.require_mlp_tp_gather:
@@ -415,6 +421,8 @@ class EAGLEDraftCudaGraphRunner:
         bs = self.capture_bs[index]
         if bs != raw_bs:
             buffers.seq_lens.fill_(self.seq_len_fill_value)
+            # Padded graph lanes must write to reserved cache slot 0.
+            # DSv4 replay metadata relies on these zero-filled padding slots.
             buffers.out_cache_loc.zero_()
             buffers.positions.zero_()
             buffers.topk_p.zero_()
@@ -461,6 +469,11 @@ class EAGLEDraftCudaGraphRunner:
             forward_batch.batch_size = bs
             forward_batch.seq_lens = buffers.seq_lens[:bs]
             forward_batch.req_pool_indices = buffers.req_pool_indices[:bs]
+            # Replay metadata must see the same padded cache-location layout as
+            # the captured graph, not the raw request batch.
+            forward_batch.out_cache_loc = buffers.out_cache_loc[
+                : num_tokens * self.speculative_num_steps
+            ]
             forward_batch.positions = buffers.positions[:num_tokens]
 
         if forward_batch.seq_lens_cpu is not None:
@@ -469,24 +482,28 @@ class EAGLEDraftCudaGraphRunner:
             buffers.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
-        self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
-            forward_batch, bs
-        )
-        self.raw_bs = raw_bs
-        self.bs = bs
-        # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph
+        try:
+            self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
+                forward_batch, bs
+            )
+            self.raw_bs = raw_bs
+            self.bs = bs
+            # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph
 
-        # Replay
-        self._replay(forward_batch)
+            # Replay
+            self._replay(forward_batch)
+        finally:
+            if bs != raw_bs:
+                forward_batch.batch_size = original_batch_size
+                forward_batch.positions = original_positions
+                forward_batch.seq_lens = original_seq_lens
+                forward_batch.req_pool_indices = original_req_pool_indices
+                forward_batch.out_cache_loc = original_out_cache_loc
+                forward_batch.seq_lens_cpu = original_seq_lens_cpu
+
         out = self.output_buffers[bs]
 
         if bs != raw_bs:
             out = self._postprocess_output_to_raw_bs(out, raw_bs)
-            forward_batch.batch_size = raw_bs
-            forward_batch.positions = buffers.positions[:raw_num_token]
-            forward_batch.seq_lens = buffers.seq_lens[:raw_bs]
-            forward_batch.req_pool_indices = buffers.req_pool_indices[:raw_bs]
-            if forward_batch.seq_lens_cpu is not None:
-                forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:raw_bs]
 
         return out

--- a/test/registered/unit/spec/test_eagle_draft_dsv4_padding.py
+++ b/test/registered/unit/spec/test_eagle_draft_dsv4_padding.py
@@ -1,0 +1,264 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.attention.deepseek_v4_backend import (
+    DeepseekV4MultiStepBackend,
+    _split_eagle_draft_out_cache_loc_by_step,
+)
+from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
+    EAGLEDraftCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class _NoopDeepepAdapter:
+    def replay(self):
+        pass
+
+
+class _RecordingDraftBackend:
+    def __init__(self, *, raise_on_init: bool = False):
+        self.calls = []
+        self.raise_on_init = raise_on_init
+
+    def init_forward_metadata_replay_cuda_graph(self, forward_batch, bs):
+        self.calls.append(
+            {
+                "bs": bs,
+                "batch_size": forward_batch.batch_size,
+                "seq_lens": forward_batch.seq_lens.clone(),
+                "req_pool_indices": forward_batch.req_pool_indices.clone(),
+                "out_cache_loc": forward_batch.out_cache_loc.clone(),
+                "positions": forward_batch.positions.clone(),
+            }
+        )
+        if self.raise_on_init:
+            raise RuntimeError("metadata init failed")
+
+
+class _RecordingDSV4StepBackend:
+    def __init__(self):
+        self.calls = []
+        self._replay_forward_batch = None
+
+    def init_forward_metadata_replay_cuda_graph(
+        self,
+        bs,
+        req_pool_indices,
+        seq_lens,
+        seq_lens_sum,
+        encoder_lens,
+        forward_mode,
+        spec_info,
+        seq_lens_cpu,
+    ):
+        del encoder_lens, forward_mode, spec_info
+        self.calls.append(
+            {
+                "bs": bs,
+                "req_pool_indices": req_pool_indices.clone(),
+                "seq_lens": seq_lens.clone(),
+                "seq_lens_sum": seq_lens_sum,
+                "seq_lens_cpu": seq_lens_cpu.clone(),
+                "out_cache_loc": self._replay_forward_batch.out_cache_loc.clone(),
+            }
+        )
+
+
+def _make_runner(draft_attn_backend):
+    def _noop_replay(forward_batch):
+        del forward_batch
+
+    runner = object.__new__(EAGLEDraftCudaGraphRunner)
+    runner.deepep_adapter = _NoopDeepepAdapter()
+    runner.buffers = SimpleNamespace(
+        seq_lens=torch.empty(4, dtype=torch.int32),
+        out_cache_loc=torch.empty(12, dtype=torch.int64),
+        positions=torch.empty(4, dtype=torch.int64),
+        topk_p=torch.empty((4, 1), dtype=torch.float32),
+        topk_index=torch.empty((4, 1), dtype=torch.int64),
+        hidden_states=None,
+        req_pool_indices=torch.empty(4, dtype=torch.int64),
+        seq_lens_cpu=torch.empty(4, dtype=torch.int32),
+        global_num_tokens_gpu=None,
+        global_num_tokens_for_logprob_gpu=None,
+    )
+    runner.capture_bs = [1, 2, 4, 8]
+    runner.num_tokens_per_bs = 1
+    runner.speculative_num_steps = 3
+    runner.require_mlp_tp_gather = False
+    runner.require_gathered_buffer = False
+    runner.seq_len_fill_value = 1
+    runner.draft_attn_backend = draft_attn_backend
+    runner.model_runner = SimpleNamespace(
+        model_config=SimpleNamespace(vocab_size=32000)
+    )
+    runner.output_buffers = {
+        4: (
+            torch.arange(4, dtype=torch.int64),
+            torch.arange(10, 14, dtype=torch.int64),
+            torch.arange(20, 24, dtype=torch.int64),
+        )
+    }
+    runner._replay = _noop_replay
+    return runner
+
+
+def _make_forward_batch():
+    return SimpleNamespace(
+        batch_size=3,
+        seq_lens=torch.tensor([5, 7, 11], dtype=torch.int32),
+        req_pool_indices=torch.tensor([101, 102, 103], dtype=torch.int64),
+        out_cache_loc=torch.tensor(
+            [10, 11, 12, 20, 21, 22, 30, 31, 32], dtype=torch.int64
+        ),
+        positions=torch.tensor([5, 7, 11], dtype=torch.int64),
+        seq_lens_cpu=torch.tensor([5, 7, 11], dtype=torch.int32),
+        seq_lens_sum=23,
+        spec_info=SimpleNamespace(
+            topk_p=torch.ones((3, 1), dtype=torch.float32),
+            topk_index=torch.zeros((3, 1), dtype=torch.int64),
+            hidden_states=None,
+        ),
+    )
+
+
+class TestEagleDraftDSV4Padding(unittest.TestCase):
+    def test_replay_pads_out_cache_loc_for_metadata(self):
+        draft_attn_backend = _RecordingDraftBackend()
+        runner = _make_runner(draft_attn_backend)
+        forward_batch = _make_forward_batch()
+
+        out = EAGLEDraftCudaGraphRunner.replay(runner, forward_batch)
+
+        self.assertEqual(
+            [x.tolist() for x in out],
+            [[0, 1, 2], [10, 11, 12], [20, 21, 22]],
+        )
+        call = draft_attn_backend.calls[0]
+        self.assertEqual(call["bs"], 4)
+        self.assertEqual(call["batch_size"], 4)
+        self.assertEqual(call["seq_lens"].tolist(), [5, 7, 11, 1])
+        self.assertEqual(call["req_pool_indices"].tolist(), [101, 102, 103, 0])
+        self.assertEqual(
+            call["out_cache_loc"].tolist(),
+            [10, 11, 12, 20, 21, 22, 30, 31, 32, 0, 0, 0],
+        )
+        self.assertEqual(call["positions"].tolist(), [5, 7, 11, 0])
+
+    def test_replay_restores_forward_batch_after_metadata_error(self):
+        draft_attn_backend = _RecordingDraftBackend(raise_on_init=True)
+        runner = _make_runner(draft_attn_backend)
+        forward_batch = _make_forward_batch()
+        original_batch_size = forward_batch.batch_size
+        original_seq_lens = forward_batch.seq_lens
+        original_req_pool_indices = forward_batch.req_pool_indices
+        original_out_cache_loc = forward_batch.out_cache_loc
+        original_positions = forward_batch.positions
+        original_seq_lens_cpu = forward_batch.seq_lens_cpu
+
+        with self.assertRaisesRegex(RuntimeError, "metadata init failed"):
+            EAGLEDraftCudaGraphRunner.replay(runner, forward_batch)
+
+        self.assertEqual(forward_batch.batch_size, original_batch_size)
+        self.assertIs(forward_batch.seq_lens, original_seq_lens)
+        self.assertIs(forward_batch.req_pool_indices, original_req_pool_indices)
+        self.assertIs(forward_batch.out_cache_loc, original_out_cache_loc)
+        self.assertIs(forward_batch.positions, original_positions)
+        self.assertIs(forward_batch.seq_lens_cpu, original_seq_lens_cpu)
+        self.assertEqual(
+            draft_attn_backend.calls[0]["out_cache_loc"].tolist(),
+            [10, 11, 12, 20, 21, 22, 30, 31, 32, 0, 0, 0],
+        )
+
+    def test_dsv4_multistep_replay_passes_per_step_cache_locs(self):
+        backend = object.__new__(DeepseekV4MultiStepBackend)
+        backend.topk = 1
+        backend.speculative_num_steps = 3
+        backend.attn_backends = [_RecordingDSV4StepBackend() for _ in range(3)]
+        forward_batch = _make_forward_batch()
+        original_out_cache_loc = torch.tensor(
+            [10, 11, 12, 20, 21, 22, 30, 31, 32, 0, 0, 0],
+            dtype=torch.int64,
+        )
+        forward_batch.batch_size = 4
+        forward_batch.seq_lens = torch.tensor([5, 7, 11, 1], dtype=torch.int32)
+        forward_batch.req_pool_indices = torch.tensor(
+            [101, 102, 103, 0], dtype=torch.int64
+        )
+        forward_batch.seq_lens_cpu = torch.tensor([5, 7, 11, 1], dtype=torch.int32)
+        forward_batch.out_cache_loc = original_out_cache_loc
+
+        DeepseekV4MultiStepBackend.init_forward_metadata_replay_cuda_graph(
+            backend, forward_batch, 4
+        )
+
+        self.assertEqual(
+            backend.attn_backends[0].calls[0]["out_cache_loc"].tolist(),
+            [10, 20, 30, 0],
+        )
+        self.assertEqual(
+            backend.attn_backends[1].calls[0]["out_cache_loc"].tolist(),
+            [11, 21, 31, 0],
+        )
+        self.assertEqual(backend.attn_backends[2].calls, [])
+        self.assertIs(forward_batch.out_cache_loc, original_out_cache_loc)
+        for step_backend in backend.attn_backends:
+            self.assertIsNone(step_backend._replay_forward_batch)
+
+    def test_split_draft_cache_locs_uses_step_major_order(self):
+        out_cache_loc = torch.tensor(
+            [
+                10,
+                11,
+                12,
+                20,
+                21,
+                22,
+                30,
+                31,
+                32,
+                0,
+                0,
+                0,
+            ],
+            dtype=torch.int64,
+        )
+
+        split = _split_eagle_draft_out_cache_loc_by_step(
+            out_cache_loc,
+            batch_size=4,
+            topk=1,
+            speculative_num_steps=3,
+        )
+
+        torch.testing.assert_close(
+            split,
+            torch.tensor(
+                [
+                    [10, 20, 30, 0],
+                    [11, 21, 31, 0],
+                    [12, 22, 32, 0],
+                ],
+                dtype=torch.int64,
+            ),
+        )
+
+    def test_split_draft_cache_locs_rejects_unpadded_input(self):
+        out_cache_loc = torch.arange(9, dtype=torch.int64)
+
+        with self.assertRaisesRegex(ValueError, "must be padded"):
+            _split_eagle_draft_out_cache_loc_by_step(
+                out_cache_loc,
+                batch_size=4,
+                topk=1,
+                speculative_num_steps=3,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes an EAGLE v2 draft CUDA graph replay metadata mismatch for DSv4 compressed attention. In the reported failure from #25512, the draft replay path pads `raw_bs=3` to `graph_bs=4`:

```text
EAGLE draft cuda graph replay padding: raw_bs=3 graph_bs=4 raw_out_cache_loc=9 padded_out_cache_loc=12 steps=3 topk=1
```

The runner padded `batch_size`, `seq_lens`, `req_pool_indices`, and `positions`, but DSv4 replay metadata still observed the raw `out_cache_loc` layout. DSv4 compressed attention builds replay metadata from cache locations before graph replay, so the mismatch can produce invalid page metadata and surface later as an async CUDA illegal memory access.

This PR makes the replay metadata contract explicit: graph replay sees the padded graph-bucket cache-location buffer, and DSv4 receives the per-draft-step slice it expects.

Refs #25512.

## Modifications

- Update `EAGLEDraftCudaGraphRunner.replay` to pass the padded `buffers.out_cache_loc` layout into draft attention replay metadata initialization when `raw_bs` is padded to a captured CUDA graph bucket.
- Restore mutated `ForwardBatch` fields with `try/finally` so metadata/replay errors do not leave the batch in a padded state.
- Keep padded graph lanes zero-filled so they write to reserved cache slot 0.
- Update `DeepseekV4MultiStepBackend.init_forward_metadata_replay_cuda_graph` to split EAGLE's request-major draft cache-location layout into per-step slices before initializing each DSv4 draft-step backend.
- Add a loud invariant in DSv4 decode replay metadata if a caller passes a full multi-step `out_cache_loc` buffer where a per-step slice is expected.
- Add registered CPU regression coverage for:
  - `raw_bs=3 -> graph_bs=4` padded `out_cache_loc` replay wiring,
  - `ForwardBatch` restoration after metadata init failure,
  - DSv4 per-step cache-location slicing,
  - rejection of unpadded EAGLE draft cache-location input.

## Accuracy Tests

- `PYTHONPATH=python python -m compileall -q python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py python/sglang/srt/layers/attention/deepseek_v4_backend.py test/registered/unit/spec/test_eagle_draft_dsv4_padding.py`
- `ruff check python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py python/sglang/srt/layers/attention/deepseek_v4_backend.py test/registered/unit/spec/test_eagle_draft_dsv4_padding.py`
- `git diff --check`
- Focused source-level smoke test for the patched runner replay path and DSv4 multi-step slicing.
- L4 CUDA smoke for the padded DSv4 split helper:
  - input: `[10,11,12,20,21,22,30,31,32,0,0,0]`
  - output: `[[10,20,30,0], [11,21,31,0], [12,22,32,0]]`

## Speed Tests and Profiling

Not run. This patch does not change attention kernels. It does change DSv4 EAGLE replay metadata initialization to compute metadata per draft step instead of copying step-0 metadata, because DSv4 compressed-attention metadata is step-specific.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->