### PR TITLE
[Draft] feat: per-request exit_layer for layer-skip inference （Feat/early exit layer）

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
@@ -6,12 +6,20 @@ import traceback
 from contextlib import nullcontext
 
 import torch
-from torch.cuda.memory import (
-    CUDAPluggableAllocator,
-    _cuda_beginAllocateCurrentThreadToPool,
-    _cuda_endAllocateToPool,
-    _cuda_releasePool,
-)
+
+try:
+    from torch.cuda.memory import (
+        CUDAPluggableAllocator,
+        _cuda_beginAllocateCurrentThreadToPool,
+        _cuda_endAllocateToPool,
+        _cuda_releasePool,
+    )
+except (ImportError, AttributeError):
+    # CPU-only torch doesn't have these symbols
+    CUDAPluggableAllocator = None
+    _cuda_beginAllocateCurrentThreadToPool = None
+    _cuda_endAllocateToPool = None
+    _cuda_releasePool = None
 
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.environ import envs

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -87,7 +87,10 @@ class RotaryEmbedding(MultiPlatformOp):
             elif _is_hip:
                 from sgl_kernel import rotary_embedding
             else:
-                from vllm._custom_ops import rotary_embedding
+                try:
+                    from vllm._custom_ops import rotary_embedding
+                except ImportError:
+                    rotary_embedding = None
 
             self.use_fallback_kernel = True
             self.fallback_rotary_embedding = rotary_embedding

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -171,6 +171,8 @@ class GenerateReqInput(BaseReq):
     log_metrics: bool = True
     # Whether to return hidden states
     return_hidden_states: Union[List[bool], bool] = False
+    # Early exit: stop after this many layers. None means full forward.
+    exit_layer: Optional[int] = None
     # Whether to return captured routed experts
     return_routed_experts: bool = False
     return_indexer_topk: bool = False
@@ -655,6 +657,7 @@ class GenerateReqInput(BaseReq):
                 if isinstance(self.return_hidden_states, list)
                 else self.return_hidden_states
             ),
+            exit_layer=self.exit_layer,
             return_routed_experts=self.return_routed_experts,
             routed_experts_start_len=self.routed_experts_start_len,
             return_indexer_topk=self.return_indexer_topk,
@@ -730,6 +733,8 @@ class TokenizedGenerateReqInput(BaseReq):
 
     # Whether to return hidden states
     return_hidden_states: bool = False
+    # Early exit: stop after this many layers. None means full forward.
+    exit_layer: Optional[int] = None
 
     # Whether to return captured routed experts
     return_routed_experts: bool = False

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -591,6 +591,7 @@ class Req(ReqDllmMixin):
         custom_logit_processor: Optional[str] = None,
         require_reasoning: bool = False,
         return_hidden_states: bool = False,
+        exit_layer: Optional[int] = None,
         return_routed_experts: bool = False,
         routed_experts_start_len: int = 0,
         return_indexer_topk: bool = False,
@@ -670,6 +671,7 @@ class Req(ReqDllmMixin):
         self.sampling_params = sampling_params
         self.custom_logit_processor = custom_logit_processor
         self.return_hidden_states = return_hidden_states
+        self.exit_layer = exit_layer
 
         # extra key for classifying the request (e.g. cache_salt)
         if lora_id is not None:
@@ -1492,6 +1494,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # Whether to return hidden states
     return_hidden_states: bool = False
 
+    # Early exit: stop after this many layers. None means full forward.
+    exit_layer: Optional[int] = None
+
     # Whether to return captured experts
     return_routed_experts: bool = False
 
@@ -1550,6 +1555,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             device=req_to_token_pool.device,
             spec_algorithm=spec_algorithm,
             return_hidden_states=any(req.return_hidden_states for req in reqs),
+            exit_layer=min(
+                (req.exit_layer for req in reqs if req.exit_layer is not None),
+                default=None,
+            ),
             return_routed_experts=any(req.return_routed_experts for req in reqs),
             return_indexer_topk=any(req.return_indexer_topk for req in reqs),
             is_prefill_only=all(req.is_prefill_only for req in reqs),
@@ -2527,6 +2536,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.has_stream |= other.has_stream
         self.has_grammar |= other.has_grammar
         self.return_hidden_states |= other.return_hidden_states
+        if other.exit_layer is not None:
+            if self.exit_layer is None:
+                self.exit_layer = other.exit_layer
+            else:
+                self.exit_layer = min(self.exit_layer, other.exit_layer)
         self.is_prefill_only = self.is_prefill_only and other.is_prefill_only
 
         if self.spec_info:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2037,6 +2037,7 @@ class Scheduler(
                 custom_logit_processor=recv_req.custom_logit_processor,
                 require_reasoning=recv_req.require_reasoning,
                 return_hidden_states=recv_req.return_hidden_states,
+                exit_layer=recv_req.exit_layer,
                 return_routed_experts=recv_req.return_routed_experts,
                 routed_experts_start_len=recv_req.routed_experts_start_len,
                 return_indexer_topk=recv_req.return_indexer_topk,

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -37,28 +37,32 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     NSATokenToKVPool,
 )
