### PR TITLE
Fix DSV4 topk v2 fused PDL trigger

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh
@@ -340,6 +340,7 @@ topk_fused_transform(const __grid_constant__ TopKParams params) {
     Large::stage1_init(smem);
     device::PDLWaitPrimary<true>();
     Large::stage1_prologue(params.get_scores(batch_id) + offset, length, smem);
+    device::PDLTriggerSecondary<true>();
     Large::stage1(s_topk_indices, length, smem);
     Large::stage1_epilogue(transform, offset, ws, smem);
     cooperative_groups::this_cluster().sync();


### PR DESCRIPTION
 ## Motivation
  
  The DSV4 topk v2 fused path uses Programmatic Dependent Launch (PDL) for the long-context small-batch path.
  
  In the large-sequence branch of `topk_fused_transform`, the kernel waits for the primary launch and runs the stage-1 prologue, but it does not trigger the secondary launch before
  entering stage-1. Other PDL-enabled topk paths trigger the secondary launch after their prologue. This makes the fused path inconsistent with the rest of the topk v2 PDL flow and can
  leave unnecessary dependent-launch bubbles.
  
  ## Modifications
  
  Add the missing `device::PDLTriggerSecondary<true>()` after `Large::stage1_prologue(...)` in the large-sequence branch of `topk_fused_transform`.
  
  This PR is intentionally limited to the PDL trigger fix. It does not include separate correctness hardening, invalid-index guards, or debug/oracle utilities.
  
  ## Accuracy Tests
  
  This change does not alter the topk algorithm, selected indices, or output values. It only adds the missing PDL secondary-launch trigger in the existing fused execution path.
  
  
  ## Speed Tests and Profiling
  
  This change targets launch overlap in the DSV4 topk v2 fused path.
  
  Local long-context testing on DeepSeek-V4-Flash showed the fixed fused JIT v2 path remains faster than the torch fallback and the two-stage workaround for the same topk transform path.
  
  ## Checklist
  
  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the 
  speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26104513575](https://github.com/sgl-project/sglang/actions/runs/26104513575)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->