### PR TITLE
[AMD] Bump amd/Kimi-K2.5-MXFP4 revision to align with shared-experts fusion

### DIFF
--- a/test/registered/amd/test_kimi_k25_mxfp4.py
+++ b/test/registered/amd/test_kimi_k25_mxfp4.py
@@ -27,7 +27,13 @@ from sglang.test.test_utils import (
 register_amd_ci(est_time=3600, suite="stage-c-test-large-8-gpu-amd-mi35x")
 
 KIMI_K25_MXFP4_MODEL_PATH = "amd/Kimi-K2.5-MXFP4"
-KIMI_K25_MXFP4_REVISION = "b071bc6f8eb042e093e14f3b8bdbad71c18e09d3"
+# Bumped from b071bc6f -> 419004c8 (HF main HEAD as of 2026-05-18). The pinned
+# b071bc6f revision keeps shared_experts unquantized (bf16), which is
+# incompatible with the shared-experts fusion path enabled for Kimi-K2.5
+# (n_routed_experts=384) in #25390. Revisions from 94d8c1bd onward quantize
+# shared_experts to MXFP4 so the fusion can copy weights between routed and
+# shared experts without a dtype/shape mismatch.
+KIMI_K25_MXFP4_REVISION = "419004c8716cf22c929aa15d39b85e09a8a2091a"
 SERVER_LAUNCH_TIMEOUT = 3600
 
 


### PR DESCRIPTION

## Motivation
After PR25390 enabled shared-experts fusion for Kimi-K2.5 (`n_routed_experts=384`) on the AMD path, `test_kimi_k25_mxfp4.py` started failing at weight load:
```
RuntimeError: The size of tensor a (3584) must match the size of tensor b (7168) at non-singleton dimension 1
  File ".../layers/moe/fused_moe_triton/layer.py", line 492, in _load_w13
    expert_data.copy_(loaded_weight)
```
The root cause is that the currently pinned revision (`b071bc6f`, set in #22188) keeps the shared experts **unquantized**:
```json
// config.json @ b071bc6f
"exclude": [
  "lm_head",
  "re:.*self_attn.*",
  "re:.*shared_experts.*",          // shared_experts -> bf16
  "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
  ...
]
```
When the fusion path renames `mlp.shared_experts.*` → `mlp.experts.384.*` and tries to copy the bf16 (unpacked hidden dim) shared-expert weight into the MXFP4 (uint8-packed hidden dim) routed-experts slot, the dim-1 sizes don't match (`3584 = hidden/2` vs `7168 = hidden`), and `_load_w13` crashes.
The HF repo already shipped a fix on 2026-04-01 (commit `94d8c1bd` — *"quantize mlp.up_proj, mlp.down_proj, shared_experts"*) that quantizes the shared experts to MXFP4, but the test pin was never moved forward, so PR25390's fusion path always runs against a checkpoint it cannot load.
## Modifications
- Bump `KIMI_K25_MXFP4_REVISION` from `b071bc6f8eb042e093e14f3b8bdbad71c18e09d3` → `419004c8716cf22c929aa15d39b85e09a8a2091a` (current HF `main` HEAD; identical safetensors to `94d8c1bd`, only README updates + `quark_profile.yaml` deletion in between).
- Add an inline comment so future revision bumps don't accidentally regress below `94d8c1bd`.
### Why this revision is safe
Verified directly against the HF `model.safetensors.index.json` at each revision — MXFP4 weight scales for shared experts only exist from `94d8c1bd` onward:
| Revision | `shared_experts.*.weight_scale` entries | shared_experts dtype |
|---|---|---|
| `b071bc6f` (old pin) | 0 | bf16 |
| `94d8c1bd` (HF fix) | 180 (60 MoE layers × {gate, up, down}) | MXFP4 (uint8) |
| `419004c8` (new pin / main HEAD) | 180 | MXFP4 (uint8) |
After the bump, both sides of the fusion `expert_data.copy_(loaded_weight)` have matching dtype/shape, so the new fusion path enabled in PR25390 loads cleanly.
This is also the minimum-risk fix: the AMD CI keeps a single pinned rev
## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/26075873213
<img width="314" height="136" alt="image" src="https://github.com/user-attachments/assets/bbce3fb4-1fe4-4580-a6be-1812395237eb" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26075831917](https://github.com/sgl-project/sglang/actions/runs/26075831917)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->