### PR TITLE
loader: yield filtered MTP weights lazily to avoid OOM hang on multi-layer EAGLE

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -583,10 +583,12 @@ class DefaultModelLoader(BaseModelLoader):
     @classmethod
     def _filter_mtp_weights(
         cls, weights_iterator, prefix: str, draft_model_idx: int
-    ) -> Tuple[Tuple[str, torch.Tensor], ...]:
-        """Filter MTP (Multi-Token Prediction) weights to keep only the
-        specified draft model layer and remap it to layer 0."""
-        filtered_weights = []
+    ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+        """Filter MTP weights to keep only the specified draft model layer
+        and remap it to layer 0. Yields lazily so the upstream buffered
+        iterator's sliding window actually bounds CPU memory — eager
+        materialization caused page-reclaim hangs on large MoE checkpoints
+        with multi-layer EAGLE."""
         for name, tensor in weights_iterator:
             match = cls._MTP_PATTERN.match(name)
             if match is not None:
@@ -596,8 +598,7 @@ class DefaultModelLoader(BaseModelLoader):
                 new_name = name.replace(match.group(), "model.mtp.layers.0.")
             else:
                 new_name = name
-            filtered_weights.append((prefix + new_name, tensor))
-        return tuple(filtered_weights)
+            yield (prefix + new_name, tensor)
 
     def _get_all_weights(
         self,


### PR DESCRIPTION
## Summary

`DefaultModelLoader._filter_mtp_weights` was materializing the entire filtered checkpoint into a `tuple` before returning, which defeated the bounded sliding-window in `buffered_multi_thread_safetensors_weights_iterator` (`buffer_size = max_workers + 1`).

With multi-layer EAGLE on large MoE checkpoints (e.g. MiMo-V2.5-Pro, ~963 GiB fp8), each TP rank instantiates `speculative_num_steps` draft runners (each with its own `draft_model_idx`), and every runner independently re-scans the full checkpoint. The eager `tuple(filtered_weights)` held the full prefix-renamed payload resident on CPU per runner — at TP=8 with 3 draft runners that's enough live tensors per host to push it into page reclaim. The visible symptom was:

- All scheduler threads stuck on `futex_do_wait`
- `/proc/<pid>/io read_bytes = 0`, no `rchar` growth
- No progress past `Found local HF snapshot ... skipping download.`
- Identical on virtiofs and local NVMe (rules out storage)

Switching to a generator preserves behavior (callers already iterate the result; sibling `_get_weights_iterator` paths already return generators) while letting the buffered upstream actually bound CPU memory.

## Test plan

Tested on 8× B200 with MiMo-V2.5-Pro (~963 GiB fp8) and the default `enable_multithread_load=True`:

| | before (default `enable_multithread_load=True`) | after (this PR) |
|---|---|---|
| Server ready | **hangs indefinitely** (all sched in `futex_do_wait`) | ~2.5 min |
| GSM8K (200, parallel=4) | n/a (hung) | score 0.97 |
| avg accept_rate | n/a | 0.755 (over 307 batches) |
| avg accept_length | n/a | 3.27 (max 4) |
| gen throughput | n/a | ~700 tok/s |

Behaviour with the previous `--model-loader-extra-config '{"enable_multithread_load":false}'` workaround is unchanged: same accept_rate (0.753 → 0.755), same GSM8K score (0.975 → 0.97 — within noise), but server is now ~30 % faster to ready because the multi-thread loader is actually live.

Launch:
\`\`\`bash
export SGLANG_ENABLE_SPEC_V2=1
sglang serve --trust-remote-code --model-path XiaomiMiMo/MiMo-V2.5-Pro --tp 8 \
  --moe-runner-backend flashinfer_trtllm --attention-backend fa4 \
  --mem-fraction-static 0.8 --max-running-requests 128 \
  --chunked-prefill-size 16384 --swa-full-tokens-ratio 0.1 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 --enable-multi-layer-eagle \
  --reasoning-parser mimo --tool-call-parser mimo \
  --host 0.0.0.0 --port 30000
\`\`\`





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26089123904](https://github.com/sgl-project/sglang/actions/runs/26089123904)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->