### PR TITLE
Remove the dead hasattr fallback around the test-only crash counter

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -108,8 +108,6 @@ class SchedulerOutputStreamer:
     def _trigger_crash_for_tests(self, crash_threshold: int):
         # Crash trigger: crash after stream_output is called N times
         # This is used for testing purposes.
-        if not hasattr(self, "_test_stream_output_count"):
-            self._test_stream_output_count = 0
         self._test_stream_output_count += 1
         if self._test_stream_output_count >= crash_threshold:
             raise RuntimeError(


### PR DESCRIPTION
``__init__`` already seeds ``self._test_stream_output_count = 0``
on ``SchedulerOutputStreamer``, so the ``if not hasattr(self,
"_test_stream_output_count"): self._test_stream_output_count = 0``
fallback inside ``_trigger_crash_for_tests`` is dead code -- drop it
in favor of unconditional access.

Refactor chain ID: drop-trigger-crash-hasattr-guard



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26070200592](https://github.com/sgl-project/sglang/actions/runs/26070200592)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->