### PR TITLE
Delete the now-unused is_work_request from scheduler.py

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3707,18 +3707,6 @@ class Scheduler(
         pass
 
 
-def is_work_request(recv_req):
-    return isinstance(
-        recv_req,
-        (
-            TokenizedGenerateReqInput,
-            TokenizedEmbeddingReqInput,
-            BatchTokenizedGenerateReqInput,
-            BatchTokenizedEmbeddingReqInput,
-        ),
-    )
-
-
 def dispatch_event_loop(scheduler: Scheduler):
     # Dispatch to the appropriate event loop based on the disaggregation mode
     server_args = scheduler.server_args


### PR DESCRIPTION
Non-mech cleanup tail commit for the preceding free-item relocation.

Deletes ``is_work_request`` in ``scheduler.py`` — codebase-wide grep
shows zero callers (dead code from a now-defunct dispatch path).

Refactor chain ID: cleanup-scheduler-py-free-items









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->[Run #26028725481](https://github.com/sgl-project/sglang/actions/runs/26028725481)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not run on latest push** — push again to dispatch.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->