### PR TITLE
[DLLM] Onboard Nemotron-Labs-Diffusion model with FastDiffuser decoding

### DIFF
--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -25,13 +25,20 @@ class DllmAlgorithm:
     synchronous and FDFO (``--dllm-fdfo``) execution loops in ``run``.
     """
 
-    def __init__(self, config: DllmConfig):
+    def __init__(
+        self,
+        config: DllmConfig,
+    ):
+        self.config = config
         self.block_size = config.block_size
         self.mask_id = config.mask_id
         self.fdfo = config.first_done_first_out_mode
 
+    def select_block_size(self, running_bs: int) -> int:
+        return self.config.select_block_size(running_bs)
+
     @staticmethod
-    def from_server_args(server_args: ServerArgs):
+    def from_server_args(server_args: "ServerArgs"):
         config = DllmConfig.from_server_args(server_args)
         return get_algorithm(config)
 

--- a/python/sglang/srt/dllm/algorithm/fastdiffuser.py
+++ b/python/sglang/srt/dllm/algorithm/fastdiffuser.py
@@ -1,0 +1,364 @@
+"""FastDiffuser denoising for block-diffusion LMs."""
+
+import dataclasses
+import logging
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.model_runner import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+
+def _add_gumbel_noise(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    if temperature == 0:
+        return logits
+    logits = logits.to(torch.float64)
+    noise = torch.rand_like(logits, dtype=torch.float64)
+    gumbel_noise = (-torch.log(noise)) ** temperature
+    return logits.exp() / gumbel_noise
+
+
+def _get_num_transfer_tokens(mask_count: int, steps: int) -> List[int]:
+    base = mask_count // steps
+    remainder = mask_count % steps
+    return [base + (1 if i < remainder else 0) for i in range(steps)]
+
+
+class FastDiffuser(DllmAlgorithm):
+    """Fill a masked block over several bidirectional forwards."""
+
+    def __init__(self, config: DllmConfig) -> None:
+        super().__init__(config)
+        cfg = config.algorithm_config
+        self.temperature: float = cfg.get("temperature", 0.0)
+        self.threshold: Optional[float] = cfg.get("threshold", None)
+        self.max_steps: int = config.max_steps
+        self.causal_context: bool = config.causal_context
+        self.tokens_per_step: Optional[int] = cfg.get("tokens_per_step", None)
+
+        self._eos_token_id: Optional[int] = None
+
+        self._stats_forward_passes: int = 0
+        self._stats_tokens_generated: int = 0
+        self._stats_cuda_graph: int = 0
+        self._stats_eager: int = 0
+        self._stats_file: Optional[str] = cfg.get("stats_file", None)
+
+        logger.info(
+            "FastDiffuser: block_size=%d  max_steps=%d  temperature=%s  "
+            "threshold=%s",
+            self.block_size,
+            self.max_steps,
+            self.temperature,
+            self.threshold,
+        )
+
+    def _flush_stats(self) -> None:
+        if not self._stats_file:
+            return
+        import json
+        import os
+
+        data = {
+            "forward_passes": self._stats_forward_passes,
+            "tokens_generated": self._stats_tokens_generated,
+        }
+        tmp = self._stats_file + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, self._stats_file)
+
+    def _get_eos_id(self, model_runner: ModelRunner) -> Optional[int]:
+        if self._eos_token_id is None:
+            try:
+                hf_cfg = model_runner.model_config.hf_config
+                eos = getattr(hf_cfg, "eos_token_id", None)
+                if isinstance(eos, list):
+                    eos = eos[0]
+                self._eos_token_id = int(eos) if eos is not None else None
+            except (AttributeError, TypeError, ValueError, IndexError):
+                self._eos_token_id = None
+        return self._eos_token_id
+
+    def _compute_confidence(
+        self,
+        logits: torch.Tensor,  # [block_size, vocab]
+        mask_index: torch.Tensor,  # [block_size] bool
+        current_ids: torch.Tensor,  # [block_size] int
+        eos_freeze: torch.Tensor,  # [block_size] bool
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Keep mask_id out of committed tokens while matching HF confidence.
+        logits_for_argmax = logits.clone()
+        logits_for_argmax[:, self.mask_id] = -np.inf
+        logits_with_noise = _add_gumbel_noise(logits_for_argmax, self.temperature)
+        x0 = torch.argmax(logits_with_noise, dim=-1)
+        x0_p = F.softmax(logits, dim=-1).gather(-1, x0.unsqueeze(-1)).squeeze(-1)
+        x0 = torch.where(mask_index, x0, current_ids)
+        active = mask_index & ~eos_freeze
+        confidence = torch.where(active, x0_p, torch.full_like(x0_p, -np.inf))
+        return x0, confidence
+
+    def _compact_forward_batch(
+        self,
+        forward_batch: ForwardBatch,
+        active_indices: List[int],
+    ) -> ForwardBatch:
+        bs = self.block_size
+        n = len(active_indices)
+        device = forward_batch.input_ids.device
+
+        active_t = torch.tensor(active_indices, dtype=torch.long, device=device)
+        active_t_cpu = torch.tensor(active_indices, dtype=torch.long)
+
+        token_idx = torch.cat(
+            [torch.arange(a * bs, (a + 1) * bs, device=device) for a in active_indices]
+        )
+
+        new_input_ids = forward_batch.input_ids[token_idx].clone()
+        new_positions = forward_batch.positions[token_idx]
+        new_out_cache_loc = forward_batch.out_cache_loc[token_idx]
+
+        new_seq_lens = forward_batch.seq_lens[active_t]
+        new_orig_seq_lens = (
+            forward_batch.orig_seq_lens[active_t]
+            if forward_batch.orig_seq_lens is not None
+            else None
+        )
+        new_req_pool = forward_batch.req_pool_indices[active_t]
+        new_ext_seq = forward_batch.extend_seq_lens[active_t]
+        new_ext_pre = forward_batch.extend_prefix_lens[active_t]
+
+        new_ext_start = torch.zeros(n, dtype=torch.long, device=device)
+        new_ext_start[1:] = new_ext_seq[:-1].cumsum(0)
+
+        new_ext_pre_cpu = (
+            [forward_batch.extend_prefix_lens_cpu[a] for a in active_indices]
+            if forward_batch.extend_prefix_lens_cpu is not None
+            else None
+        )
+        new_ext_seq_cpu = (
+            [forward_batch.extend_seq_lens_cpu[a] for a in active_indices]
+            if forward_batch.extend_seq_lens_cpu is not None
+            else None
+        )
+        new_seq_lens_cpu = (
+            forward_batch.seq_lens_cpu[active_t_cpu]
+            if forward_batch.seq_lens_cpu is not None
+            else None
+        )
+
+        return dataclasses.replace(
+            forward_batch,
+            batch_size=n,
+            input_ids=new_input_ids,
+            req_pool_indices=new_req_pool,
+            seq_lens=new_seq_lens,
+            out_cache_loc=new_out_cache_loc,
+            seq_lens_sum=int(new_seq_lens.sum()),
+            orig_seq_lens=new_orig_seq_lens,
+            positions=new_positions,
+            extend_num_tokens=n * bs,
+            extend_seq_lens=new_ext_seq,
+            extend_prefix_lens=new_ext_pre,
+            extend_start_loc=new_ext_start,
+            extend_prefix_lens_cpu=new_ext_pre_cpu,
+            extend_seq_lens_cpu=new_ext_seq_cpu,
+            seq_lens_cpu=new_seq_lens_cpu,
+        )
+
+    def run(
+        self,
+        model_runner: ModelRunner,
+        forward_batch: ForwardBatch,
+        algo_states=None,
+    ):
+        batch_size = forward_batch.batch_size
+        eos_id = self._get_eos_id(model_runner)
+
+        mask_index_all = forward_batch.input_ids == self.mask_id
+        if not mask_index_all.any():
+            if forward_batch.input_ids.numel() == 0:
+                empty_logits = LogitsProcessorOutput(
+                    next_token_logits=None, full_logits=None
+                )
+                return empty_logits, [], None, None, False
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            return out.logits_output, [], None, None, out.can_run_graph
+
+        start_list: List[int] = []
+        for b in range(batch_size):
+            bs, be = b * self.block_size, (b + 1) * self.block_size
+            n_masks = int((forward_batch.input_ids[bs:be] == self.mask_id).sum())
+            start_list.append(self.block_size - n_masks)
+
+        finished = [False] * batch_size
+        req_steps_active = [0] * batch_size
+
+        for step in range(self.max_steps):
+            active_indices = [b for b in range(batch_size) if not finished[b]]
+            if not active_indices:
+                break
+            for b in active_indices:
+                req_steps_active[b] += 1
+
+            self._stats_forward_passes += 1
+            if len(active_indices) == batch_size:
+                out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            else:
+                compact_fb = self._compact_forward_batch(forward_batch, active_indices)
+                out = model_runner.forward(compact_fb, pp_proxy_tensors=None)
+
+            logits_output, can_run_graph = out.logits_output, out.can_run_graph
+            if can_run_graph:
+                self._stats_cuda_graph += 1
+            else:
+                self._stats_eager += 1
+
+            for compact_i, orig_b in enumerate(active_indices):
+                lbs = compact_i * self.block_size
+                lbe = lbs + self.block_size
+                bs_o = orig_b * self.block_size
+                be_o = bs_o + self.block_size
+
+                block_ids = forward_batch.input_ids[bs_o:be_o]
+                block_mask = block_ids == self.mask_id
+
+                if not block_mask.any():
+                    finished[orig_b] = True
+                    continue
+
+                block_logits = logits_output.full_logits[lbs:lbe]
+
+                # Prompt EOS should not freeze generated positions.
+                gen_start = start_list[orig_b]
+                eos_freeze = torch.zeros_like(block_mask)
+                if eos_id is not None:
+                    placed_in_gen = ~block_mask
+                    placed_in_gen[:gen_start] = False
+                    eos_placed = placed_in_gen & (block_ids == eos_id)
+                    if eos_placed.any():
+                        first_eos = int(eos_placed.nonzero(as_tuple=True)[0][0])
+                        eos_freeze[first_eos:] = True
+
+                x0, confidence = self._compute_confidence(
+                    block_logits, block_mask, block_ids, eos_freeze
+                )
+
+                remaining = int(block_mask.sum())
+                if self.threshold is not None:
+                    k = max(1, int((confidence >= self.threshold).sum()))
+                else:
+                    steps_left = self.max_steps - step
+                    k = _get_num_transfer_tokens(remaining, steps_left)[0]
+                k = min(k, remaining)
+
+                _, top_idx = torch.topk(confidence, k=k)
+                block_ids[top_idx] = x0[top_idx]
+
+                if eos_id is not None:
+                    gen_top_idx = top_idx[top_idx >= gen_start]
+                    if len(gen_top_idx) and (block_ids[gen_top_idx] == eos_id).any():
+                        gen_eos = (block_ids[gen_start:] == eos_id).nonzero(
+                            as_tuple=True
+                        )[0]
+                        if len(gen_eos):
+                            first_eos = gen_start + int(gen_eos[0])
+                            still_mask = block_ids[first_eos:] == self.mask_id
+                            block_ids[first_eos:][still_mask] = eos_id
+
+                if not (block_ids == self.mask_id).any():
+                    finished[orig_b] = True
+
+        # Refresh KV/logits for the accepted block.
+        self._stats_forward_passes += 1
+        if self.causal_context:
+            forward_batch.dllm_causal_kv_update = True
+        out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+        if self.causal_context:
+            forward_batch.dllm_causal_kv_update = False
+        logits_output, can_run_graph = out.logits_output, out.can_run_graph
+        if can_run_graph:
+            self._stats_cuda_graph += 1
+        else:
+            self._stats_eager += 1
+
+        # Threshold mode may leave masks; commit them before the next block.
+        forced_any = False
+        for b in range(batch_size):
+            bs_o = b * self.block_size
+            be_o = bs_o + self.block_size
+            block_ids = forward_batch.input_ids[bs_o:be_o]
+            remaining_mask = (block_ids == self.mask_id).clone()
+            if not remaining_mask.any():
+                continue
+            block_logits = logits_output.full_logits[bs_o:be_o].clone()
+            block_logits[:, self.mask_id] = -np.inf
+            x0_final = torch.argmax(block_logits, dim=-1)
+            if eos_id is not None:
+                gen_start = start_list[b]
+                placed_in_gen = ~remaining_mask
+                placed_in_gen[:gen_start] = False
+                eos_placed = placed_in_gen & (block_ids == eos_id)
+                if eos_placed.any():
+                    first_eos = int(eos_placed.nonzero(as_tuple=True)[0][0])
+                    remaining_mask[first_eos:] = False
+            if remaining_mask.any():
+                block_ids[remaining_mask] = x0_final[remaining_mask]
+                forced_any = True
+
+        if forced_any:
+            self._stats_forward_passes += 1
+            if self.causal_context:
+                forward_batch.dllm_causal_kv_update = True
+            out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+            if self.causal_context:
+                forward_batch.dllm_causal_kv_update = False
+            logits_output, can_run_graph = out.logits_output, out.can_run_graph
+            if can_run_graph:
+                self._stats_cuda_graph += 1
+            else:
+                self._stats_eager += 1
+
+        token_grid = forward_batch.input_ids.reshape(batch_size, self.block_size)
+        next_token_ids_list = [
+            token_grid[b, start_list[b] :] for b in range(batch_size)
+        ]
+
+        if self._stats_file:
+            import json as _json
+
+            with open(self._stats_file, "a") as _sf:
+                for b in range(batch_size):
+                    fp = req_steps_active[b]
+                    tokens = int(next_token_ids_list[b].shape[0])
+                    self._stats_tokens_generated += tokens
+                    tpfp = tokens / fp if fp > 0 else 0.0
+                    _sf.write(
+                        _json.dumps(
+                            {
+                                "forward_passes": fp,
+                                "tokens": tokens,
+                                "tokens_per_fp": round(tpfp, 4),
+                            }
+                        )
+                        + "\n"
+                    )
+
+        logger.debug(
+            "FastDiffuser block done: CG=%d  eager=%d  total_fp=%d",
+            self._stats_cuda_graph,
+            self._stats_eager,
+            self._stats_forward_passes,
+        )
+        return logits_output, next_token_ids_list, None, None, can_run_graph
+
+
+Algorithm = FastDiffuser

--- a/python/sglang/srt/dllm/attention.py
+++ b/python/sglang/srt/dllm/attention.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sglang.srt.layers.radix_attention import AttentionType
+
+if TYPE_CHECKING:
+    from sglang.srt.dllm.config import DllmConfig
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+def get_dllm_causal_attention(
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+    dllm_config: DllmConfig | None,
+    default_causal: bool,
+) -> bool:
+    """Return DLLM causal masking while preserving non-DLLM backend defaults."""
+    if dllm_config is None or layer.attn_type != AttentionType.ENCODER_ONLY:
+        return default_causal
+    if layer.is_cross_attention:
+        return False
+    if not dllm_config.causal_context:
+        return False
+    return (
+        not forward_batch.forward_mode.is_dllm_extend()
+        or forward_batch.dllm_causal_kv_update
+    )

--- a/python/sglang/srt/dllm/config.py
+++ b/python/sglang/srt/dllm/config.py
@@ -1,7 +1,32 @@
-from typing import Any
+import logging
+from typing import TYPE_CHECKING, Any
 
-from sglang.srt.configs.model_config import ModelConfig
-from sglang.srt.server_args import ServerArgs
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def load_dllm_algorithm_config(algorithm_config_path: str | None) -> dict[str, Any]:
+    if algorithm_config_path is None:
+        return {}
+
+    try:
+        import yaml
+    except ImportError:
+        raise ImportError(
+            "Please install PyYAML to use YAML config files. " "`pip install pyyaml`"
+        )
+    with open(algorithm_config_path, "r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def should_defer_cuda_graph_capture(server_args: "ServerArgs") -> bool:
+    if server_args.dllm_algorithm != "LinearSpec":
+        return False
+
+    algorithm_config = load_dllm_algorithm_config(server_args.dllm_algorithm_config)
+    return bool(algorithm_config.get("lora_path"))
 
 
 class DllmConfig:
@@ -12,6 +37,9 @@ class DllmConfig:
         block_size: int,
         mask_id: int,
         max_running_requests: int,
+        max_steps: int,
+        causal_context: bool = False,
+        block_size_tiers: list[dict[str, int]] | None = None,
         first_done_first_out_mode: bool = False,
     ):
         self.algorithm = algorithm
@@ -19,14 +47,69 @@ class DllmConfig:
         self.block_size = block_size
         self.mask_id = mask_id
         self.max_running_requests = max_running_requests
+        self.max_steps = max_steps
         self.first_done_first_out_mode = first_done_first_out_mode
+        # Causal prefix KV for Nemotron diffusion-style instruct models.
+        # Off for bidirectional-prefix models such as LLaDA2.
+        self.causal_context = causal_context
+        self.block_size_tiers: list[dict[str, int]] | None = None
+        if block_size_tiers:
+            if algorithm != "LinearSpec":
+                raise ValueError(
+                    "block_size_tiers are only supported with LinearSpec; "
+                    f"got dllm_algorithm={algorithm}."
+                )
+            tiers = sorted(
+                (
+                    {
+                        "max_running_bs": int(t["max_running_bs"]),
+                        "block_size": int(t["block_size"]),
+                    }
+                    for t in block_size_tiers
+                ),
+                key=lambda t: t["max_running_bs"],
+            )
+            for i in range(1, len(tiers)):
+                if tiers[i]["max_running_bs"] <= tiers[i - 1]["max_running_bs"]:
+                    raise ValueError(
+                        "block_size_tiers max_running_bs must be strictly "
+                        f"ascending; got {[t['max_running_bs'] for t in tiers]}"
+                    )
+            if tiers[-1]["max_running_bs"] < max_running_requests:
+                raise ValueError(
+                    f"block_size_tiers last tier max_running_bs="
+                    f"{tiers[-1]['max_running_bs']} is below "
+                    f"max_running_requests={max_running_requests}; add a "
+                    f"catch-all tier (e.g. max_running_bs: 9999)."
+                )
+            self.block_size_tiers = tiers
+            max_tier_block = max(t["block_size"] for t in tiers)
+            if self.block_size != max_tier_block:
+                logger.warning(
+                    "DllmConfig: overriding static block_size=%d with "
+                    "max(block_size_tiers.block_size)=%d for KV pool sizing.",
+                    self.block_size,
+                    max_tier_block,
+                )
+                self.block_size = max_tier_block
+
+    def select_block_size(self, running_bs: int) -> int:
+        """Pick the block size for the current running batch size."""
+        if not self.block_size_tiers:
+            return self.block_size
+        for tier in self.block_size_tiers:
+            if running_bs <= tier["max_running_bs"]:
+                return tier["block_size"]
+        return self.block_size_tiers[-1]["block_size"]
 
     @staticmethod
     def from_server_args(
-        server_args: ServerArgs,
+        server_args: "ServerArgs",
     ):
         if server_args.dllm_algorithm is None:
             return None
+
+        from sglang.srt.configs.model_config import ModelConfig
 
         model_config = ModelConfig.from_server_args(
             server_args,
@@ -37,6 +120,8 @@ class DllmConfig:
             "LLaDA2MoeModelLM": {"block_size": 32, "mask_id": 156895},
             "SDARForCausalLM": {"block_size": 4, "mask_id": 151669},
             "SDARMoeForCausalLM": {"block_size": 4, "mask_id": 151669},
+            "DiffEncoderModel": {"block_size": 32, "mask_id": 151662},
+            "NemotronLabsDiffusionModel": {"block_size": 32, "mask_id": 100},
         }
 
         arch = model_config.hf_config.architectures[0]
@@ -47,26 +132,21 @@ class DllmConfig:
         else:
             raise RuntimeError(f"Unknown diffusion LLM: {arch}")
 
-        max_running_requests = (
-            1
-            if server_args.max_running_requests is None
-            else server_args.max_running_requests
+        algorithm_config = load_dllm_algorithm_config(server_args.dllm_algorithm_config)
+        block_size = algorithm_config.get("block_size", block_size)
+        max_steps = algorithm_config.get("max_steps", block_size)
+        causal_context = algorithm_config.get("causal_context", False)
+        block_size_tiers = algorithm_config.get("block_size_tiers", None)
+        # yaml override wins over server_args default; sync-only algorithms
+        # like FastDiffuser / LinearSpec opt out via the yaml.
+        first_done_first_out_mode = algorithm_config.get(
+            "first_done_first_out_mode", server_args.dllm_fdfo
         )
 
-        algorithm_config = {}
-        if server_args.dllm_algorithm_config is not None:
-            try:
-                import yaml
-            except ImportError:
-                raise ImportError(
-                    "Please install PyYAML to use YAML config files. "
-                    "`pip install pyyaml`"
-                )
-            with open(server_args.dllm_algorithm_config, "r") as f:
-                algorithm_config = yaml.safe_load(f)
-
-            # Parse common algorithm configurations
-            block_size = algorithm_config.get("block_size", block_size)
+        if server_args.max_running_requests is not None:
+            max_running_requests = server_args.max_running_requests
+        else:
+            max_running_requests = 1
 
         return DllmConfig(
             algorithm=server_args.dllm_algorithm,
@@ -74,5 +154,8 @@ class DllmConfig:
             block_size=block_size,
             mask_id=mask_id,
             max_running_requests=max_running_requests,
-            first_done_first_out_mode=server_args.dllm_fdfo,
+            max_steps=max_steps,
+            causal_context=causal_context,
+            block_size_tiers=block_size_tiers,
+            first_done_first_out_mode=first_done_first_out_mode,
         )

--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -4,6 +4,8 @@ import enum
 from array import array
 from typing import TYPE_CHECKING, Optional
 
+import torch
+
 from sglang.srt.dllm.config import DllmConfig
 
 if TYPE_CHECKING:
@@ -24,12 +26,20 @@ class ReqDllmMixin:
         self.dllm_algo_state = None
         self.dllm_block_offset = 0
         self.dllm_config = dllm_config
+        self.dllm_active_block_size: Optional[int] = None
 
         if self.dllm_config is not None:
-            if len(self.origin_input_ids) < self.dllm_config.block_size:
+            if self.dllm_config.causal_context:
+                self.dllm_phase = DllmReqPhase.INCOMING_PREFILL
+            elif len(self.origin_input_ids) < self.dllm_config.block_size:
                 self.dllm_phase = DllmReqPhase.INCOMING_DECODE
             else:
                 self.dllm_phase = DllmReqPhase.INCOMING_PREFILL
+
+    def _dllm_block_size(self: Req) -> int:
+        if self.dllm_active_block_size is not None:
+            return self.dllm_active_block_size
+        return self.dllm_config.block_size
 
     def is_dllm(self: Req) -> bool:
         return self.dllm_config is not None
@@ -41,18 +51,20 @@ class ReqDllmMixin:
         ]
 
     def determine_dllm_phase(self: Req):
-        if self.dllm_incomplete_ids:
-            self.dllm_phase = DllmReqPhase.STAGING_DECODE
-            return
-
+        bs = self._dllm_block_size()
         prefix_length = len(self.prefix_indices)
-        min_required_length = prefix_length + self.dllm_config.block_size
+        min_required_length = prefix_length + bs
 
         if len(self.full_untruncated_fill_ids) < min_required_length:
-            # still incoming stage
             return
 
-        input_block = self.full_untruncated_fill_ids[prefix_length:min_required_length]
+        if self.dllm_config.causal_context:
+            latest_block_start = len(self.full_untruncated_fill_ids) - bs
+            input_block = self.full_untruncated_fill_ids[latest_block_start:]
+        else:
+            input_block = self.full_untruncated_fill_ids[
+                prefix_length:min_required_length
+            ]
         is_prefill_phase = self.dllm_config.mask_id not in input_block
 
         if is_prefill_phase:
@@ -61,33 +73,78 @@ class ReqDllmMixin:
             self.dllm_phase = DllmReqPhase.STAGING_DECODE
 
     def _init_fill_ids_for_dllm(self: Req):
-        if self.dllm_incomplete_ids:
-            prefix_len = len(self.prefix_indices)
-            assert len(self.dllm_incomplete_ids) == self.dllm_config.block_size
-            self.full_untruncated_fill_ids = (
-                self.full_untruncated_fill_ids[:prefix_len] + self.dllm_incomplete_ids
+        if self.dllm_config.causal_context:
+            self.dllm_block_offset = len(self.origin_input_ids) + len(self.output_ids)
+        else:
+            self.dllm_block_offset = (
+                0
+                if not self.dllm_initialized
+                else self.dllm_block_offset + self._dllm_block_size()
             )
-            # extend_range is (re)computed by the staging adder
-            # (add_dllm_staging_req) before this req is scheduled, mirroring the
-            # non-incomplete path which also defers it to the adder.
-            return
-
-        self.dllm_block_offset = (
-            0
-            if not self.dllm_initialized
-            else self.dllm_block_offset + self.dllm_config.block_size
-        )
         self.full_untruncated_fill_ids = (
             self.origin_input_ids
             + self.output_ids
-            + array("q", [self.dllm_config.mask_id] * self.dllm_config.block_size)
+            + array("q", [self.dllm_config.mask_id] * self._dllm_block_size())
         )
         self.dllm_initialized = True
 
+    def _set_dllm_extend_range_to_fill_len(self: Req):
+        prefix_len = len(self.prefix_indices)
+        self.set_extend_range(prefix_len, len(self.full_untruncated_fill_ids))
+
+    def init_prompt_cache_input(self: Req):
+        self.full_untruncated_fill_ids = array("q", self.origin_input_ids)
+        self.prefix_indices = torch.empty((0,), dtype=torch.int64)
+        self._set_dllm_extend_range_to_fill_len()
+
+    def check_finished_stop_before_length(self: Req, new_accepted_len: int = 1):
+        if self.finished():
+            return
+
+        if self.to_finish:
+            self.finished_reason = self.to_finish
+            self.to_finish = None
+            return
+
+        if new_accepted_len <= 0:
+            return
+
+        new_accepted_tokens = self.output_ids[-new_accepted_len:]
+
+        if self._check_token_based_finish(new_accepted_tokens):
+            return
+
+        if self._check_vocab_boundary_finish(new_accepted_tokens):
+            return
+
+        if self._check_str_based_finish():
+            return
+
+        from sglang.srt.managers.schedule_batch import (
+            FINISH_LENGTH,
+            FINISH_MATCHED_TOKEN,
+        )
+
+        if len(self.output_ids) >= self.sampling_params.max_new_tokens:
+            self.finished_reason = FINISH_LENGTH(
+                length=self.sampling_params.max_new_tokens
+            )
+            self.finished_len = self.sampling_params.max_new_tokens
+            return
+
+        if self.grammar is not None and self.grammar.is_terminated():
+            self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
+
     def _update_block_offset_for_dllm(self):
         prefix_len = len(self.prefix_indices)
-        assert (
-            prefix_len % self.dllm_config.block_size == 0
-        ), f"Unexpected prefix len: {prefix_len}"
+        if (
+            not self.output_ids
+            and self.dllm_active_block_size is None
+            and prefix_len % self.dllm_config.block_size != 0
+        ):
+            raise ValueError(
+                f"DLLM prefix len {prefix_len} is not aligned to "
+                f"block_size {self.dllm_config.block_size}"
+            )
         if prefix_len > self.dllm_block_offset:
             self.dllm_block_offset = prefix_len

--- a/python/sglang/srt/dllm/mixin/schedule_batch.py
+++ b/python/sglang/srt/dllm/mixin/schedule_batch.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from itertools import chain
+from typing import Optional
+
+import torch
+
+from sglang.srt.mem_cache.allocation import alloc_for_extend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils.common import is_pin_memory_available
+
+
+class ScheduleBatchDllmMixin:
+    def prepare_for_dllm_block_extend(self, buffers: Optional[dict] = None):
+        self.forward_mode = ForwardMode.DLLM_EXTEND
+
+        reqs = self.reqs
+        bs = len(reqs)
+        device = self.device
+
+        fill_ids = [r.get_fill_ids() for r in reqs]
+        input_ids = [ids[len(r.prefix_indices) :] for ids, r in zip(fill_ids, reqs)]
+        seq_lens = [len(ids) for ids in fill_ids]
+        orig_seq_lens = [
+            max(len(r.full_untruncated_fill_ids), len(r.origin_input_ids)) for r in reqs
+        ]
+        prefix_lens = [len(r.prefix_indices) for r in reqs]
+        extend_lens = [r.extend_range.length for r in reqs]
+        input_id_lens = [len(ids) for ids in input_ids]
+        extend_num_tokens = sum(input_id_lens)
+
+        flat_input_ids = list(chain.from_iterable(input_ids))
+
+        cache = buffers
+        if (
+            cache is None
+            or cache["bs"] != bs
+            or cache["extend_num_tokens"] < extend_num_tokens
+        ):
+            pin_memory = is_pin_memory_available(device)
+            cache = {
+                "bs": bs,
+                "extend_num_tokens": extend_num_tokens,
+                "input_ids_host": torch.empty(
+                    extend_num_tokens, dtype=torch.int64, pin_memory=pin_memory
+                ),
+                "input_ids_dev": torch.empty(
+                    extend_num_tokens, dtype=torch.int64, device=device
+                ),
+                "seq_lens_host": torch.empty(
+                    bs, dtype=torch.int64, pin_memory=pin_memory
+                ),
+                "seq_lens_dev": torch.empty(bs, dtype=torch.int64, device=device),
+                "seq_lens_cpu": torch.empty(bs, dtype=torch.int64),
+                "orig_seq_lens_host": torch.empty(
+                    bs, dtype=torch.int32, pin_memory=pin_memory
+                ),
+                "orig_seq_lens_dev": torch.empty(bs, dtype=torch.int32, device=device),
+            }
+        self._dllm_block_buffers = cache
+
+        cache["input_ids_host"][:extend_num_tokens].copy_(
+            torch.tensor(flat_input_ids, dtype=torch.int64), non_blocking=False
+        )
+        cache["seq_lens_host"][:bs].copy_(
+            torch.tensor(seq_lens, dtype=torch.int64), non_blocking=False
+        )
+        cache["seq_lens_cpu"][:bs] = cache["seq_lens_host"][:bs]
+        cache["orig_seq_lens_host"][:bs].copy_(
+            torch.tensor(orig_seq_lens, dtype=torch.int32), non_blocking=False
+        )
+
+        cache["input_ids_dev"][:extend_num_tokens].copy_(
+            cache["input_ids_host"][:extend_num_tokens], non_blocking=True
+        )
+        cache["seq_lens_dev"][:bs].copy_(cache["seq_lens_host"][:bs], non_blocking=True)
+        cache["orig_seq_lens_dev"][:bs].copy_(
+            cache["orig_seq_lens_host"][:bs], non_blocking=True
+        )
+
+        self.prefix_lens = prefix_lens
+        self.extend_lens = extend_lens
+        self.seq_lens = cache["seq_lens_dev"][:bs]
+        self.seq_lens_cpu = cache["seq_lens_cpu"][:bs].clone()
+        self.extend_num_tokens = extend_num_tokens
+
+        out_cache_loc, req_pool_indices_tensor, req_pool_indices = alloc_for_extend(
+            self
+        )
+
+        for i, (req, seq_len) in enumerate(zip(reqs, seq_lens)):
+            req.req_pool_idx = req_pool_indices[i]
+            req.extend_batch_idx += 1
+            req.kv_committed_len = seq_len
+            req.kv.kv_allocated_len = seq_len
+
+        self.input_ids = cache["input_ids_dev"][:extend_num_tokens]
+        self.req_pool_indices = req_pool_indices_tensor
+        self.orig_seq_lens = cache["orig_seq_lens_dev"][:bs]
+        self.out_cache_loc = out_cache_loc
+        self.seq_lens_sum = sum(seq_lens)

--- a/python/sglang/srt/dllm/mixin/schedule_policy.py
+++ b/python/sglang/srt/dllm/mixin/schedule_policy.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+
+class PrefillAdderDllmMixin:
+    def add_dllm_prompt_cache_req(self, req):
+        from sglang.srt.managers.schedule_policy import (
+            CLIP_MAX_NEW_TOKENS,
+            AddReqResult,
+        )
+
+        total_tokens = req.extend_range.length + min(
+            max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
+            CLIP_MAX_NEW_TOKENS,
+        )
+
+        if total_tokens >= self.rem_total_tokens:
+            return AddReqResult.NO_TOKEN
+
+        input_tokens = self.ceil_paged_tokens(req.extend_range.length)
+
+        if input_tokens >= self.rem_input_tokens and len(self.can_run_list) != 0:
+            return AddReqResult.OTHER
+
+        self.can_run_list.append(req)
+        self._update_prefill_budget(
+            len(req.prefix_indices),
+            input_tokens,
+            min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS),
+            req.retracted_stain,
+        )
+        return AddReqResult.CONTINUE

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -4,13 +4,17 @@ import logging
 from array import array
 from typing import TYPE_CHECKING, List, Optional, Set, Union
 
+import torch
+
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sglang.srt.managers.scheduler_components.metrics_reporter import PrefillStats
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +23,32 @@ if TYPE_CHECKING:
 
 
 class SchedulerDllmMixin:
+    @staticmethod
+    def _truncate_dllm_tokens_for_finish(req: Req, token_ids: List[int]) -> List[int]:
+        remaining = req.sampling_params.max_new_tokens - len(req.output_ids)
+        if remaining <= 0:
+            return []
+
+        token_ids = token_ids[:remaining]
+        if req.sampling_params.ignore_eos:
+            return token_ids
+
+        stop_ids: Set[int] = set(req.sampling_params.stop_token_ids or [])
+        stop_ids.update(req.eos_token_ids or [])
+
+        tokenizer = req.tokenizer
+        if tokenizer is not None:
+            eos_token_id = getattr(tokenizer, "eos_token_id", None)
+            if eos_token_id is not None:
+                stop_ids.add(eos_token_id)
+            stop_ids.update(getattr(tokenizer, "additional_stop_token_ids", []) or [])
+
+        for i, token_id in enumerate(token_ids):
+            if token_id in stop_ids:
+                return token_ids[: i + 1]
+
+        return token_ids
+
     def init_diffusion_llm(self: Scheduler):
         self.dllm_config = (
             DllmConfig.from_server_args(self.server_args)
@@ -26,44 +56,89 @@ class SchedulerDllmMixin:
             else None
         )
         self.dllm_manager = DllmManager(dllm_config=self.dllm_config)
+        self._dllm_block_buffers: Optional[dict] = None
+        self._dllm_cached_sampling_info = None
+        self._dllm_cached_sampling_info_reqs_id: Optional[int] = None
+        self._dllm_inner_k_blocks = (
+            self.dllm_config.algorithm_config.get("inner_k_blocks", 1)
+            if self.dllm_config is not None
+            else 1
+        )
+        self._dllm_stats_skip_count = 0
+        self._dllm_tier_hist: dict[int, int] = {}
+        self._dllm_tier_blocks: int = 0
+        self._dllm_pending_tier_bs: Optional[int] = None
 
     def get_new_batch_dllm(
         self: Scheduler, running_batch: ScheduleBatch
     ) -> Optional[ScheduleBatch]:
-        """Generate a new batch for DLLM (Diffusion LLM) scheduling."""
-        if self.enable_priority_preemption:
+        """Build the next DLLM batch."""
+        if self.enable_priority_scheduling:
             running_batch.batch_is_full = False
 
-        # Early exit if batch is full or no requests available
-        if self._should_skip_prefill(running_batch=running_batch):
+        if self._should_skip_prefill(running_batch):
             return None
 
         running_bs = len(running_batch.reqs)
         self.policy.calc_priority(self.waiting_queue)
 
-        # Create prefill adder with resource constraints
-        adder = self._create_dllm_prefill_adder(running_bs, running_batch=running_batch)
+        adder = self._create_dllm_prefill_adder(running_bs, running_batch)
 
-        # Initialize DLLM manager and transfer requests
-        self.dllm_manager.init_next_round()
+        self._prepare_staging_reqs()
         self._fetch_waiting_reqs()
 
-        # Process batches
-        forward_mode = self._process_dllm_batches(adder, running_batch=running_batch)
+        forward_mode = self._process_dllm_batches(adder, running_batch)
 
         can_run_list = adder.can_run_list
         if not can_run_list:
             return None
 
-        # Record metrics and update state
         set_time_batch(can_run_list, "set_forward_entry_time")
         self._update_state_for_batch(can_run_list, adder)
 
-        # Create and prepare batch
-        new_batch = self._create_dllm_batch(
-            can_run_list, forward_mode, adder=adder, running_batch=running_batch
-        )
-        return new_batch
+        batch = self._create_dllm_batch(can_run_list, forward_mode, adder, running_batch)
+
+        pending_tier_bs = self._dllm_pending_tier_bs
+        if (
+            getattr(self.dllm_config, "block_size_tiers", None)
+            and batch is not None
+            and batch.reqs
+            and pending_tier_bs is not None
+        ):
+            batch.dllm_block_size = pending_tier_bs
+
+        if getattr(self.dllm_config, "block_size_tiers", None):
+            # Histogram reports the block_size actually dispatched (from
+            # _prepare_staging_reqs / _dllm_pending_tier_bs). Falling back to
+            # select_block_size(running_bs) here is wrong because running_bs
+            # is sampled at function entry, before the new batch is built,
+            # so it's always the *previous* batch's running count.
+            picked = (
+                pending_tier_bs
+                if pending_tier_bs is not None
+                else self.dllm_config.select_block_size(running_bs)
+            )
+            dispatched_bs = (
+                batch.batch_size() if batch is not None and batch.reqs else 0
+            )
+            self._dllm_tier_hist[picked] = self._dllm_tier_hist.get(picked, 0) + 1
+            self._dllm_tier_blocks += 1
+            if self._dllm_tier_blocks % 200 == 0:
+                tot = self._dllm_tier_blocks
+                breakdown = ", ".join(
+                    f"bs={k}: {v} ({v / tot * 100:.1f}%)"
+                    for k, v in sorted(self._dllm_tier_hist.items())
+                )
+                logger.info(
+                    "DLLM TIER POLICY (%d blocks): %s "
+                    "[last batch_size=%d -> block_size=%d]",
+                    tot,
+                    breakdown,
+                    dispatched_bs,
+                    picked,
+                )
+
+        return batch
 
     def process_batch_result_dllm(
         self: Scheduler,
@@ -73,133 +148,218 @@ class SchedulerDllmMixin:
         if result.copy_done is not None:
             result.copy_done.synchronize()
 
-        fdfo_mode = self.dllm_config.first_done_first_out_mode
-        assert (
-            not fdfo_mode or result.accept_length_per_req_cpu is not None
-        ), "FDFO dLLM result is missing accept lengths."
+        if not batch.forward_mode.is_dllm_extend():
+            self.metrics_reporter.report_prefill_stats(
+                batch=batch,
+                prefill_stats=batch.prefill_stats,
+                can_run_cuda_graph=False,
+                dp_cooperation_info=batch.dp_cooperation_info,
+            )
+            return
 
-        # Sync mode emits tokens only once a block fully resolves; FDFO always
-        # commits (resolved blocks decode, unresolved blocks stash + free KV).
-        if fdfo_mode or result.next_token_ids:
-            block_size = self.dllm_config.block_size
-            algo_states = result.dllm_algo_state
-
+        if result.next_token_ids:
             self.token_to_kv_pool_allocator.free_group_begin()
+
             for idx in range(batch.batch_size()):
                 req = batch.reqs[idx]
 
-                if not fdfo_mode:
-                    next_token_ids = result.next_token_ids[idx].tolist()
-                    new_tokens = len(next_token_ids)
-                    if new_tokens == 0:
-                        continue
-
-                    req.full_untruncated_fill_ids[
-                        req.extend_range.end - new_tokens : req.extend_range.end
-                    ] = array("q", next_token_ids)
-                    self.metrics_reporter.num_generated_tokens += new_tokens
-
-                    req.output_ids.extend(next_token_ids)
-                    req.update_finish_state(new_accepted_len=new_tokens)
-
-                    if req.finished():
-                        release_kv_cache(req, self.tree_cache)
-                        req.time_stats.set_completion_time()
+                next_token_ids = result.next_token_ids[idx].tolist()
+                next_token_ids = self._truncate_dllm_tokens_for_finish(
+                    req, next_token_ids
+                )
+                new_tokens = len(next_token_ids)
+                block_bs = (
+                    req.dllm_active_block_size
+                    if req.dllm_active_block_size is not None
+                    else self.dllm_config.block_size
+                )
+                if new_tokens == 0:
+                    # No accepted tokens: release the speculative block now.
+                    rejected = block_bs
+                    free_start = req.kv_committed_len - rejected
+                    free_end = req.kv_committed_len
+                    free_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, free_start:free_end
+                    ]
+                    self.token_to_kv_pool_allocator.free(free_indices)
+                    req.kv_committed_len = free_start
+                    req.kv.kv_allocated_len = free_start
                     continue
 
-                next_token_ids = result.next_token_ids[idx]
-                assert len(next_token_ids) == block_size
-
-                if result.accept_length_per_req_cpu[idx] == 0:
-                    # Block unresolved: stash partial state and free the KV slots
-                    # of the still-masked block so the next FDFO round can
-                    # re-denoise it without leaking the previous allocation.
-                    req.dllm_incomplete_ids = array("q", next_token_ids)
-                    req.dllm_algo_state = (
-                        algo_states[idx] if algo_states is not None else None
-                    )
-                    old_prefix_len = len(req.prefix_indices)
-                    new_fill_len = req.extend_range.end
-                    if new_fill_len > old_prefix_len:
-                        kv_indices_to_free = self.req_to_token_pool.req_to_token[
-                            req.req_pool_idx, old_prefix_len:new_fill_len
-                        ]
-                        self.token_to_kv_pool_allocator.free(kv_indices_to_free)
-                    continue
-
-                req.dllm_incomplete_ids = array("q")
-                req.dllm_algo_state = None
-
-                # Mirror the resolved block into the committed fill ids so the
-                # prefix cache keys on the real tokens, not the mask block, next
-                # round. Index relative to extend_range.end (the truncated/
-                # committed length), which can be shorter than
-                # full_untruncated_fill_ids when the staging adder truncates the
-                # block to the KV budget.
                 req.full_untruncated_fill_ids[
-                    req.extend_range.end - block_size : req.extend_range.end
+                    req.extend_range.end - new_tokens : req.extend_range.end
                 ] = array("q", next_token_ids)
+                self.metrics_reporter.num_generated_tokens += new_tokens
 
-                len_input = len(req.origin_input_ids)
-                len_fill = req.extend_range.end
-                if len_fill <= len_input:
-                    continue
-
-                if len_fill - len(next_token_ids) < len_input:
-                    next_token_ids = next_token_ids[len_input - len_fill :]
-
-                self.metrics_reporter.num_generated_tokens += len(next_token_ids)
                 req.output_ids.extend(next_token_ids)
-                req.update_finish_state(new_accepted_len=len(next_token_ids))
+
+                if new_tokens < block_bs:
+                    rejected = block_bs - new_tokens
+                    free_start = req.kv_committed_len - rejected
+                    free_end = req.kv_committed_len
+                    free_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, free_start:free_end
+                    ]
+                    self.token_to_kv_pool_allocator.free(free_indices)
+                    req.kv_committed_len = free_start
+                    req.kv.kv_allocated_len = free_start
+
+                req.check_finished_stop_before_length(new_accepted_len=new_tokens)
 
                 if req.finished():
-                    release_kv_cache(req, self.tree_cache)
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
                     req.time_stats.set_completion_time()
 
-            self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
+            need_stream = any(
+                r.finished() or getattr(r, "stream", False) for r in batch.reqs
+            )
+            if need_stream:
+                self.output_streamer.stream_output(batch.reqs, batch.return_logprob)
+
             self.token_to_kv_pool_allocator.free_group_end()
 
-        self.metrics_reporter.report_prefill_stats(
-            batch=batch,
-            prefill_stats=batch.prefill_stats,
-            can_run_cuda_graph=result.can_run_cuda_graph,
-            dp_cooperation_info=batch.dp_cooperation_info,
-        )
+        can_run_cuda_graph = getattr(result, "can_run_cuda_graph", False)
+        should_report_stats = True
+        if (
+            batch.forward_mode.is_dllm_extend()
+            and not self.metrics_reporter.current_scheduler_metrics_enabled
+        ):
+            self._dllm_stats_skip_count += 1
+            should_report_stats = self._dllm_stats_skip_count >= 20
+            if should_report_stats:
+                self._dllm_stats_skip_count = 0
+
+        if should_report_stats:
+            self.metrics_reporter.report_prefill_stats(
+                batch=batch,
+                prefill_stats=batch.prefill_stats,
+                can_run_cuda_graph=can_run_cuda_graph,
+                dp_cooperation_info=batch.dp_cooperation_info,
+            )
+
+
+    def maybe_run_dllm_inner_loop(self: Scheduler, batch: ScheduleBatch) -> None:
+        inner_k = getattr(self, "_dllm_inner_k_blocks", 1)
+        if (
+            inner_k > 1
+            and self.dllm_config is not None
+            and batch.forward_mode == ForwardMode.DLLM_EXTEND
+            and batch.batch_size() == 1
+            and not batch.reqs[0].finished()
+            and not self.waiting_queue
+            and len(self.dllm_manager.waiting_queue) == 1
+        ):
+            self._dllm_run_inner_k_blocks(batch, inner_k - 1)
+
+    def _dllm_run_inner_k_blocks(self: Scheduler, batch: ScheduleBatch, k: int) -> None:
+        """Run extra single-request DLLM_EXTEND blocks in place."""
+        if not batch.forward_mode.is_dllm_extend() or batch.batch_size() != 1:
+            raise RuntimeError(
+                "_dllm_run_inner_k_blocks called with invalid batch state: "
+                f"forward_mode={batch.forward_mode}, "
+                f"batch_size={batch.batch_size()}"
+            )
+        req = batch.reqs[0]
+        for _ in range(k):
+            self._set_active_block_size_for(batch)
+            req.init_next_round_input()
+            if req.req_pool_idx is not None and req.kv_committed_len > 0:
+                kv_len = req.kv_committed_len
+                req.prefix_indices = self.req_to_token_pool.req_to_token[
+                    req.req_pool_idx, :kv_len
+                ].to(torch.int64)
+                req.determine_dllm_phase()
+                req._set_dllm_extend_range_to_fill_len()
+
+            batch.prepare_for_dllm_block_extend(buffers=self._dllm_block_buffers)
+            self._dllm_block_buffers = getattr(batch, "_dllm_block_buffers", None)
+            batch.forward_mode = ForwardMode.DLLM_EXTEND
+            batch.decoding_reqs = None
+
+            result = self.run_batch(batch)
+            self.process_batch_result(batch, result)
+
+            if req.finished():
+                break
+
+    def _set_active_block_size_for(self: Scheduler, batch: ScheduleBatch) -> None:
+        if not getattr(self.dllm_config, "block_size_tiers", None):
+            return
+        running_bs = max(1, batch.batch_size())
+        bs = self.dllm_config.select_block_size(running_bs)
+        batch.dllm_block_size = bs
+        for req in batch.reqs:
+            req.dllm_active_block_size = bs
+
+    def _prepare_staging_reqs(self: Scheduler) -> None:
+        if getattr(self.dllm_config, "block_size_tiers", None):
+            staging_set = set(id(r) for r in self.dllm_manager.staging_queue)
+            decode_reqs = [
+                r
+                for r in self.dllm_manager.waiting_queue
+                if getattr(r, "dllm_phase", None)
+                in (DllmReqPhase.STAGING_DECODE, DllmReqPhase.INCOMING_DECODE)
+                or id(r) in staging_set
+            ]
+            running_bs = max(1, len(decode_reqs))
+            tier_bs = self.dllm_config.select_block_size(running_bs)
+            self._dllm_pending_tier_bs = tier_bs
+            for req in decode_reqs:
+                old_bs = req.dllm_active_block_size
+                req.dllm_active_block_size = tier_bs
+                if (
+                    id(req) not in staging_set
+                    and req.dllm_phase == DllmReqPhase.STAGING_DECODE
+                    and old_bs != tier_bs
+                ):
+                    req.init_next_round_input()
+                    if req.req_pool_idx is not None and req.kv_committed_len > 0:
+                        kv_len = req.kv_committed_len
+                        req.prefix_indices = self.req_to_token_pool.req_to_token[
+                            req.req_pool_idx, :kv_len
+                        ].to(torch.int64)
+                        req.determine_dllm_phase()
+                        req._set_dllm_extend_range_to_fill_len()
+        for req in self.dllm_manager.staging_queue:
+            req.init_next_round_input()
+            if req.req_pool_idx is not None and req.kv_committed_len > 0:
+                kv_len = req.kv_committed_len
+                # The Triton writer reads prefix tensors as int64.
+                req.prefix_indices = self.req_to_token_pool.req_to_token[
+                    req.req_pool_idx, :kv_len
+                ].to(torch.int64)
+                req.determine_dllm_phase()
+                req._set_dllm_extend_range_to_fill_len()
+        self.dllm_manager.staging_queue = []
 
     def _fetch_waiting_reqs(self: Scheduler):
-        # Calculate how many requests can be added to DLLM manager
         max_dllm_capacity = self.dllm_config.max_running_requests - len(
             self.dllm_manager.waiting_queue
         )
         num_requests_to_add = min(max_dllm_capacity, len(self.waiting_queue))
-
         if num_requests_to_add > 0:
             requests_to_add = self.waiting_queue[:num_requests_to_add]
             self.dllm_manager.add_waiting_reqs(requests_to_add)
             self.waiting_queue = self.waiting_queue[num_requests_to_add:]
 
     def _should_skip_prefill(self: Scheduler, running_batch: ScheduleBatch) -> bool:
-        """Check if DLLM prefill should be skipped."""
         if (
             running_batch.batch_is_full or not self.waiting_queue
         ) and self.dllm_manager.is_empty():
             return True
-
         running_bs = len(running_batch.reqs)
         if (
             self.get_num_allocatable_reqs(running_bs) <= 0
             and self.dllm_manager.is_empty()
-            and not self.enable_priority_preemption
+            and not self.enable_priority_scheduling
         ):
             running_batch.batch_is_full = True
             return True
-
         return False
 
     def _create_dllm_prefill_adder(
         self: Scheduler, running_bs: int, running_batch: ScheduleBatch
     ) -> PrefillAdder:
-        """Create a prefill adder configured for DLLM scheduling."""
         return PrefillAdder(
             self.page_size,
             self.tree_cache,
@@ -217,10 +377,15 @@ class SchedulerDllmMixin:
     def _process_dllm_batches(
         self: Scheduler, adder: PrefillAdder, running_batch: ScheduleBatch
     ) -> ForwardMode:
-        """Process prefill or decode batches for DLLM."""
-        forward_mode = ForwardMode.DLLM_EXTEND
+        incoming_prefill = [
+            req
+            for req in self.dllm_manager.waiting_queue
+            if req.dllm_phase == DllmReqPhase.INCOMING_PREFILL
+        ]
+        if incoming_prefill:
+            self._process_incoming_prefill_reqs(adder, incoming_prefill)
+            return ForwardMode.EXTEND
 
-        # Try prefill batch first
         prefill_reqs = self.dllm_manager.get_prefill_requests()
         if prefill_reqs:
             self._process_batch_by_phase(
@@ -231,7 +396,6 @@ class SchedulerDllmMixin:
                 running_batch=running_batch,
             )
         else:
-            # Fall back to decode batch
             decode_reqs = self.dllm_manager.get_decode_requests()
             self._process_batch_by_phase(
                 adder,
@@ -241,7 +405,32 @@ class SchedulerDllmMixin:
                 running_batch=running_batch,
             )
 
-        return forward_mode
+        return ForwardMode.DLLM_EXTEND
+
+    def _process_incoming_prefill_reqs(
+        self: Scheduler, adder: PrefillAdder, reqs: List[Req]
+    ) -> None:
+        for req in reqs:
+            running_bs = len(self.running_batch.reqs)
+            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
+                self.running_batch.batch_is_full = True
+
+            if self.running_batch.batch_is_full:
+                if (
+                    not self.enable_priority_scheduling
+                    or not adder.preempt_to_schedule(req, self.server_args)
+                ):
+                    break
+
+            req.init_prompt_cache_input()
+            if req.last_node is None and hasattr(self.tree_cache, "root_node"):
+                req.last_node = self.tree_cache.root_node
+            res = adder.add_dllm_prompt_cache_req(req)
+
+            if res != AddReqResult.CONTINUE:
+                if res == AddReqResult.NO_TOKEN:
+                    self.running_batch.batch_is_full = True
+                break
 
     def _process_batch_by_phase(
         self,
@@ -251,11 +440,10 @@ class SchedulerDllmMixin:
         incoming_phase: DllmReqPhase,
         running_batch: ScheduleBatch,
     ) -> None:
-        """Process a batch, separating staging and incoming requests."""
         staging_reqs = [req for req in batch if req.dllm_phase == staging_phase]
         if staging_reqs:
-            staging_result = self.process_dllm_staging_reqs(adder, staging_reqs)
-            if staging_result != AddReqResult.CONTINUE:
+            result = self.process_dllm_staging_reqs(adder, staging_reqs)
+            if result != AddReqResult.CONTINUE:
                 return
 
         incoming_reqs = [req for req in batch if req.dllm_phase == incoming_phase]
@@ -267,8 +455,6 @@ class SchedulerDllmMixin:
     def _update_state_for_batch(
         self: Scheduler, can_run_list: List[Req], adder: PrefillAdder
     ) -> None:
-        """Update state for the batch."""
-
         if adder.preempt_list:
             for req in adder.preempt_list:
                 self._add_request_to_queue(req)
@@ -284,7 +470,6 @@ class SchedulerDllmMixin:
         adder: PrefillAdder,
         running_batch: ScheduleBatch,
     ) -> ScheduleBatch:
-        """Create and prepare a new DLLM batch."""
         new_batch = ScheduleBatch.init_new(
             can_run_list,
             self.req_to_token_pool,
@@ -295,17 +480,39 @@ class SchedulerDllmMixin:
             self.spec_algorithm,
             dllm_config=self.dllm_config,
         )
-        new_batch.prepare_for_extend()
+
+        if forward_mode == ForwardMode.DLLM_EXTEND:
+            new_batch.prepare_for_dllm_block_extend(
+                buffers=self._dllm_block_buffers,
+            )
+            self._dllm_block_buffers = getattr(new_batch, "_dllm_block_buffers", None)
+
+            reqs_signature = tuple(id(r) for r in can_run_list)
+            if (
+                self._dllm_cached_sampling_info is not None
+                and self._dllm_cached_sampling_info_reqs_id == reqs_signature
+            ):
+                new_batch.sampling_info = self._dllm_cached_sampling_info
+                penalizer_orchestrator = new_batch.sampling_info.penalizer_orchestrator
+                if penalizer_orchestrator is not None:
+                    penalizer_orchestrator.batch = new_batch
+            else:
+                new_batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
+                    new_batch,
+                    self.model_config.vocab_size,
+                )
+                self._dllm_cached_sampling_info = new_batch.sampling_info
+                self._dllm_cached_sampling_info_reqs_id = reqs_signature
+        else:
+            new_batch.prepare_for_extend()
+
         new_batch.forward_mode = forward_mode
         new_batch.decoding_reqs = None
 
-        # Record prefill stats for logging after forward
-        from sglang.srt.managers.scheduler_components.metrics_reporter import (
-            PrefillStats,
-        )
-
         new_batch.prefill_stats = PrefillStats.from_adder(
-            adder, running_batch.reqs, self.enable_priority_scheduling
+            adder,
+            running_batch.reqs,
+            getattr(self, "enable_priority_scheduling", False),
         )
 
         return new_batch
@@ -316,23 +523,22 @@ class SchedulerDllmMixin:
         reqs: List[Req],
         running_batch: ScheduleBatch,
     ) -> AddReqResult:
-        """Process incoming DLLM requests with resource allocation and preemption."""
         res = AddReqResult.CONTINUE
+        pending_tier_bs = self._dllm_pending_tier_bs
         for req in reqs:
-            # Check if batch is full
-            running_bs = len(running_batch.reqs)
+            running_bs = len(self.running_batch.reqs)
             if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
                 running_batch.batch_is_full = True
 
-            # Try preemption if batch is full
-            if running_batch.batch_is_full:
+            if self.running_batch.batch_is_full:
                 if (
-                    not self.enable_priority_preemption
+                    not self.enable_priority_scheduling
                     or not adder.preempt_to_schedule(req, self.server_args)
                 ):
                     break
 
-            # Prepare and add request
+            if pending_tier_bs is not None:
+                req.dllm_active_block_size = pending_tier_bs
             req.init_next_round_input(self.tree_cache)
             res = adder.add_one_req(
                 req,
@@ -350,23 +556,15 @@ class SchedulerDllmMixin:
     def process_dllm_staging_reqs(
         self: Scheduler, adder: PrefillAdder, reqs: List[Req]
     ) -> AddReqResult:
-        """Process staging DLLM requests with resource allocation."""
         for req in reqs:
             res = adder.add_dllm_staging_req(req)
             if res == AddReqResult.NO_TOKEN:
                 return res
-
         return AddReqResult.CONTINUE
 
 
 class DllmManager:
-    """
-    Manager for Diffusion LLM request scheduling.
-
-    Maintains two queues:
-    - waiting_queue: The requests waiting to be scheduled with max running requests limit
-    - staging_queue: Requests allocated resources by PrefillAdder
-    """
+    """Tracks active DLLM requests between scheduler rounds."""
 
     def __init__(self, dllm_config: Optional[DllmConfig] = None):
         self.dllm_config = dllm_config
@@ -377,57 +575,38 @@ class DllmManager:
         self.staging_queue: List[Req] = []
 
     def get_prefill_requests(self) -> List[Req]:
-        """Get all prefill requests from waiting queue."""
         return [req for req in self.waiting_queue if req.is_dllm_prefill()]
 
     def get_decode_requests(self) -> List[Req]:
-        """Get all decode requests from waiting queue."""
         return [req for req in self.waiting_queue if not req.is_dllm_prefill()]
 
     def add_waiting_reqs(self, reqs: Union[Req, List[Req]]) -> None:
-        """Add requests to waiting queue with redundancy check."""
-        assert self.dllm_config is not None, "Diffusion LLM config is not set."
-
+        assert self.dllm_config is not None
         reqs_to_add = reqs if isinstance(reqs, list) else [reqs]
-
-        # Check for duplicate request IDs
         if self._has_duplicate_reqs(reqs_to_add):
             raise RuntimeError("Redundant requests detected in dLLM requests.")
-
         self.waiting_queue.extend(reqs_to_add)
 
     def add_staging_reqs(self, reqs: Union[Req, List[Req]]) -> None:
-        """Add requests to staging queue (allocated by PrefillAdder)."""
         reqs_to_add = reqs if isinstance(reqs, list) else [reqs]
         self.staging_queue.extend(reqs_to_add)
 
     def _has_duplicate_reqs(self, reqs: List[Req]) -> bool:
-        """Check if any request ID already exists in waiting queue."""
         existing_rids: Set[str] = {r.rid for r in self.waiting_queue}
         return any(req.rid in existing_rids for req in reqs)
 
     def any_staging_reqs(self) -> bool:
-        """Check if there are requests in staging queue."""
         return self.dllm_config is not None and len(self.staging_queue) > 0
 
     def is_empty(self) -> bool:
-        """Check if both queues are empty or DLLM is not configured."""
         if self.dllm_config is None:
             return True
         return len(self.waiting_queue) == 0
 
     def increment_inflight_middle_chunks(self) -> None:
-        """Increment chunked count for all staging requests."""
         for req in self.staging_queue:
             req.inflight_middle_chunks += 1
 
     def filter_finished_reqs(self) -> None:
-        """Remove finished requests from both queues."""
         self.waiting_queue = [req for req in self.waiting_queue if not req.finished()]
         self.staging_queue = [req for req in self.staging_queue if not req.finished()]
-
-    def init_next_round(self) -> None:
-        """Initialize staging requests for next round and clear staging queue."""
-        for req in self.staging_queue:
-            req.init_next_round_input()
-        self.staging_queue = []

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -23,6 +23,7 @@ from sglang.kernels.ops.attention.utils import (
     assert_buffer_fits,
     create_flashinfer_kv_indices_triton,
 )
+from sglang.srt.dllm.attention import get_dllm_causal_attention
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -203,6 +204,7 @@ def fast_prefill_plan(
     o_data_type: Optional[Union[str, torch.dtype]] = None,
     non_blocking: bool = True,
     fixed_split_size: Optional[int] = None,
+    disable_split_kv: bool = False,
     prefix_len_ptr: Optional[torch.Tensor] = None,
     token_pos_in_items_ptr: Optional[torch.Tensor] = None,
     token_pos_in_items_len: int = 0,
@@ -291,7 +293,7 @@ def fast_prefill_plan(
         causal,
         window_left,
         fixed_split_size if fixed_split_size is not None else -1,
-        False,  # disable_split_kv
+        disable_split_kv,
         0,  # num_colocated_ctas
     ]
     self._plan_info = self._cached_module.plan(*args)
@@ -479,9 +481,10 @@ class FlashInferAttnBackend(AttentionBackend):
 
         fmha_backend = "auto"
         if is_sm100_supported():
-            # Disable CUTLASS backend when piecewise cuda graph is enabled
-            # due to TMA descriptor initialization issues on SM100 GPUs.
-            if not check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE):
+            if (
+                not check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
+                and not self.is_dllm_model
+            ):
                 fmha_backend = "cutlass"
         self.prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
             self.workspace_buffer, "NHD", backend=fmha_backend
@@ -714,19 +717,17 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
 
-        if (
-            spec_info is not None
-            and spec_info.ragged_verify_layout is not None
-            and forward_mode.is_target_verify()
-        ):
-            raise NotImplementedError(
-                "FlashInfer does not support ragged verify in cuda graph; "
-                "disable SGLANG_RAGGED_VERIFY_MODE for this configuration."
-            )
+        dllm_causal = getattr(forward_batch, "dllm_causal_kv_update", False)
 
         if in_capture:
             num_tokens = forward_batch.positions.numel()
-            self._prepare_cuda_graph_metadata(bs, num_tokens, forward_mode, spec_info)
+            self._prepare_cuda_graph_metadata(
+                bs,
+                num_tokens,
+                forward_mode,
+                spec_info,
+                dllm_causal=dllm_causal,
+            )
 
         if forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
@@ -753,16 +754,32 @@ class FlashInferAttnBackend(AttentionBackend):
                 spec_info=spec_info,
             )
         elif forward_mode.is_dllm_extend():
+            block_size = (
+                getattr(forward_batch, "dllm_block_size", None)
+                or self.dllm_config.block_size
+            )
+            metadata_key = (
+                f"causal_{bs}_bs{block_size}" if dllm_causal else f"{bs}_bs{block_size}"
+            )
+            prefix_lens = seq_lens - block_size
+            if in_capture:
+                max_pool_len = self.indices_updater_prefill.req_to_token.shape[1]
+                capture_prefix_len = min(8192, max(0, max_pool_len - block_size))
+                seq_lens = torch.full_like(seq_lens, capture_prefix_len + block_size)
+                seq_lens_cpu = seq_lens.cpu()
+                seq_lens_sum = int(seq_lens.sum().item())
+                prefix_lens = torch.full_like(seq_lens, capture_prefix_len)
             self.indices_updater_prefill.update(
                 req_pool_indices[:bs],
                 seq_lens[:bs],
                 seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
                 seq_lens_sum,
-                prefix_lens=seq_lens - self.dllm_config.block_size,
-                prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
+                prefix_lens=prefix_lens[:bs],
+                prefill_wrappers=self.prefill_cuda_graph_metadata[metadata_key],
                 use_ragged=not self.use_paged,
                 encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
                 spec_info=None,
+                disable_split_kv=True,
             )
         elif forward_mode.is_draft_extend_v2():
             self.indices_updater_prefill.update(
@@ -981,10 +998,9 @@ class FlashInferAttnBackend(AttentionBackend):
                 # Use new backend-specific implementation
                 multi_item_params = self._process_multi_item_scoring(forward_batch)
 
-            self._prepare_dequant_workspace_metadata_for_extend(
-                forward_batch, use_ragged
+            dllm_disable_split_kv = (
+                self.is_dllm_model and forward_batch.forward_mode.is_dllm_extend()
             )
-
             self.indices_updater_prefill.update(
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
@@ -999,7 +1015,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=forward_batch.cross_attention_custom_mask,
                 extend_prefix_lens_cpu=forward_batch.extend_prefix_lens_cpu,
-                custom_kv_indices=self.dq_page_table,
+                disable_split_kv=dllm_disable_split_kv,
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrappers_paged,
@@ -1213,6 +1229,7 @@ class FlashInferAttnBackend(AttentionBackend):
         num_tokens: int,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
+        dllm_causal: bool = False,
     ) -> None:
         if forward_mode.is_decode_or_idle():
             decode_wrappers = self._create_decode_wrappers(bs, num_tokens)
@@ -1225,7 +1242,20 @@ class FlashInferAttnBackend(AttentionBackend):
                 and getattr(spec_info, "custom_mask", None) is not None
             )
             prefill_wrappers = self._create_prefill_wrappers(bs, use_custom_mask)
-            self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
+            if forward_mode.is_dllm_extend():
+                block_size = (
+                    max(1, num_tokens // bs)
+                    if num_tokens and bs
+                    else self.dllm_config.block_size
+                )
+                metadata_key = (
+                    f"causal_{bs}_bs{block_size}"
+                    if dllm_causal
+                    else f"{bs}_bs{block_size}"
+                )
+            else:
+                metadata_key = bs
+            self.prefill_cuda_graph_metadata[metadata_key] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(
                 prefill_wrappers, forward_mode.is_dllm_extend(), False
             )
@@ -1305,9 +1335,14 @@ class FlashInferAttnBackend(AttentionBackend):
                     *self._kv_write_scales(layer),
                 )
 
-            causal = (
-                not layer.is_cross_attention
-                and layer.attn_type != AttentionType.ENCODER_ONLY
+            causal = get_dllm_causal_attention(
+                layer,
+                forward_batch,
+                self.dllm_config,
+                default_causal=(
+                    not layer.is_cross_attention
+                    and layer.attn_type != AttentionType.ENCODER_ONLY
+                ),
             )
             o = prefill_wrapper_paged.forward(
                 q.view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -1350,6 +1385,12 @@ class FlashInferAttnBackend(AttentionBackend):
                 or layer.attn_type == AttentionType.ENCODER_ONLY
             ):
                 causal = False
+            causal = get_dllm_causal_attention(
+                layer,
+                forward_batch,
+                self.dllm_config,
+                default_causal=causal,
+            )
             if not self.is_dllm_model and layer.attn_type == AttentionType.ENCODER_ONLY:
                 save_kv_cache = False
 
@@ -1367,6 +1408,21 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
 
             else:
+                if not self.is_dllm_model:
+                    causal = True
+
+                pdl_kwargs = {}
+                if self.is_dllm_model:
+                    import inspect as _inspect
+
+                    if (
+                        "enable_pdl"
+                        in _inspect.signature(
+                            self.prefill_wrapper_ragged.forward_return_lse
+                        ).parameters
+                    ):
+                        pdl_kwargs["enable_pdl"] = False
+
                 swa_window_left = (
                     layer.sliding_window_size
                     if not (
@@ -1383,6 +1439,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     sm_scale=layer.scaling,
                     window_left=swa_window_left,
                     logits_soft_cap=logits_soft_cap,
+                    **pdl_kwargs,
                 )
                 o2, s2 = prefill_wrapper_paged.forward_return_lse(
                     q.view(-1, layer.tp_q_head_num, layer.head_dim),
@@ -1391,6 +1448,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     sm_scale=layer.scaling,
                     window_left=swa_window_left,
                     logits_soft_cap=logits_soft_cap,
+                    **pdl_kwargs,
                 )
 
                 o, _ = _safe_merge_state(o1, s1, o2, s2)
@@ -1791,7 +1849,7 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         extend_prefix_lens_cpu: Optional[List[int]] = None,
-        custom_kv_indices: Optional[torch.Tensor] = None,
+        disable_split_kv: bool = False,
     ):
         # Keep the signature for type checking. It will be assigned during runtime.
         raise NotImplementedError()
@@ -1811,7 +1869,7 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         extend_prefix_lens_cpu: Optional[List[int]] = None,
-        custom_kv_indices: Optional[torch.Tensor] = None,
+        disable_split_kv: bool = False,
     ):
         if use_ragged:
             assert prefix_lens is not None
@@ -1841,7 +1899,7 @@ class FlashInferIndicesUpdaterPrefill:
             fixed_split_size=fixed_split_size,
             multi_item_params=multi_item_params,
             seq_lens_cpu=seq_lens_cpu,
-            custom_kv_indices=custom_kv_indices,
+            disable_split_kv=disable_split_kv,
         )
 
     def update_sliding_window(
@@ -1859,7 +1917,7 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         extend_prefix_lens_cpu: Optional[List[int]] = None,
-        custom_kv_indices: Optional[torch.Tensor] = None,
+        disable_split_kv: bool = False,
     ):
         if custom_kv_indices is not None:
             raise RuntimeError(
@@ -1927,6 +1985,7 @@ class FlashInferIndicesUpdaterPrefill:
                 fixed_split_size=fixed_split_size,
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=swa_paged_custom_mask,
+                disable_split_kv=disable_split_kv,
             )
 
     def _build_swa_prefix_custom_mask(
@@ -1985,7 +2044,7 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         extend_prefix_lens_cpu: Optional[List[int]] = None,
-        custom_kv_indices: Optional[torch.Tensor] = None,
+        disable_split_kv: bool = False,
     ):
         if custom_kv_indices is not None:
             raise RuntimeError(
@@ -2021,6 +2080,7 @@ class FlashInferIndicesUpdaterPrefill:
                 cross_attention_custom_mask=(
                     cross_attention_custom_mask if wrapper_id == 1 else None
                 ),
+                disable_split_kv=disable_split_kv,
             )
 
     def call_begin_forward(
@@ -2042,6 +2102,7 @@ class FlashInferIndicesUpdaterPrefill:
         multi_item_params: Optional[MultiItemScoringParams] = None,
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
         seq_lens_cpu: Optional[torch.Tensor] = None,
+        disable_split_kv: bool = False,
         custom_kv_indices: Optional[torch.Tensor] = None,
     ):
         bs = len(seq_lens)
@@ -2192,6 +2253,7 @@ class FlashInferIndicesUpdaterPrefill:
             custom_mask=use_custom_mask,
             non_blocking=True,
             fixed_split_size=fixed_split_size,
+            disable_split_kv=disable_split_kv,
             prefix_len_ptr=prefix_len_ptr,
             token_pos_in_items_ptr=token_pos_in_items_ptr,
             token_pos_in_items_len=token_pos_in_items_len,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -69,6 +69,7 @@ from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
 )
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.dllm.mixin.req import ReqDllmMixin
+from sglang.srt.dllm.mixin.schedule_batch import ScheduleBatchDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_evict_dsv4_state,
@@ -1800,7 +1801,7 @@ def _compute_chunked_req_next_prompt_token(
 
 
 @dataclasses.dataclass
-class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+class ScheduleBatch(ScheduleBatchDllmMixin, ScheduleBatchDisaggregationDecodeMixin):
     """Store all information of a batch on the scheduler."""
 
     # === Core: request list (ForwardBatch derives lora_ids / rids / grammars / positions from it) ===
@@ -1940,6 +1941,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # Diffusion LLM
     dllm_config: Optional[DllmConfig] = None
+    dllm_block_size: Optional[int] = None
 
     # === Host metadata crossing to ForwardBatch (CPU lists / mirrors) ===
     seq_lens_cpu: torch.Tensor = None  # shape: [b], int64
@@ -2221,8 +2223,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
             # If input_embeds are available, store them
             if req.input_embeds is not None:
-                # Slice to match extend_input_len — PrefillAdder truncates
-                # fill_len/extend_input_len on chunk overflow but not input_embeds.
+                # Slice to match PrefillAdder truncation.
                 input_embeds.extend(
                     req.input_embeds[pre_len : pre_len + req.extend_range.length]
                 )

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 import torch
 
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.dllm.mixin.schedule_policy import PrefillAdderDllmMixin
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_in_seq_split
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
@@ -438,7 +439,7 @@ class AddReqResult(Enum):
     OTHER = auto()  # Other reasons to stop adding requests
 
 
-class PrefillAdder:
+class PrefillAdder(PrefillAdderDllmMixin):
     def __init__(
         self,
         page_size: int,
@@ -739,14 +740,9 @@ class PrefillAdder:
         return _rem_tokens
 
     def _add_dllm_req(self, req: Req, prefix_len: int):
-        # FIXME: consider the case when rem_dllm_tokens < dllm_block_size,
-        # the diffusion unmask process may have some problems
-        # Make sure at least one page is available
-        trunc_len = (
-            min(self.rem_dllm_tokens, self.dllm_block_size)
-            // self.page_size
-            * self.page_size
-        )
+        # DLLM block_size (e.g. 32) is smaller than page_size (e.g. 64),
+        # so do NOT floor-divide by page_size or trunc_len becomes 0.
+        trunc_len = min(self.rem_dllm_tokens, self.dllm_block_size)
 
         req.set_extend_range(prefix_len, prefix_len + trunc_len)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1523,6 +1523,7 @@ class Scheduler(
             if batch:
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
+                self.maybe_run_dllm_inner_loop(batch)
             else:
                 # When the server is idle, do self-check and re-init some states.
                 self.on_idle()
@@ -2683,13 +2684,10 @@ class Scheduler(
 
         if self.dllm_config is not None and self.dllm_manager.any_staging_reqs():
             chunked_req_to_exclude.update(self.dllm_manager.staging_queue)
-            for req in self.dllm_manager.staging_queue:
-                if self.dllm_config.first_done_first_out_mode:
-                    if not req.dllm_incomplete_ids:
-                        self.stash_chunked_request(req)
-                    self.req_to_token_pool.free(req)
-                else:
-                    self.stash_chunked_request(req)
+            # DLLM reqs manage KV explicitly (via req_to_token_pool).  Skip
+            # stash_chunked_request to avoid inserting mask-token keys into the
+            # radix tree and the double-free that would follow from tree eviction
+            # freeing pages that were also freed by the stale-KV cleanup step.
 
         if self.chunked_req is not None:
             # Move the chunked request out of the batch so that we can merge

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -365,6 +365,12 @@ class TpModelWorker(BaseTpWorker):
         self.model_runner.init_cuda_graphs(
             capture_decode_cuda_graph=capture_decode_cuda_graph
         )
+        if (
+            self.server_args.defer_cuda_graph_capture
+            and self.dllm_algorithm is not None
+            and hasattr(self.dllm_algorithm, "setup")
+        ):
+            self.dllm_algorithm.setup(self.model_runner)
         for mr in self.model_runner_list[1:]:
             mr.init_cuda_graphs(capture_decode_cuda_graph=capture_decode_cuda_graph)
 
@@ -388,7 +394,11 @@ class TpModelWorker(BaseTpWorker):
         )
 
     def _init_model_runner(self):
+        from sglang.srt.dllm.config import should_defer_cuda_graph_capture
         from sglang.srt.model_executor.model_runner import ModelRunner
+
+        if should_defer_cuda_graph_capture(self.server_args):
+            self.server_args.defer_cuda_graph_capture = True
 
         self._model_runner = ModelRunner(
             model_config=self.model_config,
@@ -430,6 +440,22 @@ class TpModelWorker(BaseTpWorker):
 
         if self.server_args.dllm_algorithm is not None:
             self.dllm_algorithm = DllmAlgorithm.from_server_args(self.server_args)
+            # Let the algorithm load auxiliary weights and set CUDA graph
+            # capture hooks before graphs are captured.
+            if hasattr(self.dllm_algorithm, "setup"):
+                self.dllm_algorithm.setup(self._model_runner)
+
+            graph_runner = getattr(
+                self._model_runner, "decode_cuda_graph_runner", None
+            ) or getattr(self._model_runner, "graph_runner", None)
+            if (
+                self.server_args.defer_cuda_graph_capture
+                and graph_runner is not None
+                and hasattr(graph_runner, "init_capture")
+                and not getattr(graph_runner, "capture_done", False)
+            ):
+                logger.info("Capturing deferred CUDA graphs for DLLM.")
+                graph_runner.init_capture()
         else:
             self.dllm_algorithm = None
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -142,8 +142,16 @@ def _set_kv_buffer_impl(
     alt_stream: Optional[torch.cuda.Stream] = None,
     same_kv_dim: bool = True,
 ) -> None:
+    from sglang.srt.model_executor.runner import get_is_capture_mode
+
+    is_capture_mode = get_is_capture_mode()
     row_bytes = row_dim * store_dtype.itemsize
-    if (_is_cuda or _is_hip) and same_kv_dim and can_use_store_cache(row_bytes):
+    if (
+        (_is_cuda or _is_hip)
+        and same_kv_dim
+        and can_use_store_cache(row_bytes)
+        and not is_capture_mode
+    ):
         return store_cache(
             k.view(-1, row_dim),
             v.view(-1, row_dim),
@@ -164,9 +172,7 @@ def _set_kv_buffer_impl(
             row_dim,
         )
 
-    from sglang.srt.model_executor.runner import get_is_capture_mode
-
-    if get_is_capture_mode() and alt_stream is not None:
+    if is_capture_mode and alt_stream is not None:
         current_stream = device_module.current_stream()
         alt_stream.wait_stream(current_stream)
         k_cache[indices] = k

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -639,6 +639,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if skip_attn_backend_init:
             self.mark_forward_metadata_ready()
 
+    # For DLLM: when True the final KV-update pass inside FastDiffuser should use
+    # causal attention (matching HF's causal_context=True KV-update pass).
+    # Set by FastDiffuser.run() before the final forward, cleared afterwards.
+    dllm_causal_kv_update: bool = False
+
+    dllm_block_size: Optional[int] = None
+
     @classmethod
     def init_new(
         cls,
@@ -811,8 +818,13 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             return ret
 
         # Override the positions with diffusion LLM or spec_info
-        if batch.dllm_config is not None:
-            block_size = batch.dllm_config.block_size
+        if batch.dllm_config is not None and ret.forward_mode.is_dllm_extend():
+            block_size = (
+                batch.dllm_block_size
+                if batch.dllm_block_size is not None
+                else batch.dllm_config.block_size
+            )
+            ret.dllm_block_size = block_size
             # Use int64 for AMD rotary embedding kernel compatibility
             positions_dtype = torch.int64 if is_hip() or _is_npu else torch.int32
             ret.positions = torch.tensor(

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -177,6 +177,10 @@ def build_replay_fb_view(
         # when mamba-track is disabled.
         mamba_track_indices=getattr(buffers, "mamba_track_indices", None),
         spec_info=forward_batch.spec_info,
+        dllm_causal_kv_update=getattr(
+            forward_batch, "dllm_causal_kv_update", False
+        ),
+        dllm_block_size=getattr(forward_batch, "dllm_block_size", None),
     )
 
 
@@ -243,6 +247,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         self.dllm_config = DllmConfig.from_server_args(model_runner.server_args)
         self.is_dllm = self.dllm_config is not None
+        self.dllm_causal = False
         self.attn_backend = attn_backend or model_runner.attn_backend
         self.speculative_num_steps = (
             model_runner.server_args.speculative_num_steps
@@ -272,6 +277,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.capture_forward_mode = ForwardMode.TARGET_VERIFY
         elif self.is_dllm:
             self.capture_forward_mode = ForwardMode.DLLM_EXTEND
+
+        self._dllm_tiers = (
+            getattr(self.dllm_config, "block_size_tiers", None)
+            if self.is_dllm
+            else None
+        )
 
         # --- bucket sizes ---------------------------------------------
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(
@@ -309,7 +320,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         # Attention backend
         self.max_bs = max(self.capture_bs)
-        self.max_num_token = self.max_bs * self.captured_req_width
+        self.max_num_token = max(bs * self._num_tokens_for(bs) for bs in self.capture_bs)
         self.attn_backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
 
         # Init PDMux if needed
@@ -400,11 +411,19 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
         # --- backend ---------------------------------------------------
         self.backend = resolve_decode_backend(self)
+        self.capture_done = False
 
         # --- capture --------------------------------------------------
+        if not model_runner.server_args.defer_cuda_graph_capture:
+            self.init_capture()
+
+    def init_capture(self):
+        if self.capture_done:
+            return
         try:
             with model_capture_mode():
                 self.capture()
+            self.capture_done = True
         except RuntimeError as e:
             raise Exception(
                 f"Capture cuda graph failed: {e}\n" f"{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
@@ -458,73 +477,26 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         return "nolora"
 
     @staticmethod
-    def _forward_is_dp_local(model_runner) -> bool:
-        """The DSpark dense draft runs attn-TP-local (draft_tp_context): each
-        DP rank drafts independently with no cross-DP collective, so its
-        hand-built batches carry no dp-global metadata and must key graphs by
-        local batch size. Everything else keeps the dp-global padding path."""
-        if not model_runner.is_draft_worker:
-            return False
-        if not model_runner.spec_algorithm.is_dspark():
-            return False
-        from sglang.srt.speculative.dspark_components.dspark_config import (
-            draft_is_deepseek_v4,
-        )
+    def _compose_variant_label(
+        variant_label: Optional[str], dllm_causal: bool
+    ) -> Optional[str]:
+        if not dllm_causal:
+            return variant_label
+        return f"causal_{variant_label}" if variant_label else "causal"
 
-        return not draft_is_deepseek_v4(server_args=model_runner.server_args)
-
-    def _ragged_capture_slots(self, num_tokens: int) -> int:
-        if envs.SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE.get():
-            return num_tokens // self.captured_req_width
-        return min(num_tokens, self.max_bs)
-
-    def _capture_ragged_verify_layout(self, num_tokens: int):
-        if not self.ragged_verify_mode:
-            return None
-        if envs.SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE.get():
-            return None
-        from sglang.srt.speculative.ragged_verify import (
-            RaggedVerifyLayout,
-            build_capture_verify_lens,
-        )
-
-        verify_lens_cpu = build_capture_verify_lens(
-            num_tokens=num_tokens,
-            num_slots=self._ragged_capture_slots(num_tokens),
-            num_draft_tokens=self.captured_req_width,
-        )
-        return RaggedVerifyLayout.from_verify_lens(
-            verify_lens_cpu=verify_lens_cpu,
-            device=self.device,
-            grid=self.capture_num_tokens,
-        )
+    def _num_tokens_for(self, bs: int) -> int:
+        if self._dllm_tiers:
+            return int(self.dllm_config.select_block_size(bs))
+        if self.is_dllm:
+            return int(self.dllm_config.block_size)
+        return self.captured_req_width
 
     def can_run_graph(self, forward_batch: ForwardBatch):
         # Disable for token embedding overrides (dynamic per-request)
         if forward_batch.replace_embeds is not None:
             return False
-
-        ragged_layout = (
-            resolve_ragged_verify_layout(forward_batch)
-            if self.ragged_verify_mode
-            else None
-        )
-        if ragged_layout is not None:
-            return self._can_run_ragged_verify_graph(forward_batch, ragged_layout)
-        if self.ragged_verify_mode and forward_batch.forward_mode.is_target_verify():
+        if self.is_dllm and not forward_batch.forward_mode.is_dllm_extend():
             return False
-
-        # Uniform-width replay invariant: the batch's actual per-request width
-        # must match this runner's capture width; anything else falls back to
-        # eager. (Unset widths pass: not every path fills the field yet.)
-        spec_info = forward_batch.spec_info
-        if (
-            spec_info is not None
-            and spec_info.num_tokens_per_req > 0
-            and spec_info.num_tokens_per_req != self.captured_req_width
-        ):
-            return False
-
         if self.require_mlp_tp_gather:
             # Raw sync values are per-rank request counts on decode-family
             # rounds -- no width division, no per-algorithm enumeration.
@@ -532,9 +504,26 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             cuda_graph_bs = forward_batch.batch_size
 
-        graph_key = cuda_graph_bs
-        if self.enable_pdmux:
-            graph_key = f"{get_current_stream_idx()}_{cuda_graph_bs}"
+        if (
+            self.is_dllm
+            and self._dllm_tiers
+            and forward_batch.dllm_block_size is not None
+        ):
+            target_bs = cuda_graph_bs
+            if not self.disable_padding:
+                if cuda_graph_bs > self.max_bs:
+                    return False
+                target_bs = self._pad_to_bucket(cuda_graph_bs, self.capture_bs)
+            if int(forward_batch.dllm_block_size) != self._num_tokens_for(target_bs):
+                return False
+
+        variant_label = self._resolve_lora_variant(forward_batch)
+        dllm_causal = getattr(forward_batch, "dllm_causal_kv_update", False)
+        graph_key = self._make_graph_key(
+            cuda_graph_bs,
+            get_current_stream_idx() if self.enable_pdmux else None,
+            self._compose_variant_label(variant_label, dllm_causal),
+        )
 
         is_bs_supported = (
             self.backend.can_run(forward_batch, graph_key)
@@ -680,8 +669,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         """
         bs = size
         buffers: DecodeInputBuffers = self.buffers
