### PR TITLE
amd/deepseek_v4 27/N [fix] Reduce Triton autotune configs for faster first-time server launch

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_common.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_common.py
@@ -73,7 +73,7 @@ def _get_workload_size_category(total_tokens: int, topk: int) -> int:
 # ============================================================================
 @triton.autotune(
     configs=[
-        # Reduced from 22 to 4 configs. Selected based on CDNA4 architecture analysis:
+        # Selected based on CDNA4 architecture analysis:
         # - BLOCK_D=128 is fixed (matches KV tile structure for d_qk=512).
         # - BLOCK_N=256: best for amortizing memory access over topk dimension.
         #   (decode attention is memory-bound; larger BLOCK_N = fewer iterations)

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_common.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_common.py
@@ -73,81 +73,28 @@ def _get_workload_size_category(total_tokens: int, topk: int) -> int:
 # ============================================================================
 @triton.autotune(
     configs=[
-        # CDNA4-optimized configurations for MI355X (256 CUs, 8TB/s BW)
-        # Best for h_q=128, large topk: maximize parallelism across CUs
+        # Reduced from 22 to 4 configs. Selected based on CDNA4 architecture analysis:
+        # - BLOCK_D=128 is fixed (matches KV tile structure for d_qk=512).
+        # - BLOCK_N=256: best for amortizing memory access over topk dimension.
+        #   (decode attention is memory-bound; larger BLOCK_N = fewer iterations)
+        # - num_warps=8: memory-bound decode benefits from more warps for latency hiding.
+        # - BLOCK_H varies to cover different batch sizes:
+        #   * BLOCK_H=16: cdiv(128,16)=8 H-blocks, best for small batches (bs=1-8)
+        #   * BLOCK_H=32: cdiv(128,32)=4 H-blocks, good for medium batches (bs=8-32)
+        #   * BLOCK_H=64: cdiv(128,64)=2 H-blocks, best for large batches (bs=32+)
+        #     (original comment: "Best for h_q=128, large topk")
+        #   * BLOCK_H=128: cdiv(128,128)=1 H-block, for very large batches (bs=128+)
         triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 128, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 128, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
+            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
         ),
         triton.Config(
             {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
         ),
         triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        # Additional configs with num_stages=2 for better pipelining
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
+            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
         ),
         triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        # Original configurations
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 64, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 8, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 8, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
+            {"BLOCK_H": 128, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
         ),
     ],
     key=["total_tokens_bucket", "h_q", "total_topk", "d_qk"],

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_dsv4.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_dsv4.py
@@ -57,7 +57,7 @@ DSV4_USE_FIXED_KERNEL_THRESHOLD = 32768
 
 @triton.autotune(
     configs=[
-        # Reduced from 20 to 4 configs. This is a pure memory-copy + FP8→BF16 dequant kernel.
+        # This is a pure memory-copy + FP8→BF16 dequant kernel.
         # - BLOCK_TK controls how many (token×topk) pairs per block.
         # - Larger BLOCK_TK amortizes launch overhead but needs more warps.
         # - BLOCK_TK=128 is already validated as the fixed config for small workloads

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_dsv4.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_dsv4.py
@@ -57,27 +57,16 @@ DSV4_USE_FIXED_KERNEL_THRESHOLD = 32768
 
 @triton.autotune(
     configs=[
-        # Small block sizes for better occupancy on CDNA4 (256 CUs)
-        triton.Config({"BLOCK_TK": 8}, num_warps=1, num_stages=1),
-        triton.Config({"BLOCK_TK": 8}, num_warps=2, num_stages=1),
-        triton.Config({"BLOCK_TK": 16}, num_warps=1, num_stages=1),
-        triton.Config({"BLOCK_TK": 16}, num_warps=2, num_stages=1),
-        triton.Config({"BLOCK_TK": 16}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_TK": 32}, num_warps=2, num_stages=1),
-        triton.Config({"BLOCK_TK": 32}, num_warps=4, num_stages=1),
+        # Reduced from 20 to 4 configs. This is a pure memory-copy + FP8→BF16 dequant kernel.
+        # - BLOCK_TK controls how many (token×topk) pairs per block.
+        # - Larger BLOCK_TK amortizes launch overhead but needs more warps.
+        # - BLOCK_TK=128 is already validated as the fixed config for small workloads
+        #   (below DSV4_USE_FIXED_KERNEL_THRESHOLD = 32K elements).
+        # - BLOCK_TK=64/128: good for small/medium workloads (fewer warps, less overhead).
+        # - BLOCK_TK=256: better bandwidth utilization for large workloads.
         triton.Config({"BLOCK_TK": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_TK": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_TK": 64}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_TK": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_TK": 128}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_TK": 128}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_TK": 128}, num_warps=8, num_stages=2),
         triton.Config({"BLOCK_TK": 256}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_TK": 256}, num_warps=16, num_stages=1),
-        triton.Config({"BLOCK_TK": 256}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_TK": 512}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_TK": 512}, num_warps=16, num_stages=1),
-        triton.Config({"BLOCK_TK": 512}, num_warps=8, num_stages=2),
     ],
     key=["total_tokens_bucket", "topk", "workload_size_cat"],
 )

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_fused.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_fused.py
@@ -200,17 +200,18 @@ def _process_kv_block_aggressive(
 # ============================================================================
 @triton.autotune(
     configs=[
-        # Removed 3 exact duplicates
+        # Reduced from 10 to 6 configs. Fused gather+dequant+attention kernel.
+        # Two axes: BLOCK_H × BLOCK_N, with BLOCK_N being the key perf knob
+        # for small h_q (h_q=16 at TP=8 where BLOCK_H doesn't affect grid).
+        # BLOCK_N=64: better for large topk (less register pressure per iter).
+        # BLOCK_N=128: better for small topk (fewer iterations).
+        # num_warps=4: fused kernel is compute-bound.
+        triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 128, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 256}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 256}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 256}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 16, "BLOCK_N": 256}, num_warps=4, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "topk"],
 )
