### PR TITLE
[Fix] PD-disaggregation warmup for VLMs uses /generate, not /v1/chat/completions (#22765)

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1965,6 +1965,11 @@ def _execute_server_warmup(server_args: ServerArgs):
 
         else:
             logger.info(f"Start of pd disaggregation warmup ...")
+            # The PD-disaggregation warmup payload below is `/generate`-style
+            # (input_ids + bootstrap fields); for a VLM with tokenizer init,
+            # request_name was set to `/v1/chat/completions` above, which
+            # would 422 on this payload. Force `/generate` here.
+            request_name = "/generate"
             json_data = {
                 "sampling_params": {
                     "temperature": 0.0,


### PR DESCRIPTION

## Motivation

Fixes sgl-project/sglang#22765.

When launching a VLM (`has_image_understanding=True`) in PD-disaggregation
mode without `--skip-tokenizer-init`, the warmup request fails with
HTTP 422 and the server is left as `ServerStatus.UnHealthy`. Reproduction
(from the upstream issue):

```bash
python -m sglang.launch_server \
  --model-path /data/share/model/Qwen3-VL-2B-Instruct \
  --trust-remote-code \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend nixl \
  --disaggregation-bootstrap-port 8998 \
  --host 0.0.0.0 --port 6120
```

## Root cause

In `_execute_server_warmup` (`python/sglang/srt/entrypoints/http_server.py`):

```python
# lines 1887-1893 — request_name chosen up front
if model_info["is_generation"]:
    if is_vlm and not server_args.skip_tokenizer_init:
        request_name = "/v1/chat/completions"
    else:
        request_name = "/generate"
```

In the PD branch (lines 1966-1991), `json_data` is **overwritten** with
a `/generate`-style payload (`input_ids` + `bootstrap_host` + `bootstrap_room`),
but `request_name` is **not** updated, so the request is `POST /v1/chat/completions`
with `/generate` fields. `ChatCompletionRequest` rejects the unknown
`bootstrap_host` / `bootstrap_room` / `input_ids` fields (plus the
missing `messages` / `model`) → HTTP 422 → `ServerStatus.UnHealthy`.

## Modifications

`python/sglang/srt/entrypoints/http_server.py` — inside the
`disaggregation_mode != "null"` branch of `_execute_server_warmup`,
force `request_name = "/generate"` before composing the PD warmup
payload. The non-PD VLM image-warmup path is unchanged.

## Duplicate-check

**Track A — PR cites the issue:**

```
search/issues?q=repo:sgl-project/sglang+is:pr+22765+in:body  →  total_count: 0
```

No PR references #22765.

**Track B — comments on issue:** 0 comments per the search API result;
no maintainer/contributor signals to scan.

