### PR TITLE
Add GB10 FP8 fused MoE Triton config

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_GB10,dtype=fp8_w8a8.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_GB10,dtype=fp8_w8a8.json
@@ -1,0 +1,146 @@
+{
+  "1": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 5
+  },
+  "2": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 8,
+    "num_stages": 2
+  },
+  "4": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 8,
+    "num_stages": 4
+  },
+  "8": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 8,
+    "num_stages": 4
+  },
+  "16": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 8,
+    "num_stages": 4
+  },
+  "24": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "32": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 5
+  },
+  "48": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 5
+  },
+  "64": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 2
+  },
+  "96": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 5
+  },
+  "128": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 4
+  },
+  "256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 3
+  },
+  "512": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 4
+  },
+  "1024": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 8,
+    "num_stages": 2
+  },
+  "1536": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "2048": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "3072": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "4096": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 64,
+    "num_warps": 4,
+    "num_stages": 3
+  }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -14,6 +14,26 @@ from sglang.srt.utils import get_device_name, is_hip
 
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
+_LOW_SMEM_FP8_DEFAULT_CUTOFF_BYTES = 128 * 1024
+
+
+@functools.lru_cache(maxsize=None)
+def _get_cuda_shared_memory_per_block_optin() -> Optional[int]:
+    if _is_hip or not torch.cuda.is_available():
+        return None
+    try:
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    except (AssertionError, RuntimeError):
+        return None
+    return getattr(props, "shared_memory_per_block_optin", None)
+
+
+def _use_low_smem_fp8_default() -> bool:
+    smem_limit = _get_cuda_shared_memory_per_block_optin()
+    return (
+        smem_limit is not None
+        and smem_limit < _LOW_SMEM_FP8_DEFAULT_CUTOFF_BYTES
+    )
 
 
 def get_config_file_name(
@@ -163,23 +183,42 @@ def get_default_config(
         return config
     if dtype == "fp8_w8a8":
         if block_shape is None:
-            config = {
-                "BLOCK_SIZE_M": 128,
-                "BLOCK_SIZE_N": 256,
-                "BLOCK_SIZE_K": 128,
-                "GROUP_SIZE_M": 32,
-                "num_warps": 8,
-                "num_stages": 2 if _is_hip else 4,
-            }
-            if M <= E:
+            if _use_low_smem_fp8_default():
                 config = {
-                    "BLOCK_SIZE_M": 64,
-                    "BLOCK_SIZE_N": 128,
-                    "BLOCK_SIZE_K": 128,
+                    "BLOCK_SIZE_M": 32,
+                    "BLOCK_SIZE_N": 64,
+                    "BLOCK_SIZE_K": 256,
                     "GROUP_SIZE_M": 1,
                     "num_warps": 4,
+                    "num_stages": 4,
+                }
+                if M > E:
+                    config = {
+                        "BLOCK_SIZE_M": 64,
+                        "BLOCK_SIZE_N": 128,
+                        "BLOCK_SIZE_K": 256,
+                        "GROUP_SIZE_M": 64,
+                        "num_warps": 4,
+                        "num_stages": 2,
+                    }
+            else:
+                config = {
+                    "BLOCK_SIZE_M": 128,
+                    "BLOCK_SIZE_N": 256,
+                    "BLOCK_SIZE_K": 128,
+                    "GROUP_SIZE_M": 32,
+                    "num_warps": 8,
                     "num_stages": 2 if _is_hip else 4,
                 }
+                if M <= E:
+                    config = {
+                        "BLOCK_SIZE_M": 64,
+                        "BLOCK_SIZE_N": 128,
+                        "BLOCK_SIZE_K": 128,
+                        "GROUP_SIZE_M": 1,
+                        "num_warps": 4,
+                        "num_stages": 2 if _is_hip else 4,
+                    }
         else:
             # Block-wise quant: BLOCK_SIZE_K must be divisible by block_shape[1]
             config = {

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py
@@ -30,10 +30,7 @@ def _get_cuda_shared_memory_per_block_optin() -> Optional[int]:
 
 def _use_low_smem_fp8_default() -> bool:
     smem_limit = _get_cuda_shared_memory_per_block_optin()
-    return (
-        smem_limit is not None
-        and smem_limit < _LOW_SMEM_FP8_DEFAULT_CUTOFF_BYTES
-    )
+    return smem_limit is not None and smem_limit < _LOW_SMEM_FP8_DEFAULT_CUTOFF_BYTES
 
 
 def get_config_file_name(


### PR DESCRIPTION
## Motivation

Add a tuned fused MoE Triton FP8 config for NVIDIA GB10 for the Qwen3 MoE shape `E=128, N=768`.

Without a GB10-specific config, SGLang falls back to the default MoE kernel config for this shape.

## Modifications

Added the Triton 3.6.0 config generated by the fused MoE tuner:

`python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_GB10,dtype=fp8_w8a8.json`

This PR intentionally only adds the tuned config. A separate issue/PR can track tuner behavior for checkpoints whose metadata reports `block_shape: [0, None]`.

## Accuracy Tests

Not applicable. This PR only adds a fused MoE Triton tuning config and does not change model math or kernel code.

## Speed Tests and Profiling

The config was generated on actual NVIDIA GB10 hardware with:

```bash
python3 benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py \
  --model <Qwen3-30B-A3B FP8 ModelOpt checkpoint> \
  --tp-size 1 \
  --dtype fp8_w8a8 \
  --batch-size <batch_size> \
  --tune
```

Observed facts from the benchmark logs:

- GPU: `NVIDIA GB10`
- `nvidia-smi --query-gpu=name,compute_cap,memory.total`: `NVIDIA GB10, 12.1, [N/A]`
- PyTorch CUDA device name: `NVIDIA GB10`
- CUDA capability from PyTorch: `12.1`
- PyTorch-reported SM count: `48`
- PyTorch-reported total memory: `128495886336`
- `shared_memory_per_block`: `49152`
- `shared_memory_per_block_optin`: `101376`
- `shared_memory_per_multiprocessor`: `102400`
- PyTorch: `2.11.0+cu130`
- Triton: `3.6.0`
- SGLang version under test: `0.0.0.dev1+g688b679af`

The tuner observed this model/config shape:

```json
{
  "architecture": "Qwen3MoeForCausalLM",
  "block_shape": [0, null],
  "dtype": "torch.bfloat16",
  "hidden_size": 2048,
  "num_experts": 128,
  "shard_intermediate_size": 1536,
  "topk": 8
}
```

All default batch sizes completed successfully:

`1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024, 1536, 2048, 3072, 4096`

The longest tuning job was batch size `4096`; its log ended with:

```text
Tuning took 9659.23 seconds
Completed tuning for batch_size=4096
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`python -m json.tool` passed for the added JSON.)
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable; config-only PR.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable; config-only PR.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27562189842](https://github.com/sgl-project/sglang/actions/runs/27562189842)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27562189313](https://github.com/sgl-project/sglang/actions/runs/27562189313)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->