### PR TITLE
fix: adapt dots_vlm for transformers v5

### DIFF
--- a/python/sglang/srt/multimodal/processors/dots_vlm.py
+++ b/python/sglang/srt/multimodal/processors/dots_vlm.py
@@ -33,8 +33,8 @@ class DotsVLMImageProcessor(BaseMultimodalProcessor):
         merge_size = vision_config.spatial_merge_size
 
         self.IMAGE_FACTOR = patch_size * merge_size
-        self.MIN_PIXELS = _processor.image_processor.min_pixels
-        self.MAX_PIXELS = _processor.image_processor.max_pixels
+        self.MIN_PIXELS = _processor.image_processor.size["shortest_edge"]
+        self.MAX_PIXELS = _processor.image_processor.size["longest_edge"]
         self.MAX_RATIO = 200
         self.mm_tokens = MultimodalSpecialTokens(
             image_token=self.IMAGE_TOKEN,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Motivation
The primary goal of this pull request is to ensure compatibility with `transformers` version 5 API changes in the vision-language model processor, specifically for `DotsVLMImageProcessor`. 
In newer versions of the `transformers` library, image size configuration properties like `min_pixels` and `max_pixels` have been moved and are now nested within the `.size` dictionary. Direct attribute access (e.g., `image_processor.min_pixels`) raises an `AttributeError`. This PR updates the logic to fetch these values correctly.
<img width="907" height="596" alt="da8f1d5091b054d8474c9fdc72927782" src="https://github.com/user-attachments/assets/d3658b16-6812-45a7-919b-48f7c92d8891" />

## Modifications
- **`python/sglang/srt/multimodal/processors/dots_vlm.py`**:
  - Updated the assignment of `self.MIN_PIXELS` and `self.MAX_PIXELS`. The values are now retrieved from `_processor.image_processor.size["shortest_edge"]` and `_processor.image_processor.size["longest_edge"]` respectively, removing the deprecated direct access to `.min_pixels` and `.max_pixels`.
## Accuracy Tests
<img width="1983" height="396" alt="acb2af0a3d9536bc66867691eb0e9133" src="https://github.com/user-attachments/assets/8ccb54a1-d941-47a6-9f71-4a098208e07f" />

These changes resolve an initialization/API compatibility issue (AttributeError). It does not affect model weights, arithmetic logic, or the generated tensor values. Local testing confirms that pipelines utilizing `DotsVLMImageProcessor` can now initialize and preprocess image inputs successfully without crashing.
## Speed Tests and Profiling
N/A. These updates are limited to the initialization phase and do not impact the core inference speed or throughput of the model.
## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
## Review and Merge Process
1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR. 



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #26110389291](https://github.com/sgl-project/sglang/actions/runs/26110389291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #26110389055](https://github.com/sgl-project/sglang/actions/runs/26110389055)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->