### PR TITLE
Fix AttributeError in encode_arguments_to_dsml for non-dict JSON values

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -155,7 +155,9 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
         arguments = tool_call["arguments"]
 
     if not isinstance(arguments, dict):
-        arguments = {"arguments": arguments if isinstance(arguments, str) else to_json(arguments)}
+        arguments = {
+            "arguments": arguments if isinstance(arguments, str) else to_json(arguments)
+        }
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -152,7 +152,10 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
     try:
         arguments = json.loads(tool_call["arguments"])
     except Exception as err:
-        arguments = {"arguments": tool_call["arguments"]}
+        arguments = tool_call["arguments"]
+
+    if not isinstance(arguments, dict):
+        arguments = {"arguments": arguments if isinstance(arguments, str) else to_json(arguments)}
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(


### PR DESCRIPTION
## Motivation

`encode_arguments_to_dsml()` in `encoding_dsv4.py` crashes with `AttributeError: "str" object has no attribute "items"` when `tool_call["arguments"]` is a valid JSON-encoded **scalar** value (e.g. `"\"San Francisco\""`, `"42"`, `"true"`).

### Root cause

```python
try:
    arguments = json.loads(tool_call["arguments"])  # succeeds, returns str
except Exception:
    arguments = {"arguments": tool_call["arguments"]}  # only reached on parse failure

for k, v in arguments.items():  # AttributeError when arguments is str
```

`json.loads()` succeeds for valid JSON scalars but returns a non-dict Python type (`str`, `int`, `float`, `bool`, `list`). The `except` branch only handles parse failures, not successful-but-non-dict results.

## Modifications

- Add an `isinstance(arguments, dict)` guard after the `json.loads()` / `except` block.
- Non-dict values are wrapped into `{"arguments": <value>}` to provide a consistent dict structure for the `.items()` iteration.

```diff
     try:
         arguments = json.loads(tool_call["arguments"])
     except Exception:
-        arguments = {"arguments": tool_call["arguments"]}
+        arguments = tool_call["arguments"]
+
+    if not isinstance(arguments, dict):
+        arguments = {"arguments": arguments if isinstance(arguments, str) else to_json(arguments)}
 
     for k, v in arguments.items():
```

## Verification

Reproduced and verified on a 2-node 16×H100 cluster running DeepSeek-V4-Flash-FP8 in PD disaggregation mode (SGLang `v0.0.0.dev1+gedb1b3f8f`):

**Before fix** — request with `tool_calls[].function.arguments = "\"San Francisco\""` → HTTP 500:
```
AttributeError: "str" object has no attribute "items"
  File "encoding_dsv4.py", line 157, in encode_arguments_to_dsml
```

**After fix** — same request → HTTP 200, correct response.

## Checklist

- [x] 1-file change, minimal scope
- [x] No new dependencies
- [x] Backward compatible (dict arguments unaffected)
- [x] Tested on live cluster















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26060401435](https://github.com/sgl-project/sglang/actions/runs/26060401435)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->