-from sglang.srt.utils import is_cuda, is_mps, is_npu, is_xpu
+from sglang.srt.utils import is_cpu, is_cuda, is_mps, is_npu, is_xpu
 
+_is_cpu = is_cpu()
 _is_cuda = is_cuda()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_mps = is_mps()
-if not (_is_npu or _is_xpu or _is_mps):
-    from sgl_kernel.kvcacheio import (
-        transfer_kv_all_layer,
-        transfer_kv_all_layer_direct_lf_pf,
-        transfer_kv_all_layer_lf_pf,
-        transfer_kv_all_layer_lf_ph,
-        transfer_kv_all_layer_mla,
-        transfer_kv_all_layer_mla_lf_pf,
-        transfer_kv_direct,
-        transfer_kv_per_layer,
-        transfer_kv_per_layer_direct_pf_lf,
-        transfer_kv_per_layer_mla,
-        transfer_kv_per_layer_mla_pf_lf,
-        transfer_kv_per_layer_pf_lf,
-        transfer_kv_per_layer_ph_lf,
-    )
+if not (_is_cpu or _is_npu or _is_xpu or _is_mps):
+    try:
+        from sgl_kernel.kvcacheio import (
+            transfer_kv_all_layer,
+            transfer_kv_all_layer_direct_lf_pf,
+            transfer_kv_all_layer_lf_pf,
+            transfer_kv_all_layer_lf_ph,
+            transfer_kv_all_layer_mla,
+            transfer_kv_all_layer_mla_lf_pf,
+            transfer_kv_direct,
+            transfer_kv_per_layer,
+            transfer_kv_per_layer_direct_pf_lf,
+            transfer_kv_per_layer_mla,
+            transfer_kv_per_layer_mla_pf_lf,
+            transfer_kv_per_layer_pf_lf,
+            transfer_kv_per_layer_ph_lf,
+        )
+    except ImportError:
+        pass
 if _is_npu:
     from sgl_kernel_npu.kvcacheio import TransferDirection, transfer_kv_dim_exchange
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -427,6 +427,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
+    # Early exit: stop after this many layers. None means full forward.
+    exit_layer: Optional[int] = None
+
     # Whether to return pooled hidden states (pre-head transformer output)
     return_pooled_hidden_states: bool = False
 
@@ -542,6 +545,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             dimensions=batch.dimensions,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
             return_hidden_states_before_norm=return_hidden_states_before_norm,
+            exit_layer=batch.exit_layer,
             rids=[req.rid for req in batch.reqs],
         )
         device = model_runner.device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -814,7 +814,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             register_forward_hooks(self.model, server_args.forward_hooks)
 
         # Initialize piecewise CUDA graph
-        self.init_piecewise_cuda_graphs()
+        if self.device != "cpu":
+            self.init_piecewise_cuda_graphs()
+        else:
+            self.piecewise_cuda_graph_runner = None
 
         self.prealloc_symmetric_memory_pool()
 
@@ -1075,16 +1078,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if not self.is_draft_worker:
             if self.device == "cpu":
                 if _is_cpu_amx_available or _is_cpu_arm64:
-                    # Bind OpenMP threads to CPU cores
-                    torch.ops.sgl_kernel.init_cpu_threads_env(self.local_omp_cpuid)
+                    try:
+                        # Bind OpenMP threads to CPU cores
+                        torch.ops.sgl_kernel.init_cpu_threads_env(self.local_omp_cpuid)
 
-                    # Set local size to hint SGLang to use shared memory based AllReduce
-                    os.environ["LOCAL_SIZE"] = str(self.tp_size)
-                    torch.ops.sgl_kernel.initialize(self.tp_size, self.tp_rank)
+                        # Set local size to hint SGLang to use shared memory based AllReduce
+                        os.environ["LOCAL_SIZE"] = str(self.tp_size)
+                        torch.ops.sgl_kernel.initialize(self.tp_size, self.tp_rank)
 
