### PR TITLE
[Quantization][Bugfix]: Join multi-arg RuntimeError in Quark _check_scheme_supported

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -294,10 +294,12 @@ class QuarkConfig(QuantizationConfig):
 
             supported = capability >= min_capability
             if error and not supported:
+                # Pass a single joined message; RuntimeError stringifies
+                # multiple positional args as a tuple repr.
                 raise RuntimeError(
-                    "Quantization scheme is not supported for ",
-                    f"the current GPU. Min capability: {min_capability}. ",
-                    f"Current capability: {capability}.",
+                    "Quantization scheme is not supported for "
+                    f"the current GPU. Min capability: {min_capability}. "
+                    f"Current capability: {capability}."
                 )
             return supported
         else:

--- a/test/registered/unit/layers/quantization/test_quark_config.py
+++ b/test/registered/unit/layers/quantization/test_quark_config.py
@@ -1,0 +1,87 @@
+"""Unit tests for QuarkConfig — CPU-only, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+from sglang.test.test_utils import CustomTestCase
+
+_GET_CAP = "sglang.srt.layers.quantization.quark.quark.get_device_capability"
+
+
+def _bare_config() -> QuarkConfig:
+    """Skip __init__ — _check_scheme_supported reads no instance attributes."""
+    return QuarkConfig.__new__(QuarkConfig)
+
+
+class TestCheckSchemeSupportedError(CustomTestCase):
+    """Regression for `RuntimeError("a", "b", "c")` being passed three args.
+
+    Bug: `_check_scheme_supported` raised `RuntimeError` with three positional
+    string fragments. `RuntimeError.__str__` formats `self.args` as a tuple
+    when `len(args) != 1`, so the user saw
+        ('Quantization scheme is not supported for ', 'the current GPU…', 'Current capability: 70.')
+    instead of a sentence. Fix: pass one already-joined message.
+    """
+
+    def test_error_is_single_argument(self):
+        # The structural assertion that catches the bug regardless of wording.
+        with patch(_GET_CAP, return_value=(7, 0)):  # capability = 70 < 200
+            with self.assertRaises(RuntimeError) as ctx:
+                _bare_config()._check_scheme_supported(min_capability=200)
+        err = ctx.exception
+        self.assertEqual(
+            len(err.args),
+            1,
+            f"RuntimeError must carry a single joined message, got {err.args!r}",
+        )
+
+    def test_error_message_renders_as_sentence(self):
+        with patch(_GET_CAP, return_value=(7, 0)):
+            with self.assertRaises(RuntimeError) as ctx:
+                _bare_config()._check_scheme_supported(min_capability=200)
+        msg = str(ctx.exception)
+        # Tuple-repr leakage shows up as a leading '(' and quote-comma joins.
+        self.assertFalse(
+            msg.startswith("("),
+            f"error message starts with '(' (tuple repr leaked): {msg!r}",
+        )
+        self.assertNotIn(
+            "', '",
+            msg,
+            f"error message contains tuple-style fragment join: {msg!r}",
+        )
+
+    def test_error_message_content(self):
+        with patch(_GET_CAP, return_value=(7, 0)):
+            with self.assertRaises(RuntimeError) as ctx:
+                _bare_config()._check_scheme_supported(min_capability=200)
+        msg = str(ctx.exception)
+        self.assertIn("Quantization scheme is not supported", msg)
+        self.assertIn("Min capability: 200", msg)
+        self.assertIn("Current capability: 70", msg)
+
+    # ---- Guardrails: unchanged code paths ---------------------------------
+
+    def test_unsupported_returns_false_when_error_disabled(self):
+        with patch(_GET_CAP, return_value=(7, 0)):
+            ok = _bare_config()._check_scheme_supported(min_capability=200, error=False)
+        self.assertFalse(ok)
+
+    def test_supported_returns_true(self):
+        with patch(_GET_CAP, return_value=(8, 0)):  # capability = 80 >= 70
+            ok = _bare_config()._check_scheme_supported(min_capability=70)
+        self.assertTrue(ok)
+
+    def test_no_device_returns_false(self):
+        with patch(_GET_CAP, return_value=None):
+            ok = _bare_config()._check_scheme_supported(min_capability=70)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`QuarkConfig._check_scheme_supported` raises a capability-mismatch error like this:

```python
raise RuntimeError(
    "Quantization scheme is not supported for ",
    f"the current GPU. Min capability: {min_capability}. ",
    f"Current capability: {capability}.",
)
```

That passes **three positional arguments** to `RuntimeError`. `Exception.__str__` formats `self.args` as a tuple repr when `len(args) != 1`, so the message the user actually sees today is the tuple-stringified mess on the left, not the intended sentence on the right:

| Today (buggy) | After this PR |
|---|---|
| `('Quantization scheme is not supported for ', 'the current GPU. Min capability: 200. ', 'Current capability: 70.')` | `Quantization scheme is not supported for the current GPU. Min capability: 200. Current capability: 70.` |

Parens, quoted fragments, and quote-comma joins all leak through — what looked like three message fragments meant to be concatenated were instead stored as three separate `args` entries.

## Modifications

**`python/sglang/srt/layers/quantization/quark/quark.py:187-192`** — replace the three-argument call with a single message built via adjacent string-literal concatenation. The diff is a two-character semantic change (drop two commas) plus a short clarifying comment:

```python
raise RuntimeError(
    "Quantization scheme is not supported for "
    f"the current GPU. Min capability: {min_capability}. "
    f"Current capability: {capability}."
)
```

No other code paths in the function change.

**`test/registered/unit/layers/quantization/test_quark_config.py`** (new) — CPU-only regression test registered to `base-a-test-cpu` (`est_time=5`). Six cases:

| Test | Purpose | On unfixed code |
|---|---|---|
| `test_error_is_single_argument` | structural — asserts `len(err.args) == 1` | **fails** (gets 3 args) |
| `test_error_message_renders_as_sentence` | rejects leading `(` and quote-comma fragment joins | **fails** |
| `test_error_message_content` | substring sanity check on the rendered message | passes either way |
| `test_unsupported_returns_false_when_error_disabled` | guardrail for `error=False` branch | passes |
| `test_supported_returns_true` | guardrail for the `supported` path | passes |
| `test_no_device_returns_false` | guardrail for `get_device_capability() is None` | passes |

The test mocks `sglang.srt.layers.quantization.quark.quark.get_device_capability` and uses `QuarkConfig.__new__(QuarkConfig)` to skip `__init__` (the method under test reads no instance attributes).

## Accuracy Tests

N/A — this is an error-formatting fix. It does not touch quantization math, kernel selection, or any model-output code path. The exception is raised only on the unsupported-capability branch; values returned by `_check_scheme_supported` (`True` / `False`) are unchanged.

## Speed Tests and Profiling

N/A — no kernel changes, no hot-path modifications. The change is to an exception-construction expression that only fires on a fatal-startup error.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — N/A; bug fix, no API/behavior change.
- [x] Provide accuracy and speed benchmark results — see above; not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28313702146](https://github.com/sgl-project/sglang/actions/runs/28313702146)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28313702094](https://github.com/sgl-project/sglang/actions/runs/28313702094)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->