### PR TITLE
[MXFP4 KV Cache] MXFP4 KV Cache: support blockfp4-hadamard-quant

### DIFF
--- a/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
+++ b/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
@@ -309,7 +309,8 @@ class BlockFP4KVMethod(FP4KVCacheQuantMethod):
     """Block-wise FP4 single-level scaling (similar to MXFP4 but block_size=16)."""
 
     name = "blockfp4"
-    SCALE_BLOCK_SIZE = 16
+    SCALE_BLOCK_SIZE = 32
+    HADAMARD_ROTATE = False
 
     def needs_dequant_workspace(self) -> bool:
         return True
@@ -377,8 +378,12 @@ class BlockFP4KVMethod(FP4KVCacheQuantMethod):
     ) -> None:
         from sglang.srt.layers.quantization.kvfp4_tensor import BlockFP4KVQuantizeUtil
 
-        cache_k_fp4, cache_k_sf = BlockFP4KVQuantizeUtil.batched_quantize(cache_k)
-        cache_v_fp4, cache_v_sf = BlockFP4KVQuantizeUtil.batched_quantize(cache_v)
+        cache_k_fp4, cache_k_sf = BlockFP4KVQuantizeUtil.batched_quantize(
+            cache_k, self.SCALE_BLOCK_SIZE, self.HADAMARD_ROTATE
+        )
+        cache_v_fp4, cache_v_sf = BlockFP4KVQuantizeUtil.batched_quantize(
+            cache_v, self.SCALE_BLOCK_SIZE, self.HADAMARD_ROTATE
+        )
         k_buffer[loc] = cache_k_fp4
         v_buffer[loc] = cache_v_fp4
         k_scale_buffer[loc] = cache_k_sf
@@ -394,8 +399,12 @@ class BlockFP4KVMethod(FP4KVCacheQuantMethod):
     ) -> tuple[Tensor, Tensor]:
         from sglang.srt.layers.quantization.kvfp4_tensor import BlockFP4KVQuantizeUtil
 
