### PR TITLE
fix: handle multi-token think_end_token without crashing

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -674,6 +674,14 @@ class Scheduler(
             )
             if len(think_end_ids) == 1:
                 self.model_config.think_end_id = think_end_ids[0]
+            elif self.server_args.enable_strict_thinking:
+                raise ValueError(
+                    f"--enable-strict-thinking requires think_end_token "
+                    f"'{reasoning_parser.detector.think_end_token}' to encode "
+                    f"to exactly one token, but this tokenizer produces "
+                    f"{len(think_end_ids)}. Use a model whose tokenizer has "
+                    f"the think_end_token as a single vocabulary entry."
+                )
             else:
                 logger.warning(
                     "think_end_token '%s' encodes to %d tokens (expected 1). "

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -229,7 +229,7 @@ from sglang.srt.observability.req_time_stats import (
     set_time_batch,
 )
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
-from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.parser.reasoning_parser import ReasoningParser, resolve_think_end_id
 from sglang.srt.platforms import current_platform
 from sglang.srt.plugins import load_plugins
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -669,28 +669,11 @@ class Scheduler(
             reasoning_parser = ReasoningParser(
                 model_type=self.server_args.reasoning_parser, stream_reasoning=False
             )
-            think_end_ids = self.tokenizer.encode(
-                reasoning_parser.detector.think_end_token, add_special_tokens=False
+            self.model_config.think_end_id = resolve_think_end_id(
+                self.tokenizer,
+                reasoning_parser,
+                self.server_args.enable_strict_thinking,
             )
-            if len(think_end_ids) == 1:
-                self.model_config.think_end_id = think_end_ids[0]
-            elif self.server_args.enable_strict_thinking:
-                raise ValueError(
-                    f"--enable-strict-thinking requires think_end_token "
-                    f"'{reasoning_parser.detector.think_end_token}' to encode "
-                    f"to exactly one token, but this tokenizer produces "
-                    f"{len(think_end_ids)}. Use a model whose tokenizer has "
-                    f"the think_end_token as a single vocabulary entry."
-                )
-            else:
-                logger.warning(
-                    "think_end_token '%s' encodes to %d tokens (expected 1). "
-                    "Constrained reasoning grammar and reasoning token counting "
-                    "will be disabled for this model. The reasoning parser will "
-                    "still function for output parsing.",
-                    reasoning_parser.detector.think_end_token,
-                    len(think_end_ids),
-                )
 
     def init_mamba_backend(self) -> None:
         initialize_mamba_selective_state_update_backend(self.server_args)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -669,9 +669,20 @@ class Scheduler(
             reasoning_parser = ReasoningParser(
                 model_type=self.server_args.reasoning_parser, stream_reasoning=False
             )
-            self.model_config.think_end_id = self.tokenizer.encode(
+            think_end_ids = self.tokenizer.encode(
                 reasoning_parser.detector.think_end_token, add_special_tokens=False
-            )[0]
+            )
+            if len(think_end_ids) == 1:
+                self.model_config.think_end_id = think_end_ids[0]
+            else:
+                logger.warning(
+                    "think_end_token '%s' encodes to %d tokens (expected 1). "
+                    "Constrained reasoning grammar and reasoning token counting "
+                    "will be disabled for this model. The reasoning parser will "
+                    "still function for output parsing.",
+                    reasoning_parser.detector.think_end_token,
+                    len(think_end_ids),
+                )
 
     def init_mamba_backend(self) -> None:
         initialize_mamba_selective_state_update_backend(self.server_args)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1,7 +1,40 @@
+import logging
 from typing import Dict, List, Optional, Tuple, Type
 
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.parser.harmony_parser import HarmonyParser
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_think_end_id(tokenizer, reasoning_parser, enable_strict_thinking=False):
+    """Resolve think_end_token to a single token ID, or None if not possible.
+
+    Raises ValueError when enable_strict_thinking is set and the token
+    cannot be represented as a single ID.
+    """
+    think_end_ids = tokenizer.encode(
+        reasoning_parser.detector.think_end_token, add_special_tokens=False
+    )
+    if len(think_end_ids) == 1:
+        return think_end_ids[0]
+    if enable_strict_thinking:
+        raise ValueError(
+            f"--enable-strict-thinking requires think_end_token "
+            f"'{reasoning_parser.detector.think_end_token}' to encode "
+            f"to exactly one token, but this tokenizer produces "
+            f"{len(think_end_ids)}. Use a model whose tokenizer has "
+            f"the think_end_token as a single vocabulary entry."
+        )
+    logger.warning(
+        "think_end_token '%s' encodes to %d tokens (expected 1). "
+        "Constrained reasoning grammar and reasoning token counting "
+        "will be disabled for this model. The reasoning parser will "
+        "still function for output parsing.",
+        reasoning_parser.detector.think_end_token,
+        len(think_end_ids),
+    )
+    return None
 
 
 class StreamingParseResult:

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -14,6 +14,7 @@ from sglang.srt.parser.reasoning_parser import (
     Qwen3Detector,
     ReasoningParser,
     StreamingParseResult,
+    resolve_think_end_id,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -1544,6 +1545,47 @@ class TestPoolsideV1Registered(CustomTestCase):
         rp = ReasoningParser("poolside_v1", stream_reasoning=True)
         self.assertEqual(rp.detector.reasoning_default, "explicit_enable_thinking")
         self.assertTrue(rp.detector.thinks_internally)
+
+
+class _FakeTokenizer:
+    def __init__(self, think_end_ids):
+        self._think_end_ids = think_end_ids
+
+    def encode(self, text, add_special_tokens=False):
+        return list(self._think_end_ids)
+
+
+class TestResolveThinkEndId(CustomTestCase):
+    def _parser(self):
+        return ReasoningParser("deepseek-r1", stream_reasoning=False)
+
+    def test_single_token(self):
+        result = resolve_think_end_id(_FakeTokenizer([128009]), self._parser())
+        self.assertEqual(result, 128009)
+
+    def test_multi_token_without_strict(self):
+        result = resolve_think_end_id(_FakeTokenizer([151, 6031, 235]), self._parser())
+        self.assertIsNone(result)
+
+    def test_multi_token_with_strict_raises(self):
+        with self.assertRaises(ValueError):
+            resolve_think_end_id(
+                _FakeTokenizer([151, 6031, 235]),
+                self._parser(),
+                enable_strict_thinking=True,
+            )
+
+    def test_empty_encoding_without_strict(self):
+        result = resolve_think_end_id(_FakeTokenizer([]), self._parser())
+        self.assertIsNone(result)
+
+    def test_empty_encoding_with_strict_raises(self):
+        with self.assertRaises(ValueError):
+            resolve_think_end_id(
+                _FakeTokenizer([]),
+                self._parser(),
+                enable_strict_thinking=True,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #24843.

Starting the server with `--reasoning-parser deepseek-v3` crashes if the model's tokenizer splits `</think>` into multiple tokens (e.g. DeepSeek-V3-0324). The scheduler does `tokenizer.encode("</think>")[0]`, which silently grabs just the first sub-token (`</` instead of `</think>`), and then `ReasonerGrammarBackend` raises a `ValueError` killing the server.

I verified that `</think>` genuinely does not exist as a single token in DeepSeek-V3-0324's vocabulary. `convert_tokens_to_ids` returns `None`, it's not in `added_tokens_encoder` or `all_special_tokens`. The tokenizer splits it into `['</', 'think', '>']`. For comparison, Qwen3 and DeepSeek-R1-0528 both have `</think>` as a proper added token and `encode()` returns a single ID.

## What this PR does

The scheduler now checks the token count before assigning `think_end_id`. If `</think>` encodes to more than one token, `think_end_id` stays `None` and a warning is logged. All downstream consumers already guard on `think_end_id is not None` (verified in `batch_result_processor.py`, `base_grammar_backend.py`, `eagle_info.py`, `ngram_info.py`), so the server starts normally.

The text-based reasoning parser still works (it does string matching, not token matching), so `reasoning_content` still shows up in responses. Only grammar-enforced thinking budget is disabled, which was never working for these models anyway since the server crashed on startup.

## How I validated

- Reproduced the crash on `main` with DeepSeek-V3-0324's tokenizer, confirmed `ValueError`
- Verified the fix logs a warning, `think_end_id` stays `None`, server starts
- Verified single-token models (Qwen3, DeepSeek-R1-0528) still set `think_end_id` correctly
- All 19 existing tests in `test_reasoner_grammar_backend.py` pass





















































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26595179645](https://github.com/sgl-project/sglang/actions/runs/26595179645)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26595179497](https://github.com/sgl-project/sglang/actions/runs/26595179497)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->