### PR TITLE
[Deps] Use cu13 extra for nvidia cutlass dsl

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "ninja",
   "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "numpy",
-  "nvidia-cutlass-dsl[cu13]==4.5.0",
+  "nvidia-cutlass-dsl[cu13]==4.5.1",
   "nvidia-ml-py",
   "openai-harmony==0.0.4",
   "openai==2.6.1",


### PR DESCRIPTION
## Summary

Add `[cu13]` extra to `nvidia-cutlass-dsl` dependency since we already default to CUDA 13 and optionally upgrade to 4.5.1

Should fix #25564

## Test Plan

CI









































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26077315178](https://github.com/sgl-project/sglang/actions/runs/26077315178)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->