### PR TITLE
Respect user override for Gemma4 attention backend

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2192,13 +2192,19 @@ class ServerArgs:
             )
             self.disable_hybrid_swa_memory = True
         elif model_arch == "Gemma4ForConditionalGeneration":
-            if is_sm100_supported():
-                self.attention_backend = "trtllm_mha"
+            if self.is_attention_backend_not_set():
+                if is_sm100_supported():
+                    self.attention_backend = "trtllm_mha"
+                else:
+                    self.attention_backend = "triton"
+                logger.info(
+                    f"Use {self.attention_backend} as default attention backend for Gemma4"
+                )
             else:
-                self.attention_backend = "triton"
-            logger.info(
-                f"Use {self.attention_backend} as default attention backend for Gemma4"
-            )
+                assert self.attention_backend in ("trtllm_mha", "triton"), (
+                    f"Gemma4 only supports trtllm_mha or triton attention backend, "
+                    f"got {self.attention_backend}"
+                )
         elif model_arch == "MossVLForConditionalGeneration":
             if self.is_attention_backend_not_set():
                 self.prefill_attention_backend = "flashinfer"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2192,19 +2192,30 @@ class ServerArgs:
             )
             self.disable_hybrid_swa_memory = True
         elif model_arch == "Gemma4ForConditionalGeneration":
+            default_attention_backend = (
+                "trtllm_mha" if is_sm100_supported() else "triton"
+            )
             if self.is_attention_backend_not_set():
-                if is_sm100_supported():
-                    self.attention_backend = "trtllm_mha"
-                else:
-                    self.attention_backend = "triton"
+                self.attention_backend = default_attention_backend
                 logger.info(
                     f"Use {self.attention_backend} as default attention backend for Gemma4"
                 )
             else:
-                assert self.attention_backend in ("trtllm_mha", "triton"), (
-                    f"Gemma4 only supports trtllm_mha or triton attention backend, "
-                    f"got {self.attention_backend}"
-                )
+                # If only one split backend is set, keep the other side on a
+                # Gemma4-compatible fallback instead of letting generic backend
+                # selection choose an unsupported backend later.
+                if self.attention_backend is None:
+                    self.attention_backend = default_attention_backend
+
+            prefill_backend, decode_backend = self.get_attention_backends()
+            accepted_backends = ("trtllm_mha", "triton")
+            assert (
+                prefill_backend in accepted_backends
+                and decode_backend in accepted_backends
+            ), (
+                "Gemma4 only supports trtllm_mha or triton attention backend, "
+                f"got prefill={prefill_backend}, decode={decode_backend}"
+            )
         elif model_arch == "MossVLForConditionalGeneration":
             if self.is_attention_backend_not_set():
                 self.prefill_attention_backend = "flashinfer"


### PR DESCRIPTION
## Summary
- Follow-up to #25006. The Gemma4 default-backend block was unconditionally overwriting `self.attention_backend`, so `--attention-backend` was silently ignored.
- Only auto-select (`trtllm_mha` on sm100, `triton` otherwise) when no backend has been set by the user.
- If the user did pass `--attention-backend`, assert it is one of `trtllm_mha` or `triton` (the two Gemma4-supported backends).

## Test plan
- [x] Launch Gemma4 with no `--attention-backend` on an sm100 GPU and confirm `trtllm_mha` is selected (log line).
- [x] Launch Gemma4 with no `--attention-backend` on a non-sm100 GPU and confirm `triton` is selected.
- [x] Launch Gemma4 with `--attention-backend trtllm_mha` / `triton` and confirm the user value is preserved (no log override).
- [x] Launch Gemma4 with `--attention-backend flashinfer` and confirm the assertion fires with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->