### PR TITLE
[Test] Add SamplingParams unit tests for stop tokens and regex

### DIFF
--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -68,6 +68,16 @@ class TestSamplingParamsInit(CustomTestCase):
         sp = SamplingParams(stop_token_ids=[])
         self.assertIsNone(sp.stop_token_ids)
 
+    def test_stop_token_ids_filters_none_and_casts_to_int(self):
+        """Nullable stop token IDs are filtered before integer normalization."""
+        sp = SamplingParams(stop_token_ids=["1", None, 2, "2"])
+        self.assertEqual(sp.stop_token_ids, {1, 2})
+
+    def test_stop_token_ids_all_none_becomes_none(self):
+        """A list without usable stop IDs is normalized to None."""
+        sp = SamplingParams(stop_token_ids=[None, None])
+        self.assertIsNone(sp.stop_token_ids)
+
 
 class TestSamplingParamsVerify(CustomTestCase):
 
@@ -330,6 +340,12 @@ class TestSamplingParamsNormalize(CustomTestCase):
         sp = SamplingParams(stop_regex=r"[a-z]{3}")
         sp.normalize(tokenizer=None)
         self.assertEqual(sp.stop_regex_max_len, 3)
+
+    def test_stop_regex_list_uses_longest_pattern(self):
+        """Regex buffering uses the longest pattern in a stop_regex list."""
+        sp = SamplingParams(stop_regex=[r"ok", r"(foo|quux)\d{2}"])
+        sp.normalize(tokenizer=None)
+        self.assertEqual(sp.stop_regex_max_len, 6)
 
 
 class TestRegexMaxLength(CustomTestCase):


### PR DESCRIPTION
## Summary

Adds unit coverage for `SamplingParams` normalization behavior in `srt/sampling`:

- filters `None` values from nullable `stop_token_ids` inputs
- casts usable stop token IDs to `int` and deduplicates them
- treats all-null `stop_token_ids` as no stop token IDs
- computes `stop_regex_max_len` from the longest regex when `stop_regex` is a list

This addresses part of #20865.

## Test

```bash
PYTHONPATH=python python -m pytest test/registered/unit/sampling/test_sampling_params.py -v
```

```text
69 passed, 7 warnings in 7.09s
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->