### PR TITLE
[lora] Enable piecewise CUDA graph (PCG) for prefill with LoRA (triton + BCG fallback)

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -168,6 +168,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         max_loras: int,
         compute_dtype: torch.dtype,
         moe_layer,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 1 of LoRA CUDA graph init: MoE intermediate buffers.
 
@@ -178,6 +179,13 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         This is backend-agnostic because MoE LoRA always uses the same
         fused Triton kernel (TritonRunnerCoreWithLoRA) regardless of which
         dense LoRA backend is selected.
+
+        Args:
+            max_num_tokens_pcg: PCG token bucket upper bound. Most MoE LoRA
+                intermediate buffers are sized along the *token* axis (one
+                row per routed token). In decode num_tokens = bs, but in
+                prefill (PCG) num_tokens can be much larger (e.g. 8192).
+                Pass None when PCG is disabled.
         """
         base = moe_layer.base_layer
         top_k = base.top_k
@@ -188,8 +196,12 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         dtype = compute_dtype
         num_experts = base.num_experts
 
+        # Token-axis upper bound for prefill-PCG-aware allocations.
+        # weight_indices_long stays bs-axis since it is filled per-sequence.
+        max_tokens = max(max_bs, max_num_tokens_pcg or 0)
+
         block_size_m = 64
-        max_num_tokens_padded = max_bs * top_k + num_experts * (block_size_m - 1)
+        max_num_tokens_padded = max_tokens * top_k + num_experts * (block_size_m - 1)
         max_num_tokens_padded = (
             (max_num_tokens_padded + block_size_m - 1) // block_size_m
         ) * block_size_m
@@ -197,16 +209,16 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
 
         self.moe_cg_buffers = {
             "intermediate_cache1": torch.empty(
-                (max_bs, top_k, N), device=device, dtype=dtype
+                (max_tokens, top_k, N), device=device, dtype=dtype
             ),
             "intermediate_cache2": torch.empty(
-                (max_bs * top_k, N // 2), device=device, dtype=dtype
+                (max_tokens * top_k, N // 2), device=device, dtype=dtype
             ),
             "intermediate_cache3": torch.empty(
-                (max_bs, top_k, hidden_dim), device=device, dtype=dtype
+                (max_tokens, top_k, hidden_dim), device=device, dtype=dtype
             ),
             "out_hidden_states": torch.empty(
-                (max_bs, hidden_dim), device=device, dtype=dtype
+                (max_tokens, hidden_dim), device=device, dtype=dtype
             ),
             "sorted_token_ids_lora": torch.empty(
                 (max_loras * max_num_tokens_padded,),
@@ -225,6 +237,8 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             # int64 copy of weight_indices for index_fill_(), which requires
             # LongTensor.  weight_indices itself must stay int32 because the
             # CUDA moe_lora_align kernel casts it to int32_t*.
+            # weight_indices is per-sequence (filled idx_buf[:bs]=wi[:bs]) so
+            # stays sized by max_bs even under PCG.
             "weight_indices_long": torch.zeros(
                 max_bs, dtype=torch.int64, device=device
             ),
@@ -235,7 +249,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
                 device=device,
             ),
             "token_mask": torch.empty(
-                (max_loras * max_bs * top_k,),
+                (max_loras * max_tokens * top_k,),
                 dtype=torch.int32,
                 device=device,
             ),

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -146,6 +146,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         self,
         max_bs_in_cuda_graph: int,
         num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
 
@@ -154,6 +155,10 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         Args:
             max_bs_in_cuda_graph: maximum batch size for CUDA Graph mode
             num_tokens_per_bs: number of tokens per sequence (1 for decoding, >1 for target_verify)
+            max_num_tokens_pcg: PCG token bucket upper bound (= max(server_args.piecewise_cuda_graph_tokens))
+                                so prefill graph capture/replay can share the same pinned buffers.
+                                Pass None when PCG is disabled. Each backend may use this to
+                                widen its capture-time buffer allocations.
         """
         pass
 

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -219,11 +219,25 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
         self,
         max_bs_in_cuda_graph: int,
         num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
