### PR TITLE
Use SGLANG_CACHE_DIR env for gpu_p2p_access_cache path

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
@@ -21,6 +21,7 @@ from typing_extensions import ParamSpec
 
 from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from sglang.srt.distributed.parallel_state import in_the_same_node_as
+from sglang.srt.environ import envs as sglang_envs
 from sglang.srt.utils import is_cuda, is_hip, is_musa
 
 logger = logging.getLogger(__name__)
@@ -261,8 +262,8 @@ def gpu_p2p_access_check(src: int, tgt: int) -> bool:
         cuda_visible_devices = ",".join(str(i) for i in range(num_dev))
 
     # VLLM_CACHE_ROOT -> SGLANG_CACHE_ROOT
-    # "~/.cache/vllm" -> "~/.cache/sglang"
-    SGLANG_CACHE_ROOT = os.path.expanduser("~/.cache/sglang")
+    # "~/.cache/vllm" -> envs.SGLANG_CACHE_DIR
+    SGLANG_CACHE_ROOT = os.path.expanduser(sglang_envs.SGLANG_CACHE_DIR.get())
     path = os.path.join(
         SGLANG_CACHE_ROOT, f"gpu_p2p_access_cache_for_{cuda_visible_devices}.json"
     )


### PR DESCRIPTION
## Summary

- Replace hardcoded `~/.cache/sglang` with the configurable `SGLANG_CACHE_DIR` environment variable for the GPU P2P access cache path in `custom_all_reduce_utils.py`.
- This allows CI and other environments to customize the cache location via the existing `envs.SGLANG_CACHE_DIR` setting.

## Original commits

- `427e07dc6`

## Test plan

- [x] Verified the before-state matches OSS main
- [x] Verified `SGLANG_CACHE_DIR` exists in OSS `environ.py`
- [ ] CI via `/tag-and-rerun-ci`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26061758942](https://github.com/sgl-project/sglang/actions/runs/26061758942)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->