### PR TITLE
Hoist hisparse and decode-offload setup out of init_cache_with_memory_pool

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -453,6 +453,29 @@ class Scheduler(
         # Init cache and memory pool
         self.init_cache_with_memory_pool()
 
+        if self.enable_hisparse:
+            # Coordinator was created inside ModelRunner.initialize() before CUDA graph capture
+            self.hisparse_coordinator = self.tp_worker.model_runner.hisparse_coordinator
+            self.hisparse_coordinator.set_decode_producer_stream(self.forward_stream)
+
+        if (
+            self.server_args.disaggregation_mode == "decode"
+            and self.server_args.disaggregation_decode_enable_offload_kvcache
+        ):
+            self.decode_offload_manager = DecodeKVCacheOffloadManager(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                tp_group=(
+                    self.attn_tp_cpu_group
+                    if self.server_args.enable_dp_attention
+                    else self.tp_cpu_group
+                ),
+                tree_cache=self.tree_cache,
+                server_args=self.server_args,
+            )
+        else:
+            self.decode_offload_manager = None
+
         # Register draft KV pool (when spec + HiCache co-enabled).
         kv_cache_builder.maybe_register_hicache_draft(
             tree_cache=self.tree_cache,
@@ -984,25 +1007,6 @@ class Scheduler(
             and not self.tree_cache.supports_streaming_session()
         ):
             self.tree_cache = StreamingSession(self.tree_cache)
-
-        if self.enable_hisparse:
-            # Coordinator was created inside ModelRunner.initialize() before CUDA graph capture
-            self.hisparse_coordinator = self.tp_worker.model_runner.hisparse_coordinator
-            self.hisparse_coordinator.set_decode_producer_stream(self.forward_stream)
-
-        if (
-            server_args.disaggregation_mode == "decode"
-            and server_args.disaggregation_decode_enable_offload_kvcache
-        ):
-            self.decode_offload_manager = DecodeKVCacheOffloadManager(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                tp_group=params.tp_cache_group,
-                tree_cache=self.tree_cache,
-                server_args=self.server_args,
-            )
-        else:
-            self.decode_offload_manager = None
 
         embedding_cache_size = envs.SGLANG_VLM_CACHE_SIZE_MB.get()
         init_mm_embedding_cache(embedding_cache_size * 1024 * 1024)


### PR DESCRIPTION
Pure block-move pre-prep for ``extract-build-kv-cache``.

Move tail blocks from the body of
``Scheduler.init_cache_with_memory_pool`` to ``Scheduler.__init__``,
immediately after the ``self.init_cache_with_memory_pool()`` call:

- ``if self.enable_hisparse: ...`` (``hisparse_coordinator`` ref-grab +
  ``set_decode_producer_stream(...)``).
- ``if (server_args.disaggregation_mode == "decode" and ...): ...
  else: self.decode_offload_manager = None`` (decode-offload manager
  construction).

Method-local refs that no longer resolve in ``Scheduler.__init__`` are
rewritten to their ``self.X`` form:

- ``server_args.disaggregation_mode`` → ``self.server_args.disaggregation_mode``
- ``server_args.disaggregation_decode_enable_offload_kvcache`` →
  ``self.server_args.disaggregation_decode_enable_offload_kvcache``
- ``params.tp_cache_group`` (local alias) → the inlined conditional
  ``(self.attn_tp_cpu_group if self.server_args.enable_dp_attention else
  self.tp_cpu_group)``.

Diff is one delete from
``Scheduler.init_cache_with_memory_pool`` plus one insert into
``Scheduler.__init__``. ``git --color-moved`` should mark the relocated
lines as moved (modulo the ref rewrites listed above).

Refactor chain ID: extract-build-kv-cache-pre-move



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->