### PR TITLE
[Quantization][Bugfix] Preserve 3-D output shape in Quark W4A4 MXFP4 apply_weights

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -305,8 +305,11 @@ class QuarkW4A4MXFP4(QuarkLinearScheme):
 
         if x.dim() == 3:
             three_d = True
-            x = x.view(-1, x.shape[-1])
+            # Capture the original (B, S) prefix BEFORE flattening; otherwise
+            # `x.shape[:-1]` is (B*S,) and the final `y.view(*output_shape)`
+            # silently returns a 2-D tensor to a 3-D caller.
             output_shape = [*x.shape[:-1], layer.weight.shape[0]]
+            x = x.view(-1, x.shape[-1])
 
         # use_fused_quant_gemm = true, x_q is a bf16/fp16 num
         # x_s is not None = true, x_q is uint8 num

--- a/test/registered/unit/layers/quantization/test_quark_w4a4_mxfp4.py
+++ b/test/registered/unit/layers/quantization/test_quark_w4a4_mxfp4.py
@@ -1,0 +1,125 @@
+"""Unit tests for QuarkW4A4MXFP4.apply_weights shape contract — CPU-only, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4 import (
+    QuarkW4A4MXFP4,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_layer(out_features: int, packed_in_half: int) -> SimpleNamespace:
+    """Stub layer that exposes only the attributes apply_weights reads:
+    layer.weight       (shape[0] = out_features)
+    layer.weight_scale (passthrough; only identity-compared)
+    """
+    return SimpleNamespace(
+        weight=torch.zeros(out_features, packed_in_half, dtype=torch.uint8),
+        weight_scale=torch.zeros(out_features, packed_in_half // 16, dtype=torch.uint8),
+    )
+
+
+def _patch_aiter_kernels(out_features: int):
+    """Patch the two aiter symbols referenced by `apply_weights` so the
+    function runs on CPU without an actual GEMM.
+
+    - `dynamic_mxfp4_quant(x)` returns a uint8 packed pair `(x_q, x_s)` whose
+      first dim matches `x.shape[0]`. apply_weights only reads `x_q.shape[0]`
+      and `x_q.device` from the result, so the exact contents don't matter.
+    - `gemm_afp4wfp4(x_q, w, x_s, w_s, out_dtype, y)` is a no-op writer — the
+      caller already allocated `y` at the correct shape, which is exactly what
+      this test validates.
+
+    `create=True` lets the patch succeed even when the module did not import
+    these names (e.g. on a non-HIP CI host), so the same test exercises both
+    environments.
+    """
+    target = "sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4"
+
+    def _fake_quant(x):
+        n = x.shape[0]
+        h_packed = max(1, x.shape[-1] // 2)
+        x_q = torch.zeros(n, h_packed, dtype=torch.uint8, device=x.device)
+        x_s = torch.zeros(n, max(1, h_packed // 16), dtype=torch.uint8, device=x.device)
+        return x_q, x_s
+
+    return (
+        patch(f"{target}.dynamic_mxfp4_quant", side_effect=_fake_quant, create=True),
+        patch(f"{target}.gemm_afp4wfp4", return_value=None, create=True),
+    )
+
+
+class TestQuarkW4A4MXFP4ApplyWeightsShape(CustomTestCase):
+    """Regression tests for the 3-D output_shape bug.
+
+    Bug: output_shape = [*x.shape[:-1], layer.weight.shape[0]] was computed
+    AFTER `x = x.view(-1, x.shape[-1])`, so x.shape[:-1] was already
+    [B*S] instead of [B, S]. The function then returned a 2-D tensor where
+    callers expected 3-D, silently corrupting the shape contract.
+    """
+
+    def setUp(self):
+        # The two specs are stored but never read on the path under test.
+        self.scheme = QuarkW4A4MXFP4(weight_quant_spec={}, input_quant_spec={})
+        # `out_dtype` is captured at __init__ from torch.get_default_dtype();
+        # pin it so the empty(y) allocation is deterministic.
+        self.scheme.out_dtype = torch.bfloat16
+
+    # ---- Bug-catchers: must FAIL on the unfixed code ------------------------
+
+    def test_3d_input_returns_3d_output(self):
+        # Bug facet: 3-D activation in → 3-D activation out, with the original
+        # batch/seq dims preserved (not collapsed to B*S).
+        B, S, H, OUT = 2, 4, 64, 128
+        x = torch.randn(B, S, H, dtype=torch.bfloat16)
+        layer = _make_layer(out_features=OUT, packed_in_half=H // 2)
+
+        quant_patch, gemm_patch = _patch_aiter_kernels(OUT)
+        with quant_patch, gemm_patch:
+            out = self.scheme.apply_weights(layer, x)
+
+        self.assertEqual(
+            out.dim(), 3, f"expected 3-D output, got shape {tuple(out.shape)}"
+        )
+        self.assertEqual(tuple(out.shape), (B, S, OUT))
+
+    def test_3d_input_preserves_batch_dim_separately(self):
+        # Extra coverage: vary B and S to confirm both dims are preserved
+        # individually (and not, e.g., B and S getting swapped).
+        for B, S in [(1, 8), (3, 1), (5, 7)]:
+            with self.subTest(B=B, S=S):
+                H, OUT = 32, 16
+                x = torch.randn(B, S, H, dtype=torch.bfloat16)
+                layer = _make_layer(out_features=OUT, packed_in_half=H // 2)
+
+                quant_patch, gemm_patch = _patch_aiter_kernels(OUT)
+                with quant_patch, gemm_patch:
+                    out = self.scheme.apply_weights(layer, x)
+
+                self.assertEqual(tuple(out.shape), (B, S, OUT))
+
+    # ---- Guardrails: must pass on both buggy and fixed code -----------------
+
+    def test_2d_input_returns_2d_output(self):
+        # 2-D path is unchanged by the fix — keep it as a regression guard.
+        N, H, OUT = 6, 64, 128
+        x = torch.randn(N, H, dtype=torch.bfloat16)
+        layer = _make_layer(out_features=OUT, packed_in_half=H // 2)
+
+        quant_patch, gemm_patch = _patch_aiter_kernels(OUT)
+        with quant_patch, gemm_patch:
+            out = self.scheme.apply_weights(layer, x)
+
+        self.assertEqual(tuple(out.shape), (N, OUT))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`QuarkW4A4MXFP4.apply_weights` is supposed to be rank-preserving — 2-D activations in, 2-D out; 3-D activations in, 3-D out. The 3-D branch flattens `(B, S, H)` to `(B*S, H)` before the GEMM and reshapes back at the end via `y.view(*output_shape)`.

`output_shape` was computed *after* the flatten, so it picked up the post-flatten dims (`B*S`) instead of `(B, S)`. The function then returned a 2-D tensor where the caller expected 3-D, silently violating the shape contract. Downstream consumers (residuals, layernorms, attention) would either misbroadcast or eventually crash on a confusing rank mismatch.

The buggy ordering was introduced in #9671, survived the revert in #9959, and re-landed in #10008.

## Modifications

**`python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py`** — compute `output_shape` *before* `x = x.view(-1, x.shape[-1])`. One assignment moved up by one line; added a short comment explaining why the ordering matters. No behavior change for the 2-D path or the `fused_gemm_split_cat` early-return path.

```python
if x.dim() == 3:
    three_d = True
    # Capture the original (B, S) prefix BEFORE flattening; otherwise
    # `x.shape[:-1]` is (B*S,) and the final `y.view(*output_shape)`
    # silently returns a 2-D tensor to a 3-D caller.
    output_shape = [*x.shape[:-1], layer.weight.shape[0]]
    x = x.view(-1, x.shape[-1])
```

**`test/registered/unit/layers/quantization/test_quark_w4a4_mxfp4.py`** — new CPU-only regression test (registered to `base-a-test-cpu`, `est_time=5`). Three cases:

| Test | Purpose | On unfixed code |
|---|---|---|
| `test_3d_input_returns_3d_output` | `(2, 4, 64)` in → must come back `(2, 4, 128)` | **fails** (returns `(8, 128)`) |
| `test_3d_input_preserves_batch_dim_separately` | parametrized `(1,8)`, `(3,1)`, `(5,7)` — catches `B↔S` swaps | **fails** |
| `test_2d_input_returns_2d_output` | guardrail — 2-D path is unchanged | passes on both |

The test mocks `dynamic_mxfp4_quant` and `gemm_afp4wfp4` with `create=True` so it runs on CI hosts where the aiter symbols aren't imported. The fake GEMM is a no-op writer — the caller pre-allocates the output `y` at the shape this PR validates, which is exactly what the test exercises.

## Accuracy Tests

The fix is pure shape arithmetic; it doesn't touch quant or GEMM math. Output values are unchanged on the 2-D path and on the `fused_gemm_split_cat` path. On the 3-D path the values were already correct — only the returned tensor's rank was wrong.

Kernel-level GPU smoke on MI325X (gfx942, `HIP_VISIBLE_DEVICES=7`) ran `apply_weights` end-to-end with real `aiter.dynamic_mxfp4_quant`: the fixed shape arithmetic, the flatten, the real quant kernel, and the `torch.empty(B*S, OUT)` output allocation all succeeded. The downstream `gemm_afp4wfp4` call was blocked by a missing `gfx942-GEMM-AFP4WFP4.json` config on this aiter install (unrelated to this fix).

The new unit test was run in a fresh editable install (3/3 pass) and pre-commit passes on both modified files (`isort`, `ruff`, `black`, `codespell`, `check-registered-tests`).

## Speed Tests and Profiling

N/A — no kernel changes, no hot-path modifications. The fix relocates one Python-side tensor-metadata assignment by one line.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — N/A; bug fix, no API/behavior change.
- [x] Provide accuracy and speed benchmark results — see above; not applicable for a pure-shape fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28313701852](https://github.com/sgl-project/sglang/actions/runs/28313701852)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28313701800](https://github.com/sgl-project/sglang/actions/runs/28313701800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->