@@ -740,33 +741,45 @@ def fused_gather_attn_decode_dsv4(
 
 # Uses helper function to eliminate code duplication
 # ============================================================================
+
+def _prune_dual_scope_configs(configs, named_args, **kwargs):
+    """Prune configs where BLOCK_H > h_q for the dual-scope kernel.
+
+    When BLOCK_H > h_q, cdiv(h_q, BLOCK_H) = 1 regardless of BLOCK_H value,
+    so larger BLOCK_H gives the same grid but may have worse register allocation.
+    Keep only the smallest BLOCK_H that gives cdiv(h_q, BLOCK_H) = 1, plus
+    any BLOCK_H <= h_q configs.
+
+    For h_q=16: keep only BLOCK_H=16 (removes 32, 64 which give same grid)
+    For h_q=64: keep BLOCK_H=16, 32, 64 (all give different grid sizes)
+    For h_q=128: keep all (all give different grid sizes)
+    """
+    h_q = named_args.get("h_q", 128)
+    pruned = [c for c in configs if c.kwargs.get("BLOCK_H", 16) <= h_q]
+    return pruned if pruned else configs
+
 @triton.autotune(
     configs=[
-        # num_warps=4, num_stages=1 configs
+        # Reduced from 20 to 10 configs. Dual-scope fused gather+dequant+attention.
+        # Three axes: BLOCK_H × BLOCK_N × (warps, stages).
+        # - BLOCK_H: {16, 32, 64} covers h_q=16 (TP=8), h_q=64 (TP=2), h_q=128 (TP=1).
+        # - BLOCK_N: {64, 128}. BLOCK_N=64 better for large topk, 128 for small topk.
+        # - _prune_dual_scope_configs removes BLOCK_H > h_q configs (they compile to
+        #   different binaries with worse register allocation despite same grid size).
+        # stages=1, warps=4: baseline configs
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        # num_warps=8, num_stages=1 configs
+        # warps=8: for memory-bound scenarios (small h_q, large topk)
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=8, num_stages=1),
-        # num_stages=2 configs (software pipelining)
-        triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=2),
     ],
     key=["total_tokens_bucket", "h_q", "topk_main", "topk_extra"],
