### PR TITLE
Log per-request time stats in a dedicated tail step

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -142,13 +142,7 @@ class SchedulerOutputStreamer:
                 continue
 
             acc.accept(req=req)
-
-            if (
-                req.finished()
-                and self.ps.attn_tp_rank == 0
-                and self.server_args.enable_request_time_stats_logging
-            ):
-                req.log_time_stats()
+            self._maybe_log_time_stats(req=req)
 
         dp_ranks = [self.ps.dp_rank] * len(acc.rids) if acc.rids else None
 
@@ -199,6 +193,14 @@ class SchedulerOutputStreamer:
                     dp_ranks=dp_ranks,
                 )
             )
+
+    def _maybe_log_time_stats(self, *, req: Req) -> None:
+        if (
+            req.finished()
+            and self.ps.attn_tp_rank == 0
+            and self.server_args.enable_request_time_stats_logging
+        ):
+            req.log_time_stats()
 
     def _stream_output_embedding(self, reqs: List[Req]):
         rids = []


### PR DESCRIPTION
The gated ``req.log_time_stats()`` call inside the
``_stream_output_generation`` for-loop is extracted into a private
``SchedulerOutputStreamer._maybe_log_time_stats`` helper. The loop
body now reads ``self._maybe_log_time_stats(req=req)`` after
``acc.accept(req=req)``.

The helper lives on the streamer (not on
``_GenerationStreamAccumulator``) because the gate predicates --
``self.ps.attn_tp_rank == 0`` and
``self.server_args.enable_request_time_stats_logging`` -- are owned
by the streamer; the accumulator has no business knowing about
rank-zero or time-stats config.

``to_payload`` remains a NotImplementedError stub on the accumulator
-- wired next.

Refactor chain ID: extract-maybe-log-time-stats



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26070152276](https://github.com/sgl-project/sglang/actions/runs/26070152276)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->