### PR TITLE
Revert "Support Qwen3.5 NVFP4 MTP DeepEP (#24906)"

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -105,12 +105,8 @@ class GDNKernelDispatcher:
         else:
             raise ValueError(f"Unsupported GDN prefill backend: {prefill_backend}")
 
-        # Verify kernel: use FlashInfer only when the selected FlashInfer kernel
-        # supports MTP verify. On SM100+ FlashInfer GDN decode is supported, but
-        # its MTP verify path is not, so keep Triton as the verify fallback.
-        if (
-            decode_backend.is_flashinfer() or prefill_backend.is_flashinfer()
-        ) and flashinfer_kernel.supports_target_verify:
+        # Verify kernel: use FlashInfer if either decode or prefill selected it
+        if decode_backend.is_flashinfer() or prefill_backend.is_flashinfer():
             self.verify_kernel = flashinfer_kernel
         else:
             self.verify_kernel = triton_kernel

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -98,7 +98,6 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         sm_major = torch.cuda.get_device_capability()[0]
         self.use_state_pool = sm_major != 9
-        self.supports_target_verify = sm_major == 9
 
         if sm_major == 9:
             if self._prefill_fn is None:

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -4,7 +4,6 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import torch
-import torch.nn.functional as F
 
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
 from sglang.srt.environ import envs
@@ -127,23 +126,17 @@ class DeepEPMoE(FusedMoE):
 
         self.deepep_mode = get_deepep_mode()
 
-        if quant_config is None and hasattr(self.dispatcher, "set_quant_config"):
-            self.dispatcher.set_quant_config({"bf16_dispatch": True})
-
         if (
             self.deepep_mode.enable_low_latency()
             and not _is_npu
             and not _is_hip
             and not (
                 get_moe_runner_backend().is_flashinfer_cutedsl()
-                and self.quant_config is not None
                 and self.quant_config.get_name() == "modelopt_fp4"
             )
-            and quant_config is not None
         ):
             # AMD HIP, NPU supports low_latency deepep without deepgemm
             # NV FP4 quantization with flashinfer_cutedsl also supports low_latency deepep without deepgemm
-            # Unquantized draft MoE uses BF16 DeepEP dispatch and a local fallback.
             assert (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             ), f"DeepEP {self.deepep_mode} mode requires deep_gemm"
@@ -209,20 +202,13 @@ class DeepEPMoE(FusedMoE):
             assert DispatchOutputChecker.format_is_deepep(dispatch_output)
             output = self.forward_npu(dispatch_output)
         elif DispatchOutputChecker.format_is_deepep_normal(dispatch_output):
-            if self.quant_config is None:
-                raise NotImplementedError(
-                    "Unquantized DeepEP MoE currently supports low_latency mode only"
-                )
-            elif self.use_w4afp8:
+            if self.use_w4afp8:
                 output = self.forward_cutlass_w4afp8(dispatch_output)
             else:
                 assert False, "forward_deepgemm_contiguous is deprecated"
         elif DispatchOutputChecker.format_is_deepep_ll(dispatch_output):
-            if self.quant_config is None:
-                output = self.forward_unquantized_deepep_ll(dispatch_output)
-            elif (
+            if (
                 get_moe_runner_backend().is_flashinfer_cutedsl()
-                and self.quant_config is not None
                 and self.quant_config.get_name() == "modelopt_fp4"
             ):
                 output = self.forward_flashinfer_cutedsl(dispatch_output)
@@ -256,37 +242,6 @@ class DeepEPMoE(FusedMoE):
             topk_weights=topk_weights,
             overlap_args=overlap_args,
         )
-
-    def forward_unquantized_deepep_ll(
-        self,
-        dispatch_output: DeepEPLLDispatchOutput,
-    ):
-        hidden_states, hidden_states_scale, _, _, masked_m, _ = dispatch_output
-        assert hidden_states_scale is None
-        assert self.moe_runner_config.activation == "silu"
-        assert self.moe_runner_config.is_gated
-        assert hidden_states.dim() == 3
-
-        num_experts, max_tokens, _ = hidden_states.shape
-        token_offsets = torch.arange(max_tokens, device=hidden_states.device)
-        valid_mask = (
-            token_offsets.unsqueeze(0) < masked_m[:num_experts].unsqueeze(1)
-        ).unsqueeze(-1)
-        hidden_states = hidden_states.masked_fill(~valid_mask, 0)
-
-        gate_up = torch.bmm(hidden_states, self.w13_weight.transpose(1, 2))
-        w13_bias = getattr(self, "w13_weight_bias", None)
-        if w13_bias is not None:
-            gate_up = gate_up + w13_bias.unsqueeze(1)
-
-        gate, up = gate_up.chunk(2, dim=-1)
-        hidden_states = F.silu(gate) * up
-
-        output = torch.bmm(hidden_states, self.w2_weight.transpose(1, 2))
-        w2_bias = getattr(self, "w2_weight_bias", None)
-        if w2_bias is not None:
-            output = output + w2_bias.unsqueeze(1)
-        return output.masked_fill(~valid_mask, 0)
 
     def forward_flashinfer_cutedsl(
         self,

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -625,19 +625,16 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
     ):
         use_nvfp4 = use_fp8 = False
         input_global_scale = self.quant_config.get("input_global_scale", None)
-        bf16_dispatch = self.quant_config.get("bf16_dispatch", False)
         if input_global_scale is not None:
             use_nvfp4 = True
         else:
             backend = get_moe_runner_backend()
             # BF16 dispatch is needed when:
-            #   - quant_config requests BF16 dispatch explicitly
             #   - flashinfer_cutedsl: kernel quantizes to NVFP4 internally
             #   - NPU with SGLANG_DEEPEP_BF16_DISPATCH: INT8 input + BF16 weight GMM not supported
             #   - deep_gemm with SGLANG_DEEPEP_BF16_DISPATCH: user requests BF16 dispatch
             need_bf16_dispatch = (
-                bf16_dispatch
-                or backend.is_flashinfer_cutedsl()
+                backend.is_flashinfer_cutedsl()
                 or (_is_npu and envs.SGLANG_DEEPEP_BF16_DISPATCH.get())
                 or (backend.is_deep_gemm() and envs.SGLANG_DEEPEP_BF16_DISPATCH.get())
             )


### PR DESCRIPTION
## Summary

Reverts #24906 ("Support Qwen3.5 NVFP4 MTP DeepEP").

This reverts merge commit `8d5b347edd9b192c3a339d32a5af666af4400fe0`.

## Conflict resolution

`git revert -m 1` conflicted on `python/sglang/srt/layers/moe/ep_moe/layer.py` because #23760 ([MoE] Unify DeepEPMoE+MoriEPMoE through AITER MoeRunner pre/post-permute) landed after #24906 and removed `forward_aiter` as part of the AITER → MoeRunner migration.

- The revert wanted to remove `forward_unquantized_deepep_ll` (added by #24906) **and** restore `forward_aiter`.
- Restoring `forward_aiter` would undo unrelated refactor work from #23760.

Resolution: drop `forward_unquantized_deepep_ll` only; leave the post-#23760 state of `forward_aiter` (i.e. removed). No remaining callers of `forward_unquantized_deepep_ll` in the tree (verified by grep).

The other three files in #24906 (`gdn_backend.py`, `gdn_flashinfer.py`, `deepep.py`) reverted cleanly.

## Test plan

- [ ] CI green
- [ ] Confirm with #24906 author / Qwen3.5 NVFP4 MTP DeepEP users that the revert is acceptable





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #25998193667](https://github.com/sgl-project/sglang/actions/runs/25998193667)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->