### PR TITLE
[Core][Metrics] Expose scheduler queue pressure by waiting reason

### DIFF
--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.observability.metrics_collector import QueueCount
+from sglang.srt.observability.metrics_collector import (
+    QueueCount,
+    compute_normalized_queue_pressure,
+)
 from sglang.srt.utils.common import ceil_align, raise_error_or_warn
 from sglang.srt.utils.watchdog import WatchdogRaw
 
@@ -523,6 +526,11 @@ class SchedulerRuntimeCheckerMixin:
         self.stats.num_queue_reqs = QueueCount.from_reqs(
             self.waiting_queue, priority_enabled
         )
+        self.stats.scheduler_queue_pressure_capacity = (
+            compute_normalized_queue_pressure(
+                self.stats.num_queue_reqs.total, self.max_running_requests
+            )
+        )
         self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.stats.num_prefill_bootstrap_queue_reqs = QueueCount.from_reqs(
@@ -531,6 +539,10 @@ class SchedulerRuntimeCheckerMixin:
             self.stats.num_prefill_inflight_queue_reqs = QueueCount.from_reqs(
                 self.disagg_prefill_inflight_queue, priority_enabled
             )
+            deferred_queue_reqs = (
+                self.stats.num_prefill_bootstrap_queue_reqs.total
+                + self.stats.num_prefill_inflight_queue_reqs.total
+            )
         if self.disaggregation_mode == DisaggregationMode.DECODE:
             self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
                 self.disagg_decode_prealloc_queue.queue, priority_enabled
@@ -538,6 +550,21 @@ class SchedulerRuntimeCheckerMixin:
             self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
                 self.disagg_decode_transfer_queue.queue, priority_enabled
             )
+            deferred_queue_reqs = (
+                self.stats.num_decode_prealloc_queue_reqs.total
+                + self.stats.num_decode_transfer_queue_reqs.total
+                + len(self.disagg_decode_prealloc_queue.retracted_queue)
+            )
+        if self.disaggregation_mode not in (
+            DisaggregationMode.PREFILL,
+            DisaggregationMode.DECODE,
+        ):
+            deferred_queue_reqs = 0
+        self.stats.scheduler_queue_pressure_deferred = (
+            compute_normalized_queue_pressure(
+                deferred_queue_reqs, self.max_running_requests
+            )
+        )
         self.metrics_collector.log_stats(self.stats)
 
     def _check_tree_cache(self: Scheduler):

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -10,6 +10,7 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.observability.metrics_collector import (
     QueueCount,
+    compute_deferred_queue_reqs,
     compute_normalized_queue_pressure,
 )
 from sglang.srt.utils.common import ceil_align, raise_error_or_warn
@@ -526,10 +527,8 @@ class SchedulerRuntimeCheckerMixin:
         self.stats.num_queue_reqs = QueueCount.from_reqs(
             self.waiting_queue, priority_enabled
         )
