### PR TITLE
Add fused_inplace_qknorm_rope to HunyuanVideo model

### DIFF
--- a/python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
+++ b/python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
@@ -37,6 +37,13 @@ BENCH_CASES = (
     # Z-Image-Turbo default 1024x1024 config: dim=3840, num_heads=30 -> head_dim=128.
     CaseSpec("zimage_1024", 1, 4096, 30, 128, 128, False),
     CaseSpec("batch2_medium", 2, 2048, 24, 128, 128, False),
+    # HunyuanVideo: num_heads=24, attention_head_dim=128, rope_axes_dim
+    # sums to 128 (16 + 56 + 56). Token counts cover the image-stream
+    # input to a single attention call for a short-clip / medium-clip
+    # configuration. The text-stream (~256 tokens, no RoPE) is covered
+    # by bench_qknorm.py.
+    CaseSpec("hunyuanvideo_short", 1, 8192, 24, 128, 128, False),
+    CaseSpec("hunyuanvideo_medium", 1, 24576, 24, 128, 128, False),
 )
 CASE_BY_NAME = {case.name: case for case in BENCH_CASES}
 CASE_NAMES = get_benchmark_range(

--- a/python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
+++ b/python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
@@ -46,17 +46,9 @@ BENCH_CASES = (
     CaseSpec("hunyuanvideo_medium", 1, 24576, 24, 128, 128, False),
 )
 CASE_BY_NAME = {case.name: case for case in BENCH_CASES}
-
-# `hunyuanvideo_medium` (1×24576×24×128 → ~75M elements, ~150 MB Q/K
-# tensors each, ~1 GB working set per case across split + fused providers)
-# is ~3x the per-case wall time of the existing cases. Excluded from the
-# default CI range to keep `register_cuda_ci(est_time=13, ...)` honest;
-# still runs via `--cases hunyuanvideo_medium` or `--cases <full-list>`
-# for standalone perf verification.
-_CI_EXCLUDE = frozenset({"hunyuanvideo_medium"})
 CASE_NAMES = get_benchmark_range(
     full_range=[case.name for case in BENCH_CASES],
-    ci_range=[case.name for case in BENCH_CASES if case.name not in _CI_EXCLUDE],
+    ci_range=[case.name for case in BENCH_CASES],
 )
 LINE_VALS = ["split", "fused"]
 LINE_NAMES = ["JIT QKNorm + FlashInfer RoPE", "SGL JIT Fused QKNorm+RoPE"]

--- a/python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
+++ b/python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
@@ -46,9 +46,17 @@ BENCH_CASES = (
     CaseSpec("hunyuanvideo_medium", 1, 24576, 24, 128, 128, False),
 )
 CASE_BY_NAME = {case.name: case for case in BENCH_CASES}
+
+# `hunyuanvideo_medium` (1×24576×24×128 → ~75M elements, ~150 MB Q/K
+# tensors each, ~1 GB working set per case across split + fused providers)
+# is ~3x the per-case wall time of the existing cases. Excluded from the
+# default CI range to keep `register_cuda_ci(est_time=13, ...)` honest;
+# still runs via `--cases hunyuanvideo_medium` or `--cases <full-list>`
+# for standalone perf verification.
+_CI_EXCLUDE = frozenset({"hunyuanvideo_medium"})
 CASE_NAMES = get_benchmark_range(
     full_range=[case.name for case in BENCH_CASES],
-    ci_range=[case.name for case in BENCH_CASES],
+    ci_range=[case.name for case in BENCH_CASES if case.name not in _CI_EXCLUDE],
 )
 LINE_VALS = ["split", "fused"]
 LINE_NAMES = ["JIT QKNorm + FlashInfer RoPE", "SGL JIT Fused QKNorm+RoPE"]

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import torch
@@ -46,29 +46,6 @@ from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
     current_platform,
 )
-
-
-def _build_qknorm_rope_cos_sin_cache(
-    freqs_cis: Optional[tuple[torch.Tensor, torch.Tensor]],
-) -> Optional[torch.Tensor]:
-    """Pack ``(cos, sin)`` into the ``[num_tokens, head_dim]`` fp32 layout that
-    ``apply_qk_norm_with_optional_rope`` expects.
-
-    Built once per ``HunyuanVideoTransformer3DModel.forward`` (where
-    ``freqs_cis`` is produced) and threaded through every block, avoiding the
-    ``num_blocks * num_steps`` redundant cats the previous per-block build
-    paid on every denoise step.
-    """
-    if freqs_cis is None:
-        return None
-    cos, sin = freqs_cis
-    return torch.cat(
-        [
-            cos.to(dtype=torch.float32).contiguous(),
-            sin.to(dtype=torch.float32).contiguous(),
-        ],
-        dim=-1,
-    )
 
 
 class MMDoubleStreamBlock(nn.Module):
@@ -210,7 +187,6 @@ class MMDoubleStreamBlock(nn.Module):
         txt: torch.Tensor,
         vec: torch.Tensor,
         freqs_cis: tuple,
-        cos_sin_cache: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Process modulation vectors
         img_mod_outputs = self.img_mod(vec)
@@ -255,13 +231,14 @@ class MMDoubleStreamBlock(nn.Module):
         # img_q here (both from the same qkv split), so the `.to(...)` was a
         # no-op. Dropped intentionally; dtype preservation is covered by
         # ``test_helper_preserves_input_dtype_*`` in the unit tests.
-        #
-        # ``cos_sin_cache`` is built once per
-        # ``HunyuanVideoTransformer3DModel.forward`` and threaded in; the
-        # ``None`` branch is a back-compat fallback for any external caller
-        # that still passes only ``freqs_cis``.
-        if cos_sin_cache is None:
-            cos_sin_cache = _build_qknorm_rope_cos_sin_cache(freqs_cis)
+        cos, sin = freqs_cis
+        cos_sin_cache = torch.cat(
+            [
+                cos.to(dtype=torch.float32).contiguous(),
+                sin.to(dtype=torch.float32).contiguous(),
+            ],
+            dim=-1,
+        )
         head_dim = img_q.shape[-1]
         img_q, img_k = apply_qk_norm_with_optional_rope(
             q=img_q.contiguous(),
@@ -420,7 +397,6 @@ class MMSingleStreamBlock(nn.Module):
         vec: torch.Tensor,
         txt_len: int,
         freqs_cis: tuple[torch.Tensor, torch.Tensor],
-        cos_sin_cache: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # Process modulation
         mod_shift, mod_scale, mod_gate = self.modulation(vec).chunk(3, dim=-1)
@@ -460,12 +436,14 @@ class MMSingleStreamBlock(nn.Module):
         txt_k = qkv[:, img_len:, 1].contiguous()
         txt_v = qkv[:, img_len:, 2]
 
-        # ``cos_sin_cache`` is built once per
-        # ``HunyuanVideoTransformer3DModel.forward`` and threaded in; the
-        # ``None`` branch is a back-compat fallback for any external caller
-        # that still passes only ``freqs_cis``.
-        if cos_sin_cache is None:
-            cos_sin_cache = _build_qknorm_rope_cos_sin_cache(freqs_cis)
+        cos, sin = freqs_cis
+        cos_sin_cache = torch.cat(
+            [
+                cos.to(dtype=torch.float32).contiguous(),
+                sin.to(dtype=torch.float32).contiguous(),
+            ],
+            dim=-1,
+        )
         head_dim = img_q.shape[-1]
 
         # Image stream: fused QK-Norm + RoPE.
@@ -739,13 +717,6 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
 
         freqs_cis = (freqs_cos, freqs_sin) if freqs_cos is not None else None
 
-        # Build the [num_tokens, head_dim] fp32 cos_sin_cache once here and
-        # thread it through every block, so the apply_qk_norm_with_optional_rope
-        # call sites in MMDoubleStreamBlock / MMSingleStreamBlock don't pay a
-        # fresh torch.cat per block per denoise step (was N_blocks * N_steps
-        # redundant allocations).
-        cos_sin_cache = _build_qknorm_rope_cos_sin_cache(freqs_cis)
-
         should_skip_forward = self.should_skip_forward_for_cached_states(
             img=img, vec=vec
         )
@@ -758,7 +729,7 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
 
             # Process through double stream blocks
             for index, block in enumerate(self.double_blocks):
-                double_block_args = [img, txt, vec, freqs_cis, cos_sin_cache]
+                double_block_args = [img, txt, vec, freqs_cis]
                 img, txt = block(*double_block_args)
             # Merge txt and img to pass through single stream blocks
             x = torch.cat((img, txt), 1)
@@ -771,7 +742,6 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
                         vec,
                         txt_seq_len,
                         freqs_cis,
-                        cos_sin_cache,
                     ]
                     x = block(*single_block_args)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -221,16 +221,10 @@ class MMDoubleStreamBlock(nn.Module):
         )
         img_q, img_k, img_v = img_qkv[:, :, 0], img_qkv[:, :, 1], img_qkv[:, :, 2]
 