-        if num_tokens is None:
-            num_tokens = bs * self.captured_req_width
+        ntpb = self._num_tokens_for(bs)
+        num_tokens = bs * ntpb
 
         # Registry-owned FB-shared slots come through the registry (which
         # shares physical storage with self.buffers via source=...); the rest
@@ -807,6 +796,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             lora_ids=lora_ids,
             rids_int=rids_int,
             bootstrap_room_ids_int=bootstrap_room_ids_int,
+            dllm_block_size=ntpb if self.is_dllm else None,
         )
 
         # Trip the coordinator so the hisparse code path is captured into the
@@ -903,10 +893,33 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 with torch_compile_decoration.patch_model(
                     self.model_runner.model,
                     bs in self.compile_bs,
-                    num_tokens=bs * self.captured_req_width,
+                    num_tokens=bs * self._num_tokens_for(bs),
                     tp_group=self.model_runner.tp_group,
                 ) as forward:
+                    if self.is_dllm:
+                        pre_draft = getattr(self, "_dllm_pre_draft_hook", None)
+                        if pre_draft is not None:
+                            pre_draft()
+
                     self.capture_one_shape(bs, forward, stream_idx, variant_label)
+
+                    if self.is_dllm and self.dllm_config.causal_context:
+                        pre_verify = getattr(self, "_dllm_pre_verify_hook", None)
+                        if pre_verify is not None:
+                            pre_verify()
+                        causal_variant = self._compose_variant_label(
+                            variant_label, True
+                        )
+                        self.capture_one_shape(
+                            bs,
+                            forward,
+                            stream_idx,
+                            causal_variant,
+                            dllm_causal=True,
+                        )
+                        post_verify = getattr(self, "_dllm_post_verify_hook", None)
+                        if post_verify is not None:
+                            post_verify()
 
     def capture_one_shape(
         self,
@@ -914,9 +927,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         forward: Callable,
         stream_idx: Optional[int] = None,
         variant_label: Optional[str] = None,
+        dllm_causal: bool = False,
     ):