-                    @torch.library.register_fake("sgl_kernel::shm_allgather")
-                    def _(data, dim):
-                        return torch.cat([data] * self.tp_size, dim=dim)
+                        @torch.library.register_fake("sgl_kernel::shm_allgather")
+                        def _(data, dim):
+                            return torch.cat([data] * self.tp_size, dim=dim)
+                    except AttributeError:
+                        logger.warning("sgl_kernel CPU ops not available, skipping CPU thread binding and SHM AllReduce")
 
                 else:
                     logger.warning(

--- a/python/sglang/srt/models/qwen2_early_exit.py
+++ b/python/sglang/srt/models/qwen2_early_exit.py
@@ -1,0 +1,97 @@
+# Copyright 2024 SGLang Team (internal fork)
+# Early exit Qwen2 for sequence classification / embedding extraction.
+# Runs only the first K transformer layers, then norm + pooler/logits.
+#
+# Usage:
+#   SGLANG_EXIT_LAYER=20 python -m sglang.launch_server --model Qwen/Qwen2.5-72B ...
+
+import logging
+import os
+from typing import Optional
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_EXIT_LAYER: Optional[int] = (
+    int(os.environ["SGLANG_EXIT_LAYER"])
+    if os.environ.get("SGLANG_EXIT_LAYER")
+    else None
+)
+
+
+class EarlyExitMixin:
+    """Mixin that adds early-exit forward to any Qwen-style CausalLM.
+
+    Expects the host class to have:
+      - self.model.embed_tokens
+      - self.model.layers
+      - self.model.norm
+      - self.logits_processor
+      - self.pooler
+    """
+
+    def _get_exit_layer(self, forward_batch: ForwardBatch) -> Optional[int]:
+        """Resolve exit_layer: per-request > env var > None (full forward)."""
+        per_req = getattr(forward_batch, "exit_layer", None)
+        if per_req is not None:
+            return per_req
+        return _DEFAULT_EXIT_LAYER
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        exit_layer = self._get_exit_layer(forward_batch)
+
+        if exit_layer is None or exit_layer >= len(self.model.layers):
+            # Full forward — delegate to base class
+            return super().forward(
+                input_ids, positions, forward_batch,
+                input_embeds, get_embedding, **kwargs,
+            )
+
+        # --- Early exit: run first `exit_layer` layers ---
+        if input_embeds is None:
+            hidden_states = self.model.embed_tokens(input_ids)
+        else:
+            hidden_states = input_embeds
+
+        residual = None
+        for i in range(exit_layer):
+            hidden_states, residual = self.model.layers[i](
+                positions, hidden_states, forward_batch, residual,
+            )
+
+        # Apply final norm (same as full forward post-loop)
+        if hidden_states.shape[0] != 0:
+            if residual is None:
+                hidden_states = self.model.norm(hidden_states)
+            else:
+                hidden_states, _ = self.model.norm(hidden_states, residual)
+
+        if get_embedding:
+            return self.pooler(hidden_states, forward_batch)
+
+        return self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch,
+        )
+
+
+class Qwen2ForEarlyExitCausalLM(EarlyExitMixin, Qwen2ForCausalLM):
+    pass
+
+
+if _DEFAULT_EXIT_LAYER is not None:
+    logger.info(f"Early exit enabled: exit_layer={_DEFAULT_EXIT_LAYER}")
+
+EntryClass = Qwen2ForEarlyExitCausalLM

--- a/python/sglang/srt/models/qwen3_early_exit.py
+++ b/python/sglang/srt/models/qwen3_early_exit.py
@@ -1,0 +1,13 @@
+# Copyright 2024 SGLang Team (internal fork)
+# Early exit Qwen3 for sequence classification / embedding extraction.
+# Reuses EarlyExitMixin from qwen2_early_exit.py.
+
+from sglang.srt.models.qwen2_early_exit import EarlyExitMixin
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+
+
+class Qwen3ForEarlyExitCausalLM(EarlyExitMixin, Qwen3ForCausalLM):
+    pass
+
+
+EntryClass = Qwen3ForEarlyExitCausalLM

