### PR TITLE
Move create_scheduler_watchdog from runtime_checker mixin to scheduler.py

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -187,7 +187,6 @@ from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
 from sglang.srt.managers.scheduler_recv_skipper import SchedulerRecvSkipper
 from sglang.srt.managers.scheduler_runtime_checker_mixin import (
     SchedulerRuntimeCheckerMixin,
-    create_scheduler_watchdog,
 )
 from sglang.srt.managers.utils import GenerationBatchResult, validate_input_length
 from sglang.srt.mem_cache import kv_cache_builder
@@ -238,6 +237,7 @@ from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+from sglang.srt.utils.watchdog import WatchdogRaw
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
 if is_mps():
@@ -320,6 +320,30 @@ def validate_dflash_request(req: Req) -> Optional[str]:
         )
 
     return None
+
+
+def create_scheduler_watchdog(
+    scheduler: "Scheduler", watchdog_timeout: float, soft: bool = False
+) -> WatchdogRaw:
+    def dump_info() -> str:
+        if scheduler.is_initializing:
+            return ""
+        _, messages = scheduler._check_all_pools(
+            scheduler.pool_stats_observer.get_pool_stats()
+        )
+        return (
+            f"{scheduler.cur_batch.batch_size()=}\n"
+            f"{scheduler.cur_batch.reqs=}\n" + "\n".join(messages)
+        )
+
+    return WatchdogRaw(
+        debug_name="Scheduler",
+        get_counter=lambda: scheduler.forward_ct,
+        is_active=lambda: scheduler.is_initializing or scheduler.cur_batch is not None,
+        watchdog_timeout=watchdog_timeout,
+        soft=soft,
+        dump_info=dump_info,
+    )
 
 
 class Scheduler(

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -9,7 +9,6 @@ from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.observability.metrics_collector import QueueCount
 from sglang.srt.utils.common import ceil_align, raise_error_or_warn
-from sglang.srt.utils.watchdog import WatchdogRaw
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
@@ -281,27 +280,3 @@ class SchedulerRuntimeCheckerMixin:
             or (self.is_hybrid_ssm and self.tree_cache.supports_mamba())
         ):
             self.tree_cache.sanity_check()
-
-
-def create_scheduler_watchdog(
-    scheduler: Scheduler, watchdog_timeout: float, soft: bool = False
-) -> WatchdogRaw:
-    def dump_info() -> str:
-        if scheduler.is_initializing:
-            return ""
-        _, messages = scheduler._check_all_pools(
-            scheduler.pool_stats_observer.get_pool_stats()
-        )
-        return (
-            f"{scheduler.cur_batch.batch_size()=}\n"
-            f"{scheduler.cur_batch.reqs=}\n" + "\n".join(messages)
-        )
-
-    return WatchdogRaw(
-        debug_name="Scheduler",
-        get_counter=lambda: scheduler.forward_ct,
-        is_active=lambda: scheduler.is_initializing or scheduler.cur_batch is not None,
-        watchdog_timeout=watchdog_timeout,
-        soft=soft,
-        dump_info=dump_info,
-    )


### PR DESCRIPTION
Pre-prep for the ``introduce-invariant-checker`` mech split.

Cut ``create_scheduler_watchdog`` (module-level free function) from
``scheduler_runtime_checker_mixin.py`` and paste verbatim just before
``class Scheduler(`` in ``scheduler.py``. Wrap the ``scheduler: Scheduler``
annotation in a string forward reference (``scheduler: "Scheduler"``)
because ``Scheduler`` is defined later in the same module.

Imports updated:
- ``scheduler.py``: drop ``create_scheduler_watchdog`` from the grouped
  ``from sglang.srt.managers.scheduler_runtime_checker_mixin import (...)``
  block; add ``from sglang.srt.utils.watchdog import WatchdogRaw``.
- ``scheduler_runtime_checker_mixin.py``: drop the now-unused
  ``from sglang.srt.utils.watchdog import WatchdogRaw`` import.

Body otherwise byte-identical (``git --color-moved=dimmed-zebra`` shows the
moved function as a single hunk). This is a pure mechanical relocation of
an already-existing free function (per MECH_COMMIT_SPLIT.md "何时不拆"
single-commit exception).

Refactor chain ID: introduce-invariant-checker-pre-move



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->