### PR TITLE
Fix flush_cache AttributeError on is_stats_logging_rank

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3320,7 +3320,7 @@ class Scheduler(
                 current_platform.empty_cache()
             # Per-DP-group leader logs once: ranks within a DP group are
             # state-synchronous, but DP groups may diverge.
-            if self.is_stats_logging_rank:
+            if self.metrics_reporter.is_stats_logging_rank:
                 logger.info("Cache flushed successfully!")
             success = True
         else:


### PR DESCRIPTION
## Summary
- `flush_cache` still accesses `self.is_stats_logging_rank` after PR #25630 moved that attribute onto `SchedulerMetricsReporter`. Any call to `/flush_cache` crashes the Scheduler with `AttributeError: 'Scheduler' object has no attribute 'is_stats_logging_rank'`, which then triggers `SIGQUIT` and tears the server down.
- Fix is one line: route the access through `self.metrics_reporter`, matching the other accesses in `flush_cache` (e.g. `self.metrics_reporter.reset_metrics()` two lines above).

## Repro
This crashes any scheduled / manual main CI run today — e.g. https://github.com/sgl-project/sglang/actions/runs/26029167069 — because `bench_serving` posts to `/flush_cache` between warmup and the actual benchmark. Four jobs failed for the same reason (`base-b-test-1-gpu-large/small`, `extra-a-test-1-gpu-large`).

Server-side traceback:

```
File "python/sglang/srt/managers/scheduler.py", line 3323, in flush_cache
    if self.is_stats_logging_rank:
AttributeError: 'Scheduler' object has no attribute 'is_stats_logging_rank'
[...] SIGQUIT received [...]
```

## Test plan
- [x] `pre-commit run --files python/sglang/srt/managers/scheduler.py`
- [ ] Full CI on this PR (requesting `run-ci` + `run-ci-extra`)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26030411397](https://github.com/sgl-project/sglang/actions/runs/26030411397)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not run on latest push** -- push again to dispatch.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->