### PR TITLE
Confine max-prefix-len to where it is used and drop the leftover variable

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1022,11 +1022,11 @@ class Req(ReqDllmMixin):
             max_prefix_len = min(max_prefix_len, self.logprob_start_len)
         max_prefix_len = max(max_prefix_len, 0)
         token_ids = self.fill_ids[:max_prefix_len]
+        del max_prefix_len
 
         # Disable prefix caching when embed overrides are present: same token IDs
         # with different override vectors must not share cached KV values.
         if self.positional_embed_overrides is not None:
-            max_prefix_len = 0
             token_ids = []
 
         if tree_cache is not None:


### PR DESCRIPTION
In Req.init_next_round_input, max_prefix_len is only consumed by
`token_ids = self.fill_ids[:max_prefix_len]`. The subsequent
`max_prefix_len = 0` in the positional_embed_overrides branch was a
dead assignment (never read again). Add an explicit `del max_prefix_len`
right after the slice to enforce single-use, and drop the dead reassignment.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26070291116](https://github.com/sgl-project/sglang/actions/runs/26070291116)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->