### PR TITLE
Fix PD disaggregation warmup: set request_name and improve error logging

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1965,6 +1965,7 @@ def _execute_server_warmup(server_args: ServerArgs):
 
         else:
             logger.info(f"Start of pd disaggregation warmup ...")
+            request_name = "/generate"
             json_data = {
                 "sampling_params": {
                     "temperature": 0.0,
@@ -1997,9 +1998,9 @@ def _execute_server_warmup(server_args: ServerArgs):
                 _global_state.tokenizer_manager.server_status = ServerStatus.Up
             else:
                 logger.info(
-                    "Prefill disaggregation mode warm Up Failed, status code: {}".format(
-                        res.status_code
-                    )
+                    "Disaggregation warmup failed (mode=%s), status code: %s",
+                    server_args.disaggregation_mode,
+                    res.status_code,
                 )
                 _global_state.tokenizer_manager.server_status = ServerStatus.UnHealthy
 


### PR DESCRIPTION
## Summary

- Set `request_name = "/generate"` in the PD disaggregation warmup path so the warmup request uses the correct endpoint.
- Improve the warmup failure log message to include the disaggregation mode and use proper logger formatting instead of string `.format()`.

## Original commits

- `6419b5d39`

## Test plan

- Verify PD disaggregation warmup uses `/generate` endpoint correctly.
- Check that warmup failure logs now display the disaggregation mode.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #26000042075](https://github.com/sgl-project/sglang/actions/runs/26000042075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->