### PR TITLE
Fix docstring for B200 FP4 test

### DIFF
--- a/test/registered/dsv4/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/dsv4/test_deepseek_v4_flash_fp4_b200.py
@@ -1,4 +1,4 @@
-"""B200 per-commit CI: DeepSeek-V4-Flash FP4 (LowLatency recipe).
+"""B200 per-commit CI: DeepSeek-V4-Flash FP4 (LowLatency + Balanced recipes).
 
 Launches TP=4 with flashinfer_mxfp4 MoE runner + EAGLE speculative decoding.
 Runs 12 ServerSanity probes (correctness, streaming, concurrency, determinism)


### PR DESCRIPTION
Fix docstring to mention both LowLatency and Balanced recipes.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26053741445](https://github.com/sgl-project/sglang/actions/runs/26053741445)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->