-        max_num_segments = (
+        # Phase 2 (chunked SGMV + PCG): widen capture-time buffers to cover both
+        # decode (max_bs * num_tokens_per_bs tokens) AND PCG token buckets
+        # (max_num_tokens_pcg up to e.g. 8192). The dynamic chunk-count problem
+        # (number of segments varies per batch) is NOT solved here — kernels
+        # using grid=bs under use_cuda_graph=True still work, but kernels that
+        # depend on num_segments will need follow-up work (Phase 2 step 11b).
+        decode_max_num_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        pcg_max_num_tokens = max_num_tokens_pcg or 0
+        max_num_tokens = max(decode_max_num_tokens, pcg_max_num_tokens)
+
+        decode_max_num_segments = (
             (num_tokens_per_bs + MIN_CHUNK_SIZE - 1) // MIN_CHUNK_SIZE
         ) * max_bs_in_cuda_graph
-        max_num_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        pcg_max_num_segments = (
+            (pcg_max_num_tokens + MIN_CHUNK_SIZE - 1) // MIN_CHUNK_SIZE
+        )
+        max_num_segments = max(decode_max_num_segments, pcg_max_num_segments)
         with torch.device("cuda"):
             self.cuda_graph_batch_info = LoRABatchInfo(
                 bs=max_bs_in_cuda_graph,

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -417,6 +417,10 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
             weight_indices=weight_indices,
             permutation=permutation,
             expected_tokens=expected_tokens,
+            # lm_head LoRA pruned path runs eager (outside captured PCG region),
+            # so its batch_info must NOT advertise use_cuda_graph=True — that
+            # is what layers.py:_get_lm_head_batch_info refuses.
+            use_cuda_graph=False,
         )
 
     @staticmethod

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -375,6 +375,10 @@ class TritonLoRABackend(BaseLoRABackend):
             max_len=max(seg_lens_cpu),
             seg_lens=seg_lens,
             seg_indptr=seg_indptr,
+            # lm_head LoRA pruned path runs eager (outside captured PCG region),
+            # so its batch_info must NOT advertise use_cuda_graph=True — that
+            # is what layers.py:_get_lm_head_batch_info refuses.
+            use_cuda_graph=False,
             weight_indices=torch.tensor(
                 seg_weight_indices_cpu, dtype=torch.int32, device=self.device
             ),

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -143,8 +143,13 @@ class TritonLoRABackend(BaseLoRABackend):
         self,
         max_bs_in_cuda_graph: int,
         num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
-        max_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        # decode-shape upper bound (bs * 1 token per seq)
+        decode_max_tokens = max_bs_in_cuda_graph * num_tokens_per_bs
+        # PCG token bucket upper bound (e.g. piecewise_cuda_graph_tokens max)
+        # so the same pinned buffer survives prefill capture/replay as well.
+        max_tokens = max(decode_max_tokens, max_num_tokens_pcg or 0)
         mlpb = self.max_loras_per_batch
         with torch.device("cuda"):
             self.cuda_graph_batch_info = LoRABatchInfo(
@@ -155,7 +160,7 @@ class TritonLoRABackend(BaseLoRABackend):
                     (max_bs_in_cuda_graph,), num_tokens_per_bs, dtype=torch.int32
                 ),
                 seg_indptr=torch.zeros(max_bs_in_cuda_graph + 1, dtype=torch.int32),
-                max_len=num_tokens_per_bs,
+                max_len=max_tokens,
                 weight_indices=torch.zeros(max_bs_in_cuda_graph, dtype=torch.int32),
                 lora_ranks=torch.zeros(mlpb, dtype=torch.int32),
                 scalings=torch.zeros(mlpb, dtype=torch.float),

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -259,6 +259,40 @@ class TritonLoRABackend(BaseLoRABackend):
             batch_info = self.cuda_graph_batch_info
             batch_info.bs = forward_batch.batch_size
             batch_info.num_segments = forward_batch.batch_size
+            # SILENT-BUG FIX (PCG/BCG + LoRA + EXTEND): previously the
+            # cuda_graph path left seg_lens / seg_indptr / max_len at their
+            # init defaults ([num_tokens_per_bs]*max_bs, cumsum-of-defaults,
+            # num_tokens_per_bs). For DECODE that is correct (1 token per
+            # seq). For EXTEND (PCG/BCG replay), it meant the sgemm_lora
+            # kernel applied LoRA to only num_tokens_per_bs (==1) tokens
+            # per sequence — silently truncating the per-prompt LoRA work
+            # to a single token regardless of actual prompt length. Update
+            # those fields here to reflect the live batch.
+            if forward_batch.forward_mode.is_extend():
+                extend_lens_cpu = list(forward_batch.extend_seq_lens_cpu)
+                seg_lens_tensor = torch.tensor(
+                    extend_lens_cpu[:bs],
+                    dtype=torch.int32,
+                    pin_memory=True,
+                    device="cpu",
+                )
+                batch_info.seg_lens[:bs].copy_(seg_lens_tensor, non_blocking=True)
+                batch_info.seg_indptr[0:1].zero_()
+                torch.cumsum(
+                    batch_info.seg_lens[:bs],
+                    dim=0,
+                    out=batch_info.seg_indptr[1 : bs + 1],
+                )
+                # NOTE: do NOT update batch_info.max_len here. max_len is a
+                # Python int used in the sgemm kernel grid (cdiv(max_len, BLOCK_S))
+                # so under Inductor / Dynamo it is a specialization guard.
+                # Changing it between capture (max_len = bucket size) and live
+                # (max_len = actual max seq len, often smaller after bisect-up
+                # to a bigger bucket) triggers a runtime recompile that hits
+                # `PCG capture stream is not set`. Leave max_len at its init
+                # value (covers the largest bucket); the kernel internally
+                # early-returns via `if pid_s * BLOCK_S >= seg_len: return`,
+                # so the extra grid_0 blocks beyond actual seg_len are no-ops.
         else:
             max_len = (
                 # Calculate max_len from the CPU copy to avoid D2H transfer.

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -124,6 +124,13 @@ class LoRAManager:
                 can share the pinned cuda_graph_batch_info. None = PCG disabled.
         """
         self.max_bs_in_cuda_graph = max_bs_in_cuda_graph
+        # When max_num_tokens_pcg is supplied, the pinned cuda_graph_batch_info
+        # is sized large enough to cover prefill (EXTEND) too. Use this to
+        # route the upstream prepare_lora_batch() call from init_new directly
+        # into the pinned buffer for EXTEND, avoiding the wasted fresh-alloc
+        # done by the non-cuda-graph path. PCG.replay can then skip a second
+        # prepare_lora_batch call.
+        self._cuda_graph_supports_extend = max_num_tokens_pcg is not None
         self.lora_backend.init_cuda_graph_batch_info(
             max_bs_in_cuda_graph=max_bs_in_cuda_graph,
             num_tokens_per_bs=num_tokens_per_bs,
@@ -332,10 +339,22 @@ class LoRAManager:
 
         # force_cuda_graph=True lets PCG (extend) drive in-place batch info updates
         # even though ForwardMode.EXTEND is not in ForwardMode.is_cuda_graph().
+        # Additionally, when the pinned cuda_graph_batch_info was sized for PCG
+        # (max_num_tokens_pcg supplied), route EXTEND through it directly so the
+        # upstream init_new call writes into the pinned buffer once, instead of
+        # doing the throwaway fresh-alloc path followed by a second pass in
+        # PCG.replay (which was the source of long-prompt regression).
         use_cuda_graph = (
             hasattr(self, "max_bs_in_cuda_graph")
             and bs <= self.max_bs_in_cuda_graph
-            and (forward_batch.forward_mode.is_cuda_graph() or force_cuda_graph)
+            and (
+                forward_batch.forward_mode.is_cuda_graph()
+                or force_cuda_graph
+                or (
+                    getattr(self, "_cuda_graph_supports_extend", False)
+                    and forward_batch.forward_mode.is_extend()
+                )
+            )
         )
 
         weight_indices = [0] * len(forward_batch.lora_ids)

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -131,18 +131,29 @@ class LoRAManager:
         )
 
     def init_cuda_graph_moe_buffers(
-        self, max_bs: int, max_loras: int, compute_dtype, moe_layer
+        self,
+        max_bs: int,
+        max_loras: int,
+        compute_dtype,
+        moe_layer,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 1 of LoRA CUDA graph init: MoE intermediate buffers.
 
         Called before init_memory_pool() so memory profiling accounts for them.
         Phase 2 (dense batch metadata) is handled later via init_cuda_graph_batch_info().
+
+        Args:
+            max_num_tokens_pcg: PCG token bucket upper bound so MoE LoRA
+                token-axis buffers also cover prefill capture/replay.
+                Pass None when PCG is disabled.
         """
         self.lora_backend.init_cuda_graph_moe_buffers(
             max_bs=max_bs,
             max_loras=max_loras,
             compute_dtype=compute_dtype,
             moe_layer=moe_layer,
+            max_num_tokens_pcg=max_num_tokens_pcg,
         )
 
     def create_lora_update_result(

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -108,17 +108,26 @@ class LoRAManager:
         )
 
     def init_cuda_graph_batch_info(
-        self, max_bs_in_cuda_graph: int, num_tokens_per_bs: int
+        self,
+        max_bs_in_cuda_graph: int,
+        num_tokens_per_bs: int,
+        max_num_tokens_pcg: Optional[int] = None,
     ):
         """Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
 
         Called during CudaGraphRunner.__init__(), after init_memory_pool().
         Phase 1 (MoE buffers) is handled earlier via init_cuda_graph_moe_buffers().
+
+        Args:
+            max_num_tokens_pcg: PCG token bucket upper bound (max of
+                server_args.piecewise_cuda_graph_tokens) so prefill capture/replay
+                can share the pinned cuda_graph_batch_info. None = PCG disabled.
         """
         self.max_bs_in_cuda_graph = max_bs_in_cuda_graph
         self.lora_backend.init_cuda_graph_batch_info(
             max_bs_in_cuda_graph=max_bs_in_cuda_graph,
             num_tokens_per_bs=num_tokens_per_bs,
+            max_num_tokens_pcg=max_num_tokens_pcg,
         )
 
     def init_cuda_graph_moe_buffers(
@@ -302,14 +311,20 @@ class LoRAManager:
             lora_lm_head_module=self.lm_head_module,  # merge into embedding or lora module
         )
 
-    def prepare_lora_batch(self, forward_batch: ForwardBatch):
+    def prepare_lora_batch(
+        self,
+        forward_batch: ForwardBatch,
+        force_cuda_graph: bool = False,
+    ):
         # set up batch info shared by all lora modules
         bs = forward_batch.batch_size
 
+        # force_cuda_graph=True lets PCG (extend) drive in-place batch info updates
+        # even though ForwardMode.EXTEND is not in ForwardMode.is_cuda_graph().
         use_cuda_graph = (
             hasattr(self, "max_bs_in_cuda_graph")
             and bs <= self.max_bs_in_cuda_graph
-            and forward_batch.forward_mode.is_cuda_graph()
+            and (forward_batch.forward_mode.is_cuda_graph() or force_cuda_graph)
         )
 
         weight_indices = [0] * len(forward_batch.lora_ids)

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -339,22 +339,14 @@ class LoRAManager:
 
         # force_cuda_graph=True lets PCG (extend) drive in-place batch info updates
         # even though ForwardMode.EXTEND is not in ForwardMode.is_cuda_graph().
-        # Additionally, when the pinned cuda_graph_batch_info was sized for PCG
-        # (max_num_tokens_pcg supplied), route EXTEND through it directly so the
-        # upstream init_new call writes into the pinned buffer once, instead of
-        # doing the throwaway fresh-alloc path followed by a second pass in
-        # PCG.replay (which was the source of long-prompt regression).
+        # The auto-route via _cuda_graph_supports_extend was reverted because it
+        # caused eager EXTEND fallbacks (e.g. PCG can_run==False for batched LoRA)
+        # to read stale max_len from the pinned buffer, ballooning kernel grids.
+        # Now only PCG/BCG.replay opt in explicitly via force_cuda_graph=True.
         use_cuda_graph = (
             hasattr(self, "max_bs_in_cuda_graph")
             and bs <= self.max_bs_in_cuda_graph
-            and (
-                forward_batch.forward_mode.is_cuda_graph()
-                or force_cuda_graph
-                or (
-                    getattr(self, "_cuda_graph_supports_extend", False)
-                    and forward_batch.forward_mode.is_extend()
-                )
-            )
+            and (forward_batch.forward_mode.is_cuda_graph() or force_cuda_graph)
         )
 
         weight_indices = [0] * len(forward_batch.lora_ids)

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -249,6 +249,16 @@ class BreakableCudaGraphRunner:
             req_pool_indices = torch.arange(bs, dtype=torch.int64)
             orig_seq_lens = torch.full((bs,), num_tokens, dtype=torch.int64)
 
+        # Mirror PCG's LoRA-aware capture: empty lora_ids drives the kernels to
+        # launch but early-return, so the captured graph records the kernel
+        # presence. Replay overwrites the pinned cuda_graph_batch_info with
+        # live lora ids.
+        capture_lora_ids = (
+            [None] * bs
+            if self.model_runner.server_args.enable_lora
+            else None
+        )
+
         return ForwardBatch(
             forward_mode=ForwardMode.EXTEND,
             batch_size=bs,
@@ -296,13 +306,24 @@ class BreakableCudaGraphRunner:
             capture_hidden_mode=CaptureHiddenMode.NULL,
             num_token_non_padded=None,
             global_forward_mode=ForwardMode.EXTEND,
-            lora_ids=None,
+            lora_ids=capture_lora_ids,
         )
+
+    def _maybe_prepare_lora(self, forward_batch):
+        """Mirror PCG: populate pinned LoRABatchInfo for the capture/replay batch."""
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
 
     def _warmup(self):
         """Warmup the model with a forward pass."""
         num_tokens = self.capture_num_tokens[0]
         forward_batch = self._build_capture_forward_batch(num_tokens)
+        self._maybe_prepare_lora(forward_batch)
         self.model_runner.attn_backend.init_forward_metadata(forward_batch)
         self._run_forward(forward_batch, num_tokens)
 
@@ -358,6 +379,7 @@ class BreakableCudaGraphRunner:
     def _capture_one(self, num_tokens, pool, stream):
         """Capture a breakable CUDA graph for one token size."""
         forward_batch = self._build_capture_forward_batch(num_tokens)
+        self._maybe_prepare_lora(forward_batch)
         self.model_runner.attn_backend.init_forward_metadata(forward_batch)
 
         def run_once():
@@ -379,6 +401,17 @@ class BreakableCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
+        # Re-run prepare_lora_batch with force_cuda_graph=True so the LoRA
+        # backend writes batch metadata into the pinned cuda_graph_batch_info
+        # whose address was baked into the captured graph (mirrors PCG.replay).
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
+
         num_tokens = len(forward_batch.input_ids)
         index = bisect.bisect_left(self.capture_num_tokens, num_tokens)
         static_num_tokens = self.capture_num_tokens[index]

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -366,6 +366,15 @@ class BreakableCudaGraphRunner:
             return False
         if forward_batch.replace_embeds is not None:
             return False
+        # Mirror PCG's bs>1 LoRA gate: BCG also captures at bs=1, so live
+        # bs>1 LoRA would only apply LoRA kernels to the first sequence
+        # (kernel grid baked-in at capture-time bs=1). Refuse so the engine
+        # falls back to eager prefill (correct, no silent truncation).
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.batch_size > 1
+        ):
+            return False
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
             for start_len, seq_len in zip(
@@ -401,10 +410,16 @@ class BreakableCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        # Note: prepare_lora_batch is NOT called here anymore. When PCG (or
-        # BCG) is enabled, lora_manager._cuda_graph_supports_extend is True
-        # so the upstream init_new call already routes EXTEND through the
-        # pinned cuda_graph_batch_info. Calling again duplicated CPU work.
+        # Re-run prepare_lora_batch with force_cuda_graph=True so the LoRA
+        # backend writes batch metadata into the pinned cuda_graph_batch_info
+        # baked into the captured BreakableCUDAGraph (mirrors PCG.replay).
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
 
         num_tokens = len(forward_batch.input_ids)
         index = bisect.bisect_left(self.capture_num_tokens, num_tokens)

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -401,16 +401,10 @@ class BreakableCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        # Re-run prepare_lora_batch with force_cuda_graph=True so the LoRA
-        # backend writes batch metadata into the pinned cuda_graph_batch_info
-        # whose address was baked into the captured graph (mirrors PCG.replay).
-        if (
-            self.model_runner.server_args.enable_lora
-            and forward_batch.lora_ids is not None
-        ):
-            self.model_runner.lora_manager.prepare_lora_batch(
-                forward_batch, force_cuda_graph=True
-            )
+        # Note: prepare_lora_batch is NOT called here anymore. When PCG (or
+        # BCG) is enabled, lora_manager._cuda_graph_supports_extend is True
+        # so the upstream init_new call already routes EXTEND through the
+        # pinned cuda_graph_batch_info. Calling again duplicated CPU work.
 
         num_tokens = len(forward_batch.input_ids)
         index = bisect.bisect_left(self.capture_num_tokens, num_tokens)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -661,9 +661,19 @@ class CudaGraphRunner:
             # Phase 2 of LoRA CUDA graph init: dense LoRA batch metadata.
             # Phase 1 (MoE buffers) was handled earlier in ModelRunner via
             # lora_manager.init_cuda_graph_moe_buffers().
+            # Pass PCG token upper bound so the same pinned buffers can also be
+            # reused for prefill piecewise capture/replay (Phase 1: triton backend).
+            pcg_tokens = self.model_runner.server_args.piecewise_cuda_graph_tokens
+            max_num_tokens_pcg = (
+                max(pcg_tokens)
+                if pcg_tokens
+                and not self.model_runner.server_args.disable_piecewise_cuda_graph
+                else None
+            )
             self.model_runner.lora_manager.init_cuda_graph_batch_info(
                 max_bs_in_cuda_graph=self.max_bs,
                 num_tokens_per_bs=self.num_tokens_per_bs,
+                max_num_tokens_pcg=max_num_tokens_pcg,
             )
 
         enable_mamba_track = (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2810,18 +2810,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
-        # B5: PCG capture path triggers `lm_head LoRA with pruned batch info`
-        # RuntimeError (lora/layers.py:319-325) inside warmup_compile. Skip PCG
-        # when the active LoRA config targets lm_head until that path is made
-        # graph-safe.
-        if self.server_args.enable_lora and "lm_head" in getattr(
-            getattr(self, "lora_manager", None), "target_modules", set()
-        ):
-            logger.warning(
-                "Disable piecewise CUDA graph because --enable-lora targets lm_head; "
-                "the lm_head LoRA pruned path is not yet graph-safe."
-            )
-            return
+        # Note: lm_head LoRA pruned path is kept compatible with PCG by forcing
+        # its dedicated lm_head_batch_info.use_cuda_graph=False in
+        # triton/chunked backends (the pruned compute runs eager OUTSIDE the
+        # captured graph region, so it does not need cuda-graph metadata).
 
         # Collect attention layers and moe layers from the model
         self.model.model = resolve_language_model(self.model)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2810,6 +2810,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             )
             return
 
+        # B5: PCG capture path triggers `lm_head LoRA with pruned batch info`
+        # RuntimeError (lora/layers.py:319-325) inside warmup_compile. Skip PCG
+        # when the active LoRA config targets lm_head until that path is made
+        # graph-safe.
+        if self.server_args.enable_lora and "lm_head" in getattr(
+            getattr(self, "lora_manager", None), "target_modules", set()
+        ):
+            logger.warning(
+                "Disable piecewise CUDA graph because --enable-lora targets lm_head; "
+                "the lm_head LoRA pruned path is not yet graph-safe."
+            )
+            return
+
         # Collect attention layers and moe layers from the model
         self.model.model = resolve_language_model(self.model)
         language_model = getattr(self.model, "language_model", self.model)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1998,14 +1998,28 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         max_bs = self.server_args.cuda_graph_max_bs
         max_loras = self.server_args.max_loras_per_batch
+        # Token-axis upper bound for prefill-PCG-aware MoE buffer sizing.
+        # When PCG is disabled this is None and the legacy max_bs-only sizing
+        # is preserved.
+        pcg_tokens = self.server_args.piecewise_cuda_graph_tokens
+        max_num_tokens_pcg = (
+            max(pcg_tokens)
+            if pcg_tokens and not self.server_args.disable_piecewise_cuda_graph
+            else None
+        )
         for module in self.model.modules():
             if isinstance(module, FusedMoEWithLoRA):
                 self.lora_manager.init_cuda_graph_moe_buffers(
-                    max_bs, max_loras, self.dtype, module
+                    max_bs,
+                    max_loras,
+                    self.dtype,
+                    module,
+                    max_num_tokens_pcg=max_num_tokens_pcg,
                 )
                 logger.info(
                     f"Pre-allocated shared MoE LoRA CUDA graph buffers "
-                    f"(max_bs={max_bs}, max_loras={max_loras})"
+                    f"(max_bs={max_bs}, max_loras={max_loras}, "
+                    f"max_num_tokens_pcg={max_num_tokens_pcg})"
                 )
                 break
 

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -492,6 +492,23 @@ class PiecewiseCudaGraphRunner:
         # lm_head_batch_info.use_cuda_graph=False in the backend (see
         # triton/chunked_backend._build_lm_head_batch_info). No need to
         # blacklist whole batches here.
+        #
+        # PCG capture is performed with batch_size=1 (one logical sequence
+        # carrying all num_tokens tokens). LoRA triton kernels launch with a
+        # grid of `(_, batch_info.bs)` (sgemm_lora_a/b at lines 150-155), so
+        # a live batch_size != 1 changes the kernel grid shape — Dynamo's
+        # specialization guard fails, a runtime recompile fires, and the
+        # captured PCG stream is no longer in scope, hitting the
+        # `AssertionError: PCG capture stream is not set` in
+        # cuda_piecewise_backend.py. Refuse PCG for batched LoRA requests so
+        # the engine falls back to eager prefill (still correct, no crash).
+        # BCG (BreakableCudaGraphRunner) does not have this limitation
+        # because it does not go through Inductor / Dynamo.
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.batch_size > 1
+        ):
+            return False
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
             for start_len, seq_len in zip(
@@ -839,13 +856,18 @@ class PiecewiseCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        # Note: prepare_lora_batch is NOT called here anymore. The upstream
-        # call in forward_batch_info.init_new already routed EXTEND through
-        # the pinned cuda_graph_batch_info path because
-        # lora_manager._cuda_graph_supports_extend is True when PCG was
-        # initialized (max_num_tokens_pcg was supplied). Calling again here
-        # would duplicate the CPU permutation/segments build + async copies
-        # and was the source of the long-prompt PCG regression.
+        # Re-run prepare_lora_batch with force_cuda_graph=True so the backend
+        # writes batch metadata into the pinned cuda_graph_batch_info baked
+        # into the captured graph. The upstream init_new call wrote into a
+        # fresh allocation under use_cuda_graph=False (because EXTEND is not
+        # in is_cuda_graph()); we overwrite that here.
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
 
         with enable_piecewise_cuda_graph():
             static_forward_batch = self.replay_prepare(forward_batch, **kwargs)

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -388,6 +388,17 @@ class PiecewiseCudaGraphRunner:
             if buffers.mamba_track_seqlens is not None
             else None
         )
+
+        # During warmup_compile (torch.compile JIT trace) we need LoRA kernels
+        # to appear in the FX graph if --enable-lora is set; otherwise the
+        # compiled model will be missing LoRA ops and capture/replay will mismatch.
+        # Mirror the capture path: empty LoRA ids — kernels still launch, early
+        # return on rank=0. bs=1 for warmup.
+        if self.model_runner.server_args.enable_lora:
+            warmup_lora_ids = [None]
+        else:
+            warmup_lora_ids = None
+
         with torch.device(self.device):
             forward_batch = ForwardBatch(
                 forward_mode=ForwardMode.EXTEND,
@@ -429,8 +440,13 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=warmup_lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
+            )
+
+        if warmup_lora_ids is not None:
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
             )
 
         # Attention backend
