### PR TITLE
fix(openai): three API request validation fixes

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -383,6 +383,19 @@ class CompletionRequest(BaseModel):
             raise ValueError("max_tokens must be positive")
         return v
 
+    @field_validator("logit_bias")
+    @classmethod
+    def validate_logit_bias_range(cls, v):
+        if v is None:
+            return v
+        for token_id, bias in v.items():
+            if not -100 <= bias <= 100:
+                raise ValueError(
+                    f"logit_bias value {bias} for token '{token_id}' is out of range. "
+                    "Values must be between -100 and 100."
+                )
+        return v
+
 
 class SglExt(BaseModel):
     """SGLang extension fields for OpenAI-compatible responses.
@@ -841,6 +854,19 @@ class ChatCompletionRequest(BaseModel):
             }
 
         return values
+
+    @field_validator("logit_bias")
+    @classmethod
+    def validate_logit_bias_range(cls, v):
+        if v is None:
+            return v
+        for token_id, bias in v.items():
+            if not -100 <= bias <= 100:
+                raise ValueError(
+                    f"logit_bias value {bias} for token '{token_id}' is out of range. "
+                    "Values must be between -100 and 100."
+                )
+        return v
 
     def to_sampling_params(
         self,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -445,10 +445,27 @@ class OpenAIServingChat(OpenAIServingBase):
                 f"This model supports at most {server_context_length} completion tokens."
             )
 
+        if request.stream and (request.n or 1) > 1:
+            return (
+                "Streaming is not supported when n > 1. "
+                "Either set stream=false or set n=1."
+            )
+
         if request.response_format and request.response_format.type == "json_schema":
             schema = getattr(request.response_format.json_schema, "schema_", None)
             if schema is None:
                 return "schema_ is required for json_schema response format request."
+
+        if (
+            request.continue_final_message
+            and request.messages
+            and len(request.messages) == 1
+            and getattr(request.messages[0], "role", None) == "assistant"
+        ):
+            return (
+                "continue_final_message requires at least one non-assistant message "
+                "before the final assistant message."
+            )
 
         return None
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -60,6 +60,12 @@ class OpenAIServingCompletion(OpenAIServingBase):
         if not prompt or (isinstance(prompt, list) and all(not p for p in prompt)):
             return "Prompt cannot be empty"
 
+        if request.stream and (request.n or 1) > 1:
+            return (
+                "Streaming is not supported when n > 1. "
+                "Either set stream=false or set n=1."
+            )
+
         return None
 
     def _convert_to_internal_request(

--- a/test/registered/srt/test_openai_request_validation.py
+++ b/test/registered/srt/test_openai_request_validation.py
@@ -1,0 +1,222 @@
+"""
+Unit tests for three OpenAI API compliance validation fixes:
+
+1. n > 1 combined with stream=true is rejected (chat and completions).
+   OpenAI's API does not support streaming multiple candidates simultaneously.
+
+2. continue_final_message=true with only a single assistant message is
+   rejected. Stripping the only message would produce an empty list and
+   cause an IndexError downstream.
+
+3. logit_bias values outside [-100, 100] are rejected at construction time
+   via Pydantic validation, matching OpenAI's documented constraint.
+
+All tests exercise request validation directly without a live server.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionMessageUserParam,
+    ChatCompletionRequest,
+    CompletionRequest,
+    ResponseFormat,
+)
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(5, "base-a-test-cpu")
+
+_USER_MSG = ChatCompletionMessageUserParam(role="user", content="hi")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chat_serving():
+    serving = MagicMock(spec=OpenAIServingChat)
+    serving._validate_request = OpenAIServingChat._validate_request.__get__(
+        serving, OpenAIServingChat
+    )
+    serving.tokenizer_manager = MagicMock()
+    serving.tokenizer_manager.server_args.context_length = None
+    serving.tokenizer_manager.server_args.allow_auto_truncate = False
+    return serving
+
+
+def _make_completion_serving():
+    serving = MagicMock(spec=OpenAIServingCompletion)
+    serving._validate_request = OpenAIServingCompletion._validate_request.__get__(
+        serving, OpenAIServingCompletion
+    )
+    return serving
+
+
+def _chat(**kwargs):
+    defaults = dict(model="test-model", messages=[_USER_MSG])
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+def _completion(**kwargs):
+    defaults = dict(model="test-model", prompt="hello")
+    defaults.update(kwargs)
+    return CompletionRequest(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# n > 1 + stream
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingWithMultipleCandidates(unittest.TestCase):
+    def setUp(self):
+        self.chat = _make_chat_serving()
+        self.completion = _make_completion_serving()
+
+    # Chat — rejected
+
+    def test_chat_n2_stream_returns_error(self):
+        err = self.chat._validate_request(_chat(n=2, stream=True))
+        self.assertIsNotNone(err)
+        self.assertIn("stream", err.lower())
+
+    def test_chat_n5_stream_returns_error(self):
+        err = self.chat._validate_request(_chat(n=5, stream=True))
+        self.assertIsNotNone(err)
+
+    # Chat — allowed
+
+    def test_chat_n2_no_stream_is_allowed(self):
+        self.assertIsNone(self.chat._validate_request(_chat(n=2, stream=False)))
+
+    def test_chat_n1_stream_is_allowed(self):
+        self.assertIsNone(self.chat._validate_request(_chat(n=1, stream=True)))
+
+    def test_chat_default_n_stream_is_allowed(self):
+        self.assertIsNone(self.chat._validate_request(_chat(stream=True)))
+
+    # Completions — rejected
+
+    def test_completion_n2_stream_returns_error(self):
+        err = self.completion._validate_request(_completion(n=2, stream=True))
+        self.assertIsNotNone(err)
+        self.assertIn("stream", err.lower())
+
+    def test_completion_n3_stream_returns_error(self):
+        err = self.completion._validate_request(_completion(n=3, stream=True))
+        self.assertIsNotNone(err)
+
+    # Completions — allowed
+
+    def test_completion_n2_no_stream_is_allowed(self):
+        self.assertIsNone(
+            self.completion._validate_request(_completion(n=2, stream=False))
+        )
+
+    def test_completion_n1_stream_is_allowed(self):
+        self.assertIsNone(
+            self.completion._validate_request(_completion(n=1, stream=True))
+        )
+
+
+# ---------------------------------------------------------------------------
+# continue_final_message with only-assistant message
+# ---------------------------------------------------------------------------
+
+
+class TestContinueFinalMessageValidation(unittest.TestCase):
+    def setUp(self):
+        self.chat = _make_chat_serving()
+
+    def _assistant_msg(self):
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionMessageGenericParam,
+        )
+
+        return ChatCompletionMessageGenericParam(role="assistant", content="sure")
+
+    def test_single_assistant_with_continue_returns_error(self):
+        req = _chat(
+            messages=[self._assistant_msg()],
+            continue_final_message=True,
+        )
+        err = self.chat._validate_request(req)
+        self.assertIsNotNone(err)
+        self.assertIn("continue_final_message", err)
+
+    def test_user_then_assistant_with_continue_is_allowed(self):
+        req = _chat(
+            messages=[_USER_MSG, self._assistant_msg()],
+            continue_final_message=True,
+        )
+        self.assertIsNone(self.chat._validate_request(req))
+
+    def test_single_user_message_no_continue_is_allowed(self):
+        self.assertIsNone(
+            self.chat._validate_request(_chat(messages=[_USER_MSG]))
+        )
+
+    def test_single_assistant_no_continue_is_allowed(self):
+        req = _chat(
+            messages=[self._assistant_msg()],
+            continue_final_message=False,
+        )
+        self.assertIsNone(self.chat._validate_request(req))
+
+
+# ---------------------------------------------------------------------------
+# logit_bias range validation
+# ---------------------------------------------------------------------------
+
+
+class TestLogitBiasRangeValidation(unittest.TestCase):
+    # CompletionRequest
+
+    def test_completion_bias_above_100_raises(self):
+        with self.assertRaises(Exception):
+            _completion(logit_bias={"1234": 101.0})
+
+    def test_completion_bias_below_minus_100_raises(self):
+        with self.assertRaises(Exception):
+            _completion(logit_bias={"1234": -101.0})
+
+    def test_completion_bias_at_100_is_allowed(self):
+        self.assertEqual(_completion(logit_bias={"1": 100.0}).logit_bias["1"], 100.0)
+
+    def test_completion_bias_at_minus_100_is_allowed(self):
+        self.assertEqual(
+            _completion(logit_bias={"1": -100.0}).logit_bias["1"], -100.0
+        )
+
+    def test_completion_no_logit_bias_is_allowed(self):
+        self.assertIsNone(_completion().logit_bias)
+
+    # ChatCompletionRequest
+
+    def test_chat_bias_above_100_raises(self):
+        with self.assertRaises(Exception):
+            _chat(logit_bias={"42": 150.0})
+
+    def test_chat_bias_below_minus_100_raises(self):
+        with self.assertRaises(Exception):
+            _chat(logit_bias={"42": -200.0})
+
+    def test_chat_bias_in_range_is_allowed(self):
+        req = _chat(logit_bias={"42": 50.0, "99": -75.0})
+        self.assertEqual(req.logit_bias["42"], 50.0)
+
+    def test_chat_no_logit_bias_is_allowed(self):
+        self.assertIsNone(_chat().logit_bias)
+
+    def test_chat_multiple_tokens_one_out_of_range_raises(self):
+        with self.assertRaises(Exception):
+            _chat(logit_bias={"1": 10.0, "2": 50.0, "3": 101.0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/srt/test_openai_request_validation.py
+++ b/test/registered/srt/test_openai_request_validation.py
@@ -21,7 +21,6 @@ from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionMessageUserParam,
     ChatCompletionRequest,
     CompletionRequest,
-    ResponseFormat,
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
@@ -157,9 +156,7 @@ class TestContinueFinalMessageValidation(unittest.TestCase):
         self.assertIsNone(self.chat._validate_request(req))
 
     def test_single_user_message_no_continue_is_allowed(self):
-        self.assertIsNone(
-            self.chat._validate_request(_chat(messages=[_USER_MSG]))
-        )
+        self.assertIsNone(self.chat._validate_request(_chat(messages=[_USER_MSG])))
 
     def test_single_assistant_no_continue_is_allowed(self):
         req = _chat(
@@ -189,9 +186,7 @@ class TestLogitBiasRangeValidation(unittest.TestCase):
         self.assertEqual(_completion(logit_bias={"1": 100.0}).logit_bias["1"], 100.0)
 
     def test_completion_bias_at_minus_100_is_allowed(self):
-        self.assertEqual(
-            _completion(logit_bias={"1": -100.0}).logit_bias["1"], -100.0
-        )
+        self.assertEqual(_completion(logit_bias={"1": -100.0}).logit_bias["1"], -100.0)
 
     def test_completion_no_logit_bias_is_allowed(self):
         self.assertIsNone(_completion().logit_bias)


### PR DESCRIPTION
## Summary

Three small OpenAI API compliance fixes in the request validation layer.

### 1. Reject `n > 1` combined with `stream=true`

OpenAI's API returns 400 for this combination — streaming multiple completion candidates simultaneously is not supported. SGLang previously accepted it silently with undefined behavior.

Added a check to `_validate_request` in both `serving_chat.py` and `serving_completions.py`.

### 2. Reject `continue_final_message=true` with a single assistant-only message

`_handle_last_assistant_message` strips the final assistant message from the list. If that was the only message, `messages` becomes empty and downstream code hits an `IndexError` → 500. Now returns a clear 400 instead.

### 3. Reject `logit_bias` values outside `[-100, 100]`

OpenAI's [API docs](https://platform.openai.com/docs/api-reference/chat/create#chat-create-logit_bias) require values in this range. Out-of-range values were previously passed through silently. Added a `@field_validator` on `logit_bias` in both `CompletionRequest` and `ChatCompletionRequest` in `protocol.py`.

## Changes

- `serving_chat.py`: stream+n check, continue_final_message guard
- `serving_completions.py`: stream+n check
- `protocol.py`: `@field_validator` for `logit_bias` on both request models

## Test plan

- [ ] `pytest test/registered/srt/test_openai_request_validation.py -v` (CPU, no GPU needed)
- [ ] `n=2` + `stream=true` → 400 for chat and completions
- [ ] `continue_final_message=true` with only one assistant message → 400
- [ ] `logit_bias` value of 101 → 400; value of 100 → allowed













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26690714433](https://github.com/sgl-project/sglang/actions/runs/26690714433)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26690714378](https://github.com/sgl-project/sglang/actions/runs/26690714378)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->