### PR TITLE
[LoRA] Fix counter accounting for parallel sampling prefix cache

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1445,12 +1445,29 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 tmp_obj = copy.copy(objs[i])
                 tokenized_obj = copy.copy(tokenized_objs[i])
                 tokenized_obj.rid = tmp_obj.regenerate_rid()
-                tokenized_obj.sampling_params = copy.copy(tokenized_obj.sampling_params)
-                tokenized_obj.sampling_params.max_new_tokens = 0
-                tokenized_obj.stream = False
-                self._init_req_state(tmp_obj)
-                self._send_one_request(tokenized_obj)
-                await self._wait_one_response(tmp_obj, request).__anext__()
+                prefix_lora_id = None
+                sent_to_scheduler = False
+                try:
+                    if self.server_args.enable_lora and tmp_obj.lora_path:
+                        prefix_lora_id = await self.lora_registry.acquire(
+                            tmp_obj.lora_path
+                        )
+                        tmp_obj.lora_id = prefix_lora_id
+                        tokenized_obj.lora_id = prefix_lora_id
+                    tokenized_obj.sampling_params = copy.copy(
+                        tokenized_obj.sampling_params
+                    )
+                    tokenized_obj.sampling_params.max_new_tokens = 0
+                    tokenized_obj.stream = False
+                    self._init_req_state(tmp_obj)
+                    self._send_one_request(tokenized_obj)
+                    sent_to_scheduler = True
+                    await self._wait_one_response(tmp_obj, request).__anext__()
+                except Exception:
+                    if prefix_lora_id is not None and not sent_to_scheduler:
+                        self.rid_to_state.pop(tmp_obj.rid, None)
+                        await self.lora_registry.release(prefix_lora_id)
+                    raise
 
             # Expand requests, assign new rids for them, and send them
             for i in range(batch_size):


### PR DESCRIPTION
## Motivation

Fixes #25864

Batch parallel sampling creates extra prefix-cache requests before sending the expanded sample requests. When these prefix-cache requests use LoRA, they are released through the normal request-finish path, but they were not previously accounted for in `LoRARegistry.acquire()`.

This could make the LoRA usage counter go negative. In our reproduction with native `/generate`, `batch_size=2`, `sampling_params.n=4`, and dynamic LoRA loading:

- Before fix: `acquire=8`, `release=10`, counter became `-2`, and `/unload_lora_adapter` timed out.
- After fix: `acquire=10`, `release=10`, counter returned to `0`, and `/unload_lora_adapter` returned `200 OK`.

## Modifications

- Account for LoRA usage for the prefix-cache requests created in the `parallel_sample_num > 1` batch path.
- Propagate the acquired LoRA id to both the request object and tokenized request.
- Add rollback logic for the small failure window before the prefix-cache request is sent to the scheduler.

This keeps LoRA acquire/release balanced for batch parallel sampling without changing non-LoRA requests or normal `n=1` requests.

## Accuracy Tests

N/A. This change only fixes LoRA usage-counter accounting in the tokenizer manager. It does not change model weights, kernels, sampling logic, or model forward computation.

## Speed Tests and Profiling

N/A. This change only adds LoRA registry accounting for internal prefix-cache requests in the batch parallel sampling path.

Local validation:

```text
single_n1_lora: generate 200, outputs=1/1, unload 200
single_n4_lora: generate 200, outputs=4/4, unload 200
batch2_n1_lora: generate 200, outputs=2/2, unload 200
batch2_n4_lora: generate 200, outputs=8/8, unload 200
batch3_n2_lora: generate 200, outputs=6/6, unload 200
batch2_n4_no_lora: generate 200, outputs=8/8
```

Focused reproduction after fix:

```text
/load_lora_adapter: 200
/generate: 200
/unload_lora_adapter: 200

LoRA counter:
prefix-cache acquire/release balanced
parallel sample releases returned counter to 0
wait_for_unload done with count=0
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26078570621](https://github.com/sgl-project/sglang/actions/runs/26078570621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->