@@ -471,6 +487,13 @@ class PiecewiseCudaGraphRunner:
             return False
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
+            return False
+        # B5: lm_head LoRA pruned path raises RuntimeError under use_cuda_graph=True
+        # (lora/layers.py: ParallelLMHeadWithLoRA.apply_lora). Until that path is
+        # made graph-safe, refuse PCG when the active LoRA config targets lm_head.
+        if self.model_runner.server_args.enable_lora and "lm_head" in getattr(
+            self.model_runner.lora_manager, "target_modules", set()
+        ):
             return False
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
@@ -602,13 +625,15 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 
         if lora_ids is not None:
-            self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
 
         self.model_runner.attn_backend.init_forward_metadata(forward_batch)
 
@@ -817,6 +842,19 @@ class PiecewiseCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
+        # Re-run prepare_lora_batch with force_cuda_graph=True so the backend
+        # writes batch metadata into the pinned cuda_graph_batch_info buffer
+        # whose address was baked into the captured graph. The upstream call in
+        # forward_batch_info.init_new ran with use_cuda_graph=False (EXTEND is
+        # not in is_cuda_graph()), so we overwrite its fresh allocations here.
+        if (
+            self.model_runner.server_args.enable_lora
+            and forward_batch.lora_ids is not None
+        ):
+            self.model_runner.lora_manager.prepare_lora_batch(
+                forward_batch, force_cuda_graph=True
+            )
+
         with enable_piecewise_cuda_graph():
             static_forward_batch = self.replay_prepare(forward_batch, **kwargs)
             # Replay

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -488,13 +488,10 @@ class PiecewiseCudaGraphRunner:
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
             return False