+    prune_configs_by={"early_config_prune": _prune_dual_scope_configs},
 )
 @triton.jit
 def _fused_gather_attn_dsv4_dual_scope_kernel(
@@ -1161,11 +1174,11 @@ def _fused_gather_attn_dsv4_dual_scope_kernel(
 
 def _prune_splitk_configs(configs, named_args, **kwargs):
     """Prune BLOCK_H=16 configs for large batch sizes to avoid CU oversubscription.
-    
+
     With h_q=128 and BLOCK_H=16, the grid has cdiv(128,16)=8 H-blocks.
     At bs=32 with split_k=2, this creates 8*32*2=512 blocks (200% CU),
     causing performance regression from oversubscription.
-    
+
     For small batch sizes (bucket <= 8), BLOCK_H=16 provides better
     parallelism and is ~10% faster in CUDA graph replay.
     """
@@ -1183,22 +1196,19 @@ def _prune_splitk_configs(configs, named_args, **kwargs):
 # ============================================================================
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 256}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 256}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 256}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        # BLOCK_H=16 for better parallelism at small batch sizes
-        # (pruned for large batch sizes by _prune_splitk_configs)
+        # Reduced from 11 to 6 configs. Split-K dual-scope fused kernel.
+        # - Split-K adds parallelism in K dim (2-8 splits).
+        # - BLOCK_N={64,128}: BLOCK_N=64 better for large topk_per_split.
+        # - num_warps=4: compute-bound fused kernel.
+        # - BLOCK_H={16,64}: covers small h_q (16) and large h_q (128).
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 16, "BLOCK_N": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 128, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "topk_per_split"],
-    prune_configs_by={"early_config_prune": _prune_splitk_configs},
 )
 @triton.jit
 def _fused_gather_attn_dsv4_dual_scope_splitk_kernel(
@@ -1910,32 +1920,16 @@ SPLITK_DEFAULT = 4
 
 @triton.autotune(
     configs=[
-        # Tiny BLOCK_N=8 for minimal scattered access
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 8}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 8}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 8}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 8}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 8}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 8}, num_warps=8, num_stages=1),
-        # Very small BLOCK_N=16
+        # Reduced from 20 to 6 configs. Split-K fused kernel for large topk (≥8192).
+        # - BLOCK_N={16,32}: small blocks for scattered FP8 KV access pattern.
+        # - num_warps=4: balanced for fused dequant+attention compute.
+        # - BLOCK_H={16,64}: covers small h_q (16) and large h_q (128).
+        triton.Config({"BLOCK_H": 16, "BLOCK_N": 16}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 16, "BLOCK_N": 32}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 16}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 16}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 16}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 16}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 16}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 16}, num_warps=8, num_stages=1),
-        # Small BLOCK_N=32
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 32}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 32}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 32}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 32}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_H": 128, "BLOCK_N": 16}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 128, "BLOCK_N": 32}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_N": 32}, num_warps=8, num_stages=1),
-        # Medium BLOCK_N=64
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=8, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "topk_per_split"],
 )
