### PR TITLE
[SP] Fix runtime_max_tokens_per_rank for sequence parallelism

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -212,11 +212,16 @@ class FlashinferDispatcher(BaseDispatcher):
         payloads.append(topk_ids)
         payloads.append(topk_weights)
 
-        self.runtime_max_tokens_per_rank = (
-            max(get_dp_global_num_tokens())
-            if get_dp_global_num_tokens() is not None
-            else x.shape[0]
-        )
+        dp_global = get_dp_global_num_tokens()
+        if dp_global is not None and len(dp_global) > 1:
+            # DP attention: multiple DP ranks with different token counts.
+            # Use the max across ranks so the A2A workspace fits the fattest.
+            self.runtime_max_tokens_per_rank = max(dp_global)
+        else:
+            # dp_size=1 or SP: use the actual input tensor size (post-scatter
+            # in SP mode, full batch otherwise).  Avoids the pre-scatter
+            # scheduler count which can exceed the workspace cap.
+            self.runtime_max_tokens_per_rank = x.shape[0]
         recv_tensors = self.moe_a2a.dispatch(
             self.dummy_topk_ids_current_rank if self.has_dummy_token else topk_ids,
             payloads,


### PR DESCRIPTION
## Summary

- When using sequence parallelism (SP), the pre-scatter scheduler token count from `get_dp_global_num_tokens()` can exceed the A2A workspace cap, causing issues.
- This fix uses `x.shape[0]` (the post-scatter tensor size) when `dp_size==1` or SP is active, and reserves the max-across-ranks logic for true DP attention with multiple ranks.
- Reduces TTFT for llama4x with sequence parallelism enabled.

## Original commits

- `886108914`

## Test plan

- [x] Verified the before-state matches OSS main
- [ ] CI via `/tag-and-rerun-ci`





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26061560048](https://github.com/sgl-project/sglang/actions/runs/26061560048)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->