### PR TITLE
[AMD] Guard Qwen3.5 layers against empty hidden states

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -463,6 +463,9 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         2. Core attention (custom op)
         3. Output projection
         """
+        if hidden_states.shape[0] == 0:
+            return hidden_states
+
         projected_states_qkvz, projected_states_ba = self._forward_input_proj(
             hidden_states
         )
@@ -848,6 +851,8 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
+        if hidden_states.shape[0] == 0:
+            return hidden_states
         qkv, _ = self.qkv_proj(hidden_states)
 
         if self.attn_output_gate:

--- a/test/registered/unit/models/test_qwen3_5_empty_tensor.py
+++ b/test/registered/unit/models/test_qwen3_5_empty_tensor.py
@@ -1,0 +1,60 @@
+"""Unit tests for Qwen3.5 empty hidden state handling in local compute paths."""
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.models.qwen3_5 import (
+    Qwen3_5AttentionDecoderLayer,
+    Qwen3_5GatedDeltaNet,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _SentinelCalled(RuntimeError):
+    pass
+
+
+def _raise(name):
+    raise _SentinelCalled(f"{name} was called for an empty hidden_states tensor")
+
+
+def _empty_hidden_states():
+    return torch.empty((0, 64), dtype=torch.float32)
+
+
+class TestQwen3_5EmptyTensor(CustomTestCase):
+    def test_gated_delta_net_skips_input_proj_on_empty(self):
+        """GatedDeltaNet returns early before _forward_input_proj on empty input."""
+        layer = object.__new__(Qwen3_5GatedDeltaNet)
+        layer._forward_input_proj = types.MethodType(
+            lambda self, hidden_states: _raise("_forward_input_proj"),
+            layer,
+        )
+
+        output = Qwen3_5GatedDeltaNet.forward(layer, _empty_hidden_states(), object())
+
+        self.assertEqual(output.shape, torch.Size([0, 64]))
+
+    def test_self_attention_skips_qkv_proj_on_empty(self):
+        """self_attention returns early before qkv_proj on empty input."""
+        layer = object.__new__(Qwen3_5AttentionDecoderLayer)
+        layer.qkv_proj = types.MethodType(
+            lambda self, hidden_states: _raise("qkv_proj"),
+            layer,
+        )
+        positions = torch.empty((0,), dtype=torch.long)
+
+        output = Qwen3_5AttentionDecoderLayer.self_attention(
+            layer, positions, _empty_hidden_states(), object()
+        )
+
+        self.assertEqual(output.shape, torch.Size([0, 64]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Some Qwen3.5 execution paths can receive empty `hidden_states` tensors, for example when a rank has no active tokens during scheduling or graph-capture related paths.

For empty inputs, Qwen3.5 local compute paths should preserve the empty tensor contract instead of entering projection or attention kernels that expect non-empty work. This PR adds narrow guards around the local compute paths while preserving the layer-level communicator flow, so DP collective operations remain synchronized across ranks.

## Modifications

- Return early from `Qwen3_5GatedDeltaNet.forward` when `hidden_states.shape[0] == 0`.
- Return early from `Qwen3_5AttentionDecoderLayer.self_attention` when `hidden_states.shape[0] == 0`.
- Add unit tests that verify empty hidden states do not enter downstream local compute sentinel paths.

## Test plan

```bash
PYTHONPATH=python python3 -m pytest test/registered/unit/models/test_qwen3_5_empty_tensor.py -q