### PR TITLE
Use triton_attn as default vision attention on B300 (SM103)

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -951,7 +951,7 @@ class VisionAttention(nn.Module):
             major, minor = get_device_capability()
             if major == 9:
                 backend = "fa3"
-            elif major == 10:
+            elif major == 10 and minor != 3:
                 backend = "fa4"
             else:
                 backend = "triton_attn"


### PR DESCRIPTION
## Summary
- FA4 is not yet validated on B300 (SM103). Default the vision attention backend to `triton_attn` on SM103 while keeping `fa4` on B200/GB200 (SM100).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26015091624](https://github.com/sgl-project/sglang/actions/runs/26015091624)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->