-        self.stats.scheduler_queue_pressure_capacity = (
-            compute_normalized_queue_pressure(
-                self.stats.num_queue_reqs.total, self.max_running_requests
-            )
+        self.stats.scheduler_queue_pressure_capacity = compute_normalized_queue_pressure(
+            self.stats.num_queue_reqs.total, self.max_running_requests
         )
         self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -539,10 +538,6 @@ class SchedulerRuntimeCheckerMixin:
             self.stats.num_prefill_inflight_queue_reqs = QueueCount.from_reqs(
                 self.disagg_prefill_inflight_queue, priority_enabled
             )
-            deferred_queue_reqs = (
-                self.stats.num_prefill_bootstrap_queue_reqs.total
-                + self.stats.num_prefill_inflight_queue_reqs.total
-            )
         if self.disaggregation_mode == DisaggregationMode.DECODE:
             self.stats.num_decode_prealloc_queue_reqs = QueueCount.from_reqs(
                 self.disagg_decode_prealloc_queue.queue, priority_enabled
@@ -550,20 +545,16 @@ class SchedulerRuntimeCheckerMixin:
             self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
                 self.disagg_decode_transfer_queue.queue, priority_enabled
             )
-            deferred_queue_reqs = (
-                self.stats.num_decode_prealloc_queue_reqs.total
-                + self.stats.num_decode_transfer_queue_reqs.total
-                + len(self.disagg_decode_prealloc_queue.retracted_queue)
-            )
-        if self.disaggregation_mode not in (
-            DisaggregationMode.PREFILL,
-            DisaggregationMode.DECODE,
-        ):
-            deferred_queue_reqs = 0
-        self.stats.scheduler_queue_pressure_deferred = (
-            compute_normalized_queue_pressure(
-                deferred_queue_reqs, self.max_running_requests
-            )
+        self.stats.scheduler_queue_pressure_deferred = compute_normalized_queue_pressure(
+            compute_deferred_queue_reqs(
+                self.disaggregation_mode,
+                self.disagg_prefill_bootstrap_queue.queue,
+                self.disagg_prefill_inflight_queue,
+                self.disagg_decode_prealloc_queue.queue,
+                self.disagg_decode_transfer_queue.queue,
+                self.disagg_decode_prealloc_queue.retracted_queue,
+            ),
+            self.max_running_requests,
         )
         self.metrics_collector.log_stats(self.stats)
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -65,6 +65,8 @@ class SchedulerStats:
     # Basics
     num_running_reqs: QueueCount = field(default_factory=QueueCount)
     num_queue_reqs: QueueCount = field(default_factory=QueueCount)
+    scheduler_queue_pressure_capacity: float = 0.0
+    scheduler_queue_pressure_deferred: float = 0.0
     num_grammar_queue_reqs: int = 0
     gen_throughput: float = 0.0
     cache_hit_rate: float = 0.0
@@ -162,6 +164,13 @@ def compute_routing_key_stats(routing_keys: List[Optional[str]]) -> tuple:
     return len(key_counts), list(key_counts.values())
 
 
+def compute_normalized_queue_pressure(queued_reqs: int, capacity: int) -> float:
+    """Returns queue pressure normalized by configured capacity."""
+    if capacity <= 0:
+        return 0.0
+    return queued_reqs / capacity
+
+
 @dataclass
 class DPCooperationInfo:
     # Users can derive that, except for cases with idle, num_decode_ranks=world_size-num_prefill_ranks
@@ -215,6 +224,17 @@ class SchedulerMetricsCollector:
             name="sglang:num_queue_reqs",
             documentation="The number of requests in the waiting queue.",
             labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+        self.scheduler_queue_pressure = Gauge(
+            name="sglang:scheduler_queue_pressure",
+            documentation=(
+                "Normalized scheduler queue pressure, computed as queued requests "
+                "divided by configured max_running_requests. "
+                "reason=capacity tracks the main waiting queue; reason=deferred tracks "
+                "secondary disaggregation queues."
+            ),
+            labelnames=list(labels.keys()) + ["reason"],
             multiprocess_mode="mostrecent",
         )
         self.num_grammar_queue_reqs = Gauge(
@@ -956,6 +976,13 @@ class SchedulerMetricsCollector:
                 labels["priority"] = str(priority)
                 gauge.labels(**labels).set(value)
 
+    def _log_gauge_with_reason(
+        self, gauge: Gauge, reason: str, data: Union[int, float]
+    ) -> None:
+        labels = dict(self.labels)
+        labels["reason"] = reason
+        gauge.labels(**labels).set(data)
+
     def _log_histogram(self, histogram, data: Union[int, float]) -> None:
         histogram.labels(**self.labels).observe(data)
 
@@ -1107,6 +1134,16 @@ class SchedulerMetricsCollector:
         # Basics
         self._log_gauge_queue_count(self.num_running_reqs, stats.num_running_reqs)
         self._log_gauge_queue_count(self.num_queue_reqs, stats.num_queue_reqs)
+        self._log_gauge_with_reason(
+            self.scheduler_queue_pressure,
+            "capacity",
+            stats.scheduler_queue_pressure_capacity,
+        )
+        self._log_gauge_with_reason(
+            self.scheduler_queue_pressure,
+            "deferred",
+            stats.scheduler_queue_pressure_deferred,
+        )
         self._log_gauge(self.num_grammar_queue_reqs, stats.num_grammar_queue_reqs)
         self._log_gauge(self.gen_throughput, stats.gen_throughput)
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.observability.utils import exponential_buckets, generate_buckets
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_bool_env_var
@@ -169,6 +170,26 @@ def compute_normalized_queue_pressure(queued_reqs: int, capacity: int) -> float:
     if capacity <= 0:
         return 0.0
     return queued_reqs / capacity
+
+
+def compute_deferred_queue_reqs(
+    disaggregation_mode: DisaggregationMode,
+    prefill_bootstrap_queue: list,
+    prefill_inflight_queue: list,
+    decode_prealloc_queue: list,
+    decode_transfer_queue: list,
+    decode_retracted_queue: Optional[list] = None,
+) -> int:
+    """Returns the number of deferred requests behind disaggregation queues."""
+    if disaggregation_mode == DisaggregationMode.PREFILL:
+        return len(prefill_bootstrap_queue) + len(prefill_inflight_queue)
+    if disaggregation_mode == DisaggregationMode.DECODE:
+        return (
+            len(decode_prealloc_queue)
+            + len(decode_transfer_queue)
+            + len(decode_retracted_queue or [])
+        )
+    return 0
 
 
 @dataclass

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -26,6 +26,7 @@ from sglang.srt.observability.metrics_collector import (
     QueueCount,
     SchedulerMetricsCollector,
     SchedulerStats,
+    compute_deferred_queue_reqs,
     compute_normalized_queue_pressure,
     compute_routing_key_stats,
 )
@@ -332,6 +333,26 @@ class SchedulerMetricsMixin:
             var_decode_kv_tokens=decode_q.variance(),
         )
 
+    def _update_scheduler_queue_pressure(self: Scheduler) -> None:
+        self.stats.scheduler_queue_pressure_capacity = (
+            compute_normalized_queue_pressure(
+                self.stats.num_queue_reqs.total, self.max_running_requests
+            )
+        )
+        self.stats.scheduler_queue_pressure_deferred = (
+            compute_normalized_queue_pressure(
+                compute_deferred_queue_reqs(
+                    self.disaggregation_mode,
+                    self.disagg_prefill_bootstrap_queue.queue,
+                    self.disagg_prefill_inflight_queue,
+                    self.disagg_decode_prealloc_queue.queue,
+                    self.disagg_decode_transfer_queue.queue,
+                    self.disagg_decode_prealloc_queue.retracted_queue,
+                ),
+                self.max_running_requests,
+            )
+        )
+
     def update_spec_metrics(self: Scheduler, bs: int, num_correct_drafts: int):
         self.spec_num_accept_tokens += num_correct_drafts + bs
         self.spec_num_forward_ct += bs
@@ -575,11 +596,7 @@ class SchedulerMetricsMixin:
             self.stats.num_queue_reqs = QueueCount.from_reqs(
                 self.waiting_queue, priority_enabled
             )
-            self.stats.scheduler_queue_pressure_capacity = (
-                compute_normalized_queue_pressure(
-                    self.stats.num_queue_reqs.total, self.max_running_requests
-                )
-            )
+            self._update_scheduler_queue_pressure()
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
 
@@ -767,6 +784,7 @@ class SchedulerMetricsMixin:
             self.stats.num_queue_reqs = QueueCount.from_reqs(
                 self.waiting_queue, priority_enabled
             )
+            self._update_scheduler_queue_pressure()
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.gen_throughput = self.last_gen_throughput
             self.stats.cache_hit_rate = cache_hit_rate

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -26,6 +26,7 @@ from sglang.srt.observability.metrics_collector import (
     QueueCount,
     SchedulerMetricsCollector,
     SchedulerStats,
+    compute_normalized_queue_pressure,
     compute_routing_key_stats,
 )
 from sglang.srt.utils.device_timer import DeviceTimer
@@ -574,6 +575,11 @@ class SchedulerMetricsMixin:
             self.stats.num_queue_reqs = QueueCount.from_reqs(
                 self.waiting_queue, priority_enabled
             )
+            self.stats.scheduler_queue_pressure_capacity = (
+                compute_normalized_queue_pressure(
+                    self.stats.num_queue_reqs.total, self.max_running_requests
+                )
+            )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
 
@@ -593,6 +599,10 @@ class SchedulerMetricsMixin:
                 self.stats.num_prefill_inflight_queue_reqs = QueueCount.from_reqs(
                     self.disagg_prefill_inflight_queue, priority_enabled
                 )
+                deferred_queue_reqs = (
+                    self.stats.num_prefill_bootstrap_queue_reqs.total
+                    + self.stats.num_prefill_inflight_queue_reqs.total
+                )
                 self.stats.kv_transfer_speed_gb_s = self.kv_transfer_speed_gb_s
                 self.stats.kv_transfer_latency_ms = self.kv_transfer_latency_ms
             elif self.disaggregation_mode == DisaggregationMode.DECODE:
@@ -602,6 +612,18 @@ class SchedulerMetricsMixin:
                 self.stats.num_decode_transfer_queue_reqs = QueueCount.from_reqs(
                     self.disagg_decode_transfer_queue.queue, priority_enabled
                 )
+                deferred_queue_reqs = (
+                    self.stats.num_decode_prealloc_queue_reqs.total
+                    + self.stats.num_decode_transfer_queue_reqs.total
+                    + len(self.disagg_decode_prealloc_queue.retracted_queue)
+                )
+            else:
+                deferred_queue_reqs = 0
+            self.stats.scheduler_queue_pressure_deferred = (
+                compute_normalized_queue_pressure(
+                    deferred_queue_reqs, self.max_running_requests
+                )
+            )
 
             # Utilization / LoRA / HiCache
             self.calculate_utilization()

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -8,6 +8,7 @@ from prometheus_client.samples import Sample
 from sglang.srt.environ import envs
 from sglang.srt.observability.metrics_collector import (
     ROUTING_KEY_REQ_COUNT_BUCKET_BOUNDS,
+    compute_normalized_queue_pressure,
     compute_routing_key_stats,
 )
 from sglang.srt.utils import kill_process_tree
@@ -162,6 +163,7 @@ class TestEnableMetrics(CustomTestCase):
             "sglang:token_usage",
             "sglang:gen_throughput",
             "sglang:num_queue_reqs",
+            "sglang:scheduler_queue_pressure",
             "sglang:num_grammar_queue_reqs",
             "sglang:cache_hit_rate",
             "sglang:spec_accept_length",
@@ -216,6 +218,13 @@ class TestEnableMetrics(CustomTestCase):
             ("sglang:process_cpu_seconds_total", {"component": "tokenizer"}),
         ]
         _check_metrics_positive(self, metrics, metrics_to_check)
+
+        pressure_reasons = {
+            sample.labels.get("reason")
+            for sample in metrics["sglang:scheduler_queue_pressure"]
+        }
+        self.assertIn("capacity", pressure_reasons)
+        self.assertIn("deferred", pressure_reasons)
 
         if expect_mfu_metrics:
             # Estimated perf metrics may have multiple series (e.g., by rank). Ensure
@@ -300,6 +309,13 @@ class TestComputeRoutingKeyStats(unittest.TestCase):
         num_unique, req_counts = compute_routing_key_stats(routing_keys)
         self.assertEqual(num_unique, 4)
         self.assertEqual(sorted(req_counts), [1, 5, 15, 250])
+
+
+class TestComputeNormalizedQueuePressure(unittest.TestCase):
+    def test_normalized_queue_pressure(self):
+        self.assertEqual(compute_normalized_queue_pressure(5, 10), 0.5)
+        self.assertEqual(compute_normalized_queue_pressure(0, 10), 0.0)
+        self.assertEqual(compute_normalized_queue_pressure(7, 0), 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a Prometheus gauge for normalized scheduler queue pressure so control planes can compare replicas with different capacities.

- sglang:scheduler_queue_pressure with reason=capacity|deferred
- normalizes queue depth by max_running_requests
- surfaces both the main waiting queue and deferred/disaggregation queues
- adds metrics coverage for the new series







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->