### PR TITLE
fix: pass lora_ids to ForwardBatch in PiecewiseCudaGraphRunner

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -602,7 +602,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)


### PR DESCRIPTION
## Motivation

Fixes #25307.

`PiecewiseCudaGraphRunner.capture_one_batch_size()` computes dummy `lora_ids` for CUDA graph capture (line 560) but then passes `lora_ids=None` to `ForwardBatch` (line 605). When `prepare_lora_batch()` runs right after, it sees `forward_batch.lora_ids is None` and fails.

The standard `CudaGraphRunner` already passes the variable correctly (line 1059 in `cuda_graph_runner.py`).

## What this PR does

Passes the computed `lora_ids` variable instead of hardcoded `None`. One-line change.

## How I validated

Confirmed the bug by reading the code: `lora_ids` is computed at line 560, thrown away at line 605, then `prepare_lora_batch` at line 611 expects it to be set. Also confirmed the standard `CudaGraphRunner` already does this correctly as a reference.

Reproducing the actual crash requires GPU + LoRA (the issue provides a repro command with `Qwen/Qwen3-0.6B` + `AIPlans/Qwen3-0.6B-DPO`).





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26116368578](https://github.com/sgl-project/sglang/actions/runs/26116368578)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->