-        # B5: lm_head LoRA pruned path raises RuntimeError under use_cuda_graph=True
-        # (lora/layers.py: ParallelLMHeadWithLoRA.apply_lora). Until that path is
-        # made graph-safe, refuse PCG when the active LoRA config targets lm_head.
-        if self.model_runner.server_args.enable_lora and "lm_head" in getattr(
-            self.model_runner.lora_manager, "target_modules", set()
-        ):
-            return False
+        # lm_head LoRA pruned path is kept graph-safe by forcing its dedicated
+        # lm_head_batch_info.use_cuda_graph=False in the backend (see
+        # triton/chunked_backend._build_lm_head_batch_info). No need to
+        # blacklist whole batches here.
         num_tokens = len(forward_batch.input_ids)
         if forward_batch.return_logprob:
             for start_len, seq_len in zip(

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -839,18 +839,13 @@ class PiecewiseCudaGraphRunner:
         forward_batch: ForwardBatch,
         **kwargs,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors, EmbeddingPoolerOutput]:
-        # Re-run prepare_lora_batch with force_cuda_graph=True so the backend
-        # writes batch metadata into the pinned cuda_graph_batch_info buffer
-        # whose address was baked into the captured graph. The upstream call in
-        # forward_batch_info.init_new ran with use_cuda_graph=False (EXTEND is
-        # not in is_cuda_graph()), so we overwrite its fresh allocations here.
-        if (
-            self.model_runner.server_args.enable_lora
-            and forward_batch.lora_ids is not None
-        ):
-            self.model_runner.lora_manager.prepare_lora_batch(
-                forward_batch, force_cuda_graph=True
-            )
+        # Note: prepare_lora_batch is NOT called here anymore. The upstream
+        # call in forward_batch_info.init_new already routed EXTEND through
+        # the pinned cuda_graph_batch_info path because
+        # lora_manager._cuda_graph_supports_extend is True when PCG was
+        # initialized (max_num_tokens_pcg was supplied). Calling again here
+        # would duplicate the CPU permutation/segments build + async copies
+        # and was the source of the long-prompt PCG regression.
 
         with enable_piecewise_cuda_graph():
             static_forward_batch = self.replay_prepare(forward_batch, **kwargs)