-        # Fused QK-Norm + RoPE for the image stream. Collapses two RMSNorm
-        # kernels and two _apply_rotary_emb passes into a single in-place
-        # fused JIT kernel on CUDA (fp16/bf16); falls back to eager + fused
-        # rotary otherwise. Same code path that Flux and Qwen-Image use.
-        #
-        # NOTE: the pre-refactor path did `q_norm(q).to(img_v)` and similar.
-        # RMSNorm.forward preserves input dtype, and img_v shares dtype with
-        # img_q here (both from the same qkv split), so the `.to(...)` was a
-        # no-op. Dropped intentionally; dtype preservation is covered by
-        # ``test_helper_preserves_input_dtype_*`` in the unit tests.
+        # Fused QK-Norm + RoPE on the image stream (Flux / Qwen-Image wiring).
+        # The pre-refactor `q_norm(q).to(img_v)` cast was a no-op (RMSNorm
+        # preserves dtype, img_q and img_v share dtype) and is dropped here;
+        # dtype preservation is pinned by ``test_helper_preserves_input_dtype_*``.
         cos, sin = freqs_cis
         cos_sin_cache = torch.cat(
             [
@@ -264,12 +258,9 @@ class MMDoubleStreamBlock(nn.Module):
         )
         txt_q, txt_k, txt_v = txt_qkv[:, :, 0], txt_qkv[:, :, 1], txt_qkv[:, :, 2]
 
-        # Fused QK-Norm for the text stream (no RoPE on text tokens). Drops
-        # the two RMSNorm kernels into a single in-place fused JIT kernel.
-        # head_dim is reused from the img stream above -- safe here because
-        # HunyuanVideo's MMDoubleStreamBlock ties img and txt attention
-        # head_dim by architecture (both Q/K projections share num_heads and
-        # hidden_size); update if a future variant decouples them.
+        # Fused QK-Norm only on the text stream (no rope on text tokens).
+        # head_dim is reused from the img stream: img/txt share num_heads
+        # and hidden_size in MMDoubleStreamBlock by architecture.
         txt_q, txt_k = apply_qk_norm_with_optional_rope(
             q=txt_q.contiguous(),
             k=txt_k.contiguous(),
@@ -417,18 +408,12 @@ class MMSingleStreamBlock(nn.Module):
         qkv = qkv.view(batch_size, seq_len, 3, self.num_attention_heads, -1)
         img_len = seq_len - txt_len
 
-        # Split image / text streams BEFORE QK-Norm so the image portion can
-        # route through the fused QK-Norm + RoPE kernel in a single in-place
-        # pass (replacing the prior 2x RMSNorm + 2x _apply_rotary_emb pattern)
-        # and the text portion through the fused QK-Norm only kernel.
-        #
-        # Only Q and K need contiguous tensors: the fused kernel only mutates
-        # those (see `mutates_args=["q", "k"]` on `fused_inplace_qknorm_rope`).
-        # The V tensors stay as strided views -- ``UlyssesAttention.forward``
-        # does ``torch.cat([q, k, v], dim=0)`` downstream, which handles
-        # non-contiguous inputs fine and avoids two unnecessary full-size
-        # copies per single-stream block (~2x extra HBM traffic at LTX-2 /
-        # HunyuanVideo shapes).
+        # Split img/txt before QK-Norm so the img portion can route through
+        # fused QK-Norm + RoPE and the txt portion through fused QK-Norm only.
+        # Only Q/K are made contiguous: the fused kernel mutates only those
+        # (``mutates_args=["q", "k"]``); ``UlyssesAttention.forward`` does
+        # ``torch.cat([q, k, v])`` downstream, which accepts non-contiguous V
+        # and saves V-sized HBM copies per block at HunyuanVideo shapes.
         img_q = qkv[:, :img_len, 0].contiguous()
         img_k = qkv[:, :img_len, 1].contiguous()
         img_v = qkv[:, :img_len, 2]
@@ -458,10 +443,9 @@ class MMSingleStreamBlock(nn.Module):
             allow_inplace=True,
         )
 
-        # Text stream: fused QK-Norm only (no RoPE on text tokens). q_norm /
-        # k_norm and head_dim are shared with the img stream above -- the
-        # single-stream block uses one set of norm modules for the full
-        # qkv tensor, so the txt half reuses the same projections.
+        # Text stream: fused QK-Norm only (no rope). q_norm/k_norm/head_dim
+        # are reused -- the single-stream block has one set of norm modules
+        # for the full qkv tensor, shared between the img and txt halves.
         txt_q, txt_k = apply_qk_norm_with_optional_rope(
             q=txt_q,
             k=txt_k,

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 import torch
@@ -46,6 +46,29 @@ from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
     current_platform,
 )
+
+
+def _build_qknorm_rope_cos_sin_cache(
+    freqs_cis: Optional[tuple[torch.Tensor, torch.Tensor]],
+) -> Optional[torch.Tensor]:
+    """Pack ``(cos, sin)`` into the ``[num_tokens, head_dim]`` fp32 layout that
+    ``apply_qk_norm_with_optional_rope`` expects.
+
+    Built once per ``HunyuanVideoTransformer3DModel.forward`` (where
+    ``freqs_cis`` is produced) and threaded through every block, avoiding the
+    ``num_blocks * num_steps`` redundant cats the previous per-block build
+    paid on every denoise step.
+    """
+    if freqs_cis is None:
+        return None
+    cos, sin = freqs_cis
+    return torch.cat(
+        [
+            cos.to(dtype=torch.float32).contiguous(),
+            sin.to(dtype=torch.float32).contiguous(),
+        ],
+        dim=-1,
+    )
 
 
 class MMDoubleStreamBlock(nn.Module):
@@ -187,6 +210,7 @@ class MMDoubleStreamBlock(nn.Module):
         txt: torch.Tensor,
         vec: torch.Tensor,
         freqs_cis: tuple,
+        cos_sin_cache: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Process modulation vectors
         img_mod_outputs = self.img_mod(vec)
@@ -225,14 +249,19 @@ class MMDoubleStreamBlock(nn.Module):
         # kernels and two _apply_rotary_emb passes into a single in-place
         # fused JIT kernel on CUDA (fp16/bf16); falls back to eager + fused
         # rotary otherwise. Same code path that Flux and Qwen-Image use.
-        cos, sin = freqs_cis
-        cos_sin_cache = torch.cat(
-            [
-                cos.to(dtype=torch.float32).contiguous(),
-                sin.to(dtype=torch.float32).contiguous(),
-            ],
-            dim=-1,
-        )
+        #
+        # NOTE: the pre-refactor path did `q_norm(q).to(img_v)` and similar.
+        # RMSNorm.forward preserves input dtype, and img_v shares dtype with
+        # img_q here (both from the same qkv split), so the `.to(...)` was a
+        # no-op. Dropped intentionally; dtype preservation is covered by
+        # ``test_helper_preserves_input_dtype_*`` in the unit tests.
+        #
+        # ``cos_sin_cache`` is built once per
+        # ``HunyuanVideoTransformer3DModel.forward`` and threaded in; the
+        # ``None`` branch is a back-compat fallback for any external caller
+        # that still passes only ``freqs_cis``.
+        if cos_sin_cache is None:
+            cos_sin_cache = _build_qknorm_rope_cos_sin_cache(freqs_cis)
         head_dim = img_q.shape[-1]
         img_q, img_k = apply_qk_norm_with_optional_rope(
             q=img_q.contiguous(),
@@ -260,6 +289,10 @@ class MMDoubleStreamBlock(nn.Module):
 
         # Fused QK-Norm for the text stream (no RoPE on text tokens). Drops
         # the two RMSNorm kernels into a single in-place fused JIT kernel.
+        # head_dim is reused from the img stream above -- safe here because
+        # HunyuanVideo's MMDoubleStreamBlock ties img and txt attention
+        # head_dim by architecture (both Q/K projections share num_heads and
+        # hidden_size); update if a future variant decouples them.
         txt_q, txt_k = apply_qk_norm_with_optional_rope(
             q=txt_q.contiguous(),
             k=txt_k.contiguous(),
@@ -387,6 +420,7 @@ class MMSingleStreamBlock(nn.Module):
         vec: torch.Tensor,
         txt_len: int,
         freqs_cis: tuple[torch.Tensor, torch.Tensor],
+        cos_sin_cache: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # Process modulation
         mod_shift, mod_scale, mod_gate = self.modulation(vec).chunk(3, dim=-1)
@@ -426,14 +460,12 @@ class MMSingleStreamBlock(nn.Module):
         txt_k = qkv[:, img_len:, 1].contiguous()
         txt_v = qkv[:, img_len:, 2]
 
-        cos, sin = freqs_cis
-        cos_sin_cache = torch.cat(
-            [
-                cos.to(dtype=torch.float32).contiguous(),
-                sin.to(dtype=torch.float32).contiguous(),
-            ],
-            dim=-1,
-        )
+        # ``cos_sin_cache`` is built once per
+        # ``HunyuanVideoTransformer3DModel.forward`` and threaded in; the
+        # ``None`` branch is a back-compat fallback for any external caller
+        # that still passes only ``freqs_cis``.
+        if cos_sin_cache is None:
+            cos_sin_cache = _build_qknorm_rope_cos_sin_cache(freqs_cis)
         head_dim = img_q.shape[-1]
 
         # Image stream: fused QK-Norm + RoPE.
@@ -448,7 +480,10 @@ class MMSingleStreamBlock(nn.Module):
             allow_inplace=True,
         )
 
-        # Text stream: fused QK-Norm only (no RoPE on text tokens).
+        # Text stream: fused QK-Norm only (no RoPE on text tokens). q_norm /
+        # k_norm and head_dim are shared with the img stream above -- the
+        # single-stream block uses one set of norm modules for the full
+        # qkv tensor, so the txt half reuses the same projections.
         txt_q, txt_k = apply_qk_norm_with_optional_rope(
             q=txt_q,
             k=txt_k,
@@ -704,6 +739,13 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
 
         freqs_cis = (freqs_cos, freqs_sin) if freqs_cos is not None else None
 
+        # Build the [num_tokens, head_dim] fp32 cos_sin_cache once here and
+        # thread it through every block, so the apply_qk_norm_with_optional_rope
+        # call sites in MMDoubleStreamBlock / MMSingleStreamBlock don't pay a
+        # fresh torch.cat per block per denoise step (was N_blocks * N_steps
+        # redundant allocations).
+        cos_sin_cache = _build_qknorm_rope_cos_sin_cache(freqs_cis)
+
         should_skip_forward = self.should_skip_forward_for_cached_states(
             img=img, vec=vec
         )
@@ -716,7 +758,7 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
 
             # Process through double stream blocks
             for index, block in enumerate(self.double_blocks):
-                double_block_args = [img, txt, vec, freqs_cis]
+                double_block_args = [img, txt, vec, freqs_cis, cos_sin_cache]
                 img, txt = block(*double_block_args)
             # Merge txt and img to pass through single stream blocks
             x = torch.cat((img, txt), 1)
@@ -729,6 +771,7 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
                         vec,
                         txt_seq_len,
                         freqs_cis,
+                        cos_sin_cache,
                     ]
                     x = block(*single_block_args)
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -20,6 +20,7 @@ from sglang.multimodal_gen.runtime.layers.layernorm import (
     LayerNormScaleShift,
     RMSNorm,
     ScaleResidualLayerNormScaleShift,
+    apply_qk_norm_with_optional_rope,
 )
 from sglang.multimodal_gen.runtime.layers.linear import ReplicatedLinear
 from sglang.multimodal_gen.runtime.layers.mlp import MLP
@@ -27,7 +28,6 @@ from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config impor
     QuantizationConfig,
 )
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
-    _apply_rotary_emb,
     get_rotary_pos_embed,
 )
 from sglang.multimodal_gen.runtime.layers.visual_embedding import (
@@ -221,16 +221,30 @@ class MMDoubleStreamBlock(nn.Module):
         )
         img_q, img_k, img_v = img_qkv[:, :, 0], img_qkv[:, :, 1], img_qkv[:, :, 2]
 
-        # Apply QK-Norm if needed
-
-        img_q = self.img_attn_q_norm(img_q.contiguous()).to(img_v)
-        img_k = self.img_attn_k_norm(img_k.contiguous()).to(img_v)
-        # Apply rotary embeddings
+        # Fused QK-Norm + RoPE for the image stream. Collapses two RMSNorm
+        # kernels and two _apply_rotary_emb passes into a single in-place
+        # fused JIT kernel on CUDA (fp16/bf16); falls back to eager + fused
+        # rotary otherwise. Same code path that Flux and Qwen-Image use.
         cos, sin = freqs_cis
-        img_q, img_k = (
-            _apply_rotary_emb(img_q, cos, sin, is_neox_style=False),
-            _apply_rotary_emb(img_k, cos, sin, is_neox_style=False),
+        cos_sin_cache = torch.cat(
+            [
+                cos.to(dtype=torch.float32).contiguous(),
+                sin.to(dtype=torch.float32).contiguous(),
+            ],
+            dim=-1,
         )
+        head_dim = img_q.shape[-1]
+        img_q, img_k = apply_qk_norm_with_optional_rope(
+            q=img_q.contiguous(),
+            k=img_k.contiguous(),
+            q_norm=self.img_attn_q_norm,
+            k_norm=self.img_attn_k_norm,
+            head_dim=head_dim,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=False,
+            allow_inplace=True,
+        )
+
         # Prepare text for attention using fused operation
         txt_attn_input = self.txt_attn_norm(txt, txt_attn_shift, txt_attn_scale)
 
@@ -244,9 +258,17 @@ class MMDoubleStreamBlock(nn.Module):
         )
         txt_q, txt_k, txt_v = txt_qkv[:, :, 0], txt_qkv[:, :, 1], txt_qkv[:, :, 2]
 
-        # Apply QK-Norm if needed
-        txt_q = self.txt_attn_q_norm(txt_q.contiguous()).to(txt_q.dtype)
-        txt_k = self.txt_attn_k_norm(txt_k.contiguous()).to(txt_k.dtype)
+        # Fused QK-Norm for the text stream (no RoPE on text tokens). Drops
+        # the two RMSNorm kernels into a single in-place fused JIT kernel.
+        txt_q, txt_k = apply_qk_norm_with_optional_rope(
+            q=txt_q.contiguous(),
+            k=txt_k.contiguous(),
+            q_norm=self.txt_attn_q_norm,
+            k_norm=self.txt_attn_k_norm,
+            head_dim=head_dim,
+            cos_sin_cache=None,
+            allow_inplace=True,
+        )
 
         # Run distributed attention
         img_attn, txt_attn = self.attn(img_q, img_k, img_v, txt_q, txt_k, txt_v)
@@ -383,21 +405,50 @@ class MMSingleStreamBlock(nn.Module):
         # Process QKV
         batch_size, seq_len = qkv.shape[0], qkv.shape[1]
         qkv = qkv.view(batch_size, seq_len, 3, self.num_attention_heads, -1)
-        q, k, v = qkv[:, :, 0], qkv[:, :, 1], qkv[:, :, 2]
+        img_len = seq_len - txt_len
 
-        # Apply QK-Norm
-        q = self.q_norm(q.contiguous()).to(v.dtype)
-        k = self.k_norm(k.contiguous()).to(v.dtype)
+        # Split image / text streams BEFORE QK-Norm so the image portion can
+        # route through the fused QK-Norm + RoPE kernel in a single in-place
+        # pass (replacing the prior 2x RMSNorm + 2x _apply_rotary_emb pattern)
+        # and the text portion through the fused QK-Norm only kernel.
+        img_q = qkv[:, :img_len, 0].contiguous()
+        img_k = qkv[:, :img_len, 1].contiguous()
+        img_v = qkv[:, :img_len, 2].contiguous()
+        txt_q = qkv[:, img_len:, 0].contiguous()
+        txt_k = qkv[:, img_len:, 1].contiguous()
+        txt_v = qkv[:, img_len:, 2].contiguous()
 
-        # Split into image and text parts
-        img_q, txt_q = q[:, :-txt_len], q[:, -txt_len:]
-        img_k, txt_k = k[:, :-txt_len], k[:, -txt_len:]
-        img_v, txt_v = v[:, :-txt_len], v[:, -txt_len:]
-        # Apply rotary embeddings to image parts
         cos, sin = freqs_cis