-        num_tokens = size * self.captured_req_width
-        bs = self._ragged_capture_slots(num_tokens) if self.ragged_verify_mode else size
+        bs = size
+        num_tokens = bs * self._num_tokens_for(bs)
 
         # Sanity-check: --debug-cuda-graph requires breakable backend.
         if self.model_runner.server_args.debug_cuda_graph:
@@ -932,6 +946,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         # DeepEP adapter, …) so they must run inside the same ForwardContext
         # that wraps the warmup/capture forward.
         with forward_context(ForwardContext(attn_backend=attn_backend)):
+            if dllm_causal:
+                forward_batch.dllm_causal_kv_update = True
+
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
 
             if forward_batch.lora_ids is not None:
@@ -1094,9 +1111,14 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     forward_batch.input_embeds
                 )
             variant_label = self._resolve_lora_variant(forward_batch)
+            self.dllm_causal = getattr(
+                forward_batch, "dllm_causal_kv_update", False
+            )
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
             self._replay_graph_key = self._make_graph_key(
-                graph_size_key, stream_idx, variant_label
+                self.bs,
+                stream_idx,
+                self._compose_variant_label(variant_label, self.dllm_causal),
             )
             return
 
@@ -1104,13 +1126,22 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         self.recapture_if_needed(forward_batch)
 
         raw_bs = forward_batch.batch_size