### PR DESCRIPTION
## Motivation

Today `server_args._handle_piecewise_cuda_graph()` unconditionally disables piecewise CUDA graph (PCG) when `--enable-lora` is set, so LoRA serving always falls back to **eager prefill**. This is the largest prefill optimization in SGLang, so giving it up costs TTFT.

This PR makes PCG with LoRA work on the prefill (`ForwardMode.EXTEND`) path for the **bs=1 single-stream case**, and also wires LoRA capture/replay into `BreakableCudaGraphRunner` (BCG) as the alternative path for chunked SGMV / MoE. The fix is opt-in via `--enforce-piecewise-cuda-graph` (default behavior preserved).

⚠️ **bs>1 LoRA + PCG/BCG is gated to eager fallback** in this PR — see "Limitations" below for the architectural reason. The fix is correct but doesn't deliver the PCG speedup for batched LoRA serving; that requires a follow-up kernel/capture refactor.

## What's in the PR (6 commits)

1. **`[lora] Enable piecewise CUDA graph with LoRA (prefill EXTEND, triton + chunked buffer)`**
   - Fix `piecewise_cuda_graph_runner.py:605` `lora_ids=None` → `lora_ids=lora_ids` passthrough bug.
   - Mirror in `warmup_compile` so torch.compile's FX trace sees LoRA kernels.
   - Add `force_cuda_graph: bool = False` to `lora_manager.prepare_lora_batch` — PCG opts in without changing `ForwardMode.is_cuda_graph()` semantics.
   - Widen `init_cuda_graph_batch_info` and `triton_backend` / `chunked_backend` pinned buffers (`permutation`, `seg_lens`, `seg_indptr`, `weight_indices`) to cover both decode and PCG token buckets.

