### PR TITLE
[NVIDIA] Fix BF16 FlashInfer TRTLLM MoE RL weight update

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -69,6 +69,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
+from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
 from sglang.srt.runtime_context import (
     get_exec,
     get_global_dwdp_manager,
@@ -544,41 +545,6 @@ class FusedMoE(torch.nn.Module):
         elif shard_id == "w2":
             param_data[expert_id] = loaded_weight
 
-    def _narrow_padded_param_and_loaded_weight(
-        self,
-        param_data: torch.Tensor,
-        loaded_weight: torch.Tensor,
-        param_data_start: int,
-        weight_start: int,
-        dim: int,
-        param_shard_size: int,
-        weight_shard_size: int,
-        narrow_weight: bool = True,
-    ):
-        if narrow_weight:
-            actual_shard_size = max(
-                min(weight_shard_size, loaded_weight.size(dim) - weight_start), 0
-            )
-            if actual_shard_size > 0:
-                loaded_weight = loaded_weight.narrow(
-                    dim, weight_start, actual_shard_size
-                )
-            else:
-                loaded_weight = torch.zeros_like(
-                    param_data.narrow(dim, param_data_start, 0)
-                )
-        else:
-            actual_shard_size = min(loaded_weight.size(dim), param_shard_size)
-
-        pad_size = param_shard_size - actual_shard_size
-        if pad_size > 0:
-            param_data.narrow(
-                dim, param_data_start + actual_shard_size, pad_size
-            ).zero_()
-
-        param_data = param_data.narrow(dim, param_data_start, actual_shard_size)
-        return param_data, loaded_weight
-
     def _load_model_weight_or_group_weight_scale(
         self,
         shard_dim: int,
@@ -657,13 +623,12 @@ class FusedMoE(torch.nn.Module):
             param_shard_size = expert_data.shape[shard_dim]
         else:
             raise NotImplementedError
+        # Keep the generic load path's historical assumption: the source
+        # shard size matches the destination param shard size. The fused
+        # FlashInfer TRTLLM W13 path below overrides this from loaded_weight
+        # because each half can have a different source and padded destination
+        # size.
         weight_shard_size = param_shard_size
-        if (
-            self.use_flashinfer_trtllm_moe
-            and not self.use_presharded_weights
-            and not is_bias
-        ):
-            weight_shard_size = loaded_weight.shape[shard_dim] // self.moe_tp_size
 
         # Narrow parameter and load.
         # w1, gate_proj: Load into first logical weight of w13.
@@ -677,6 +642,10 @@ class FusedMoE(torch.nn.Module):
         else:
             start = 0
 
+        # Hot-update can load a fused W13 tensor, while FlashInfer TRTLLM stores
+        # the destination as two separately padded halves, e.g.
+        # [W3][W3 pad][W1][W1 pad]. Copy each half separately so W1 data does
+        # not spill into W3 padding.
         if (
             self.use_flashinfer_trtllm_moe
             and shard_id == "w13"
@@ -688,24 +657,22 @@ class FusedMoE(torch.nn.Module):
             if not self.use_presharded_weights:
                 weight_shard_size //= self.moe_tp_size
             weight_half_size = weight_shard_size // 2
-            weight_start = (
-                0 if self.use_presharded_weights else weight_shard_size * tp_rank
-            )
+            weight_start = weight_shard_size * tp_rank
 
             for param_start, source_start in (
                 (0, weight_start),
                 (param_half_size, weight_start + weight_half_size),
             ):
                 half_expert_data, half_loaded_weight = (
-                    self._narrow_padded_param_and_loaded_weight(
+                    narrow_padded_param_and_loaded_weight(
                         expert_data,
                         loaded_weight,
                         param_start,
                         source_start,
                         shard_dim,
                         param_half_size,
-                        weight_half_size,
-                        not self.use_presharded_weights,
+                        narrow_weight=not self.use_presharded_weights,
+                        weight_shard_size=weight_half_size,
                     )
                 )
                 half_loaded_weight = _maybe_copy_weight_view_before_h2d(
@@ -717,15 +684,15 @@ class FusedMoE(torch.nn.Module):
         if self.use_padded_loading:
             if _is_cpu and is_bias:
                 shard_dim = 1
-            expert_data, loaded_weight = self._narrow_padded_param_and_loaded_weight(
+            expert_data, loaded_weight = narrow_padded_param_and_loaded_weight(
                 expert_data,
                 loaded_weight,
                 start,
                 weight_shard_size * tp_rank,
                 shard_dim,
                 param_shard_size,
-                weight_shard_size,
-                not self.use_presharded_weights,
+                narrow_weight=not self.use_presharded_weights,
+                weight_shard_size=weight_shard_size,
             )
         else:
             if not self.use_presharded_weights:
@@ -786,26 +753,22 @@ class FusedMoE(torch.nn.Module):
             # this parameter is a weight matrix
             # for w2 in TP, it shards the input_features, i.e., shard_dim=2
             param_shard_size = expert_data.shape[shard_dim]
+        # Keep the generic load path's historical assumption: the source
+        # shard size matches the destination param shard size.
         weight_shard_size = param_shard_size
-        if (
-            self.use_flashinfer_trtllm_moe
-            and not self.use_presharded_weights
-            and not is_bias
-        ):
-            weight_shard_size = loaded_weight.shape[shard_dim] // self.moe_tp_size
 
         if self.use_padded_loading:
             if _is_cpu and is_bias:
                 shard_dim = 1
-            expert_data, loaded_weight = self._narrow_padded_param_and_loaded_weight(
+            expert_data, loaded_weight = narrow_padded_param_and_loaded_weight(
                 expert_data,
                 loaded_weight,
                 0,  # param_data_start
                 weight_shard_size * tp_rank,
                 shard_dim,
                 param_shard_size,
-                weight_shard_size,
-                not self.use_presharded_weights,
+                narrow_weight=not self.use_presharded_weights,
+                weight_shard_size=weight_shard_size,
             )
         else:
             if not is_bias and not self.use_presharded_weights:

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -652,16 +652,21 @@ class FusedMoE(torch.nn.Module):
             and self.moe_runner_config.is_gated
             and not is_bias
         ):
+            # A fused W13 source is laid out as two logical halves, W1 then W3.
+            # Shard each half independently before copying into the padded
+            # FlashInfer TRTLLM destination layout.
             param_half_size = expert_data.shape[shard_dim] // 2
-            weight_shard_size = loaded_weight.shape[shard_dim]
+            source_half_size = loaded_weight.shape[shard_dim] // 2
+            weight_half_shard_size = source_half_size
             if not self.use_presharded_weights:
-                weight_shard_size //= self.moe_tp_size
-            weight_half_size = weight_shard_size // 2
-            weight_start = weight_shard_size * tp_rank
+                weight_half_shard_size //= self.moe_tp_size
+            weight_start = (
+                0 if self.use_presharded_weights else weight_half_shard_size * tp_rank
+            )
 
             for param_start, source_start in (
                 (0, weight_start),
-                (param_half_size, weight_start + weight_half_size),
+                (param_half_size, source_half_size + weight_start),
             ):
                 half_expert_data, half_loaded_weight = (
                     narrow_padded_param_and_loaded_weight(
@@ -672,7 +677,7 @@ class FusedMoE(torch.nn.Module):
                         shard_dim,
                         param_half_size,
                         narrow_weight=not self.use_presharded_weights,
-                        weight_shard_size=weight_half_size,
+                        weight_shard_size=weight_half_shard_size,
                     )
                 )
                 half_loaded_weight = _maybe_copy_weight_view_before_h2d(

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -623,12 +623,13 @@ class FusedMoE(torch.nn.Module):
             param_shard_size = expert_data.shape[shard_dim]
         else:
             raise NotImplementedError
-        # Keep the generic load path's historical assumption: the source
-        # shard size matches the destination param shard size. The fused
-        # FlashInfer TRTLLM W13 path below overrides this from loaded_weight
-        # because each half can have a different source and padded destination
-        # size.
         weight_shard_size = param_shard_size
+        if self.use_padded_loading and not self.use_presharded_weights and not is_bias:
+            if not (shard_id == "w13" and self.moe_runner_config.is_gated):
+                # FlashInfer TRTLLM may pad the destination shard to 128, while
+                # the checkpoint tensor is still unpadded. Slice the source by
+                # its real per-rank size, then copy into the padded destination.
+                weight_shard_size = loaded_weight.shape[shard_dim] // self.moe_tp_size
 
         # Narrow parameter and load.
         # w1, gate_proj: Load into first logical weight of w13.
@@ -652,9 +653,9 @@ class FusedMoE(torch.nn.Module):
             and self.moe_runner_config.is_gated
             and not is_bias
         ):
-            # A fused W13 source is laid out as two logical halves, W1 then W3.
-            # Shard each half independently before copying into the padded
-            # FlashInfer TRTLLM destination layout.
+            # A fused W13 source is laid out as two logical halves, W1 then W3,
+            # while FlashInfer TRTLLM stores W13 as W3 then W1. Shard each
+            # source half independently before copying into the padded layout.
             param_half_size = expert_data.shape[shard_dim] // 2
             source_half_size = loaded_weight.shape[shard_dim] // 2
             weight_half_shard_size = source_half_size
@@ -665,8 +666,8 @@ class FusedMoE(torch.nn.Module):
             )
 
             for param_start, source_start in (
-                (0, weight_start),
-                (param_half_size, source_half_size + weight_start),
+                (0, source_half_size + weight_start),
+                (param_half_size, weight_start),
             ):
                 half_expert_data, half_loaded_weight = (
                     narrow_padded_param_and_loaded_weight(
@@ -676,7 +677,7 @@ class FusedMoE(torch.nn.Module):
                         source_start,
                         shard_dim,
                         param_half_size,
-                        narrow_weight=not self.use_presharded_weights,
+                        narrow_weight=True,
                         weight_shard_size=weight_half_shard_size,
                     )
                 )
@@ -758,9 +759,11 @@ class FusedMoE(torch.nn.Module):
             # this parameter is a weight matrix
             # for w2 in TP, it shards the input_features, i.e., shard_dim=2
             param_shard_size = expert_data.shape[shard_dim]
-        # Keep the generic load path's historical assumption: the source
-        # shard size matches the destination param shard size.
         weight_shard_size = param_shard_size
+        if self.use_padded_loading and not self.use_presharded_weights and not is_bias:
+            # FlashInfer TRTLLM may pad the destination shard to 128, while the
+            # checkpoint tensor is still unpadded.
+            weight_shard_size = loaded_weight.shape[shard_dim] // self.moe_tp_size
 
         if self.use_padded_loading:
             if _is_cpu and is_bias:

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -69,7 +69,6 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.model_loader.weight_utils import narrow_padded_param_and_loaded_weight
 from sglang.srt.runtime_context import (
     get_exec,
     get_global_dwdp_manager,
@@ -301,6 +300,9 @@ class FusedMoE(torch.nn.Module):
 
         assert intermediate_size % self.moe_tp_size == 0
         self.intermediate_size_per_partition = intermediate_size // self.moe_tp_size
+        self.intermediate_size_per_partition_unpadded = (
+            self.intermediate_size_per_partition
+        )
         self.reduce_results = reduce_results
         self.use_presharded_weights = use_presharded_weights
 
@@ -542,6 +544,41 @@ class FusedMoE(torch.nn.Module):
         elif shard_id == "w2":
             param_data[expert_id] = loaded_weight
 
+    def _narrow_padded_param_and_loaded_weight(
+        self,
+        param_data: torch.Tensor,
+        loaded_weight: torch.Tensor,
+        param_data_start: int,
+        weight_start: int,
+        dim: int,
+        param_shard_size: int,
+        weight_shard_size: int,
+        narrow_weight: bool = True,
+    ):
+        if narrow_weight:
+            actual_shard_size = max(
+                min(weight_shard_size, loaded_weight.size(dim) - weight_start), 0
+            )
+            if actual_shard_size > 0:
+                loaded_weight = loaded_weight.narrow(
+                    dim, weight_start, actual_shard_size
+                )
+            else:
+                loaded_weight = torch.zeros_like(
+                    param_data.narrow(dim, param_data_start, 0)
+                )
+        else:
+            actual_shard_size = min(loaded_weight.size(dim), param_shard_size)
+
+        pad_size = param_shard_size - actual_shard_size
+        if pad_size > 0:
+            param_data.narrow(
+                dim, param_data_start + actual_shard_size, pad_size
+            ).zero_()
+
+        param_data = param_data.narrow(dim, param_data_start, actual_shard_size)
+        return param_data, loaded_weight
+
     def _load_model_weight_or_group_weight_scale(
         self,
         shard_dim: int,
@@ -612,14 +649,21 @@ class FusedMoE(torch.nn.Module):
 
         if shard_id in {"w1", "w3"} and self.moe_runner_config.is_gated:
             # non-fused version
-            shard_size = expert_data.shape[shard_dim] // 2
+            param_shard_size = expert_data.shape[shard_dim] // 2
         elif shard_id in {"w13"} or (
             shard_id in {"w1", "w3"} and not self.moe_runner_config.is_gated
         ):
             # fused version
-            shard_size = expert_data.shape[shard_dim]
+            param_shard_size = expert_data.shape[shard_dim]
         else:
             raise NotImplementedError
+        weight_shard_size = param_shard_size
+        if (
+            self.use_flashinfer_trtllm_moe
+            and not self.use_presharded_weights
+            and not is_bias
+        ):
+            weight_shard_size = loaded_weight.shape[shard_dim] // self.moe_tp_size
 
         # Narrow parameter and load.
         # w1, gate_proj: Load into first logical weight of w13.
@@ -629,20 +673,58 @@ class FusedMoE(torch.nn.Module):
         if (
             (switch_w13 and shard_id == "w1") or (not switch_w13 and shard_id == "w3")
         ) and self.moe_runner_config.is_gated:
-            start = shard_size
+            start = param_shard_size
         else:
             start = 0
+
+        if (
+            self.use_flashinfer_trtllm_moe
+            and shard_id == "w13"
+            and self.moe_runner_config.is_gated
+            and not is_bias
+        ):
+            param_half_size = expert_data.shape[shard_dim] // 2
+            weight_shard_size = loaded_weight.shape[shard_dim]
+            if not self.use_presharded_weights:
+                weight_shard_size //= self.moe_tp_size
+            weight_half_size = weight_shard_size // 2
+            weight_start = (
+                0 if self.use_presharded_weights else weight_shard_size * tp_rank
+            )
+
+            for param_start, source_start in (
+                (0, weight_start),
+                (param_half_size, weight_start + weight_half_size),
+            ):
+                half_expert_data, half_loaded_weight = (
+                    self._narrow_padded_param_and_loaded_weight(
+                        expert_data,
+                        loaded_weight,
+                        param_start,
+                        source_start,
+                        shard_dim,
+                        param_half_size,
+                        weight_half_size,
+                        not self.use_presharded_weights,
+                    )
+                )
+                half_loaded_weight = _maybe_copy_weight_view_before_h2d(
+                    half_loaded_weight
+                )
+                half_expert_data.copy_(half_loaded_weight)
+            return
 
         if self.use_padded_loading:
             if _is_cpu and is_bias:
                 shard_dim = 1
-            expert_data, loaded_weight = narrow_padded_param_and_loaded_weight(
+            expert_data, loaded_weight = self._narrow_padded_param_and_loaded_weight(
                 expert_data,
                 loaded_weight,
                 start,
-                shard_size * tp_rank,
+                weight_shard_size * tp_rank,
                 shard_dim,
-                shard_size,
+                param_shard_size,
+                weight_shard_size,
                 not self.use_presharded_weights,
             )
         else:
@@ -651,10 +733,10 @@ class FusedMoE(torch.nn.Module):
                     # do not transpose for bias
                     loaded_weight = loaded_weight.transpose(-2, -1)
                 loaded_weight = loaded_weight.narrow(
-                    shard_dim, shard_size * tp_rank, shard_size
+                    shard_dim, param_shard_size * tp_rank, param_shard_size
                 )
 
-            expert_data = expert_data.narrow(shard_dim, start, shard_size)
+            expert_data = expert_data.narrow(shard_dim, start, param_shard_size)
         loaded_weight = _maybe_copy_weight_view_before_h2d(loaded_weight)
         expert_data.copy_(loaded_weight)
 
@@ -699,22 +781,30 @@ class FusedMoE(torch.nn.Module):
         if is_bias:
             # this expert_data is a bias, not weight,
             # for w2_weight_bias in TP, it does not need to be sharded
-            shard_size = expert_data.shape[-1]
+            param_shard_size = expert_data.shape[-1]
         else:
             # this parameter is a weight matrix
             # for w2 in TP, it shards the input_features, i.e., shard_dim=2
-            shard_size = expert_data.shape[shard_dim]
+            param_shard_size = expert_data.shape[shard_dim]
+        weight_shard_size = param_shard_size
+        if (
+            self.use_flashinfer_trtllm_moe
+            and not self.use_presharded_weights
+            and not is_bias
+        ):
+            weight_shard_size = loaded_weight.shape[shard_dim] // self.moe_tp_size
 
         if self.use_padded_loading:
             if _is_cpu and is_bias:
                 shard_dim = 1
-            expert_data, loaded_weight = narrow_padded_param_and_loaded_weight(
+            expert_data, loaded_weight = self._narrow_padded_param_and_loaded_weight(
                 expert_data,
                 loaded_weight,
                 0,  # param_data_start
-                shard_size * tp_rank,
+                weight_shard_size * tp_rank,
                 shard_dim,
-                shard_size,
+                param_shard_size,
+                weight_shard_size,
                 not self.use_presharded_weights,
             )
         else:
@@ -722,7 +812,7 @@ class FusedMoE(torch.nn.Module):
                 if self.use_triton_kernels:
                     loaded_weight = loaded_weight.transpose(-2, -1)
                 loaded_weight = loaded_weight.narrow(
-                    shard_dim, shard_size * tp_rank, shard_size
+                    shard_dim, param_shard_size * tp_rank, param_shard_size
                 )
 
         # w2, down_proj: Load into only logical weight of w2.

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
 
@@ -83,13 +84,6 @@ def _set_flashinfer_trtllm_bf16_layout_meta(
     if packed_shape is not None:
         meta["packed_shape"] = tuple(packed_shape)
     setattr(param, _FLASHINFER_TRTLLM_BF16_LAYOUT_META_ATTR, meta)
-
-
-def _product(shape: tuple[int, ...]) -> int:
-    result = 1
-    for size in shape:
-        result *= size
-    return result
 
 
 def _zero_flashinfer_trtllm_bf16_padding(layer: torch.nn.Module) -> None:
@@ -450,28 +444,21 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             ):
                 return
             if (
-                w13_layout == _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED
-                or w2_layout == _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED
+                w13_layout != _FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL
+                or w2_layout != _FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL
             ):
                 raise RuntimeError(
-                    "FlashInfer TRT-LLM BF16 MoE weights must be both canonical "
-                    "or both packed before process_weights_after_loading."
+                    "FlashInfer TRT-LLM BF16 MoE weights must have canonical "
+                    "layout metadata before process_weights_after_loading."
                 )
 
+            # Ensure padded slots are zero before packing. For example, hot
+            # update may restore params back to canonical shape with a reshape,
+            # not an inverse unpack, so padding can contain old packed values.
             _zero_flashinfer_trtllm_bf16_padding(layer)
 
             canonical_shape_w13 = tuple(layer.w13_weight.data.shape)
             canonical_shape_w2 = tuple(layer.w2_weight.data.shape)
-            _set_flashinfer_trtllm_bf16_layout_meta(
-                layer.w13_weight,
-                canonical_shape=canonical_shape_w13,
-                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
-            )
-            _set_flashinfer_trtllm_bf16_layout_meta(
-                layer.w2_weight,
-                canonical_shape=canonical_shape_w2,
-                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
-            )
             # The cached indices are GPU tensors. Colocated weight offloading
             # can release their backing memory between reloads, so rebuild them
             # once per post-processing cycle.
@@ -604,24 +591,18 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         meta = _get_flashinfer_trtllm_bf16_layout_meta(param)
         expected_shape = tuple(meta.get("canonical_shape", expected_shape))
         current_shape = tuple(param.data.shape)
-        if current_shape == expected_shape:
-            _set_flashinfer_trtllm_bf16_layout_meta(
-                param,
-                canonical_shape=expected_shape,
-                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
-                packed_shape=meta.get("packed_shape"),
-            )
-            return
 
-        expected_numel = _product(expected_shape)
-        if param.data.numel() != expected_numel:
-            raise RuntimeError(
-                f"Cannot restore flashinfer TRT-LLM BF16 MoE weight shape for {weight_name}: "
-                f"current shape={current_shape}, expected shape={expected_shape}."
-            )
+        if current_shape != expected_shape:
+            expected_numel = math.prod(expected_shape)
+            if param.data.numel() != expected_numel:
+                raise RuntimeError(
+                    f"Cannot restore flashinfer TRT-LLM BF16 MoE weight shape for {weight_name}: "
+                    f"current shape={current_shape}, expected shape={expected_shape}."
+                )
 
-        self._cache_permute_indices.clear()
-        param.data = param.data.reshape(expected_shape)
+            self._cache_permute_indices.clear()
+            param.data = param.data.reshape(expected_shape)
+
         _set_flashinfer_trtllm_bf16_layout_meta(
             param,
             canonical_shape=expected_shape,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -59,6 +59,60 @@ _is_cpu = is_cpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
+_FLASHINFER_TRTLLM_BF16_LAYOUT_META_ATTR = (
+    "_sglang_flashinfer_trtllm_bf16_layout_meta"
+)
+_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL = "canonical"
+_FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED = "flashinfer_trtllm_bf16"
+
+
+def _get_flashinfer_trtllm_bf16_layout_meta(param: Parameter) -> dict:
+    return getattr(param, _FLASHINFER_TRTLLM_BF16_LAYOUT_META_ATTR, {})
+
+
+def _set_flashinfer_trtllm_bf16_layout_meta(
+    param: Parameter,
+    *,
+    canonical_shape: tuple[int, ...],
+    storage_layout: str,
+    packed_shape: tuple[int, ...] | None = None,
+) -> None:
+    meta = dict(_get_flashinfer_trtllm_bf16_layout_meta(param))
+    meta["canonical_shape"] = tuple(canonical_shape)
+    meta["storage_layout"] = storage_layout
+    if packed_shape is not None:
+        meta["packed_shape"] = tuple(packed_shape)
+    setattr(param, _FLASHINFER_TRTLLM_BF16_LAYOUT_META_ATTR, meta)
+
+
+def _product(shape: tuple[int, ...]) -> int:
+    result = 1
+    for size in shape:
+        result *= size
+    return result
+
+
+def _zero_flashinfer_trtllm_bf16_padding(layer: torch.nn.Module) -> None:
+    padded_size = getattr(layer, "intermediate_size_per_partition", None)
+    unpadded_size = getattr(layer, "intermediate_size_per_partition_unpadded", None)
+    if (
+        padded_size is None
+        or unpadded_size is None
+        or unpadded_size >= padded_size
+    ):
+        return
+
+    w13_weight = layer.w13_weight.data
+    w2_weight = layer.w2_weight.data
+    if w13_weight.dim() == 3:
+        w13_weight[:, unpadded_size:padded_size, :].zero_()
+        if layer.moe_runner_config.is_gated:
+            w13_weight[:, padded_size + unpadded_size : 2 * padded_size, :].zero_()
+
+    if w2_weight.dim() == 3:
+        w2_weight[:, :, unpadded_size:padded_size].zero_()
+
+
 if _use_aiter:
     from aiter.ops.shuffle import shuffle_weight
     from aiter.tuned_gemm import tgemm
@@ -299,6 +353,12 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         )
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
+        if self.use_flashinfer_trtllm_moe:
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                w13_weight,
+                canonical_shape=tuple(w13_weight.data.shape),
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
+            )
 
         if self.with_bias:
             w13_weight_bias = torch.nn.Parameter(
@@ -321,6 +381,12 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         )
         layer.register_parameter("w2_weight", w2_weight)
         set_weight_attrs(w2_weight, extra_weight_attrs)
+        if self.use_flashinfer_trtllm_moe:
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                w2_weight,
+                canonical_shape=tuple(w2_weight.data.shape),
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
+            )
 
         if self.with_bias:
             w2_weight_bias = torch.nn.Parameter(
@@ -374,6 +440,38 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
+            w13_meta = _get_flashinfer_trtllm_bf16_layout_meta(layer.w13_weight)
+            w2_meta = _get_flashinfer_trtllm_bf16_layout_meta(layer.w2_weight)
+            w13_layout = w13_meta.get("storage_layout")
+            w2_layout = w2_meta.get("storage_layout")
+            if (
+                w13_layout == _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED
+                and w2_layout == _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED
+            ):
+                return
+            if (
+                w13_layout == _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED
+                or w2_layout == _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED
+            ):
+                raise RuntimeError(
+                    "FlashInfer TRT-LLM BF16 MoE weights must be both canonical "
+                    "or both packed before process_weights_after_loading."
+                )
+
+            _zero_flashinfer_trtllm_bf16_padding(layer)
+
+            canonical_shape_w13 = tuple(layer.w13_weight.data.shape)
+            canonical_shape_w2 = tuple(layer.w2_weight.data.shape)
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                layer.w13_weight,
+                canonical_shape=canonical_shape_w13,
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
+            )
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                layer.w2_weight,
+                canonical_shape=canonical_shape_w2,
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
+            )
             # The cached indices are GPU tensors. Colocated weight offloading
             # can release their backing memory between reloads, so rebuild them
             # once per post-processing cycle.
@@ -442,6 +540,19 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             layer.w2_weight.data = layer.w2_weight.data.reshape(
                 layer.num_local_experts, *new_shape_w2
             )
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                layer.w13_weight,
+                canonical_shape=canonical_shape_w13,
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED,
+                packed_shape=tuple(layer.w13_weight.data.shape),
+            )
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                layer.w2_weight,
+                canonical_shape=canonical_shape_w2,
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED,
+                packed_shape=tuple(layer.w2_weight.data.shape),
+            )
+
         if _is_npu:
             # The kernels set the dispatcher output dtype themselves -- they are
             # the ones that know what their gmms expect. NPUUnquantMoEMethod
@@ -458,41 +569,65 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         param: torch.nn.Parameter,
         weight_name: str,
     ) -> None:
-        """Restore canonical BF16 MoE load shapes before hot weight copy.
+        """Prepare BF16 MoE params for canonical hot-update loading.
 
         The flashinfer TRT-LLM BF16 postprocess reshapes expert weights into
-        block layout. During weight update, checkpoint tensors are in
-        canonical layout and need a temporary shape restore for copy.
+        block layout. During weight update, checkpoint tensors are canonical
+        replacement values, so the packed storage can be discarded and reused as
+        a canonical load buffer before copy.
         """
-        if not get_moe_runner_backend().is_flashinfer_trtllm_routed():
+        if not self.use_flashinfer_trtllm_moe:
             return
 
         expected_shape = None
-        if weight_name.endswith(".experts.w13_weight"):
+        if param is getattr(layer, "w13_weight", None) or weight_name.endswith(
+            ".experts.w13_weight"
+        ):
             w13_rows = (
                 2 * layer.intermediate_size_per_partition
                 if layer.moe_runner_config.is_gated
                 else layer.intermediate_size_per_partition
             )
             expected_shape = (layer.num_local_experts, w13_rows, layer.hidden_size)
-        elif weight_name.endswith(".experts.w2_weight"):
+        elif param is getattr(layer, "w2_weight", None) or weight_name.endswith(
+            ".experts.w2_weight"
+        ):
             expected_shape = (
                 layer.num_local_experts,
                 layer.hidden_size,
                 layer.intermediate_size_per_partition,
             )
 
-        if expected_shape is None or tuple(param.data.shape) == expected_shape:
+        if expected_shape is None:
             return
 
-        expected_numel = expected_shape[0] * expected_shape[1] * expected_shape[2]
+        meta = _get_flashinfer_trtllm_bf16_layout_meta(param)
+        expected_shape = tuple(meta.get("canonical_shape", expected_shape))
+        current_shape = tuple(param.data.shape)
+        if current_shape == expected_shape:
+            _set_flashinfer_trtllm_bf16_layout_meta(
+                param,
+                canonical_shape=expected_shape,
+                storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
+                packed_shape=meta.get("packed_shape"),
+            )
+            return
+
+        expected_numel = _product(expected_shape)
         if param.data.numel() != expected_numel:
             raise RuntimeError(
                 f"Cannot restore flashinfer TRT-LLM BF16 MoE weight shape for {weight_name}: "
-                f"current shape={tuple(param.data.shape)}, expected shape={expected_shape}."
+                f"current shape={current_shape}, expected shape={expected_shape}."
             )
 
+        self._cache_permute_indices.clear()
         param.data = param.data.reshape(expected_shape)
+        _set_flashinfer_trtllm_bf16_layout_meta(
+            param,
+            canonical_shape=expected_shape,
+            storage_layout=_FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL,
+            packed_shape=meta.get("packed_shape", current_shape),
+        )
 
     def _aiter_ck_moe_supported(self, layer) -> bool:
         # aiter CK fused-MoE requires intermediate_size_per_partition to be 128-aligned

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -60,9 +60,7 @@ _is_cpu = is_cpu()
 _is_npu = is_npu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
-_FLASHINFER_TRTLLM_BF16_LAYOUT_META_ATTR = (
-    "_sglang_flashinfer_trtllm_bf16_layout_meta"
-)
+_FLASHINFER_TRTLLM_BF16_LAYOUT_META_ATTR = "_sglang_flashinfer_trtllm_bf16_layout_meta"
 _FLASHINFER_TRTLLM_BF16_LAYOUT_CANONICAL = "canonical"
 _FLASHINFER_TRTLLM_BF16_LAYOUT_PACKED = "flashinfer_trtllm_bf16"
 
@@ -89,11 +87,7 @@ def _set_flashinfer_trtllm_bf16_layout_meta(
 def _zero_flashinfer_trtllm_bf16_padding(layer: torch.nn.Module) -> None:
     padded_size = getattr(layer, "intermediate_size_per_partition", None)
     unpadded_size = getattr(layer, "intermediate_size_per_partition_unpadded", None)
-    if (
-        padded_size is None
-        or unpadded_size is None
-        or unpadded_size >= padded_size
-    ):
+    if padded_size is None or unpadded_size is None or unpadded_size >= padded_size:
         return
 
     w13_weight = layer.w13_weight.data

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -1770,9 +1770,23 @@ def narrow_padded_param_and_loaded_weight(
     dim,
     shard_size,
     narrow_weight=True,
+    weight_shard_size=None,
 ):
-    actual_shard_size = get_actual_shard_size(
-        shard_size, weight_start, loaded_weight.size(dim)
+    """Return matching param/weight slices and zero padded param tail.
+
+    shard_size is the size of the destination param shard, including any
+    padding. weight_shard_size is the size of the incoming weight shard before
+    destination padding; it defaults to shard_size for existing callers.
+    """
+    if weight_shard_size is None:
+        weight_shard_size = shard_size
+
+    if not narrow_weight:
+        weight_start = 0
+
+    actual_shard_size = min(
+        shard_size,
+        get_actual_shard_size(weight_shard_size, weight_start, loaded_weight.size(dim)),
     )
 
     if narrow_weight:

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -141,8 +141,8 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         canonical_w2_shape = tuple(layer.w2_weight.shape)
         layer.quant_method.process_weights_after_loading(layer)
 
-        # process_weights_after_loading packs canonical weights into the
-        # FlashInfer TRTLLM runtime layout.
+        # Test precondition: hot update below must start from packed params,
+        # otherwise it would not exercise restore-before-load.
         self.assertNotEqual(tuple(layer.w13_weight.shape), canonical_w13_shape)
         self.assertNotEqual(tuple(layer.w2_weight.shape), canonical_w2_shape)
 

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -46,7 +46,12 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         ).reshape(shape)
         return (values / 1000 + offset).to(torch.bfloat16)
 
-    def _make_layer(self):
+    def _make_layer(
+        self,
+        tp_size=1,
+        tp_rank=0,
+        use_weight_loader_fused=False,
+    ):
         from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
         from sglang.srt.layers.moe.token_dispatcher import standard
 
@@ -55,8 +60,8 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         with (
             patch.object(fm, "get_moe_expert_parallel_world_size", return_value=1),
             patch.object(fm, "get_moe_expert_parallel_rank", return_value=0),
-            patch.object(fm, "get_moe_tensor_parallel_world_size", return_value=1),
-            patch.object(fm, "get_moe_tensor_parallel_rank", return_value=0),
+            patch.object(fm, "get_moe_tensor_parallel_world_size", return_value=tp_size),
+            patch.object(fm, "get_moe_tensor_parallel_rank", return_value=tp_rank),
             patch.object(std, "get_moe_expert_parallel_world_size", return_value=1),
             patch.object(std, "get_moe_expert_parallel_rank", return_value=0),
         ):
@@ -67,6 +72,7 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
                 layer_id=0,
                 top_k=1,
                 params_dtype=torch.bfloat16,
+                use_weight_loader_fused=use_weight_loader_fused,
             )
             return layer.cuda()
 
@@ -157,6 +163,53 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         layer.quant_method.process_weights_after_loading(layer)
         self.assertNotEqual(tuple(layer.w13_weight.shape), canonical_w13_shape)
         self.assertNotEqual(tuple(layer.w2_weight.shape), canonical_w2_shape)
+
+    def test_fused_w13_load_shards_each_half_independently(self):
+        tp_size = 2
+        per_rank_size = self.intermediate_size // tp_size
+
+        for tp_rank in range(tp_size):
+            with self.subTest(tp_rank=tp_rank):
+                layer = self._make_layer(
+                    tp_size=tp_size,
+                    tp_rank=tp_rank,
+                    use_weight_loader_fused=True,
+                )
+                padded_per_rank_size = layer.intermediate_size_per_partition
+                full_w13 = self._make_weight(
+                    (
+                        self.num_experts,
+                        2 * self.intermediate_size,
+                        self.hidden_size,
+                    ),
+                    offset=200 + tp_rank,
+                )
+
+                layer.weight_loader_fused(
+                    layer.w13_weight,
+                    full_w13,
+                    "model.layers.0.mlp.experts.gate_up_proj.weight",
+                    "w13",
+                )
+
+                first_half_start = per_rank_size * tp_rank
+                second_half_start = self.intermediate_size + per_rank_size * tp_rank
+                torch.testing.assert_close(
+                    layer.w13_weight[:, :per_rank_size, :],
+                    full_w13[
+                        :, first_half_start : first_half_start + per_rank_size, :
+                    ],
+                )
+                torch.testing.assert_close(
+                    layer.w13_weight[
+                        :,
+                        padded_per_rank_size : padded_per_rank_size + per_rank_size,
+                        :,
+                    ],
+                    full_w13[
+                        :, second_half_start : second_half_start + per_rank_size, :
+                    ],
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -49,37 +49,15 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
         from sglang.srt.layers.moe.token_dispatcher import standard
 
+        fm = fused_moe_layer
+        std = standard
         with (
-            patch.object(
-                fused_moe_layer,
-                "get_moe_expert_parallel_world_size",
-                return_value=1,
-            ),
-            patch.object(
-                fused_moe_layer,
-                "get_moe_expert_parallel_rank",
-                return_value=0,
-            ),
-            patch.object(
-                fused_moe_layer,
-                "get_moe_tensor_parallel_world_size",
-                return_value=1,
-            ),
-            patch.object(
-                fused_moe_layer,
-                "get_moe_tensor_parallel_rank",
-                return_value=0,
-            ),
-            patch.object(
-                standard,
-                "get_moe_expert_parallel_world_size",
-                return_value=1,
-            ),
-            patch.object(
-                standard,
-                "get_moe_expert_parallel_rank",
-                return_value=0,
-            ),
+            patch.object(fm, "get_moe_expert_parallel_world_size", return_value=1),
+            patch.object(fm, "get_moe_expert_parallel_rank", return_value=0),
+            patch.object(fm, "get_moe_tensor_parallel_world_size", return_value=1),
+            patch.object(fm, "get_moe_tensor_parallel_rank", return_value=0),
+            patch.object(std, "get_moe_expert_parallel_world_size", return_value=1),
+            patch.object(std, "get_moe_expert_parallel_rank", return_value=0),
         ):
             layer = FusedMoE(
                 num_experts=self.num_experts,
@@ -133,80 +111,32 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         return loaded
 
     def _assert_canonical_update_visible(self, layer, loaded):
-        self.assertEqual(
-            tuple(layer.w13_weight.shape),
-            (
-                self.num_experts,
-                2 * self.padded_intermediate_size,
-                self.hidden_size,
-            ),
-        )
-        self.assertEqual(
-            tuple(layer.w2_weight.shape),
-            (
-                self.num_experts,
-                self.hidden_size,
-                self.padded_intermediate_size,
-            ),
-        )
+        real = self.intermediate_size
+        padded = self.padded_intermediate_size
 
         for expert_id, (w1, w3, w2) in enumerate(loaded):
             # FlashInfer TRTLLM stores W13 in W3/W1 order.
+            torch.testing.assert_close(layer.w13_weight[expert_id, :real, :], w3)
             torch.testing.assert_close(
-                layer.w13_weight[
-                    expert_id,
-                    : self.intermediate_size,
-                    :,
-                ],
-                w3,
+                layer.w13_weight[expert_id, padded : padded + real, :], w1
             )
-            torch.testing.assert_close(
-                layer.w13_weight[
-                    expert_id,
-                    self.padded_intermediate_size : self.padded_intermediate_size
-                    + self.intermediate_size,
-                    :,
-                ],
-                w1,
-            )
-            torch.testing.assert_close(
-                layer.w2_weight[
-                    expert_id,
-                    :,
-                    : self.intermediate_size,
-                ],
-                w2,
-            )
+            torch.testing.assert_close(layer.w2_weight[expert_id, :, :real], w2)
 
             self.assertTrue(
                 torch.all(
-                    layer.w13_weight[
-                        expert_id,
-                        self.intermediate_size : self.padded_intermediate_size,
-                        :,
-                    ]
+                    layer.w13_weight[expert_id, real:padded, :]
                     == 0
                 ).item()
             )
             self.assertTrue(
                 torch.all(
-                    layer.w13_weight[
-                        expert_id,
-                        self.padded_intermediate_size
-                        + self.intermediate_size : 2
-                        * self.padded_intermediate_size,
-                        :,
-                    ]
+                    layer.w13_weight[expert_id, padded + real : 2 * padded, :]
                     == 0
                 ).item()
             )
             self.assertTrue(
                 torch.all(
-                    layer.w2_weight[
-                        expert_id,
-                        :,
-                        self.intermediate_size : self.padded_intermediate_size,
-                    ]
+                    layer.w2_weight[expert_id, :, real:padded]
                     == 0
                 ).item()
             )
@@ -214,17 +144,21 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
     def test_hot_update_reloads_canonical_weights_after_flashinfer_pack(self):
         layer = self._make_layer()
 
-        initial_loaded = self._load_all_experts(layer, offset=0)
-        self._assert_canonical_update_visible(layer, initial_loaded)
-
+        self._load_all_experts(layer, offset=0)
         canonical_w13_shape = tuple(layer.w13_weight.shape)
         canonical_w2_shape = tuple(layer.w2_weight.shape)
         layer.quant_method.process_weights_after_loading(layer)
 
+        # process_weights_after_loading packs canonical weights into the
+        # FlashInfer TRTLLM runtime layout.
         self.assertNotEqual(tuple(layer.w13_weight.shape), canonical_w13_shape)
         self.assertNotEqual(tuple(layer.w2_weight.shape), canonical_w2_shape)
 
+        # Mimic hot update: params are packed, but replacement weights are
+        # canonical. The weight loader should restore canonical shape first.
         updated_loaded = self._load_all_experts(layer, offset=100)
+        self.assertEqual(tuple(layer.w13_weight.shape), canonical_w13_shape)
+        self.assertEqual(tuple(layer.w2_weight.shape), canonical_w2_shape)
         self._assert_canonical_update_visible(layer, updated_loaded)
 
         layer.quant_method.process_weights_after_loading(layer)

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -110,36 +110,28 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
             loaded.append((w1, w3, w2))
         return loaded
 
+    def _assert_equal(self, actual, expected):
+        if not torch.is_tensor(expected):
+            expected = torch.full_like(actual, expected)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
     def _assert_canonical_update_visible(self, layer, loaded):
         real = self.intermediate_size
         padded = self.padded_intermediate_size
 
         for expert_id, (w1, w3, w2) in enumerate(loaded):
             # FlashInfer TRTLLM stores W13 in W3/W1 order.
-            torch.testing.assert_close(layer.w13_weight[expert_id, :real, :], w3)
-            torch.testing.assert_close(
+            self._assert_equal(layer.w13_weight[expert_id, :real, :], w3)
+            self._assert_equal(
                 layer.w13_weight[expert_id, padded : padded + real, :], w1
             )
-            torch.testing.assert_close(layer.w2_weight[expert_id, :, :real], w2)
+            self._assert_equal(layer.w2_weight[expert_id, :, :real], w2)
 
-            self.assertTrue(
-                torch.all(
-                    layer.w13_weight[expert_id, real:padded, :]
-                    == 0
-                ).item()
+            self._assert_equal(layer.w13_weight[expert_id, real:padded, :], 0)
+            self._assert_equal(
+                layer.w13_weight[expert_id, padded + real : 2 * padded, :], 0
             )
-            self.assertTrue(
-                torch.all(
-                    layer.w13_weight[expert_id, padded + real : 2 * padded, :]
-                    == 0
-                ).item()
-            )
-            self.assertTrue(
-                torch.all(
-                    layer.w2_weight[expert_id, :, real:padded]
-                    == 0
-                ).item()
-            )
+            self._assert_equal(layer.w2_weight[expert_id, :, real:padded], 0)
 
     def test_hot_update_reloads_canonical_weights_after_flashinfer_pack(self):
         layer = self._make_layer()

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -51,16 +51,20 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         tp_size=1,
         tp_rank=0,
         use_weight_loader_fused=False,
+        intermediate_size=None,
     ):
         from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
         from sglang.srt.layers.moe.token_dispatcher import standard
 
+        intermediate_size = intermediate_size or self.intermediate_size
         fm = fused_moe_layer
         std = standard
         with (
             patch.object(fm, "get_moe_expert_parallel_world_size", return_value=1),
             patch.object(fm, "get_moe_expert_parallel_rank", return_value=0),
-            patch.object(fm, "get_moe_tensor_parallel_world_size", return_value=tp_size),
+            patch.object(
+                fm, "get_moe_tensor_parallel_world_size", return_value=tp_size
+            ),
             patch.object(fm, "get_moe_tensor_parallel_rank", return_value=tp_rank),
             patch.object(std, "get_moe_expert_parallel_world_size", return_value=1),
             patch.object(std, "get_moe_expert_parallel_rank", return_value=0),
@@ -68,7 +72,7 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
             layer = FusedMoE(
                 num_experts=self.num_experts,
                 hidden_size=self.hidden_size,
-                intermediate_size=self.intermediate_size,
+                intermediate_size=intermediate_size,
                 layer_id=0,
                 top_k=1,
                 params_dtype=torch.bfloat16,
@@ -197,7 +201,7 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
                 torch.testing.assert_close(
                     layer.w13_weight[:, :per_rank_size, :],
                     full_w13[
-                        :, first_half_start : first_half_start + per_rank_size, :
+                        :, second_half_start : second_half_start + per_rank_size, :
                     ],
                 )
                 torch.testing.assert_close(
@@ -207,9 +211,76 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
                         :,
                     ],
                     full_w13[
-                        :, second_half_start : second_half_start + per_rank_size, :
+                        :, first_half_start : first_half_start + per_rank_size, :
                     ],
                 )
+
+    def test_tp_padded_load_uses_unpadded_source_shard(self):
+        tp_size = 8
+        tp_rank = 3
+        intermediate_size = 768
+        shard_size = intermediate_size // tp_size
+        padded_shard_size = 128
+        source_shard = slice(tp_rank * shard_size, (tp_rank + 1) * shard_size)
+        layer = self._make_layer(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            intermediate_size=intermediate_size,
+        )
+
+        loaded = []
+        for expert_id in range(self.num_experts):
+            expert_offset = expert_id * 10
+            w1 = self._make_weight(
+                (intermediate_size, self.hidden_size), expert_offset + 1
+            )
+            w3 = self._make_weight(
+                (intermediate_size, self.hidden_size), expert_offset + 3
+            )
+            w2 = self._make_weight(
+                (self.hidden_size, intermediate_size), expert_offset + 2
+            )
+            self._load_expert(layer, expert_id, w1, w3, w2)
+            loaded.append((w1, w3, w2))
+
+        self.assertEqual(
+            tuple(layer.w13_weight.shape),
+            (self.num_experts, 2 * padded_shard_size, self.hidden_size),
+        )
+        self.assertEqual(
+            tuple(layer.w2_weight.shape),
+            (self.num_experts, self.hidden_size, padded_shard_size),
+        )
+
+        for expert_id, (w1, w3, w2) in enumerate(loaded):
+            self._assert_equal(
+                layer.w13_weight[expert_id, :shard_size, :], w3[source_shard, :]
+            )
+            self._assert_equal(
+                layer.w13_weight[
+                    expert_id,
+                    padded_shard_size : padded_shard_size + shard_size,
+                    :,
+                ],
+                w1[source_shard, :],
+            )
+            self._assert_equal(
+                layer.w2_weight[expert_id, :, :shard_size], w2[:, source_shard]
+            )
+            self._assert_equal(
+                layer.w13_weight[expert_id, shard_size:padded_shard_size, :], 0
+            )
+            self._assert_equal(
+                layer.w13_weight[
+                    expert_id,
+                    padded_shard_size + shard_size : 2 * padded_shard_size,
+                    :,
+                ],
+                0,
+            )
+            self._assert_equal(
+                layer.w2_weight[expert_id, :, shard_size:padded_shard_size], 0
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -1,0 +1,236 @@
+import math
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe import initialize_moe_config
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-b200")
+
+
+class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
+    num_experts = 2
+    hidden_size = 128
+    intermediate_size = 192
+    padded_intermediate_size = 256
+
+    def setUp(self):
+        super().setUp()
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required for FlashInfer TRTLLM BF16 MoE packing.")
+        if torch.cuda.get_device_capability()[0] < 10:
+            self.skipTest("FlashInfer TRTLLM BF16 MoE is only tested on SM100+.")
+
+        try:
+            import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm  # noqa: F401
+            from flashinfer.fused_moe.core import convert_to_block_layout  # noqa: F401
+        except ImportError as err:
+            self.skipTest(f"FlashInfer TRTLLM MoE helpers are unavailable: {err}")
+
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_runner_backend="flashinfer_trtllm",
+        )
+        set_global_server_args_for_scheduler(server_args)
+        initialize_moe_config(server_args)
+
+    def _make_weight(self, shape, offset):
+        values = torch.arange(
+            math.prod(shape), device="cuda", dtype=torch.float32
+        ).reshape(shape)
+        return (values / 1000 + offset).to(torch.bfloat16)
+
+    def _make_layer(self):
+        from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
+        from sglang.srt.layers.moe.token_dispatcher import standard
+
+        with (
+            patch.object(
+                fused_moe_layer,
+                "get_moe_expert_parallel_world_size",
+                return_value=1,
+            ),
+            patch.object(
+                fused_moe_layer,
+                "get_moe_expert_parallel_rank",
+                return_value=0,
+            ),
+            patch.object(
+                fused_moe_layer,
+                "get_moe_tensor_parallel_world_size",
+                return_value=1,
+            ),
+            patch.object(
+                fused_moe_layer,
+                "get_moe_tensor_parallel_rank",
+                return_value=0,
+            ),
+            patch.object(
+                standard,
+                "get_moe_expert_parallel_world_size",
+                return_value=1,
+            ),
+            patch.object(
+                standard,
+                "get_moe_expert_parallel_rank",
+                return_value=0,
+            ),
+        ):
+            layer = FusedMoE(
+                num_experts=self.num_experts,
+                hidden_size=self.hidden_size,
+                intermediate_size=self.intermediate_size,
+                layer_id=0,
+                top_k=1,
+                params_dtype=torch.bfloat16,
+            )
+            return layer.cuda()
+
+    def _load_expert(self, layer, expert_id, w1, w3, w2):
+        prefix = f"model.layers.0.mlp.experts.{expert_id}"
+        layer.weight_loader(
+            layer.w13_weight,
+            w1,
+            f"{prefix}.gate_proj.weight",
+            "w1",
+            expert_id,
+        )
+        layer.weight_loader(
+            layer.w13_weight,
+            w3,
+            f"{prefix}.up_proj.weight",
+            "w3",
+            expert_id,
+        )
+        layer.weight_loader(
+            layer.w2_weight,
+            w2,
+            f"{prefix}.down_proj.weight",
+            "w2",
+            expert_id,
+        )
+
+    def _load_all_experts(self, layer, offset):
+        loaded = []
+        for expert_id in range(self.num_experts):
+            expert_offset = offset + expert_id * 10
+            w1 = self._make_weight(
+                (self.intermediate_size, self.hidden_size), expert_offset + 1
+            )
+            w3 = self._make_weight(
+                (self.intermediate_size, self.hidden_size), expert_offset + 3
+            )
+            w2 = self._make_weight(
+                (self.hidden_size, self.intermediate_size), expert_offset + 2
+            )
+            self._load_expert(layer, expert_id, w1, w3, w2)
+            loaded.append((w1, w3, w2))
+        return loaded
+
+    def _assert_canonical_update_visible(self, layer, loaded):
+        self.assertEqual(
+            tuple(layer.w13_weight.shape),
+            (
+                self.num_experts,
+                2 * self.padded_intermediate_size,
+                self.hidden_size,
+            ),
+        )
+        self.assertEqual(
+            tuple(layer.w2_weight.shape),
+            (
+                self.num_experts,
+                self.hidden_size,
+                self.padded_intermediate_size,
+            ),
+        )
+
+        for expert_id, (w1, w3, w2) in enumerate(loaded):
+            # FlashInfer TRTLLM stores W13 in W3/W1 order.
+            torch.testing.assert_close(
+                layer.w13_weight[
+                    expert_id,
+                    : self.intermediate_size,
+                    :,
+                ],
+                w3,
+            )
+            torch.testing.assert_close(
+                layer.w13_weight[
+                    expert_id,
+                    self.padded_intermediate_size : self.padded_intermediate_size
+                    + self.intermediate_size,
+                    :,
+                ],
+                w1,
+            )
+            torch.testing.assert_close(
+                layer.w2_weight[
+                    expert_id,
+                    :,
+                    : self.intermediate_size,
+                ],
+                w2,
+            )
+
+            self.assertTrue(
+                torch.all(
+                    layer.w13_weight[
+                        expert_id,
+                        self.intermediate_size : self.padded_intermediate_size,
+                        :,
+                    ]
+                    == 0
+                ).item()
+            )
+            self.assertTrue(
+                torch.all(
+                    layer.w13_weight[
+                        expert_id,
+                        self.padded_intermediate_size
+                        + self.intermediate_size : 2
+                        * self.padded_intermediate_size,
+                        :,
+                    ]
+                    == 0
+                ).item()
+            )
+            self.assertTrue(
+                torch.all(
+                    layer.w2_weight[
+                        expert_id,
+                        :,
+                        self.intermediate_size : self.padded_intermediate_size,
+                    ]
+                    == 0
+                ).item()
+            )
+
+    def test_hot_update_reloads_canonical_weights_after_flashinfer_pack(self):
+        layer = self._make_layer()
+
+        initial_loaded = self._load_all_experts(layer, offset=0)
+        self._assert_canonical_update_visible(layer, initial_loaded)
+
+        canonical_w13_shape = tuple(layer.w13_weight.shape)
+        canonical_w2_shape = tuple(layer.w2_weight.shape)
+        layer.quant_method.process_weights_after_loading(layer)
+
+        self.assertNotEqual(tuple(layer.w13_weight.shape), canonical_w13_shape)
+        self.assertNotEqual(tuple(layer.w2_weight.shape), canonical_w2_shape)
+
+        updated_loaded = self._load_all_experts(layer, offset=100)
+        self._assert_canonical_update_visible(layer, updated_loaded)
+
+        layer.quant_method.process_weights_after_loading(layer)
+        self.assertNotEqual(tuple(layer.w13_weight.shape), canonical_w13_shape)
+        self.assertNotEqual(tuple(layer.w2_weight.shape), canonical_w2_shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -27,8 +27,9 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
             self.skipTest("FlashInfer TRTLLM BF16 MoE is only tested on SM100+.")
 
         try:
-            import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm  # noqa: F401
             from flashinfer.fused_moe.core import convert_to_block_layout  # noqa: F401
+
+            import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm  # noqa: F401
         except ImportError as err:
             self.skipTest(f"FlashInfer TRTLLM MoE helpers are unavailable: {err}")
 

--- a/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
+++ b/test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py
@@ -1,16 +1,20 @@
 import math
 import unittest
-from unittest.mock import patch
+from contextlib import ExitStack
 
 import torch
 
-from sglang.srt.layers.moe import initialize_moe_config
+from sglang.srt.layers.moe import MoeA2ABackend, MoeRunnerBackend
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.runtime_context import get_context, get_flags, get_parallel
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=20, suite="base-b-kernel-unit-1-gpu-b200")
+register_cuda_ci(
+    est_time=20,
+    stage="base-b-kernel-unit",
+    runner_config="4-gpu-b200",
+)
 
 
 class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
@@ -33,12 +37,20 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         except ImportError as err:
             self.skipTest(f"FlashInfer TRTLLM MoE helpers are unavailable: {err}")
 
-        server_args = ServerArgs(
-            model_path="dummy",
-            moe_runner_backend="flashinfer_trtllm",
+        overrides = ExitStack()
+        self.addCleanup(overrides.close)
+        overrides.enter_context(
+            get_context().override_server_args(
+                moe_a2a_backend="none",
+                moe_runner_backend="flashinfer_trtllm",
+            )
         )
-        set_global_server_args_for_scheduler(server_args)
-        initialize_moe_config(server_args)
+        overrides.enter_context(
+            get_flags().moe.override(
+                a2a_backend=MoeA2ABackend.NONE,
+                runner_backend=MoeRunnerBackend.FLASHINFER_TRTLLM,
+            )
+        )
 
     def _make_weight(self, shape, offset):
         values = torch.arange(
@@ -53,21 +65,12 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
         use_weight_loader_fused=False,
         intermediate_size=None,
     ):
-        from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
-        from sglang.srt.layers.moe.token_dispatcher import standard
-
         intermediate_size = intermediate_size or self.intermediate_size
-        fm = fused_moe_layer
-        std = standard
-        with (
-            patch.object(fm, "get_moe_expert_parallel_world_size", return_value=1),
-            patch.object(fm, "get_moe_expert_parallel_rank", return_value=0),
-            patch.object(
-                fm, "get_moe_tensor_parallel_world_size", return_value=tp_size
-            ),
-            patch.object(fm, "get_moe_tensor_parallel_rank", return_value=tp_rank),
-            patch.object(std, "get_moe_expert_parallel_world_size", return_value=1),
-            patch.object(std, "get_moe_expert_parallel_rank", return_value=0),
+        with get_parallel().override(
+            moe_ep_size=1,
+            moe_ep_rank=0,
+            moe_tp_size=tp_size,
+            moe_tp_rank=tp_rank,
         ):
             layer = FusedMoE(
                 num_experts=self.num_experts,
@@ -210,9 +213,7 @@ class TestFlashInferTrtllmBf16HotUpdate(CustomTestCase):
                         padded_per_rank_size : padded_per_rank_size + per_rank_size,
                         :,
                     ],
-                    full_w13[
-                        :, first_half_start : first_half_start + per_rank_size, :
-                    ],
+                    full_w13[:, first_half_start : first_half_start + per_rank_size, :],
                 )
 
     def test_tp_padded_load_uses_unpadded_source_shard(self):


### PR DESCRIPTION
## Summary

Fix BF16 FlashInfer TRTLLM MoE hot weight update.

With this change:
### Pure inference is unchanged:
`load_weights -> process_weights_after_loading -> packed params -> infer`

### RL rollout update changes from the broken flow:
`packed params -> load canonical update weights into packed layout -> ERROR`

to:
`packed params -> restore canonical shape -> load canonical update weights -> process_weights_after_loading -> packed params`

## Changes

- Track canonical/packed layout metadata for BF16 FlashInfer TRTLLM MoE weights.
- Restore packed params to canonical shape before weight loading.
- Re-pack canonical weights in `process_weights_after_loading()`.
- Handle fused `w13` loading when destination halves have padding.
- Add a regression test for hot update after FlashInfer packing.

## Test

```bash
python3 -m pytest -q test/registered/moe/test_flashinfer_trtllm_bf16_hot_update.py -s

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30841029629](https://github.com/sgl-project/sglang/actions/runs/30841029629)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30841030518](https://github.com/sgl-project/sglang/actions/runs/30841030518)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->