### PR TITLE
[HiCache & HybridModel] nixl hicache backend support hybrid model

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/README.md
+++ b/python/sglang/srt/mem_cache/storage/nixl/README.md
@@ -143,6 +143,69 @@ python3 -m sglang.launch_server \
 ⚠️ **Note**:
 This method is convenient for testing / experimenting. For production or multi-plugin setups, it is always recommended to use the config file based approach.
 
+### 4. Validated Hybrid-Model Example
+
+The following setup was validated against a hybrid Mamba model with HiCache enabled:
+
+- model: `Qwen/Qwen3.5-0.8B`
+- storage backend: `nixl`
+- NIXL plugin: `POSIX` with `io_uring`
+- HiCache layout: `page_first`
+- model type: hybrid attention + Mamba sidecar cache (`KV + MAMBA`)
+
+Important details from this validation:
+
+- Use a real `.toml` file path with `--hicache-storage-backend-extra-config`.
+- Do not point SGLang at `nixl.config.toml.sample` directly, because SGLang validates the file extension and `.sample` is not accepted.
+- For this validated path, the storage directory was provided through `SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR`.
+
+Example TOML file:
+
+```toml
+[plugin.posix]
+use_uring = "true"
+active = true
+```
+
+Example serve command for a hybrid model:
+
+```bash
+export SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR=/tmp/sglang_nixl_e2e_storage
+
+~/ve_sgl_dev/bin/sglang serve \
+  --model-path /workspace/LLM_models/Qwen3.5-0.8B \
+  --served-model-name Qwen/Qwen3.5-0.8B \
+  --host 127.0.0.1 \
+  --port 31000 \
+  --enable-hierarchical-cache \
+  --hicache-ratio 2 \
+  --hicache-io-backend kernel \
+  --hicache-mem-layout page_first \
+  --hicache-storage-prefetch-policy wait_complete \
+  --page-size 256 \
+  --log-level info \
+  --disable-cuda-graph \
+  --hicache-storage-backend nixl \
+  --hicache-storage-backend-extra-config @/tmp/nixl.config.toml \
+  --mamba-scheduler-strategy extra_buffer
+```
+
+Expected behavior for this validated setup:
+
+- the server starts with `Attached hybrid Mamba pool stack to HiMambaRadixCache: pools=KV + MAMBA`
+- NIXL logs show `Backend POSIX was instantiated`
+- the storage directory contains KV files plus Mamba sidecar files such as `..._0_1.mamba`
+- after restarting the server against the same storage directory, a repeated long prompt shows large `cached_tokens` in the response metadata
+
+Minimal end-to-end validation flow:
+
+1. Start the server with the TOML file shown above.
+2. Send a long prompt once to populate storage.
+3. Restart the server against the same `SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR`.
+4. Send the same long prompt again and confirm that `meta_info.cached_tokens` is high.
+
+In the validated run used for this backend, the repeated 6000-token prompt returned `cached_tokens: 5888`.
+
 
 ## Running Unit Tests
 

--- a/python/sglang/srt/mem_cache/storage/nixl/README.md
+++ b/python/sglang/srt/mem_cache/storage/nixl/README.md
@@ -149,21 +149,20 @@ The following setup was validated against a hybrid Mamba model with HiCache enab
 
 - model: `Qwen/Qwen3.5-0.8B`
 - storage backend: `nixl`
-- NIXL plugin: `POSIX` with `io_uring`
+- NIXL plugin: `POSIX`
 - HiCache layout: `page_first`
 - model type: hybrid attention + Mamba sidecar cache (`KV + MAMBA`)
 
 Important details from this validation:
 
 - Use a real `.toml` file path with `--hicache-storage-backend-extra-config`.
-- Do not point SGLang at `nixl.config.toml.sample` directly, because SGLang validates the file extension and `.sample` is not accepted.
 - For this validated path, the storage directory was provided through `SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR`.
+- Use `--mamba-scheduler-strategy extra_buffer` to support larger than 1 page size
 
 Example TOML file:
 
 ```toml
 [plugin.posix]
-use_uring = "true"
 active = true
 ```
 
@@ -173,10 +172,9 @@ Example serve command for a hybrid model:
 export SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR=/tmp/sglang_nixl_e2e_storage
 
 ~/ve_sgl_dev/bin/sglang serve \
