### PR TITLE
[WIP][Gemma4] Triton `extend_attention` tuning to improve TTFT and TPOT

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -32,13 +32,14 @@ if _is_cuda:
 _is_hip = is_hip()
 
 
-def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
+def _get_block_sizes_for_extend_attention(Lq: int, Lv: int, max_len_extend: int):
     """
     Get block sizes and configuration for extend attention kernels.
 
     Args:
         Lq: Query head dimension
         Lv: Value head dimension
+        max_len_extend: Maximum extend length per sequence in the batch
 
     Returns:
         tuple: (BLOCK_DMODEL, BLOCK_DPE, BLOCK_DV, BLOCK_M, BLOCK_N, num_warps)
@@ -76,6 +77,8 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
             # Blackwell data-center architecture (GB200, B200, sm_100a)
             if Lq <= 256:
                 BLOCK_M, BLOCK_N = (64, 64)
+            elif max_len_extend <= 16:
+                BLOCK_M, BLOCK_N = (16, 64)
             else:
                 BLOCK_M, BLOCK_N = (32, 64)
         elif _is_cuda and CUDA_CAPABILITY[0] >= 9:
@@ -591,7 +594,7 @@ def extend_attention_fwd(
 
     # Get block sizes and configuration
     BLOCK_DMODEL, BLOCK_DPE, BLOCK_DV, BLOCK_M, BLOCK_N, num_warps = (
-        _get_block_sizes_for_extend_attention(Lq, Lv)
+        _get_block_sizes_for_extend_attention(Lq, Lv, max_len_extend)
     )
 
     sm_scale = sm_scale or 1.0 / (Lq**0.5)
@@ -1001,7 +1004,7 @@ def extend_attention_fwd_unified(
 
     # Get block sizes and configuration
     BLOCK_DMODEL, BLOCK_DPE, BLOCK_DV, BLOCK_M, BLOCK_N, num_warps = (
-        _get_block_sizes_for_extend_attention(Lq, Lv)
+        _get_block_sizes_for_extend_attention(Lq, Lv, max_len_extend)
     )
 
     sm_scale = sm_scale or 1.0 / (Lq**0.5)

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -74,12 +74,10 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
                 BLOCK_M, BLOCK_N = (32, 32)
         elif _is_cuda and CUDA_CAPABILITY[0] == 10:
             # Blackwell data-center architecture (GB200, B200, sm_100a)
-            # sm_100a has different register constraints from Hopper; Hopper block sizes
-            # cause PTX register exhaustion (>255 regs) for large head dims (Lq=512).
             if Lq <= 256:
                 BLOCK_M, BLOCK_N = (64, 64)
             else:
-                BLOCK_M, BLOCK_N = (16, 64)
+                BLOCK_M, BLOCK_N = (32, 64)
         elif _is_cuda and CUDA_CAPABILITY[0] >= 9:
             # Hopper architecture (H100, etc.)
             if Lq <= 256:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2192,13 +2192,19 @@ class ServerArgs:
             )
             self.disable_hybrid_swa_memory = True
         elif model_arch == "Gemma4ForConditionalGeneration":
-            if is_sm100_supported():
-                self.attention_backend = "trtllm_mha"
+            if self.is_attention_backend_not_set():
+                if is_sm100_supported():
+                    self.attention_backend = "trtllm_mha"
+                else:
+                    self.attention_backend = "triton"
+                logger.info(
+                    f"Use {self.attention_backend} as default attention backend for Gemma4"
+                )
             else:
-                self.attention_backend = "triton"
-            logger.info(
-                f"Use {self.attention_backend} as default attention backend for Gemma4"
-            )
+                assert self.attention_backend in ("trtllm_mha", "triton"), (
+                    f"Gemma4 only supports trtllm_mha or triton attention backend, "
+                    f"got {self.attention_backend}"
+                )
         elif model_arch == "MossVLForConditionalGeneration":
             if self.is_attention_backend_not_set():
                 self.prefill_attention_backend = "flashinfer"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2192,19 +2192,30 @@ class ServerArgs:
             )
             self.disable_hybrid_swa_memory = True
         elif model_arch == "Gemma4ForConditionalGeneration":
+            default_attention_backend = (
+                "trtllm_mha" if is_sm100_supported() else "triton"
+            )
             if self.is_attention_backend_not_set():
-                if is_sm100_supported():
-                    self.attention_backend = "trtllm_mha"
-                else:
-                    self.attention_backend = "triton"
+                self.attention_backend = default_attention_backend
                 logger.info(
                     f"Use {self.attention_backend} as default attention backend for Gemma4"
                 )
             else:
-                assert self.attention_backend in ("trtllm_mha", "triton"), (
-                    f"Gemma4 only supports trtllm_mha or triton attention backend, "
-                    f"got {self.attention_backend}"
-                )
+                # If only one split backend is set, keep the other side on a
+                # Gemma4-compatible fallback instead of letting generic backend
+                # selection choose an unsupported backend later.
+                if self.attention_backend is None:
+                    self.attention_backend = default_attention_backend
+
+            prefill_backend, decode_backend = self.get_attention_backends()
+            accepted_backends = ("trtllm_mha", "triton")
+            assert (
+                prefill_backend in accepted_backends
+                and decode_backend in accepted_backends
+            ), (
+                "Gemma4 only supports trtllm_mha or triton attention backend, "
+                f"got prefill={prefill_backend}, decode={decode_backend}"
+            )
         elif model_arch == "MossVLForConditionalGeneration":
             if self.is_attention_backend_not_set():
                 self.prefill_attention_backend = "flashinfer"


### PR DESCRIPTION
## Motivation

Improving 31B TTFT performance when using Triton attention. Stacking on top of https://github.com/sgl-project/sglang/pull/25547

## Modifications

Use `BLOCK_M=32, BLOCK_N=64` for SM100 large-head Triton extend attention. This restores the faster path that #22079 avoided for older Torch/Triton; current stack on `main` is `torch 2.11.0+cu130` and `triton 3.6.0`.

## Accuracy Tests

NVFP4 on both B200 and GB200

```bash
python3 -m sglang.launch_server \
    --model-path nvidia/Gemma-4-31B-IT-NVFP4 \
    --port 18000 \
    --host 0.0.0.0 \
    --attention-backend triton \
    --context-length 8192 \
    --max-running-requests 64
```

B200 GSM8K result: `0.764079`
GB200 GSM8K result: ` 0.783` 
Both over 1314 examples (`api=completion`, `max_tokens=512`, `num_threads=200`).

## Speed Tests and Profiling

BF16 server:

```bash
python3 -m sglang.launch_server \
    --model-path google/gemma-4-31B-it \
    --port 18000 \
    --host 0.0.0.0 \
    --attention-backend triton \
    --speculative-algorithm FROZEN_KV_MTP \
    --speculative-draft-model-path google/gemma-4-31B-it-assistant \
    --speculative-num-steps 5 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 6 \
    --context-length 65536 \
    --chunked-prefill-size 8192 \ 
    --mem-fraction-static 0.85 \
    --max-running-requests 32
```

Client: generated-shared-prefix, 16 prompts, concurrency 1, input/output `10000/800`.

Result: TTFT `796.80 ms`, TPOT `10.40 ms`, accept length `4.57`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->