### PR TITLE
Fix MXFP4 MoE empty batch fallback

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1125,6 +1125,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self._fi_kernel == "cutlass_sm90":
             return self._apply_sm90_cutlass(layer, x, topk_output)
         if self.use_flashinfer:
+            if x.shape[0] == 0:
+                return StandardCombineInput(
+                    hidden_states=torch.empty(
+                        0,
+                        x.shape[-1],
+                        dtype=torch.bfloat16,
+                        device=x.device,
+                    )
+                )
+
             # When bf16 mode is enabled, we don't need to quantize the input,
             # TRT-LLM automatically handles quantization in the kernel implementation and pipelines it with GEMM operations,
             # which can theoretically improve performance

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -346,6 +346,16 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         intermediate_size = w2.shape[2] * 2 if w2.dtype == torch.uint8 else w2.shape[2]
         hidden_size = w13.shape[2] * 2 if w13.dtype == torch.uint8 else w13.shape[2]
 
+        if hidden_states.shape[0] == 0:
+            return StandardCombineInput(
+                hidden_states=torch.empty(
+                    0,
+                    hidden_size,
+                    dtype=torch.bfloat16,
+                    device=hidden_states.device,
+                )
+            )
+
         num_local_experts = layer.num_local_experts
         if w13_scale.dim() == 2:
             w13_scale = w13_scale.reshape(num_local_experts, 2 * intermediate_size, -1)

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1000,6 +1000,8 @@ class DeepseekV4Model(nn.Module):
                 hc_eps=self.hc_eps,
             )
         shape, dtype = x.size(), x.dtype
+        if x.shape[0] == 0:
+            return torch.empty((0, shape[-1]), dtype=dtype, device=x.device)
         x = x.flatten(1).float()
         rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + self.norm_eps)
         mixes = F.linear(x, hc_fn) * rsqrt
@@ -1066,7 +1068,12 @@ class DeepseekV4Model(nn.Module):
             # Flatten 3D mHC tensor for PP IPC.
             return PPProxyTensors({"hidden_states": hidden_states.flatten(1)})
 
-        pre_hc_head = hidden_states.flatten(1)
+        if hidden_states.shape[0] == 0:
+            pre_hc_head = hidden_states.new_empty(
+                (0, self.hc_mult * self.hidden_size)
+            )
+        else:
+            pre_hc_head = hidden_states.flatten(1)
 
         hidden_states = self.hc_head(
             hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -101,6 +101,8 @@ class DeepseekV4ModelNextN(nn.Module):
         hc_base: torch.Tensor,
     ):
         shape, dtype = x.size(), x.dtype
+        if x.shape[0] == 0:
+            return torch.empty((0, shape[-1]), dtype=dtype, device=x.device)
         x = x.flatten(1).float()
         rsqrt = torch.rsqrt(x.square().mean(-1, keepdim=True) + self.rms_norm_eps)
         mixes = F.linear(x, hc_fn) * rsqrt
@@ -153,7 +155,12 @@ class DeepseekV4ModelNextN(nn.Module):
             input_ids_global=input_ids_global,
         )
 
-        pre_hc_head = hidden_states.flatten(1)
+        if hidden_states.shape[0] == 0:
+            pre_hc_head = hidden_states.new_empty(
+                (0, self.hc_mult * self.config.hidden_size)
+            )
+        else:
+            pre_hc_head = hidden_states.flatten(1)
 
         hidden_states = self.hc_head(
             hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base


### PR DESCRIPTION
## Motivation

  When using FlashInfer MXFP4 MoE, a rank can legitimately receive an empty token batch, for example with EP/DP routing or MegaMoE fallback paths.

  In that case, the activation scale tensor from `mxfp8_quantize()` has zero elements. The current code then calls `reshape(..., -1)`, which is ambiguous for an empty tensor and raises:

  ```text
  RuntimeError: cannot reshape tensor of 0 elements into shape [0, -1]

  This PR fixes the empty-batch crash.

  ## Modifications

  Add an early return for empty token batches in the FlashInfer MXFP4 MoE paths:

  - python/sglang/srt/layers/quantization/mxfp4.py
  - python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py

  For num_tokens == 0, the MoE result is an empty bf16 tensor with shape [0, hidden_size], so we return it directly before entering activation quantization or the FlashInfer kernel path.

  Non-empty batches are unchanged.

  ## Accuracy Tests

  This change only affects the num_tokens == 0 path. No model output tokens are produced on that path, and non-empty inference uses the same code path as before.

  Verified with:

  python3 -m py_compile \
    python/sglang/srt/layers/quantization/mxfp4.py \
    python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py

  ## Speed Tests and Profiling

  No speed impact is expected for normal non-empty batches because the existing quantization and kernel paths are unchanged.

  For empty batches, this avoids unnecessary activation quantization/kernel dispatch and returns the empty output directly.

  ## Checklist

  - [x] Format your code according to the Format code with pre-commit (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the Run and add unit tests (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to Write documentations (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to Test the accuracy (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and Benchmark the speed
    (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26083434764](https://github.com/sgl-project/sglang/actions/runs/26083434764)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->