### PR TITLE
ci: pr-states no longer overwrites running run state when label is removed

### DIFF
--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -82,10 +82,8 @@ jobs:
             const hasCI = labels.includes('run-ci');
             const hasExtra = labels.includes('run-ci-extra');
 
-            // Only `unlabeled` events have a real race against label removal
-            // vs an in-flight run. Other no-label fires (opened / synchronize /
-            // reopened / unrelated labeled / workflow_run) don't need to wait:
-            // any existing run is long-indexed or genuinely absent.
+            // Pre-sleep below only matters when a label was just removed;
+            // other no-label fires don't race against fresh indexing.
             const justRemovedLabel = context.eventName === 'pull_request_target'
                                      && context.payload.action === 'unlabeled';
 
@@ -110,14 +108,10 @@ jobs:
             }
 
             // Query unconditionally: removing a label does NOT cancel an
-            // in-flight workflow, so a run from before label removal can
-            // still be live. Label state only picks the fallback text.
-            //
-            // Retry budget:
-            // - With label: pre-sleep + retry absorb fresh-push indexing lag.
-            // - Without label + just-removed-label event: pre-sleep + 1 lookup
-            //   catches removal-immediately-after-push.
-            // - Without label + other events: 1 lookup, no wait.
+            // in-flight workflow, so a run from before removal can still be
+            // live. Label state only picks the fallback text. labelOnOpts
+            // covers fresh-push indexing race; labelOffOpts only pre-sleeps
+            // on just-removed-label to catch removal-after-push.
             const labelOnOpts  = { preSleepMs: LABEL_ON_PRESLEEP_MS, attempts: RETRY_ATTEMPTS, delayMs: RETRY_DELAY_MS };
             const labelOffOpts = { preSleepMs: justRemovedLabel ? LABEL_OFF_PRESLEEP_MS : 0, attempts: 1 };
             const ptRun = await findRun('pr-test.yml', hasCI ? labelOnOpts : labelOffOpts);
@@ -133,9 +127,8 @@ jobs:
             const notExtraEnabledText = ':warning: **Not enabled** -- add `run-ci-extra` label to opt in.';
             const stalePushText = ':warning: **Not run on latest push** -- push again to dispatch.';
 
-            // Status icon distinguishes live / success / gate-failed / cancelled
-            // so the body reflects the actual run state instead of looking
-            // uniformly "dispatched" even when call-gate failed.
+            // Status icon: body otherwise looks uniformly "dispatched" even
+            // for gate-failed runs (call-gate exits on missing label).
             function runIcon(run) {
               if (run.status !== 'completed') return ':hourglass_flowing_sand:';
               switch (run.conclusion) {

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -90,7 +90,7 @@ jobs:
               });
               return data.workflow_runs[0] || null;
             }