+        if self._dllm_tiers and forward_batch.dllm_block_size is not None:
+            ntpb = int(forward_batch.dllm_block_size)
+        elif self.is_dllm:
+            ntpb = int(self.dllm_config.block_size)
+        else:
+            ntpb = self.captured_req_width
+        raw_num_token = raw_bs * ntpb
 
-        if is_ragged:
-            raw_num_token = ragged_layout.graph_num_tokens
-            graph_size_key = self._ragged_graph_num_tokens(raw_num_token)
-            assert graph_size_key == ragged_layout.graph_num_tokens, (
-                f"ragged verify tier mismatch: runner tier {graph_size_key} != "
-                f"layout graph_num_tokens {ragged_layout.graph_num_tokens}"
+        if self.require_mlp_tp_gather:
+            max_num_tokens = max(forward_batch.global_num_tokens_cpu)
+            max_batch_size = (
+                max_num_tokens / ntpb
+                if self.model_runner.spec_algorithm.is_eagle()
+                or self.model_runner.spec_algorithm.is_standalone()
+                or self.model_runner.spec_algorithm.is_dflash()
+                else max_num_tokens
             )
             bs = self._ragged_capture_slots(graph_size_key)
             assert bs >= raw_bs, (
@@ -1142,7 +1173,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             raw_bs=raw_bs,
             padded_bs=bs,
             raw_num_tokens=raw_num_token,
-            padded_num_tokens=padded_num_tokens,
+            padded_num_tokens=bs * ntpb,
             pp_proxy_tensors=pp_proxy_tensors,
         )
 
@@ -1178,7 +1209,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             buffers=buffers,
             bs=bs,
             raw_bs=raw_bs,
-            num_tokens=padded_num_tokens,
+            num_tokens=bs * ntpb,
             seq_len_fill_value=self.seq_len_fill_value,
             capture_forward_mode=self.capture_forward_mode,
             is_encoder_decoder=self.is_encoder_decoder,
@@ -1188,8 +1219,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         self.raw_bs = raw_bs
         self.raw_num_token = raw_num_token
         self.bs = bs
-        if is_ragged:
-            self._ragged_graph_size = graph_size_key
+        self.dllm_causal = getattr(forward_batch, "dllm_causal_kv_update", False)
 
         if self.model_runner.hisparse_coordinator is not None:
             self.model_runner.hisparse_coordinator.num_real_reqs.fill_(raw_bs)
@@ -1197,7 +1227,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         variant_label = self._resolve_lora_variant(forward_batch)
         stream_idx = get_current_stream_idx() if self.enable_pdmux else None
         self._replay_graph_key = self._make_graph_key(
-            graph_size_key, stream_idx, variant_label
+            self.bs,
+            stream_idx,
+            self._compose_variant_label(variant_label, self.dllm_causal),
         )
 
     def _ragged_graph_num_tokens(self, total_verify_tokens: int) -> int:

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -637,6 +637,12 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         # tc_piecewise captures with ForwardMode.EXTEND and spec_info=None.
         if forward_batch.forward_mode.is_target_verify():
             return False
+        # DLLM extend must never use the prefill graph: that path computes only
+        # next-token logits, so the diffusion denoiser's per-position full_logits
+        # come back None (crashes LinearSpec at bs>1 when the bs-specific decode
+        # graph is absent). DLLM runs on the dllm-aware decode graph or eager.
+        if forward_batch.forward_mode.is_dllm_extend():
+            return False
         if forward_batch.capture_hidden_mode != self.capture_hidden_mode:
             return False
         # BCG-with-captured-metadata under DP attention: every rank must

--- a/python/sglang/srt/models/nemotron_labs_dllm.py
+++ b/python/sglang/srt/models/nemotron_labs_dllm.py
@@ -1,0 +1,676 @@
+# coding=utf-8
+"""Nemotron Labs diffusion model definitions."""
+
+import logging
+from typing import Iterable, Optional, Tuple, Union
+
+import torch
+from torch import nn
+from transformers.configuration_utils import PretrainedConfig
+
+from sglang.srt.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import (
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_attention import AttentionType, RadixAttention
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.llama import LlamaMLP
+from sglang.srt.models.qwen2 import Qwen2MLP
+from sglang.srt.models.utils import (
+    WeightsMapper,
+    create_fused_set_kv_buffer_arg,
+    enable_fused_set_kv_buffer,
+)
+from sglang.srt.utils import add_prefix, is_cuda, make_layers
+
+logger = logging.getLogger(__name__)
+_is_cuda = is_cuda()
+
+
+class QwenDiffuserAttention(nn.Module):
+    """Bidirectional Qwen3 attention with per-head Q/K RMSNorm."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.total_num_heads = config.num_attention_heads
+        self.total_kv_heads = config.num_key_value_heads
+        tp_size = get_tensor_model_parallel_world_size()
+
+        self.num_heads = self.total_num_heads // tp_size
+        self.num_kv_heads = max(1, self.total_kv_heads // tp_size)
+        self.head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+        )
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.use_qk_norm = not getattr(config, "disable_qk_norm", False)
+
+        self.qkv_proj = QKVParallelLinear(
+            config.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_kv_heads,
+            bias=getattr(config, "attention_bias", False),
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+        if self.use_qk_norm:
+            self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+            self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            config.hidden_size,
+            bias=getattr(config, "attention_bias", False),
+            quant_config=quant_config,
+            prefix=add_prefix("o_proj", prefix),
+        )
+
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=getattr(config, "rope_theta", 1_000_000.0),
+            rope_scaling=getattr(config, "rope_scaling", None),
+        )
+
+        self.attn = RadixAttention(
+            self.num_heads,
+            self.head_dim,
+            self.scale,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            attn_type=AttentionType.ENCODER_ONLY,
+            prefix=add_prefix("attn", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if hidden_states.shape[0] == 0:
+            return hidden_states
+
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        if self.use_qk_norm:
+            q = self.q_norm(q.reshape(-1, self.head_dim)).view(q.shape)
+            k = self.k_norm(k.reshape(-1, self.head_dim)).view(k.shape)
+
+        can_fuse = (
+            self.head_dim == self.rotary_emb.rotary_dim
+            and enable_fused_set_kv_buffer(forward_batch)
+        )
+        q, k = self.rotary_emb(
+            positions,
+            q,
+            k,
+            fused_set_kv_buffer_arg=(
+                create_fused_set_kv_buffer_arg(v, self.attn, forward_batch)
+                if can_fuse
+                else None
+            ),
+        )
+        context = self.attn(q, k, v, forward_batch, save_kv_cache=not can_fuse)
+
+        out, _ = self.o_proj(context)
+        return out
+
+
+class QwenDiffuserLayer(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attn = QwenDiffuserAttention(
+            config, layer_id, quant_config, prefix=add_prefix("self_attn", prefix)
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.mlp = Qwen2MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(positions, hidden_states, forward_batch)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class QwenDiffuserModel(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("embed_tokens", prefix),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: QwenDiffuserLayer(
+                config, idx, quant_config, prefix=prefix
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=add_prefix("layers", prefix),
+        )
+
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer(return_tuple=True)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+        if self.pp_group.is_first_rank:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            residual = None
+        else:
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        for i in range(self.start_layer, self.end_layer):
+            hidden_states, residual = self.layers[i](
+                positions, hidden_states, forward_batch, residual
+            )
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+        if not forward_batch.forward_mode.is_idle():
+            if residual is None:
+                hidden_states = self.norm(hidden_states)
+            else:
+                hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+class DiffEncoderModel(nn.Module):
+    """Qwen3-based Nemotron diffusion checkpoint."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+        self.config = config
+
+        self.model = QwenDiffuserModel(
+            config,
+            quant_config,
+            prefix=add_prefix("model", prefix),
+        )
+
+        if self.pp_group.is_last_rank:
+            self.diffusion_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("diffusion_head", prefix),
+            )
+        self.logits_processor = LogitsProcessor(config, return_full_logits=True)
+
+    @property
+    def start_layer(self):
+        return self.model.start_layer
+
+    @property
+    def end_layer(self):
+        return self.model.end_layer
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors
+        )
+        if self.pp_group.is_last_rank:
+            return self.logits_processor(
+                input_ids, hidden_states, self.diffusion_head, forward_batch
+            )
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            (".self_attn.qkv_proj", ".self_attn.q_proj", "q"),
+            (".self_attn.qkv_proj", ".self_attn.k_proj", "k"),
+            (".self_attn.qkv_proj", ".self_attn.v_proj", "v"),
+            (".mlp.gate_up_proj", ".mlp.gate_proj", 0),
+            (".mlp.gate_up_proj", ".mlp.up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+
+        for name, loaded_weight in weights:
+            if name.startswith("encoder."):
+                name = "model." + name[len("encoder.") :]
+
+            is_stacked = False
+            for param_name, shard_name, shard_id in stacked_params_mapping:
+                if shard_name not in name:
+                    continue
+                name = name.replace(shard_name, param_name)
+                if name in params_dict:
+                    weight_loader = getattr(
+                        params_dict[name], "weight_loader", default_weight_loader
+                    )
+                    weight_loader(params_dict[name], loaded_weight, shard_id)
+                is_stacked = True
+                break
+
+            if is_stacked:
+                continue
+
+            if name not in params_dict:
+                continue
+            weight_loader = getattr(
+                params_dict[name], "weight_loader", default_weight_loader
+            )
+            weight_loader(params_dict[name], loaded_weight)
+
+
+def _llama4_q_scale(positions: torch.Tensor, beta: float, max_pos: int) -> torch.Tensor:
+    """Return the Llama-4 per-token Q scale."""
+    return (
+        1.0 + beta * torch.log(1.0 + torch.floor(positions.float() / max_pos))
+    ).unsqueeze(-1)
+
+
+class NemotronLabsDiffusionAttention(nn.Module):
+    """Bidirectional Ministral attention with Llama-4 Q scaling."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        causal: bool = False,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.total_num_heads = config.num_attention_heads
+        self.total_kv_heads = config.num_key_value_heads
+        tp_size = get_tensor_model_parallel_world_size()
+
+        self.num_heads = self.total_num_heads // tp_size
+        self.num_kv_heads = max(1, self.total_kv_heads // tp_size)
+        self.head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+        )
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scale = self.head_dim**-0.5
+
+        rope_params = getattr(config, "rope_parameters", {}) or {}
+        self.llama4_beta: Optional[float] = rope_params.get(
+            "llama_4_scaling_beta", None
+        )
+        self.max_pos = rope_params.get(
+            "original_max_position_embeddings",
+            getattr(config, "max_position_embeddings", 16384),
+        )
+
+        self.qkv_proj = QKVParallelLinear(
+            config.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_kv_heads,
+            bias=getattr(config, "attention_bias", False),
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            config.hidden_size,
+            bias=getattr(config, "attention_bias", False),
+            quant_config=quant_config,
+            prefix=add_prefix("o_proj", prefix),
+        )
+
+        rope_scaling = getattr(config, "rope_scaling", None) or rope_params or None
+        rope_base = rope_params.get(
+            "rope_theta", getattr(config, "rope_theta", 1_000_000.0)
+        )
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=rope_base,
+            rope_scaling=rope_scaling,
+        )
+
+        attn_type = AttentionType.DECODER if causal else AttentionType.ENCODER_ONLY
+        self.attn = RadixAttention(
+            self.num_heads,
+            self.head_dim,
+            self.scale,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            attn_type=attn_type,
+            prefix=add_prefix("attn", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if hidden_states.shape[0] == 0:
+            return hidden_states
+
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        # The eager rotary fallback expects contiguous split views.
+        if not forward_batch.forward_mode.is_dllm_extend():
+            q, k = q.contiguous(), k.contiguous()
+        q, k = self.rotary_emb(positions, q, k)
+
+        if self.llama4_beta is not None:
+            scale = _llama4_q_scale(positions, self.llama4_beta, self.max_pos).to(
+                q.dtype
+            )
+            q = q.view(-1, self.num_heads, self.head_dim)
+            q = (q * scale.unsqueeze(1)).view(-1, self.num_heads * self.head_dim)
+
+        context = self.attn(q, k, v, forward_batch, save_kv_cache=True)
+        out, _ = self.o_proj(context)
+        return out
+
+
+class NemotronLabsDiffusionLayer(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        causal: bool = False,
+    ) -> None:
+        super().__init__()
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attn = NemotronLabsDiffusionAttention(
+            config,
+            layer_id,
+            quant_config,
+            prefix=add_prefix("self_attn", prefix),
+            causal=causal,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.mlp = LlamaMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(positions, hidden_states, forward_batch)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class NemotronLabsDiffusionEncoder(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("embed_tokens", prefix),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        causal = getattr(config, "ar_mode", False)
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: NemotronLabsDiffusionLayer(
+                config, idx, quant_config, prefix=prefix, causal=causal
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=add_prefix("layers", prefix),
+        )
+
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer(return_tuple=True)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+        if self.pp_group.is_first_rank:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            residual = None
+        else:
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        for i in range(self.start_layer, self.end_layer):
+            hidden_states, residual = self.layers[i](
+                positions, hidden_states, forward_batch, residual
+            )
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+        if not forward_batch.forward_mode.is_idle():
+            if residual is None:
+                hidden_states = self.norm(hidden_states)
+            else:
+                hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+class NemotronLabsDiffusionModel(nn.Module):
+    """Ministral-based Nemotron Labs diffusion checkpoint."""
+
+    hf_to_sglang_mapper = WeightsMapper(orig_to_new_prefix={"encoder.": "model."})
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+        self.config = config
+
+        self.model = NemotronLabsDiffusionEncoder(
+            config,
+            quant_config,
+            prefix=add_prefix("model", prefix),
+        )
+
+        if self.pp_group.is_last_rank:
+            self.diffusion_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("diffusion_head", prefix),
+            )
+        self.logits_processor = LogitsProcessor(config, return_full_logits=True)
+
+    @property
+    def start_layer(self):
+        return self.model.start_layer
+
+    @property
+    def end_layer(self):
+        return self.model.end_layer
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors
+        )
+        if self.pp_group.is_last_rank:
+            return self.logits_processor(
+                input_ids, hidden_states, self.diffusion_head, forward_batch
+            )
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            (".self_attn.qkv_proj", ".self_attn.q_proj", "q"),
+            (".self_attn.qkv_proj", ".self_attn.k_proj", "k"),
+            (".self_attn.qkv_proj", ".self_attn.v_proj", "v"),
+            (".mlp.gate_up_proj", ".mlp.gate_proj", 0),
+            (".mlp.gate_up_proj", ".mlp.up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+
+        for name, loaded_weight in weights:
+            if name.startswith("encoder."):
+                name = "model." + name[len("encoder.") :]
+
+            is_stacked = False
+            for param_name, shard_name, shard_id in stacked_params_mapping:
+                if shard_name not in name:
+                    continue
+                name = name.replace(shard_name, param_name)
+                if name in params_dict:
+                    weight_loader = getattr(
+                        params_dict[name], "weight_loader", default_weight_loader
+                    )
+                    weight_loader(params_dict[name], loaded_weight, shard_id)
+                is_stacked = True
+                break
+
+            if is_stacked:
+                continue
+
+            if name not in params_dict:
+                continue
+            weight_loader = getattr(
+                params_dict[name], "weight_loader", default_weight_loader
+            )
+            weight_loader(params_dict[name], loaded_weight)
+
+
+EntryClass = [DiffEncoderModel, NemotronLabsDiffusionModel]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2468,6 +2468,10 @@ class ServerArgs:
             action=argparse.BooleanOptionalAction,
         ),
     ] = True
+    # Set internally (no CLI) when a dllm algorithm bakes auxiliary weights into
+    # the CUDA graphs (e.g. LinearSpec + LoRA): capture is deferred until after
+    # the algorithm's setup() has run. See dllm.config.should_defer_cuda_graph_capture.
+    defer_cuda_graph_capture: A[bool, Arg(no_cli=True)] = False
 
     # -------------------------------------------------------------------------
     # PD disaggregation

--- a/test/registered/dllm/configs/nemotron_labs_fastdiffuser.yaml
+++ b/test/registered/dllm/configs/nemotron_labs_fastdiffuser.yaml
@@ -1,0 +1,2 @@
+algorithm: FastDiffuser
+causal_context: true

--- a/test/registered/dllm/test_nemotron_labs_diffusion.py
+++ b/test/registered/dllm/test_nemotron_labs_diffusion.py
@@ -1,0 +1,128 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=240, stage="base-b", runner_config="1-gpu-large")
+
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.send_one import BenchArgs, send_one_prompt
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+_MODEL = "nvidia/Nemotron-Labs-Diffusion-8B"
+_CONFIG_DIR = "test/registered/dllm/configs"
+_COMMON_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--tp-size",
+    "1",
+    "--mem-fraction-static",
+    "0.9",
+    "--max-running-requests",
+    "4",
+    "--attention-backend",
+    "flashinfer",
+    "--cuda-graph-bs",
+    "1",
+    "2",
+    "3",
+    "4",
+    "--context-length",
+    "4096",
+]
+
+_PROMPT = "In one sentence, explain why batching improves GPU inference throughput."
+_SPEED_PROMPT = (
+    "Human: Explain linear self-speculation for language model serving.\n\n"
+    "Assistant:"
+)
+
+
+def _completion(base_url, model, max_new_tokens=96):
+    response = requests.post(
+        base_url + "/v1/completions",
+        json={
+            "model": model,
+            "prompt": _PROMPT,
+            "max_tokens": max_new_tokens,
+            "temperature": 0.0,
+        },
+        timeout=180,
+    )
+    if response.status_code != 200:
+        raise AssertionError(response.text)
+    body = response.json()
+    completion_tokens = body.get("usage", {}).get("completion_tokens", 0)
+    text = body["choices"][0]["text"]
+    return completion_tokens, text
+
+
+class NemotronLabsDiffusionTestBase:
+    algorithm = None
+    config_name = None
+    min_speed = None
+    summary_name = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = _MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=_COMMON_SERVER_ARGS
+            + [
+                "--dllm-algorithm",
+                cls.algorithm,
+                "--dllm-algorithm-config",
+                f"{_CONFIG_DIR}/{cls.config_name}",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_generates_completion(self):
+        completion_tokens, text = _completion(self.base_url, self.model)
+        self.assertGreater(completion_tokens, 0, "model produced zero tokens")
+        self.assertIsInstance(text, str)
+        self.assertGreater(len(text.strip()), 0)
+
+    def test_bs_1_speed(self):
+        args = BenchArgs(
+            port=int(self.base_url.split(":")[-1]),
+            max_new_tokens=512,
+            prompt=_SPEED_PROMPT,
+        )
+        _acc_length, speed = send_one_prompt(args)
+        print(f"{speed=:.2f}")
+
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_bs_1_speed ({self.summary_name}) tp=1\n"
+                f"{speed=:.2f} token/s\n"
+            )
+            self.assertGreater(speed, self.min_speed)
+
+
+class TestNemotronLabsDiffusionFastDiffuser(
+    NemotronLabsDiffusionTestBase, CustomTestCase
+):
+    algorithm = "FastDiffuser"
+    config_name = "nemotron_labs_fastdiffuser.yaml"
+    min_speed = 30
+    summary_name = "nemotron-labs-diffusion-8b-fastdiffuser"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_req_finish.py
+++ b/test/registered/unit/managers/test_req_finish.py
@@ -1,0 +1,44 @@
+import unittest
+
+from sglang.srt.managers.schedule_batch import (
+    FINISH_LENGTH,
+    FINISH_MATCHED_TOKEN,
+    Req,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="stage-a-test-cpu")
+
+
+class TestReqFinish(CustomTestCase):
+    def _req(self, rid: str):
+        req = Req(
+            rid=rid,
+            origin_input_text="",
+            origin_input_ids=[1],
+            sampling_params=SamplingParams(max_new_tokens=2, stop_token_ids=[7]),
+        )
+        req.output_ids = [5, 7]
+        return req
+
+    def test_update_finish_state_keeps_length_priority_by_default(self):
+        req = self._req("length-first")
+
+        req.update_finish_state(new_accepted_len=2)
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 2)
+
+    def test_check_finished_can_check_stop_token_before_length(self):
+        req = self._req("stop-token-first")
+
+        req.check_finished_stop_before_length(new_accepted_len=2)
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        self.assertEqual(req.finished_len, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

First PR of the staged Nemotron Labs Diffusion upstreaming stack (tracked in #25802): add the released `nvidia/Nemotron-Labs-Diffusion-8B` model, the shared diffusion-LLM (DLLM) runtime integration it needs, and one working decoder — `FastDiffuser`. This change is independently runnable and does not depend on later planned interfaces.

LinearSpec, LoRA/AR mode, the FA4 attention backend, LearnedSampler, and evaluation helpers are staged as later PRs — see #25802 for the full stack and end-to-end validation.

## Scope

- Add the released Ministral-based `NemotronLabsDiffusionModel` implementation.
- Add causal-context DLLM request, scheduler, schedule-batch/policy, and KV-accounting integration.
- Add FlashInfer and decode/prefill CUDA-graph plumbing for diffusion decoding.
- Add FastDiffuser block denoising with EOS handling and compacted active batches.
- Add the internal `defer_cuda_graph_capture` server arg for algorithms that bake auxiliary weights into CUDA graphs.
- Keep the shared KV write implementation unchanged.

## Reviewability

| | Commits | Files | Additions | Deletions |
| --- | ---: | ---: | ---: | ---: |
| This PR | 1 | 22 | 2,183 | 339 |

Base: `238b2b2c9` (current `main` at rebase). LinearSpec and later extension hooks are intentionally out of scope.

## Validation

Performed on this PR's commit after rebasing onto `main` (`238b2b2c9`):

- Clean diff, no conflict markers; Python compilation and changed-file static checks pass.
- Request-finish unit tests pass.
- FastDiffuser end-to-end on B200 (flashinfer + torch.compile + CUDA graph, TP=1):

| Metric | Result |
| --- | --- |
| GSM8K accuracy (1,319 questions) | 93.2% (1229/1319) |
| SPEED-Bench throughput (231, single-turn, concurrency 1) | 151.3 tok/s |

The registered FastDiffuser B200 end-to-end test and its config ship with this PR. Full-stack serving validation across the complete stack (adds LinearSpec + FA4 for ~5.5× throughput) is summarized in the tracker #25802.

## Checklist

- [x] Scoped to onboarding + FastDiffuser; LinearSpec, FA4, LearnedSampler, and eval split into later staged PRs.
- [x] Concise, implementation-focused comments and docstrings.
- [x] Ships focused FastDiffuser E2E and request-finish tests.
- [x] Attaches FastDiffuser GSM8K + SPEED-Bench evidence.
- [x] Rebased onto current `main` immediately before update.
- [x] Clean diff and conflict-marker checks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
