### PR TITLE
[Diffusion] [NPU] Fix HunyuanVideo crash on NPU

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -251,7 +251,7 @@ class MMDoubleStreamBlock(nn.Module):
         # Run distributed attention
         img_attn, txt_attn = self.attn(img_q, img_k, img_v, txt_q, txt_k, txt_v)
         img_attn_out, _ = self.img_attn_proj(
-            img_attn.view(batch_size, image_seq_len, -1)
+            img_attn.reshape(batch_size, image_seq_len, -1)
         )
         # Use fused operation for residual connection, normalization, and modulation
         img_mlp_input, img_residual = self.img_attn_residual_mlp_norm(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

HunyuanVideo fails on Ascend NPU. The Torch SDPA backend on NPU returns attention output tensors that are non-contiguous in memory, which causes Tensor.view() to raise:                                   
`RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.`

cmd:
`python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate --model-path=hunyuanvideo-community/HunyuanVideo  --prompt="A curious raccoon" --num-gpus 1`

<details>
<summary>error log</summary>
...
[05-17 08:30:48] [DenoisingStage] started...

  0%|          | 0/50 [00:00<?, ?it/s][91m[05-17 08:30:48] [denoising_step_0] Error during execution after 142.7848 ms: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter
Traceback (most recent call last):
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1290, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 943, in _run_denoising_step
    noise_pred = self._predict_noise_with_cfg(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1440, in _predict_noise_with_cfg
    predictions = [predict_fn(branch) for branch in cfg_policy.branches]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1440, in <listcomp>
    predictions = [predict_fn(branch) for branch in cfg_policy.branches]
                   ^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1409, in predict_fn
    raw = self._predict_noise(
          ^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1604, in _predict_noise
    return current_model(
           ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py", line 661, in forward
    img, txt = block(*double_block_args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py", line 254, in forward
    img_attn.view(batch_size, image_seq_len, -1)
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter[0;0m

  0%|          | 0/50 [00:00<?, ?it/s]
[91m[05-17 08:30:48] [DenoisingStage] Error during execution after 153.9740 ms: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter
Traceback (most recent call last):
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 290, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1290, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 943, in _run_denoising_step
    noise_pred = self._predict_noise_with_cfg(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1440, in _predict_noise_with_cfg
    predictions = [predict_fn(branch) for branch in cfg_policy.branches]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1440, in <listcomp>
    predictions = [predict_fn(branch) for branch in cfg_policy.branches]
                   ^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1409, in predict_fn
    raw = self._predict_noise(
          ^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1604, in _predict_noise
    return current_model(
           ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py", line 661, in forward
    img, txt = block(*double_block_args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py", line 254, in forward
    img_attn.view(batch_size, image_seq_len, -1)
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter[0;0m
[91m[05-17 08:30:48] Error executing request ada26008-79c4-42ba-a71c-ffb14c9b7d3d: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter
Traceback (most recent call last):
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 323, in _execute_forward_common
    result = forward_fn()
             ^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py", line 261, in <lambda>
    forward_fn=lambda: self.pipeline.forward(req, self.server_args),
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py", line 808, in forward
    return self.executor.execute_with_profiling(self.stages, batch, server_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/pipeline_executor.py", line 84, in execute_with_profiling
    batch = self.execute(stages, batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 114, in execute
    return self._execute_stages(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 102, in _execute_stages
    batch = stage(batch, server_args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 290, in __call__
    result = self.forward(batch, server_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1290, in forward
    self._run_denoising_step(ctx, step, batch, server_args)
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 943, in _run_denoising_step
    noise_pred = self._predict_noise_with_cfg(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1440, in _predict_noise_with_cfg
    predictions = [predict_fn(branch) for branch in cfg_policy.branches]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1440, in <listcomp>
    predictions = [predict_fn(branch) for branch in cfg_policy.branches]
                   ^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1409, in predict_fn
    raw = self._predict_noise(
          ^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1604, in _predict_noise
    return current_model(
           ^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py", line 661, in forward
    img, txt = block(*double_block_args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py", line 254, in forward
    img_attn.view(batch_size, image_seq_len, -1)
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter[0;0m
[91m[05-17 08:30:48] Failed to generate output for prompt: Error executing request ada26008-79c4-42ba-a71c-ffb14c9b7d3d: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter
Traceback (most recent call last):
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/utils/logging_utils.py", line 626, in log_generation_timer
    yield timer
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request ada26008-79c4-42ba-a71c-ffb14c9b7d3d: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter[0;0m
[91m[05-17 08:30:48] Generation failed: Error executing request ada26008-79c4-42ba-a71c-ffb14c9b7d3d: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter
Traceback (most recent call last):
  File "/root/overlap/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 257, in generate
    raise Exception(f"{output_batch.error}")
Exception: Error executing request ada26008-79c4-42ba-a71c-ffb14c9b7d3d: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
[ERROR] 2026-05-17-08:30:48 (PID:284423, Device:0, RankID:0) ERR01001 OPS invalid parameter[0;0m
[93m[05-17 08:30:48] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-17 08:30:49] Worker 0: Shutdown complete.
[93m[05-17 08:30:58] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m
</details>

## Modifications

<!-- Detail the changes made in this pull request. -->


- Changed `img_attn.view(batch_size, image_seq_len, -1)` to `img_attn.reshape(batch_size, image_seq_len, -1)` in `MMDoubleStreamBlock.forward()` (python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py, line 254).


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

cmd:
`python -m sglang.multimodal_gen.runtime.entrypoints.cli.main generate --model-path=hunyuanvideo-community/HunyuanVideo  --prompt="A curious raccoon" --num-gpus 1`

result:
`success`

<details>
<summary>Full success log</summary>
[05-18 02:56:05] server_args: {"model_path": "/root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773", "model_id": null, "backend": "auto", "attention_backend": null, "attention_backend_config": {}, "component_attention_backends": {}, "cache_dit_config": null, "nccl_port": null, "trust_remote_code": false, "revision": null, "num_gpus": 1, "performance_mode": "auto", "tp_size": 1, "sp_degree": 1, "ulysses_degree": 1, "ring_degree": 1, "dp_size": 1, "dp_degree": 1, "enable_cfg_parallel": false, "cfg_parallel_degree": 1, "hsdp_replicate_dim": 1, "hsdp_shard_dim": 1, "dist_timeout": 3600, "pipeline_class_name": null, "lora_path": null, "lora_nickname": "default", "lora_scale": 1.0, "lora_merge_mode": "auto", "lora_weight_name": null, "component_paths": {}, "transformer_weights_path": null, "quantization": null, "quantization_ignored_layers": null, "lora_target_modules": null, "dit_cpu_offload": true, "dit_layerwise_offload": false, "layerwise_offload_components": null, "dit_offload_prefetch_size": 0.0, "text_encoder_cpu_offload": true, "image_encoder_cpu_offload": true, "vae_cpu_offload": false, "use_fsdp_inference": false, "pin_cpu_memory": true, "ltx2_two_stage_device_mode": null, "comfyui_mode": false, "enable_torch_compile": false, "warmup": false, "warmup_resolutions": null, "warmup_steps": 1, "disable_autocast": false, "master_port": 30005, "host": "127.0.0.1", "port": 30000, "webui": false, "webui_port": 12312, "scheduler_port": 5635, "batching_mode": "dynamic", "batching_max_size": 1, "batching_delay_ms": 0.0, "batching_config": null, "enable_batching_metrics": false, "strict_ports": false, "output_path": "outputs/", "input_save_path": "inputs/uploads", "prompt_file_path": null, "model_paths": {}, "model_loaded": {"transformer": true, "vae": true, "video_vae": true, "audio_vae": true, "video_dit": true, "audio_dit": true, "dual_tower_bridge": true}, "boundary_ratio": null, "base_gpu_id": 0, "disagg_role": "monolithic", "disagg_timeout": 600, "disagg_dispatch_policy": "round_robin", "disagg_mode": false, "disagg_server_addr": null, "encoder_urls": null, "denoiser_urls": null, "decoder_urls": null, "encoder_tp": null, "denoiser_tp": null, "denoiser_sp": null, "denoiser_ulysses": null, "denoiser_ring": null, "decoder_tp": null, "disagg_transfer_pool_size": 268435456, "disagg_p2p_hostname": "127.0.0.1", "disagg_ib_device": null, "pool_work_endpoint": null, "pool_result_endpoint": null, "log_level": "info", "uvicorn_access_log_exclude_prefixes": [], "enable_trace": false, "otlp_traces_endpoint": "localhost:4317"}
[05-18 02:56:05] Diffusers version: 0.32.0.dev0
[05-18 02:56:05] Local mode: True
[05-18 02:56:05] Starting server...
[05-18 02:56:23] Scheduler bind at endpoint: tcp://127.0.0.1:5635
[05-18 02:56:24] get env LOCAL_RANK = 0
[05-18 02:56:24] get env WORLD_SIZE = 1
[05-18 02:56:24] get env RANK = 0
[05-18 02:56:24] Initializing distributed environment with world_size=1, device=npu:0, timeout=3600
[05-18 02:56:24] Setting distributed timeout to 3600 seconds
[05-18 02:56:24] No pipeline_class_name specified, using model_index.json
[05-18 02:56:25] Diffusers version: 0.32.0.dev0
[05-18 02:56:25] Using pipeline from model_index.json: HunyuanVideoPipeline
[05-18 02:56:25] Loading pipeline modules...
[05-18 02:56:25] Model already exists locally and is complete
[05-18 02:56:25] Model path: /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773
[05-18 02:56:25] Diffusers version: 0.32.0.dev0
[05-18 02:56:25] Loading pipeline modules from config: {'_class_name': 'HunyuanVideoPipeline', '_diffusers_version': '0.32.0.dev0', 'scheduler': ['diffusers', 'FlowMatchEulerDiscreteScheduler'], 'text_encoder': ['transformers', 'LlamaModel'], 'text_encoder_2': ['transformers', 'CLIPTextModel'], 'tokenizer': ['transformers', 'LlamaTokenizerFast'], 'tokenizer_2': ['transformers', 'CLIPTokenizer'], 'transformer': ['diffusers', 'HunyuanVideoTransformer3DModel'], 'vae': ['diffusers', 'AutoencoderKLHunyuanVideo']}
[05-18 02:56:25] Loading required components: ['text_encoder', 'text_encoder_2', 'tokenizer', 'tokenizer_2', 'vae', 'transformer', 'scheduler']
[05-18 02:56:25] Memory-aware component load order: ['transformer', 'text_encoder', 'vae', 'text_encoder_2', 'tokenizer_2', 'tokenizer', 'scheduler']

Loading required modules:   0%|          | 0/7 [00:00<?, ?it/s][05-18 02:56:25] Loading transformer from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/transformer. avail mem: 60.54 GB
[05-18 02:56:25] Loading HunyuanVideoTransformer3DModel from 6 safetensors file(s) , param_dtype: torch.bfloat16
[05-18 02:56:25] Using Torch SDPA backend.
[05-18 02:56:25] Attention backend not specified for transformer, using torch_sdpa backend for transformer
[05-18 02:56:25] Using Torch SDPA backend.


Loading safetensors checkpoint shards:   0% Completed | 0/6 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards:  17% Completed | 1/6 [00:00<00:00,  5.81it/s]
[A

Loading safetensors checkpoint shards:  33% Completed | 2/6 [00:00<00:01,  2.22it/s]
[A

Loading safetensors checkpoint shards:  50% Completed | 3/6 [00:00<00:00,  3.23it/s]
[A

Loading safetensors checkpoint shards:  67% Completed | 4/6 [00:01<00:00,  3.66it/s]
[A

Loading safetensors checkpoint shards:  83% Completed | 5/6 [00:01<00:00,  4.03it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 6/6 [00:01<00:00,  4.24it/s]

[05-18 02:56:36] Loaded transformer: HunyuanVideoTransformer3DModel (sgl-diffusion version). model size: 23.88 GB, consumed GPU mem: 0.04 GB, avail GPU mem: 60.50 GB

Loading required modules:  14%|█▍        | 1/7 [00:11<01:08, 11.43s/it][05-18 02:56:36] Loading text_encoder from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/text_encoder. avail mem: 60.50 GB
[05-18 02:56:36] Using Torch SDPA backend.
[05-18 02:56:36] Attention backend not specified for text_encoder, using torch_sdpa backend for text_encoder


Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:00<00:00,  8.17it/s]
[A

Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:00<00:00,  3.17it/s]
[A

Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.60it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  3.00it/s]

[05-18 02:56:43] Applied FSDP to 98 submodules in FSDPLlamaModel using explicit shard conditions
[05-18 02:56:43] Loaded text_encoder: FSDPLlamaModel (sgl-diffusion version). model size: 13.98 GB, consumed GPU mem: 0.03 GB, avail GPU mem: 60.47 GB

Loading required modules:  29%|██▊       | 2/7 [00:18<00:45,  9.05s/it][05-18 02:56:43] Loading vae from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/vae. avail mem: 60.47 GB
[93m[05-18 02:56:44] VAE unexpected keys: ['encoder.conv_in.conv.bias', 'encoder.conv_in.conv.weight', 'encoder.conv_norm_out.bias', 'encoder.conv_norm_out.weight', 'encoder.conv_out.conv.bias', 'encoder.conv_out.conv.weight', 'encoder.down_blocks.0.downsamplers.0.conv.conv.bias', 'encoder.down_blocks.0.downsamplers.0.conv.conv.weight', 'encoder.down_blocks.0.resnets.0.conv1.conv.bias', 'encoder.down_blocks.0.resnets.0.conv1.conv.weight', 'encoder.down_blocks.0.resnets.0.conv2.conv.bias', 'encoder.down_blocks.0.resnets.0.conv2.conv.weight', 'encoder.down_blocks.0.resnets.0.norm1.bias', 'encoder.down_blocks.0.resnets.0.norm1.weight', 'encoder.down_blocks.0.resnets.0.norm2.bias', 'encoder.down_blocks.0.resnets.0.norm2.weight', 'encoder.down_blocks.0.resnets.1.conv1.conv.bias', 'encoder.down_blocks.0.resnets.1.conv1.conv.weight', 'encoder.down_blocks.0.resnets.1.conv2.conv.bias', 'encoder.down_blocks.0.resnets.1.conv2.conv.weight', 'encoder.down_blocks.0.resnets.1.norm1.bias', 'encoder.down_blocks.0.resnets.1.norm1.weight', 'encoder.down_blocks.0.resnets.1.norm2.bias', 'encoder.down_blocks.0.resnets.1.norm2.weight', 'encoder.down_blocks.1.downsamplers.0.conv.conv.bias', 'encoder.down_blocks.1.downsamplers.0.conv.conv.weight', 'encoder.down_blocks.1.resnets.0.conv1.conv.bias', 'encoder.down_blocks.1.resnets.0.conv1.conv.weight', 'encoder.down_blocks.1.resnets.0.conv2.conv.bias', 'encoder.down_blocks.1.resnets.0.conv2.conv.weight', 'encoder.down_blocks.1.resnets.0.conv_shortcut.conv.bias', 'encoder.down_blocks.1.resnets.0.conv_shortcut.conv.weight', 'encoder.down_blocks.1.resnets.0.norm1.bias', 'encoder.down_blocks.1.resnets.0.norm1.weight', 'encoder.down_blocks.1.resnets.0.norm2.bias', 'encoder.down_blocks.1.resnets.0.norm2.weight', 'encoder.down_blocks.1.resnets.1.conv1.conv.bias', 'encoder.down_blocks.1.resnets.1.conv1.conv.weight', 'encoder.down_blocks.1.resnets.1.conv2.conv.bias', 'encoder.down_blocks.1.resnets.1.conv2.conv.weight', 'encoder.down_blocks.1.resnets.1.norm1.bias', 'encoder.down_blocks.1.resnets.1.norm1.weight', 'encoder.down_blocks.1.resnets.1.norm2.bias', 'encoder.down_blocks.1.resnets.1.norm2.weight', 'encoder.down_blocks.2.downsamplers.0.conv.conv.bias', 'encoder.down_blocks.2.downsamplers.0.conv.conv.weight', 'encoder.down_blocks.2.resnets.0.conv1.conv.bias', 'encoder.down_blocks.2.resnets.0.conv1.conv.weight', 'encoder.down_blocks.2.resnets.0.conv2.conv.bias', 'encoder.down_blocks.2.resnets.0.conv2.conv.weight', 'encoder.down_blocks.2.resnets.0.conv_shortcut.conv.bias', 'encoder.down_blocks.2.resnets.0.conv_shortcut.conv.weight', 'encoder.down_blocks.2.resnets.0.norm1.bias', 'encoder.down_blocks.2.resnets.0.norm1.weight', 'encoder.down_blocks.2.resnets.0.norm2.bias', 'encoder.down_blocks.2.resnets.0.norm2.weight', 'encoder.down_blocks.2.resnets.1.conv1.conv.bias', 'encoder.down_blocks.2.resnets.1.conv1.conv.weight', 'encoder.down_blocks.2.resnets.1.conv2.conv.bias', 'encoder.down_blocks.2.resnets.1.conv2.conv.weight', 'encoder.down_blocks.2.resnets.1.norm1.bias', 'encoder.down_blocks.2.resnets.1.norm1.weight', 'encoder.down_blocks.2.resnets.1.norm2.bias', 'encoder.down_blocks.2.resnets.1.norm2.weight', 'encoder.down_blocks.3.resnets.0.conv1.conv.bias', 'encoder.down_blocks.3.resnets.0.conv1.conv.weight', 'encoder.down_blocks.3.resnets.0.conv2.conv.bias', 'encoder.down_blocks.3.resnets.0.conv2.conv.weight', 'encoder.down_blocks.3.resnets.0.norm1.bias', 'encoder.down_blocks.3.resnets.0.norm1.weight', 'encoder.down_blocks.3.resnets.0.norm2.bias', 'encoder.down_blocks.3.resnets.0.norm2.weight', 'encoder.down_blocks.3.resnets.1.conv1.conv.bias', 'encoder.down_blocks.3.resnets.1.conv1.conv.weight', 'encoder.down_blocks.3.resnets.1.conv2.conv.bias', 'encoder.down_blocks.3.resnets.1.conv2.conv.weight', 'encoder.down_blocks.3.resnets.1.norm1.bias', 'encoder.down_blocks.3.resnets.1.norm1.weight', 'encoder.down_blocks.3.resnets.1.norm2.bias', 'encoder.down_blocks.3.resnets.1.norm2.weight', 'encoder.mid_block.attentions.0.group_norm.bias', 'encoder.mid_block.attentions.0.group_norm.weight', 'encoder.mid_block.attentions.0.to_k.bias', 'encoder.mid_block.attentions.0.to_k.weight', 'encoder.mid_block.attentions.0.to_out.0.bias', 'encoder.mid_block.attentions.0.to_out.0.weight', 'encoder.mid_block.attentions.0.to_q.bias', 'encoder.mid_block.attentions.0.to_q.weight', 'encoder.mid_block.attentions.0.to_v.bias', 'encoder.mid_block.attentions.0.to_v.weight', 'encoder.mid_block.resnets.0.conv1.conv.bias', 'encoder.mid_block.resnets.0.conv1.conv.weight', 'encoder.mid_block.resnets.0.conv2.conv.bias', 'encoder.mid_block.resnets.0.conv2.conv.weight', 'encoder.mid_block.resnets.0.norm1.bias', 'encoder.mid_block.resnets.0.norm1.weight', 'encoder.mid_block.resnets.0.norm2.bias', 'encoder.mid_block.resnets.0.norm2.weight', 'encoder.mid_block.resnets.1.conv1.conv.bias', 'encoder.mid_block.resnets.1.conv1.conv.weight', 'encoder.mid_block.resnets.1.conv2.conv.bias', 'encoder.mid_block.resnets.1.conv2.conv.weight', 'encoder.mid_block.resnets.1.norm1.bias', 'encoder.mid_block.resnets.1.norm1.weight', 'encoder.mid_block.resnets.1.norm2.bias', 'encoder.mid_block.resnets.1.norm2.weight', 'quant_conv.bias', 'quant_conv.weight'][0;0m
[05-18 02:56:44] Loaded vae: AutoencoderKLHunyuanVideo (sgl-diffusion version). model size: 0.27 GB, consumed GPU mem: 0.23 GB, avail GPU mem: 60.23 GB

Loading required modules:  43%|████▎     | 3/7 [00:19<00:20,  5.02s/it][05-18 02:56:44] Loading text_encoder_2 from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/text_encoder_2. avail mem: 60.23 GB
[05-18 02:56:45] Using Torch SDPA backend.
[05-18 02:56:45] Attention backend not specified for text_encoder_2, using torch_sdpa backend for text_encoder_2


Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
[A

Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  5.80it/s]
[A
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  5.78it/s]

[05-18 02:56:46] Applied FSDP to 13 submodules in FSDPCLIPTextModel using explicit shard conditions
[05-18 02:56:46] Loaded text_encoder_2: FSDPCLIPTextModel (sgl-diffusion version). model size: 0.23 GB, consumed GPU mem: 0.02 GB, avail GPU mem: 60.22 GB

Loading required modules:  57%|█████▋    | 4/7 [00:20<00:11,  3.78s/it][05-18 02:56:46] Loading tokenizer_2 from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/tokenizer_2. avail mem: 60.22 GB
[05-18 02:56:46] Loaded tokenizer_2: CLIPTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.22 GB

Loading required modules:  71%|███████▏  | 5/7 [00:21<00:04,  2.46s/it][05-18 02:56:46] Loading tokenizer from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/tokenizer. avail mem: 60.22 GB
[05-18 02:56:47] Loaded tokenizer: LlamaTokenizer (sgl-diffusion version). model size: NA GB, consumed GPU mem: -0.00 GB, avail GPU mem: 60.22 GB

Loading required modules:  86%|████████▌ | 6/7 [00:22<00:02,  2.18s/it][05-18 02:56:47] Loading scheduler from /root/.cache/huggingface/hub/models--hunyuanvideo-community--HunyuanVideo/snapshots/e8c2aaa66fe3742a32c11a6766aecbf07c56e773/scheduler. avail mem: 60.22 GB
[05-18 02:56:47] Loaded scheduler: FlowMatchEulerDiscreteScheduler (sgl-diffusion version). model size: NA GB, consumed GPU mem: 0.00 GB, avail GPU mem: 60.22 GB

Loading required modules: 100%|██████████| 7/7 [00:22<00:00,  3.24s/it]
[05-18 02:56:47] Creating pipeline stages...
[05-18 02:56:47] Using Torch SDPA backend.
[05-18 02:56:47] Pipeline instantiated
[05-18 02:56:47] Worker 0: Initialized device, model, and distributed environment.
[05-18 02:56:47] Worker 0: Scheduler loop started.
[05-18 02:56:47] Adjusting number of frames from 125 to 125 based on model
[05-18 02:56:47] Processing 1 grouped request(s)
[05-18 02:56:47] Sampling params:
                       width: 1280
                      height: 720
                  num_frames: 125
                         fps: 24
                      prompt: <redacted, len=17>
                  neg_prompt: <redacted, len=392>
                        seed: 42
                 infer_steps: 50
      num_outputs_per_prompt: 1
              guidance_scale: 1.0
     embedded_guidance_scale: 6
                    n_tokens: None
                  flow_shift: 7
                  image_path: None
                 save_output: True
            output_file_path: outputs/A_curious_raccoon_20260518-025647_7d574410.mp4
        
[05-18 02:56:47] Running pipeline stages: ['InputValidationStage', 'prompt_encoding_stage_primary', 'TimestepPreparationStage', 'LatentPreparationStage', 'DenoisingStage', 'DecodingStage']
[05-18 02:56:47] [InputValidationStage] started...
[05-18 02:56:47] [InputValidationStage] finished in 0.0003 seconds
[05-18 02:56:47] [TextEncodingStage] started...
[rank0]:[W518 02:56:48.659609638 TensorFactories.cpp:340] Warning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (function operator())
[05-18 02:56:50] [TextEncodingStage] finished in 2.1961 seconds
[05-18 02:56:50] [TimestepPreparationStage] started...
[05-18 02:56:50] [TimestepPreparationStage] finished in 0.0015 seconds
[05-18 02:56:50] [LatentPreparationStage] started...
[05-18 02:56:50] [LatentPreparationStage] finished in 0.0005 seconds
[05-18 02:56:50] [DenoisingStage] started...

  0%|          | 0/50 [00:00<?, ?it/s]
  2%|▏         | 1/50 [00:46<37:59, 46.52s/it]
  4%|▍         | 2/50 [02:15<57:19, 71.66s/it]
  6%|▌         | 3/50 [03:44<1:02:23, 79.65s/it]
  8%|▊         | 4/50 [05:14<1:03:59, 83.47s/it]
 10%|█         | 5/50 [06:43<1:04:09, 85.54s/it]
 12%|█▏        | 6/50 [08:12<1:03:40, 86.84s/it]
 14%|█▍        | 7/50 [09:42<1:02:52, 87.72s/it]
 16%|█▌        | 8/50 [11:11<1:01:45, 88.22s/it]
 18%|█▊        | 9/50 [12:40<1:00:31, 88.56s/it]
 20%|██        | 10/50 [14:10<59:12, 88.82s/it] 
 22%|██▏       | 11/50 [15:39<57:52, 89.03s/it]
 24%|██▍       | 12/50 [17:09<56:28, 89.18s/it]
 26%|██▌       | 13/50 [18:38<55:01, 89.24s/it]
 28%|██▊       | 14/50 [20:08<53:33, 89.27s/it]
 30%|███       | 15/50 [21:37<52:04, 89.27s/it]
 32%|███▏      | 16/50 [23:06<50:36, 89.32s/it]
 34%|███▍      | 17/50 [24:36<49:09, 89.38s/it]
 36%|███▌      | 18/50 [26:05<47:39, 89.37s/it]
 38%|███▊      | 19/50 [27:35<46:10, 89.36s/it]
 40%|████      | 20/50 [29:04<44:40, 89.34s/it]
 42%|████▏     | 21/50 [30:33<43:11, 89.35s/it]
 44%|████▍     | 22/50 [32:03<41:42, 89.39s/it]
 46%|████▌     | 23/50 [33:32<40:12, 89.36s/it]
 48%|████▊     | 24/50 [35:01<38:42, 89.34s/it]
 50%|█████     | 25/50 [36:31<37:13, 89.32s/it]
 52%|█████▏    | 26/50 [38:00<35:44, 89.34s/it]
 54%|█████▍    | 27/50 [39:29<34:15, 89.37s/it]
 56%|█████▌    | 28/50 [40:59<32:45, 89.33s/it]
 58%|█████▊    | 29/50 [42:28<31:15, 89.31s/it]
 60%|██████    | 30/50 [43:57<29:45, 89.29s/it]
 62%|██████▏   | 31/50 [45:26<28:16, 89.31s/it]
 64%|██████▍   | 32/50 [46:56<26:48, 89.36s/it]
 66%|██████▌   | 33/50 [48:25<25:18, 89.35s/it]
 68%|██████▊   | 34/50 [49:55<23:49, 89.37s/it]
 70%|███████   | 35/50 [51:24<22:20, 89.35s/it]
 72%|███████▏  | 36/50 [52:53<20:51, 89.36s/it]
 74%|███████▍  | 37/50 [54:23<19:22, 89.41s/it]
 76%|███████▌  | 38/50 [55:52<17:52, 89.41s/it]
 78%|███████▊  | 39/50 [57:22<16:23, 89.40s/it]
 80%|████████  | 40/50 [58:51<14:53, 89.37s/it]
 82%|████████▏ | 41/50 [1:00:20<13:24, 89.38s/it]
 84%|████████▍ | 42/50 [1:01:50<11:55, 89.41s/it]
 86%|████████▌ | 43/50 [1:03:19<10:25, 89.38s/it]
 88%|████████▊ | 44/50 [1:04:49<08:56, 89.40s/it]
 90%|█████████ | 45/50 [1:06:18<07:26, 89.37s/it]
 92%|█████████▏| 46/50 [1:07:47<05:57, 89.38s/it]
 94%|█████████▍| 47/50 [1:09:17<04:28, 89.41s/it]
 96%|█████████▌| 48/50 [1:10:46<02:58, 89.37s/it]
 98%|█████████▊| 49/50 [1:12:15<01:29, 89.34s/it]
100%|██████████| 50/50 [1:13:45<00:00, 89.30s/it]
100%|██████████| 50/50 [1:13:45<00:00, 88.50s/it]
[05-18 04:10:35] [DenoisingStage] average time per step: 88.5009 seconds
[05-18 04:10:35] [DenoisingStage] finished in 4425.0530 seconds
[05-18 04:10:35] [DecodingStage] started...
[05-18 04:12:09] [DecodingStage] finished in 94.8128 seconds
[05-18 04:12:13] Output saved to [1;36moutputs/A_curious_raccoon_20260518-025647_7d574410.mp4[0;0m
[05-18 04:12:13] Pixel data generated successfully in [92m4525.87[0;0m seconds
[05-18 04:12:13] Memory usage - Max peak: 52634.00 MB, Avg peak: 52634.00 MB
[93m[05-18 04:12:13] Generator was garbage collected without being shut down. Attempting to shut down the local server and client.[0;0m
[05-18 04:12:14] Worker 0: Shutdown complete.
[93m[05-18 04:12:23] Local worker sglang-diffusionWorker-0 did not terminate gracefully, forcing.[0;0m

</details>

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

NA

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #26022951065](https://github.com/sgl-project/sglang/actions/runs/26022951065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->