### PR TITLE
[CPU] enable AVX512 for AMD EPYC and Intel Cooper Lake (up to 15×)

### DIFF
--- a/sgl-kernel/csrc/cpu/benchmark/CMakeLists.txt
+++ b/sgl-kernel/csrc/cpu/benchmark/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.18)
+project(sgl_kernel_cpu_bench CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported)
+if(ipo_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+endif()
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+execute_process(
+    COMMAND ${Python_EXECUTABLE}
+            -c "import torch; print(torch.utils.cmake_prefix_path)"
+    OUTPUT_VARIABLE TORCH_PY_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+list(APPEND CMAKE_PREFIX_PATH ${TORCH_PY_PREFIX}/Torch)
+find_package(Torch REQUIRED)
+
+set(CPU_KERNEL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
+set(SGL_KERNEL_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+# Source files for CPU kernels (same as the main build)
+file(GLOB CPU_SOURCES
+    ${CPU_KERNEL_DIR}/*.cpp
+    ${CPU_KERNEL_DIR}/mamba/*.cpp
+    ${CPU_KERNEL_DIR}/model/*.cpp
+)
+list(FILTER CPU_SOURCES EXCLUDE REGEX "torch_extension_cpu.cpp")
+list(FILTER CPU_SOURCES EXCLUDE REGEX "interface.cpp")
+
+find_library(NUMA_LIB numa)
+
+add_executable(bench_cpu_kernels bench_cpu_kernels.cpp ${CPU_SOURCES})
+target_include_directories(bench_cpu_kernels PRIVATE
+    ${TORCH_INCLUDE_DIRS}
+    ${CPU_KERNEL_DIR}
+    ${SGL_KERNEL_ROOT}
+    ${SGL_KERNEL_ROOT}/include
+)
+target_link_libraries(bench_cpu_kernels PRIVATE ${TORCH_LIBRARIES} ${NUMA_LIB})
+target_compile_options(bench_cpu_kernels PRIVATE -march=native -fopenmp)
+target_link_options(bench_cpu_kernels PRIVATE -fopenmp)

--- a/sgl-kernel/csrc/cpu/benchmark/bench_cpu_kernels.cpp
+++ b/sgl-kernel/csrc/cpu/benchmark/bench_cpu_kernels.cpp
@@ -1,0 +1,55 @@
+// Build: mkdir build && cd build && cmake .. && make -j
+// Usage: ./bench_cpu_kernels [--iters 200]
+
+#include <ATen/ATen.h>
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <vector>
+
+at::Tensor silu_and_mul_cpu(at::Tensor& input);
+at::Tensor gelu_tanh_and_mul_cpu(const at::Tensor& input);
+at::Tensor gelu_and_mul_cpu(const at::Tensor& input);
+
+double bench(std::function<void()> fn, int warmup = 20, int iters = 200) {
+  for (int i = 0; i < warmup; ++i)
+    fn();
+  std::vector<double> times;
+  times.reserve(iters);
+  for (int i = 0; i < iters; ++i) {
+    auto t0 = std::chrono::high_resolution_clock::now();
+    fn();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    times.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() / 1000.0);
+  }
+  std::sort(times.begin(), times.end());
+  return times[iters / 2];
+}
+
+int main(int argc, char** argv) {
+  int iters = 200;
+  for (int i = 1; i < argc; ++i)
+    if (std::string(argv[i]) == "--iters" && i + 1 < argc) iters = std::stoi(argv[++i]);
+
+  std::cout << "CPU Activation Kernel Benchmark (iters=" << iters << ")\n";
+  std::cout << "Threads: " << at::get_num_threads() << "\n\n";
+  std::cout << "  kernel            batch    dim    time(us)" << std::endl;
+
+  std::vector<std::pair<int, int>> configs = {{1, 7168}, {32, 14336}, {128, 14336}, {512, 14336}};
+
+  for (auto [bs, d] : configs) {
+    auto input = torch::randn({bs, d * 2}, torch::kBFloat16);
+
+    double t1 = bench([&]() { silu_and_mul_cpu(input); }, 20, iters);
+    printf("  silu_and_mul      %5d  %5d  %10.1f\n", bs, d, t1);
+
+    double t2 = bench([&]() { gelu_tanh_and_mul_cpu(input); }, 20, iters);
+    printf("  gelu_tanh_and_mul %5d  %5d  %10.1f\n", bs, d, t2);
+
+    double t3 = bench([&]() { gelu_and_mul_cpu(input); }, 20, iters);
+    printf("  gelu_and_mul      %5d  %5d  %10.1f\n", bs, d, t3);
+  }
+  return 0;
+}

--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#if defined(__AVX512F__) && defined(__AVX512BF16__) && defined(__AMX_BF16__)
+// AMX support is dispatched at runtime via OneDNN brgemm;
+// only AVX512F + AVX512BF16 are needed at compile time here.
+#if defined(__AVX512F__) && defined(__AVX512BF16__)
 #define CPU_CAPABILITY_AVX512
 #endif
 


### PR DESCRIPTION
## Motivation

`CPU_CAPABILITY_AVX512` in `sgl-kernel/csrc/cpu/vec.h` is gated by three compile-time macros:

```cpp
#if defined(__AVX512F__) && defined(__AVX512BF16__) && defined(__AMX_BF16__)
```

`__AMX_BF16__` is Intel Sapphire Rapids+ exclusive. This incorrectly excludes all CPUs that fully support AVX512-BF16 but lack AMX:

- **AMD EPYC Genoa / Bergamo / Turin** (Zen 4 / Zen 5)
- **Intel Cooper Lake**

On these CPUs, `CPU_CAPABILITY_AVX512` is never defined, so:
- Vectorized transcendental functions (exp, log, tanh via SLEEF) fall back to scalar `libm`
- BF16↔FP32 conversion loses `_mm512_cvtne2ps_pbh` / `_mm512_dpbf16_ps` intrinsics
- All AVX512 vectorized activation, attention, and GEMM kernels are disabled

This causes **10–15× slowdown** on activation kernels and significant throughput loss on GEMM.

## Modifications

Remove `__AMX_BF16__` from the preprocessor guard. The remaining check (`__AVX512F__ && __AVX512BF16__`) is sufficient because:

1. All code gated by `CPU_CAPABILITY_AVX512` uses only AVX512F + AVX512-BF16 intrinsics
2. AMX GEMM (`brgemm`) is accessed via PyTorch's `at::native::cpublas::brgemm()`, which uses OneDNN runtime CPUID dispatch — no compile-time `__AMX_BF16__` needed

**No impact on Intel SPR+** — AMX is still detected and used at runtime by OneDNN. The binary behavior on Intel Sapphire Rapids and newer is unchanged.

Also adds a standalone C++ micro-benchmark (`sgl-kernel/csrc/cpu/benchmark/`) for reproducing activation kernel performance.

## Benchmark

AMD EPYC 9R14, 64 cores, PyTorch 2.12, BF16, `batch=512, dim=14336`:

| Kernel | Without fix (scalar) | With fix (AVX512) | Speedup |
|--------|---:|---:|---:|
| `silu_and_mul` | 885 µs | 91 µs | **9.8×** |
| `gelu_tanh_and_mul` | 3697 µs | 243 µs | **15.2×** |
| `gelu_and_mul` | 1727 µs | 129 µs | **13.4×** |

Full sweep (64 threads):

| Kernel | Batch | Dim | Scalar (µs) | AVX512 (µs) | Speedup |
|--------|:---:|:---:|---:|---:|---:|
| `silu_and_mul` | 1 | 7168 | 29.7 | 3.8 | 7.8× |
| `gelu_tanh_and_mul` | 1 | 7168 | 90.8 | 12.9 | 7.0× |
| `gelu_and_mul` | 1 | 7168 | 45.7 | 5.7 | 8.0× |
| `silu_and_mul` | 32 | 14336 | 73.9 | 20.3 | 3.6× |
| `gelu_tanh_and_mul` | 32 | 14336 | 226.6 | 38.2 | 5.9× |
| `gelu_and_mul` | 32 | 14336 | 106.4 | 23.9 | 4.5× |
| `silu_and_mul` | 128 | 14336 | 160.8 | 29.4 | 5.5× |
| `gelu_tanh_and_mul` | 128 | 14336 | 821.6 | 70.3 | 11.7× |
| `gelu_and_mul` | 128 | 14336 | 237.4 | 38.0 | 6.2× |
| `silu_and_mul` | 512 | 14336 | 885.3 | 90.7 | 9.8× |
| `gelu_tanh_and_mul` | 512 | 14336 | 3696.6 | 243.1 | 15.2× |
| `gelu_and_mul` | 512 | 14336 | 1726.9 | 129.1 | 13.4× |

Reproduce:
```bash
cd sgl-kernel/csrc/cpu/benchmark
mkdir build && cd build && cmake .. && make -j
./bench_cpu_kernels
```

## Checklist

- [x] Format code according to [pre-commit guidelines](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit)
- [x] Provide speed benchmark results according to [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed)
- [x] Follow SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26075757436](https://github.com/sgl-project/sglang/actions/runs/26075757436)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->