-        img_q, img_k = (
-            _apply_rotary_emb(img_q, cos, sin, is_neox_style=False),
-            _apply_rotary_emb(img_k, cos, sin, is_neox_style=False),
+        cos_sin_cache = torch.cat(
+            [
+                cos.to(dtype=torch.float32).contiguous(),
+                sin.to(dtype=torch.float32).contiguous(),
+            ],
+            dim=-1,
+        )
+        head_dim = img_q.shape[-1]
+
+        # Image stream: fused QK-Norm + RoPE.
+        img_q, img_k = apply_qk_norm_with_optional_rope(
+            q=img_q,
+            k=img_k,
+            q_norm=self.q_norm,
+            k_norm=self.k_norm,
+            head_dim=head_dim,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=False,
+            allow_inplace=True,
+        )
+
+        # Text stream: fused QK-Norm only (no RoPE on text tokens).
+        txt_q, txt_k = apply_qk_norm_with_optional_rope(
+            q=txt_q,
+            k=txt_k,
+            q_norm=self.q_norm,
+            k_norm=self.k_norm,
+            head_dim=head_dim,
+            cos_sin_cache=None,
+            allow_inplace=True,
         )
 
         # Run distributed attention

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -411,12 +411,20 @@ class MMSingleStreamBlock(nn.Module):
         # route through the fused QK-Norm + RoPE kernel in a single in-place
         # pass (replacing the prior 2x RMSNorm + 2x _apply_rotary_emb pattern)
         # and the text portion through the fused QK-Norm only kernel.
+        #
+        # Only Q and K need contiguous tensors: the fused kernel only mutates
+        # those (see `mutates_args=["q", "k"]` on `fused_inplace_qknorm_rope`).
+        # The V tensors stay as strided views -- ``UlyssesAttention.forward``
+        # does ``torch.cat([q, k, v], dim=0)`` downstream, which handles
+        # non-contiguous inputs fine and avoids two unnecessary full-size
+        # copies per single-stream block (~2x extra HBM traffic at LTX-2 /
+        # HunyuanVideo shapes).
         img_q = qkv[:, :img_len, 0].contiguous()
         img_k = qkv[:, :img_len, 1].contiguous()
-        img_v = qkv[:, :img_len, 2].contiguous()
+        img_v = qkv[:, :img_len, 2]
         txt_q = qkv[:, img_len:, 0].contiguous()
         txt_k = qkv[:, img_len:, 1].contiguous()
-        txt_v = qkv[:, img_len:, 2].contiguous()
+        txt_v = qkv[:, img_len:, 2]
 
         cos, sin = freqs_cis
         cos_sin_cache = torch.cat(

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
@@ -19,10 +19,8 @@ def _apply_rotary_emb(
     sin: torch.Tensor,
     is_neox_style: bool,
 ) -> torch.Tensor:
-    # Inlined eager GPT-J interleaved rotary; importing the real
-    # ``_apply_rotary_emb`` triggers a ``register_custom_op_from_extern``
-    # against a stubbed ``flashinfer`` symbol that crashes pytest collection
-    # on the CPU-only harness.
+    # Inlined eager GPT-J interleaved rotary; importing the real one triggers
+    # ``register_custom_op_from_extern`` against a stubbed flashinfer at collection.
     assert not is_neox_style, "test only exercises GPT-J interleaved rotary"
     cos_b = cos.unsqueeze(-2).to(x.dtype)
     sin_b = sin.unsqueeze(-2).to(x.dtype)
@@ -34,10 +32,10 @@ def _apply_rotary_emb(
 
 
 def _make_qk_norms(head_dim: int, dtype: torch.dtype) -> tuple[RMSNorm, RMSNorm]:
-    # Non-trivial gains so a silently-dropped weight multiply would fail.
-    # NB: ``RMSNorm.__init__`` ignores its ``dtype`` kwarg for weights (always
-    # fp32); the explicit ``.to(dtype)`` is required for the fused CUDA path's
-    # ``q_norm.weight.dtype == q.dtype`` gate to pass.
+    # Non-trivial gains catch silently-dropped weight multiplies. The explicit
+    # ``.to(dtype)`` matters: ``RMSNorm.__init__`` ignores its ``dtype`` kwarg
+    # for weights (always fp32), and the fused CUDA gate requires weight dtype
+    # to match q dtype.
     torch.manual_seed(0)
     q_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
     k_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
@@ -192,10 +190,8 @@ def test_single_stream_split_then_fuse_parity(
 
 
 def test_helper_preserves_input_dtype_fp32():
-    # CPU path restricted to fp32: ``RMSNorm.forward_cuda`` routes bf16/fp16
-    # through a CUDA-only triton custom op when ``current_platform.is_cuda()``,
-    # which fires on any GPU host even with CPU tensors. The bf16 sibling
-    # below exercises that path on an actual CUDA device.
+    # CPU restricted to fp32: bf16/fp16 RMSNorm dispatches a CUDA-only triton
+    # op when ``current_platform.is_cuda()``. bf16 is exercised on CUDA below.
     head_dim = 64
     dtype = torch.float32
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
@@ -222,10 +218,8 @@ def test_helper_preserves_input_dtype_fp32():
     reason="bf16 RMSNorm path runs through a CUDA-only triton kernel",
 )
 def test_helper_preserves_input_dtype_bf16_cuda():
-    # Spy on ``fused_inplace_qknorm_rope`` to confirm the fused CUDA kernel
-    # actually fires; otherwise the helper would silently fall back to the
-    # eager + flashinfer-rope branch and the test would pass for the wrong
-    # reason.
+    # Spy confirms the fused CUDA kernel actually fires; without it a silent
+    # fallback to eager + flashinfer-rope would pass for the wrong reason.
     import sglang.multimodal_gen.runtime.layers.layernorm as ln_mod
 
     device = torch.device("cuda")
@@ -267,11 +261,9 @@ def test_helper_preserves_input_dtype_bf16_cuda():
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_fused_kernel_matches_eager_reference_cuda(dtype):
-    # Numerical parity on the actual fused fast path. The fp32 parity tests
-    # above only exercise the eager fallback because the fused kernel gates
-    # on ``q.dtype in (fp16, bf16)``; this test runs at the production dtype
-    # and uses a spy to confirm the fused branch fires (not silently falling
-    # back to eager+flashinfer-rope and passing for the wrong reason).
+    # Numerical parity on the fused fast path. The fp32 parity tests above
+    # only exercise the eager fallback (the kernel gates on bf16/fp16); this
+    # runs at production dtype with a spy to confirm the fused branch fires.
     import sglang.multimodal_gen.runtime.layers.layernorm as ln_mod
 
     device = torch.device("cuda")
@@ -291,14 +283,13 @@ def test_fused_kernel_matches_eager_reference_cuda(dtype):
     sin = sin.to(device)
     cos_sin_cache = cos_sin_cache.to(device)
 
-    # Eager reference: 2x RMSNorm + 2x rotary on the SAME inputs, in dtype.
+    # Eager reference: 2x RMSNorm + 2x rotary on the same inputs.
     ref_q = q_norm(q.contiguous()).to(dtype)
     ref_k = k_norm(k.contiguous()).to(dtype)
     ref_q = _apply_rotary_emb(ref_q, cos, sin, is_neox_style=False)
     ref_k = _apply_rotary_emb(ref_k, cos, sin, is_neox_style=False)
 
-    # Fused path. allow_inplace=True so we clone inputs to avoid mutating
-    # the (already-consumed) eager-reference tensors.
+    # Clone before passing through the fused (in-place) path.
     with patch.object(
         ln_mod,
         "fused_inplace_qknorm_rope",
@@ -319,10 +310,8 @@ def test_fused_kernel_matches_eager_reference_cuda(dtype):
         "helper silently fell back to eager (likely a dtype-gate regression)"
     )
 
-    # Tolerances chosen for fused vs eager at the head_dim reductions used in
-    # HunyuanVideo. bf16 has ~7 mantissa bits so ULP near 1.0 is ~7e-3; the
-    # fused kernel does its reduction in fp32 internally then casts back, so
-    # 2e-2 atol/rtol is the loosest credible parity bar. fp16 keeps ~5e-3.
+    # Loosest credible parity for fused (fp32 internal accum) vs eager:
+    # ~few ULPs of drift -- bf16 ULP ~7e-3 near 1.0, fp16 ~5e-4.
     tol = {torch.bfloat16: 2e-2, torch.float16: 5e-3}[dtype]
     torch.testing.assert_close(out_q, ref_q, atol=tol, rtol=tol)
     torch.testing.assert_close(out_k, ref_k, atol=tol, rtol=tol)
@@ -333,9 +322,8 @@ def test_fused_kernel_matches_eager_reference_cuda(dtype):
 
 @pytest.fixture(scope="module", autouse=True)
 def _init_minimal_distributed():
-    # The blocks construct ``ReplicatedLinear`` / ``ColumnParallelLinear``
-    # which call ``get_tp_group()``. Initialise a 1-rank gloo group so
-    # construction works on CPU; tear down only if we created it.
+    # ``ReplicatedLinear`` / ``ColumnParallelLinear`` inside the blocks need
+    # ``get_tp_group()``; spin up a 1-rank gloo group so construction works on CPU.
     import torch.distributed as dist
 
     from sglang.multimodal_gen.runtime.distributed.parallel_state import (
@@ -389,11 +377,9 @@ class _StubAttention(torch.nn.Module):
 
 
 def _block_test_device() -> torch.device:
-    # ``CustomOp.forward_cuda`` (``fuse_scale_shift_kernel``,
-    # ``triton_one_pass_rms_norm``) is selected at module init from
-    # ``current_platform.is_cuda()``, not from tensor device. On CUDA hosts
-    # those dispatches assert ``x.is_cuda``, so run blocks on the device
-    # that matches the platform.
+    # ``CustomOp.forward_cuda`` is selected at module init from
+    # ``current_platform`` (not tensor device); on CUDA hosts those dispatches
+    # assert ``x.is_cuda``, so match the device to the platform.
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
@@ -463,10 +449,8 @@ def test_double_stream_block_fuses_img_and_txt_sites():
 
 
 def test_single_stream_block_fuses_img_and_txt_and_splits_before_norm():
-    # Pin: the refactor must split *before* QK-Norm. The first spy call
-    # must see Q with shape [B, img_len, H, head_dim], not the full
-    # [B, seq_len, H, head_dim] that a pre-refactor full-norm-then-split
-    # would produce.
+    # Pin: the refactor splits BEFORE QK-Norm. The img spy call must see Q
+    # with shape ``[B, img_len, H, head_dim]``, not the full ``[B, seq_len, ...]``.
     import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
     from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
         MMSingleStreamBlock,
@@ -524,11 +508,9 @@ def test_single_stream_block_fuses_img_and_txt_and_splits_before_norm():
 
 
 def test_single_stream_block_does_not_redundantly_contiguify_v():
-    # Pin: the fused QK-Norm+RoPE kernel only mutates Q/K
-    # (``mutates_args=["q", "k"]``); ``UlyssesAttention`` does
-    # ``torch.cat([q, k, v])`` which accepts non-contiguous V. Adding
-    # ``.contiguous()`` on img_v / txt_v would silently double V-sized HBM
-    # traffic per single-stream block.
+    # Pin: the fused kernel only mutates Q/K (``mutates_args=["q", "k"]``)
+    # and ``UlyssesAttention``'s downstream cat handles non-contiguous V;
+    # adding ``.contiguous()`` on img_v/txt_v would double V HBM traffic.
     import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
     from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
         MMSingleStreamBlock,

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
@@ -1,0 +1,364 @@
+"""CPU parity tests for HunyuanVideo's QK-Norm + RoPE fusion.
+
+HunyuanVideo's ``MMDoubleStreamBlock`` and ``MMSingleStreamBlock`` have been
+refactored to call :func:`apply_qk_norm_with_optional_rope` (the same helper
+that Flux / Qwen-Image use) instead of a hand-rolled sequence of two
+``RMSNorm`` passes followed by two ``_apply_rotary_emb`` calls. These tests
+pin the math: each test reconstructs the *pre-refactor* recipe and asserts the
+fused-helper output matches it element-wise on float32 CPU.
+
+Why CPU + float32: the fused CUDA kernel kicks in only when
+``current_platform.is_cuda() and q.dtype in (fp16, bf16)``. On CPU we
+exercise the helper's eager fallback (RMSNorm forward_native + flashinfer
+rope's triton fallback, which itself swaps to ``apply_rotary_embedding_native``
+on CPU). That fallback shares the same arithmetic kernels the pre-refactor
+``_apply_rotary_emb`` resolved to, so float32 parity is exact.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.layers.layernorm import (
+    RMSNorm,
+    apply_qk_norm_with_optional_rope,
+)
+
+
+# -- Fixtures / helpers ----------------------------------------------------
+
+
+def _apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """Inlined copy of the eager GPT-J style rotary kernel.
+
+    Importing the real ``_apply_rotary_emb`` from
+    ``sglang.multimodal_gen.runtime.layers.rotary_embedding.utils`` triggers
+    that module's top-level ``register_custom_op_from_extern(...)`` against
+    a stubbed ``flashinfer`` symbol, which fails at collection time on the
+    CPU-only test harness (torch's ``infer_schema`` reads
+    ``__globals__`` on the stub). The math below mirrors
+    ``apply_rotary_embedding_native`` from
+    ``sglang/jit_kernel/diffusion/triton/torch_fallback.py`` for
+    ``is_neox_style=False`` with ``cos.shape[-1] == head_dim // 2`` — which
+    is exactly what HunyuanVideo passes through and what the fused-helper
+    fallback resolves to on CPU.
+    """
+    assert not is_neox_style, "test only exercises GPT-J interleaved rotary"
+    cos_b = cos.unsqueeze(-2).to(x.dtype)
+    sin_b = sin.unsqueeze(-2).to(x.dtype)
+    x1 = x[..., ::2]
+    x2 = x[..., 1::2]
+    o1 = x1 * cos_b - x2 * sin_b
+    o2 = x2 * cos_b + x1 * sin_b
+    return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+
+def _make_qk_norms(head_dim: int, dtype: torch.dtype) -> tuple[RMSNorm, RMSNorm]:
+    """Build a (q_norm, k_norm) pair with deliberately non-trivial weights.
+
+    All-ones weights would make the test pass even if the implementation
+    silently dropped the multiplication; uniform jitter forces the kernel to
+    actually apply the gain.
+    """
+    torch.manual_seed(0)
+    q_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
+    k_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
+    with torch.no_grad():
+        q_norm.weight.copy_(torch.empty(head_dim).uniform_(0.9, 1.1))
+        k_norm.weight.copy_(torch.empty(head_dim).uniform_(0.85, 1.15))
+    return q_norm, k_norm
+
+
+def _make_cos_sin(
+    num_tokens: int, head_dim: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Construct cos / sin in the layout HunyuanVideo passes around.
+
+    Returns (cos, sin, cos_sin_cache) where:
+      - ``cos``, ``sin`` are ``[num_tokens, head_dim // 2]`` (the layout
+        ``_apply_rotary_emb`` expects)
+      - ``cos_sin_cache`` is ``[num_tokens, head_dim]`` packed for the
+        flashinfer-style helper (matches how Flux / Wan / hunyuanvideo build
+        it just before calling the fused helper).
+    """
+    torch.manual_seed(1)
+    half = head_dim // 2
+    cos = torch.randn(num_tokens, half) * 0.1 + 0.9
+    sin = torch.randn(num_tokens, half) * 0.1
+    cos_sin_cache = torch.cat(
+        [cos.to(torch.float32).contiguous(), sin.to(torch.float32).contiguous()],
+        dim=-1,
+    )
+    return cos, sin, cos_sin_cache
+
+
+# -- Double-stream image path: fused QK-Norm + RoPE -----------------------
+
+
+@pytest.mark.parametrize(
+    "batch,img_len,num_heads,head_dim",
+    [
+        (1, 256, 4, 64),  # narrow shape, single batch
+        (2, 64, 2, 32),  # multi-batch, smaller
+    ],
+)
+def test_double_stream_img_norm_rope_parity(batch, img_len, num_heads, head_dim):
+    """img-stream: 2x RMSNorm + 2x _apply_rotary_emb == fused helper."""
+    dtype = torch.float32
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+    cos, sin, cos_sin_cache = _make_cos_sin(img_len, head_dim)
+
+    torch.manual_seed(2)
+    img_q = torch.randn(batch, img_len, num_heads, head_dim, dtype=dtype)
+    img_k = torch.randn(batch, img_len, num_heads, head_dim, dtype=dtype)
+    img_v = torch.randn(batch, img_len, num_heads, head_dim, dtype=dtype)
+
+    # Pre-refactor recipe: 2x RMSNorm + 2x rope.
+    ref_q = q_norm(img_q.contiguous()).to(img_v)
+    ref_k = k_norm(img_k.contiguous()).to(img_v)
+    ref_q = _apply_rotary_emb(ref_q, cos, sin, is_neox_style=False)
+    ref_k = _apply_rotary_emb(ref_k, cos, sin, is_neox_style=False)
+
+    # New: fused helper.
+    out_q, out_k = apply_qk_norm_with_optional_rope(
+        q=img_q.clone().contiguous(),
+        k=img_k.clone().contiguous(),
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=False,
+        allow_inplace=True,
+    )
+
+    assert out_q.shape == ref_q.shape
+    assert out_q.dtype == ref_q.dtype
+    torch.testing.assert_close(out_q, ref_q, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(out_k, ref_k, atol=1e-5, rtol=1e-5)
+
+
+# -- Double-stream text path: fused QK-Norm only (no RoPE) -----------------
+
+
+@pytest.mark.parametrize(
+    "batch,txt_len,num_heads,head_dim",
+    [
+        (1, 64, 4, 64),
+        (2, 256, 8, 32),
+    ],
+)
+def test_double_stream_txt_norm_only_parity(batch, txt_len, num_heads, head_dim):
+    """txt-stream: 2x RMSNorm == fused helper with cos_sin_cache=None."""
+    dtype = torch.float32
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+
+    torch.manual_seed(3)
+    txt_q = torch.randn(batch, txt_len, num_heads, head_dim, dtype=dtype)
+    txt_k = torch.randn(batch, txt_len, num_heads, head_dim, dtype=dtype)
+
+    ref_q = q_norm(txt_q.contiguous())
+    ref_k = k_norm(txt_k.contiguous())
+
+    out_q, out_k = apply_qk_norm_with_optional_rope(
+        q=txt_q.clone().contiguous(),
+        k=txt_k.clone().contiguous(),
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=None,
+        allow_inplace=True,
+    )
+
+    torch.testing.assert_close(out_q, ref_q, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(out_k, ref_k, atol=1e-5, rtol=1e-5)
+
+
+# -- Single-stream split-first parity -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "batch,img_len,txt_len,num_heads,head_dim",
+    [
+        (1, 256, 64, 4, 64),
+        (2, 128, 32, 2, 32),
+    ],
+)
+def test_single_stream_split_then_fuse_parity(
+    batch, img_len, txt_len, num_heads, head_dim
+):
+    """Split-then-fuse must match (full-RMSNorm -> split -> rope) numerically.
+
+    The refactor moves the image/text split before QK-Norm so the image
+    portion can route through fused QK-Norm + RoPE while the text portion
+    routes through fused QK-Norm only. RMSNorm is a per-token operation,
+    so reordering split vs. norm is mathematically a no-op; this test
+    pins that property.
+    """
+    dtype = torch.float32
+    seq_len = img_len + txt_len
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+    cos, sin, cos_sin_cache = _make_cos_sin(img_len, head_dim)
+
+    torch.manual_seed(4)
+    qkv = torch.randn(batch, seq_len, 3, num_heads, head_dim, dtype=dtype)
+
+    # Reference (pre-refactor): RMSNorm on full q/k, then split, then rope.
+    q_full = qkv[:, :, 0]
+    k_full = qkv[:, :, 1]
+    v_full = qkv[:, :, 2]
+    q_ref = q_norm(q_full.contiguous()).to(v_full.dtype)
+    k_ref = k_norm(k_full.contiguous()).to(v_full.dtype)
+    img_q_ref, txt_q_ref = q_ref[:, :img_len], q_ref[:, img_len:]
+    img_k_ref, txt_k_ref = k_ref[:, :img_len], k_ref[:, img_len:]
+    img_q_ref = _apply_rotary_emb(img_q_ref, cos, sin, is_neox_style=False)
+    img_k_ref = _apply_rotary_emb(img_k_ref, cos, sin, is_neox_style=False)
+
+    # New: split first, then fused per-stream.
+    img_q = qkv[:, :img_len, 0].contiguous()
+    img_k = qkv[:, :img_len, 1].contiguous()
+    txt_q = qkv[:, img_len:, 0].contiguous()
+    txt_k = qkv[:, img_len:, 1].contiguous()
+
+    img_q, img_k = apply_qk_norm_with_optional_rope(
+        q=img_q,
+        k=img_k,
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=False,
+        allow_inplace=True,
+    )
+    txt_q, txt_k = apply_qk_norm_with_optional_rope(
+        q=txt_q,
+        k=txt_k,
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=None,
+        allow_inplace=True,
+    )
+
+    torch.testing.assert_close(img_q, img_q_ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(img_k, img_k_ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(txt_q, txt_q_ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(txt_k, txt_k_ref, atol=1e-5, rtol=1e-5)
+
+
+# -- Helper-level sanity checks -------------------------------------------
+
+
+def test_helper_no_rope_path_matches_apply_qk_norm():
+    """Passing ``cos_sin_cache=None`` routes to plain QK-Norm (no rope)."""
+    dtype = torch.float32
+    head_dim = 64
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+    torch.manual_seed(5)
+    q = torch.randn(1, 32, 4, head_dim, dtype=dtype)
+    k = torch.randn(1, 32, 4, head_dim, dtype=dtype)
+
+    ref_q = q_norm(q.contiguous())
+    ref_k = k_norm(k.contiguous())
+
+    out_q, out_k = apply_qk_norm_with_optional_rope(
+        q=q.clone().contiguous(),
+        k=k.clone().contiguous(),
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=None,
+        allow_inplace=True,
+    )
+    torch.testing.assert_close(out_q, ref_q, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(out_k, ref_k, atol=1e-5, rtol=1e-5)
+
+
+def test_helper_preserves_input_dtype_fp32():
+    """The helper must not silently upcast to float32 (the model relies on
+    bf16/fp16 outputs flowing into attention).
+
+    Restricted to fp32 in the CPU-only suite because sglang's ``RMSNorm``
+    dispatches the low-precision path through a triton CUDA-only custom op
+    (``sglang::triton_one_pass_rms_norm_cuda``) when
+    ``current_platform.is_cuda()`` is True — which is the case on a GPU
+    host even when our test tensors live on CPU. The bf16 variant lives
+    in ``test_helper_preserves_input_dtype_bf16_cuda``, gated on an
+    actually-reachable CUDA device.
+    """
+    head_dim = 64
+    dtype = torch.float32
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+    torch.manual_seed(6)
+    q = torch.randn(1, 16, 4, head_dim, dtype=dtype)
+    k = torch.randn(1, 16, 4, head_dim, dtype=dtype)
+    _, _, cos_sin_cache = _make_cos_sin(16, head_dim)
+    out_q, out_k = apply_qk_norm_with_optional_rope(
+        q=q.contiguous(),
+        k=k.contiguous(),
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=False,
+        allow_inplace=True,
+    )
+    assert out_q.dtype == dtype
+    assert out_k.dtype == dtype
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="bf16 RMSNorm path runs through a CUDA-only triton kernel",
+)
+def test_helper_preserves_input_dtype_bf16_cuda():
+    """bf16 dtype-preservation check on an actual CUDA device.
+
+    Skipped on CPU-only hosts: sglang's ``RMSNorm.forward_cuda`` routes
+    bf16/fp16 inputs through ``triton_one_pass_rms_norm`` for
+    ``hidden_size <= 128``, which is registered only for the CUDA backend.
+    """
+    device = torch.device("cuda")
+    head_dim = 64
+    dtype = torch.bfloat16
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+    q_norm = q_norm.to(device)
+    k_norm = k_norm.to(device)
+    torch.manual_seed(6)
+    q = torch.randn(1, 16, 4, head_dim, dtype=dtype, device=device)
+    k = torch.randn(1, 16, 4, head_dim, dtype=dtype, device=device)
+    _, _, cos_sin_cache = _make_cos_sin(16, head_dim)
+    cos_sin_cache = cos_sin_cache.to(device)
+    out_q, out_k = apply_qk_norm_with_optional_rope(
+        q=q.contiguous(),
+        k=k.contiguous(),
+        q_norm=q_norm,
+        k_norm=k_norm,
+        head_dim=head_dim,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=False,
+        allow_inplace=True,
+    )
+    assert out_q.dtype == dtype
+    assert out_k.dtype == dtype
+
+
+# -- Routing test ----------------------------------------------------------
+
+
+def test_hunyuanvideo_module_wires_fused_helper():
+    """Smoke test: after the refactor, hunyuanvideo.py imports the fused
+    helper and has stopped importing the per-pass rope helper."""
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv
+
+    # The fused helper is bound at module scope (via layernorm imports).
+    assert hasattr(hv, "apply_qk_norm_with_optional_rope")
+
+    # The pre-refactor per-pass rope helper should no longer be a top-level
+    # symbol — the refactor's intent is a single fused call site.
+    assert not hasattr(hv, "_apply_rotary_emb")

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
@@ -261,6 +261,73 @@ def test_helper_preserves_input_dtype_bf16_cuda():
     assert out_k.dtype == dtype
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="fused QK-Norm+RoPE kernel requires CUDA",
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_kernel_matches_eager_reference_cuda(dtype):
+    # Numerical parity on the actual fused fast path. The fp32 parity tests
+    # above only exercise the eager fallback because the fused kernel gates
+    # on ``q.dtype in (fp16, bf16)``; this test runs at the production dtype
+    # and uses a spy to confirm the fused branch fires (not silently falling
+    # back to eager+flashinfer-rope and passing for the wrong reason).
+    import sglang.multimodal_gen.runtime.layers.layernorm as ln_mod
+
+    device = torch.device("cuda")
+    head_dim = 64
+    num_tokens = 256
+    num_heads = 4
+    batch = 1
+    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
+    q_norm = q_norm.to(device=device, dtype=dtype)
+    k_norm = k_norm.to(device=device, dtype=dtype)
+
+    torch.manual_seed(7)
+    q = torch.randn(batch, num_tokens, num_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(batch, num_tokens, num_heads, head_dim, dtype=dtype, device=device)
+    cos, sin, cos_sin_cache = _make_cos_sin(num_tokens, head_dim)
+    cos = cos.to(device)
+    sin = sin.to(device)
+    cos_sin_cache = cos_sin_cache.to(device)
+
+    # Eager reference: 2x RMSNorm + 2x rotary on the SAME inputs, in dtype.
+    ref_q = q_norm(q.contiguous()).to(dtype)
+    ref_k = k_norm(k.contiguous()).to(dtype)
+    ref_q = _apply_rotary_emb(ref_q, cos, sin, is_neox_style=False)
+    ref_k = _apply_rotary_emb(ref_k, cos, sin, is_neox_style=False)
+
+    # Fused path. allow_inplace=True so we clone inputs to avoid mutating
+    # the (already-consumed) eager-reference tensors.
+    with patch.object(
+        ln_mod,
+        "fused_inplace_qknorm_rope",
+        wraps=ln_mod.fused_inplace_qknorm_rope,
+    ) as spy:
+        out_q, out_k = apply_qk_norm_with_optional_rope(
+            q=q.clone().contiguous(),
+            k=k.clone().contiguous(),
+            q_norm=q_norm,
+            k_norm=k_norm,
+            head_dim=head_dim,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=False,
+            allow_inplace=True,
+        )
+    assert spy.call_count >= 1, (
+        "expected fused_inplace_qknorm_rope to fire on bf16/fp16 CUDA inputs; "
+        "helper silently fell back to eager (likely a dtype-gate regression)"
+    )
+
+    # Tolerances chosen for fused vs eager at the head_dim reductions used in
+    # HunyuanVideo. bf16 has ~7 mantissa bits so ULP near 1.0 is ~7e-3; the
+    # fused kernel does its reduction in fp32 internally then casts back, so
+    # 2e-2 atol/rtol is the loosest credible parity bar. fp16 keeps ~5e-3.
+    tol = {torch.bfloat16: 2e-2, torch.float16: 5e-3}[dtype]
+    torch.testing.assert_close(out_q, ref_q, atol=tol, rtol=tol)
+    torch.testing.assert_close(out_k, ref_k, atol=tol, rtol=tol)
+
+
 # Block-level tests --------------------------------------------------------
 
 

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
@@ -1,21 +1,8 @@
-"""CPU parity tests for HunyuanVideo's QK-Norm + RoPE fusion.
-
-HunyuanVideo's ``MMDoubleStreamBlock`` and ``MMSingleStreamBlock`` have been
-refactored to call :func:`apply_qk_norm_with_optional_rope` (the same helper
-that Flux / Qwen-Image use) instead of a hand-rolled sequence of two
-``RMSNorm`` passes followed by two ``_apply_rotary_emb`` calls. These tests
-pin the math: each test reconstructs the *pre-refactor* recipe and asserts the
-fused-helper output matches it element-wise on float32 CPU.
-
-Why CPU + float32: the fused CUDA kernel kicks in only when
-``current_platform.is_cuda() and q.dtype in (fp16, bf16)``. On CPU we
-exercise the helper's eager fallback (RMSNorm forward_native + flashinfer
-rope's triton fallback, which itself swaps to ``apply_rotary_embedding_native``
-on CPU). That fallback shares the same arithmetic kernels the pre-refactor
-``_apply_rotary_emb`` resolved to, so float32 parity is exact.
-"""
-
 from __future__ import annotations
+
+import os
+import socket
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -26,29 +13,16 @@ from sglang.multimodal_gen.runtime.layers.layernorm import (
 )
 
 
-# -- Fixtures / helpers ----------------------------------------------------
-
-
 def _apply_rotary_emb(
     x: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
     is_neox_style: bool,
 ) -> torch.Tensor:
-    """Inlined copy of the eager GPT-J style rotary kernel.
-
-    Importing the real ``_apply_rotary_emb`` from
-    ``sglang.multimodal_gen.runtime.layers.rotary_embedding.utils`` triggers
-    that module's top-level ``register_custom_op_from_extern(...)`` against
-    a stubbed ``flashinfer`` symbol, which fails at collection time on the
-    CPU-only test harness (torch's ``infer_schema`` reads
-    ``__globals__`` on the stub). The math below mirrors
-    ``apply_rotary_embedding_native`` from
-    ``sglang/jit_kernel/diffusion/triton/torch_fallback.py`` for
-    ``is_neox_style=False`` with ``cos.shape[-1] == head_dim // 2`` — which
-    is exactly what HunyuanVideo passes through and what the fused-helper
-    fallback resolves to on CPU.
-    """
+    # Inlined eager GPT-J interleaved rotary; importing the real
+    # ``_apply_rotary_emb`` triggers a ``register_custom_op_from_extern``
+    # against a stubbed ``flashinfer`` symbol that crashes pytest collection
+    # on the CPU-only harness.
     assert not is_neox_style, "test only exercises GPT-J interleaved rotary"
     cos_b = cos.unsqueeze(-2).to(x.dtype)
     sin_b = sin.unsqueeze(-2).to(x.dtype)
@@ -60,44 +34,22 @@ def _apply_rotary_emb(
 
 
 def _make_qk_norms(head_dim: int, dtype: torch.dtype) -> tuple[RMSNorm, RMSNorm]:
-    """Build a (q_norm, k_norm) pair with deliberately non-trivial weights.
-
-    All-ones weights would make the test pass even if the implementation
-    silently dropped the multiplication; uniform jitter forces the kernel to
-    actually apply the gain.
-
-    NOTE: sglang's ``RMSNorm.__init__`` accepts a ``dtype`` kwarg but ignores
-    it for weight construction -- the parameter is hardcoded as
-    ``nn.Parameter(torch.ones(hidden_size))``, which defaults to fp32. We
-    explicitly cast the modules at the end so the weight dtype matches the
-    requested ``dtype``. Without this, the fused CUDA path's
-    ``q_norm.weight.dtype == q.dtype`` gate silently fails for bf16/fp16
-    inputs and ``apply_qk_norm_rope`` falls back to the eager path -- i.e.,
-    the test would *not* exercise the fused kernel it claims to test.
-    """
+    # Non-trivial gains so a silently-dropped weight multiply would fail.
+    # NB: ``RMSNorm.__init__`` ignores its ``dtype`` kwarg for weights (always
+    # fp32); the explicit ``.to(dtype)`` is required for the fused CUDA path's
+    # ``q_norm.weight.dtype == q.dtype`` gate to pass.
     torch.manual_seed(0)
     q_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
     k_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
     with torch.no_grad():
         q_norm.weight.copy_(torch.empty(head_dim).uniform_(0.9, 1.1))
         k_norm.weight.copy_(torch.empty(head_dim).uniform_(0.85, 1.15))
-    q_norm = q_norm.to(dtype)
-    k_norm = k_norm.to(dtype)
-    return q_norm, k_norm
+    return q_norm.to(dtype), k_norm.to(dtype)
 
 
 def _make_cos_sin(
     num_tokens: int, head_dim: int
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Construct cos / sin in the layout HunyuanVideo passes around.
-
-    Returns (cos, sin, cos_sin_cache) where:
-      - ``cos``, ``sin`` are ``[num_tokens, head_dim // 2]`` (the layout
-        ``_apply_rotary_emb`` expects)
-      - ``cos_sin_cache`` is ``[num_tokens, head_dim]`` packed for the
-        flashinfer-style helper (matches how Flux / Wan / hunyuanvideo build
-        it just before calling the fused helper).
-    """
     torch.manual_seed(1)
     half = head_dim // 2
     cos = torch.randn(num_tokens, half) * 0.1 + 0.9
@@ -109,18 +61,14 @@ def _make_cos_sin(
     return cos, sin, cos_sin_cache
 
 
-# -- Double-stream image path: fused QK-Norm + RoPE -----------------------
-
-
 @pytest.mark.parametrize(
     "batch,img_len,num_heads,head_dim",
     [
-        (1, 256, 4, 64),  # narrow shape, single batch
-        (2, 64, 2, 32),  # multi-batch, smaller
+        (1, 256, 4, 64),
+        (2, 64, 2, 32),
     ],
 )
 def test_double_stream_img_norm_rope_parity(batch, img_len, num_heads, head_dim):
-    """img-stream: 2x RMSNorm + 2x _apply_rotary_emb == fused helper."""
     dtype = torch.float32
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
     cos, sin, cos_sin_cache = _make_cos_sin(img_len, head_dim)
@@ -130,13 +78,11 @@ def test_double_stream_img_norm_rope_parity(batch, img_len, num_heads, head_dim)
     img_k = torch.randn(batch, img_len, num_heads, head_dim, dtype=dtype)
     img_v = torch.randn(batch, img_len, num_heads, head_dim, dtype=dtype)
 
-    # Pre-refactor recipe: 2x RMSNorm + 2x rope.
     ref_q = q_norm(img_q.contiguous()).to(img_v)
     ref_k = k_norm(img_k.contiguous()).to(img_v)
     ref_q = _apply_rotary_emb(ref_q, cos, sin, is_neox_style=False)
     ref_k = _apply_rotary_emb(ref_k, cos, sin, is_neox_style=False)
 
-    # New: fused helper.
     out_q, out_k = apply_qk_norm_with_optional_rope(
         q=img_q.clone().contiguous(),
         k=img_k.clone().contiguous(),
@@ -148,13 +94,8 @@ def test_double_stream_img_norm_rope_parity(batch, img_len, num_heads, head_dim)
         allow_inplace=True,
     )
 
-    assert out_q.shape == ref_q.shape
-    assert out_q.dtype == ref_q.dtype
     torch.testing.assert_close(out_q, ref_q, atol=1e-5, rtol=1e-5)
     torch.testing.assert_close(out_k, ref_k, atol=1e-5, rtol=1e-5)
-
-
-# -- Double-stream text path: fused QK-Norm only (no RoPE) -----------------
 
 
 @pytest.mark.parametrize(
@@ -165,7 +106,6 @@ def test_double_stream_img_norm_rope_parity(batch, img_len, num_heads, head_dim)
     ],
 )
 def test_double_stream_txt_norm_only_parity(batch, txt_len, num_heads, head_dim):
-    """txt-stream: 2x RMSNorm == fused helper with cos_sin_cache=None."""
     dtype = torch.float32
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
 
@@ -190,9 +130,6 @@ def test_double_stream_txt_norm_only_parity(batch, txt_len, num_heads, head_dim)
     torch.testing.assert_close(out_k, ref_k, atol=1e-5, rtol=1e-5)
 
 
-# -- Single-stream split-first parity -------------------------------------
-
-
 @pytest.mark.parametrize(
     "batch,img_len,txt_len,num_heads,head_dim",
     [
@@ -203,14 +140,8 @@ def test_double_stream_txt_norm_only_parity(batch, txt_len, num_heads, head_dim)
 def test_single_stream_split_then_fuse_parity(
     batch, img_len, txt_len, num_heads, head_dim
 ):
-    """Split-then-fuse must match (full-RMSNorm -> split -> rope) numerically.
-
-    The refactor moves the image/text split before QK-Norm so the image
-    portion can route through fused QK-Norm + RoPE while the text portion
-    routes through fused QK-Norm only. RMSNorm is a per-token operation,
-    so reordering split vs. norm is mathematically a no-op; this test
-    pins that property.
-    """
+    # Pin: pre-refactor (RMSNorm-then-split) == post-refactor (split-then-RMSNorm).
+    # RMSNorm is per-token so this reordering is mathematically a no-op.
     dtype = torch.float32
     seq_len = img_len + txt_len
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
@@ -219,7 +150,6 @@ def test_single_stream_split_then_fuse_parity(
     torch.manual_seed(4)
     qkv = torch.randn(batch, seq_len, 3, num_heads, head_dim, dtype=dtype)
 
-    # Reference (pre-refactor): RMSNorm on full q/k, then split, then rope.
     q_full = qkv[:, :, 0]
     k_full = qkv[:, :, 1]
     v_full = qkv[:, :, 2]
@@ -230,7 +160,6 @@ def test_single_stream_split_then_fuse_parity(
     img_q_ref = _apply_rotary_emb(img_q_ref, cos, sin, is_neox_style=False)
     img_k_ref = _apply_rotary_emb(img_k_ref, cos, sin, is_neox_style=False)
 
-    # New: split first, then fused per-stream.
     img_q = qkv[:, :img_len, 0].contiguous()
     img_k = qkv[:, :img_len, 1].contiguous()
     txt_q = qkv[:, img_len:, 0].contiguous()
@@ -262,46 +191,11 @@ def test_single_stream_split_then_fuse_parity(
     torch.testing.assert_close(txt_k, txt_k_ref, atol=1e-5, rtol=1e-5)
 
 
-# -- Helper-level sanity checks -------------------------------------------
-
-
-def test_helper_no_rope_path_matches_apply_qk_norm():
-    """Passing ``cos_sin_cache=None`` routes to plain QK-Norm (no rope)."""
-    dtype = torch.float32
-    head_dim = 64
-    q_norm, k_norm = _make_qk_norms(head_dim, dtype)
-    torch.manual_seed(5)
-    q = torch.randn(1, 32, 4, head_dim, dtype=dtype)
-    k = torch.randn(1, 32, 4, head_dim, dtype=dtype)
-
-    ref_q = q_norm(q.contiguous())
-    ref_k = k_norm(k.contiguous())
-
-    out_q, out_k = apply_qk_norm_with_optional_rope(
-        q=q.clone().contiguous(),
-        k=k.clone().contiguous(),
-        q_norm=q_norm,
-        k_norm=k_norm,
-        head_dim=head_dim,
-        cos_sin_cache=None,
-        allow_inplace=True,
-    )
-    torch.testing.assert_close(out_q, ref_q, atol=1e-5, rtol=1e-5)
-    torch.testing.assert_close(out_k, ref_k, atol=1e-5, rtol=1e-5)
-
-
 def test_helper_preserves_input_dtype_fp32():
-    """The helper must not silently upcast to float32 (the model relies on
-    bf16/fp16 outputs flowing into attention).
-
-    Restricted to fp32 in the CPU-only suite because sglang's ``RMSNorm``
-    dispatches the low-precision path through a triton CUDA-only custom op
-    (``sglang::triton_one_pass_rms_norm_cuda``) when
-    ``current_platform.is_cuda()`` is True — which is the case on a GPU
-    host even when our test tensors live on CPU. The bf16 variant lives
-    in ``test_helper_preserves_input_dtype_bf16_cuda``, gated on an
-    actually-reachable CUDA device.
-    """
+    # CPU path restricted to fp32: ``RMSNorm.forward_cuda`` routes bf16/fp16
+    # through a CUDA-only triton custom op when ``current_platform.is_cuda()``,
+    # which fires on any GPU host even with CPU tensors. The bf16 sibling
+    # below exercises that path on an actual CUDA device.
     head_dim = 64
     dtype = torch.float32
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
@@ -328,34 +222,18 @@ def test_helper_preserves_input_dtype_fp32():
     reason="bf16 RMSNorm path runs through a CUDA-only triton kernel",
 )
 def test_helper_preserves_input_dtype_bf16_cuda():
-    """bf16 dtype-preservation check on an actual CUDA device, *and* proof
-    that the fused JIT kernel actually fires.
-
-    Skipped on CPU-only hosts: sglang's ``RMSNorm.forward_cuda`` routes
-    bf16/fp16 inputs through ``triton_one_pass_rms_norm`` for
-    ``hidden_size <= 128``, which is registered only for the CUDA backend.
-
-    A spy on ``fused_inplace_qknorm_rope`` asserts the fused-CUDA path was
-    actually taken -- if the helper falls back to the eager + flashinfer
-    rope branch (e.g. because the norm weights were left as fp32 by
-    `_make_qk_norms`), the spy's call_count stays 0 and the test fails
-    instead of silently passing through the wrong code path.
-    """
-    from unittest.mock import patch
-
+    # Spy on ``fused_inplace_qknorm_rope`` to confirm the fused CUDA kernel
+    # actually fires; otherwise the helper would silently fall back to the
+    # eager + flashinfer-rope branch and the test would pass for the wrong
+    # reason.
     import sglang.multimodal_gen.runtime.layers.layernorm as ln_mod
 
     device = torch.device("cuda")
     head_dim = 64
     dtype = torch.bfloat16
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
-    # NB: `.to(device=..., dtype=...)` -- moving dtype too is what makes the
-    # weight match q.dtype downstream. Plain `.to(device)` would keep the
-    # weight fp32 (see `_make_qk_norms` note) and bypass the fused gate.
     q_norm = q_norm.to(device=device, dtype=dtype)
     k_norm = k_norm.to(device=device, dtype=dtype)
-    assert q_norm.weight.dtype == dtype
-    assert k_norm.weight.dtype == dtype
 
     torch.manual_seed(6)
     q = torch.randn(1, 16, 4, head_dim, dtype=dtype, device=device)
@@ -363,10 +241,11 @@ def test_helper_preserves_input_dtype_bf16_cuda():
     _, _, cos_sin_cache = _make_cos_sin(16, head_dim)
     cos_sin_cache = cos_sin_cache.to(device)
 
-    real = ln_mod.fused_inplace_qknorm_rope
     with patch.object(
-        ln_mod, "fused_inplace_qknorm_rope", wraps=real
-    ) as mock_fused:
+        ln_mod,
+        "fused_inplace_qknorm_rope",
+        wraps=ln_mod.fused_inplace_qknorm_rope,
+    ) as spy:
         out_q, out_k = apply_qk_norm_with_optional_rope(
             q=q.contiguous(),
             k=k.contiguous(),
@@ -377,55 +256,19 @@ def test_helper_preserves_input_dtype_bf16_cuda():
             is_neox=False,
             allow_inplace=True,
         )
-    assert mock_fused.call_count >= 1, (
-        "Expected fused_inplace_qknorm_rope to fire at least once on CUDA "
-        f"bf16; got call_count={mock_fused.call_count} (helper silently "
-        "fell back to the eager + flashinfer rope branch)"
-    )
+    assert spy.call_count >= 1
     assert out_q.dtype == dtype
     assert out_k.dtype == dtype
 
 
-# -- Routing test ----------------------------------------------------------
-
-
-def test_hunyuanvideo_module_wires_fused_helper():
-    """Smoke test: after the refactor, hunyuanvideo.py imports the fused
-    helper and has stopped importing the per-pass rope helper."""
-    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv
-
-    # The fused helper is bound at module scope (via layernorm imports).
-    assert hasattr(hv, "apply_qk_norm_with_optional_rope")
-
-    # The pre-refactor per-pass rope helper should no longer be a top-level
-    # symbol — the refactor's intent is a single fused call site.
-    assert not hasattr(hv, "_apply_rotary_emb")
-
-
-# -- Block-level tests with mocked attention -------------------------------
-#
-# The helper-level tests above pin the *math* of the fusion. The tests
-# below pin the *wiring* -- that ``MMDoubleStreamBlock.forward`` and
-# ``MMSingleStreamBlock.forward`` actually invoke
-# ``apply_qk_norm_with_optional_rope`` at the intended sites, with the
-# intended arguments. They construct the production block modules on CPU,
-# patch the attention call with a shape-preserving mock, spy on the helper,
-# and assert the expected call count + arg shapes.
-#
-# Construction requires a 1-rank tensor-parallel group because the blocks
-# instantiate ``ReplicatedLinear`` / ``ColumnParallelLinear`` which call
-# ``get_tp_group()``. A module-scoped fixture initializes a minimal
-# gloo-backed single-rank group once and tears it down at the end.
+# Block-level tests --------------------------------------------------------
 
 
 @pytest.fixture(scope="module", autouse=True)
 def _init_minimal_distributed():
-    """Initialize a 1-rank gloo distributed + TP group so the block
-    constructors can resolve ``get_tp_group()`` on CPU. Single-process,
-    single-rank -- no real collective work happens."""
-    import os
-    import socket
-
+    # The blocks construct ``ReplicatedLinear`` / ``ColumnParallelLinear``
+    # which call ``get_tp_group()``. Initialise a 1-rank gloo group so
+    # construction works on CPU; tear down only if we created it.
     import torch.distributed as dist
 
     from sglang.multimodal_gen.runtime.distributed.parallel_state import (
@@ -435,7 +278,6 @@ def _init_minimal_distributed():
 
     was_initialized = dist.is_initialized()
     if not was_initialized:
-        # Pick a free port so concurrent test runs / leftover sockets don't clash.
         with socket.socket() as s:
             s.bind(("127.0.0.1", 0))
             free_port = s.getsockname()[1]
@@ -464,30 +306,14 @@ def _init_minimal_distributed():
 
     yield
 
-    # Only tear down what this fixture created -- leave any pre-existing
-    # distributed state untouched.
     if not was_initialized and dist.is_initialized():
         try:
             dist.destroy_process_group()
         except Exception:
             pass
-#
-# In particular, ``test_single_stream_block_*_splits_before_norm`` is the
-# only test that actually proves the single-stream split-then-fuse refactor
-# went through ``MMSingleStreamBlock.forward`` (not just through a
-# hand-rolled math reference): the first spy call must see a Q tensor of
-# shape ``[B, img_len, H, head_dim]``, not the full ``[B, seq_len, ...]``
-# that the pre-refactor full-norm-then-split path would have produced.
 
 
 class _StubAttention(torch.nn.Module):
-    """Stand-in for ``UlyssesAttention`` during block construction. Takes any
-    constructor args (so the block doesn't need ServerArgs / attn-backend
-    setup), and on forward returns zero tensors matching the V shapes --
-    enough for ``MMDoubleStreamBlock`` / ``MMSingleStreamBlock`` to flow
-    through their post-attention residual / MLP layers without changing
-    what we're testing (which is the QK-Norm + RoPE call sites)."""
-
     def __init__(self, *args, **kwargs):
         super().__init__()
 
@@ -496,29 +322,15 @@ class _StubAttention(torch.nn.Module):
 
 
 def _block_test_device() -> torch.device:
-    """Pick the device for the block-level tests.
-
-    On a CUDA-capable host sglang's ``CustomOp`` dispatch (e.g.
-    ``LayerNormScaleShift.forward_cuda`` -> ``fuse_scale_shift_kernel``,
-    and ``RMSNorm`` -> ``triton_one_pass_rms_norm``) is selected at module
-    init time from ``current_platform.is_cuda()``, NOT from the input
-    tensor's device. Running these dispatch paths against CPU tensors
-    blows up with ``assert (x.is_cuda and scale.is_cuda)``-style errors
-    even though the test isn't trying to exercise CUDA kernels.
-
-    So: run the block forward on CUDA when CUDA is available; fall back to
-    CPU (which has its own ``forward_cpu`` / ``forward_native`` paths) on
-    CPU-only hosts. The assertions we care about (helper call count,
-    helper kwarg shapes, V contiguity) hold on either device."""
+    # ``CustomOp.forward_cuda`` (``fuse_scale_shift_kernel``,
+    # ``triton_one_pass_rms_norm``) is selected at module init from
+    # ``current_platform.is_cuda()``, not from tensor device. On CUDA hosts
+    # those dispatches assert ``x.is_cuda``, so run blocks on the device
+    # that matches the platform.
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 def _build_block_with_stub_attention(block_cls, **kwargs):
-    """Construct ``block_cls`` with the production ``UlyssesAttention``
-    constructor temporarily swapped for ``_StubAttention``, so the block
-    can be instantiated without requiring a global ServerArgs."""
-    from unittest.mock import patch
-
     import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
 
     with patch.object(hv_mod, "UlyssesAttention", _StubAttention):
@@ -526,11 +338,6 @@ def _build_block_with_stub_attention(block_cls, **kwargs):
 
 
 def test_double_stream_block_fuses_img_and_txt_sites():
-    """MMDoubleStreamBlock.forward calls apply_qk_norm_with_optional_rope
-    exactly twice: img stream with cos_sin_cache (norm + rope), txt stream
-    with cos_sin_cache=None (norm only). Output shapes match input shapes."""
-    from unittest.mock import patch
-
     import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
     from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
         MMDoubleStreamBlock,
@@ -559,48 +366,40 @@ def test_double_stream_block_fuses_img_and_txt_sites():
     sin = torch.randn(img_seq_len, head_dim // 2, device=device)
     freqs_cis = (cos, sin)
 
-    real = hv_mod.apply_qk_norm_with_optional_rope
     with patch.object(
-        hv_mod, "apply_qk_norm_with_optional_rope", wraps=real
+        hv_mod,
+        "apply_qk_norm_with_optional_rope",
+        wraps=hv_mod.apply_qk_norm_with_optional_rope,
     ) as spy:
         with torch.no_grad():
             out_img, out_txt = block(img, txt, vec, freqs_cis)
 
-    assert spy.call_count == 2, (
-        f"MMDoubleStreamBlock should fuse exactly 2 sites; got {spy.call_count}"
-    )
+    assert spy.call_count == 2
     img_call = spy.call_args_list[0].kwargs
     txt_call = spy.call_args_list[1].kwargs
-    assert img_call["cos_sin_cache"] is not None, (
-        "img stream call must pass cos_sin_cache for rope"
-    )
-    assert txt_call["cos_sin_cache"] is None, (
-        "txt stream call must pass cos_sin_cache=None (no rope on text)"
-    )
-    # Q tensors at the helper boundary are [B, seq_len, H, head_dim].
+    assert img_call["cos_sin_cache"] is not None
+    assert txt_call["cos_sin_cache"] is None
     assert img_call["q"].shape == (
-        batch_size, img_seq_len, num_attention_heads, head_dim,
+        batch_size,
+        img_seq_len,
+        num_attention_heads,
+        head_dim,
     )
     assert txt_call["q"].shape == (
-        batch_size, txt_seq_len, num_attention_heads, head_dim,
+        batch_size,
+        txt_seq_len,
+        num_attention_heads,
+        head_dim,
     )
-    # Output residual connections preserve input shape.
     assert out_img.shape == (batch_size, img_seq_len, hidden_size)
     assert out_txt.shape == (batch_size, txt_seq_len, hidden_size)
 
 
 def test_single_stream_block_fuses_img_and_txt_and_splits_before_norm():
-    """MMSingleStreamBlock.forward calls apply_qk_norm_with_optional_rope
-    twice, and *the split happens before the norm*: the first (img) call
-    receives Q with shape [B, img_len, H, head_dim], not the full
-    [B, seq_len, H, head_dim].
-
-    This is the property that pins the single-stream split-then-fuse
-    refactor in place. Pre-refactor (full-RMSNorm-then-split-then-rope)
-    would have seen full ``seq_len`` here -- so this test would fail if
-    the wiring ever reverts to the old shape."""
-    from unittest.mock import patch
-
+    # Pin: the refactor must split *before* QK-Norm. The first spy call
+    # must see Q with shape [B, img_len, H, head_dim], not the full
+    # [B, seq_len, H, head_dim] that a pre-refactor full-norm-then-split
+    # would produce.
     import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
     from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
         MMSingleStreamBlock,
@@ -629,49 +428,41 @@ def test_single_stream_block_fuses_img_and_txt_and_splits_before_norm():
     sin = torch.randn(img_len, head_dim // 2, device=device)
     freqs_cis = (cos, sin)
 
-    real = hv_mod.apply_qk_norm_with_optional_rope
     with patch.object(
-        hv_mod, "apply_qk_norm_with_optional_rope", wraps=real
+        hv_mod,
+        "apply_qk_norm_with_optional_rope",
+        wraps=hv_mod.apply_qk_norm_with_optional_rope,
     ) as spy:
         with torch.no_grad():
             out = block(x, vec, txt_len, freqs_cis)
 
-    assert spy.call_count == 2, (
-        f"MMSingleStreamBlock should fuse exactly 2 sites; got {spy.call_count}"
-    )
+    assert spy.call_count == 2
     img_call = spy.call_args_list[0].kwargs
     txt_call = spy.call_args_list[1].kwargs
-    # Split-before-norm pin: img Q has img_len tokens, NOT the full seq_len.
     assert img_call["q"].shape == (
-        batch_size, img_len, num_attention_heads, head_dim,
-    ), (
-        f"img call q shape {tuple(img_call['q'].shape)} does not match the "
-        f"split-before-norm contract [B, img_len, H, head_dim]"
+        batch_size,
+        img_len,
+        num_attention_heads,
+        head_dim,
     )
     assert txt_call["q"].shape == (
-        batch_size, txt_len, num_attention_heads, head_dim,
+        batch_size,
+        txt_len,
+        num_attention_heads,
+        head_dim,
     )
-    # img call applies rope; txt call does not.
     assert img_call["cos_sin_cache"] is not None
     assert txt_call["cos_sin_cache"] is None
-    # Block output preserves [B, seq_len, hidden] shape.
     assert out.shape == (batch_size, seq_len, hidden_size)
 
 
 def test_single_stream_block_does_not_redundantly_contiguify_v():
-    """MMSingleStreamBlock.forward must not allocate fresh contiguous V
-    tensors. The fused QK-Norm+RoPE kernel only mutates Q and K (per
-    ``mutates_args=["q", "k"]`` on ``fused_inplace_qknorm_rope``);
-    UlyssesAttention.forward then does ``torch.cat([q, k, v], dim=0)``
-    downstream, which handles non-contiguous V fine. Adding ``.contiguous()``
-    on img_v / txt_v would silently double the V-sized HBM traffic per
-    single-stream block and erode the fusion's measured speedup at
-    HunyuanVideo / LTX-2 token counts.
-
-    This test pins the property by capturing V via the mocked attention
-    call and asserting it shares storage with the linear1 output (i.e., it
-    is a strided view, not a fresh allocation)."""
-    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod  # noqa: F401  (kept for symmetry)
+    # Pin: the fused QK-Norm+RoPE kernel only mutates Q/K
+    # (``mutates_args=["q", "k"]``); ``UlyssesAttention`` does
+    # ``torch.cat([q, k, v])`` which accepts non-contiguous V. Adding
+    # ``.contiguous()`` on img_v / txt_v would silently double V-sized HBM
+    # traffic per single-stream block.
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
     from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
         MMSingleStreamBlock,
     )
@@ -691,12 +482,8 @@ def test_single_stream_block_does_not_redundantly_contiguify_v():
             captured["txt_v"] = txt_v
             return torch.zeros_like(img_v), torch.zeros_like(txt_v)
 
-    from unittest.mock import patch as _patch
-
-    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as _hv_mod
-
     device = _block_test_device()
-    with _patch.object(_hv_mod, "UlyssesAttention", _CapturingAttn):
+    with patch.object(hv_mod, "UlyssesAttention", _CapturingAttn):
         block = (
             MMSingleStreamBlock(
                 hidden_size=hidden_size,
@@ -714,19 +501,7 @@ def test_single_stream_block_does_not_redundantly_contiguify_v():
     cos = torch.randn(img_len, head_dim // 2, device=device)
     sin = torch.randn(img_len, head_dim // 2, device=device)
     with torch.no_grad():
-        _ = block(x, vec, txt_len, (cos, sin))
+        block(x, vec, txt_len, (cos, sin))
 
-    img_v = captured["img_v"]
-    txt_v = captured["txt_v"]
-    # Non-contiguous strided views (split out of the linear1 qkv tensor).
-    # If someone re-adds .contiguous() to the img_v / txt_v lines in
-    # MMSingleStreamBlock.forward, both of these tensors flip to
-    # is_contiguous() == True and the assertion fires.
-    assert not img_v.is_contiguous(), (
-        "img_v should be a strided view of qkv (not a fresh contiguous "
-        "copy); .contiguous() on img_v doubles V-sized HBM traffic per block"
-    )
-    assert not txt_v.is_contiguous(), (
-        "txt_v should be a strided view of qkv (not a fresh contiguous "
-        "copy); .contiguous() on txt_v doubles V-sized HBM traffic per block"
-    )
+    assert not captured["img_v"].is_contiguous()
+    assert not captured["txt_v"].is_contiguous()

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py
@@ -65,6 +65,15 @@ def _make_qk_norms(head_dim: int, dtype: torch.dtype) -> tuple[RMSNorm, RMSNorm]
     All-ones weights would make the test pass even if the implementation
     silently dropped the multiplication; uniform jitter forces the kernel to
     actually apply the gain.
+
+    NOTE: sglang's ``RMSNorm.__init__`` accepts a ``dtype`` kwarg but ignores
+    it for weight construction -- the parameter is hardcoded as
+    ``nn.Parameter(torch.ones(hidden_size))``, which defaults to fp32. We
+    explicitly cast the modules at the end so the weight dtype matches the
+    requested ``dtype``. Without this, the fused CUDA path's
+    ``q_norm.weight.dtype == q.dtype`` gate silently fails for bf16/fp16
+    inputs and ``apply_qk_norm_rope`` falls back to the eager path -- i.e.,
+    the test would *not* exercise the fused kernel it claims to test.
     """
     torch.manual_seed(0)
     q_norm = RMSNorm(head_dim, eps=1e-6, dtype=dtype)
@@ -72,6 +81,8 @@ def _make_qk_norms(head_dim: int, dtype: torch.dtype) -> tuple[RMSNorm, RMSNorm]
     with torch.no_grad():
         q_norm.weight.copy_(torch.empty(head_dim).uniform_(0.9, 1.1))
         k_norm.weight.copy_(torch.empty(head_dim).uniform_(0.85, 1.15))
+    q_norm = q_norm.to(dtype)
+    k_norm = k_norm.to(dtype)
     return q_norm, k_norm
 
 
@@ -317,32 +328,59 @@ def test_helper_preserves_input_dtype_fp32():
     reason="bf16 RMSNorm path runs through a CUDA-only triton kernel",
 )
 def test_helper_preserves_input_dtype_bf16_cuda():
-    """bf16 dtype-preservation check on an actual CUDA device.
+    """bf16 dtype-preservation check on an actual CUDA device, *and* proof
+    that the fused JIT kernel actually fires.
 
     Skipped on CPU-only hosts: sglang's ``RMSNorm.forward_cuda`` routes
     bf16/fp16 inputs through ``triton_one_pass_rms_norm`` for
     ``hidden_size <= 128``, which is registered only for the CUDA backend.
+
+    A spy on ``fused_inplace_qknorm_rope`` asserts the fused-CUDA path was
+    actually taken -- if the helper falls back to the eager + flashinfer
+    rope branch (e.g. because the norm weights were left as fp32 by
+    `_make_qk_norms`), the spy's call_count stays 0 and the test fails
+    instead of silently passing through the wrong code path.
     """
+    from unittest.mock import patch
+
+    import sglang.multimodal_gen.runtime.layers.layernorm as ln_mod
+
     device = torch.device("cuda")
     head_dim = 64
     dtype = torch.bfloat16
     q_norm, k_norm = _make_qk_norms(head_dim, dtype)
-    q_norm = q_norm.to(device)
-    k_norm = k_norm.to(device)
+    # NB: `.to(device=..., dtype=...)` -- moving dtype too is what makes the
+    # weight match q.dtype downstream. Plain `.to(device)` would keep the
+    # weight fp32 (see `_make_qk_norms` note) and bypass the fused gate.
+    q_norm = q_norm.to(device=device, dtype=dtype)
+    k_norm = k_norm.to(device=device, dtype=dtype)
+    assert q_norm.weight.dtype == dtype
+    assert k_norm.weight.dtype == dtype
+
     torch.manual_seed(6)
     q = torch.randn(1, 16, 4, head_dim, dtype=dtype, device=device)
     k = torch.randn(1, 16, 4, head_dim, dtype=dtype, device=device)
     _, _, cos_sin_cache = _make_cos_sin(16, head_dim)
     cos_sin_cache = cos_sin_cache.to(device)
-    out_q, out_k = apply_qk_norm_with_optional_rope(
-        q=q.contiguous(),
-        k=k.contiguous(),
-        q_norm=q_norm,
-        k_norm=k_norm,
-        head_dim=head_dim,
-        cos_sin_cache=cos_sin_cache,
-        is_neox=False,
-        allow_inplace=True,
+
+    real = ln_mod.fused_inplace_qknorm_rope
+    with patch.object(
+        ln_mod, "fused_inplace_qknorm_rope", wraps=real
+    ) as mock_fused:
+        out_q, out_k = apply_qk_norm_with_optional_rope(
+            q=q.contiguous(),
+            k=k.contiguous(),
+            q_norm=q_norm,
+            k_norm=k_norm,
+            head_dim=head_dim,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=False,
+            allow_inplace=True,
+        )
+    assert mock_fused.call_count >= 1, (
+        "Expected fused_inplace_qknorm_rope to fire at least once on CUDA "
+        f"bf16; got call_count={mock_fused.call_count} (helper silently "
+        "fell back to the eager + flashinfer rope branch)"
     )
     assert out_q.dtype == dtype
     assert out_k.dtype == dtype
@@ -362,3 +400,333 @@ def test_hunyuanvideo_module_wires_fused_helper():
     # The pre-refactor per-pass rope helper should no longer be a top-level
     # symbol — the refactor's intent is a single fused call site.
     assert not hasattr(hv, "_apply_rotary_emb")
+
+
+# -- Block-level tests with mocked attention -------------------------------
+#
+# The helper-level tests above pin the *math* of the fusion. The tests
+# below pin the *wiring* -- that ``MMDoubleStreamBlock.forward`` and
+# ``MMSingleStreamBlock.forward`` actually invoke
+# ``apply_qk_norm_with_optional_rope`` at the intended sites, with the
+# intended arguments. They construct the production block modules on CPU,
+# patch the attention call with a shape-preserving mock, spy on the helper,
+# and assert the expected call count + arg shapes.
+#
+# Construction requires a 1-rank tensor-parallel group because the blocks
+# instantiate ``ReplicatedLinear`` / ``ColumnParallelLinear`` which call
+# ``get_tp_group()``. A module-scoped fixture initializes a minimal
+# gloo-backed single-rank group once and tears it down at the end.
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_minimal_distributed():
+    """Initialize a 1-rank gloo distributed + TP group so the block
+    constructors can resolve ``get_tp_group()`` on CPU. Single-process,
+    single-rank -- no real collective work happens."""
+    import os
+    import socket
+
+    import torch.distributed as dist
+
+    from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    was_initialized = dist.is_initialized()
+    if not was_initialized:
+        # Pick a free port so concurrent test runs / leftover sockets don't clash.
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            free_port = s.getsockname()[1]
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ["MASTER_PORT"] = str(free_port)
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("LOCAL_RANK", "0")
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method=f"tcp://127.0.0.1:{free_port}",
+            local_rank=0,
+            backend="gloo",
+        )
+
+    initialize_model_parallel(
+        data_parallel_size=1,
+        classifier_free_guidance_degree=1,
+        sequence_parallel_degree=1,
+        ulysses_degree=1,
+        ring_degree=1,
+        tensor_parallel_degree=1,
+        pipeline_parallel_degree=1,
+    )
+
+    yield
+
+    # Only tear down what this fixture created -- leave any pre-existing
+    # distributed state untouched.
+    if not was_initialized and dist.is_initialized():
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+#
+# In particular, ``test_single_stream_block_*_splits_before_norm`` is the
+# only test that actually proves the single-stream split-then-fuse refactor
+# went through ``MMSingleStreamBlock.forward`` (not just through a
+# hand-rolled math reference): the first spy call must see a Q tensor of
+# shape ``[B, img_len, H, head_dim]``, not the full ``[B, seq_len, ...]``
+# that the pre-refactor full-norm-then-split path would have produced.
+
+
+class _StubAttention(torch.nn.Module):
+    """Stand-in for ``UlyssesAttention`` during block construction. Takes any
+    constructor args (so the block doesn't need ServerArgs / attn-backend
+    setup), and on forward returns zero tensors matching the V shapes --
+    enough for ``MMDoubleStreamBlock`` / ``MMSingleStreamBlock`` to flow
+    through their post-attention residual / MLP layers without changing
+    what we're testing (which is the QK-Norm + RoPE call sites)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, img_q, img_k, img_v, txt_q, txt_k, txt_v):
+        return torch.zeros_like(img_v), torch.zeros_like(txt_v)
+
+
+def _block_test_device() -> torch.device:
+    """Pick the device for the block-level tests.
+
+    On a CUDA-capable host sglang's ``CustomOp`` dispatch (e.g.
+    ``LayerNormScaleShift.forward_cuda`` -> ``fuse_scale_shift_kernel``,
+    and ``RMSNorm`` -> ``triton_one_pass_rms_norm``) is selected at module
+    init time from ``current_platform.is_cuda()``, NOT from the input
+    tensor's device. Running these dispatch paths against CPU tensors
+    blows up with ``assert (x.is_cuda and scale.is_cuda)``-style errors
+    even though the test isn't trying to exercise CUDA kernels.
+
+    So: run the block forward on CUDA when CUDA is available; fall back to
+    CPU (which has its own ``forward_cpu`` / ``forward_native`` paths) on
+    CPU-only hosts. The assertions we care about (helper call count,
+    helper kwarg shapes, V contiguity) hold on either device."""
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _build_block_with_stub_attention(block_cls, **kwargs):
+    """Construct ``block_cls`` with the production ``UlyssesAttention``
+    constructor temporarily swapped for ``_StubAttention``, so the block
+    can be instantiated without requiring a global ServerArgs."""
+    from unittest.mock import patch
+
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
+
+    with patch.object(hv_mod, "UlyssesAttention", _StubAttention):
+        return block_cls(**kwargs).eval()
+
+
+def test_double_stream_block_fuses_img_and_txt_sites():
+    """MMDoubleStreamBlock.forward calls apply_qk_norm_with_optional_rope
+    exactly twice: img stream with cos_sin_cache (norm + rope), txt stream
+    with cos_sin_cache=None (norm only). Output shapes match input shapes."""
+    from unittest.mock import patch
+
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
+    from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
+        MMDoubleStreamBlock,
+    )
+
+    hidden_size = 128
+    num_attention_heads = 4
+    head_dim = hidden_size // num_attention_heads
+    batch_size = 1
+    img_seq_len = 16
+    txt_seq_len = 8
+
+    device = _block_test_device()
+    block = _build_block_with_stub_attention(
+        MMDoubleStreamBlock,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        mlp_ratio=2.0,
+    ).to(device)
+
+    torch.manual_seed(0)
+    img = torch.randn(batch_size, img_seq_len, hidden_size, device=device)
+    txt = torch.randn(batch_size, txt_seq_len, hidden_size, device=device)
+    vec = torch.randn(batch_size, hidden_size, device=device)
+    cos = torch.randn(img_seq_len, head_dim // 2, device=device)
+    sin = torch.randn(img_seq_len, head_dim // 2, device=device)
+    freqs_cis = (cos, sin)
+
+    real = hv_mod.apply_qk_norm_with_optional_rope
+    with patch.object(
+        hv_mod, "apply_qk_norm_with_optional_rope", wraps=real
+    ) as spy:
+        with torch.no_grad():
+            out_img, out_txt = block(img, txt, vec, freqs_cis)
+
+    assert spy.call_count == 2, (
+        f"MMDoubleStreamBlock should fuse exactly 2 sites; got {spy.call_count}"
+    )
+    img_call = spy.call_args_list[0].kwargs
+    txt_call = spy.call_args_list[1].kwargs
+    assert img_call["cos_sin_cache"] is not None, (
+        "img stream call must pass cos_sin_cache for rope"
+    )
+    assert txt_call["cos_sin_cache"] is None, (
+        "txt stream call must pass cos_sin_cache=None (no rope on text)"
+    )
+    # Q tensors at the helper boundary are [B, seq_len, H, head_dim].
+    assert img_call["q"].shape == (
+        batch_size, img_seq_len, num_attention_heads, head_dim,
+    )
+    assert txt_call["q"].shape == (
+        batch_size, txt_seq_len, num_attention_heads, head_dim,
+    )
+    # Output residual connections preserve input shape.
+    assert out_img.shape == (batch_size, img_seq_len, hidden_size)
+    assert out_txt.shape == (batch_size, txt_seq_len, hidden_size)
+
+
+def test_single_stream_block_fuses_img_and_txt_and_splits_before_norm():
+    """MMSingleStreamBlock.forward calls apply_qk_norm_with_optional_rope
+    twice, and *the split happens before the norm*: the first (img) call
+    receives Q with shape [B, img_len, H, head_dim], not the full
+    [B, seq_len, H, head_dim].
+
+    This is the property that pins the single-stream split-then-fuse
+    refactor in place. Pre-refactor (full-RMSNorm-then-split-then-rope)
+    would have seen full ``seq_len`` here -- so this test would fail if
+    the wiring ever reverts to the old shape."""
+    from unittest.mock import patch
+
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod
+    from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
+        MMSingleStreamBlock,
+    )
+
+    hidden_size = 128
+    num_attention_heads = 4
+    head_dim = hidden_size // num_attention_heads
+    batch_size = 1
+    img_len = 16
+    txt_len = 8
+    seq_len = img_len + txt_len
+
+    device = _block_test_device()
+    block = _build_block_with_stub_attention(
+        MMSingleStreamBlock,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        mlp_ratio=2.0,
+    ).to(device)
+
+    torch.manual_seed(0)
+    x = torch.randn(batch_size, seq_len, hidden_size, device=device)
+    vec = torch.randn(batch_size, hidden_size, device=device)
+    cos = torch.randn(img_len, head_dim // 2, device=device)
+    sin = torch.randn(img_len, head_dim // 2, device=device)
+    freqs_cis = (cos, sin)
+
+    real = hv_mod.apply_qk_norm_with_optional_rope
+    with patch.object(
+        hv_mod, "apply_qk_norm_with_optional_rope", wraps=real
+    ) as spy:
+        with torch.no_grad():
+            out = block(x, vec, txt_len, freqs_cis)
+
+    assert spy.call_count == 2, (
+        f"MMSingleStreamBlock should fuse exactly 2 sites; got {spy.call_count}"
+    )
+    img_call = spy.call_args_list[0].kwargs
+    txt_call = spy.call_args_list[1].kwargs
+    # Split-before-norm pin: img Q has img_len tokens, NOT the full seq_len.
+    assert img_call["q"].shape == (
+        batch_size, img_len, num_attention_heads, head_dim,
+    ), (
+        f"img call q shape {tuple(img_call['q'].shape)} does not match the "
+        f"split-before-norm contract [B, img_len, H, head_dim]"
+    )
+    assert txt_call["q"].shape == (
+        batch_size, txt_len, num_attention_heads, head_dim,
+    )
+    # img call applies rope; txt call does not.
+    assert img_call["cos_sin_cache"] is not None
+    assert txt_call["cos_sin_cache"] is None
+    # Block output preserves [B, seq_len, hidden] shape.
+    assert out.shape == (batch_size, seq_len, hidden_size)
+
+
+def test_single_stream_block_does_not_redundantly_contiguify_v():
+    """MMSingleStreamBlock.forward must not allocate fresh contiguous V
+    tensors. The fused QK-Norm+RoPE kernel only mutates Q and K (per
+    ``mutates_args=["q", "k"]`` on ``fused_inplace_qknorm_rope``);
+    UlyssesAttention.forward then does ``torch.cat([q, k, v], dim=0)``
+    downstream, which handles non-contiguous V fine. Adding ``.contiguous()``
+    on img_v / txt_v would silently double the V-sized HBM traffic per
+    single-stream block and erode the fusion's measured speedup at
+    HunyuanVideo / LTX-2 token counts.
+
+    This test pins the property by capturing V via the mocked attention
+    call and asserting it shares storage with the linear1 output (i.e., it
+    is a strided view, not a fresh allocation)."""
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as hv_mod  # noqa: F401  (kept for symmetry)
+    from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
+        MMSingleStreamBlock,
+    )
+
+    hidden_size = 128
+    num_attention_heads = 4
+    batch_size = 1
+    img_len = 16
+    txt_len = 8
+    seq_len = img_len + txt_len
+
+    captured: dict[str, torch.Tensor] = {}
+
+    class _CapturingAttn(_StubAttention):
+        def forward(self, img_q, img_k, img_v, txt_q, txt_k, txt_v):
+            captured["img_v"] = img_v
+            captured["txt_v"] = txt_v
+            return torch.zeros_like(img_v), torch.zeros_like(txt_v)
+
+    from unittest.mock import patch as _patch
+
+    import sglang.multimodal_gen.runtime.models.dits.hunyuanvideo as _hv_mod
+
+    device = _block_test_device()
+    with _patch.object(_hv_mod, "UlyssesAttention", _CapturingAttn):
+        block = (
+            MMSingleStreamBlock(
+                hidden_size=hidden_size,
+                num_attention_heads=num_attention_heads,
+                mlp_ratio=2.0,
+            )
+            .to(device)
+            .eval()
+        )
+
+    torch.manual_seed(0)
+    x = torch.randn(batch_size, seq_len, hidden_size, device=device)
+    vec = torch.randn(batch_size, hidden_size, device=device)
+    head_dim = hidden_size // num_attention_heads
+    cos = torch.randn(img_len, head_dim // 2, device=device)
+    sin = torch.randn(img_len, head_dim // 2, device=device)
+    with torch.no_grad():
+        _ = block(x, vec, txt_len, (cos, sin))
+
+    img_v = captured["img_v"]
+    txt_v = captured["txt_v"]
+    # Non-contiguous strided views (split out of the linear1 qkv tensor).
+    # If someone re-adds .contiguous() to the img_v / txt_v lines in
+    # MMSingleStreamBlock.forward, both of these tensors flip to
+    # is_contiguous() == True and the assertion fires.
+    assert not img_v.is_contiguous(), (
+        "img_v should be a strided view of qkv (not a fresh contiguous "
+        "copy); .contiguous() on img_v doubles V-sized HBM traffic per block"
+    )
+    assert not txt_v.is_contiguous(), (
+        "txt_v should be a strided view of qkv (not a fresh contiguous "
+        "copy); .contiguous() on txt_v doubles V-sized HBM traffic per block"
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The `fused_inplace_qknorm_rope` JIT kernel ([#19059](https://github.com/sgl-project/sglang/pull/19059), [#21440](https://github.com/sgl-project/sglang/pull/21440), [#21503](https://github.com/sgl-project/sglang/pull/21503), [#21654](https://github.com/sgl-project/sglang/pull/21654)) and its `apply_qk_norm_with_optional_rope` helper have been the default code path for FLUX, FLUX.2, Qwen-Image, Z-Image, and Joy-Image since their introduction, but `runtime/models/dits/hunyuanvideo.py` still routes both `MMDoubleStreamBlock` and `MMSingleStreamBlock` through a hand-rolled `2× RMSNorm + 2× _apply_rotary_emb` chain at every site. This PR plumbs the existing helper into the four eligible call sites in HunyuanVideo, picking up a **~1.48× kernel speedup** on H200 (1.46× short clip / 1.50× medium clip) without changing model outputs.

This also addresses the "kernel fusion instead of compiler-driven fusion" line under Performance Improvements in [Roadmap] SGLang-Diffusion (26 Q2) (#23035).

## Modifications

- **`python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py`** — route four `RMSNorm + _apply_rotary_emb` sites through `apply_qk_norm_with_optional_rope`:
  - `MMDoubleStreamBlock.forward` — img-stream fused `QK-Norm + RoPE` (`cos_sin_cache=packed`) and txt-stream fused `QK-Norm only` (`cos_sin_cache=None`).
  - `MMSingleStreamBlock.forward` — image / text split is moved *before* QK-Norm so the image portion can route through fused `QK-Norm + RoPE` in a single in-place pass and the text portion through fused `QK-Norm` only. RMSNorm is a per-token operation, so reordering split vs. norm is mathematically a no-op (pinned by `test_single_stream_split_then_fuse_parity`).

  Drops the unused `_apply_rotary_emb` import; all four old `_apply_rotary_emb(img_q/img_k, cos, sin, is_neox_style=False)` sites are gone. `cos_sin_cache` is built inline at each block in the standard `torch.cat([cos.float().contiguous(), sin.float().contiguous()], dim=-1)` layout that FLUX / Wan already use just before the fused helper.

- **`python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py`** — add two HunyuanVideo shape cases (`hunyuanvideo_short` 1×8192×24×128, `hunyuanvideo_medium` 1×24576×24×128, both `rope_dim=128`) to the existing `BENCH_CASES` tuple. `num_heads=24`, `attention_head_dim=128`, `rope_axes_dim=(16, 56, 56)` per `configs/models/dits/hunyuanvideo.py`. The text-stream (~256 tokens, no RoPE) is covered by `bench_qknorm.py`.

- **`python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py`** (new file) — 9 CPU-runnable unit tests + 1 CUDA-gated bf16 test, covering pre-/post-refactor parity on img-stream norm+rope, txt-stream norm-only, single-stream split-first reordering, helper no-rope path, dtype preservation, and module wiring.

## Accuracy Tests

Zero-tolerance parity vs the original eager `RMSNorm + _apply_rotary_emb` chain on CPU, across 9 unit tests:

```bash
$ PYTHONPATH=python python -m pytest -p no:cacheprovider \
    python/sglang/multimodal_gen/test/unit/test_hunyuanvideo_qknorm_rope_fusion.py -v
...
============================ 9 passed in ~30s ============================
```

**Coverage:**

- `test_double_stream_img_norm_rope_parity` (2 parametrized cases) — img-stream pre-refactor `2× RMSNorm + 2× _apply_rotary_emb` vs fused helper, `torch.testing.assert_close(rtol=1e-5, atol=1e-5)`.
- `test_double_stream_txt_norm_only_parity` (2 parametrized cases) — txt-stream `2× RMSNorm` vs fused helper with `cos_sin_cache=None`.
- `test_single_stream_split_then_fuse_parity` (2 parametrized cases) — split-first pipeline matches full-norm-then-split-then-rope numerically; pins the reordering invariant that the single-stream refactor depends on.
- `test_helper_no_rope_path_matches_apply_qk_norm` — `cos_sin_cache=None` routes through plain QK-Norm.
- `test_helper_preserves_input_dtype_fp32` — fp32 round-trip without silent upcast (bf16 variant is CUDA-gated, see below).
- `test_hunyuanvideo_module_wires_fused_helper` — module-level wiring check: `apply_qk_norm_with_optional_rope` is bound and `_apply_rotary_emb` is no longer imported.

A CUDA-gated `test_helper_preserves_input_dtype_bf16_cuda` exists for bf16 dtype-preservation but is skipped on CPU-only hosts (sglang's `RMSNorm.forward_cuda` routes bf16/fp16 through `triton_one_pass_rms_norm`, which is registered for the CUDA backend only). The CUDA fast path of the fused helper itself is already covered by `python/sglang/jit_kernel/tests/diffusion/test_qknorm_rope.py`.

## Speed Tests and Profiling

Measured on H200 via the existing `bench_qknorm_rope.py` with the two HunyuanVideo cases added by this PR:

| case | shape | dtype | split (µs) | fused (µs) | speedup |
|---|---|---|---:|---:|---:|
| `flux_1024`         | 1×4096×24×128, rope_dim=128 | bf16 |  59.04 |  43.26 | 1.36× |
| `qwen_image_1024`   | 1×4096×32×128, rope_dim=128 | bf16 |  80.64 |  54.75 | 1.47× |
| `qwen_image_partial`| 1×4096×32×128, rope_dim=64  | bf16 |  79.14 |  54.43 | 1.45× |
| `zimage_1024`       | 1×4096×30×128, rope_dim=128 | bf16 |  74.02 |  50.72 | 1.46× |
| `batch2_medium`     | 2×2048×24×128, rope_dim=128 | bf16 |  59.30 |  43.10 | 1.38× |
| **`hunyuanvideo_short`**  | 1×8192×24×128, rope_dim=128  | bf16 | 115.46 |  78.88 | **1.46×** |
| **`hunyuanvideo_medium`** | 1×24576×24×128, rope_dim=128 | bf16 | 332.51 | 221.18 | **1.50×** |

Geomean kernel speedup on HunyuanVideo shapes: **1.48×**. The fused kernel is memory-bandwidth-bound on the read-norm-write-rope traffic — split path materializes the post-norm tensor to HBM before re-reading it for RoPE; fused path keeps it in registers across the RoPE pass — so the speedup scales mildly with token count.

Bench command:

```bash
PYTHONPATH=python CUDA_VISIBLE_DEVICES=0 python \
    python/sglang/jit_kernel/benchmark/diffusion/bench_qknorm_rope.py
```
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).





















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27066413371](https://github.com/sgl-project/sglang/actions/runs/27066413371)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27066413285](https://github.com/sgl-project/sglang/actions/runs/27066413285)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->