### PR TITLE
fix(function_call): use sequential call index in parse_base_json

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -89,7 +89,13 @@ class BaseFormatDetector(ABC):
 
             results.append(
                 ToolCallItem(
-                    tool_index=tool_indices.get(name, -1),
+                    # Use the sequential call position (0, 1, 2 …) so the
+                    # OpenAI tool_calls[].index field is ordered correctly.
+                    # Previously this used tool_indices.get(name) which gave
+                    # the tool's position in the *tools list*, producing wrong
+                    # indices when the model called tools in a different order
+                    # than they were defined.
+                    tool_index=len(results),
                     name=name,
                     parameters=json.dumps(
                         act.get("parameters") or act.get("arguments", {}),

--- a/test/registered/function_call/test_parse_base_json_index.py
+++ b/test/registered/function_call/test_parse_base_json_index.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for parse_base_json sequential tool_index assignment.
+
+OpenAI's tool_calls[].index must be the sequential position of the call
+within the response (0, 1, 2, …), not the tool's position in the tools
+definition list.
+
+Previously, parse_base_json used tool_indices.get(name) which returned
+the tool's position in the *tools list*, producing wrong indices when the
+model called tools in a different order than they were defined, or called
+the same tool multiple times.
+"""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.hermes_detector import HermesDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(5, "base-a-test-cpu")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name):
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            description=f"{name} tool",
+            parameters={
+                "type": "object",
+                "properties": {"x": {"type": "number"}},
+                "required": ["x"],
+            },
+        ),
+    )
+
+
+def _tools():
+    """Define tools in order: add (index 0), multiply (index 1), subtract (index 2)."""
+    return [_make_tool("add"), _make_tool("multiply"), _make_tool("subtract")]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseBaseJsonCallIndex(unittest.TestCase):
+    """parse_base_json must assign sequential call positions, not tools-list positions."""
+
+    def setUp(self):
+        self.detector = HermesDetector()
+
+    def _parse(self, action, tools=None):
+        if tools is None:
+            tools = _tools()
+        return self.detector.parse_base_json(action, tools)
+
+    # -- Single call ---------------------------------------------------------
+
+    def test_single_call_index_is_zero(self):
+        action = [{"name": "multiply", "arguments": {"x": 3}}]
+        items = self._parse(action)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].tool_index, 0)
+        self.assertEqual(items[0].name, "multiply")
+
+    def test_single_first_tool_index_is_zero(self):
+        """First tool in list called alone → index 0, not tools-list position."""
+        action = [{"name": "add", "arguments": {"x": 1}}]
+        items = self._parse(action)
+        self.assertEqual(items[0].tool_index, 0)
+
+    # -- Multi-call sequential indexing -------------------------------------
+
+    def test_two_calls_sequential_indices(self):
+        """Two calls → indices 0, 1 regardless of their order in the tools list."""
+        action = [
+            {"name": "multiply", "arguments": {"x": 2}},
+            {"name": "add", "arguments": {"x": 5}},
+        ]
+        items = self._parse(action)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].tool_index, 0)
+        self.assertEqual(items[0].name, "multiply")
+        self.assertEqual(items[1].tool_index, 1)
+        self.assertEqual(items[1].name, "add")
+
+    def test_three_calls_sequential_indices(self):
+        action = [
+            {"name": "subtract", "arguments": {"x": 10}},
+            {"name": "add", "arguments": {"x": 3}},
+            {"name": "multiply", "arguments": {"x": 7}},
+        ]
+        items = self._parse(action)
+        self.assertEqual(len(items), 3)
+        for expected_idx, item in enumerate(items):
+            self.assertEqual(item.tool_index, expected_idx)
+
+    def test_same_tool_called_twice_sequential(self):
+        """Calling the same tool twice → indices 0 and 1."""
+        action = [
+            {"name": "add", "arguments": {"x": 1}},
+            {"name": "add", "arguments": {"x": 2}},
+        ]
+        items = self._parse(action)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].tool_index, 0)
+        self.assertEqual(items[1].tool_index, 1)
+
+    def test_index_not_tools_list_position(self):
+        """Regression: 'subtract' is at tools-list index 2; as the first call it must be 0."""
+        action = [{"name": "subtract", "arguments": {"x": 5}}]
+        items = self._parse(action)
+        self.assertEqual(len(items), 1)
+        # Must be 0 (call position), not 2 (tools-list position).
+        self.assertEqual(items[0].tool_index, 0)
+
+    # -- Correct argument parsing --------------------------------------------
+
+    def test_arguments_field_parsed(self):
+        action = [{"name": "add", "arguments": {"x": 42}}]
+        items = self._parse(action)
+        self.assertEqual(json.loads(items[0].parameters), {"x": 42})
+
+    def test_parameters_field_parsed(self):
+        action = [{"name": "add", "parameters": {"x": 7}}]
+        items = self._parse(action)
+        self.assertEqual(json.loads(items[0].parameters), {"x": 7})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`parse_base_json` was setting `tool_index` using `tool_indices.get(name)`, which returns the tool's position in the **tools definition list**. This produces wrong `tool_calls[].index` values in the OpenAI response whenever the model calls tools in a different order than they were defined, or calls the same tool more than once.

**Example of the bug:**

Tools defined as `[weather (idx 0), stock (idx 1)]`, model calls `[stock, weather]`:
```json
// Before (wrong)
"tool_calls": [{"index": 1, "function": {"name": "stock"}},
              {"index": 0, "function": {"name": "weather"}}]

// After (correct)
"tool_calls": [{"index": 0, "function": {"name": "stock"}},
              {"index": 1, "function": {"name": "weather"}}]
```

OpenAI's spec requires `tool_calls[].index` to be the **sequential position of the call within the response** (0, 1, 2, …).

## Changes

- **`base_format_detector.py`** (`parse_base_json`): replace `tool_indices.get(name, -1)` with `len(results)` (the 0-based position of the current call in the result list before appending).

This affects all detectors that delegate non-stream parsing to `parse_base_json`: Hermes, Qwen25, Mistral, GLM, Gemma4, Hunyuan, DeepSeekV3/V31/V32, InternLM, Llama32, Poolside, Step3, MiMo, LFM2, GigaChat3, and others.

Also fixes Kimi K2 tool call ID generation which relies on `tool_index` being the local sequential position (per the comment in `serving_chat.py _process_tool_call_id`).

## Test plan

- [ ] `pytest test/registered/function_call/test_parse_base_json_index.py -v` (CPU, no GPU needed)
- [ ] Multi-tool call with out-of-order tools → sequential indices 0, 1, 2
- [ ] Same tool called twice → indices 0, 1
- [ ] Single call of a non-first tool → index 0 (not its tools-list position)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26690713470](https://github.com/sgl-project/sglang/actions/runs/26690713470)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26690713418](https://github.com/sgl-project/sglang/actions/runs/26690713418)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->