### PR TITLE
Fix PCG silently bypassed for EAGLE speculative decoding

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -230,6 +230,14 @@ class PiecewiseCudaGraphRunner:
         if model_runner.server_args.enable_return_hidden_states:
             self.capture_hidden_mode = CaptureHiddenMode.FULL
 
+        spec_algo = model_runner.spec_algorithm
+        if (
+            spec_algo.is_eagle()
+            or spec_algo.is_standalone()
+            or spec_algo.is_dflash()
+        ):
+            self.capture_hidden_mode = CaptureHiddenMode.FULL
+
         self.max_num_tokens = (
             max(self.capture_num_tokens) if self.capture_num_tokens else 8192
         )
@@ -425,7 +433,7 @@ class PiecewiseCudaGraphRunner:
                 mrope_positions=mrope_positions,
                 spec_algorithm=None,
                 spec_info=None,
-                capture_hidden_mode=CaptureHiddenMode.NULL,
+                capture_hidden_mode=self.capture_hidden_mode,
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
@@ -598,7 +606,7 @@ class PiecewiseCudaGraphRunner:
                 mrope_positions=mrope_positions,
                 spec_algorithm=None,
                 spec_info=None,
-                capture_hidden_mode=CaptureHiddenMode.NULL,
+                capture_hidden_mode=self.capture_hidden_mode,
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1128,6 +1128,12 @@ class EAGLEWorker(TpModelWorker):
             else CaptureHiddenMode.LAST
         )
         batch.spec_info.capture_hidden_mode = capture_mode
+
+        batch.forward_mode = (
+            ForwardMode.DRAFT_EXTEND
+            if not batch.forward_mode.is_idle()
+            else ForwardMode.IDLE
+        )
         batch.seq_lens_cpu_cache = seq_lens_cpu
         forward_batch = ForwardBatch.init_new(batch, self.draft_model_runner)
         forward_batch.return_logprob = False