-        k_bf16 = BlockFP4KVQuantizeUtil.batched_dequantize(k_fp4, k_scales)
-        v_bf16 = BlockFP4KVQuantizeUtil.batched_dequantize(v_fp4, v_scales)
+        k_bf16 = BlockFP4KVQuantizeUtil.batched_dequantize(
+            k_fp4, k_scales, self.HADAMARD_ROTATE
+        )
+        v_bf16 = BlockFP4KVQuantizeUtil.batched_dequantize(
+            v_fp4, v_scales, self.HADAMARD_ROTATE
+        )
         return k_bf16.to(torch.float8_e4m3fn), v_bf16.to(torch.float8_e4m3fn)
 
     def compute_cell_size(

--- a/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
+++ b/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
@@ -306,7 +306,7 @@ class NVFP4KVMethod(FP4KVCacheQuantMethod):
 
 
 class BlockFP4KVMethod(FP4KVCacheQuantMethod):
-    """Block-wise FP4 single-level scaling (similar to MXFP4 but block_size=16)."""
+    """Block-wise FP4 single-level scaling."""
 
     name = "blockfp4"
     SCALE_BLOCK_SIZE = 32

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -14,6 +14,7 @@
 
 # Define a enum class for FP4 formats, including MXFP4, NVFP4 and future formats
 from enum import Enum
+from typing import Optional
 
 import torch
 
@@ -61,30 +62,50 @@ E2M1_BOUNDS = torch.tensor(
 class BlockFP4KVQuantizeUtil:
     """Block-wise FP4 (E2M1) quantization for KV cache.
 
-    Similar to MXFP4 but uses block_size=16 (MXFP4 spec defines block_size=32).
-    Each block of 16 elements shares one uint8 exponent-only scale factor.
+    Similar to MXFP4 but uses block_size=16, 32, 64 or 128
+    (MXFP4 spec defines block_size=32).
+    Each block of block_size elements shares one uint8 exponent-only scale factor.
     """
 
     @staticmethod
-    @torch.compile
-    def batched_quantize(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def batched_quantize(
+        tensor: torch.Tensor,
+        block_size: Optional[int] = None,
+        hadamard_rotate: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Quantize tensor to KVFP4 format
         Args:
             tensor: Input tensor of shape [B, M, N]
-
+            block_size: Block size for quantization
+            hadamard_rotate: Whether to apply Hadamard rotation to the tensor
         Returns:
             quant_tensor: Quantized tensor of shape [B, M, N/2]
-            scale_factors: Scale factors of shape [B, M*N/16]
+            scale_factors: Scale factors of shape [B, M*N/block_size]
         """
         b, m, n = tensor.shape
 
-        # Reshape to [B, M*N/16, 16] for block-wise quantization
-        reshaped = tensor.view(b, m * n // 16, 16)
+        if block_size is None:
+            block_size = 32
+
+        # Reshape to [B, M*N/block_size, block_size] for block-wise quantization
+        reshaped = tensor.view(b, m * n // block_size, block_size)
 
         # Compute scale factors per block
-        block_max = reshaped.abs().max(dim=-1, keepdim=True).values
-        scale_exp = torch.ceil(torch.log2(torch.clamp(block_max / E2M1_MAX, min=1e-10)))
+        if hadamard_rotate:
+            from sglang.jit_kernel.hadamard import hadamard_transform
+
+            reshaped = hadamard_transform(reshaped, scale=block_size**-0.5)
+            block_std = reshaped.std(dim=-1, correction=0, keepdim=True)
+            scale_exp = torch.floor(
+                torch.log2(block_std * (2.92247856 / E2M1_MAX) + 1e-8)
+            )
+        else:
+            block_max = reshaped.abs().max(dim=-1, keepdim=True).values
+            scale_exp = torch.ceil(
+                torch.log2(torch.clamp(block_max / E2M1_MAX, min=1e-10))
+            )
+
         scale_factors = (scale_exp + 127).squeeze(-1).to(torch.uint8)
 
         # Apply scaling
@@ -95,7 +116,11 @@ class BlockFP4KVQuantizeUtil:
         abs_vals = scaled.abs()
 
         # Pure tensor version (CUDA Graph safe)
-        magnitude_bits = torch.sum(abs_vals.unsqueeze(-1) >= E2M1_BOUNDS, dim=-1)
+        bounds = E2M1_BOUNDS.to(device=abs_vals.device)
+        magnitude_bits = torch.sum(abs_vals.unsqueeze(-1) >= bounds, dim=-1)
+        is_midpoint = torch.any(abs_vals.unsqueeze(-1) == bounds, dim=-1)
+        tie_round_down = is_midpoint & ((magnitude_bits % 2) == 1)
+        magnitude_bits = magnitude_bits - tie_round_down.to(magnitude_bits.dtype)
 
         # Combine sign and magnitude
         fp4_vals = sign_bits + magnitude_bits.to(torch.uint8)
@@ -111,20 +136,22 @@ class BlockFP4KVQuantizeUtil:
     def batched_dequantize(
         quant_tensor: torch.Tensor,
         scale_factors: torch.Tensor,
+        hadamard_rotate: bool = False,
         dtype: torch.dtype = torch.bfloat16,
     ) -> torch.Tensor:
         """
         Dequantize KVFP4 tensor
         Args:
             quant_tensor: Quantized tensor of shape [B, M, N/2]
-            scale_factors: Scale factors of shape [B, M*N/16]
+            scale_factors: Scale factors of shape [B, M*N/block_size]
+            hadamard_rotate: Whether to apply Hadamard rotation to the tensor
             dtype: Target dtype for output
-
         Returns:
             Dequantized tensor of shape [B, M, N]
         """
         b, m, n_half = quant_tensor.shape
         n = n_half * 2
+        block_size = (m * n) // scale_factors.shape[-1]
 
         # More efficient unpacking using bit operations
         fp4_vals = torch.empty(b, m, n, dtype=torch.uint8, device=quant_tensor.device)
@@ -136,16 +163,20 @@ class BlockFP4KVQuantizeUtil:
         magnitude_idx = fp4_vals & 0x07
 
         # Convert to float values
-        float_vals = E2M1_VALUES[magnitude_idx.long()]
+        float_vals = E2M1_VALUES.to(device=quant_tensor.device)[magnitude_idx.long()]
         float_vals = torch.where(sign_mask, -float_vals, float_vals)
 
         # Reshape for block-wise scaling
-        reshaped = float_vals.view(b, m * n // 16, 16)
+        reshaped = float_vals.view(b, m * n // block_size, block_size)
 
         # Apply scale factors
         scale_exp = scale_factors.float() - 127
         scaled = reshaped * torch.exp2(scale_exp.unsqueeze(-1))
 
+        if hadamard_rotate:
+            from sglang.jit_kernel.hadamard import hadamard_transform
+
+            scaled = hadamard_transform(scaled, scale=block_size**-0.5)
         return scaled.view(b, m, n).to(dtype)
 
 

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -58,6 +58,9 @@ E2M1_BOUNDS = torch.tensor(
     [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5], dtype=torch.float32, device=_device
 )
 
+# Factor for Gaussian distribution to mxfp4 scale factor conversion, refer to: https://github.com/IST-DASLab/qutlass
+GAUSSIAN_FACTOR = 2.92247856
+
 
 class BlockFP4KVQuantizeUtil:
     """Block-wise FP4 (E2M1) quantization for KV cache.
@@ -68,6 +71,7 @@ class BlockFP4KVQuantizeUtil:
     """
 
     @staticmethod
+    @torch.compile
     def batched_quantize(
         tensor: torch.Tensor,
         block_size: Optional[int] = None,
@@ -98,7 +102,7 @@ class BlockFP4KVQuantizeUtil:
             reshaped = hadamard_transform(reshaped, scale=block_size**-0.5)
             block_std = reshaped.std(dim=-1, correction=0, keepdim=True)
             scale_exp = torch.floor(
-                torch.log2(block_std * (2.92247856 / E2M1_MAX) + 1e-8)
+                torch.log2(block_std * (GAUSSIAN_FACTOR / E2M1_MAX) + 1e-8)
             )
         else:
             block_max = reshaped.abs().max(dim=-1, keepdim=True).values

--- a/test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py
+++ b/test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py
@@ -20,6 +20,11 @@ def skip_if_no_blackwell_nvfp4(func):
     )(func)
 
 
+def skip_if_no_cuda(func):
+    """Skip test if CUDA is not available."""
+    return unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")(func)
+
+
 class TestKVCacheQuantRegistry(CustomTestCase):
     """Test the registry and factory function."""
 
@@ -196,7 +201,7 @@ class TestBlockFP4KVMethod(CustomTestCase):
         self.assertEqual(len(bufs["k_buffer"]), layers)
         self.assertEqual(bufs["k_buffer"][0].shape, (size, heads, dim // 2))
         # MXFP4 flattens head dims for scales
-        self.assertEqual(bufs["k_scale_buffer"][0].shape, (size, (heads * dim) // 16))
+        self.assertEqual(bufs["k_scale_buffer"][0].shape, (size, (heads * dim) // 32))
 
     def test_quantize_dequantize_roundtrip_cpu(self):
         """Test MXFP4 quantize→dequantize roundtrip on CPU."""
@@ -243,6 +248,26 @@ class TestBlockFP4KVQuantizeUtil(CustomTestCase):
         x = torch.randn(4, 8, 128, dtype=torch.bfloat16)
         packed, scales = BlockFP4KVQuantizeUtil.batched_quantize(x)
         reconstructed = BlockFP4KVQuantizeUtil.batched_dequantize(packed, scales)
+
+        self.assertEqual(reconstructed.shape, x.shape)
+        rel_error = (
+            x.float() - reconstructed.float()
+        ).abs().mean() / x.float().abs().mean()
+        self.assertLess(rel_error, 0.5)
+
+    @skip_if_no_cuda
+    def test_hadamard_roundtrip_cuda(self):
+        from sglang.srt.layers.quantization.kvfp4_tensor import BlockFP4KVQuantizeUtil
+
+        torch.manual_seed(42)
+        x = torch.randn(4, 8, 128, dtype=torch.bfloat16, device="cuda")
+
+        packed, scales = BlockFP4KVQuantizeUtil.batched_quantize(
+            x, block_size=32, hadamard_rotate=True
+        )
+        reconstructed = BlockFP4KVQuantizeUtil.batched_dequantize(
+            packed, scales, hadamard_rotate=True
+        )
 
         self.assertEqual(reconstructed.shape, x.shape)
         rel_error = (


### PR DESCRIPTION
 ## Motivation

  Current MXFP4 KV cache support is still limited compared with NVFP4. However, MXFP4 can be useful across a broader range of hardware, so this PR adds an initial accuracy-improvement path for BlockFP4/
  MXFP4-style KV cache quantization.

  The implementation is inspired by the Quest/MXFP4 quantization flow in https://github.com/IST-DASLab/qutlass. This PR focuses on the first functional version in Python/Torch. Follow-up PRs can add Triton acceleration kernels and E2E accuracy.

  ## Modifications

 - Add a Hadamard-rotated BlockFP4 KV cache quantization path with block size 32.
 - Align scale handling and FP4 round-to-nearest-even behavior with the MXFP4 reference flow.
 - Update BlockFP4 unit tests, including CUDA roundtrip coverage.
 
  ## Test Plan
- [ ] `pytest test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py -v`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->