### PR TITLE
fix: store DeepSeek-V4 KV pool as uint8

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -65,6 +65,9 @@ class DeepSeekV4SingleKVPool(KVCache):
             start_layer,
             end_layer,
         )
+        # Byte-packed pool: backing tensor is always uint8 regardless of the
+        # logical kv-cache dtype (base KVCache only sets this for fp8-enum dtypes).
+        self.store_dtype = torch.uint8
         self.qk_nope_head_dim = qk_nope_head_dim
         self.qk_rope_head_dim = qk_rope_head_dim
 

--- a/test/registered/unit/mem_cache/test_deepseek_v4_pool_store_dtype_unit.py
+++ b/test/registered/unit/mem_cache/test_deepseek_v4_pool_store_dtype_unit.py
@@ -1,0 +1,55 @@
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4SingleKVPool
+from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=3, stage="base-b", runner_config="1-gpu-small")
+
+# DSV4 byte-packed KV layout: qk_nope_head_dim FP8 (448) + qk_rope_head_dim
+# BF16 (64*2) + nope FP8 scales + scale_pad == 584 bytes/token.
+QK_NOPE_HEAD_DIM = 448
+QK_ROPE_HEAD_DIM = 64
+
+
+class TestDeepSeekV4PoolStoreDtype(CustomTestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA/ROCm is required for DeepSeekV4SingleKVPool.")
+        if is_npu() or is_xpu():
+            self.skipTest("DSV4 pool tests only support CUDA/ROCm.")
+        if not (is_cuda() or is_hip()):
+            self.skipTest("CUDA/ROCm not available.")
+
+    def _build_pool(self, dtype: torch.dtype) -> DeepSeekV4SingleKVPool:
+        page_size = 64
+        return DeepSeekV4SingleKVPool(
+            page_size,
+            page_size,
+            dtype,
+            QK_NOPE_HEAD_DIM,
+            QK_ROPE_HEAD_DIM,
+            1,
+            "cuda",
+            False,
+        )
+
+    def test_non_fp8_kv_dtype_does_not_break_byte_packed_pool(self):
+        # Repro for #25118: under the AMD torch-fallback config the kv-cache
+        # dtype is bf16 (not an fp8 enum), which previously left
+        # store_dtype == bf16 and crashed create_buffer's uint8 assertion.
+        pool = self._build_pool(torch.bfloat16)
+        self.assertEqual(pool.store_dtype, torch.uint8)
+        self.assertEqual(pool.kv_buffer[0].dtype, torch.uint8)
+
+    def test_fp8_kv_dtype_still_uint8_backed(self):
+        pool = self._build_pool(torch.float8_e4m3fn)
+        self.assertEqual(pool.store_dtype, torch.uint8)
+        self.assertEqual(pool.kv_buffer[0].dtype, torch.uint8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #25118.

DeepSeek-V4's single KV pool uses a byte-packed backing buffer. The backing tensor must be `torch.uint8` even when the logical kv-cache dtype is not an fp8 dtype. On the AMD torch-fallback path, the logical dtype can be `torch.bfloat16`, which previously caused `DeepSeekV4SingleKVPool.create_buffer()` to trip `assert self.store_dtype == torch.uint8` during scheduler startup.

## Modifications

- Force `DeepSeekV4SingleKVPool.store_dtype` to `torch.uint8` before buffer allocation.
- Add a unit test covering the bf16 trigger path and the existing fp8 path.

## Accuracy Tests

Not applicable. This fixes KV pool allocation dtype and does not change model outputs.

## Speed Tests and Profiling

Not applicable. This change only establishes the storage dtype invariant before buffer allocation.

## Tests

- `python3 -m compileall -q python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py test/registered/unit/mem_cache/test_deepseek_v4_pool_store_dtype_unit.py`
- `python3 scripts/ci/check_registered_tests.py`
- On `amd-gpu2` MI300X with `rocm/sgl-dev:rocm720-mi30x-339e36e-20260512-DSv4`:
  - `python3 test/registered/unit/mem_cache/test_deepseek_v4_pool_store_dtype_unit.py -v`
  - Result: 2 tests passed.

Full DeepSeek-V4-Flash server E2E was not run.

## Checklist

- [ ] Format your code according to the Format code with pre-commit guide.
- [x] Add unit tests according to the Run and add unit tests guide.
- [x] Update documentation according to Write documentations. (No docs change needed.)
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed. (Not applicable.)
- [x] Follow the SGLang code style guidance.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26040643109](https://github.com/sgl-project/sglang/actions/runs/26040643109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->