2. **`[lora] Route lm_head LoRA pruned path to eager under PCG (fine-grained)`**
   - `lora/layers.py:_get_lm_head_batch_info` raises on `batch_info.use_cuda_graph=True`. The pruned lm_head path runs eager outside the captured region, so force its dedicated `LoRABatchInfo` `use_cuda_graph=False` in `_build_lm_head_batch_info` (triton + chunked).

3. **`[lora] Size MoE LoRA Phase 1 buffers for PCG token bucket too`**
   - Plumb `max_num_tokens_pcg` through `model_runner._init_lora_cuda_graph_moe_buffers` → `lora_manager.init_cuda_graph_moe_buffers` → `base_backend.init_cuda_graph_moe_buffers`.
   - Token-axis allocations use `max(max_bs, max_num_tokens_pcg or 0)` (intermediate_cache1/2/3, out_hidden_states, sorted_token_ids_lora, token_mask). `weight_indices_long` stays `max_bs` (per-sequence).

4. **`[lora] Wire LoRA capture/replay into BreakableCudaGraphRunner`**
   - Mirror PCG's LoRA-aware capture/replay in BCG: empty `lora_ids=[None]*bs` during capture, `_maybe_prepare_lora` hook with `force_cuda_graph=True`. BCG bypasses Dynamo, so it's the right path for chunked SGMV / MoE (which hit Dynamo issues under PCG today).

