### PR TITLE
Add spec_verify_calls_total metric for speculative decoding

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2218,6 +2218,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             ):
                 cached_tokens_details = recv_obj.cached_tokens_details[i]
 
+            spec_verify_ct = (
+                recv_obj.spec_verify_ct[i]
+                if hasattr(recv_obj, "spec_verify_ct")
+                and recv_obj.spec_verify_ct
+                and len(recv_obj.spec_verify_ct) > i
+                else 0
+            )
+
             self.metrics_collector.observe_one_finished_request(
                 labels,
                 recv_obj.prompt_tokens[i],
@@ -2226,6 +2234,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 state.time_stats.get_e2e_latency(),
                 self._request_has_grammar(state.obj),
                 cached_tokens_details,
+                spec_verify_ct=spec_verify_ct,
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1342,6 +1342,11 @@ class TokenizerMetricsCollector:
             documentation="Number of generation tokens processed.",
             labelnames=labels.keys(),
         )
+        self.spec_verify_calls_total = Counter(
+            name="sglang:spec_verify_calls_total",
+            documentation="Number of speculative decoding verification calls.",
+            labelnames=labels.keys(),
+        )
 
         default_bucket_prompt_tokens = [
             100,
@@ -1542,9 +1547,12 @@ class TokenizerMetricsCollector:
         e2e_latency: float,
         has_grammar: bool,
         cached_tokens_details: Optional[Dict[str, Any]] = None,
+        spec_verify_ct: int = 0,
     ):
         self.prompt_tokens_total.labels(**labels).inc(prompt_tokens)
         self.generation_tokens_total.labels(**labels).inc(generation_tokens)
+        if spec_verify_ct > 0:
+            self.spec_verify_calls_total.labels(**labels).inc(spec_verify_ct)
 
         # Report cached tokens with detailed source breakdown
         if cached_tokens > 0:


### PR DESCRIPTION
## Summary

- Add a new Prometheus counter `sglang:spec_verify_calls_total` that tracks the number of speculative decoding verification calls per request.
- The counter is incremented in `observe_one_finished_request` when `spec_verify_ct > 0`.
- The `spec_verify_ct` field is extracted from the recv object in tokenizer_manager, with safe fallback to 0 if unavailable.

## Original commits

- `318a5f14e`

## Test plan

- [ ] Verify metric is registered and visible at `/metrics` endpoint
- [ ] Confirm counter increments correctly during speculative decoding
- [ ] Confirm no impact when speculative decoding is not in use (counter stays at 0)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26062371070](https://github.com/sgl-project/sglang/actions/runs/26062371070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->