### PR TITLE
[npu] adapt NVIDIA-Nemotron-3-Super-120B on npu

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -2009,7 +2009,9 @@ class AscendAttnBackend(AttentionBackend):
                 )
                 return attn_out
 
-            if self.use_fia and getattr(self, "use_npu_fused_infer_attention_score", True):
+            if self.use_fia and getattr(
+                self, "use_npu_fused_infer_attention_score", True
+            ):
                 if self.forward_metadata.seq_lens_cpu_int is None:
                     actual_seq_len_kv = self.forward_metadata.seq_lens_cpu_list
                 else:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -284,6 +284,14 @@ class AscendAttnBackend(AttentionBackend):
                 in model_runner.model_config.hf_config.architectures
             ):
                 self.use_native_sdpa = True
+            elif (
+                "NemotronHForCausalLM"
+                in model_runner.model_config.hf_config.architectures
+            ):
+                self.use_native_sdpa = True
+                self.use_npu_paged_attention = False
+                self.use_npu_fused_infer_attention_score = False
+
         self.native_attn = AscendTorchNativeAttnBackend()
         self.graph_metadata = {}
         self.max_context_len = model_runner.model_config.context_len
@@ -2001,7 +2009,7 @@ class AscendAttnBackend(AttentionBackend):
                 )
                 return attn_out
 
-            if self.use_fia:
+            if self.use_fia and getattr(self, "use_npu_fused_infer_attention_score", True):
                 if self.forward_metadata.seq_lens_cpu_int is None:
                     actual_seq_len_kv = self.forward_metadata.seq_lens_cpu_list
                 else:
@@ -2046,7 +2054,11 @@ class AscendAttnBackend(AttentionBackend):
                     )
             # there are some accuracy issues in cross attention scene to use torch_npu._npu_flash_attention_qlens
             # forward_batch.encoder_lens is not None in cross attention scend, we add native attn to solve accuracy issues
-            elif forward_batch.encoder_lens is None and layer.logit_cap == 0:
+            elif (
+                forward_batch.encoder_lens is None
+                and layer.logit_cap == 0
+                and getattr(self, "use_npu_paged_attention", True)
+            ):
                 query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
                 num_tokens = query.shape[0]
                 if not self.use_alibi:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -12,8 +12,10 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     HybridLinearAttnBackend,
     MambaAttnBackendBase,
 )
+from sglang.srt.layers.attention.mamba.mamba import MambaMixer2
 from sglang.srt.layers.attention.mamba.mamba2_metadata import (
     ForwardMetadata,
+    Mamba2Metadata,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -205,7 +207,41 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
 
 
 class AscendMamba2AttnBackend(AscendMambaAttnBackendBase):
-    pass
+    """Ascend Attention backend wrapper for Mamba2Mixer kernels."""
+
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__(model_runner)
+        config = model_runner.mamba2_config
+        assert config is not None
+        self.mamba_chunk_size = config.mamba_chunk_size
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        metadata = self._forward_metadata(forward_batch)
+        self.forward_metadata = Mamba2Metadata.prepare_mixed(
+            metadata,
+            self.mamba_chunk_size,
+            forward_batch,
+        )
+
+    def forward(
+        self,
+        mixer: MambaMixer2,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+        layer_id: int,
+        mup_vector: Optional[torch.Tensor] = None,
+        use_triton_causal_conv: bool = False,
+    ):
+        assert isinstance(self.forward_metadata, Mamba2Metadata)
+        layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer_id)
+        return mixer.forward(
+            hidden_states=hidden_states,
+            output=output,
+            layer_cache=layer_cache,
+            metadata=self.forward_metadata,
+            mup_vector=mup_vector,
+            use_triton_causal_conv=use_triton_causal_conv,
+        )
 
 
 class AscendHybridLinearAttnBackend(HybridLinearAttnBackend):

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -17,7 +17,7 @@ from sglang.srt.layers.attention.mamba.mamba2_metadata import (
     ForwardMetadata,
     Mamba2Metadata,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardMode, ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput

--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -58,6 +58,8 @@ elif is_npu():
 
 LoaderFunction = Callable[[torch.Tensor, torch.Tensor], None]
 
+_is_npu = is_npu()
+
 logger = logging.getLogger(__name__)
 
 
@@ -519,9 +521,11 @@ class MambaMixer2(torch.nn.Module):
             )  # this is the form that causal-conv see
             ccfn = (
                 causal_conv1d_fn
-                if not use_triton_causal_conv
+                if not use_triton_causal_conv or _is_npu
                 else causal_conv1d_fn_triton
             )
