### PR TITLE
Quiet test_bs_1_speed CI log

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3463,7 +3463,8 @@ class Scheduler(
 
             if empty_cache:
                 current_platform.empty_cache()
-            logger.info("Cache flushed successfully!")
+            if self.is_stats_logging_rank:
+                logger.info("Cache flushed successfully!")
             success = True
         else:
             logging.warning(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3463,6 +3463,8 @@ class Scheduler(
 
             if empty_cache:
                 current_platform.empty_cache()
+            # Per-DP-group leader logs once: ranks within a DP group are
+            # state-synchronous, but DP groups may diverge.
             if self.is_stats_logging_rank:
                 logger.info("Cache flushed successfully!")
             success = True

--- a/python/sglang/test/kits/spec_decoding_kit.py
+++ b/python/sglang/test/kits/spec_decoding_kit.py
@@ -14,8 +14,9 @@ class SpecDecodingMixin:
         acc_length, speed = 0.0, 0.0
         for attempt in range(1, self.bs_1_speed_attempts + 1):
             requests.get(self.base_url + "/flush_cache")
-            acc_length, speed = send_one_prompt(args)
-            print(f"attempt {attempt}: {acc_length=:.2f} {speed=:.2f}")
+            acc_length, speed = send_one_prompt(
+                args, label=f"attempt {attempt}", print_output=False
+            )
             if acc_length > self.accept_length_thres and speed > self.bs_1_speed_thres:
                 break
         requests.get(self.base_url + "/flush_cache")

--- a/python/sglang/test/send_one.py
+++ b/python/sglang/test/send_one.py
@@ -105,7 +105,11 @@ class BenchArgs:
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
 
-def send_one_prompt(args: BenchArgs):
+def send_one_prompt(
+    args: BenchArgs,
+    label: Optional[str] = None,
+    print_output: bool = True,
+):
     base_url = f"http://{args.host}:{args.port}"
 
     # Construct the input
@@ -235,10 +239,12 @@ def send_one_prompt(args: BenchArgs):
     speed = ret["meta_info"]["completion_tokens"] / latency
     tokens = ret["meta_info"]["completion_tokens"]
 
-    if not args.stream:
+    if not args.stream and print_output:
         print(ret["text"])
 
     print()
+    if label is not None:
+        print(label)
     headers = ["Latency (s)", "Tokens", "Acc Length", "Speed (token/s)"]
     rows = [[f"{latency:.3f}", f"{tokens}", f"{acc_length:.3f}", f"{speed:.2f}"]]
     msg = tabulate.tabulate(rows, headers=headers, tablefmt="pretty")


### PR DESCRIPTION
Reduce log noise in the spec-decoding bs_1_speed CI path: dedupe per-TP cache flush log, drop the verbose response dump, and label the result table with the attempt index instead of a separate print.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->