### PR TITLE
Move on_idle from runtime_checker mixin into Scheduler

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3031,6 +3031,37 @@ class Scheduler(
             if_success = False
         return ClearHiCacheReqOutput(success=if_success)
 
+    def on_idle(self):
+        """Idle housekeeping: guard, check, metrics, reset, sleep."""
+        if not self.is_fully_idle():
+            return
+
+        # memory leak check (skipped for hisparse — pool counters intentionally
+        # diverge during host-backup, see _get_swa_token_info clamp).
+        if not self.enable_hisparse:
+            has_leak, messages = self._check_all_pools(self.get_pool_stats())
+            if has_leak:
+                self._report_leak("pool", "\n".join(messages))
+            self._check_req_pool()
+
+        # tree cache sanity check
+        self._check_tree_cache()
+
+        # metrics every 30s
+        self._maybe_log_idle_metrics()
+
+        # kv event publishing
+        self._publish_kv_events()
+
+        # reset token ratio
+        self.new_token_ratio = self.init_new_token_ratio
+
+        # reset device timer window so idle time isn't counted
+        self.reset_device_timer_window()
+
+        # sleep until next event
+        self.maybe_sleep_on_idle()
+
     def is_fully_idle(self, for_health_check=False) -> bool:
         # Health check piggybacks on running requests in process_output.
         # Only running_batch + waiting_queue guarantee active GPU processing;

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -548,37 +548,6 @@ class SchedulerRuntimeCheckerMixin:
         ):
             self.tree_cache.sanity_check()
 
-    def on_idle(self: Scheduler):
-        """Idle housekeeping: guard, check, metrics, reset, sleep."""
-        if not self.is_fully_idle():
-            return
-
-        # memory leak check (skipped for hisparse — pool counters intentionally
-        # diverge during host-backup, see _get_swa_token_info clamp).
-        if not self.enable_hisparse:
-            has_leak, messages = self._check_all_pools(self.get_pool_stats())
-            if has_leak:
-                self._report_leak("pool", "\n".join(messages))
-            self._check_req_pool()
-
-        # tree cache sanity check
-        self._check_tree_cache()
-
-        # metrics every 30s
-        self._maybe_log_idle_metrics()
-
-        # kv event publishing
-        self._publish_kv_events()
-
-        # reset token ratio
-        self.new_token_ratio = self.init_new_token_ratio
-
-        # reset device timer window so idle time isn't counted
-        self.reset_device_timer_window()
-
-        # sleep until next event
-        self.maybe_sleep_on_idle()
-
 
 def create_scheduler_watchdog(
     scheduler: Scheduler, watchdog_timeout: float, soft: bool = False


### PR DESCRIPTION
Move ``on_idle`` (the idle housekeeping orchestrator) from
``scheduler_runtime_checker_mixin.py`` into the Scheduler main class
(``scheduler.py``), per the explicit human decision on this method's
ownership in ``components/scheduler/index.md``.

The method is placed immediately before ``Scheduler.is_fully_idle`` to
keep the idle-related cluster contiguous. Body is byte-identical apart
from dropping the ``self: Scheduler`` parameter annotation (now redundant
since it lives on Scheduler directly).

``_maybe_log_idle_metrics`` (``on_idle``'s metric flush helper) is
intentionally NOT moved here. It is a metrics-collection routine, not an
orchestrator, so it gets relocated directly from
``SchedulerRuntimeCheckerMixin`` into ``SchedulerMetricsReporter`` by a
downstream commit (``maybe-log-idle-metrics-to-metrics-reporter-move``).
Until that commit runs, ``self._maybe_log_idle_metrics()`` inside
``on_idle`` continues to resolve via mixin inheritance.

No behavior change. Subsequent commits (``introduce-pool-stats-observer`` /
``introduce-invariant-checker`` / ``introduce-kv-events-publisher`` /
``introduce-metrics-reporter``) will rewire the cross-class calls this
body makes (``self.get_pool_stats()`` / ``self._check_all_pools`` /
``self._publish_kv_events`` / ``self.reset_device_timer_window`` etc.) to
the new sister components.

Refactor chain ID: on-idle-to-scheduler-main-move



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->