### PR TITLE
[CI] Enable weight prefetch for 8-gpu-h200 basic tests

### DIFF
--- a/test/registered/8-gpu-models/test_minimax_m25_basic.py
+++ b/test/registered/8-gpu-models/test_minimax_m25_basic.py
@@ -36,6 +36,7 @@ class TestMiniMaxM25Basic(CustomTestCase):
             "minimax-append-think",
             "--model-loader-extra-config",
             '{"enable_multithread_load": true, "num_threads": 64}',
+            "--weight-loader-prefetch-checkpoints",
         ]
         cls.process = popen_launch_server(
             cls.model,

--- a/test/registered/8-gpu-models/test_minimax_m25_basic.py
+++ b/test/registered/8-gpu-models/test_minimax_m25_basic.py
@@ -14,7 +14,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=290, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=250, stage="base-c", runner_config="8-gpu-h200")
 
 MINIMAX_M25_MODEL_PATH = "MiniMaxAI/MiniMax-M2.5"
 

--- a/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
+++ b/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
@@ -72,6 +72,7 @@ class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):
                 "500",
                 "--max-running-requests",
                 "4",
+                "--weight-loader-prefetch-checkpoints",
             ],
             env={"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"},
         )

--- a/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
+++ b/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
@@ -24,7 +24,7 @@ MAMBA_TRACK_INTERVAL = 128
 DSV4_FLASH_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
 DSV4_FLASH_LAUNCH_TIMEOUT = 3600
 
-register_cuda_ci(est_time=768, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=745, stage="base-c", runner_config="8-gpu-h200")
 
 
 class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):


### PR DESCRIPTION
## Motivation

Two per-commit 8-GPU CI tests in the `base-c-test-8-gpu-h200` suite are dominated by checkpoint weight loading on every PR:

- `TestMiniMaxM25Basic` (MiniMax-M2.5, 8×H200)
- `TestUnifiedMambaHiCache` (Qwen3-Next-80B-A3B-Instruct, TP=4 + HiCache + UnifiedRadixCache)

Without prefetch, the loader streams shards from disk before staging them to GPU, which inflates server boot time and slows the per-commit gate.

## Modifications

Add `--weight-loader-prefetch-checkpoints` to the `popen_launch_server` flags of both tests so the existing loader can overlap disk reads with H2D copies:

- `test/registered/8-gpu-models/test_minimax_m25_basic.py`: alongside the existing `--model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 64}'`.
- `test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py`: on `TestUnifiedMambaHiCache.setUpClass`.

`est_time` updated in both files to reflect the measured runtime with prefetch (see below).

No model code, no public API, no behavioral change at inference time — the flag only affects the load-time path of these CI tests.

## Accuracy Tests

N/A — CI-only flag flip; model outputs are unaffected. Existing assertions in both tests (GSM8K, MMLU, multi-turn cache-hit checks) guard correctness, and they all passed on the manually-rerun PR jobs.

## Speed Tests and Profiling

Measured on `8-gpu-h200`. Baseline is the latest successful scheduled main run ([26009245139](https://github.com/sgl-project/sglang/actions/runs/26009245139), partition 0 of `base-c-test-8-gpu-h200`). PR numbers are the manually-rerun jobs against the PR branch ([MiniMaxM25 run 26059316967](https://github.com/sgl-project/sglang/actions/runs/26059316967), [Mamba run 26059554220](https://github.com/sgl-project/sglang/actions/runs/26059554220)).

**Weight-loading wall time (max across TP ranks):**

| Test | Model | Baseline (main) | PR (prefetch) | Speedup |
|---|---|---|---|---|
| `TestMiniMaxM25Basic` | MiniMax-M2.5 (TP=8) | 120.88 s | **20.32 s** | **5.9×** (-100 s) |
| `TestUnifiedMambaHiCache` | Qwen3-Next-80B (TP=4) | 57.05 s | **23.82 s** | **2.4×** (-33 s) |

**File-level test wall time:**

| File | Baseline (main) | PR | Saved | `est_time` |
|---|---|---|---|---|
| `test_minimax_m25_basic.py` | 319.0 s | 246 s | -73 s | 290 → **250** |
| `test_unified_radix_cache_kl_hicache.py` | 793.8 s | 747 s | -47 s | 768 → **745** |

The radix-cache file contains a second test class (`TestUnifiedDeepSeekV4FlashHiCache`) which this PR leaves unchanged, so its load time is unaffected; the file-level saving comes entirely from `TestUnifiedMambaHiCache`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)