### PR TITLE
Move the retract-decode ratio estimation onto the new-token-ratio tracker

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -56,6 +56,9 @@ from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
+    NewTokenRatioTracker,
+)
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
@@ -2229,16 +2232,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.filter_batch(keep_indices=sorted_indices)
 
         # Reqs in batch are filtered
-        total_decoded_tokens = sum(len(r.output_ids) for r in self.reqs)
-        total_max_new_tokens = sum(r.sampling_params.max_new_tokens for r in self.reqs)
-
         new_estimate_ratio = (
-            total_decoded_tokens
-            + envs.SGLANG_RETRACT_DECODE_STEPS.get() * len(self.reqs)
-        ) / (
-            total_max_new_tokens + 1
-        )  # avoid zero division
-        new_estimate_ratio = min(1.0, new_estimate_ratio)
+            NewTokenRatioTracker.estimate_new_token_ratio_after_retract(self.reqs)
+        )
 
         return retracted_reqs, new_estimate_ratio, reqs_to_abort
 

--- a/python/sglang/srt/managers/scheduler_components/new_token_ratio_tracker.py
+++ b/python/sglang/srt/managers/scheduler_components/new_token_ratio_tracker.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
 
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
 
 
 @dataclass(slots=True, kw_only=True)
@@ -30,3 +36,16 @@ class NewTokenRatioTracker:
 
     def reset(self) -> None:
         self.current = self.init
+
+    @staticmethod
+    def estimate_new_token_ratio_after_retract(reqs: Sequence[Req]) -> float:
+        total_decoded_tokens = sum(len(r.output_ids) for r in reqs)
+        total_max_new_tokens = sum(r.sampling_params.max_new_tokens for r in reqs)
+
+        new_estimate_ratio = (
+            total_decoded_tokens + envs.SGLANG_RETRACT_DECODE_STEPS.get() * len(reqs)
+        ) / (
+            total_max_new_tokens + 1
+        )  # avoid zero division
+        new_estimate_ratio = min(1.0, new_estimate_ratio)
+        return new_estimate_ratio


### PR DESCRIPTION
``ScheduleBatch.retract_decode`` ended with an inline block that
computed the post-retract ``new_token_ratio`` from the surviving
``self.reqs``. The calculation is purely a function of the request
list's decoded-token counts and sampling-params max-new-tokens; it
has no dependency on the retraction state machine, only on the
post-filter batch contents -- and the value it produces is consumed
by ``NewTokenRatioTracker`` (the tracker's ``current`` is reassigned
to this estimate at the retract callsite in ``Scheduler``).

Move the block to ``NewTokenRatioTracker.estimate_new_token_ratio_after_retract``
as a public ``@staticmethod``. Pairing the calculation with the
tracker -- which is the consumer of the resulting value -- keeps the
``new_token_ratio`` lifecycle (init / decay / reset / post-retract
estimate) all expressed on one type.

- ``retract_decode``: inline calc collapses to a single call,
  ``NewTokenRatioTracker.estimate_new_token_ratio_after_retract(self.reqs)``.
- ``schedule_batch.py``: gains an import of ``NewTokenRatioTracker``.
- ``Sequence[Req]`` parameter type uses ``from __future__ import
  annotations`` and ``TYPE_CHECKING`` to keep the tracker module free
  of a runtime import cycle on ``schedule_batch``.

Refactor chain ID: extract-retract-decode-ratio-calc



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26070269487](https://github.com/sgl-project/sglang/actions/runs/26070269487)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->