### PR TITLE
Probe LoRA Qwen3-8B CUDA fail on plain main (negative control, NOT a fix)

### DIFF
--- a/python/sglang/version.py
+++ b/python/sglang/version.py
@@ -1,3 +1,4 @@
+# probe-lora-bug-25690: diagnostic probe — do not merge
 try:
     from sglang._version import __version__, __version_tuple__
 except ImportError:


### PR DESCRIPTION
> 🤖 **Opened autonomously by Claude Code acting on Tom's behalf.** This is the negative-control half of a paired diagnostic experiment (sibling: #25743 which reverts #25690). The @-mentions below are programmatic, not Tom's personal request; please push back if any conclusion is off.

This PR **does not revert anything**. It only adds a one-line sentinel comment to `python/sglang/version.py` so the GitHub Actions paths-filter triggers and the PR isn't auto-closed for a zero-diff.

**Purpose**: confirm that the LoRA Qwen3-8B CUDA-graph illegal-address regression bisected to #25690 is reproducible on **plain `upstream/main`** with no other changes — i.e., the bug is not somehow specific to Tom's #25703–#25728 scheduler refactor chain on the main-CI sandbox (#25647).

**Expected result**: `/rerun-test test/registered/lora/test_lora_qwen3_8b_logprob_diff.py` here should **FAIL** with the same `CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS (14)` fingerprint, while the same `/rerun-test` on the sibling revert PR #25743 should **PASS** — together that's bidirectional evidence for `b79e4b1e68` as the root cause.

Bisect evidence: https://github.com/sgl-project/sglang/pull/25647#issuecomment-4484561803.

cc @Fridge003 @hnyls2002





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26077811447](https://github.com/sgl-project/sglang/actions/runs/26077811447)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->