### PR TITLE
Fix disaggregated decode load token accounting

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2099,10 +2099,10 @@ class GetLoadsReqOutput(BaseReq):
     num_used_tokens: int = field(
         metadata={"metric": ("gauge", "Number of tokens in use")}
     )
-    # num_used_tokens + pending prefill tokens (waiting-queue seqlen, incl.
-    # disagg bootstrap/prealloc/transfer queues). Used for DP balance.
+    # num_used_tokens plus pending tokens not already allocated in the KV pool.
+    # Used for DP balance.
     num_total_tokens: int = field(
-        metadata={"metric": ("gauge", "Used tokens plus pending prefill tokens")}
+        metadata={"metric": ("gauge", "Used tokens plus pending unallocated tokens")}
     )
     max_total_num_tokens: int = field(
         metadata={"metric": ("gauge", "Maximum token capacity")}

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -104,14 +104,24 @@ class SchedulerLoadInquirer:
         num_running_reqs = len(self.get_running_batch().reqs)
 
         waiting_queues = [self.get_waiting_queue()]
+        pending_token_queues = [self.get_waiting_queue()]
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            waiting_queues.append(self.get_disagg_prefill_bootstrap_queue().queue)
+            prefill_bootstrap_queue = self.get_disagg_prefill_bootstrap_queue().queue
+            waiting_queues.append(prefill_bootstrap_queue)
+            pending_token_queues.append(prefill_bootstrap_queue)
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
-            waiting_queues.append(self.get_disagg_decode_prealloc_queue().queue)
-            waiting_queues.append(self.get_disagg_decode_transfer_queue().queue)
-            waiting_queues.append(
+            decode_prealloc_queue = self.get_disagg_decode_prealloc_queue().queue
+            decode_transfer_queue = self.get_disagg_decode_transfer_queue().queue
+            decode_retracted_queue = (
                 self.get_disagg_decode_prealloc_queue().retracted_queue
             )
+            waiting_queues.append(decode_prealloc_queue)
+            waiting_queues.append(decode_transfer_queue)
+            waiting_queues.append(decode_retracted_queue)
+            # In disaggregated decode, transfer-queue requests and transferred
+            # waiting-queue requests have already pre-allocated decode-side KV
+            # slots, so they are already included in num_used_tokens.
+            pending_token_queues = [decode_prealloc_queue, decode_retracted_queue]
 
         num_waiting_reqs = sum(len(queue) for queue in waiting_queues)
         num_waiting_uncached_tokens = self.get_num_waiting_uncached_tokens()
@@ -119,7 +129,7 @@ class SchedulerLoadInquirer:
             self.pool_stats_observer.get_pool_stats().get_kv_token_stats()
         )
         num_total_tokens = num_used_tokens + sum(
-            req.seqlen for queue in waiting_queues for req in queue
+            req.seqlen for queue in pending_token_queues for req in queue
         )
 
         memory = None


### PR DESCRIPTION
## Summary
- Avoid double-counting disaggregated decode requests whose decode-side KV slots are already preallocated.
- Keep decode request-count accounting unchanged for waiting, prealloc, transfer, and retracted queues.
- Add unit coverage for decode vs. prefill num_total_tokens accounting.
- This issue is blocking https://github.com/sgl-project/sglang/pull/25235
## Details
In disaggregated decode, requests in the transfer queue and requests that have already moved into the decode waiting queue have preallocated decode-side KV slots. Those tokens are already reflected in num_used_tokens from the KV pool stats. Adding their sequence lengths again to num_total_tokens overstates decode DP load and can mislead total_tokens load balancing.

This change only adds token load from queues that are not already represented in KV usage: decode prealloc and retracted requests. Prefill accounting still includes waiting and bootstrap queues.

## Tests
- python3 -m py_compile python/sglang/srt/managers/scheduler_components/load_inquirer.py python/sglang/srt/managers/io_struct.py test/registered/unit/managers/test_load_inquirer.py
- git diff --check

Not run locally: unit test execution is blocked by the local system Python missing required project dependencies, starting with numpy.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27402807501](https://github.com/sgl-project/sglang/actions/runs/27402807501)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27402807325](https://github.com/sgl-project/sglang/actions/runs/27402807325)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->