### PR DESCRIPTION
 ## Motivation

  Follow-up to #22128 — confirms and fixes the issue [@Chen-0210 flagged in that PR](https://github.com/sgl-project/sglang/pull/22128#issuecomment-XXXXX): when piecewise CUDA graph (PCG) is enabled together with
  EAGLE / EAGLE3 / NEXTN (FROZEN_KV_MTP) / STANDALONE / DFLASH speculative decoding, **every target prefill silently falls back to eager** because the `can_run()` guard added in #22128 rejects it.

  Root cause:

  1. `PiecewiseCudaGraphRunner.__init__` initializes `self.capture_hidden_mode = CaptureHiddenMode.NULL` and only upgrades it to `FULL` when `--enable-return-hidden-states` is set. The two dummy `ForwardBatch`
  constructions for `warmup_compile()` and `capture_one_batch_size()` then hard-code `capture_hidden_mode=CaptureHiddenMode.NULL`, so the captured FX graph / cudagraph does not contain the hidden-states return
  path.
  2. At runtime, every EAGLE-family target prefill sets `forward_batch.capture_hidden_mode = FULL` (the draft worker seeds from the target's last-layer hidden states — see
  `eagle_worker.forward_batch_speculative_generation`).
  3. The new guard in #22128 — `if forward_batch.capture_hidden_mode != self.capture_hidden_mode: return False` — therefore rejects 100% of target prefills, and they fall through to the eager path.

  The existing `TestPCGWithMTP` does not surface this because it passes the deprecated `--enable-piecewise-cuda-graph` (a no-op since #22128's deprecation, see `server_args.py`), and
  `Qwen3_5MoeForConditionalGeneration` is on the multimodal auto-disable list, so PCG is disabled entirely. Replacing the flag with `--enforce-piecewise-cuda-graph` (matching the EAGLE3 / STANDALONE / NGRAM tests
  in the same file) reproduces the miss immediately:

  PCG_DBG miss_hidden: batch=CaptureHiddenMode.FULL runner=CaptureHiddenMode.NULL
  hit lines: 0    miss lines: 21

  Once fix (1) lets PCG actually replay the target prefill, a second pre-existing bug surfaces: `eagle_worker.forward_draft_extend` does not set `batch.forward_mode = DRAFT_EXTEND` (its sibling
  `forward_draft_extend_after_decode` already does). The draft batch therefore inherits `forward_mode=EXTEND` from the target prefill, and multimodal-aware draft models (`Qwen3_5ForCausalLMMTP`) take the
  target-prefill multimodal embed branch and assert on `mm_input_embeds`. Masked while PCG never actually replayed target prefill, exposed the moment it does.

  ## Modifications

  `python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py`

  - Force `self.capture_hidden_mode = CaptureHiddenMode.FULL` when the spec algorithm is EAGLE / EAGLE3 / NEXTN / STANDALONE / DFLASH. NGRAM has no draft model so it keeps `NULL`.
  - Use `self.capture_hidden_mode` (instead of hard-coded `CaptureHiddenMode.NULL`) on the two dummy `ForwardBatch` constructions in `warmup_compile()` and `capture_one_batch_size()`, so the captured FX/cudagraph
  includes the hidden-states return path.

  `python/sglang/srt/speculative/eagle_worker.py` — `forward_draft_extend()`

  - Set `batch.forward_mode = ForwardMode.DRAFT_EXTEND` before `ForwardBatch.init_new(...)`, mirroring `forward_draft_extend_after_decode()`.

  26 lines added across two files; no API changes.

  ## Accuracy Tests

  GSM8K (200 examples, qwen3 thinking mode) on Qwen3.5-35B-A3B + NEXTN + `--enforce-piecewise-cuda-graph` + TP=2 on 2× H100:

  |                                 | Before fix (PCG bypassed) | After fix (PCG hits) |
  |---------------------------------|---------------------------|----------------------|
  | `avg_spec_accept_length`        | 3.47                      | 3.49                 |

  `avg_spec_accept_length` is unchanged within noise — confirming the fix does not perturb spec-decoding correctness; it just lets PCG actually run.

  ## Speed Tests and Profiling

  `bench_serving --dataset-name random --random-input 4096 --random-output 32 --num-prompts 32 --max-concurrency 1`, same model / TP / hardware as above:

  | Metric                          | Before     | After      | Δ        |
  |---------------------------------|-----------:|-----------:|---------:|
  | Mean TTFT (ms)                  | 237.0      | 66.4       | **−72%** |
  | Median TTFT (ms)                | 243.2      | 65.0       | −73%     |
  | P99 TTFT (ms)                   | 269.3      | 99.2       | −63%     |
  | Mean E2E latency (ms)           | 291.0      | 117.7      | −60%     |
  | Request throughput (req/s)      | 3.43       | 8.45       | **+146%**|
  | Output throughput (tok/s)       | 57.6       | 142.1      | +146%    |
  | Mean ITL (ms)                   | 3.42       | 3.24       | −5%      |

  Decode-side ITL is unchanged (PCG only covers prefill; decode already used the regular CUDA graph).

  torch.profiler trace of a single 4096-token prefill on the same setup:

  | Trace metric                            | Before | After | Δ        |
  |-----------------------------------------|-------:|------:|---------:|
  | Prefill GPU window (ms)                 | 174    | 59    | **−66%** |
  | `cudaLaunchKernel` events (whole trace) | 3186   | 1486  | −53%     |
  | `cudaGraphLaunch` events (whole trace)  | 23     | 64    | +41 (PCG replays) |
  | GPU kernel total time (ms)              | 203.8  | 124.3 | −39%     |

  Kernel-timeline view (top = before, bottom = after; yellow = `cudaGraphLaunch`, red = `cudaLaunchKernel`, blue/green/purple = GPU kernels):

  <!-- attach prefill_zoom.png from the run -->

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the
  speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->