### PR TITLE
[LoRA] Fix slot accounting for chunked prefill requests

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2721,7 +2721,9 @@ class Scheduler(
             self._chunked_req_scheduled_last_iter = False
 
         if self.enable_lora:
-            running_loras = {req.lora_id for req in self.running_batch.reqs}
+            running_loras = {req.lora_id for req in self.running_batch.reqs} | {
+                req.lora_id for req in adder.can_run_list
+            }
 
             if self.lora_drainer:
                 self.lora_drainer.update_draining_state(


### PR DESCRIPTION
## Motivation

I hit a LoRA scheduler assertion when stress testing SGLang with many concurrent LoRA requests.

Reproduction setup:

- Model: `Qwen/Qwen3-4B-Instruct-2507`
- `--enable-lora`
- `--max-loras-per-batch 8`
- `--max-loaded-loras 16`
- `--tp-size 1`
- 20 concurrent requests
- Requests use different LoRA adapters
- Input length around 1024 tokens
- Output length around 128 tokens

The failure happens when an existing `chunked_req` is added to `adder.can_run_list` before the scheduler scans the waiting queue. However, LoRA admission accounting only considered `self.running_batch.reqs`.

As a result, the scheduler could admit one additional LoRA request from the waiting queue while the chunked request was already staged for the current prefill batch. This produced a forward batch with 9 unique LoRAs while `max_loras_per_batch=8`, later triggering the assertion in `LoRAManager.fetch_new_loras`.

## Modifications

Include LoRA ids from `adder.can_run_list` when initializing `running_loras` before scheduling additional waiting requests.

This makes LoRA admission accounting include both:

- LoRAs already in the running batch.
- LoRAs already staged for the current prefill batch, including chunked prefill requests.

## Accuracy Tests

This change only affects scheduler admission accounting for LoRA requests. It does not change model weights, kernels, or forward computation.

Manual reproduction before the fix:

- Reproduced the issue with the setup above.
- Debug logs showed that a chunked request was already staged in `adder.can_run_list`.
- The scheduler then admitted another LoRA request because `running_loras` only counted `self.running_batch.reqs`.
- The final forward batch reached 9 unique LoRA ids while `max_loras_per_batch=8`.
- This triggered the assertion in `LoRAManager.fetch_new_loras`.

Manual validation after the fix:

- Re-ran the same LoRA stress workload.
- No assertion failure was observed.
- The maximum observed unique LoRA count stayed at 8.
- Verified that LoRA slots can still be fully utilized:
  - `Prefill batch, #new-seq: 8` observed.
  - `Decode batch, #running-req: 8` observed.
- Ran pre-commit on the modified file:
  - `SKIP=no-commit-to-branch pre-commit run --files python/sglang/srt/managers/scheduler.py --show-diff-on-failure`

## Speed Tests and Profiling

No speed regression is expected. The change only adds a small set union over requests already selected for the current prefill batch.

Manual benchmark validation after the fix:

- The same LoRA stress workload completed successfully.
- LoRA batch slots were still able to reach the configured limit of `8/8`.
- Observed full-slot scheduling in logs:
  - `Prefill batch, #new-seq: 8`
  - `Decode batch, #running-req: 8`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Unit tests and documentation updates are not included because this is a small scheduler accounting fix. The behavior was validated with a manual LoRA chunked-prefill reproduction.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->