### PR TITLE
Confine req-pool-idx assignment to the pool allocator

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1774,9 +1774,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_num_tokens = extend_num_tokens
 
         # Allocate memory
-        out_cache_loc, req_pool_indices_tensor, req_pool_indices = alloc_for_extend(
-            self
-        )
+        out_cache_loc, req_pool_indices_tensor, _ = alloc_for_extend(self)
 
         # Set fields
         input_embeds = []
@@ -1792,7 +1790,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         mamba_track_seqlens_cpu = []
 
         for i, (req, seq_len, pre_len) in enumerate(zip(reqs, seq_lens, prefix_lens)):
-            req.req_pool_idx = req_pool_indices[i]
             assert seq_len - pre_len == req.extend_input_len
 
             req.extend_batch_idx += 1


### PR DESCRIPTION
`alloc_for_extend` → `alloc_req_slots` → `ReqToTokenPool.alloc` already
writes `r.req_pool_idx` on each Req (see ReqToTokenPool.alloc line 182-183
and HybridReqToTokenPool delegating via super()). The
`req.req_pool_idx = req_pool_indices[i]` line at the top of the per-req loop
in ScheduleBatch.prepare_for_extend was thus a tautological reassignment
duplicating the pool's own bookkeeping. Drop it so the field is set
exclusively from inside the allocator. The now-unused `req_pool_indices`
list return value of `alloc_for_extend` is consumed with `_` for clarity;
the tensor variant is still used to populate the batch.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26070369450](https://github.com/sgl-project/sglang/actions/runs/26070369450)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->