### PR TITLE
Add no_combine support to cutlass_moe_fp4

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -359,6 +359,7 @@ def cutlass_moe_fp4(
     topk_ids: torch.Tensor,
     params: CutlassMoEParams,
     apply_router_weight_on_input: bool = False,
+    no_combine: bool = False,
 ):
     """
     MoE implementation for FP4 Inputs
@@ -492,6 +493,8 @@ def cutlass_moe_fp4(
     del int_fp4, int_blockscale
     c2 = shuffle_rows(c2, c_map, (m_a * num_topk, params.hidden_size))
     c2 = c2.view(m_a, num_topk, params.hidden_size)
+    if no_combine:
+        return c2.to(out_dtype)
     if not apply_router_weight_on_input:
         c2 = c2 * topk_weights.view(m_a, num_topk, 1).to(out_dtype)
     return c2.sum(dim=1).to(out_dtype)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2175,6 +2175,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             topk_ids=topk_ids,
             params=layer.cutlass_moe_params,
             apply_router_weight_on_input=moe_runner_config.apply_router_weight_on_input,
+            no_combine=moe_runner_config.no_combine,
         ).to(x.dtype)
         # Scale by routed_scaling_factor is fused into select_experts.
         return StandardCombineInput(hidden_states=output)


### PR DESCRIPTION
## Summary

- Add `no_combine` parameter to `cutlass_moe_fp4()` so it can return per-expert outputs without combining (matching the triton path).
- Wire the parameter through from `ModelOptNvFp4FusedMoEMethod` via `moe_runner_config.no_combine`.
- Enables FP4 MoE with TP1 in no-combine mode (needed for EP dispatch patterns).

## Original commits

- `5f5737ed0`

## Test plan

- [x] Verified before-state matches OSS main for both files
- [x] Verified `no_combine` already exists on `moe_runner_config` in OSS
- [ ] CI via `/tag-and-rerun-ci`





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26062288389](https://github.com/sgl-project/sglang/actions/runs/26062288389)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->