5. **`[lora] Avoid duplicate prepare_lora_batch in PCG/BCG replay`**
   - `init_new` already prepared LoRA; `replay()` re-ran it with `force_cuda_graph=True`. Detected the duplicate CPU work (permutation, pinned-host tensor allocs, async H2D copies). The Phase 1.5 attempt to short-circuit via `_cuda_graph_supports_extend` was reverted in commit 6 (see below).

6. **`[lora] Fix silent LoRA truncation under PCG + gate bs>1 to eager`** (NEW)
   - **Silent correctness bug**: `triton_backend.prepare_lora_batch` cuda_graph path left `seg_lens / seg_indptr` at init defaults (`[num_tokens_per_bs]*max_bs`). For DECODE that's correct (1 token per seq). For EXTEND under PCG.replay / BCG.replay, the sgemm_lora kernel applied LoRA to only `num_tokens_per_bs` (==1) tokens per sequence — silently truncating per-prompt LoRA work to a single token regardless of actual prompt length. Smoke tests still produced sensible-looking output because base-model logits dominate, but the LoRA delta was missing on tokens 1..N-1. Fix: when `forward_mode.is_extend()`, pin-copy actual `extend_seq_lens` into `batch_info.seg_lens[:bs]` and rebuild `seg_indptr` via cumsum.
   - **Do not touch `batch_info.max_len`**: it's a Python int read by the sgemm kernel grid `cdiv(max_len, BLOCK_S)`, which is an Inductor specialization guard. Capture-time `max_len = bucket size` vs live `max_len = actual seq len` would diverge after bisect-up and trigger a runtime recompile that hits `PCG capture stream is not set`. The kernel already early-returns beyond `seg_len` (`if pid_s * BLOCK_S >= seg_len: return`), so leaving `max_len` at the init constant is cheap.
   - **bs>1 LoRA gate**: PCG and BCG both capture at `batch_size=1`; live `bs>1` with LoRA changes the sgemm kernel grid `(_, batch_info.bs)`. PCG hits a Dynamo recompile assert; BCG silently processes only the first sequence (other K-1 seqs get no LoRA). Both `can_run` paths now refuse PCG/BCG when `enable_lora and batch_size > 1`, so the engine falls back to eager prefill (correct, no crash, no silent truncation). **Removing this gate requires per-(bs, num_tokens) bucket captures or a bs-invariant kernel grid; tracked as follow-up.**
   - Reverts the Phase 1.5 `_cuda_graph_supports_extend` auto-route (caused fallback eager EXTEND to read pinned `cuda_graph_batch_info` with stale init `max_len = ~16384`, ballooning grids for short prompts).

## End-to-end validation

Run on a4x-260102 (Blackwell) pod, `flashinfer` attention backend, Qwen3-8B + Qwen3-30B-A3B-Instruct-2507 (TP=4 for MoE), with the corresponding all-linear LoRA adapters (rank=32 including `lm_head`).

