### PR TITLE
fix(model_loader): reorder weight initialization and quant method post-load processing

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1328,6 +1328,12 @@ class DummyModelLoader(BaseModelLoader):
                     quant_config,
                 )
 
+            # NOTE(woosuk): For accurate performance evaluation, we assign
+            # random values to the weights.
+            initialize_dummy_weights(model)
+
+            _post_load_weights(model)
+
             for _, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)
                 if quant_method is not None:
@@ -1338,12 +1344,6 @@ class DummyModelLoader(BaseModelLoader):
                     ):
                         continue
                     quant_method.process_weights_after_loading(module)
-
-            # NOTE(woosuk): For accurate performance evaluation, we assign
-            # random values to the weights.
-            initialize_dummy_weights(model)
-
-            _post_load_weights(model)
 
         return model.eval()
 
@@ -1444,10 +1444,6 @@ class ShardedStateLoader(BaseModelLoader):
         with set_default_torch_dtype(model_config.dtype):
             with torch.device(device_config.device):
                 model = _initialize_model(model_config, self.load_config, quant_config)
-                for _, module in model.named_modules():
-                    quant_method = getattr(module, "quant_method", None)
-                    if quant_method is not None:
-                        quant_method.process_weights_after_loading(module)
             rank = get_tensor_model_parallel_rank()
             pattern = os.path.join(
                 local_model_path,
@@ -1487,6 +1483,11 @@ class ShardedStateLoader(BaseModelLoader):
                 raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
 
             _post_load_weights(model)
+
+            for _, module in model.named_modules():
+                    quant_method = getattr(module, "quant_method", None)
+                    if quant_method is not None:
+                        quant_method.process_weights_after_loading(module)
 
         return model.eval()
 

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1484,9 +1484,11 @@ class ShardedStateLoader(BaseModelLoader):
 
             _post_load_weights(model)
 
+            target_device = torch.device(device_config.device)
             for _, module in model.named_modules():
-                    quant_method = getattr(module, "quant_method", None)
-                    if quant_method is not None:
+                quant_method = getattr(module, "quant_method", None)
+                if quant_method is not None:
+                    with device_loading_context(module, target_device):
                         quant_method.process_weights_after_loading(module)
 
         return model.eval()


### PR DESCRIPTION
## Motivation

Closes https://github.com/sgl-project/sglang/issues/25653

## Modifications

Reorder the execution steps inside `DummyModelLoader/ShardedStateLoader.load_model()`  to match the sequence used by DefaultModelLoader, `quant_method.process_weights_after_loading(module)` should be called after weight init and postprocess















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26136861440](https://github.com/sgl-project/sglang/actions/runs/26136861440)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26136861324](https://github.com/sgl-project/sglang/actions/runs/26136861324)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->