### PR TITLE
Revert #25690 to unblock LoRA Qwen3-8B CUDA graph capture on main

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "datasets",
   "einops",
   "fastapi",
-  "flashinfer_python[cu13]==0.6.11.post1", # keep it aligned with jit-cache version in Dockerfile
+  "flashinfer_python==0.6.11.post1", # keep it aligned with jit-cache version in Dockerfile
   "flashinfer_cubin==0.6.11.post1",
   "gguf",
   "interegular",
@@ -37,7 +37,7 @@ dependencies = [
   "ninja",
   "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "numpy",
-  "nvidia-cutlass-dsl[cu13]==4.5.0",
+  "nvidia-cutlass-dsl==4.5.0",
   "nvidia-ml-py",
   "openai-harmony==0.0.4",
   "openai==2.6.1",

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -186,8 +186,8 @@ uninstall_stale_flashinfer() {
     # Keep flashinfer packages if version matches to avoid re-downloading:
     # - flashinfer-cubin: 150+ MB
     # - flashinfer-jit-cache: 1.2+ GB
-    FLASHINFER_PYTHON_REQUIRED=$(grep -Po -m1 'flashinfer_python(\[[^]]+\])?==\K[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
-    FLASHINFER_CUBIN_REQUIRED=$(grep -Po -m1 'flashinfer_cubin(\[[^]]+\])?==\K[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
+    FLASHINFER_PYTHON_REQUIRED=$(grep -Po -m1 '(?<=flashinfer_python==)[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
+    FLASHINFER_CUBIN_REQUIRED=$(grep -Po -m1 '(?<=flashinfer_cubin==)[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
     FLASHINFER_CUBIN_INSTALLED=$(pip show flashinfer-cubin 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
     FLASHINFER_JIT_INSTALLED=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//' || echo "")
     FLASHINFER_JIT_CU_VERSION=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+//p' || echo "")
@@ -331,22 +331,6 @@ download_flashinfer_cache() {
         PIP_CMD="$PIP_CMD" \
         PIP_INSTALL_SUFFIX="$PIP_INSTALL_SUFFIX" \
         bash "${SCRIPT_DIR}/ci_download_flashinfer_jit_cache.sh"
-
-    mark_step_done "${FUNCNAME[0]}"
-}
-
-purge_cutlass_libs_base() {
-    # nvidia-cutlass-dsl[cu13] extras are additive on PyPI: requires_dist always
-    # pulls -libs-base AND -libs-cu13 when [cu13] is requested. Both wheels write
-    # to the same site-packages paths with different content, leaving the wrapper
-    # (cutlass.py, cu13 style) mismatched with the binding (_gpu_ops_gen.py, base
-    # style) -> GPUModuleOp signature TypeError. See vllm-project/vllm#40082.
-    # Uninstall -libs-base, then force-reinstall -libs-cu13 so its files win.
-    $PIP_UNINSTALL_CMD nvidia-cutlass-dsl-libs-base $PIP_UNINSTALL_SUFFIX || true
-    CUTLASS_DSL_VERSION=$(grep -Po -m1 'nvidia-cutlass-dsl(\[[^]]+\])?==\K[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
-    if [ -n "$CUTLASS_DSL_VERSION" ]; then
-        $PIP_CMD install --force-reinstall --no-deps "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}" $PIP_INSTALL_SUFFIX
-    fi
 
     mark_step_done "${FUNCNAME[0]}"
 }
@@ -504,7 +488,6 @@ main() {
     install_sglang_kernel
     install_sglang_router
     download_flashinfer_cache
-    purge_cutlass_libs_base
     stabilize_flashinfer_jit_paths
     install_extra_deps
     install_test_tools


### PR DESCRIPTION
> 🤖 **Opened autonomously by Claude Code acting on Tom's behalf.** All the diagnostic work below — CI failure triage on #25647, the 9-probe bisect, this revert, and the `/rerun-test` request — was performed by the agent without human-in-the-loop edits. The @-mentions below are programmatic, not Tom's personal request; please push back if any conclusion is off.

This reverts #25690 ([Fix] Try to fix error caused by latest cutedsl packages — merged 2026-05-18 by @Fridge003 / @hnyls2002).

#25690 introduced a `CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS (14)` regression in the LoRA Qwen3-8B forward path during CUDA graph capture. Bisect evidence (9 probes, narrowed `ba214ef3d3..a7b3ced334` to a single commit): https://github.com/sgl-project/sglang/pull/25647#issuecomment-4484561803.

Failing test on `main`: `test/registered/lora/test_lora_qwen3_8b_logprob_diff.py::TestLoRAQwen3_8BLogprobDiff::test_lora_qwen3_8b_logprob_accuracy` (extra-a-test-1-gpu-large lane).

This PR's purpose is **diagnostic**: re-running the failing test via `/rerun-test` here should now PASS, confirming the revert restores main. It's **not** a merge candidate yet — the underlying motivation of #25690 (cutedsl wrapper/binding ABI mismatch with `GPUModuleOp` signature TypeError) still needs a proper fix from @Fridge003 / @hnyls2002.

cc @Fridge003 @hnyls2002