### PR TITLE
[Bug] Fix V4-Pro NaN on Blackwell by converting fp8_einsum input scale to ue8m0

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -623,6 +623,7 @@ class MQALayer(nn.Module):
                 o.reshape(T * G, D).contiguous(),
                 group_size=128,
             )
+            o_s = deep_gemm.ceil_to_ue8m0(o_s)
             output = torch.empty(T, G, R, device=o.device, dtype=torch.bfloat16)
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",


### PR DESCRIPTION
## Summary

- Fix DeepSeek-V4-Pro producing garbage text during autoregressive decode on Blackwell GPUs (B300/B200)
- Root cause: `deep_gemm`'s `transpose_and_pack_fp32_into_ue8m0` CUDA kernel has a packing bug — it doesn't mask mantissa bits when extracting fp32 exponent, so non-power-of-2 scale values get corrupted. This causes `fp8_einsum` to produce NaN at batch=1 (single-token decode)
- Fix: add `ceil_to_ue8m0()` on the activation scale before passing to `fp8_einsum`, ensuring mantissa bits are zero before packing
- The scale tensor is tiny (e.g. shape `(2, 32)`), so the overhead is negligible
- Detailed analysis: https://gist.github.com/yhyang201/2fce5750e44970af419f9669e10e994c









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26072487958](https://github.com/sgl-project/sglang/actions/runs/26072487958)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->