### PR TITLE
fix(openai): reject response_format + active tool_choice combination

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -913,7 +913,12 @@ class ChatCompletionRequest(BaseModel):
         )
 
         if tool_call_constraint and has_existing_constraints:
-            logger.warning("Constrained decoding is not compatible with tool calls.")
+            logger.warning(
+                "Constrained decoding (regex/ebnf/json_schema/structural_tag) is "
+                "not compatible with tool calls. The tool_call_constraint will be "
+                "ignored and only the output constraint will be applied. "
+                "Tool calls will not be generated."
+            )
         elif tool_call_constraint:
             constraint_type, constraint_value = tool_call_constraint
             if constraint_type == "structural_tag":

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -450,6 +450,23 @@ class OpenAIServingChat(OpenAIServingBase):
             if schema is None:
                 return "schema_ is required for json_schema response format request."
 
+        # response_format with json_schema or json_object applies a grammar
+        # constraint that forces the model to produce the specified JSON shape.
+        # This is mutually exclusive with active tool calling: the constraint
+        # prevents the model from emitting tool-call tokens, so tool_calls will
+        # silently always be null.  OpenAI's own API rejects this combination.
+        if (
+            request.response_format
+            and request.response_format.type in ("json_schema", "json_object")
+            and request.tools
+            and request.tool_choice != "none"
+        ):
+            return (
+                "response_format with type 'json_schema' or 'json_object' is not "
+                "compatible with tool calling. Either remove response_format, or "
+                "set tool_choice to 'none'."
+            )
+
         return None
 
     def _convert_to_internal_request(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -457,7 +457,8 @@ class OpenAIServingChat(OpenAIServingBase):
         # silently always be null.  OpenAI's own API rejects this combination.
         if (
             request.response_format
-            and request.response_format.type in ("json_schema", "json_object")
+            and getattr(request.response_format, "type", None)
+            in ("json_schema", "json_object")
             and request.tools
             and request.tool_choice != "none"
         ):

--- a/test/registered/function_call/test_response_format_tools_conflict.py
+++ b/test/registered/function_call/test_response_format_tools_conflict.py
@@ -149,7 +149,10 @@ class TestResponseFormatToolsConflict(unittest.TestCase):
         self.assertIn("response_format", err)
 
     def test_json_schema_with_named_tool_choice_returns_error(self):
-        from sglang.srt.entrypoints.openai.protocol import ToolChoice, ToolChoiceFuncName
+        from sglang.srt.entrypoints.openai.protocol import (
+            ToolChoice,
+            ToolChoiceFuncName,
+        )
 
         req = _make_request(
             tools=_make_tools(),

--- a/test/registered/function_call/test_response_format_tools_conflict.py
+++ b/test/registered/function_call/test_response_format_tools_conflict.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for the validation guard that rejects the combination of
+response_format (json_schema / json_object) with active tool calling.
+
+When both are present, the grammar constraint applied by response_format
+prevents the model from emitting tool-call tokens, so tool_calls is
+silently always null.  SGLang now returns a 400-level error instead.
+
+These tests exercise _validate_request() directly without a live server.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionMessageUserParam,
+    Function,
+    JsonSchemaResponseFormat,
+    ResponseFormat,
+    Tool,
+)
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(5, "base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_USER_MSG = ChatCompletionMessageUserParam(role="user", content="hi")
+
+
+def _make_tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="add",
+                description="Add two numbers",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["a", "b"],
+                },
+            ),
+        ),
+        Tool(
+            type="function",
+            function=Function(
+                name="multiply",
+                description="Multiply two numbers",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["a", "b"],
+                },
+            ),
+        ),
+    ]
+
+
+def _json_schema_format():
+    return ResponseFormat(
+        type="json_schema",
+        json_schema=JsonSchemaResponseFormat(
+            name="math_tool_answer",
+            **{
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "tools": {"type": "array", "items": {"type": "string"}},
+                        "expression": {"type": "string"},
+                        "result": {"type": "number"},
+                    },
+                    "required": ["tools", "expression", "result"],
+                }
+            },
+        ),
+    )
+
+
+def _json_object_format():
+    return ResponseFormat(type="json_object")
+
+
+def _make_request(**kwargs):
+    """Build a minimal ChatCompletionRequest with sensible defaults."""
+    from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+
+    defaults = dict(model="test-model", messages=[_USER_MSG])
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+def _make_serving():
+    """Return an OpenAIServingChat instance whose external deps are mocked."""
+    serving = MagicMock(spec=OpenAIServingChat)
+    serving._validate_request = OpenAIServingChat._validate_request.__get__(
+        serving, OpenAIServingChat
+    )
+    # _validate_request uses server_args.context_length and allow_auto_truncate
+    serving.tokenizer_manager = MagicMock()
+    serving.tokenizer_manager.server_args.context_length = None
+    serving.tokenizer_manager.server_args.allow_auto_truncate = False
+    return serving
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormatToolsConflict(unittest.TestCase):
+    """Validate that response_format + active tool_choice is rejected."""
+
+    def setUp(self):
+        self.serving = _make_serving()
+
+    # -- Conflict cases (should return an error string) ----------------------
+
+    def test_json_schema_with_tool_choice_auto_returns_error(self):
+        """The reproducer from the bug report: json_schema + tools + auto."""
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="auto",
+            response_format=_json_schema_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNotNone(err, "Expected a validation error but got None")
+        self.assertIn("response_format", err)
+        self.assertIn("tool", err.lower())
+
+    def test_json_schema_with_tool_choice_required_returns_error(self):
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="required",
+            response_format=_json_schema_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNotNone(err)
+        self.assertIn("response_format", err)
+
+    def test_json_schema_with_named_tool_choice_returns_error(self):
+        from sglang.srt.entrypoints.openai.protocol import ToolChoice, ToolChoiceFuncName
+
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice=ToolChoice(function=ToolChoiceFuncName(name="add")),
+            response_format=_json_schema_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNotNone(err)
+
+    def test_json_object_with_tool_choice_auto_returns_error(self):
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="auto",
+            response_format=_json_object_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNotNone(err)
+        self.assertIn("response_format", err)
+
+    def test_json_object_with_tool_choice_required_returns_error(self):
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="required",
+            response_format=_json_object_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNotNone(err)
+
+    # -- Allowed cases (should return None) ----------------------------------
+
+    def test_json_schema_with_tool_choice_none_is_allowed(self):
+        """tool_choice=none means the model will not call tools → no conflict."""
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="none",
+            response_format=_json_schema_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNone(err, f"Expected no error but got: {err}")
+
+    def test_json_object_with_tool_choice_none_is_allowed(self):
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="none",
+            response_format=_json_object_format(),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNone(err)
+
+    def test_no_response_format_with_tools_and_auto_is_allowed(self):
+        """Plain tool calling without response_format is the normal happy path."""
+        req = _make_request(tools=_make_tools(), tool_choice="auto")
+        err = self.serving._validate_request(req)
+        self.assertIsNone(err)
+
+    def test_json_schema_without_tools_is_allowed(self):
+        """response_format alone (no tools) is perfectly valid."""
+        req = _make_request(response_format=_json_schema_format())
+        err = self.serving._validate_request(req)
+        self.assertIsNone(err)
+
+    def test_json_object_without_tools_is_allowed(self):
+        req = _make_request(response_format=_json_object_format())
+        err = self.serving._validate_request(req)
+        self.assertIsNone(err)
+
+    def test_text_response_format_with_tools_is_allowed(self):
+        """type='text' sets no grammar constraint, so tool calling is fine."""
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="auto",
+            response_format=ResponseFormat(type="text"),
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNone(err)
+
+    def test_json_schema_missing_schema_field_is_caught_first(self):
+        """The existing schema_ validation fires before our new check."""
+        bad_format = ResponseFormat(type="json_schema", json_schema=None)
+        req = _make_request(
+            tools=_make_tools(),
+            tool_choice="auto",
+            response_format=bad_format,
+        )
+        err = self.serving._validate_request(req)
+        self.assertIsNotNone(err)
+        # Could be either error; important is that we don't crash
+        self.assertIsInstance(err, str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When `response_format` (`type=json_schema` or `json_object`) and `tools` with an active `tool_choice` (anything except `"none"`) were sent in the same request, SGLang silently applied the grammar constraint from `response_format` to the model output. This forced the model to produce the user-supplied JSON shape instead of tool-call tokens — `tool_calls` was always `null`, `finish_reason` was always `"stop"`, and there was no error or warning.

**Reproducer** (MiniMaxAI/MiniMax-Text-01 with `multiply`/`add` tools):
```bash
curl http://.../v1/chat/completions -d '{
  "tools": [...],
  "tool_choice": "auto",
  "response_format": {"type": "json_schema", "json_schema": {...}}
}'
# → tool_calls: null, finish_reason: "stop"  ← wrong, should be 400
```

OpenAI's own API returns `400` for this combination. SGLang now matches that behaviour.

## Changes

- **`serving_chat.py`** (`_validate_request`): adds a guard after the existing `json_schema` schema check — if `response_format.type` is `json_schema` or `json_object` **and** `tools` are active (i.e. `tool_choice != "none"`), return a clear 400 error message.
- **`protocol.py`** (`to_sampling_params`): improve the existing one-liner warning into a descriptive message explaining *why* tool calls won't be generated and what the caller should do.
- **`test/registered/function_call/test_response_format_tools_conflict.py`**: new CPU unit-test with 11 cases — 5 conflict scenarios that must return an error string, 6 allowed scenarios (`tool_choice=none`, no `response_format`, `type=text`, no `tools`) that must return `None`.

## Test plan

- [ ] `pytest test/registered/function_call/test_response_format_tools_conflict.py -v` (CPU, no GPU needed)
- [ ] Reproducer above now returns HTTP 400 with a clear message
- [ ] Normal tool calling (no `response_format`) still works end-to-end
- [ ] `response_format` alone (no `tools`) still works end-to-end







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26690711726](https://github.com/sgl-project/sglang/actions/runs/26690711726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26690711652](https://github.com/sgl-project/sglang/actions/runs/26690711652)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->