### PR TITLE
[sgl-kernel] Fix MUSA wheel METADATA version to match +musa<suffix> filename

### DIFF
--- a/scripts/ci/musa/rename_wheels_musa.sh
+++ b/scripts/ci/musa/rename_wheels_musa.sh
@@ -1,46 +1,102 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-# Rename MUSA wheels to include a +musa<suffix> build tag.
+# Align MUSA wheel filenames (+musa43/...) with internal METADATA Version and
+# WHEEL tags after build. Two drifts need fixing in lockstep:
+#   - METADATA `Version:` must carry the `+musa<suffix>` local version, or
+#     recent pip versions reject the wheel with "inconsistent version".
+#   - WHEEL `Tag:` must be `manylinux2014_*` when the filename says so;
+#     leaving it as `linux_*` can trip installers that re-derive the platform.
+# Unpack → patch WHEEL/METADATA → wheel pack (RECORD regenerated; no hand-editing).
+#
 # Usage:
 #   rename_wheels_musa.sh <musa_suffix> [wheel_dir]
 # Example:
 #   rename_wheels_musa.sh 43 sgl-kernel/dist
+set -euxo pipefail
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Usage: $0 <musa_suffix> [wheel_dir]" >&2
   exit 1
 fi
 
-MUSA_SUFFIX="$1"
+MUSA_SUFFIX="+musa$1"
 WHEEL_DIR="${2:-dist}"
 