-  --model-path /workspace/LLM_models/Qwen3.5-0.8B \
+  --model-path /path/to/Qwen3.5-0.8B \
   --served-model-name Qwen/Qwen3.5-0.8B \
   --host 127.0.0.1 \
-  --port 31000 \
   --enable-hierarchical-cache \
   --hicache-ratio 2 \
   --hicache-io-backend kernel \

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -10,6 +10,10 @@ from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorage,
     HiCacheStorageConfig,
     HiCacheStorageExtraInfo,
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+    PoolTransferResult,
 )
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
 
@@ -82,9 +86,17 @@ class HiCacheNixl(HiCacheStorage):
 
         self.registration = NixlRegistration(self.agent)
         self.is_zero_copy = False
+        self.registered_pools = {}
 
     def _get_suffixed_key(self, key: str) -> str:
         return key + self.config_suffix
+
+    def _get_component_key(
+        self, key: str, component_name: Optional[PoolName] = None
+    ) -> str:
+        if component_name in (None, PoolName.KV):
+            return self._get_suffixed_key(key)
+        return f"{self._get_suffixed_key(key)}.{component_name}"
 
     def register_buffers(
         self, buffers: Union[torch.Tensor, List[torch.Tensor], List[tuple]]
@@ -218,6 +230,79 @@ class HiCacheNixl(HiCacheStorage):
             for fd in file_fds:
                 self.file_manager.close_file(fd)
 
+    def _transfer_by_keys(
+        self,
+        buffers: List[torch.Tensor | tuple],
+        keys: List[str],
+        direction: str,
+    ) -> bool:
+        if self.backend_selector.mem_type == "FILE":
+            file_paths = []
+            for key in keys:
+                file_path = self.file_manager.get_file_path(key)
+                if direction == "WRITE" and not self.file_manager.create_file(file_path):
+                    logger.error(f"Failed to create file {file_path}")
+                    return False
+                file_paths.append(file_path)
+            return self._execute_transfer(buffers, file_paths, direction)
+        return self._execute_transfer(buffers, keys, direction)
+
+    def _query_keys_exist(self, keys: List[str]) -> List[bool]:
+        if not keys:
+            return []
+        tuples = []
+        for key in keys:
+            tuples += self.registration.create_query_tuples(
+                key,
+                self.backend_selector.mem_type,
+                self.file_manager if self.backend_selector.mem_type == "FILE" else None,
+            )
+        query_res = self.agent.query_memory(
+            tuples,
+            self.backend_selector.backend_name,
+            mem_type=self.backend_selector.mem_type,
+        )
+        return [res is not None for res in query_res]
+
+    def _get_component_keys(
+        self, keys: List[str], pool_name: Optional[PoolName] = None
+    ) -> List[str]:
+        return [self._get_component_key(key, pool_name) for key in keys]
+
+    def _prepare_pool_transfer(
+        self, transfer: PoolTransfer, for_write: bool
+    ) -> tuple[Optional[HostKVCache], List[str], List[torch.Tensor], List[int]]:
+        host_pool = self.registered_pools.get(transfer.name)
+        if host_pool is None:
+            logger.error("Host pool %s is not registered in HiCacheNixl", transfer.name)
+            return None, [], [], []
+
+        keys = transfer.keys or []
+        host_indices = transfer.host_indices
+        page_size = getattr(host_pool, "page_size", 1) or 1
+        expected = len(keys) * page_size
+        if host_indices is None or host_indices.numel() != expected:
+            logger.error(
+                "Pool %s indices length mismatch: expected %s, got %s",
+                transfer.name,
+                expected,
+                host_indices.numel() if host_indices is not None else 0,
+            )
+            return host_pool, [], [], []
+
+        page_offsets = [
+            host_indices[i * page_size].item() for i in range(len(keys))
+        ]
+        if for_write:
+            buffers = [
+                host_pool.get_data_page(page_offset, flat=True).contiguous()
+                for page_offset in page_offsets
+            ]
+        else:
+            buffers = [host_pool.get_dummy_flat_data_page() for _ in page_offsets]
+
+        return host_pool, self._get_component_keys(keys, transfer.name), buffers, page_offsets
+
     def get(
         self,
         key: str,
@@ -258,11 +343,7 @@ class HiCacheNixl(HiCacheStorage):
         # Add suffix to keys
         suffixed_keys = [self._get_suffixed_key(key) for key in keys]
 
-        if self.backend_selector.mem_type == "FILE":
-            file_paths = [self.file_manager.get_file_path(key) for key in suffixed_keys]
-            success = self._execute_transfer(dest, file_paths, "READ")
-        else:
-            success = self._execute_transfer(dest, suffixed_keys, "READ")
+        success = self._transfer_by_keys(dest, suffixed_keys, "READ")
         return target_locations if success and not target_sizes else [None] * len(keys)
 
     def set(
@@ -294,18 +375,7 @@ class HiCacheNixl(HiCacheStorage):
         # Add suffix to keys
         suffixed_keys = [self._get_suffixed_key(key) for key in keys]
 
-        if self.backend_selector.mem_type == "FILE":
-            file_paths = []
-            for key in suffixed_keys:
-                file_path = self.file_manager.get_file_path(key)
-                # New file per set, to be updated when partial writes is added to HiCache
-                if not self.file_manager.create_file(file_path):
-                    logger.error(f"Failed to create file {file_path}")
-                    return False
-                file_paths.append(file_path)
-            return self._execute_transfer(values, file_paths, "WRITE")
-        else:  # mem_type == "OBJ"
-            return self._execute_transfer(values, suffixed_keys, "WRITE")
+        return self._transfer_by_keys(values, suffixed_keys, "WRITE")
 
     ############################################################################
     # batch_*_v1 functions
@@ -313,7 +383,8 @@ class HiCacheNixl(HiCacheStorage):
     ############################################################################
 
     def clear(self) -> None:
-        self.file_manager.clear()
+        if self.file_manager is not None:
+            self.file_manager.clear()
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
         super().register_mem_pool_host(mem_pool_host)
@@ -327,6 +398,9 @@ class HiCacheNixl(HiCacheStorage):
         logger.info(
             f"HiCacheNixl: Registered mem_pool_host with layout {self.mem_pool_host.layout}, zero_copy set to {self.is_zero_copy}"
         )
+
+    def register_mem_host_pool_v2(self, host_pool: HostKVCache, host_pool_name):
+        super().register_mem_host_pool_v2(host_pool, host_pool_name)
 
     def exists(self, key: str) -> bool:
         results = self.batch_exists([key])
@@ -342,31 +416,60 @@ class HiCacheNixl(HiCacheStorage):
         if self.is_zero_copy:
             key_list = self._get_key_list_from_meta(keys)
             key_denominator = (
-                1 if not self.is_mla_model else 2
-            )  # MLA model only has k buffer, no separate v buffer
+                1 if self.is_mla_model else 2
+            )  # MLA has one interleaved buffer; non-MLA has separate k/v buffers
         else:
             key_list = [self._get_suffixed_key(key) for key in keys]
             key_denominator = 1
 
-        # obtain list of tuples by calling self.registration.create_query_tuples()
-        tuples = []
-        for key in key_list:
-            tuples += self.registration.create_query_tuples(
-                key,
-                self.backend_selector.mem_type,
-                self.file_manager if self.backend_selector.mem_type == "FILE" else None,
-            )
+        exists_results = self._query_keys_exist(key_list)
 
-        query_res = self.agent.query_memory(
-            tuples,
-            self.backend_selector.backend_name,
-            mem_type=self.backend_selector.mem_type,
-        )
-
-        for i in range(len(query_res)):
-            if query_res[i] is None:
+        for i, exists in enumerate(exists_results):
+            if not exists:
                 return i // key_denominator
-        return len(query_res) // key_denominator
+        return len(exists_results) // key_denominator
+
+    def batch_exists_v2(
+        self,
+        keys: List[str],
+        pool_transfers: Optional[List[PoolTransfer]] = None,
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> PoolTransferResult:
+        kv_pages = self.batch_exists(keys, extra_info)
+        hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
+        final_pages = kv_pages
+
+        for transfer in pool_transfers or []:
+            if final_pages == 0:
+                break
+            if transfer.name not in self.registered_pools:
+                final_pages = 0
+                break
+
+            component_keys = self._get_component_keys(keys[:kv_pages], transfer.name)
+            exists_results = self._query_keys_exist(component_keys)
+
+            boundary = 0
+            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
+                try:
+                    boundary = exists_results.index(False)
+                except ValueError:
+                    boundary = kv_pages
+            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
+                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
+                for prefix_len in range(kv_pages, 0, -1):
+                    if all(
+                        exists_results[i]
+                        for i in range(max(0, prefix_len - trailing), prefix_len)
+                    ):
+                        boundary = prefix_len
+                        break
+
+            if boundary:
+                hit_count[transfer.name] = boundary
+            final_pages = min(final_pages, boundary)
+
+        return PoolTransferResult(final_pages, hit_count)
 
     def _get_key_list_from_meta(self, keys: List[str]) -> List[str]:
         # construct the key list for NIXL transfer based on the keys and the suffix, for each key, we will have one suffixed key for k buffer and one suffixed key for v buffer if it's not an MLA model, and only one suffixed key for k buffer if it's an MLA model, since MLA model only has k/v interleaved buffer
@@ -452,11 +555,7 @@ class HiCacheNixl(HiCacheStorage):
         else:
             dest = target_tensors
 
-        if self.backend_selector.mem_type == "FILE":
-            file_paths = [self.file_manager.get_file_path(key) for key in key_strs]
-            success = self._execute_transfer(dest, file_paths, "READ")
-        else:
-            success = self._execute_transfer(dest, key_strs, "READ")
+        success = self._transfer_by_keys(dest, key_strs, "READ")
 
         return [True] * len(key_strs) if success else [False] * len(key_strs)
 
@@ -579,20 +678,7 @@ class HiCacheNixl(HiCacheStorage):
         else:
             src = target_tensors
 
-        if self.backend_selector.mem_type == "FILE":
-            file_paths = []
-            for key in key_strs:
-                file_path = self.file_manager.get_file_path(key)
-                # New file per set, to be updated when partial writes is added to HiCache
-                if not self.file_manager.create_file(file_path):
-                    logger.error(
-                        f"******** Failed to create file {file_path} *********"
-                    )
-                    return [False] * len(keys)
-                file_paths.append(file_path)
-            success = self._execute_transfer(src, file_paths, "WRITE")
-        else:  # mem_type == "OBJ"
-            success = self._execute_transfer(src, key_strs, "WRITE")
+        success = self._transfer_by_keys(src, key_strs, "WRITE")
 
         return [True] * len(keys) if success else [False] * len(keys)
 
@@ -630,3 +716,47 @@ class HiCacheNixl(HiCacheStorage):
         )
 
         return results_set
+
+    def batch_get_v2(
+        self,
+        transfers: List[PoolTransfer],
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> dict[str, List[bool]]:
+        results: dict[str, List[bool]] = {}
+        for transfer in transfers:
+            host_pool, key_strs, buffers, page_offsets = self._prepare_pool_transfer(
+                transfer, for_write=False
+            )
+            if host_pool is None or not key_strs:
+                results[transfer.name] = [False] * len(transfer.keys or [])
+                continue
+
+            success = self._transfer_by_keys(buffers, key_strs, "READ")
+            if not success:
+                results[transfer.name] = [False] * len(key_strs)
+                continue
+
+            for page_offset, data_page in zip(page_offsets, buffers):
+                host_pool.set_from_flat_data_page(page_offset, data_page)
+            results[transfer.name] = [True] * len(key_strs)
+        return results
+
+    def batch_set_v2(
+        self,
+        transfers: List[PoolTransfer],
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> dict[str, List[bool]]:
+        results: dict[str, List[bool]] = {}
+        for transfer in transfers:
+            _, key_strs, buffers, _ = self._prepare_pool_transfer(
+                transfer, for_write=True
+            )
+            if not key_strs:
+                results[transfer.name] = [False] * len(transfer.keys or [])
+                continue
+
+            success = self._transfer_by_keys(buffers, key_strs, "WRITE")
+            results[transfer.name] = [True] * len(key_strs) if success else [False] * len(
+                key_strs
+            )
+        return results

--- a/python/sglang/srt/mem_cache/storage/nixl/test_hicache_nixl_storage.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/test_hicache_nixl_storage.py
@@ -7,12 +7,37 @@ from unittest.mock import MagicMock
 
 import torch
 
-from sglang.srt.mem_cache.hicache_storage import HiCacheStorageConfig
-from sglang.srt.mem_cache.storage.nixl.hicache_nixl import HiCacheNixl
+from sglang.srt.mem_cache.hicache_storage import (
+    HiCacheStorageConfig,
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+)
 from sglang.srt.mem_cache.storage.nixl.nixl_utils import (
     NixlFileManager,
     NixlRegistration,
 )
+
+try:
+    from sglang.srt.mem_cache.storage.nixl.hicache_nixl import HiCacheNixl
+except ImportError:
+    HiCacheNixl = None
+
+
+class FakePool:
+    def __init__(self, page_size: int = 1, page_bytes: int = 4):
+        self.page_size = page_size
+        self.page_bytes = page_bytes
+        self.data = {}
+
+    def get_dummy_flat_data_page(self) -> torch.Tensor:
+        return torch.zeros(self.page_bytes, dtype=torch.uint8)
+
+    def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
+        self.data[index] = data_page.clone()
+
+    def get_data_page(self, index: int, flat: bool = True) -> torch.Tensor:
+        return self.data[index].clone()
 
 
 class TestNixlUnified(unittest.TestCase):
@@ -20,6 +45,9 @@ class TestNixlUnified(unittest.TestCase):
 
     def setUp(self):
         """Set up test environment."""
+        if HiCacheNixl is None:
+            self.skipTest("NIXL not available, skipping NIXL storage tests")
+
         # Create test directories
         self.test_dir = "/tmp/test_nixl_unified"
         os.makedirs(self.test_dir, exist_ok=True)
@@ -258,6 +286,92 @@ class TestNixlUnified(unittest.TestCase):
 
         # Test buffer registration
         self.assertIsNotNone(self.hicache.register_buffers(tensor))
+
+    def test_batch_exists_v2_respects_pool_hit_policies(self):
+        keys = ["k0", "k1", "k2", "k3"]
+        self.hicache.registered_pools = {
+            PoolName.MAMBA: FakePool(),
+            PoolName.INDEXER: FakePool(),
+        }
+        self.hicache.batch_exists = MagicMock(return_value=4)
+
+        existing = {
+            self.hicache._get_component_key("k0", PoolName.INDEXER),
+            self.hicache._get_component_key("k1", PoolName.INDEXER),
+            self.hicache._get_component_key("k2", PoolName.INDEXER),
+            self.hicache._get_component_key("k0", PoolName.MAMBA),
+            self.hicache._get_component_key("k1", PoolName.MAMBA),
+            self.hicache._get_component_key("k2", PoolName.MAMBA),
+        }
+        self.hicache._query_keys_exist = MagicMock(
+            side_effect=lambda query_keys: [key in existing for key in query_keys]
+        )
+
+        result = self.hicache.batch_exists_v2(
+            keys,
+            [
+                PoolTransfer(name=PoolName.INDEXER, hit_policy=PoolHitPolicy.ALL_PAGES),
+                PoolTransfer(
+                    name=PoolName.MAMBA,
+                    hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                    keys=["k2"],
+                ),
+            ],
+        )
+
+        self.assertEqual(result.kv_hit_pages, 3)
+        self.assertEqual(result.extra_pool_hit_pages[PoolName.INDEXER], 3)
+        self.assertEqual(result.extra_pool_hit_pages[PoolName.MAMBA], 3)
+
+    def test_batch_get_set_v2_uses_pool_component_keys(self):
+        pool = FakePool()
+        pool.data[0] = torch.tensor([1, 2, 3, 4], dtype=torch.uint8)
+        pool.data[1] = torch.tensor([5, 6, 7, 8], dtype=torch.uint8)
+        self.hicache.registered_pools = {PoolName.MAMBA: pool}
+
+        recorded = {}
+
+        def fake_transfer(buffers, keys, direction):
+            recorded[direction] = (keys, [buf.clone() for buf in buffers])
+            if direction == "READ":
+                for i, buf in enumerate(buffers):
+                    buf.copy_(torch.full_like(buf, i + 9))
+            return True
+
+        self.hicache._transfer_by_keys = MagicMock(side_effect=fake_transfer)
+
+        transfer = PoolTransfer(
+            name=PoolName.MAMBA,
+            host_indices=torch.tensor([0, 1], dtype=torch.int64),
+            keys=["p0", "p1"],
+        )
+
+        set_results = self.hicache.batch_set_v2([transfer])
+        self.assertEqual(set_results[PoolName.MAMBA], [True, True])
+        self.assertEqual(
+            recorded["WRITE"][0],
+            [
+                self.hicache._get_component_key("p0", PoolName.MAMBA),
+                self.hicache._get_component_key("p1", PoolName.MAMBA),
+            ],
+        )
+        self.assertTrue(
+            torch.equal(recorded["WRITE"][1][0], torch.tensor([1, 2, 3, 4], dtype=torch.uint8))
+        )
+
+        get_results = self.hicache.batch_get_v2([transfer])
+        self.assertEqual(get_results[PoolName.MAMBA], [True, True])
+        self.assertEqual(
+            recorded["READ"][0],
+            [
+                self.hicache._get_component_key("p0", PoolName.MAMBA),
+                self.hicache._get_component_key("p1", PoolName.MAMBA),
+            ],
+        )
+        self.assertTrue(torch.equal(pool.data[0], torch.tensor([9, 9, 9, 9], dtype=torch.uint8)))
+        self.assertTrue(
+            torch.equal(pool.data[1], torch.tensor([10, 10, 10, 10], dtype=torch.uint8))
+        )
 
         # Test batch registration
         tensors = [torch.randn(5, 5) for _ in range(3)]


### PR DESCRIPTION
## Motivation

Added support for the NIXL HiCache backend. Supports both Mamba and DSA models.

## Modifications

- add v2 hybrid storage APIs to HiCacheNixl
    This is the basic interface needed by hybrid HiCache controller to talk with storage backend.
- support extra pool registration for hybrid cache
    This lets NIXL know different host pools, not only KV pool, but also side pools like Mamba
- support pool-aware batch_exists_v2, batch_get_v2, batch_set_v2
    This makes storage operation work by pool type, so extra cache data can be queried and transferred correctly.
- support both ALL_PAGES and TRAILING_PAGES hit policy
    This is needed because different hybrid models have different storage hit semantics.
- update NIXL README and related tests
    This helps document the usage and gives basic coverage for the new hybrid storage behavior.

After the change, cache files will be stored as:
25755648 0163bfe5f95f0595573ee2561ba091c3767e1f8a966f8b298ea3cafa9e517f67_Qwen-Qwen3.5-9B_0_2.mamba
   2097152 0163bfe5f95f0595573ee2561ba091c3767e1f8a966f8b298ea3cafa9e517f67_Qwen-Qwen3.5-9B_0_2_k
   2097152 0163bfe5f95f0595573ee2561ba091c3767e1f8a966f8b298ea3cafa9e517f67_Qwen-Qwen3.5-9B_0_2_v

## Accuracy Tests
config: /tmp/nixl.config.toml
```
[plugin.posix]
active = true
```
mamba
```
export SGLANG_HICACHE_NIXL_BACKEND_STORAGE_DIR=/tmp/sglang_nixl_e2e_storage

sglang serve \
  --model-path /workspace/LLM_models/Qwen3.5-9B  \
  --served-model-name Qwen/Qwen3.5-9B \
  --tp 2 --reasoning-parser qwen3   \
  --enable-hierarchical-cache --hicache-ratio 2 \
  --hicache-io-backend direct --hicache-mem-layout page_first_direct  \
  --hicache-storage-prefetch-policy wait_complete  \
  --mamba-scheduler-strategy extra_buffer \
  --page-size 256 \
  --hicache-storage-backend nixl   --hicache-storage-backend-extra-config @/tmp/nixl.config.toml 
```

gsm8k (first round)
```
$ python3 bench_sglang.py --num-questions 1319 --port 30000
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:00<00:00, 10.92it/s]
Accuracy: 0.898
Invalid: 0.000
Latency: 120.841 s
Output throughput: 1268.248 token/s
```

flush cache
```
$ python3 -m sglang.srt.mem_cache.flush_cache --url http://localhost:30000
(log messages indicating flush successful)
```

gsm8k (after flush)
```
$ python3 bench_sglang.py --num-questions 1319 --port 30000
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:57<00:00, 11.21it/s]
Accuracy: 0.898
Invalid: 0.000
Latency: 117.643 s
Output throughput: 1308.504 token/s
```


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy  results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #25998300826](https://github.com/sgl-project/sglang/actions/runs/25998300826)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->