+            if _is_npu:
+                conv_state = conv_state.transpose(-2, -1)
             hidden_states_B_C_p = ccfn(
                 x,
                 conv_weights,
@@ -618,9 +622,11 @@ class MambaMixer2(torch.nn.Module):
             else:
                 ccu = (
                     causal_conv1d_update
-                    if not use_triton_causal_conv
+                    if not use_triton_causal_conv or _is_npu
                     else causal_conv1d_update_triton
                 )
+                if _is_npu:
+                    conv_state = conv_state.transpose(-2, -1)
                 hidden_states_B_C_d = ccu(
                     hidden_states_B_C_d,
                     conv_state,

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
@@ -12,6 +12,7 @@ import torch
 import triton
 import triton.language as tl
 from packaging import version
+
 from sglang.srt.utils import is_npu
 
 _is_npu = is_npu()

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
@@ -12,7 +12,9 @@ import torch
 import triton
 import triton.language as tl
 from packaging import version
+from sglang.srt.utils import is_npu
 
+_is_npu = is_npu()
 TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
 
 
@@ -560,3 +562,220 @@ def _chunk_scan_fwd(
         HAS_INITSTATES=initial_states is not None,
     )
     return out_x
+
+
+def _chunk_scan_fwd_native(
+    cb,
+    x,
+    dt,
+    dA_cumsum,
+    C,
+    states,
+    D=None,
+    z=None,
+    seq_idx=None,
+    chunk_indices=None,
+    chunk_offsets=None,
+    initial_states=None,
+    out=None,
+):
+    """
+    PyTorch native implementation of chunk scan forward pass.
+    This avoids Triton compilation issues on Ascend NPU.
+    
+    Handles pseudo-chunk mechanism for continuous batching:
+    When chunk_indices/chunk_offsets are provided, iterates over logical chunks
+    (which handle sequence boundaries within physical chunks) instead of
+    physical chunks directly.
+    """
+    batch, seqlen, nheads, headdim = x.shape
+    _, _, nchunks, chunk_size = dt.shape
+    _, _, ngroups, dstate = C.shape
+    nheads_ngroups_ratio = nheads // ngroups
+
+    assert nheads % ngroups == 0
+    assert C.shape == (batch, seqlen, ngroups, dstate)
+    assert cb.shape == (batch, nchunks, ngroups, chunk_size, chunk_size)
+    if z is not None:
+        assert z.shape == x.shape
+    if D is not None:
+        assert D.shape == (nheads, headdim) or D.shape == (nheads,)
+    assert dt.shape == (batch, nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == (batch, nheads, nchunks, chunk_size)
+    assert states.shape == (batch, nchunks, nheads, headdim, dstate)
+    assert out.shape == x.shape
+
+    # Handle seq_idx and initial_states
+    has_initial_states = False
+    if seq_idx is not None:
+        assert seq_idx.shape == (batch, seqlen)
+        if initial_states is not None:
+            assert batch == 1, "chunk scan only supports initial states with batch 1"
+            assert chunk_indices is not None and chunk_offsets is not None
+            has_initial_states = True
+        else:
+            chunk_indices, chunk_offsets = None, None
+    else:
+        chunk_indices, chunk_offsets = None, None
+
+    # Prepare output
+    if z is not None:
+        out_x = torch.empty_like(x)
+    else:
+        out_x = None
+
+    def _process_logical_chunk(b, c_idx, c_off, chunk_size_limit, prev_states_chunk):
+        """Process a single logical chunk. All intermediates computed in float32 to match Triton."""
+        n_pos = chunk_size_limit - c_off
+        if n_pos <= 0:
+            return
+
+        start_pos = c_idx * chunk_size + c_off
+        end_pos = start_pos + n_pos
+
+        # Get chunk data — convert to float32 for computation (Triton uses float32 accumulators)
+        x_chunk = x[b, start_pos:end_pos, :, :].float()  # (n_pos, nheads, headdim)
+        C_chunk = C[b, start_pos:end_pos, :, :].float()  # (n_pos, ngroups, dstate)
+        dt_chunk = dt[b, :, c_idx, c_off:c_off + n_pos].float()  # (nheads, n_pos)
+        dA_cs_chunk = dA_cumsum[b, :, c_idx, c_off:c_off + n_pos]  # (nheads, n_pos) already float32
+        cb_chunk = cb[b, c_idx, :, c_off:c_off + n_pos, c_off:c_off + n_pos].float()  # (ngroups, n_pos, n_pos)
+
+        # Expand C for all heads: (n_pos, ngroups, dstate) -> (n_pos, nheads, dstate)
+        C_expanded = C_chunk.unsqueeze(2).expand(-1, -1, nheads_ngroups_ratio, -1)
+        C_expanded = C_expanded.reshape(n_pos, nheads, dstate)
+
+        # Expand cb for all heads: (ngroups, n_pos, n_pos) -> (nheads, n_pos, n_pos)
+        cb_expanded = cb_chunk.unsqueeze(1).expand(-1, nheads_ngroups_ratio, -1, -1)
+        cb_expanded = cb_expanded.reshape(nheads, n_pos, n_pos)
+
+        # Compute dA_cs_boundary for offset correction
+        if c_off > 0:
+            dA_cs_boundary = dA_cumsum[b, :, c_idx, c_off - 1]  # (nheads,) float32
+        else:
+            dA_cs_boundary = torch.zeros(nheads, device=x.device, dtype=torch.float32)
+
+        # Compute scale_m for C @ states contribution
+        if has_initial_states:
+            # With initial states: scale = exp(dA_cs - boundary)
+            scale = torch.exp(dA_cs_chunk - dA_cs_boundary.unsqueeze(-1))  # (nheads, n_pos)
+        elif seq_idx is not None:
+            # Without initial states but with seq_idx:
+            # Zero out contribution if sequence changed at chunk boundary
+            if c_idx > 0:
+                seq_idx_prev = seq_idx[b, c_idx * chunk_size - 1]
+            else:
+                seq_idx_prev = 0
+            seq_idx_m = seq_idx[b, start_pos:end_pos]  # (n_pos,)
+            # scale = where(seq_idx_m == seq_idx_prev, exp(dA_cs), 0)
+            seq_match = (seq_idx_m == seq_idx_prev).unsqueeze(0)  # (1, n_pos)
+            scale = torch.where(seq_match, torch.exp(dA_cs_chunk), torch.zeros_like(dA_cs_chunk))
+        else:
+            scale = torch.exp(dA_cs_chunk)  # (nheads, n_pos)
+
+        # Part 1: C @ prev_states * scale (all in float32)
+        # prev_states_chunk: (nheads, headdim, dstate)
+        C_t = C_expanded.transpose(0, 1)  # (nheads, n_pos, dstate) float32
+        states_t = prev_states_chunk.float().transpose(1, 2)  # (nheads, dstate, headdim) float32
+        C_states = torch.bmm(C_t, states_t)  # (nheads, n_pos, headdim) float32
+        C_states = C_states * scale.unsqueeze(-1)  # apply scale
+        C_states = C_states.transpose(0, 1)  # (n_pos, nheads, headdim)
+
+        # Part 2: causal cb @ x with dt and dA_cs weighting
+        # IMPORTANT: Must apply causal mask BEFORE exp to avoid overflow.
+        # In the upper triangle (m < k), dA_cs_m - dA_cs_k is large positive,
+        # which causes exp() to overflow to inf. Then inf * 0 (causal mask) = NaN.
+        # The Triton kernel avoids this by never computing the upper triangle at all.
+        causal_mask = torch.tril(torch.ones(n_pos, n_pos, device=x.device, dtype=torch.bool)).unsqueeze(0)  # (1, n_pos, n_pos)
+        dA_cs_m = dA_cs_chunk.unsqueeze(-1)  # (nheads, n_pos, 1)
+        dA_cs_k = dA_cs_chunk.unsqueeze(1)   # (nheads, 1, n_pos)
+        dt_expanded = dt_chunk.unsqueeze(1)   # (nheads, 1, n_pos) - dt at K positions, broadcast over M
+        dA_diff = dA_cs_m - dA_cs_k  # (nheads, n_pos, n_pos)
+        # Zero upper triangle before exp to prevent overflow (exp(0)=1, safe)
+        dA_diff = dA_diff.masked_fill(~causal_mask, 0.0)
+        cb_scaled = cb_expanded * torch.exp(dA_diff) * dt_expanded
+        # Zero upper triangle of result (where exp gave 1 instead of needed 0)
+        cb_scaled = cb_scaled.masked_fill(~causal_mask, 0.0)
+
+        # cb @ x: (nheads, n_pos, n_pos) @ (nheads, n_pos, headdim) — all float32
+        x_chunk_t = x_chunk.transpose(0, 1)  # (nheads, n_pos, headdim) float32
+        cb_x = torch.bmm(cb_scaled, x_chunk_t)  # (nheads, n_pos, headdim) float32
+        cb_x = cb_x.transpose(0, 1)  # (n_pos, nheads, headdim)
+
+        # Combine
+        out_chunk = C_states + cb_x
+
+        # Add D term (convert D to float32 to match out_chunk on NPU)
+        if D is not None:
+            if D.dim() == 2:
+                D_exp = D.float().unsqueeze(0)  # (1, nheads, headdim)
+            else:
+                D_exp = D.float().unsqueeze(0).unsqueeze(-1)  # (1, nheads, 1)
+            out_chunk = out_chunk + x_chunk * D_exp
+
+        # Apply SiLU gating (convert z to float32 to avoid mixed dtype on NPU)
+        if z is not None:
+            z_chunk = z[b, start_pos:end_pos, :, :].float()
+            if out_x is not None:
+                out_x[b, start_pos:end_pos, :, :] = out_chunk
+            z_silu = z_chunk * torch.sigmoid(z_chunk)
+            out_chunk = out_chunk * z_silu
+
+        out[b, start_pos:end_pos, :, :] = out_chunk
+
+    # Main loop
+    if not has_initial_states:
+        # Standard path: iterate over physical chunks
+        for b in range(batch):
+            for c in range(nchunks):
+                chunk_size_limit = min(chunk_size, seqlen - c * chunk_size)
+                if chunk_size_limit <= 0:
+                    continue
+                prev_states = states[b, c, :, :, :]  # (nheads, headdim, dstate)
+                _process_logical_chunk(b, c, 0, chunk_size_limit, prev_states)
+    else:
+        # Pseudo-chunk path: iterate over logical chunks
+        num_logical_chunks = len(chunk_indices)
+        for b in range(batch):
+            for lc in range(num_logical_chunks):
+                c_idx = chunk_indices[lc].item()
+                c_off = chunk_offsets[lc].item()
+
+                # Determine chunk_size_limit
+                chunk_size_limit = min(chunk_size, seqlen - c_idx * chunk_size)
+
+                # If next logical chunk is in same physical chunk, limit to its offset
+                if lc + 1 < num_logical_chunks:
+                    c_idx_next = chunk_indices[lc + 1].item()
+                    if c_idx == c_idx_next:
+                        c_off_next = chunk_offsets[lc + 1].item()
+                        chunk_size_limit = min(c_off_next, chunk_size_limit)
+
+                if chunk_size_limit - c_off <= 0:
+                    continue
+
+                # Determine prev_states: use states or initial_states
+                start_pos = c_idx * chunk_size + c_off
+                prev_states = states[b, c_idx, :, :, :]  # default
+
+                # Check if we need to use initial_states at sequence boundary
+                if c_idx > 0:
+                    seq_idx_prev = seq_idx[b, c_idx * chunk_size - 1].item()
+                else:
+                    seq_idx_prev = 0
+
+                if start_pos < seqlen:
+                    seq_idx_m = seq_idx[b, start_pos].item()
+                else:
+                    seq_idx_m = seq_idx_prev
+
+                # Replace with initial_states if at sequence boundary
+                if (c_off == 0 and seq_idx_prev != seq_idx_m) or c_off > 0:
+                    prev_states = initial_states[seq_idx_m, :, :, :]  # (nheads, headdim, dstate)
+
+                _process_logical_chunk(b, c_idx, c_off, chunk_size_limit, prev_states)
+
+    return out_x
+
+
+if _is_npu:
+    _chunk_scan_fwd = _chunk_scan_fwd_native

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -14,8 +14,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .mamba_ssm import softplus
 from sglang.srt.utils import is_npu
+
+from .mamba_ssm import softplus
 
 _is_npu = is_npu()
 

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -15,6 +15,9 @@ import triton
 import triton.language as tl
 
 from .mamba_ssm import softplus
+from sglang.srt.utils import is_npu
+
+_is_npu = is_npu()
 
 
 @triton.jit
@@ -644,3 +647,131 @@ def chunk_state_varlen(
             HAS_INITSTATES=initial_states is not None,
         )
     return states
+
+
+def _chunk_state_varlen_native(
+    B, x, dt, dA_cumsum, cu_seqlens, chunk_states, initial_states=None
+):
+    """
+    PyTorch native implementation of chunk_state_varlen.
+    This avoids Triton compilation issues on Ascend NPU.
+    """
+    total_seqlen, nheads, headdim = x.shape
+    _, nchunks, chunk_size = dt.shape
+    _, ngroups, dstate = B.shape
+    batch = cu_seqlens.shape[0] - 1
+    cu_seqlens = cu_seqlens.contiguous()
+    assert nheads % ngroups == 0
+    assert B.shape == (total_seqlen, ngroups, dstate)
+    assert dt.shape == (nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == dt.shape
+    assert chunk_states.shape == (nchunks, nheads, headdim, dstate)
+
+    if initial_states is not None:
+        assert initial_states.shape == (batch, nheads, headdim, dstate)
+
+    states = torch.empty(
+        batch,
+        nheads,
+        headdim,
+        dstate,
+        dtype=chunk_states.dtype,
+        device=chunk_states.device,
+    )
+    states.zero_()
+
+    nheads_ngroup = nheads // ngroups
+    HAS_INITSTATES = initial_states is not None
+    Block_SIZE_K = 16
+    out_dtype = chunk_states.dtype
+    compute_dtype = torch.float32  # Match Triton kernel: all intermediates in float32
+    device = chunk_states.device
+
+    x = x.contiguous()
+    B = B.contiguous()
+    dt = dt.contiguous()
+    dA_cumsum = dA_cumsum.contiguous()
+    chunk_states = chunk_states.contiguous()
+    if HAS_INITSTATES:
+        initial_states = initial_states.contiguous()
+
+    # Process each batch
+    for pid_b in range(batch):
+        start_idx = cu_seqlens[pid_b].item()
+        end_idx = cu_seqlens[pid_b + 1].item()
+        curr_seqlen = end_idx - start_idx
+        if curr_seqlen == 0:
+            continue
+
+        # Compute current chunk id
+        pid_c = (end_idx - 1) // chunk_size
+        pid_c = min(pid_c, nchunks - 1)
+        chunk_start = pid_c * chunk_size
+
+        # Compute valid length within chunk
+        chunk_size_limit = max(0, end_idx - chunk_start)
+        if chunk_size_limit <= 0:
+            continue
+        chunk_size_limit = min(chunk_size_limit, chunk_size)
+
+        # Process each head
+        for pid_h in range(nheads):
+            group_id = pid_h // nheads_ngroup
+
+            dt_chunk = dt[pid_h, pid_c, :chunk_size_limit].to(compute_dtype)
+            dA_cs_chunk = dA_cumsum[pid_h, pid_c, :chunk_size_limit].to(compute_dtype)
+            x_chunk = x[chunk_start:chunk_start+chunk_size_limit, pid_h, :].to(compute_dtype)
+            b_chunk = B[chunk_start:chunk_start+chunk_size_limit, group_id, :].to(compute_dtype)
+
+            # Initialize accumulator in float32 (matches Triton kernel)
+            acc = torch.zeros((headdim, dstate), dtype=compute_dtype, device=device)
+
+            # Iterate over chunk elements
+            for k in range(0, chunk_size_limit, Block_SIZE_K):
+                k_end = min(k + Block_SIZE_K, chunk_size_limit)
+                x_block = x_chunk[k:k_end, :]
+                b_block = b_chunk[k:k_end, :]
+                dt_block = dt_chunk[k:k_end]
+                dA_cs_k_block = dA_cs_chunk[k:k_end]
+
+                dA_cs_last = dA_cs_chunk[-1] if chunk_size_limit > 0 else torch.tensor(0.0, dtype=compute_dtype, device=device)
+
+                block_rel_pos = torch.arange(k_end - k, device=device)
+                chunk_block_start = k
+                start_idx_cur = max(start_idx - chunk_start, 0)
+                mask = block_rel_pos >= (start_idx_cur - chunk_block_start)
+                scale = torch.exp(dA_cs_last - dA_cs_k_block) * dt_block
+                scale = torch.where(mask, scale, torch.tensor(0.0, dtype=compute_dtype, device=device))
+
+                matmul_res = torch.matmul(x_block.T, b_block * scale.unsqueeze(-1))
+                acc += matmul_res
+
+            # Handle initial states / past states
+            if (start_idx < chunk_start) or HAS_INITSTATES:
+                dA_cs_boundary = torch.tensor(0.0, dtype=compute_dtype, device=device)
+
+                if not HAS_INITSTATES:
+                    past_states = chunk_states[pid_c, pid_h, :, :].to(compute_dtype)
+                else:
+                    if start_idx < chunk_start:
+                        past_states = chunk_states[pid_c, pid_h, :, :].to(compute_dtype)
+                    else:
+                        past_states = initial_states[pid_b, pid_h, :, :].to(compute_dtype)
+                        if start_idx > chunk_start:
+                            boundary_idx = start_idx - chunk_start - 1
+                            if 0 <= boundary_idx < chunk_size_limit:
+                                dA_cs_boundary = dA_cs_chunk[boundary_idx]
+
+                scale_state = torch.exp(dA_cs_last - dA_cs_boundary)
+                acc += past_states * scale_state
+
+            # Write to states (convert back to output dtype)
+            states[pid_b, pid_h, :, :] = acc.to(out_dtype)
+
+    return states
+
+
+if _is_npu:
+    from sgl_kernel_npu.mamba.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_sate_fwd
+
+    chunk_state_varlen = _chunk_state_varlen_native

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -772,6 +772,6 @@ def _chunk_state_varlen_native(
 
 
 if _is_npu:
-    from sgl_kernel_npu.mamba.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_sate_fwd
+    from sgl_kernel_npu.mamba.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd
 
     chunk_state_varlen = _chunk_state_varlen_native

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -13,10 +13,18 @@ import triton
 from einops import rearrange
 from packaging import version
 
+from sglang.srt.utils import is_npu
+
 from .ssd_bmm import _bmm_chunk_fwd
 from .ssd_chunk_scan import _chunk_scan_fwd
 from .ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd, chunk_state_varlen
 from .ssd_state_passing import _state_passing_fwd
+
+_is_npu = is_npu()
+
+if _is_npu:
+    from sgl_kernel_npu.mamba.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd
+
 
 TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
 

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -675,6 +675,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             hidden_states = swiglu_oai(layer, hidden_states)
         elif self.moe_runner_config.activation == "silu":
             hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+        elif self.moe_runner_config.activation == "relu2":
+            hidden_states = torch.relu(hidden_states) ** 2
         else:
             from sglang.srt.layers.activation import GeluAndMul
 

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -42,6 +42,9 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     Mamba2AttnBackend,
 )
 from sglang.srt.layers.attention.mamba.mamba import MambaMixer2
+from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend import (
+    AscendMamba2AttnBackend,
+)
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,
@@ -85,8 +88,10 @@ from sglang.srt.utils import (
 )
 from sglang.srt.utils.custom_op import register_custom_op
 from sglang.utils import logger
+from sglang.srt.utils import is_npu
 
 _is_cuda = is_cuda()
+_is_npu = is_npu()
 
 
 class NemotronHMLP(nn.Module):
@@ -416,7 +421,10 @@ class NemotronHMambaDecoderLayer(nn.Module):
         output = torch.empty_like(hidden_states)
         attn_backend = forward_batch.attn_backend
         assert isinstance(attn_backend, HybridLinearAttnBackend)
-        assert isinstance(attn_backend.linear_attn_backend, Mamba2AttnBackend)
+        if _is_npu:
+            assert isinstance(attn_backend.linear_attn_backend, AscendMamba2AttnBackend)
+        else:
+            assert isinstance(attn_backend.linear_attn_backend, Mamba2AttnBackend)
         attn_backend.linear_attn_backend.forward(
             mixer=self.mixer,
             layer_id=self.layer_id,

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -42,9 +42,6 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     Mamba2AttnBackend,
 )
 from sglang.srt.layers.attention.mamba.mamba import MambaMixer2
-from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend import (
-    AscendMamba2AttnBackend,
-)
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,
@@ -84,11 +81,11 @@ from sglang.srt.utils import (
     add_prefix,
     get_current_device_stream_fast,
     is_cuda,
+    is_npu,
     make_layers,
 )
 from sglang.srt.utils.custom_op import register_custom_op
 from sglang.utils import logger
-from sglang.srt.utils import is_npu
 
 _is_cuda = is_cuda()
 _is_npu = is_npu()
@@ -422,6 +419,10 @@ class NemotronHMambaDecoderLayer(nn.Module):
         attn_backend = forward_batch.attn_backend
         assert isinstance(attn_backend, HybridLinearAttnBackend)
         if _is_npu:
+            from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend import (
+                AscendMamba2AttnBackend,
+            )
+
             assert isinstance(attn_backend.linear_attn_backend, AscendMamba2AttnBackend)
         else:
             assert isinstance(attn_backend.linear_attn_backend, Mamba2AttnBackend)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

adapt NVIDIA-Nemotron-3-Super-120B on npu
Ensure that PR https://github.com/sgl-project/sglang/pull/23783/changes is merged before merging this one. 

## Modifications

Introduce  two Triton operators(_chunk_cumsum_fwd and _chunk_sate_fwd) based on PR https://github.com/sgl-project/sglang/pull/23783/changes.
Introduce two native operators(_chunk_state_varlen_native and _chunk_scan_fwd_native) based on commit https://github.com/sgl-project/sglang/compare/main...sigama-w:sglang:granite_concise.
Add the logic for relu2.Integrate and adapt the conv1d operator.

## Accuracy Tests

Accuracy: 0.965
<img width="937" height="80" alt="image" src="https://github.com/user-attachments/assets/ba010453-e061-4a01-bb57-c3f0cbc5cf73" />


## Scipts

```shell
MODEL_PATH=/home/weights/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/
# export ASCEND_USE_FIA=True
python3 -m sglang.launch_server --model "${MODEL_PATH}" --tp 8  --base-gpu-id 8 --trust-remote-code --attention-backend ascend --device npu --mem-fraction-static 0.8 --host 127.0.0.1 --port 8015 --disable-cuda-graph
```

```shell
python ./sglang/benchmark/gsm8k/bench_sglang.py --data-path /home/gjs/test.jsonl --port 8015 --num-questions 200
```













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26030828223](https://github.com/sgl-project/sglang/actions/runs/26030828223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->