### PR TITLE
[Bug][PD][NIXL] always send aux on is_last; only expects_state when truthy

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -688,21 +688,22 @@ class NixlKVManager(CommonKVManager):
 
                         handles.append(kv_xfer_handle)
 
-                    if kv_chunk.is_last and kv_chunk.state_indices:
+                    if kv_chunk.is_last:
                         dst_info = self.decode_kv_args_table[req.agent_name]
-                        state_xfer_handles = self.maybe_send_extra(
-                            req.agent_name,
-                            kv_chunk.state_indices,
-                            dst_info.dst_state_data_ptrs,
-                            req.dst_state_indices,
-                            dst_info.gpu_id,
-                            f"{req.room}_state_{self.kv_args.engine_rank}",
-                            decode_tp_size,
-                            decode_tp_rank=dst_info.decode_tp_rank,
-                            dst_state_item_lens=dst_info.dst_state_item_lens,
-                            dst_state_dim_per_tensor=dst_info.dst_state_dim_per_tensor,
-                        )
-                        handles.extend(h for h in state_xfer_handles if h is not None)
+                        if kv_chunk.state_indices:
+                            state_xfer_handles = self.maybe_send_extra(
+                                req.agent_name,
+                                kv_chunk.state_indices,
+                                dst_info.dst_state_data_ptrs,
+                                req.dst_state_indices,
+                                dst_info.gpu_id,
+                                f"{req.room}_state_{self.kv_args.engine_rank}",
+                                decode_tp_size,
+                                decode_tp_rank=dst_info.decode_tp_rank,
+                                dst_state_item_lens=dst_info.dst_state_item_lens,
+                                dst_state_dim_per_tensor=dst_info.dst_state_dim_per_tensor,
+                            )
+                            handles.extend(h for h in state_xfer_handles if h is not None)
 
                         if kv_chunk.prefill_aux_index is None:
                             raise RuntimeError("Missing aux index for last chunk")
@@ -1974,8 +1975,11 @@ class NixlKVReceiver(CommonKVReceiver):
                     ]
                 )
 
-        # Mark that we expect state data if state_indices was provided
-        if state_indices is not None:
+        # Mark that we expect state data if state_indices was provided.
+        # Match the prefill-side truthy check (line ~697): an empty list
+        # means the model has no state types (e.g. dense LLaMA/Qwen), and
+        # prefill won't send state notifs, so we must not expect them.
+        if state_indices:
             self.kv_mgr.transfer_statuses[self.bootstrap_room].expects_state = True
 
         self.started_transfer = True

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -703,7 +703,9 @@ class NixlKVManager(CommonKVManager):
                                 dst_state_item_lens=dst_info.dst_state_item_lens,
                                 dst_state_dim_per_tensor=dst_info.dst_state_dim_per_tensor,
                             )
-                            handles.extend(h for h in state_xfer_handles if h is not None)
+                            handles.extend(
+                                h for h in state_xfer_handles if h is not None
+                            )
 
                         if kv_chunk.prefill_aux_index is None:
                             raise RuntimeError("Missing aux index for last chunk")
@@ -1976,9 +1978,9 @@ class NixlKVReceiver(CommonKVReceiver):
                 )
 
         # Mark that we expect state data if state_indices was provided.
-        # Match the prefill-side truthy check (line ~697): an empty list
-        # means the model has no state types (e.g. dense LLaMA/Qwen), and
-        # prefill won't send state notifs, so we must not expect them.
+        # Match the prefill-side truthy check: an empty list means the
+        # model has no state types (e.g. dense LLaMA/Qwen), and prefill
+        # won't send state notifs, so we must not expect them.
         if state_indices:
             self.kv_mgr.transfer_statuses[self.bootstrap_room].expects_state = True
 


### PR DESCRIPTION
<!-- Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help. -->

## Motivation

Fixes #25698.

Two asymmetries introduced in #24932 (`[PD] Refactor hybrid state transfer`) hang every NIXL P/D disagg request for **dense** models (no Mamba / SWA / NSA — i.e. LLaMA, Qwen3, Gemma, GPT-OSS, …) on `v0.5.12`. Bisects cleanly to commit `d7f4761a4`.

1. `NixlKVManager.transfer_worker` gates the aux RDMA write inside `if kv_chunk.is_last and kv_chunk.state_indices:`. For dense models, `state_indices` is `[]` (falsy from the prefill scheduler's empty `state_types`), so the whole branch short-circuits and `send_aux` is never called. Decode never receives the `{room}_aux` notification → hangs.
2. `NixlKVReceiver.send_metadata` flips `expects_state=True` whenever `state_indices is not None`. Decode receives `state_indices=[]` (non-None, empty) for dense models, so `expects_state` flips on. The corresponding prefill check at line ~692 is truthy (`if kv_chunk.state_indices:`) and (correctly) never sends a state notif, so `is_done()` waits forever for a notif that doesn't come.

Either bug alone hangs the request; both fixes are required for end-to-end disagg on dense models.

**Mooncake is unaffected** — `mooncake/conn.py:1344-1357` already gates state and aux on independent `if` blocks, and mooncake has no `expects_state` field (per-chunk return-code polling instead). Mooncake users on `v0.5.12` can keep running disagg; NIXL users currently can't.

## Modifications

`python/sglang/srt/disaggregation/nixl/conn.py`:

1. Split the `is_last` and `state_indices` gates in `transfer_worker` so the aux RDMA write always runs on `is_last`, and state only runs when `state_indices` is non-empty. Matches the `v0.5.11` shape and matches `mooncake/conn.py:1344-1357`.
2. Switch `NixlKVReceiver.send_metadata` from `if state_indices is not None:` to `if state_indices:` so `expects_state` only flips on when there's actually state to expect.

## Accuracy Tests

End-to-end manual verification on `Qwen/Qwen3-0.6B` (dense Qwen3) with NIXL UCX backend on 2× L40S, single host, tp1+tp1:

```
13:53:59.769  prefill bootstrap_thread recv KVArgsRegister (17 frames)
13:53:59.774  decode  send_metadata
13:54:00.464  prefill bootstrap_thread recv TransferInfo (10 frames)
13:54:00.555  prefill add_transfer_request (nkv=1, aux_index=1)
13:54:00.640  prefill transfer_worker DONE n_handles=2 elapsed=66ms   ← KV + aux both sent
13:54:00.640  decode  notif tag=kv  → is_done=False (aux still needed)
13:54:00.641  decode  notif tag=aux → is_done=True                    ← unblocks
```

Before either fix `n_handles=1` (aux skipped) and decode `is_done` stays `False` forever. After both fixes the request returns tokens cleanly in <2s.

I do not have access to a multi-node setup to exercise heterogeneous-TP staging here, but neither hunk changes any code path that runs only with `enable_staging=True`, `state_indices` truthy, MLA, or `decode_tp_size != attn_tp_size` — they only restore the dense-LLM path to its `v0.5.11` behavior.

## Benchmarking and Profiling

No perf change expected — same RDMA ops on the wire; no allocation or branch-count changes for the stateful paths (Mamba/SWA/NSA), and the dense-LLM path now actually completes instead of looping in `pop_transferred` until `SGLANG_DISAGGREGATION_WAITING_TIMEOUT`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests & Adding to CI](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci). <!-- Verified manually on Qwen3-0.6B; existing PD CI should catch this once it exercises a dense model -->
- [ ] Update documentation as needed, including docstrings or example tutorials.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26071445981](https://github.com/sgl-project/sglang/actions/runs/26071445981)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->