### PR TITLE
fix(eagle/dsv4): fix EAGLE draft attn init called with unshaped out_cache_loc

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -147,8 +147,10 @@ class EagleDraftWorker(BaseDraftWorker):
         else:
             ctx = empty_context()
         with (
-            ctx
-        ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+            ctx,
+            speculative_moe_backend_context(),
+            speculative_moe_a2a_backend_context(),
+        ):
             # Init draft worker
             self.draft_worker = TpModelWorker(
                 server_args=server_args,
@@ -356,13 +358,6 @@ class EagleDraftWorker(BaseDraftWorker):
                 forward_batch,
             )
         else:
-            if (
-                not forward_batch.forward_mode.is_idle()
-                and self.speculative_num_steps > 1
-            ):
-                # Skip attention backend init for 1-step draft,
-                # `draft_forward` only does sample in this case.
-                self.draft_attn_backend.init_forward_metadata(forward_batch)
             parent_list, top_scores_index, draft_tokens = self.draft_forward(
                 forward_batch
             )
@@ -439,6 +434,17 @@ class EagleDraftWorker(BaseDraftWorker):
         out_cache_loc = out_cache_loc.permute((2, 0, 1)).reshape(
             self.speculative_num_steps, -1
         )
+
+        # Must be after the reshape: some backends assert out_cache_loc.shape[0] == bs.
+        # Skip during CUDA graph capture; the graph runner calls
+        # init_forward_metadata_capture_cuda_graph separately.
+        if (
+            self.speculative_num_steps > 1
+            and not forward_batch.forward_mode.is_idle()
+            and not torch.cuda.is_current_stream_capturing()
+        ):
+            forward_batch.out_cache_loc = out_cache_loc[0]
+            self.draft_attn_backend.init_forward_metadata(forward_batch)
 
         # Return values
         score_list: List[torch.Tensor] = []


### PR DESCRIPTION
## Motivation

Fixes #24747. `EagleDraftWorker.draft` crashes with the DSV4 attention backend
(`--attention-backend dsv4/compressed`) when `--speculative-num-steps > 1`.

## Modifications

`draft()` called `self.draft_attn_backend.init_forward_metadata(forward_batch)`
before `draft_forward` reshaped `forward_batch.out_cache_loc` from
`[bs * topk * num_steps]` to per-step slices. The DSV4 backend asserts
`out_cache_loc.shape[0] == req_pool_indices.shape[0]`, so shape `[6]` vs `[2]`
(bs=2, topk=1, steps=3) crashes:

```
AssertionError: req_pool_indices.shape=torch.Size([2])
               out_cache_loc.shape=torch.Size([6])
```

Fix: remove the init call from `draft()` and move it into `draft_forward()`,
after the reshape, using `out_cache_loc[0]` (step-0 slice, shape `[bs * topk]`).
1-step draft is unchanged (init was already skipped). Other backends are
unaffected.

## Accuracy Tests

N/A - fix is in dispatch logic with no effect on kernel numerics.

## Speed Tests and Profiling

Tested on GB300 with DSV4-Flash (TP=4, `--moe-runner-backend flashinfer_mxfp4`,
`--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-attention-mode decode`,
`--cuda-graph-bs 1 2 4 8 16`):

- 12 concurrent requests, `cuda graph: True`
- ~700 tok/s gen throughput, accept_rate ~0.5
- 12+ min without crash (previously crashed immediately)

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26080457093](https://github.com/sgl-project/sglang/actions/runs/26080457093)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->