### PR TITLE
[DSv4]Fix attention CP startup barrier before CUDA graph capture

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1402,8 +1402,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger,
         )
 
-        if self.server_args.elastic_ep_backend == "mooncake":
+        if (
+            self.server_args.elastic_ep_backend == "mooncake"
+            or self.server_args.attn_cp_size > 1
+        ):
             # Mooncake does not support `monitored_barrier`
+            # In attention CP mode, `monitored_barrier` can advance rank 0
+            # through extra point-to-point steps on the same CPU process group,
+            # so later CP/CUDA graph capture collectives can see different
+            # sequence numbers across ranks.
             dist.barrier(group=get_tp_group().cpu_group)
         else:
             # Handle the case where some ranks do not finish loading.


### PR DESCRIPTION
## Motivation

In attention context parallel mode, CUDA graph capture can fail or hang because
`dist.monitored_barrier()` advances rank 0 through extra point-to-point steps on
the TP CPU process group after model loading.

The same process group is later used before CP / CUDA graph collectives, so ranks
can enter capture with different collective sequence numbers. This was observed
with DSV4 CP8 as an NCCL CP all-gather timeout during CUDA graph capture.

Repro launch command:

```bash
python -m sglang.launch_server \
  --model-path /path/to/DeepSeek-V4-Flash-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --trust-remote-code \
  --tp-size 8 \
  --enable-nsa-prefill-context-parallel \
  --nsa-prefill-cp-mode round-robin-split \
  --moe-a2a-backend deepep \
  --deepep-mode low_latency \
  --page-size 256 \
  --cuda-graph-max-bs 64 \
  --max-running-requests 64
```

Repro benchmark command:

```bash
python -m sglang.bench_one_batch_server \
  --model None \
  --base-url http://127.0.0.1:30000 \
  --batch-size 1 \
  --input-len 8192 \
  --output-len 1024 \
  --show-report
```

Observed failure before this fix:

- Server startup can finish successfully.
- The first CP/CUDA-graph-sensitive benchmark request hangs during CUDA graph
  capture.
- Logs eventually report an NCCL timeout around CP all-gather `ncclUniqueId`
  exchange / collective setup, for example a 600s timeout.
- With distributed debug enabled, rank 0 and non-zero ranks have different
  collective sequence numbers before capture.

## Modifications

Use a plain `dist.barrier()` after model loading when attention context
parallelism is enabled (`attn_cp_size > 1`), matching the existing Mooncake path
that already avoids `monitored_barrier()`.

Non-CP, non-Mooncake runs still use `dist.monitored_barrier()` and keep the
existing diagnostics for unbalanced model loading failures.

## Accuracy Tests

Not applicable. This only changes the startup synchronization primitive before
CUDA graph capture and does not change model forward computation or outputs.

## Speed Tests and Profiling

No speed impact expected.

Validation:

- `python -m py_compile python/sglang/srt/model_executor/model_runner.py`
- `git diff --check`
- DSV4 CP8 + DeepEP low-latency smoke run completed CUDA graph capture without
  the previous CP all-gather timeout.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26018295915](https://github.com/sgl-project/sglang/actions/runs/26018295915)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->