### PR TITLE
[lora] Enable piecewise CUDA graph (PCG) and breakable CUDA graph (BCG) with LoRA

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -168,6 +168,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         max_loras: int,
         compute_dtype: torch.dtype,
         moe_layer,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 1 of LoRA CUDA graph init: MoE intermediate buffers.
 
@@ -178,6 +179,13 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         This is backend-agnostic because MoE LoRA always uses the same
         fused Triton kernel (TritonRunnerCoreWithLoRA) regardless of which
         dense LoRA backend is selected.
+
+        Args:
+            max_num_tokens_pcg: PCG token bucket upper bound. Most MoE LoRA
+                intermediate buffers are sized along the *token* axis (one
+                row per routed token). In decode num_tokens = bs, but in
+                prefill (PCG) num_tokens can be much larger (e.g. 8192).
+                Pass None when PCG is disabled.
         """
         base = moe_layer.base_layer
         top_k = base.top_k
@@ -188,8 +196,12 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         dtype = compute_dtype
         num_experts = base.num_experts
 
+        # Token-axis upper bound for prefill-PCG-aware allocations.
+        # weight_indices_long stays bs-axis since it is filled per-sequence.
+        max_tokens = max(max_bs, max_num_tokens_pcg or 0)
+
         block_size_m = 64
-        max_num_tokens_padded = max_bs * top_k + num_experts * (block_size_m - 1)
+        max_num_tokens_padded = max_tokens * top_k + num_experts * (block_size_m - 1)
         max_num_tokens_padded = (
             (max_num_tokens_padded + block_size_m - 1) // block_size_m
         ) * block_size_m
@@ -197,16 +209,16 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
 
         self.moe_cg_buffers = {
             "intermediate_cache1": torch.empty(
-                (max_bs, top_k, N), device=device, dtype=dtype
+                (max_tokens, top_k, N), device=device, dtype=dtype
             ),
             "intermediate_cache2": torch.empty(
-                (max_bs * top_k, N // 2), device=device, dtype=dtype
+                (max_tokens * top_k, N // 2), device=device, dtype=dtype
             ),
             "intermediate_cache3": torch.empty(
-                (max_bs, top_k, hidden_dim), device=device, dtype=dtype
+                (max_tokens, top_k, hidden_dim), device=device, dtype=dtype
             ),
             "out_hidden_states": torch.empty(
-                (max_bs, hidden_dim), device=device, dtype=dtype
+                (max_tokens, hidden_dim), device=device, dtype=dtype
             ),
             "sorted_token_ids_lora": torch.empty(
                 (max_loras * max_num_tokens_padded,),
@@ -225,6 +237,8 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             # int64 copy of weight_indices for index_fill_(), which requires
             # LongTensor.  weight_indices itself must stay int32 because the
             # CUDA moe_lora_align kernel casts it to int32_t*.
+            # weight_indices is per-sequence (filled idx_buf[:bs]=wi[:bs]) so
+            # stays sized by max_bs even under PCG.
             "weight_indices_long": torch.zeros(
                 max_bs, dtype=torch.int64, device=device
             ),
@@ -235,7 +249,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
                 device=device,
             ),
             "token_mask": torch.empty(
-                (max_loras * max_bs * top_k,),
+                (max_loras * max_tokens * top_k,),
                 dtype=torch.int32,
                 device=device,
             ),

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -146,6 +146,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         self,
         max_bs_in_cuda_graph: int,
         num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
 
@@ -154,6 +155,10 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         Args:
             max_bs_in_cuda_graph: maximum batch size for CUDA Graph mode
             num_tokens_per_bs: number of tokens per sequence (1 for decoding, >1 for target_verify)
+            max_num_tokens_pcg: PCG token bucket upper bound (= max(server_args.piecewise_cuda_graph_tokens))
+                                so prefill graph capture/replay can share the same pinned buffers.
+                                Pass None when PCG is disabled. Each backend may use this to
+                                widen its capture-time buffer allocations.
         """
         pass
 

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -219,11 +219,25 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
         self,
         max_bs_in_cuda_graph: int,
         num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
