### PR TITLE
Sandbox: verify full main CI is green on latest main (do not merge)

### DIFF
--- a/python/sglang/version.py
+++ b/python/sglang/version.py
@@ -1,3 +1,4 @@
+# sandbox-verify-main-ci: 20260625T010800Z (do not merge)
 try:
     from sglang._version import __version__, __version_tuple__
 except ImportError:


### PR DESCRIPTION
## Summary

Sandbox PR — **do not merge**. Touches `python/sglang/version.py` with a no-op comment so paths-filter flips `main_package=true` and the full PR Test Base + PR Test Extra matrix dispatches.

Carries three labels so the workflow gates all pass:

| Label | Effect |
|---|---|
| `run-ci` | Passes `pr-gate.yml`'s `require-run-ci` gate |
| `run-ci-extra` | Allows `pr-test-extra.yml` to run on this `pull_request` event |
| `bypass-fastfail` | Makes the per-job `check-pr-test-health` action no-op (no cascade fast-fail when a single sibling fails on infra flake) |

Purpose: verify upstream/main (`f04c522534`) is green end-to-end with the full CI surface (base stages + extra stages, no fast-fail cascade). This is the PR-side equivalent of the dispatched main CI; cleaner than `gh workflow run` because the dispatch interface cannot pass `skip_pr_test_health_check`.

Close this PR after the run completes — no source change is intended to land.

## Test plan

- [x] `pre-commit run --files python/sglang/version.py`
- [ ] PR Test Base dispatches and runs to completion
- [ ] PR Test Extra dispatches and runs to completion
- [ ] No `check-pr-test-health` cascade failures







































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #28140041083](https://github.com/sgl-project/sglang/actions/runs/28140041083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28140040929](https://github.com/sgl-project/sglang/actions/runs/28140040929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->