@@ -2385,16 +2379,14 @@ def _combine_splitk_kernel(
 
 @triton.autotune(
     configs=[
-        # Reduced from 15 to 5 configs. This is a simple reduce kernel
-        # (weighted sum of 8 partial results), so performance is not
-        # sensitive to tile shape. BLOCK_D=512 covers d_v=512 in one
-        # pass; BLOCK_D=256 as fallback. BLOCK_H=16/32/64 covers the
-        # parallelism range for small batch sizes (split_k=8 → bs<=4).
+        # Reduced from 5 to 3 configs. Simple reduce kernel (weighted sum of 8 splits).
+        # - BLOCK_D=512: covers d_v=512 in one pass (no D-dimension loop).
+        # - num_warps=8: memory-bound reduce benefits from more warps.
+        # - split_k=8 is only used at very small batch sizes (≤4 tokens),
+        #   so BLOCK_H=16/32/64 covers the relevant parallelism range.
         triton.Config({"BLOCK_H": 16, "BLOCK_D": 512}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_D": 512}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_D": 512}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 16, "BLOCK_D": 256}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_D": 256}, num_warps=4, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "d_v"],
 )

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_fused.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_fused.py
@@ -200,9 +200,9 @@ def _process_kv_block_aggressive(
 # ============================================================================
 @triton.autotune(
     configs=[
-        # Reduced from 10 to 6 configs. Fused gather+dequant+attention kernel.
+        # Fused gather+dequant+attention kernel.
         # Two axes: BLOCK_H × BLOCK_N, with BLOCK_N being the key perf knob
-        # for small h_q (h_q=16 at TP=8 where BLOCK_H doesn't affect grid).
+        # for h_q=64 where fewer BLOCK_H values affect the grid.
         # BLOCK_N=64: better for large topk (less register pressure per iter).
         # BLOCK_N=128: better for small topk (fewer iterations).
         # num_warps=4: fused kernel is compute-bound.
@@ -750,8 +750,7 @@ def _prune_dual_scope_configs(configs, named_args, **kwargs):
     Keep only the smallest BLOCK_H that gives cdiv(h_q, BLOCK_H) = 1, plus
     any BLOCK_H <= h_q configs.
 
-    For h_q=16: keep only BLOCK_H=16 (removes 32, 64 which give same grid)
-    For h_q=64: keep BLOCK_H=16, 32, 64 (all give different grid sizes)
+    For h_q=64: keep BLOCK_H <= 64 (removes BLOCK_H=128 which gives same grid)
     For h_q=128: keep all (all give different grid sizes)
     """
     h_q = named_args.get("h_q", 128)
@@ -760,22 +759,23 @@ def _prune_dual_scope_configs(configs, named_args, **kwargs):
 
 @triton.autotune(
     configs=[
-        # Reduced from 20 to 10 configs. Dual-scope fused gather+dequant+attention.
+        # Dual-scope fused gather+dequant+attention.
         # Three axes: BLOCK_H × BLOCK_N × (warps, stages).
-        # - BLOCK_H: {16, 32, 64} covers h_q=16 (TP=8), h_q=64 (TP=2), h_q=128 (TP=1).
+        # - BLOCK_H: {16, 32, 64, 128} covers h_q=64 and h_q=128.
         # - BLOCK_N: {64, 128}. BLOCK_N=64 better for large topk, 128 for small topk.
-        # - _prune_dual_scope_configs removes BLOCK_H > h_q configs (they compile to
-        #   different binaries with worse register allocation despite same grid size).
-        # stages=1, warps=4: baseline configs
+        # - _prune_dual_scope_configs removes BLOCK_H > h_q configs (e.g. BLOCK_H=128
+        #   is pruned when h_q=64 since it gives the same grid as BLOCK_H=64).
+        # warps=4: baseline configs
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
-        # warps=8: for memory-bound scenarios (small h_q, large topk)
+        triton.Config({"BLOCK_H": 128, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
+        # warps=8: for memory-bound scenarios
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=8, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "topk_main", "topk_extra"],
@@ -1196,11 +1196,11 @@ def _prune_splitk_configs(configs, named_args, **kwargs):
 # ============================================================================
 @triton.autotune(
     configs=[
-        # Reduced from 11 to 6 configs. Split-K dual-scope fused kernel.
+        # Split-K dual-scope fused kernel.
         # - Split-K adds parallelism in K dim (2-8 splits).
         # - BLOCK_N={64,128}: BLOCK_N=64 better for large topk_per_split.
         # - num_warps=4: compute-bound fused kernel.
-        # - BLOCK_H={16,64}: covers small h_q (16) and large h_q (128).
+        # - BLOCK_H={16,64}: covers h_q=64 and h_q=128.
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
@@ -1209,6 +1209,7 @@ def _prune_splitk_configs(configs, named_args, **kwargs):
         triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "topk_per_split"],
+    prune_configs_by={"early_config_prune": _prune_splitk_configs},
 )
 @triton.jit
 def _fused_gather_attn_dsv4_dual_scope_splitk_kernel(
@@ -1920,10 +1921,10 @@ SPLITK_DEFAULT = 4
 
 @triton.autotune(
     configs=[
-        # Reduced from 20 to 6 configs. Split-K fused kernel for large topk (≥8192).
+        # Split-K fused kernel for large topk (≥8192).
         # - BLOCK_N={16,32}: small blocks for scattered FP8 KV access pattern.
         # - num_warps=4: balanced for fused dequant+attention compute.
-        # - BLOCK_H={16,64}: covers small h_q (16) and large h_q (128).
+        # - BLOCK_H={16,64}: covers h_q=64 and h_q=128.
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 16}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 16, "BLOCK_N": 32}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 16}, num_warps=4, num_stages=1),
@@ -2379,7 +2380,7 @@ def _combine_splitk_kernel(
 
 @triton.autotune(
     configs=[
-        # Reduced from 5 to 3 configs. Simple reduce kernel (weighted sum of 8 splits).
+        # Simple reduce kernel (weighted sum of 8 splits).
         # - BLOCK_D=512: covers d_v=512 in one pass (no D-dimension loop).
         # - num_warps=8: memory-bound reduce benefits from more warps.
         # - split_k=8 is only used at very small batch sizes (≤4 tokens),

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_splitk.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_splitk.py
@@ -24,7 +24,7 @@ from .triton_mla_kernels_decode_common import _bucket_total_tokens
 # ============================================================================
 @triton.autotune(
     configs=[
-        # Reduced from 28 to 4 configs. Split-K attention on already-gathered BF16 KV.
+        # Split-K attention on already-gathered BF16 KV.
         # - BLOCK_N=256: amortizes memory access over KV tokens (memory-bound kernel).
         # - BLOCK_D=128: matches KV tile structure.
         # - num_warps=8, num_stages=2: memory-bound kernel benefits from more warps
@@ -243,7 +243,7 @@ def _splitk_attention_kernel(
 # ============================================================================
 @triton.autotune(
     configs=[
-        # Reduced from 7 to 3 configs. Simple reduce kernel merging split-K results.
+        # Simple reduce kernel merging split-K results.
         # - BLOCK_D=128: 4 iterations to cover d_v=512.
         # - num_warps=4: sufficient for this simple reduce operation.
         # - BLOCK_H varies for different batch sizes:

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_splitk.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_splitk.py
@@ -24,106 +24,23 @@ from .triton_mla_kernels_decode_common import _bucket_total_tokens
 # ============================================================================
 @triton.autotune(
     configs=[
-        # num_stages=2 configs for software pipelining
+        # Reduced from 28 to 4 configs. Split-K attention on already-gathered BF16 KV.
+        # - BLOCK_N=256: amortizes memory access over KV tokens (memory-bound kernel).
+        # - BLOCK_D=128: matches KV tile structure.
+        # - num_warps=8, num_stages=2: memory-bound kernel benefits from more warps
+        #   and software pipelining (overlaps memory loads with compute).
+        # - BLOCK_H varies for different batch sizes:
         triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=2
+            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
         ),
         triton.Config(
             {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
         ),
         triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
             {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
         ),
         triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
-        ),
-        # num_stages=1 baseline configs
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=4, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 32, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 64, "BLOCK_N": 128, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 16, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 8, "BLOCK_N": 512, "BLOCK_D": 128}, num_warps=8, num_stages=1
-        ),
-        triton.Config(
-            {"BLOCK_H": 8, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=1
+            {"BLOCK_H": 128, "BLOCK_N": 256, "BLOCK_D": 128}, num_warps=8, num_stages=2
         ),
     ],
     key=["total_tokens_bucket", "h_q", "topk_per_split", "d_qk"],
@@ -326,13 +243,13 @@ def _splitk_attention_kernel(
 # ============================================================================
 @triton.autotune(
     configs=[
+        # Reduced from 7 to 3 configs. Simple reduce kernel merging split-K results.
+        # - BLOCK_D=128: 4 iterations to cover d_v=512.
+        # - num_warps=4: sufficient for this simple reduce operation.
+        # - BLOCK_H varies for different batch sizes:
+        triton.Config({"BLOCK_H": 16, "BLOCK_D": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 32, "BLOCK_D": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 64, "BLOCK_D": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 16, "BLOCK_D": 128}, num_warps=4, num_stages=1),
-        triton.Config({"BLOCK_H": 32, "BLOCK_D": 128}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 64, "BLOCK_D": 128}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 128, "BLOCK_D": 128}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_H": 8, "BLOCK_D": 128}, num_warps=4, num_stages=1),
     ],
     key=["total_tokens_bucket", "h_q", "split_k"],
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Update amd/deepseek_v4 integration branch

Following PRs have large set of conflict, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Reduce Triton sparse MLA decode autotune configs for faster first-time startup, as well as keeping the performance.

## Modifications

<!-- Detail the changes made in this pull request. -->
Reduce the Triton sparse MLA kernel autotune config from 143 to 44, making the first-time server launching time cost eliminates from ~30-40mins to 4mins (counting from cuda graph capture start to the capture end).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Accuracy test on GMS8K shows that it can keep aligned with before. 

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Bench results for 8k/1k cc=2/4/8/16/32 shows no obvious perf regression on TTT/ITL.
<img width="1047" height="511" alt="image" src="https://github.com/user-attachments/assets/8049382a-de81-4165-897d-f09707612838" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->