### PR TITLE
[misc] Fix bench_one_batch KV cache OOM guard

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -515,7 +515,11 @@ class _TorchBenchRunner:
         synchronize(self.torch_runner.device)
 
     def max_batch_size(self, input_len, output_len):
-        return self.torch_runner.max_total_num_tokens // (input_len + output_len)
+        allocator = self.torch_runner.token_to_kv_pool_allocator
+        kv_pool_capacity = allocator.available_size()
+        return min(self.torch_runner.max_total_num_tokens, kv_pool_capacity) // (
+            input_len + output_len
+        )
 
 
 class _MlxBenchRunner:
@@ -687,14 +691,14 @@ def latency_test_run_once(
     profile_start_step=None,
     profile_steps=None,
 ):
+    model_runner.clear()
+
     max_batch_size = model_runner.max_batch_size(input_len, output_len)
     if batch_size > max_batch_size:
         rank_print(
             f"skipping ({batch_size}, {input_len}, {output_len}) due to max batch size limit"
         )
         return
-
-    model_runner.clear()
 
     measurement_results = {
         "run_name": run_name,

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -320,8 +320,7 @@ def alloc_token_slots(
             f"{available_and_evictable_str(tree_cache)}"
         )
         logger.error(error_msg)
-        if tree_cache is not None:
-            tree_cache.pretty_print()
+        pretty_print_tree_cache(tree_cache)
         raise RuntimeError(error_msg)
 
     return (out_cache_loc, state) if backup_state else out_cache_loc
@@ -388,8 +387,7 @@ def alloc_paged_token_slots_extend(
             f"{available_and_evictable_str(tree_cache)}"
         )
         logger.error(error_msg)
-        if tree_cache is not None:
-            tree_cache.pretty_print()
+        pretty_print_tree_cache(tree_cache)
         raise RuntimeError(error_msg)
 
     return (out_cache_loc, state) if backup_state else out_cache_loc
@@ -514,8 +512,7 @@ def alloc_paged_token_slots_decode(
             f"{available_and_evictable_str(tree_cache)}"
         )
         logger.error(error_msg)
-        if tree_cache is not None:
-            tree_cache.pretty_print()
+        pretty_print_tree_cache(tree_cache)
         raise RuntimeError(error_msg)
 
     return out_cache_loc
@@ -619,5 +616,53 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     tree_cache.req_to_token_pool.free(req)
 
 
-def available_and_evictable_str(tree_cache: BasePrefixCache) -> str:
-    return tree_cache.available_and_evictable_str()
+def available_and_evictable_str(tree_cache: BasePrefixCache | None) -> str:
+    if tree_cache is None:
+        return ""
+
+    available_and_evictable = getattr(tree_cache, "available_and_evictable_str", None)
+    if callable(available_and_evictable):
+        try:
+            return available_and_evictable()
+        except Exception as exc:
+            return (
+                "Available tokens: unknown "
+                f"(available_and_evictable_str failed: {type(exc).__name__}: {exc})\n"
+            )
+
+    allocator = getattr(tree_cache, "token_to_kv_pool_allocator", None)
+    available_size = None
+    if allocator is not None and callable(getattr(allocator, "available_size", None)):
+        try:
+            available_size = allocator.available_size()
+        except Exception as exc:
+            available_size = f"unknown ({type(exc).__name__}: {exc})"
+
+    evictable_size = 0
+    if callable(getattr(tree_cache, "evictable_size", None)):
+        try:
+            evictable_size = tree_cache.evictable_size()
+        except Exception as exc:
+            evictable_size = f"unknown ({type(exc).__name__}: {exc})"
+
+    if isinstance(available_size, int) and isinstance(evictable_size, int):
+        total_size = available_size + evictable_size
+    else:
+        total_size = "unknown"
+
+    return (
+        f"Available tokens: {total_size} "
+        f"(available_size={available_size}, evictable_size={evictable_size})\n"
+    )
+
+
+def pretty_print_tree_cache(tree_cache: BasePrefixCache | None) -> None:
+    if tree_cache is None:
+        return
+
+    pretty_print = getattr(tree_cache, "pretty_print", None)
+    if callable(pretty_print):
+        try:
+            pretty_print()
+        except Exception:
+            logger.exception("Failed to pretty print tree cache")

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -28,6 +28,7 @@ import random
 import time
 import unittest
 import unittest.mock
+from types import SimpleNamespace
 
 import torch
 
@@ -773,6 +774,14 @@ class TestRadixCache(unittest.TestCase):
 
         print(cache.available_and_evictable_str())
         print(available_and_evictable_str(cache))
+
+        dummy_allocator = unittest.mock.Mock()
+        dummy_allocator.available_size.return_value = 7
+        dummy_cache = SimpleNamespace(token_to_kv_pool_allocator=dummy_allocator)
+
+        diag = available_and_evictable_str(dummy_cache)
+        self.assertIn("Available tokens: 7", diag)
+        self.assertIn("available_size=7", diag)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`bench_one_batch` uses a dummy `TreeCacheNamespace` for standalone benchmark runs. For large-context shapes, the previous max batch size guard only used `max_total_num_tokens`, which can overestimate the actual KV allocator capacity. When allocation then failed, the OOM diagnostic path could call `available_and_evictable_str()` on the dummy cache and raise an `AttributeError`, masking the real OOM/skip reason.

## Modifications

- Clear request/KV pools before the per-shape capacity check in `latency_test_run_once`.
- Bound `_TorchBenchRunner.max_batch_size()` by the actual `token_to_kv_pool_allocator.available_size()` in addition to `max_total_num_tokens`.
- Make KV cache OOM diagnostics tolerate dummy or `None` tree caches, and make `pretty_print()` failures non-fatal.
- Add unit coverage for the fallback diagnostic path used by dummy tree caches.

## Accuracy Tests

N/A. This change only touches the benchmark harness capacity guard and OOM diagnostics; it does not modify model forward computation or sampling behavior.

## Speed Tests and Profiling

N/A. This change avoids invalid benchmark shapes and improves failure diagnostics. It does not change serving/runtime kernels.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A, no user-facing documentation change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A, no accuracy or speed path change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Validation:

```bash
git diff --check -- python/sglang/bench_one_batch.py python/sglang/srt/mem_cache/common.py test/registered/unit/mem_cache/test_radix_cache_unit.py
python -m py_compile python/sglang/bench_one_batch.py python/sglang/srt/mem_cache/common.py test/registered/unit/mem_cache/test_radix_cache_unit.py
```

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26073426776](https://github.com/sgl-project/sglang/actions/runs/26073426776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->