### PR TITLE
[diffusion] Fix GLM-Image /v1/images/edits support

### DIFF
--- a/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
+++ b/python/sglang/jit_kernel/diffusion/triton/scale_shift.py
@@ -343,6 +343,8 @@ def fuse_scale_shift_kernel(
 
     B, L, C = x.shape
     output = torch.empty_like(x)
+    if x.numel() == 0:
+        return output
 
     if scale.dim() == 4:
         # scale/shift: [B, F, 1, C]

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/glm_image.py
@@ -22,7 +22,7 @@ class GlmImagePipelineConfig(SpatialImagePipelineConfig):
     vae_precision: str = "bf16"
 
     should_use_guidance: bool = False
-    task_type: ModelTaskType = ModelTaskType.T2I
+    task_type: ModelTaskType = ModelTaskType.TI2I
 
     vae_tiling: bool = False
 

--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -445,6 +445,9 @@ class _ScaleResidualNormScaleShift(CustomOp):
         shift: torch.Tensor,
         scale: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual.numel() == 0 or x.numel() == 0:
+            return self.forward_native(residual, x, gate, shift, scale)
+
         if x.shape[-1] % 256 != 0 and x.shape[-1] <= 8192:
             import warnings
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
@@ -12,6 +12,9 @@ from diffusers.utils.torch_utils import randn_tensor
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
+    ComponentUse,
+)
 from sglang.multimodal_gen.runtime.models.dits.glm_image import GlmImageKVCache
 from sglang.multimodal_gen.runtime.models.vision_utils import load_image
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
@@ -104,6 +107,19 @@ def retrieve_latents(
         return encoder_output.latents
     else:
         raise AttributeError("Could not access latents of provided encoder_output")
+
+
+def image_path_to_list(image_path: Union[str, List[str]]) -> List[str]:
+    return image_path if isinstance(image_path, list) else [image_path]
+
+
+def pooled_image_features_to_tensor(image_features) -> torch.Tensor:
+    pooler_output = getattr(image_features, "pooler_output", None)
+    if pooler_output is not None:
+        image_features = pooler_output
+    if isinstance(image_features, torch.Tensor):
+        return image_features
+    return torch.cat(tuple(image_features), dim=0)
 
 
 class GlmImageAR(PipelineStage):
@@ -219,13 +235,29 @@ class GlmImageAR(PipelineStage):
 
         prior_token_image_ids = None
         if image is not None:
-            prior_token_image_embed = self.vision_language_encoder.get_image_features(
-                inputs["pixel_values"], image_grid_thw[:-1]
+            source_grids = image_grid_thw[:-1]
+            prior_token_image_embed = pooled_image_features_to_tensor(
+                self.vision_language_encoder.get_image_features(
+                    inputs["pixel_values"], source_grids
+                )
             )
-            prior_token_image_embed = torch.cat(prior_token_image_embed, dim=0)
-            prior_token_image_ids = self.vision_language_encoder.get_image_tokens(
-                prior_token_image_embed, image_grid_thw[:-1]
+            prior_token_image_ids_d32 = self.vision_language_encoder.get_image_tokens(
+                prior_token_image_embed, source_grids
             )
+            prior_token_image_ids = []
+            prior_ids_per_source = torch.split(
+                prior_token_image_ids_d32,
+                source_grids.prod(dim=-1).tolist(),
+            )
+            for prior_ids, source_grid in zip(prior_ids_per_source, source_grids):
+                _, source_h, source_w = source_grid.tolist()
+                prior_token_image_ids.append(
+                    self._upsample_token_ids(
+                        prior_ids,
+                        int(source_h),
+                        int(source_w),
+                    ).squeeze(0)
+                )
 
         # For GLM-Image, greedy decoding is not allowed; it may cause repetitive outputs.
         # max_new_tokens must be exactly grid_h * grid_w + 1 (the +1 is for EOS).
@@ -257,12 +289,24 @@ class GlmImageAR(PipelineStage):
         prompt = batch.prompt
         height = batch.height
         width = batch.width
+        if batch.image_path is not None:
+            ar_condition_images = [
+                load_image(img_path)
+                for img_path in image_path_to_list(batch.image_path)
+            ]
+        else:
+            ar_condition_images = None
 
         device = get_local_torch_device()
+
+        if ar_condition_images is not None:
+            height = height or ar_condition_images[0].height
+            width = width or ar_condition_images[0].width
 
         time_start = time.time()
         prior_token_id, prior_token_image_ids = self.generate_prior_tokens(
             prompt=prompt,
+            image=ar_condition_images,
             height=height,
             width=width,
         )
@@ -272,6 +316,8 @@ class GlmImageAR(PipelineStage):
 
         batch.prior_token_id = prior_token_id
         batch.prior_token_image_ids = prior_token_image_ids
+        batch.height = height
+        batch.width = width
 
         return batch
 
@@ -340,6 +386,22 @@ class GlmImageBeforeDenoisingStage(PipelineStage):
             and hasattr(self.transformer.config, "sample_size")
             else 128
         )
+
+    def component_uses(
+        self, server_args: ServerArgs, stage_name: str | None = None
+    ) -> list[ComponentUse]:
+        stage_name = self._component_stage_name(stage_name)
+        uses: list[ComponentUse] = []
+        if self.transformer is not None:
+            uses.append(
+                ComponentUse(
+                    stage_name=stage_name,
+                    component_name="transformer",
+                    phase="reference_image",
+                    memory_intensive=True,
+                )
+            )
+        return uses
 
     def _parse_and_expand_shape_info(
         self, prompt: str
@@ -656,7 +718,8 @@ class GlmImageBeforeDenoisingStage(PipelineStage):
         num_inference_steps = batch.num_inference_steps
         if batch.image_path is not None:
             ar_condition_images = [
-                load_image(img_path) for img_path in batch.image_path
+                load_image(img_path)
+                for img_path in image_path_to_list(batch.image_path)
             ]
         else:
             ar_condition_images = None
@@ -675,8 +738,6 @@ class GlmImageBeforeDenoisingStage(PipelineStage):
         self._guidance_scale = guidance_scale
         self._current_timestep = None
         self._interrupt = False
-
-        batch_size = 1
 
         device = get_local_torch_device()
 
@@ -758,25 +819,32 @@ class GlmImageBeforeDenoisingStage(PipelineStage):
                 # Do not remove.
                 # It would be use to run the reference image through a
                 # forward pass at timestep 0 and keep the KV cache.
-                with set_forward_context(current_timestep=1, attn_metadata=None):
-                    _ = self.transformer(
-                        hidden_states=condition_latent,
-                        encoder_hidden_states=torch.zeros_like(prompt_embeds)[
-                            :1, :0, ...
-                        ],
-                        prior_token_id=condition_image_prior_token_id,
-                        prior_token_drop=torch.full_like(
-                            condition_image_prior_token_id, False, dtype=torch.bool
-                        ),
-                        timestep=torch.zeros((1,), device=device),
-                        target_size=torch.tensor(
-                            [condition_image.shape[-2:]], device=device
-                        ),
-                        crop_coords=torch.zeros((1, 2), device=device),
-                        attention_kwargs=attention_kwargs,
-                        kv_caches=kv_caches,
-                        kv_caches_mode="write",
-                    )
+                with self.use_declared_component(
+                    component_name="transformer",
+                    module=self.transformer,
+                    phase="reference_image",
+                ) as transformer:
+                    assert transformer is not None
+                    self.transformer = transformer
+                    with set_forward_context(current_timestep=1, attn_metadata=None):
+                        _ = transformer(
+                            hidden_states=condition_latent,
+                            encoder_hidden_states=torch.zeros_like(prompt_embeds)[
+                                :1, :0, ...
+                            ],
+                            prior_token_id=condition_image_prior_token_id,
+                            prior_token_drop=torch.full_like(
+                                condition_image_prior_token_id, False, dtype=torch.bool
+                            ),
+                            timestep=torch.zeros((1,), device=device),
+                            target_size=torch.tensor(
+                                [condition_image.shape[-2:]], device=device
+                            ),
+                            crop_coords=torch.zeros((1, 2), device=device),
+                            attention_kwargs=attention_kwargs,
+                            kv_caches=kv_caches,
+                            kv_caches_mode="write",
+                        )
 
         # 6. Prepare additional timestep conditions
         target_size = (height, width)


### PR DESCRIPTION
## Motivation

#25579

  ## Modifications

Simply marked glm-image as ti2i so `/v1/images/edits` accepts image input. A couple other runtime issuess needed to be fixed following this (ref image conditioning handling and empty tensor handling in fused CUDA paths)

  ## Accuracy Tests

1xh100, zai-org/GLM-Image

```
sglang serve \
    --model-path zai-org/GLM-Image \
    --host 0.0.0.0 \
    --port 8080
```

`/model_info`:
```
  {
    "model_path": "zai-org/GLM-Image",
    "model_type": "diffusion",
    "architectures": ["GlmImagePipeline"],
    "task_type": "TI2I",
    "is_image_gen": true
  }
```

t2i:
```
  POST /v1/images/generations
  prompt="A calico cat playing a piano on stage"
  size="1024x1024"
  num_inference_steps=30
  guidance_scale=1.5
```
<img width="1024" height="1024" alt="cat_generation_30step_1024" src="https://github.com/user-attachments/assets/1c0d9348-db84-404d-9f6d-d1dfb922672f" />

img edit:
```
  POST /v1/images/edits
  image=cat_generation_30step_1024.png
  prompt="Turn the scene into a warm watercolor illustration"
  size="1024x1024"
  num_inference_steps=30
  guidance_scale=1.5
```
<img width="1024" height="1024" alt="cat_edit_watercolor_30step_1024" src="https://github.com/user-attachments/assets/eee0a149-d7d2-45e5-a139-49f32439a174" />

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26111966085](https://github.com/sgl-project/sglang/actions/runs/26111966085)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->