### PR TITLE
Set up the idle sleeper outside of the IPC channel initialization

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -384,6 +384,7 @@ class Scheduler(
 
         # Init inter-process communication
         self.init_ipc_channels(port_args)
+        self.init_idle_sleeper()
 
         self.mm_receiver = None
         self.disagg_prefill_bootstrap_queue = None
@@ -726,7 +727,6 @@ class Scheduler(
 
     def init_ipc_channels(self, port_args: PortArgs):
         context = zmq.Context(2)
-        self.idle_sleeper = None
         self.send_metrics_from_scheduler = None
 
         if (
@@ -757,14 +757,6 @@ class Scheduler(
 
             self.send_to_tokenizer = SenderWrapper(send_to_tokenizer)
             self.send_to_detokenizer = SenderWrapper(send_to_detokenizer)
-
-            if self.server_args.sleep_on_idle:
-                self.idle_sleeper = IdleSleeper(
-                    [
-                        self.recv_from_tokenizer,
-                        self.recv_from_rpc,
-                    ]
-                )
         else:
             self.recv_from_tokenizer = None
             self.recv_from_rpc = None
@@ -778,6 +770,22 @@ class Scheduler(
             self.send_metrics_from_scheduler = get_zmq_socket(
                 context, zmq.PUSH, port_args.metrics_ipc_name, False
             )
+
+    def init_idle_sleeper(self) -> None:
+        if (
+            self.ps.pp_rank == 0
+            and self.ps.attn_tp_rank == 0
+            and self.ps.attn_cp_rank == 0
+            and self.server_args.sleep_on_idle
+        ):
+            self.idle_sleeper = IdleSleeper(
+                sockets=[
+                    self.recv_from_tokenizer,
+                    self.recv_from_rpc,
+                ],
+            )
+        else:
+            self.idle_sleeper = None
 
     def init_tokenizer(self):
         server_args = self.server_args


### PR DESCRIPTION
``init_ipc_channels`` used to also construct ``self.idle_sleeper`` when
``server_args.sleep_on_idle`` was set, conflating two concerns:

- IPC channel construction (zmq sockets used by every scheduler instance)
- An optional idle-sleep helper that wraps ``recv_from_tokenizer`` and
  ``recv_from_rpc`` after they exist.

Extract the idle_sleeper setup into a sibling method
``init_idle_sleeper`` called right after ``init_ipc_channels`` in
``Scheduler.__init__``. The new method depends on the IPC sockets being
already set, so the call order is preserved.

The conditional branching is collapsed into a single ``if`` covering all
four conditions (rank-0 PP / attn-TP / attn-CP and ``sleep_on_idle``),
with an explicit ``else`` setting ``self.idle_sleeper = None``. Equivalent
to the previous ``self.idle_sleeper = None`` upfront + nested override.

Refactor chain ID: extract-init-idle-sleeper



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26070233311](https://github.com/sgl-project/sglang/actions/runs/26070233311)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->