-wheel_files=("$WHEEL_DIR"/*.whl)
+patch_wheel_platform_tags() {
+    local wheel_file="$1"
+    # Line-end anchors: "linux_x86_64" is a substring of "manylinux2014_x86_64", so
+    # unanchored global replace corrupts tags on a second run.
+    sed -i \
+        -e 's/-linux_x86_64$/-manylinux2014_x86_64/' \
+        -e 's/-linux_aarch64$/-manylinux2014_aarch64/' \
+        "$wheel_file"
+}
 
+wheel_files=("$WHEEL_DIR"/*.whl)
 if [[ ! -e "${wheel_files[0]}" ]]; then
   echo "No wheel files found in ${WHEEL_DIR}/, nothing to rename."
   exit 0
 fi
 
 for wheel in "${wheel_files[@]}"; do
-  # Normalize platform tag to manylinux2014
-  intermediate_wheel="${wheel/linux/manylinux2014}"
+    [[ -f "$wheel" ]] || continue
 
-  # Extract Python ABI version (e.g. cp310)
-  if [[ $intermediate_wheel =~ -cp([0-9]+)- ]]; then
-    cp_version="${BASH_REMATCH[1]}"
-  else
-    echo "Could not extract Python version from wheel name: $intermediate_wheel" >&2
-    continue
-  fi
+    intermediate_wheel="$wheel"
+    case "$wheel" in
+        *-linux_x86_64.whl)
+            intermediate_wheel="${wheel%-linux_x86_64.whl}-manylinux2014_x86_64.whl"
+            ;;
+        *-linux_aarch64.whl)
+            intermediate_wheel="${wheel%-linux_aarch64.whl}-manylinux2014_aarch64.whl"
+            ;;
+    esac
+    if [[ "$wheel" != "$intermediate_wheel" ]]; then
+        mv -- "$wheel" "$intermediate_wheel"
+        wheel="$intermediate_wheel"
+    fi
 
-  # Insert +musa<suffix> before the Python ABI tag
-  new_wheel="${intermediate_wheel/-cp${cp_version}/+musa${MUSA_SUFFIX}-cp${cp_version}}"
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf -- "$TMPDIR"' ERR
 
-  if [[ "$wheel" != "$new_wheel" ]]; then
-    echo "Renaming $wheel -> $new_wheel"
-    mv -- "$wheel" "$new_wheel"
-  fi
+    "${PYTHON:-python3}" -m wheel unpack "$wheel" --dest "$TMPDIR"
+    # `find | head -1` succeeds with empty stdout when there are no matches —
+    # `set -e` won't catch that. Assert each path is real so a malformed wheel
+    # surfaces with a useful message instead of a downstream `sed: /WHEEL` error.
+    UNPACKED=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -1)
+    [[ -d "$UNPACKED" ]] || { echo "ERROR: wheel unpack produced no top-level dir for $wheel" >&2; exit 1; }
+    DIST_INFO=$(find "$UNPACKED" -maxdepth 1 -type d -name "*.dist-info" | head -1)
+    [[ -d "$DIST_INFO" ]] || { echo "ERROR: no *.dist-info under $UNPACKED (malformed wheel?): $wheel" >&2; exit 1; }
+    WHEEL_META="${DIST_INFO}/WHEEL"
+    METADATA_FILE="${DIST_INFO}/METADATA"
+    [[ -f "$WHEEL_META" && -f "$METADATA_FILE" ]] || { echo "ERROR: missing WHEEL or METADATA in $DIST_INFO" >&2; exit 1; }
+
+    patch_wheel_platform_tags "$WHEEL_META"
+
+    ORIG_VERSION=$(grep '^Version:' "$METADATA_FILE" | head -1 | sed 's/^Version:[[:space:]]*//')
+    # Empty ORIG_VERSION would fall through the `+musa` check below and silently
+    # produce `Version: +musa43` — a broken release. Fail loud instead.
+    [[ -n "$ORIG_VERSION" ]] || { echo "ERROR: no 'Version:' line in $METADATA_FILE" >&2; exit 1; }
+    if [[ "$ORIG_VERSION" == *"$MUSA_SUFFIX"* ]]; then
+        echo "Skipping $wheel: version in METADATA is already suffixed."
+        rm -rf "$TMPDIR"
+        trap - ERR
+        continue
+    fi
+    NEW_VERSION="${ORIG_VERSION}${MUSA_SUFFIX}"
+    sed -i "s/^Version:.*/Version: ${NEW_VERSION}/" "$METADATA_FILE"
+    # `sed -i` exits 0 even when the pattern matched zero lines. Verify the
+    # rewrite actually landed before we publish.
+    grep -qx "Version: ${NEW_VERSION}" "$METADATA_FILE" || { echo "ERROR: METADATA Version rewrite did not land in $METADATA_FILE" >&2; exit 1; }
+
+    OLD_BASE=$(basename "$DIST_INFO")
+    NEW_BASE="${OLD_BASE/${ORIG_VERSION}/${NEW_VERSION}}"
+    # `${var/pat/repl}` silently leaves var unchanged if pat is empty or absent.
+    [[ "$NEW_BASE" != "$OLD_BASE" ]] || { echo "ERROR: dist-info dir '$OLD_BASE' did not contain ORIG_VERSION='$ORIG_VERSION'" >&2; exit 1; }
+    mv "$DIST_INFO" "${UNPACKED}/${NEW_BASE}"
+
+    rm -f "$wheel"
+    "${PYTHON:-python3}" -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
+    rm -rf "$TMPDIR"
+    trap - ERR
 done
 
 echo "MUSA wheel renaming completed."


### PR DESCRIPTION
## Summary

The MUSA wheel rename script only renames the `.whl` file (inserting `+musa43` into the filename) but leaves the dist-info `METADATA` `Version:` field untouched. pip 22.2+ rejects such wheels with:

```
inconsistent version: expected '0.4.2.post1+musa43', but metadata has '0.4.2.post1'
```

This means `pip install sglang-kernel --index-url https://docs.sglang.io/whl/musa43` currently fails for every published MUSA wheel (v0.4.1.post1, v0.4.2, v0.4.2.post1).

The CUDA companion `sgl-kernel/rename_wheels.sh` already handles this correctly (unpack → patch METADATA + WHEEL → `wheel pack` to regenerate RECORD). This PR ports that flow to `scripts/ci/musa/rename_wheels_musa.sh`.

## Changes

- `scripts/ci/musa/rename_wheels_musa.sh`:
  - Unpack each wheel via `python -m wheel unpack`.
  - Patch `WHEEL` `Tag:` line so `linux_*` is rewritten to `manylinux2014_*` in lockstep with the filename.
  - Patch `METADATA` `Version:` line to append `+musa<suffix>`.
  - Rename the `.dist-info` directory.
  - Repack via `python -m wheel pack` (regenerates `RECORD` checksums).
  - Idempotent: a rerun on an already-suffixed wheel skips it.
  - Defensive assertions on each step (non-empty `Version:`, substitution actually landed, dist-info dir actually renamed) so a malformed wheel surfaces a clear error instead of a misleading `sed: /WHEEL` failure downstream.

## Test Plan

Local sanity-check (cannot run the full MUSA CI from this environment):

- Built a synthetic `sglang-kernel-0.4.2.post2-cp310-none-linux_x86_64.whl` and ran the script with `43` as the suffix arg.
- Verified the resulting `dist/` wheel:
  - Filename: `sglang_kernel-0.4.2.post2+musa43-cp310-none-manylinux2014_x86_64.whl`
  - METADATA `Version: 0.4.2.post2+musa43`
  - WHEEL `Tag: cp310-none-manylinux2014_x86_64`
  - RECORD regenerated, hashes consistent.
- `pip install --platform manylinux2014_x86_64 --python-version 3.10 --only-binary=:all: ...` accepts the wheel — no "inconsistent version" complaint.
- Rerunning the script on the already-patched wheel correctly skips it (idempotency).

For the next release, this script needs to run as part of `build-musa43` in `.github/workflows/release-whl-kernel.yml:444-450` (it already does — no workflow change needed).

## Follow-up

The already-published wheels in `sgl-project/whl` releases (v0.4.1.post1, v0.4.2, v0.4.2.post1) still have stale METADATA. They will need either re-uploaded assets or a new patch release before `pip install sglang-kernel --index-url ...` works for existing MUSA tags.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->