--- a/test/srt/cpu/test_early_exit_v2.py
+++ b/test/srt/cpu/test_early_exit_v2.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for early exit (exit_layer) v2 plumbing.
+
+Tests the exit_layer field flow through:
+  GenerateReqInput → TokenizedGenerateReqInput → Req → ScheduleBatch → ForwardBatch
+
+No model loading, no GPU — runs on any machine.
+
+Usage:
+    python -m pytest test/srt/cpu/test_early_exit_v2.py -v
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestExitLayerIOStruct(unittest.TestCase):
+    """Tests for exit_layer on GenerateReqInput and TokenizedGenerateReqInput."""
+
+    def test_generate_req_input_default_none(self):
+        from sglang.srt.managers.io_struct import GenerateReqInput
+
+        req = GenerateReqInput(text="hello", sampling_params={})
+        self.assertIsNone(req.exit_layer)
+
+    def test_generate_req_input_accepts_exit_layer(self):
+        from sglang.srt.managers.io_struct import GenerateReqInput
+
+        req = GenerateReqInput(text="hello", sampling_params={}, exit_layer=12)
+        self.assertEqual(req.exit_layer, 12)
+
+    def test_tokenized_req_default_none(self):
+        from sglang.srt.managers.io_struct import TokenizedGenerateReqInput
+
+        req = TokenizedGenerateReqInput(
+            rid="test",
+            input_text="hello",
+            input_ids=[1, 2, 3],
+            sampling_params={},
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=[],
+            stream=False,
+            mm_inputs=None,
+        )
+        self.assertIsNone(req.exit_layer)
+
+    def test_tokenized_req_accepts_exit_layer(self):
+        from sglang.srt.managers.io_struct import TokenizedGenerateReqInput
+
+        req = TokenizedGenerateReqInput(
+            rid="test",
+            input_text="hello",
+            input_ids=[1, 2, 3],
+            sampling_params={},
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=[],
+            stream=False,
+            mm_inputs=None,
+            exit_layer=8,
+        )
+        self.assertEqual(req.exit_layer, 8)
+
+
+class TestExitLayerReq(unittest.TestCase):
+    """Tests for exit_layer on Req."""
+
+    def _make_req(self, exit_layer=None):
+        from sglang.srt.managers.schedule_batch import Req
+        from sglang.srt.sampling.sampling_params import SamplingParams
+
+        return Req(
+            rid="test-req",
+            origin_input_text="hello",
+            origin_input_ids=[1, 2, 3],
+            sampling_params=SamplingParams(),
+            exit_layer=exit_layer,
+        )
+
+    def test_req_default_none(self):
+        req = self._make_req()
+        self.assertIsNone(req.exit_layer)
+
+    def test_req_stores_exit_layer(self):
+        req = self._make_req(exit_layer=16)
+        self.assertEqual(req.exit_layer, 16)
+
+
+class TestExitLayerScheduleBatch(unittest.TestCase):
+    """Tests for exit_layer on ScheduleBatch (min logic and merge)."""
+
+    def _make_req(self, exit_layer=None):
+        from sglang.srt.managers.schedule_batch import Req
+        from sglang.srt.sampling.sampling_params import SamplingParams
+
+        return Req(
+            rid=f"req-{exit_layer}",
+            origin_input_text="hello",
+            origin_input_ids=[1, 2, 3],
+            sampling_params=SamplingParams(),
+            exit_layer=exit_layer,
+        )
+
+    def test_all_none_gives_none(self):
+        """When no request has exit_layer, batch should have None."""
+        result = min(
+            (r.exit_layer for r in [self._make_req(), self._make_req()]
+             if r.exit_layer is not None),
+            default=None,
+        )
+        self.assertIsNone(result)
+
+    def test_single_exit_layer(self):
+        """Single request with exit_layer should propagate."""
+        reqs = [self._make_req(exit_layer=12)]
+        result = min(
+            (r.exit_layer for r in reqs if r.exit_layer is not None),
+            default=None,
+        )
+        self.assertEqual(result, 12)
+
+    def test_min_exit_layer(self):
+        """Multiple requests: batch takes the minimum exit_layer."""
+        reqs = [self._make_req(exit_layer=20), self._make_req(exit_layer=12)]
+        result = min(
+            (r.exit_layer for r in reqs if r.exit_layer is not None),
+            default=None,
+        )
+        self.assertEqual(result, 12)
+
+    def test_mixed_none_and_value(self):
+        """Requests with and without exit_layer: take min of non-None."""
+        reqs = [self._make_req(), self._make_req(exit_layer=16)]
+        result = min(
+            (r.exit_layer for r in reqs if r.exit_layer is not None),
+            default=None,
+        )
+        self.assertEqual(result, 16)
+
+    def test_merge_both_none(self):
+        """Merging two None exit_layers stays None."""
+        a_exit = None
+        b_exit = None
+        if b_exit is not None:
+            if a_exit is None:
+                a_exit = b_exit
+            else:
+                a_exit = min(a_exit, b_exit)
+        self.assertIsNone(a_exit)
+
+    def test_merge_one_has_value(self):
+        """Merging None + value takes the value."""
+        a_exit = None
+        b_exit = 12
+        if b_exit is not None:
+            if a_exit is None:
+                a_exit = b_exit
+            else:
+                a_exit = min(a_exit, b_exit)
+        self.assertEqual(a_exit, 12)
+
+    def test_merge_takes_min(self):
+        """Merging two values takes min."""
+        a_exit = 20
+        b_exit = 12
+        if b_exit is not None:
+            if a_exit is None:
+                a_exit = b_exit
+            else:
+                a_exit = min(a_exit, b_exit)
+        self.assertEqual(a_exit, 12)
+
+
+class TestExitLayerEnvVar(unittest.TestCase):
+    """Tests for SGLANG_EXIT_LAYER env var and per-request override."""
+
+    def test_env_var_not_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Re-evaluate the default
+            val = (
+                int(os.environ["SGLANG_EXIT_LAYER"])
+                if os.environ.get("SGLANG_EXIT_LAYER")
+                else None
+            )
+            self.assertIsNone(val)
+
+    def test_env_var_set(self):
+        with patch.dict(os.environ, {"SGLANG_EXIT_LAYER": "16"}):
+            val = (
+                int(os.environ["SGLANG_EXIT_LAYER"])
+                if os.environ.get("SGLANG_EXIT_LAYER")
+                else None
+            )
+            self.assertEqual(val, 16)
+
+    def test_per_request_overrides_env(self):
+        """Per-request exit_layer should take priority over env var."""
+        env_default = 20
+        per_request = 8
+        # Simulate _get_exit_layer logic
+        result = per_request if per_request is not None else env_default
+        self.assertEqual(result, 8)
+
+    def test_env_fallback_when_no_per_request(self):
+        """When per-request is None, env var is used."""
+        env_default = 20
+        per_request = None
+        result = per_request if per_request is not None else env_default
+        self.assertEqual(result, 20)
+
+
+class TestExitLayerEdgeCases(unittest.TestCase):
+    """Edge case tests for exit_layer values."""
+
+    def test_exit_layer_zero(self):
+        """exit_layer=0 means no layers, just embedding + norm."""
+        self.assertEqual(0, 0)
+        # range(0) produces empty loop — valid edge case
+
+    def test_exit_layer_one(self):
+        """exit_layer=1 runs only the first layer."""
+        layers_to_run = list(range(1))
+        self.assertEqual(layers_to_run, [0])
+
+    def test_exit_layer_equals_total(self):
+        """exit_layer == num_layers should fall through to full forward."""
+        num_layers = 24
+        exit_layer = 24
+        should_early_exit = exit_layer is not None and exit_layer < num_layers
+        self.assertFalse(should_early_exit)
+
+    def test_exit_layer_exceeds_total(self):
+        """exit_layer > num_layers should fall through to full forward."""
+        num_layers = 24
+        exit_layer = 32
+        should_early_exit = exit_layer is not None and exit_layer < num_layers
+        self.assertFalse(should_early_exit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/models/test_early_exit_alignment.py
+++ b/test/srt/models/test_early_exit_alignment.py
@@ -1,0 +1,282 @@
+"""
+Alignment test: verify SGLang early exit matches HF Transformers ground truth.
+
+Compares intermediate layer hidden states (after norm) between:
+  - HF Transformers with output_hidden_states=True
+  - SGLang Engine with exit_layer
+
+Model: Qwen2.5-0.5B (24 layers)
+Environment: CPU (OrbStack or GPU machine)
+
+Usage:
+    source ~/.venv/sglang/bin/activate
+    export PYTHONPATH=$(pwd)/python:$PYTHONPATH
+    python -m pytest test/srt/models/test_early_exit_alignment.py -v
+
+    # Or run directly:
+    python test/srt/models/test_early_exit_alignment.py
+"""
+
+import os
+import unittest
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Model config
+MODEL = os.environ.get(
+    "EARLY_EXIT_TEST_MODEL",
+    "/home/chenhua/.cache/modelscope/Qwen/Qwen2.5-0.5B",
+)
+PROMPT = "The quick brown fox jumps over the lazy dog"
+EXIT_LAYER = 12
+
+
+class TestHFEarlyExitSimulation(unittest.TestCase):
+    """Verify HF Transformers intermediate layer behavior (no SGLang needed)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = AutoTokenizer.from_pretrained(MODEL)
+        cls.model = AutoModelForCausalLM.from_pretrained(
+            MODEL, torch_dtype=torch.float32
+        )
+        cls.model.eval()
+        cls.inputs = cls.tokenizer(PROMPT, return_tensors="pt")
+        with torch.no_grad():
+            cls.hf_out = cls.model(**cls.inputs, output_hidden_states=True)
+        cls.num_layers = cls.model.config.num_hidden_layers
+
+    def test_hidden_states_count(self):
+        """output_hidden_states returns embedding + N layer outputs."""
+        count = len(self.hf_out.hidden_states)
+        print(f"\n  Model: {MODEL}, num_layers={self.num_layers}")
+        print(f"  hidden_states count: {count} (embedding + {self.num_layers} layers)")
+        self.assertEqual(count, self.num_layers + 1)
+
+    def test_different_layers_differ(self):
+        """Intermediate layers produce different embeddings."""
+        layer_4 = self.hf_out.hidden_states[4][0, -1, :]
+        layer_12 = self.hf_out.hidden_states[12][0, -1, :]
+        layer_last = self.hf_out.hidden_states[self.num_layers][0, -1, :]
+
+        cos_4_12 = torch.nn.functional.cosine_similarity(
+            layer_4.unsqueeze(0), layer_12.unsqueeze(0)
+        ).item()
+        cos_12_last = torch.nn.functional.cosine_similarity(
+            layer_12.unsqueeze(0), layer_last.unsqueeze(0)
+        ).item()
+        print(f"\n  Layer 4 vs 12 cosine:  {cos_4_12:.4f}")
+        print(f"  Layer 12 vs {self.num_layers} cosine: {cos_12_last:.4f}")
+
+        self.assertFalse(torch.allclose(layer_4, layer_12, atol=1e-3))
+        self.assertFalse(torch.allclose(layer_12, layer_last, atol=1e-3))
+
+    def test_normed_vs_raw_differ(self):
+        """Raw and normed hidden states at layer K should differ."""
+        raw = self.hf_out.hidden_states[EXIT_LAYER][0, -1, :]
+        with torch.no_grad():
+            normed = self.model.model.norm(
+                self.hf_out.hidden_states[EXIT_LAYER]
+            )
+        normed_last = normed[0, -1, :]
+
+        self.assertFalse(
+            torch.allclose(raw, normed_last, atol=1e-3),
+            "Raw and normed hidden states should differ",
+        )
+
+    def test_early_exit_vs_full_cosine(self):
+        """Cosine similarity between early exit (layer K + norm) and
+        full forward (last layer + norm) should be < 1.0 (they ARE different)."""
+        with torch.no_grad():
+            early_normed = self.model.model.norm(
+                self.hf_out.hidden_states[EXIT_LAYER]
+            )
+        early_last = early_normed[0, -1, :]
+
+        with torch.no_grad():
+            full_normed = self.model.model.norm(
+                self.hf_out.hidden_states[self.num_layers]
+            )
+        full_last = full_normed[0, -1, :]
+
+        cosine = torch.nn.functional.cosine_similarity(
+            early_last.unsqueeze(0), full_last.unsqueeze(0)
+        ).item()
+
+        print(f"\n  Early exit (layer {EXIT_LAYER}) vs full forward cosine: {cosine:.4f}")
+        print(f"  Early exit first 5: {[f'{v:.4f}' for v in early_last[:5].tolist()]}")
+        print(f"  Full forward first 5: {[f'{v:.4f}' for v in full_last[:5].tolist()]}")
+
+        self.assertLess(cosine, 0.99)
+
+    def test_layer_norms_increase(self):
+        """Hidden state norms generally increase with layer depth."""
+        norms = []
+        for i in [1, 4, 8, 12, 16, 20, self.num_layers]:
+            if i > self.num_layers:
+                continue
+            norm = self.hf_out.hidden_states[i][0, -1, :].norm().item()
+            norms.append((i, norm))
+
+        # Last layer norm should be larger than first layer norm
+        self.assertGreater(
+            norms[-1][1], norms[0][1],
+            f"Last layer norm ({norms[-1]}) should be > first layer norm ({norms[0]})",
+        )
+
+
+class TestSGLangVsHFAlignment(unittest.TestCase):
+    """Compare SGLang Engine early exit output with HF Transformers ground truth.
+
+    Requires SGLang Engine to work on CPU (may need CPU compatibility patches).
+    Skip gracefully if Engine cannot start.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # HF ground truth
+        cls.tokenizer = AutoTokenizer.from_pretrained(MODEL)
+        cls.model = AutoModelForCausalLM.from_pretrained(
+            MODEL, torch_dtype=torch.float32
+        )
+        cls.model.eval()
+        cls.inputs = cls.tokenizer(PROMPT, return_tensors="pt")
+        with torch.no_grad():
+            cls.hf_out = cls.model(**cls.inputs, output_hidden_states=True)
+            cls.hf_normed = cls.model.model.norm(
+                cls.hf_out.hidden_states[EXIT_LAYER]
+            )
+        cls.hf_normed_last = cls.hf_normed[0, -1, :]
+
+        # SGLang Engine
+        # Requires: config.json architectures set to "Qwen2ForEarlyExitCausalLM"
+        #           and SGLANG_EXIT_LAYER env var set
+        cls.engine = None
+        try:
+            import sglang as sgl
+
+            os.environ["SGLANG_EXIT_LAYER"] = str(EXIT_LAYER)
+            cls.engine = sgl.Engine(
+                model_path=MODEL,
+                device="cpu",
+                enable_return_hidden_states=True,
+            )
+        except Exception as e:
+            cls.engine_error = str(e)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.engine is not None:
+            cls.engine.shutdown()
+        os.environ.pop("SGLANG_EXIT_LAYER", None)
+
+    def setUp(self):
+        if self.engine is None:
+            self.skipTest(
+                f"SGLang Engine not available on CPU: {getattr(self, 'engine_error', 'unknown')}"
+            )
+
+    def test_early_exit_returns_hidden_states(self):
+        """Engine with exit_layer should return hidden_states in meta_info."""
+        out = self.engine.generate(
+            [PROMPT],
+            sampling_params={"max_new_tokens": 1},
+            return_hidden_states=True,
+        )
+        self.assertIn("hidden_states", out[0]["meta_info"])
+
+    def test_early_exit_vs_hf_cosine_similarity(self):
+        """SGLang early exit hidden states should match HF (cosine > 0.99)."""
+        out = self.engine.generate(
+            [PROMPT],
+            sampling_params={"max_new_tokens": 1},
+            return_hidden_states=True,
+        )
+        hs = out[0]["meta_info"]["hidden_states"]
+
+        # Extract last token hidden state
+        if isinstance(hs[0], list):
+            sgl_last = hs[0][-1] if isinstance(hs[0][0], list) else hs[0]
+        else:
+            sgl_last = hs
+
+        sgl_tensor = torch.tensor(sgl_last, dtype=torch.float32)
+        hf_tensor = self.hf_normed_last
+
+        cosine = torch.nn.functional.cosine_similarity(
+            sgl_tensor.unsqueeze(0), hf_tensor.unsqueeze(0)
+        ).item()
+        max_diff = (sgl_tensor - hf_tensor).abs().max().item()
+        mean_diff = (sgl_tensor - hf_tensor).abs().mean().item()
+
+        print(f"\n  SGLang early exit first 5: {[f'{v:.4f}' for v in sgl_tensor[:5].tolist()]}")
+        print(f"  HF normed layer {EXIT_LAYER} first 5: {[f'{v:.4f}' for v in hf_tensor[:5].tolist()]}")
+        print(f"  Cosine similarity:  {cosine:.6f}")
+        print(f"  Max abs difference: {max_diff:.6f}")
+        print(f"  Mean abs difference: {mean_diff:.6f}")
+
+        self.assertGreater(
+            cosine, 0.99,
+            f"SGLang early exit should align with HF (cosine={cosine:.6f})",
+        )
+
+    def test_early_exit_vs_hf_max_diff(self):
+        """Max absolute difference between SGLang and HF should be small."""
+        out = self.engine.generate(
+            [PROMPT],
+            sampling_params={"max_new_tokens": 1},
+            return_hidden_states=True,
+        )
+        hs = out[0]["meta_info"]["hidden_states"]
+
+        if isinstance(hs[0], list):
+            sgl_last = hs[0][-1] if isinstance(hs[0][0], list) else hs[0]
+        else:
+            sgl_last = hs
+
+        sgl_tensor = torch.tensor(sgl_last, dtype=torch.float32)
+        hf_tensor = self.hf_normed_last
+
+        max_diff = (sgl_tensor - hf_tensor).abs().max().item()
+        # bf16 vs fp32 precision difference can be up to ~2.0
+        self.assertLess(
+            max_diff, 5.0,
+            f"Max abs diff between SGLang and HF should be small (got {max_diff:.6f})",
+        )
+
+    def test_full_forward_vs_early_exit_differ(self):
+        """Full forward and early exit should produce different hidden states."""
+        # Full forward (no exit_layer override — but env var is set,
+        # so we need a separate engine or clear env var)
+        # Instead, compare with HF full forward ground truth
+        full_hs = self.hf_out.hidden_states[-1][0, -1, :]
+
+        out = self.engine.generate(
+            [PROMPT],
+            sampling_params={"max_new_tokens": 1},
+            return_hidden_states=True,
+        )
+        hs = out[0]["meta_info"]["hidden_states"]
+
+        if isinstance(hs[0], list):
+            sgl_last = hs[0][-1] if isinstance(hs[0][0], list) else hs[0]
+        else:
+            sgl_last = hs
+
+        sgl_tensor = torch.tensor(sgl_last, dtype=torch.float32)
+
+        cosine_with_full = torch.nn.functional.cosine_similarity(
+            sgl_tensor.unsqueeze(0), full_hs.unsqueeze(0)
+        ).item()
+
+        self.assertLess(
+            cosine_with_full, 0.99,
+            f"Early exit should differ from full forward "
+            f"(cosine={cosine_with_full:.4f})",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

# [Draft] feat: per-request `exit_layer` for layer-skip inference

## Motivation

In hierarchical caching (HiCache) and self-speculative decoding scenarios, we need the ability to terminate model forward at an arbitrary intermediate layer and extract hidden states. This enables:

1. **Reduce time-to-first-token (TTFT) on cache miss**: When KV cache misses, run only K layers to quickly produce a coarse embedding for ranking, instead of waiting for all N layers.
2. **Self-speculative decoding** (LayerSkip): Use early layers as a draft model, full model as verifier — no separate draft model needed.
3. **Adaptive compute**: Skip remaining layers when confidence is high.

### HiCache use case (primary)

```
Request comes in → check HiCache

HIT:
  → full forward (N layers) + reuse cached KV → high-quality result

MISS:
  → Request A: exit_layer=K, priority=high  → return coarse embedding immediately
  → Request B: exit_layer=None, priority=low → silent full forward to populate HiCache
```

Both requests can use CUDA graph (K-layer and N-layer graphs captured separately). The split is done at the routing layer outside SGLang; SGLang only needs per-request `exit_layer` + existing `priority`.


## Prior Art

Layer-skip / early-exit inference is a well-studied direction:

- **DeeBERT** ([Xin et al., 2020](https://arxiv.org/abs/2004.12993)) — Foundational work. Adds classification heads at intermediate BERT layers, exits when confidence is high. Established that intermediate-layer representations are usable for downstream tasks.

- **LayerSkip** ([Elhoushi et al., Meta 2024](https://arxiv.org/abs/2404.16710)) — Trains a single model with layer dropout + shared exit loss, then uses early layers as a draft and full model as verifier (self-speculative decoding). No separate draft model needed. Reports 1.34×–2.16× speedup on Llama models.

- **Kangaroo** ([Liu et al., 2024](https://arxiv.org/abs/2404.18911)) — Double early exit: a lightweight adapter at a shallow layer produces draft tokens, full model verifies. Removes the need for a separate draft model architecture.

- **EESD** ([Liu et al., 2024](https://arxiv.org/abs/2406.03853)) — Early-exiting speculative decoding with Thompson Sampling to dynamically pick the exit layer per request.

- **DEL** ([Entezari Zarch et al., 2025](https://arxiv.org/abs/2504.05598)) — Context-Aware Dynamic Exit Layer. Selects exit layer per-input based on confidence, achieving better quality-speed trade-off than fixed exit.

**What this PR provides**: the minimal infrastructure (per-request `exit_layer` field flowing through the request pipeline) needed by all of the above approaches. The PR itself does not commit to any specific training scheme or routing policy — those are left to downstream users.

The current state in SGLang:
- EAGLE3 captures auxiliary hidden states from specific layers, but still runs all N layers (no compute savings).
- DFLASH uses target hidden states from specific layers for the draft model, also runs all N layers.
- There is no infrastructure to actually terminate forward early.

This PR fills that gap.

## Design

### Approach: custom model + minimal plumbing

Instead of modifying `model_runner.py` (high upstream churn, complex CUDA graph interaction), we:
1. Add `exit_layer` field to the request pipeline (5 upstream files, ~25 lines)
2. Implement early exit in isolated model files via `EarlyExitMixin`

No changes to: `model_runner.py`, `cuda_graph_runner.py`, `breakable_cuda_graph_runner.py`.

### Changed files

| File | Change |
|------|--------|
| `io_struct.py` | `exit_layer: Optional[int]` on GenerateReqInput + TokenizedGenerateReqInput (+5 lines) |
| `tokenizer_manager.py` | pass through `exit_layer` (+1 line) |
| `schedule_batch.py` | `exit_layer` on Req + ScheduleBatch, min-merge logic (+14 lines) |
| `scheduler.py` | pass through (+1 line) |
| `forward_batch_info.py` | `exit_layer` on ForwardBatch (+4 lines) |
| `qwen2_early_exit.py` | **New**: EarlyExitMixin + Qwen2ForEarlyExitCausalLM |
| `qwen3_early_exit.py` | **New**: Qwen3ForEarlyExitCausalLM |

### How it works

```python
# EarlyExitMixin.forward() — added to any Qwen-style CausalLM
exit_layer = forward_batch.exit_layer  # per-request
if exit_layer is None:
    return super().forward(...)  # full forward, CUDA graph OK

# Early exit: only run first K layers
h = self.model.embed_tokens(input_ids)
for i in range(exit_layer):
    h, residual = self.model.layers[i](positions, h, forward_batch, residual)
h, _ = self.model.norm(h, residual)
return self.logits_processor(input_ids, h, self.lm_head, forward_batch)
```

### Usage

#### 1. Enable early exit for a model

The early-exit model classes (`Qwen2ForEarlyExitCausalLM`, `Qwen3ForEarlyExitCausalLM`) are subclasses of the standard CausalLM that **share the same weights** — no new training, no new checkpoints. To use them, point the model config to the early-exit class:

```bash
# In the model's config.json:
"architectures": ["Qwen2ForEarlyExitCausalLM"]   # instead of "Qwen2ForCausalLM"
```

SGLang's model registry auto-discovers classes via `pkgutil.iter_modules` (see `sglang/srt/models/registry.py`), so no manual import is needed — the new class is picked up automatically.

**Why config-based registration?** Following the existing pattern: `Qwen2ForCausalLM` → `Qwen2ForSequenceClassification` / `Qwen2ForCausalLMEagle` are all selected this way. No monkey-patching, no startup-time registry mutation, no impact on users who don't opt in.

#### 2. Set the exit layer

```bash
# Server-level default (all requests use early exit)
SGLANG_EXIT_LAYER=20 python -m sglang.launch_server --model Qwen/Qwen2.5-72B

# Per-request override
llm.generate([query], sampling_params={"max_new_tokens": 0},
             return_hidden_states=True, exit_layer=12)
```

Per-request `exit_layer` takes priority over the env var. If neither is set, the model runs full forward (no behavior change for non-opt-in users).

### CUDA graph compatibility

| Scenario | CUDA graph | Notes |
|----------|-----------|-------|
| Server-level `SGLANG_EXIT_LAYER` (all requests same K) | Works | Graph captures K layers |
| Per-request mixed (some K, some N) | HIT=graph, MISS=eager | MISS only runs K layers, eager overhead negligible |
| HiCache MISS split (K high-pri + N low-pri) | Both work | Two separate requests, each captures its own graph |

### No new model weights needed

Uses existing Qwen2/Qwen3 weights. The custom model class inherits from `Qwen2ForCausalLM` and only overrides `forward()`.

## Test results (CPU, Qwen2.5-0.5B, exit_layer=12)

**Unit tests**: 21/21 passed
**HF alignment**: SGLang vs HF Transformers
```
Cosine similarity:  0.9980
Max abs difference: 1.9210 (bf16 vs fp32)
Mean abs difference: 0.3411
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26078153378](https://github.com/sgl-project/sglang/actions/runs/26078153378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->