-        max_num_segments = (
+        # Phase 2 (chunked SGMV + PCG): widen capture-time buffers to cover both
+        # decode (max_bs * num_tokens_per_bs tokens) AND PCG token buckets
+        # (max_num_tokens_pcg up to e.g. 8192). The dynamic chunk-count problem
+        # (number of segments varies per batch) is NOT solved here — kernels
+        # using grid=bs under use_cuda_graph=True still work, but kernels that
+        # depend on num_segments will need follow-up work (Phase 2 step 11b).
+        decode_max_num_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        pcg_max_num_tokens = max_num_tokens_pcg or 0
+        max_num_tokens = max(decode_max_num_tokens, pcg_max_num_tokens)
+
+        decode_max_num_segments = (
             (num_tokens_per_bs + MIN_CHUNK_SIZE - 1) // MIN_CHUNK_SIZE
         ) * max_bs_in_cuda_graph
-        max_num_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        pcg_max_num_segments = (
+            (pcg_max_num_tokens + MIN_CHUNK_SIZE - 1) // MIN_CHUNK_SIZE
+        )
+        max_num_segments = max(decode_max_num_segments, pcg_max_num_segments)
         with torch.device("cuda"):
             self.cuda_graph_batch_info = LoRABatchInfo(
                 bs=max_bs_in_cuda_graph,

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -417,6 +417,10 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
             weight_indices=weight_indices,
             permutation=permutation,
             expected_tokens=expected_tokens,
+            # lm_head LoRA pruned path runs eager (outside captured PCG region),
+            # so its batch_info must NOT advertise use_cuda_graph=True — that
+            # is what layers.py:_get_lm_head_batch_info refuses.
+            use_cuda_graph=False,
         )
 
     @staticmethod

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -375,6 +375,10 @@ class TritonLoRABackend(BaseLoRABackend):
             max_len=max(seg_lens_cpu),
             seg_lens=seg_lens,
             seg_indptr=seg_indptr,
+            # lm_head LoRA pruned path runs eager (outside captured PCG region),
+            # so its batch_info must NOT advertise use_cuda_graph=True — that
+            # is what layers.py:_get_lm_head_batch_info refuses.
+            use_cuda_graph=False,
             weight_indices=torch.tensor(
                 seg_weight_indices_cpu, dtype=torch.int32, device=self.device
             ),

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -143,8 +143,13 @@ class TritonLoRABackend(BaseLoRABackend):
         self,
         max_bs_in_cuda_graph: int,
         num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
-        max_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        # decode-shape upper bound (bs * 1 token per seq)
+        decode_max_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        # PCG token bucket upper bound (e.g. piecewise_cuda_graph_tokens max)
+        # so the same pinned buffer survives prefill capture/replay as well.
+        max_tokens = max(decode_max_tokens, max_num_tokens_pcg or 0)
         mlpb = self.max_loras_per_batch
         with torch.device("cuda"):
             self.cuda_graph_batch_info = LoRABatchInfo(
@@ -155,7 +160,7 @@ class TritonLoRABackend(BaseLoRABackend):
                     (max_bs_in_cuda_graph,), num_tokens_per_bs, dtype=torch.int32
                 ),
                 seg_indptr=torch.zeros(max_bs_in_cuda_graph + 1, dtype=torch.int32),
-                max_len=num_tokens_per_bs,
+                max_len=max_tokens,
                 weight_indices=torch.zeros(max_bs_in_cuda_graph, dtype=torch.int32),
                 lora_ranks=torch.zeros(mlpb, dtype=torch.int32),
                 scalings=torch.zeros(mlpb, dtype=torch.float),

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -124,6 +124,13 @@ class LoRAManager:
                 can share the pinned cuda_graph_batch_info. None = PCG disabled.
         """
         self.max_bs_in_cuda_graph = max_bs_in_cuda_graph
+        # When max_num_tokens_pcg is supplied, the pinned cuda_graph_batch_info
+        # is sized large enough to cover prefill (EXTEND) too. Use this to
+        # route the upstream prepare_lora_batch() call from init_new directly
+        # into the pinned buffer for EXTEND, avoiding the wasted fresh-alloc
+        # done by the non-cuda-graph path. PCG.replay can then skip a second
+        # prepare_lora_batch call.
+        self._cuda_graph_supports_extend = max_num_tokens_pcg is not None
         self.lora_backend.init_cuda_graph_batch_info(
             max_bs_in_cuda_graph=max_bs_in_cuda_graph,
             num_tokens_per_bs=num_tokens_per_bs,
@@ -332,10 +339,22 @@ class LoRAManager:
 
         # force_cuda_graph=True lets PCG (extend) drive in-place batch info updates
         # even though ForwardMode.EXTEND is not in ForwardMode.is_cuda_graph().
+        # Additionally, when the pinned cuda_graph_batch_info was sized for PCG
+        # (max_num_tokens_pcg supplied), route EXTEND through it directly so the
+        # upstream init_new call writes into the pinned buffer once, instead of
+        # doing the throwaway fresh-alloc path followed by a second pass in
+        # PCG.replay (which was the source of long-prompt regression).
         use_cuda_graph = (
             hasattr(self, "max_bs_in_cuda_graph")
             and bs <= self.max_bs_in_cuda_graph
-            and (forward_batch.forward_mode.is_cuda_graph() or force_cuda_graph)
+            and (
+                forward_batch.forward_mode.is_cuda_graph()
+                or force_cuda_graph
+                or (
+                    getattr(self, "_cuda_graph_supports_extend", False)
+                    and forward_batch.forward_mode.is_extend()
+                )
+            )
         )
 
         weight_indices = [0] * len(forward_batch.lora_ids)

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -131,18 +131,29 @@ class LoRAManager:
         )
 
     def init_cuda_graph_moe_buffers(
-        self, max_bs: int, max_loras: int, compute_dtype, moe_layer
+        self,
+        max_bs: int,
+        max_loras: int,
+        compute_dtype,
+        moe_layer,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 1 of LoRA CUDA graph init: MoE intermediate buffers.
 
         Called before init_memory_pool() so memory profiling accounts for them.
         Phase 2 (dense batch metadata) is handled later via init_cuda_graph_batch_info().
+
+        Args:
+            max_num_tokens_pcg: PCG token bucket upper bound so MoE LoRA
+                token-axis buffers also cover prefill capture/replay.
+                Pass None when PCG is disabled.
         """
         self.lora_backend.init_cuda_graph_moe_buffers(
             max_bs=max_bs,
             max_loras=max_loras,
             compute_dtype=compute_dtype,
             moe_layer=moe_layer,
+            max_num_tokens_pcg=max_num_tokens_pcg,
         )
 
     def create_lora_update_result(

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -108,17 +108,26 @@ class LoRAManager:
         )
 
     def init_cuda_graph_batch_info(
-        self, max_bs_in_cuda_graph: int, num_tokens_per_bs: int
+        self,
+        max_bs_in_cuda_graph: int,
+        num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
 
         Called during CudaGraphRunner.__init__(), after init_memory_pool().
         Phase 1 (MoE buffers) is handled earlier via init_cuda_graph_moe_buffers().
+
+        Args:
+            max_num_tokens_pcg: PCG token bucket upper bound (max of
+                server_args.piecewise_cuda_graph_tokens) so prefill capture/replay
+                can share the pinned cuda_graph_batch_info. None = PCG disabled.
         """
         self.max_bs_in_cuda_graph = max_bs_in_cuda_graph
         self.lora_backend.init_cuda_graph_batch_info(
             max_bs_in_cuda_graph=max_bs_in_cuda_graph,
             num_tokens_per_bs=num_tokens_per_bs,
+            max_num_tokens_pcg=max_num_tokens_pcg,
         )
 
     def init_cuda_graph_moe_buffers(
@@ -302,14 +311,20 @@ class LoRAManager:
             lora_lm_head_module=self.lm_head_module,  # merge into embedding or lora module
         )
 
-    def prepare_lora_batch(self, forward_batch: ForwardBatch):
+    def prepare_lora_batch(
+        self,
+        forward_batch: ForwardBatch,
+        force_cuda_graph: bool = False,
+    ):
         # set up batch info shared by all lora modules
         bs = forward_batch.batch_size
 
+        # force_cuda_graph=True lets PCG (extend) drive in-place batch info updates
+        # even though ForwardMode.EXTEND is not in ForwardMode.is_cuda_graph().
         use_cuda_graph = (
             hasattr(self, "max_bs_in_cuda_graph")
             and bs <= self.max_bs_in_cuda_graph
-            and forward_batch.forward_mode.is_cuda_graph()
+            and (forward_batch.forward_mode.is_cuda_graph() or force_cuda_graph)
         )
 
         weight_indices = [0] * len(forward_batch.lora_ids)

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -249,6 +249,16 @@ class BreakableCudaGraphRunner:
             req_pool_indices = torch.arange(bs, dtype=torch.int64)
             orig_seq_lens = torch.full((bs,), num_tokens, dtype=torch.int64)
 
+        # Mirror PCG's LoRA-aware capture: empty lora_ids drives the kernels to
+        # launch but early-return, so the captured graph records the kernel
+        # presence. Replay overwrites the pinned cuda_graph_batch_info with
+        # live lora ids.
+        capture_lora_ids = (
+            [None] * bs
+            if self.model_runner.server_args.enable_lora
+            else None
+        )
+
         return ForwardBatch(
             forward_mode=ForwardMode.EXTEND,
             batch_size=bs,
@@ -296,13 +306,24 @@ class BreakableCudaGraphRunner:
             capture_hidden_mode=CaptureHiddenMode.NULL,
             num_token_non_padded=None,
             global_forward_mode=ForwardMode.EXTEND,
-            lora_ids=None,
+            lora_ids=capture_lora_ids,
         )
+
+    def _maybe_prepare_lora(self, forward_batch):
+        """Mirror PCG: populate pinned LoRABatchInfo for the capture/replay batch."""
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
 
     def _warmup(self):
         """Warmup the model with a forward pass."""
         num_tokens = self.capture_num_tokens[0]
         forward_batch = self._build_capture_forward_batch(num_tokens)
+        self._maybe_prepare_lora(forward_batch)
         self.model_runner.attn_backend.init_forward_metadata(forward_batch)
         self._run_forward(forward_batch, num_tokens)
 
@@ -358,6 +379,7 @@ class BreakableCudaGraphRunner:
     def _capture_one(self, num_tokens, pool, stream):
         """Capture a breakable CUDA graph for one token size."""
         forward_batch = self._build_capture_forward_batch(num_tokens)
+        self._maybe_prepare_lora(forward_batch)
         self.model_runner.attn_backend.init_forward_metadata(forward_batch)
 
         def run_once():
@@ -379,6 +401,17 @@ class BreakableCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
+        # Re-run prepare_lora_batch with force_cuda_graph=True so the LoRA
+        # backend writes batch metadata into the pinned cuda_graph_batch_info
+        # whose address was baked into the captured graph (mirrors PCG.replay).
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
+
         num_tokens = len(forward_batch.input_ids)
         index = bisect.bisect_left(self.capture_num_tokens, num_tokens)
         static_num_tokens = self.capture_num_tokens[index]

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -401,16 +401,10 @@ class BreakableCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        # Re-run prepare_lora_batch with force_cuda_graph=True so the LoRA
-        # backend writes batch metadata into the pinned cuda_graph_batch_info
-        # whose address was baked into the captured graph (mirrors PCG.replay).
-        if (
-            self.model_runner.server_args.enable_lora
-            and forward_batch.lora_ids is not None
-        ):
-            self.model_runner.lora_manager.prepare_lora_batch(
-                forward_batch, force_cuda_graph=True
-            )
+        # Note: prepare_lora_batch is NOT called here anymore. When PCG (or
+        # BCG) is enabled, lora_manager._cuda_graph_supports_extend is True
+        # so the upstream init_new call already routes EXTEND through the
+        # pinned cuda_graph_batch_info. Calling again duplicated CPU work.
 
         num_tokens = len(forward_batch.input_ids)
         index = bisect.bisect_left(self.capture_num_tokens, num_tokens)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -661,9 +661,19 @@ class CudaGraphRunner:
             # Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
             # Phase 1 (MoE buffers) was handled earlier in ModelRunner via
             # lora_manager.init_cuda_graph_moe_buffers().
+            # Pass PCG token upper bound so the same pinned buffers can also be
+            # reused for prefill piecewise capture/replay (Phase 1: triton backend).
+            pcg_tokens = self.model_runner.server_args.piecewise_cuda_graph_tokens
+            max_num_tokens_pcg = (
+                max(pcg_tokens)
+                if pcg_tokens
+                and not self.model_runner.server_args.disable_piecewise_cuda_graph
+                else None
+            )
             self.model_runner.lora_manager.init_cuda_graph_batch_info(
                 max_bs_in_cuda_graph=self.max_bs,
                 num_tokens_per_bs=self.num_tokens_per_bs,
+                max_num_tokens_pcg=max_num_tokens_pcg,
             )
 
         enable_mamba_track = (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2810,18 +2810,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
-        # B5: PCG capture path triggers `lm_head LoRA with pruned batch info`
-        # RuntimeError (lora/layers.py:319-325) inside warmup_compile. Skip PCG
-        # when the active LoRA config targets lm_head until that path is made
-        # graph-safe.
-        if self.server_args.enable_lora and "lm_head" in getattr(
-            getattr(self, "lora_manager", None), "target_modules", set()
-        ):
-            logger.warning(
-                "Disable piecewise CUDA graph because --enable-lora targets lm_head; "
-                "the lm_head LoRA pruned path is not yet graph-safe."
-            )
-            return
+        # Note: lm_head LoRA pruned path is kept compatible with PCG by forcing
+        # its dedicated lm_head_batch_info.use_cuda_graph=False in
+        # triton/chunked backends (the pruned compute runs eager OUTSIDE the
+        # captured graph region, so it does not need cuda-graph metadata).
 
         # Collect attention layers and moe layers from the model
         self.model.model = resolve_language_model(self.model)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2810,6 +2810,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
+        # B5: PCG capture path triggers `lm_head LoRA with pruned batch info`
+        # RuntimeError (lora/layers.py:319-325) inside warmup_compile. Skip PCG
+        # when the active LoRA config targets lm_head until that path is made
+        # graph-safe.
+        if self.server_args.enable_lora and "lm_head" in getattr(
+            getattr(self, "lora_manager", None), "target_modules", set()
+        ):
+            logger.warning(
+                "Disable piecewise CUDA graph because --enable-lora targets lm_head; "
+                "the lm_head LoRA pruned path is not yet graph-safe."
+            )
+            return
+
         # Collect attention layers and moe layers from the model
         self.model.model = resolve_language_model(self.model)
         language_model = getattr(self.model, "language_model", self.model)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1998,14 +1998,28 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         max_bs = self.server_args.cuda_graph_max_bs
         max_loras = self.server_args.max_loras_per_batch
+        # Token-axis upper bound for prefill-PCG-aware MoE buffer sizing.
+        # When PCG is disabled this is None and the legacy max_bs-only sizing
+        # is preserved.
+        pcg_tokens = self.server_args.piecewise_cuda_graph_tokens
+        max_num_tokens_pcg = (
+            max(pcg_tokens)
+            if pcg_tokens and not self.server_args.disable_piecewise_cuda_graph
+            else None
+        )
         for module in self.model.modules():
             if isinstance(module, FusedMoEWithLoRA):
                 self.lora_manager.init_cuda_graph_moe_buffers(
-                    max_bs, max_loras, self.dtype, module
+                    max_bs,
+                    max_loras,
+                    self.dtype,
+                    module,
+                    max_num_tokens_pcg=max_num_tokens_pcg,
                 )
                 logger.info(
                     f"Pre-allocated shared MoE LoRA CUDA graph buffers "
-                    f"(max_bs={max_bs}, max_loras={max_loras})"
+                    f"(max_bs={max_bs}, max_loras={max_loras}, "
+                    f"max_num_tokens_pcg={max_num_tokens_pcg})"
                 )
                 break
 

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -388,6 +388,17 @@ class PiecewiseCudaGraphRunner:
             if buffers.mamba_track_seqlens is not None
             else None
         )
+
+        # During warmup_compile (torch.compile JIT trace) we need LoRA kernels
+        # to appear in the FX graph if --enable-lora is set; otherwise the
+        # compiled model will be missing LoRA ops and capture/replay will mismatch.
+        # Mirror the capture path: empty LoRA ids — kernels still launch, early
+        # return on rank=0. bs=1 for warmup.
+        if self.model_runner.server_args.enable_lora:
+            warmup_lora_ids = [None]
+        else:
+            warmup_lora_ids = None
+
         with torch.device(self.device):
             forward_batch = ForwardBatch(
                 forward_mode=ForwardMode.EXTEND,
@@ -429,8 +440,13 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=warmup_lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
+            )
+
+        if warmup_lora_ids is not None:
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
             )
 
         # Attention backend
@@ -471,6 +487,13 @@ class PiecewiseCudaGraphRunner:
             return False
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
+            return False
+        # B5: lm_head LoRA pruned path raises RuntimeError under use_cuda_graph=True
+        # (lora/layers.py: ParallelLMHeadWithLoRA.apply_lora). Until that path is
+        # made graph-safe, refuse PCG when the active LoRA config targets lm_head.
+        if self.model_runner.server_args.enable_lora and "lm_head" in getattr(
+            self.model_runner.lora_manager, "target_modules", set()
+        ):
             return False
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
@@ -602,13 +625,15 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 
         if lora_ids is not None:
-            self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
 
         self.model_runner.attn_backend.init_forward_metadata(forward_batch)
 
@@ -817,6 +842,19 @@ class PiecewiseCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
+        # Re-run prepare_lora_batch with force_cuda_graph=True so the backend
+        # writes batch metadata into the pinned cuda_graph_batch_info buffer
+        # whose address was baked into the captured graph. The upstream call in
+        # forward_batch_info.init_new ran with use_cuda_graph=False (EXTEND is
+        # not in is_cuda_graph()), so we overwrite its fresh allocations here.
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
+
         with enable_piecewise_cuda_graph():
             static_forward_batch = self.replay_prepare(forward_batch, **kwargs)
             # Replay

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -488,13 +488,10 @@ class PiecewiseCudaGraphRunner:
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
             return False
-        # B5: lm_head LoRA pruned path raises RuntimeError under use_cuda_graph=True
-        # (lora/layers.py: ParallelLMHeadWithLoRA.apply_lora). Until that path is
-        # made graph-safe, refuse PCG when the active LoRA config targets lm_head.
-        if self.model_runner.server_args.enable_lora and "lm_head" in getattr(
-            self.model_runner.lora_manager, "target_modules", set()
-        ):
-            return False
+        # lm_head LoRA pruned path is kept graph-safe by forcing its dedicated
+        # lm_head_batch_info.use_cuda_graph=False in the backend (see
+        # triton/chunked_backend._build_lm_head_batch_info). No need to
+        # blacklist whole batches here.
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
             for start_len, seq_len in zip(

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -839,18 +839,13 @@ class PiecewiseCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        # Re-run prepare_lora_batch with force_cuda_graph=True so the backend
-        # writes batch metadata into the pinned cuda_graph_batch_info buffer
-        # whose address was baked into the captured graph. The upstream call in
-        # forward_batch_info.init_new ran with use_cuda_graph=False (EXTEND is
-        # not in is_cuda_graph()), so we overwrite its fresh allocations here.
-        if (
-            self.model_runner.server_args.enable_lora
-            and forward_batch.lora_ids is not None
-        ):
-            self.model_runner.lora_manager.prepare_lora_batch(
-                forward_batch, force_cuda_graph=True
-            )
+        # Note: prepare_lora_batch is NOT called here anymore. The upstream
+        # call in forward_batch_info.init_new already routed EXTEND through
+        # the pinned cuda_graph_batch_info path because
+        # lora_manager._cuda_graph_supports_extend is True when PCG was
+        # initialized (max_num_tokens_pcg was supplied). Calling again here
+        # would duplicate the CPU permutation/segments build + async copies
+        # and was the source of the long-prompt PCG regression.
 
         with enable_piecewise_cuda_graph():
             static_forward_batch = self.replay_prepare(forward_batch, **kwargs)


### PR DESCRIPTION
## Summary

Enable piecewise CUDA graph (PCG) for prefill (`ForwardMode.EXTEND`) under `--enable-lora`. Previously `_handle_piecewise_cuda_graph()` in `server_args.py` forced `disable_piecewise_cuda_graph=True` whenever LoRA was on, so the entire prefill path fell back to eager. This series unblocks the LoRA + PCG path end-to-end and adds the equivalent wiring to `BreakableCudaGraphRunner` (BCG) as a Dynamo-free alternative.

## Commits

1. **`abb959915`** — Enable PCG with LoRA (prefill EXTEND, triton + chunked buffer)
   - Fix `lora_ids=None` passthrough bug at `piecewise_cuda_graph_runner.py:605` (was discarding `[None]*bs` computed above)
   - Mirror the same lora_ids + prepare_lora_batch logic in `warmup_compile` so torch.compile's FX trace includes LoRA kernels
   - Add `force_cuda_graph` param to `lora_manager.prepare_lora_batch` so PCG can opt into the in-place backend update path without modifying `ForwardMode.is_cuda_graph()`
   - Thread `max_num_tokens_pcg` from `server_args.piecewise_cuda_graph_tokens` through `LoRAManager.init_cuda_graph_batch_info` → `BaseLoRABackend / TritonLoRABackend / ChunkedSgmvLoRABackend.init_cuda_graph_batch_info`. Widen pinned cuda_graph_batch_info buffers (permutation, seg_lens, seg_indptr, weight_indices) to cover both decode and PCG token buckets
   - PCG `can_run` initially excluded lm_head LoRA (later replaced by finer-grained fix below)

2. **`01ec7aad7`** — Route lm_head LoRA pruned path to eager under PCG (fine-grained)
   - The pruned lm_head LoRA path raises `RuntimeError` when `batch_info.use_cuda_graph=True` (`lora/layers.py:_get_lm_head_batch_info`). But that pruned compute runs eager *outside* the PCG-captured inner transformer anyway
   - Force `use_cuda_graph=False` on `lm_head_batch_info` in both triton and chunked backends' `_build_lm_head_batch_info`; the rest of the layers keep `use_cuda_graph=True` and stay captured
   - Revert the previous coarse "skip PCG entirely when lm_head is a target" guards in `model_runner.init_piecewise_cuda_graphs` and `PCG.can_run`

3. **`605447996`** — Size MoE LoRA Phase 1 buffers for PCG token bucket
   - `base_backend.init_cuda_graph_moe_buffers` token-axis allocations (`intermediate_cache1/2/3`, `out_hidden_states`, `sorted_token_ids_lora` / `expert_ids_lora` via `max_num_tokens_padded`, `token_mask`) were sized with `max_bs` only — fine for decode but undersized for prefill (where `num_tokens` can reach 8192+)
   - Plumb `max_num_tokens_pcg` through `ModelRunner._init_lora_cuda_graph_moe_buffers` → `LoRAManager.init_cuda_graph_moe_buffers` → `BaseLoRABackend.init_cuda_graph_moe_buffers`, use `max(max_bs, max_num_tokens_pcg or 0)` for token-axis dims
   - `weight_indices_long` stays `max_bs`-sized since it is filled per-sequence

4. **`c9209651b`** — Wire LoRA into `BreakableCudaGraphRunner` (BCG)
   - `_build_capture_forward_batch` stamps `lora_ids=[None]*bs` when `--enable-lora` (was hard-coded `None`)
   - New `_maybe_prepare_lora` helper that calls `lora_manager.prepare_lora_batch(force_cuda_graph=True)`
   - `_warmup`, `_capture_one`, and `replay` all call `_maybe_prepare_lora` so the captured graph records LoRA kernel launches and replay updates the pinned cuda_graph_batch_info
   - BCG bypasses torch.compile entirely — works for `--lora-backend csgmv` and MoE LoRA, both of which hit Dynamo-vs-Triton-config issues under PCG

5. **`32e7e2edf`** — Avoid duplicate `prepare_lora_batch` in PCG/BCG replay
   - `LoRAManager.init_cuda_graph_batch_info` records `_cuda_graph_supports_extend = (max_num_tokens_pcg is not None)`
   - `prepare_lora_batch` widens `use_cuda_graph` to also fire for EXTEND when `_cuda_graph_supports_extend` is True — so the upstream `forward_batch_info.init_new` call writes directly into the pinned cuda_graph_batch_info instead of doing a throwaway fresh-alloc path
   - PCG.replay and BCG.replay drop their now-redundant `prepare_lora_batch(force_cuda_graph=True)` calls

## Validated configurations (smoke tests on Qwen3-8B + Qwen3-30B-A3B-Instruct-2507)

| Backend × runner | Status | Source |
|---|---|---|
| triton + PCG + lm_head LoRA (single adapter) | ✅ | smoke #9 |
| triton + PCG + multi-adapter | ✅ | smoke #14 |
| triton + BCG + lm_head LoRA | ✅ | smoke #15 |
| **chunked (csgmv) + BCG + LoRA** | ✅ | smoke #16 |
| **MoE + BCG + LoRA (Qwen3-30B-A3B, TP=4)** | ✅ | smoke #17 |
| chunked + PCG | ❌ | Dynamo `get_device_name()` non-Tensor return — broader sglang issue, BCG is the working alternative |
| MoE + PCG | ❌ | same Dynamo issue (`fused_moe_triton_config.get_config_file_name`) — BCG works |

### Bucket sweep

Generated at every one of the 74 PCG capture buckets (`4` → `16384` tokens) plus 6 off-bucket sizes (100, 200, 1000, 5000, 10000, 13000). **74/74 + 6/6 PASSED** — no IMA, no RuntimeError, all generated tokens. Off-bucket sizes correctly pad to the next captured bucket.

## Perf (Qwen3-8B, triton, all-linear adapter rank=32, single A4X GPU)

| Prompt tokens | PCG-off | PCG-on | BCG-on | Recommendation |
|---|---|---|---|---|
| ~128 | 66.4 ms | 50.1 ms | **48.7 ms** | PCG/BCG (graph wins) |
| ~512 | 67.7 ms | 54.6 ms | **53.3 ms** | PCG/BCG (~17-25% faster TTFT) |
| ~2816 | 73.7 ms | 78.3 ms | 76.2 ms | eager (PCG/BCG slightly slower) |
| ~11264 | 207.8 ms | 228.5 ms | 220.8 ms | **eager** (graph overhead exceeds savings) |

- **Crossover ~1-2k tokens.** Short prefills dominated by kernel-launch overhead → CUDA graph helps a lot (up to -25% TTFT). Long prefills are compute-bound (attention runs eager outside the captured region), so graph savings shrink while per-request `replay_prepare` + context-manager overhead dominates → graph becomes slower. This is an architectural cuda-graph trade-off, not a LoRA bug
- **PCG-on init takes ~67s** vs ~23s eager (one-shot torch.compile JIT for 74 buckets). BCG-on init **~41s** because BCG skips Inductor
- **Jitter** at short prompts: PCG/BCG ~0.6 ms spread vs eager ~4 ms (6.7× more stable)

### Decode regression

Generate 128 tokens with bs=1 short prompt under PCG-off (= decode CUDA graph runner only) — **141.9 tokens/sec** with ±1 ms jitter, healthy baseline for Qwen3-8B. The `cuda_graph_runner.py` + `lora_manager.py` edits did not regress the production decode path.

## What is not in this PR

- **chunked + PCG** root-cause fix. The blocker is `lora_tuning_config.get_lora_configs` calling `get_device_name()` inside a `torch.compile(fullgraph=True)` region. Resolving this needs either a `torch.library.custom_op` wrapper around the Triton kernel forward, or pre-resolving the config dict outside the captured region. BCG is the working alternative for now.
- **MoE + PCG** root-cause fix. Same shape: `layers/moe/moe_runner/triton_utils/fused_moe_triton_config.get_config_file_name` is a broader sglang issue (not LoRA-specific). BCG is the working alternative.
- **Auto-disable PCG above a token threshold.** Long prompts are slower under PCG/BCG than eager. A server_args knob like `pcg_max_useful_tokens` could route long batches to eager. Out of scope here.
- **DoRA / vocab-extension LoRA adapters.** Already rejected at adapter load (`lora_manager.validate_new_adapter`), no change.

## Test plan

- [x] `--enable-lora --enforce-piecewise-cuda-graph --lora-backend triton` on Qwen3-8B with the all-linear adapter — Engine init + `generate` smoke
- [x] Same with `--enable-breakable-cuda-graph` (BCG variant)
- [x] Same on Qwen3-30B-A3B-Instruct-2507 with TP=4 and `--enable-breakable-cuda-graph` (MoE coverage)
- [x] Same with `--lora-backend csgmv` and `--enable-breakable-cuda-graph` (chunked coverage)
- [x] Two-adapter `lora_paths` test with PCG (smoke #14)
- [x] Bucket sweep across all 74 PCG capture sizes + 6 off-bucket sizes
- [x] PCG-off decode regression (141.9 tokens/sec, no degradation)
- [x] PCG-on perf @ 4 prompt sizes (128 / 512 / 2.8k / 11k tokens)
- [ ] Upstream CI `test/manual/lora/test_lora_cuda_graph.py` (gated `meta-llama/Llama-3.1-8B-Instruct` — requires HF_TOKEN)
- [ ] Mixed-rank multi-adapter (stacked tensor pads to max_rank — expected to work, not yet measured)

Full design and execution log: `/home/radixark/yushengsu/perf_opt/journal_claude.md` (944 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26098239220](https://github.com/sgl-project/sglang/actions/runs/26098239220)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->