### PR TITLE
Pre-declare mode-conditional Scheduler fields with explicit defaults

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -423,6 +423,12 @@ class Scheduler(
         # Init inter-process communication
         self.init_ipc_channels(port_args)
 
+        self.mm_receiver = None
+        self.disagg_prefill_bootstrap_queue = None
+        self.disagg_prefill_inflight_queue = None
+        self.disagg_decode_prealloc_queue = None
+        self.disagg_decode_transfer_queue = None
+
         # Init ZBAL, switch allocator should before any torch alloc action
         self.init_zbal_on_npu()
 


### PR DESCRIPTION
Pre-declare the mode-conditional Scheduler fields with ``None`` defaults
at the top of ``Scheduler.__init__``:

- ``self.mm_receiver`` — populated by ``init_disaggregation`` under mm mode
- ``self.disagg_prefill_bootstrap_queue`` — populated under disagg-prefill mode
- ``self.disagg_prefill_inflight_queue`` — populated under disagg-prefill mode
- ``self.disagg_decode_prealloc_queue`` — populated under disagg-decode mode
- ``self.disagg_decode_transfer_queue`` — populated under disagg-decode mode

These fields are read eagerly by sister-component ctors that the next
mech commits (``introduce-scheduler-request-receiver-prep`` onwards)
will introduce. Without this pre-init, those eager reads would either
need ``getattr(self, "X", DEFAULT)`` defenses (violates
``coding-style.md``) or only-work-in-mode-X conditional logic. With this
pre-init, every read site can use plain ``self.X``.

``self.enable_overlap_mlx`` is intentionally NOT pre-declared here even
though it is mode-conditional: the real assignment runs earlier in
``__init__`` (before this insertion point), so any pre-init at this
location would silently overwrite the correct value and disable MLX
overlap. The field is already unconditionally bound by the real
assignment, so no defensive pre-init is required.

Single commit, single logical change: establish "field always exists"
invariant. Follows ``MECH_COMMIT_SPLIT.md`` "trivial ``getattr`` → direct
attr access" single-commit exception.

Refactor chain ID: init-mode-conditional-defaults



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->