### PR TITLE
fix: guard against empty/filtered LLM responses in backend and eval

### DIFF
--- a/benchmark/asr/bench_sglang.py
+++ b/benchmark/asr/bench_sglang.py
@@ -47,6 +47,8 @@ async def run_asr_chat(client, model_name, y, sr):
     )
     end_time = time.perf_counter()
 
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     asr_text = response.choices[0].message.content
     latency = end_time - start_time
     return latency, asr_text

--- a/benchmark/asr/bench_sglang.py
+++ b/benchmark/asr/bench_sglang.py
@@ -47,7 +47,11 @@ async def run_asr_chat(client, model_name, y, sr):
     )
     end_time = time.perf_counter()
 
-    if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
+    if (
+        not response.choices
+        or response.choices[0].message is None
+        or response.choices[0].message.content is None
+    ):
         raise ValueError("LLM returned empty or filtered response")
     asr_text = response.choices[0].message.content
     latency = end_time - start_time

--- a/benchmark/asr/bench_sglang.py
+++ b/benchmark/asr/bench_sglang.py
@@ -47,7 +47,7 @@ async def run_asr_chat(client, model_name, y, sr):
     )
     end_time = time.perf_counter()
 
-    if not response.choices or response.choices[0].message is None:
+    if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
         raise ValueError("LLM returned empty or filtered response")
     asr_text = response.choices[0].message.content
     latency = end_time - start_time

--- a/python/sglang/eval/loogle_eval.py
+++ b/python/sglang/eval/loogle_eval.py
@@ -115,6 +115,8 @@ def analyse(args):
         if isinstance(response, dict) and "error" in response:
             continue
 
+        if not response.choices or response.choices[0].message is None:
+            continue
         hyps.append(response.choices[0].message.content.strip())
         refs.append(ex["answer"])
 

--- a/python/sglang/eval/loogle_eval.py
+++ b/python/sglang/eval/loogle_eval.py
@@ -115,7 +115,7 @@ def analyse(args):
         if isinstance(response, dict) and "error" in response:
             continue
 
-        if not response.choices or response.choices[0].message is None:
+        if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
             continue
         hyps.append(response.choices[0].message.content.strip())
         refs.append(ex["answer"])

--- a/python/sglang/eval/loogle_eval.py
+++ b/python/sglang/eval/loogle_eval.py
@@ -115,7 +115,11 @@ def analyse(args):
         if isinstance(response, dict) and "error" in response:
             continue
 
-        if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
+        if (
+            not response.choices
+            or response.choices[0].message is None
+            or response.choices[0].message.content is None
+        ):
             continue
         hyps.append(response.choices[0].message.content.strip())
         refs.append(ex["answer"])

--- a/python/sglang/lang/backend/litellm.py
+++ b/python/sglang/lang/backend/litellm.py
@@ -63,7 +63,11 @@ class LiteLLM(BaseBackend):
             **self.client_params,
             **sampling_params.to_litellm_kwargs(),
         )
-        if not ret.choices or ret.choices[0].message is None:
+        if (
+            not ret.choices
+            or ret.choices[0].message is None
+            or ret.choices[0].message.content is None
+        ):
             raise ValueError("LLM returned empty or filtered response")
         comp = ret.choices[0].message.content
 

--- a/python/sglang/lang/backend/litellm.py
+++ b/python/sglang/lang/backend/litellm.py
@@ -63,6 +63,8 @@ class LiteLLM(BaseBackend):
             **self.client_params,
             **sampling_params.to_litellm_kwargs(),
         )
+        if not ret.choices or ret.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         comp = ret.choices[0].message.content
 
         return comp, {}

--- a/python/sglang/lang/backend/openai.py
+++ b/python/sglang/lang/backend/openai.py
@@ -394,6 +394,8 @@ def openai_completion(
                 if "stop" in kwargs and kwargs["stop"] is None:
                     kwargs.pop("stop")
                 ret = client.chat.completions.create(messages=prompt, **kwargs)
+                if not ret.choices or ret.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 if len(ret.choices) == 1:
                     comp = ret.choices[0].message.content
                 else:

--- a/python/sglang/lang/backend/openai.py
+++ b/python/sglang/lang/backend/openai.py
@@ -394,7 +394,7 @@ def openai_completion(
                 if "stop" in kwargs and kwargs["stop"] is None:
                     kwargs.pop("stop")
                 ret = client.chat.completions.create(messages=prompt, **kwargs)
-                if not ret.choices or ret.choices[0].message is None:
+                if not ret.choices or any(c.message is None for c in ret.choices):
                     raise ValueError("LLM returned empty or filtered response")
                 if len(ret.choices) == 1:
                     comp = ret.choices[0].message.content

--- a/python/sglang/lang/backend/openai.py
+++ b/python/sglang/lang/backend/openai.py
@@ -395,8 +395,7 @@ def openai_completion(
                     kwargs.pop("stop")
                 ret = client.chat.completions.create(messages=prompt, **kwargs)
                 if not ret.choices or any(
-                    c.message is None or c.message.content is None
-                    for c in ret.choices
+                    c.message is None or c.message.content is None for c in ret.choices
                 ):
                     raise ValueError("LLM returned empty or filtered response")
                 if len(ret.choices) == 1:

--- a/python/sglang/lang/backend/openai.py
+++ b/python/sglang/lang/backend/openai.py
@@ -394,7 +394,10 @@ def openai_completion(
                 if "stop" in kwargs and kwargs["stop"] is None:
                     kwargs.pop("stop")
                 ret = client.chat.completions.create(messages=prompt, **kwargs)
-                if not ret.choices or any(c.message is None for c in ret.choices):
+                if not ret.choices or any(
+                    c.message is None or c.message.content is None
+                    for c in ret.choices
+                ):
                     raise ValueError("LLM returned empty or filtered response")
                 if len(ret.choices) == 1:
                     comp = ret.choices[0].message.content


### PR DESCRIPTION
## What

Adds null checks before accessing `choices[0].message` in four files:

- `python/sglang/lang/backend/openai.py` — chat completion path in `run_program_stream`
- `python/sglang/lang/backend/litellm.py` — litellm completion path in `generate`
- `python/sglang/eval/loogle_eval.py` — eval loop (skip filtered responses instead of crash)
- `benchmark/asr/bench_sglang.py` — ASR benchmark

## Why

Two silent failure modes crash at these lines:

1. **`IndexError`** — `choices` is an empty list (`[]`) when the provider returns no completions
2. **`AttributeError`** — `choices[0].message` is `None` when content is filtered (some providers return HTTP 200 with `PROHIBITED_CONTENT` finish reason). The code is in a retry loop so this crash would exhaust retries instead of being caught.

## Fix

```python
if not ret.choices or ret.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

For the eval loop, the fix skips instead of crashing so the benchmark continues.

Detected by [pact](https://github.com/qizwiz/pact) static analysis.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26073239946](https://github.com/sgl-project/sglang/actions/runs/26073239946)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->