### PR TITLE
[MLX] Stream on-the-fly quantization via lazy weight load (~270× faster, ~4.5× KV pool)

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -208,6 +208,7 @@ class MlxModelRunner:
             self.model_path,
             tokenizer_config={"trust_remote_code": self.trust_remote_code},
             return_config=True,
+            lazy=True,
         )
         self.model, _tokenizer, config = loaded
 
@@ -241,6 +242,7 @@ class MlxModelRunner:
                     group_size=group_size,
                     bits=bits,
                 )
+                mx.eval(self.model.parameters())
                 bytes_after = sum(
                     p.size * p.itemsize
                     for _, p in tree_flatten(self.model.parameters())


### PR DESCRIPTION
## Motivation

Follow-up to #24907 (on-the-fly `--quantization mlx_q4` / `mlx_q8`). The merged version of #24907 loads the full fp16 model into MLX memory before the quantize graph is constructed, because `mlx_lm.load(...)` calls `mx.eval(model.parameters())` at the end of load by default (see `mlx_lm/utils.py:418`).

On Qwen3-32B that means ~61 GB of fp16 is resident concurrently with the quantize working set on a 64 GB Mac — heavy paging, ~49 min end-to-end load, `sys_available` ≈ 2.8 GB afterward which squeezes the KV pool to ~4.8K tokens.

## Modifications

Two lines in `python/sglang/srt/hardware_backend/mlx/model_runner.py`:

1. Pass `lazy=True` to `mlx_lm_load(...)` — weights stay mmap-backed instead of being eagerly materialized inside `mlx_lm`.
2. Add `mx.eval(self.model.parameters())` immediately after `mlx_lm_quantize_model(...)` so the existing `Quantization complete in {q_time}s` log line captures the real streaming materialization (~seconds) rather than the lazy graph build (~ms).

`nn.quantize` builds one independent `mx.quantize(linear.weight, ...)` op per Linear leaf — no cross-layer dependencies in the lazy graph. With weights still lazy at the moment `mx.eval` runs, MLX can schedule per-Linear: pull one fp16 from mmap → quantize → drop the fp16 input → keep the quantized arrays. Peak memory becomes `quantized_total + small working set` instead of `fp16_total + quantized_total`.

The unconditional `mx.eval(self.model.parameters())` at the bottom of `_load_model` is kept — it is a no-op on the quantize path (idempotent) and still required on the non-quantize path to materialize before KV pool sizing.

## Test Plan

End-to-end on Qwen3-32B, `--quantization mlx_q4`, on a 64 GB M-series Mac.

|                              | post-#24907 main | + this PR      |
| ---                          | ---              | ---            |
| `Quantization complete`      | 476.85s          | **10.37s**     |
| `MLX model loaded`           | 2951.47s         | **10.88s**     |
| `sys_available` post-load    | 2.76 GB          | **11.99 GB**   |
| KV `pool_size`               | 4,797 tok        | **21,615 tok** |
| Final `mlx_used`             | 17.16 GB         | 17.16 GB       |

~270× faster end-to-end load, ~4.5× larger KV cache budget. Final memory footprint is unchanged — only peak-during-load differs.

Bare microbench isolating the materialize phase:

|                              | materialize | peak        |
| ---                          | ---         | ---         |
| `lazy=False`, single eval    | 234s        | 61.4 GB     |
| `lazy=True`, single eval     | **7s**      | **20.7 GB** |

Correctness: 4 representative prompts (factual / arithmetic / code / summary) all return correct outputs against the patched server. Existing `test/registered/unit/hardware_backend/mlx/test_quantization.py` suite covers the `MlxModelRunner(quantization=...)` paths.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(No new tests — the change is a kwarg + an explicit eval; behavior is end-to-end identical except for timing/memory. Existing tests from #24907 cover correctness.)*
- [x] Update documentation. *(N/A — no API change.)*
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->