### PR TITLE
ci: pr-states match renamed "PR Test Base" workflow_run

### DIFF
--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -10,7 +10,7 @@ on:
     # Listen to pr-test* lifecycle so reruns initiated by slash commands
     # (run.rerun / run.rerun_failed_jobs via GITHUB_TOKEN) -- which don't
     # refire pull_request_target -- still refresh the CI-states block.
-    workflows: ["PR Test", "PR Test Extra"]
+    workflows: ["PR Test Base", "PR Test Extra"]
     types: [requested, completed]
 
 permissions:


### PR DESCRIPTION
`pr-test.yml` was renamed `PR Test` -> `PR Test Base` in #25420 (2026-05-15), but the `workflow_run` filter added in #25475 (2026-05-16) still says `"PR Test"`, so Base completions never refresh the CI-states block (only Extra does). Update the filter to match.

Symptom example: #25566 — Extra finished and got rendered as ✅, Base finished hours later and stayed ⏳.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26062095347](https://github.com/sgl-project/sglang/actions/runs/26062095347)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->