-            async function findRunWithRetry(workflowFile, maxAttempts = 6, delayMs = 5000) {
+            async function findRunWithRetry(workflowFile, maxAttempts = 3, delayMs = 6000) {
               for (let i = 0; i < maxAttempts; i++) {
                 const run = await findRunBySha(workflowFile);
                 if (run) return run;
@@ -99,11 +99,19 @@ jobs:
               return null;
             }
 
-            const ptRun = hasCI ? await findRunWithRetry('pr-test.yml') : null;
-            // pr-test-extra's gate requires BOTH run-ci AND run-ci-extra
-            // (see pr-test-extra.yml check-changes if-condition), so without
-            // run-ci the extra workflow doesn't run either.
-            const peRun = (hasCI && hasExtra) ? await findRunWithRetry('pr-test-extra.yml') : null;
+            // Query unconditionally: a run may exist from before the label
+            // was removed (deleting a label does NOT cancel an in-flight
+            // workflow). Label state decides only the fallback text when no
+            // real run is found. pr-test-extra's gate requires BOTH run-ci
+            // AND run-ci-extra (see pr-test-extra.yml check-changes
+            // if-condition) -- that's enforced by the gate, not here.
+            //
+            // Retry budget: with the relevant label set, the run may not be
+            // API-visible yet right after push, so retry briefly. Without the
+            // label, any existing run was started earlier and is already in
+            // GH's index -- a single lookup is enough.
+            const ptRun = await findRunWithRetry('pr-test.yml', hasCI ? 3 : 1);
+            const peRun = await findRunWithRetry('pr-test-extra.yml', (hasCI && hasExtra) ? 3 : 1);
 
             // Treat a fully-skipped run as "no real run" — happens when the PR
             // was opened without the label and label was added later (GHA does
@@ -114,14 +122,16 @@ jobs:
             const peBlockedByCIText = ':x: **Blocked** — `run-ci` is required first.';
             const notExtraEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
             const stalePushText = ':warning: **Not run on latest push** — push again to dispatch.';
-            const ptText = !hasCI
-              ? missingCIText
-              : (isReal(ptRun) ? `[Run #${ptRun.id}](${ptRun.html_url})` : '_Not run yet_');
-            const peText = !hasCI
-              ? peBlockedByCIText
-              : !hasExtra
-                ? notExtraEnabledText
-                : (isReal(peRun) ? `[Run #${peRun.id}](${peRun.html_url})` : stalePushText);
+            const ptText = isReal(ptRun)
+              ? `[Run #${ptRun.id}](${ptRun.html_url})`
+              : (!hasCI ? missingCIText : '_Not run yet_');
+            const peText = isReal(peRun)
+              ? `[Run #${peRun.id}](${peRun.html_url})`
+              : !hasCI
+                ? peBlockedByCIText
+                : !hasExtra
+                  ? notExtraEnabledText
+                  : stalePushText;
 
             const outerStart = '<!-- pr-states:start -->';
             const outerEnd   = '<!-- pr-states:end -->';

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -1,8 +1,7 @@
 name: PR States
-# Maintains a CI-states block at the bottom of the PR body. Triggered by
-# `pull_request_target` (not `pull_request`) so fork PRs get a write-enabled
-# GITHUB_TOKEN. Safe because the workflow never checks out PR head code —
-# only reads metadata via API and PATCHes the PR body.
+# Maintains the CI-states block at the bottom of the PR body. Uses
+# pull_request_target (not pull_request) for fork-PR write access; safe
+# because we never check out PR head code, only API-read and PATCH the body.
 
 on:
   pull_request_target:
@@ -36,11 +35,9 @@ jobs:
             // Event-agnostic PR lookup.
             // - pull_request_target: PR is in the payload.
             // - workflow_run: pull_requests[] is populated for same-repo PRs;
-            //   for fork PRs it's empty and we reverse-lookup by head ref
-            //   ("forkOwner:branch"), which is the GH-documented fork-PR query
-            //   pattern and avoids the "commit must be in default branch" caveat
-            //   of listPullRequestsAssociatedWithCommit. Bail cleanly when no
-            //   open PR matches (e.g. workflow run from a push to main).
+            //   fork PRs need a head-ref reverse lookup ("forkOwner:branch")
+            //   because listPullRequestsAssociatedWithCommit requires the commit
+            //   to be in the default branch. Bail when no open PR matches.
             let prNumber;
             if (context.payload.pull_request) {
               prNumber = context.payload.pull_request.number;
@@ -79,7 +76,6 @@ jobs:
             const hasCI = labels.includes('run-ci');
             const hasExtra = labels.includes('run-ci-extra');
 
-            // Retry briefly: pr-test* may not be API-visible yet when we start.
             async function findRunBySha(workflowFile) {
               const { data } = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
@@ -99,19 +95,15 @@ jobs:
               return null;
             }
 
-            // Query unconditionally: a run may exist from before the label
-            // was removed (deleting a label does NOT cancel an in-flight
-            // workflow). Label state decides only the fallback text when no
-            // real run is found. pr-test-extra's gate requires BOTH run-ci
-            // AND run-ci-extra (see pr-test-extra.yml check-changes
-            // if-condition) -- that's enforced by the gate, not here.
+            // Query unconditionally: removing a label does NOT cancel an
+            // in-flight workflow, so a run from before label removal can
+            // still be live. Label state only picks the fallback text.
             //
             // Retry budget:
-            // - With label: pre-sleep 3s to absorb same-tick indexing lag
-            //   against a fresh push, then 3 attempts 6s apart (max 15s).
-            // - Without label: any existing run is from before label removal;
-            //   pre-sleep 6s to absorb residual API indexing lag (e.g. label
-            //   removed within seconds of push), then a single lookup.
+            // - With label: 3s pre-sleep + 3 attempts 6s apart (max 15s)
+            //   to absorb indexing lag against a fresh push.
+            // - Without label: 6s pre-sleep + 1 lookup catches the
+            //   removal-immediately-after-push edge case.
             async function findRun(workflowFile, hasLabel) {
               if (hasLabel) {
                 await new Promise(r => setTimeout(r, 3000));
@@ -121,11 +113,11 @@ jobs:
               return findRunBySha(workflowFile);
             }
             const ptRun = await findRun('pr-test.yml', hasCI);
+            // pr-test-extra gates on BOTH labels (see check-changes there).
             const peRun = await findRun('pr-test-extra.yml', hasCI && hasExtra);
 
-            // Treat a fully-skipped run as "no real run" — happens when the PR
-            // was opened without the label and label was added later (GHA does
-            // not retrigger on `labeled`).
+            // Skipped run = "no real run" -- happens when a label is added
+            // after a commit, because GHA doesn't retrigger on `labeled`.
             const isReal = (run) => run && run.conclusion !== 'skipped';
 
             const missingCIText = ':x: **Missing `run-ci` label** — add it to run CI tests.';

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -106,12 +106,19 @@ jobs:
             // AND run-ci-extra (see pr-test-extra.yml check-changes
             // if-condition) -- that's enforced by the gate, not here.
             //
-            // Retry budget: with the relevant label set, the run may not be
-            // API-visible yet right after push, so retry briefly. Without the
-            // label, any existing run was started earlier and is already in
-            // GH's index -- a single lookup is enough.
-            const ptRun = await findRunWithRetry('pr-test.yml', hasCI ? 3 : 1);
-            const peRun = await findRunWithRetry('pr-test-extra.yml', (hasCI && hasExtra) ? 3 : 1);
+            // Retry budget:
+            // - With label: race against fresh pr-test* indexing after push,
+            //   so retry briefly (3 attempts, 6s apart).
+            // - Without label: any existing run is from before label removal;
+            //   pre-sleep 6s to absorb residual API indexing lag (e.g. label
+            //   removed within seconds of push), then a single lookup.
+            async function findRun(workflowFile, hasLabel) {
+              if (hasLabel) return findRunWithRetry(workflowFile, 3, 6000);
+              await new Promise(r => setTimeout(r, 6000));
+              return findRunBySha(workflowFile);
+            }
+            const ptRun = await findRun('pr-test.yml', hasCI);
+            const peRun = await findRun('pr-test-extra.yml', hasCI && hasExtra);
 
             // Treat a fully-skipped run as "no real run" — happens when the PR
             // was opened without the label and label was added later (GHA does

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -8,8 +8,8 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_run:
     # Listen to pr-test* lifecycle so reruns initiated by slash commands
-    # (run.rerun / run.rerun_failed_jobs via GITHUB_TOKEN) — which don't
-    # refire pull_request_target — still refresh the CI-states block.
+    # (run.rerun / run.rerun_failed_jobs via GITHUB_TOKEN) -- which don't
+    # refire pull_request_target -- still refresh the CI-states block.
     workflows: ["PR Test", "PR Test Extra"]
     types: [requested, completed]
 
@@ -32,6 +32,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const RETRY_ATTEMPTS = 3;
+            const RETRY_DELAY_MS = 6000;
+            const LABEL_ON_PRESLEEP_MS = 3000;
+            const LABEL_OFF_PRESLEEP_MS = 6000;
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
             // Event-agnostic PR lookup.
             // - pull_request_target: PR is in the payload.
             // - workflow_run: pull_requests[] is populated for same-repo PRs;
@@ -76,6 +82,13 @@ jobs:
             const hasCI = labels.includes('run-ci');
             const hasExtra = labels.includes('run-ci-extra');
 
+            // Only `unlabeled` events have a real race against label removal
+            // vs an in-flight run. Other no-label fires (opened / synchronize /
+            // reopened / unrelated labeled / workflow_run) don't need to wait:
+            // any existing run is long-indexed or genuinely absent.
+            const justRemovedLabel = context.eventName === 'pull_request_target'
+                                     && context.payload.action === 'unlabeled';
+
             async function findRunBySha(workflowFile) {
               const { data } = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
@@ -86,11 +99,12 @@ jobs:
               });
               return data.workflow_runs[0] || null;
             }
-            async function findRunWithRetry(workflowFile, maxAttempts = 3, delayMs = 6000) {
-              for (let i = 0; i < maxAttempts; i++) {
+            async function findRun(workflowFile, { preSleepMs = 0, attempts = 1, delayMs = 0 }) {
+              if (preSleepMs > 0) await sleep(preSleepMs);
+              for (let i = 0; i < attempts; i++) {
                 const run = await findRunBySha(workflowFile);
                 if (run) return run;
-                if (i < maxAttempts - 1) await new Promise(r => setTimeout(r, delayMs));
+                if (i < attempts - 1) await sleep(delayMs);
               }
               return null;
             }
@@ -100,30 +114,24 @@ jobs:
             // still be live. Label state only picks the fallback text.
             //
             // Retry budget:
-            // - With label: 3s pre-sleep + 3 attempts 6s apart (max 15s)
-            //   to absorb indexing lag against a fresh push.
-            // - Without label: 6s pre-sleep + 1 lookup catches the
-            //   removal-immediately-after-push edge case.
-            async function findRun(workflowFile, hasLabel) {
-              if (hasLabel) {
-                await new Promise(r => setTimeout(r, 3000));
-                return findRunWithRetry(workflowFile, 3, 6000);
-              }
-              await new Promise(r => setTimeout(r, 6000));
-              return findRunBySha(workflowFile);
-            }
-            const ptRun = await findRun('pr-test.yml', hasCI);
+            // - With label: pre-sleep + retry absorb fresh-push indexing lag.
+            // - Without label + just-removed-label event: pre-sleep + 1 lookup
+            //   catches removal-immediately-after-push.
+            // - Without label + other events: 1 lookup, no wait.
+            const labelOnOpts  = { preSleepMs: LABEL_ON_PRESLEEP_MS, attempts: RETRY_ATTEMPTS, delayMs: RETRY_DELAY_MS };
+            const labelOffOpts = { preSleepMs: justRemovedLabel ? LABEL_OFF_PRESLEEP_MS : 0, attempts: 1 };
+            const ptRun = await findRun('pr-test.yml', hasCI ? labelOnOpts : labelOffOpts);
             // pr-test-extra gates on BOTH labels (see check-changes there).
-            const peRun = await findRun('pr-test-extra.yml', hasCI && hasExtra);
+            const peRun = await findRun('pr-test-extra.yml', (hasCI && hasExtra) ? labelOnOpts : labelOffOpts);
 
             // Skipped run = "no real run" -- happens when a label is added
             // after a commit, because GHA doesn't retrigger on `labeled`.
             const isReal = (run) => run && run.conclusion !== 'skipped';
 
-            const missingCIText = ':x: **Missing `run-ci` label** — add it to run CI tests.';
-            const peBlockedByCIText = ':x: **Blocked** — `run-ci` is required first.';
-            const notExtraEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
-            const stalePushText = ':warning: **Not run on latest push** — push again to dispatch.';
+            const missingCIText = ':x: **Missing `run-ci` label** -- add it to run CI tests.';
+            const peBlockedByCIText = ':x: **Blocked** -- `run-ci` is required first.';
+            const notExtraEnabledText = ':warning: **Not enabled** -- add `run-ci-extra` label to opt in.';
+            const stalePushText = ':warning: **Not run on latest push** -- push again to dispatch.';
 
             // Status icon distinguishes live / success / gate-failed / cancelled
             // so the body reflects the actual run state instead of looking
@@ -136,6 +144,7 @@ jobs:
                 case 'cancelled': return ':no_entry_sign:';
                 case 'timed_out': return ':alarm_clock:';
                 case 'action_required': return ':warning:';
+                case 'neutral': return ':grey_question:';
                 default: return ':grey_question:';
               }
             }

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -124,11 +124,27 @@ jobs:
             const peBlockedByCIText = ':x: **Blocked** — `run-ci` is required first.';
             const notExtraEnabledText = ':warning: **Not enabled** — add `run-ci-extra` label to opt in.';
             const stalePushText = ':warning: **Not run on latest push** — push again to dispatch.';
+
+            // Status icon distinguishes live / success / gate-failed / cancelled
+            // so the body reflects the actual run state instead of looking
+            // uniformly "dispatched" even when call-gate failed.
+            function runIcon(run) {
+              if (run.status !== 'completed') return ':hourglass_flowing_sand:';
+              switch (run.conclusion) {
+                case 'success': return ':white_check_mark:';
+                case 'failure': return ':x:';
+                case 'cancelled': return ':no_entry_sign:';
+                case 'timed_out': return ':alarm_clock:';
+                case 'action_required': return ':warning:';
+                default: return ':grey_question:';
+              }
+            }
+            const runLink = (run) => `${runIcon(run)} [Run #${run.id}](${run.html_url})`;
             const ptText = isReal(ptRun)
-              ? `[Run #${ptRun.id}](${ptRun.html_url})`
+              ? runLink(ptRun)
               : (!hasCI ? missingCIText : '_Not run yet_');
             const peText = isReal(peRun)
-              ? `[Run #${peRun.id}](${peRun.html_url})`
+              ? runLink(peRun)
               : !hasCI
                 ? peBlockedByCIText
                 : !hasExtra

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -107,13 +107,16 @@ jobs:
             // if-condition) -- that's enforced by the gate, not here.
             //
             // Retry budget:
-            // - With label: race against fresh pr-test* indexing after push,
-            //   so retry briefly (3 attempts, 6s apart).
+            // - With label: pre-sleep 3s to absorb same-tick indexing lag
+            //   against a fresh push, then 3 attempts 6s apart (max 15s).
             // - Without label: any existing run is from before label removal;
             //   pre-sleep 6s to absorb residual API indexing lag (e.g. label
             //   removed within seconds of push), then a single lookup.
             async function findRun(workflowFile, hasLabel) {
-              if (hasLabel) return findRunWithRetry(workflowFile, 3, 6000);
+              if (hasLabel) {
+                await new Promise(r => setTimeout(r, 3000));
+                return findRunWithRetry(workflowFile, 3, 6000);
+              }
               await new Promise(r => setTimeout(r, 6000));
               return findRunBySha(workflowFile);
             }


### PR DESCRIPTION
Bug fix for pr-states.yml: keep the actual workflow run link in the PR body even after the gating label is removed, instead of reverting the slot text to 'Not enabled' / 'Missing label'. Also tightens retry/sleep budget.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->