| Configuration | Status |
|---|---|
| triton + PCG + lm_head LoRA, bs=1 | ✅ generate OK, LoRA correctly applied to all tokens |
| triton + BCG + LoRA, bs=1 | ✅ init 30% faster than PCG (no torch.compile JIT) |
| chunked (csgmv) + BCG + LoRA, bs=1 | ✅ |
| MoE + BCG + LoRA (Qwen3-30B-A3B, TP=4), bs=1 | ✅ 74 buckets capture, generate OK |
| All 74 PCG capture buckets (4..16384 tokens), bs=1 | ✅ 74/74 |
| 6 off-bucket sizes (100, 200, 1000, 5000, 10000, 13000) | ✅ 6/6 (padding works) |
| Decode CUDA graph + LoRA regression | ✅ 141.9 tokens/sec stable |
| LoRA bs>1 with PCG/BCG enabled | ✅ falls back to eager (correct, no crash) |

## Performance

### bs=1 (single-stream prefill, where PCG/BCG actually run)

Qwen3-8B, triton backend, rank-32 adapter:

| Prompt tokens | Eager (PCG-off) | PCG-on | BCG-on |
|---:|---:|---:|---:|
| ~11 | 68.3 ms | **49.4 ms** (−27.7%) | **48.2 ms** (−29.4%) |
| ~128 | 67.1 ms | **50.2 ms** (−25.2%) | **48.7 ms** (−26.7%) |
| ~512 | 67.7 ms | **54.6 ms** (−19.4%) | **53.3 ms** (−21.3%) |
| ~2,816 | 73.7 ms | 78.3 ms (+6.2%) | 76.2 ms (+3.4%) |
| ~11,264 | 207.8 ms | 228.5 ms (+10.0%) | 220.8 ms (+6.3%) |

Crossover at roughly **1-2k tokens**:
- **Short prefill (≤~1k tokens)**: PCG / BCG net win because kernel-launch overhead dominates compute.
- **Long prefill (>~2k tokens)**: PCG / BCG net negative — per-request `replay_prepare` copies + context-manager setup exceeds kernel-launch savings (compute becomes the bottleneck).

PCG also cuts jitter: ~512-token prefill range drops from 4.0 ms (eager) to 0.6 ms (PCG), 6.7× tighter.

### bs>1 (batched prefill)

All three modes (eager / PCG / BCG) effectively run eager because of the bs>1 gate; perf is within noise:

| bs (~11 tok/seq) | Eager | PCG (→ eager) | BCG (→ eager) |
|---:|---:|---:|---:|
| 4 | 68.0 ms | 67.4 ms | 67.4 ms |
| 64 | 78.5 ms | 76.9 ms | 78.1 ms |
| 256 | 174.2 ms | 180.2 ms | 172.2 ms |

## Recommended usage

| Scenario | Flags |
|---|---|
| Single-stream LoRA serving, short prompts | `--enable-lora --enforce-piecewise-cuda-graph --lora-backend triton` |
| Chunked SGMV LoRA (any bs=1) | `--enable-lora --enforce-piecewise-cuda-graph --enable-breakable-cuda-graph --lora-backend csgmv` |
| MoE + LoRA (bs=1) | `--enable-lora --enforce-piecewise-cuda-graph --enable-breakable-cuda-graph` |
| Batched LoRA serving (bs>1) or long-context (>2k tokens) | leave PCG off (default) — no benefit today |

## Limitations (known, not addressed in this PR)

1. **bs>1 LoRA + PCG/BCG is gated to eager fallback.** Both runners capture at `batch_size=1`; the sgemm_lora kernel grid is `(_, batch_info.bs)`, so live `bs>1` either triggers a Dynamo recompile (PCG) or silently drops K-1 sequences of LoRA (BCG). Removing the gate requires either:
   - Capturing per `(num_tokens_bucket, bs_bucket)` pair — multiplicative in capture cost; OR
   - Making the sgemm_lora kernel grid bs-invariant (`(_, max_bs)`) with seg_lens=0 padding for unused slots — kernel changes + careful Inductor specialization handling.
   Both are out of scope here.

2. **chunked (csgmv) + PCG (without BCG)** still hits `torch._dynamo.exc.Unsupported: torch.* op returned non-Tensor` because `lora/triton_ops/lora_tuning_config.py:get_lora_configs` calls `torch.cuda.get_device_name()` from inside the Dynamo-traced region. `@torch._dynamo.disable` + `fullgraph=True` are incompatible; `allow_in_graph` rejects `LoRABatchInfo` dataclass args. Long-term fix: pre-resolve config outside the captured region, or wrap the kernel as `torch.library.custom_op` with tensor-only signature. **BCG is the working alternative for chunked.**

3. **MoE + PCG (without BCG)** has the same Dynamo blocker in sglang's `layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py:get_moe_configs` — sglang-side, not LoRA-specific. **BCG is the working alternative for MoE.**

4. **Long prompts (>~2k tokens)** see a small PCG/BCG slowdown because the per-request graph-replay overhead exceeds the kernel-launch savings in the compute-bound regime. An `auto-disable when num_tokens > threshold` heuristic would help; skipped to keep this PR scoped.

## Test plan

- [ ] CI: `test/manual/lora/test_lora_cuda_graph.py` (decode CUDA graph + LoRA regression)
- [ ] CI: existing `test/registered/lora/*` (multi-model, multi-adapter coverage)
- [ ] Manual: Llama-3.1-8B + algoprog adapter under PCG (bs=1)
- [ ] Manual: MoE LoRA on Qwen1.5-MoE-A2.7B + `MOE_LORA_PATH` under BCG (bs=1)
- [ ] Manual: bs>1 LoRA + PCG/BCG → confirm eager fallback (`can_run` returns False)
- [ ] Bench: real serving workload to validate short-prompt speedup and jitter reduction
