### PR TITLE
fix(disagg): unstuck decode aborts under prealloc pressure

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -609,7 +609,12 @@ class DecodePreallocQueue:
         if not self.queue:
             return
 
-        if all(decode_req.waiting_for_input for decode_req in self.queue):
+        # Skip poll only when all past handshake and no receiver flipped to Failed
+        # (e.g. by AbortReq); otherwise aborted reqs stay stuck until WAITING_TIMEOUT.
+        if all(decode_req.waiting_for_input for decode_req in self.queue) and not any(
+            getattr(decode_req.kv_receiver, "conclude_state", None) == KVPoll.Failed
+            for decode_req in self.queue
+        ):
             return
 
         polls = poll_and_all_reduce(

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -609,8 +609,7 @@ class DecodePreallocQueue:
         if not self.queue:
             return
 
-        # Skip poll only when all past handshake and no receiver flipped to Failed
-        # (e.g. by AbortReq); otherwise aborted reqs stay stuck until WAITING_TIMEOUT.
+        # Still poll if any receiver was aborted, otherwise it stays stuck.
         if all(decode_req.waiting_for_input for decode_req in self.queue) and not any(
             getattr(decode_req.kv_receiver, "conclude_state", None) == KVPoll.Failed
             for decode_req in self.queue

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3660,8 +3660,6 @@ class Scheduler(
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
-                    # Mark FINISH_ABORT so pop_preallocated drops it instead of
-                    # waiting for WAITING_TIMEOUT after transfer eventually starts.
                     if not isinstance(decode_req.req.finished_reason, FINISH_ABORT):
                         decode_req.req.finished_reason = FINISH_ABORT()
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3660,12 +3660,18 @@ class Scheduler(
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    # Mark FINISH_ABORT so pop_preallocated drops it instead of
+                    # waiting for WAITING_TIMEOUT after transfer eventually starts.
+                    if not isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                        decode_req.req.finished_reason = FINISH_ABORT()
 
             # Abort requests waiting for kvcache to release tree cache
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
+                    if not isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                        decode_req.req.finished_reason = FINISH_ABORT()
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1491,15 +1491,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         pass
 
     def abort_request(self, rid: str = "", abort_all: bool = False):
-        # Guard: an empty rid would be treated as a startswith-prefix that matches
-        # every request in the scheduler. Refuse it unless abort_all is set.
+        # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
             return
-        # With a single tokenizer worker, rid_to_state is authoritative, so we can
-        # short-circuit. With multiple workers each worker only sees the requests
-        # it received, so an /abort_request load-balanced to a non-owner worker
-        # must still be forwarded to the scheduler.
+        # Multi-worker: rid_to_state is per-worker, always forward to scheduler.
         if (
             not abort_all
             and self.server_args.tokenizer_worker_num == 1

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1491,7 +1491,20 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         pass
 
     def abort_request(self, rid: str = "", abort_all: bool = False):
-        if not abort_all and rid not in self.rid_to_state:
+        # Guard: an empty rid would be treated as a startswith-prefix that matches
+        # every request in the scheduler. Refuse it unless abort_all is set.
+        if not abort_all and not rid:
+            logger.warning("Ignore abort_request with empty rid and abort_all=False")
+            return
+        # With a single tokenizer worker, rid_to_state is authoritative, so we can
+        # short-circuit. With multiple workers each worker only sees the requests
+        # it received, so an /abort_request load-balanced to a non-owner worker
+        # must still be forwarded to the scheduler.
+        if (
+            not abort_all
+            and self.server_args.tokenizer_worker_num == 1
+            and rid not in self.rid_to_state
+        ):
             return
         req = AbortReq(rid=rid, abort_all=abort_all)
         self.send_to_scheduler.send_pyobj(req)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1495,7 +1495,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
             return
-        # Multi-worker: rid_to_state is per-worker, always forward to scheduler.
         if (
             not abort_all
             and self.server_args.tokenizer_worker_num == 1


### PR DESCRIPTION
Fix three abort-handling bugs that caused aborted decode requests to linger until WAITING_TIMEOUT instead of being released immediately.

1. decode.py _update_handshake_waiters: skip the early-return when any receiver has been flipped to KVPoll.Failed (e.g. by an abort), so aborted reqs are not held until transfer begins.

2. scheduler.py abort_request (DECODE): in addition to calling kv_receiver.abort(), mark req.finished_reason = FINISH_ABORT for reqs in prealloc/transfer queues, so pop_preallocated / pop_transferred actually drop them.

3. tokenizer_manager.py abort_request: always forward to the scheduler when tokenizer_worker_num > 1 (the local rid_to_state is per-worker and load balancing may route abort to a non-owner). Add a guard against empty rid being treated as a startswith-prefix match for every request.
CC @ShangmingCai 













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #26017657590](https://github.com/sgl-project/sglang/actions/runs/26017657590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->