### PR TITLE
deflake priority below-threshold test

### DIFF
--- a/test/registered/scheduler/test_priority_scheduling.py
+++ b/test/registered/scheduler/test_priority_scheduling.py
@@ -200,8 +200,9 @@ class TestPriorityScheduling(CustomTestCase):
 
         # Stagger sends so priority=0 occupies the running queue before
         # priority=5 arrives -- asyncio.gather gives no arrival-order guarantee.
-        # ignore_eos on priority=0 ensures it is still running when priority=5
-        # arrives, so the "below threshold = no preempt" path is actually exercised.
+        # ignore_eos on both: priority=0 stays running when priority=5 arrives
+        # (exercises the no-preempt path), and priority=5's runtime must exceed
+        # the stagger so its server-side e2e_latency stays > priority=0's.
         async def _run():
             first = asyncio.create_task(
                 send_concurrent_generate_requests_with_custom_params(
@@ -221,7 +222,15 @@ class TestPriorityScheduling(CustomTestCase):
             second = asyncio.create_task(
                 send_concurrent_generate_requests_with_custom_params(
                     self.base_url,
-                    [{"priority": 5, "sampling_params": {"max_new_tokens": 1000}}],
+                    [
+                        {
+                            "priority": 5,
+                            "sampling_params": {
+                                "max_new_tokens": 1000,
+                                "ignore_eos": True,
+                            },
+                        }
+                    ],
                 )
             )
             return (await first) + (await second)

--- a/test/registered/scheduler/test_priority_scheduling.py
+++ b/test/registered/scheduler/test_priority_scheduling.py
@@ -198,21 +198,35 @@ class TestPriorityScheduling(CustomTestCase):
     def test_priority_scheduling_preemption_below_threshold_validation(self):
         """Verify running requests are not preempted by requests with priorities below preemption threshold"""
 
-        responses = asyncio.run(
-            send_concurrent_generate_requests_with_custom_params(
-                self.base_url,
-                [
-                    {
-                        "priority": 0,
-                        "sampling_params": {"max_new_tokens": 10000},
-                    },
-                    {
-                        "priority": 5,
-                        "sampling_params": {"max_new_tokens": 10000},
-                    },
-                ],
+        # Stagger sends so priority=0 occupies the running queue before
+        # priority=5 arrives -- asyncio.gather gives no arrival-order guarantee.
+        # ignore_eos on priority=0 ensures it is still running when priority=5
+        # arrives, so the "below threshold = no preempt" path is actually exercised.
+        async def _run():
+            first = asyncio.create_task(
+                send_concurrent_generate_requests_with_custom_params(
+                    self.base_url,
+                    [
+                        {
+                            "priority": 0,
+                            "sampling_params": {
+                                "max_new_tokens": 1000,
+                                "ignore_eos": True,
+                            },
+                        }
+                    ],
+                )
             )
-        )
+            await asyncio.sleep(1.0)
+            second = asyncio.create_task(
+                send_concurrent_generate_requests_with_custom_params(
+                    self.base_url,
+                    [{"priority": 5, "sampling_params": {"max_new_tokens": 1000}}],
+                )
+            )
+            return (await first) + (await second)
+
+        responses = asyncio.run(_run())
 
         expected_status_and_error_messages = [
             (200, None),

--- a/test/registered/scheduler/test_priority_scheduling.py
+++ b/test/registered/scheduler/test_priority_scheduling.py
@@ -203,36 +203,16 @@ class TestPriorityScheduling(CustomTestCase):
         # ignore_eos on both: priority=0 stays running when priority=5 arrives
         # (exercises the no-preempt path), and priority=5's runtime must exceed
         # the stagger so its server-side e2e_latency stays > priority=0's.
+        async def _send(priority, **sampling):
+            return await send_concurrent_generate_requests_with_custom_params(
+                self.base_url,
+                [{"priority": priority, "sampling_params": sampling}],
+            )
+
         async def _run():
-            first = asyncio.create_task(
-                send_concurrent_generate_requests_with_custom_params(
-                    self.base_url,
-                    [
-                        {
-                            "priority": 0,
-                            "sampling_params": {
-                                "max_new_tokens": 1000,
-                                "ignore_eos": True,
-                            },
-                        }
-                    ],
-                )
-            )
+            first = asyncio.create_task(_send(0, max_new_tokens=1000, ignore_eos=True))
             await asyncio.sleep(1.0)
-            second = asyncio.create_task(
-                send_concurrent_generate_requests_with_custom_params(
-                    self.base_url,
-                    [
-                        {
-                            "priority": 5,
-                            "sampling_params": {
-                                "max_new_tokens": 1000,
-                                "ignore_eos": True,
-                            },
-                        }
-                    ],
-                )
-            )
+            second = asyncio.create_task(_send(5, max_new_tokens=1000, ignore_eos=True))
             return (await first) + (await second)
 
         responses = asyncio.run(_run())


### PR DESCRIPTION
Fixes flake in `test_priority_scheduling_preemption_below_threshold_validation`.

### Flakiness check (10 runs @ 23b10a8) — 7/10 pass

[1](https://github.com/sgl-project/sglang/actions/runs/26127247293) [2 fail](https://github.com/sgl-project/sglang/actions/runs/26127249712) [3](https://github.com/sgl-project/sglang/actions/runs/26127252236) [4](https://github.com/sgl-project/sglang/actions/runs/26127254958) [5](https://github.com/sgl-project/sglang/actions/runs/26127257561) [6](https://github.com/sgl-project/sglang/actions/runs/26127260312) [7 fail](https://github.com/sgl-project/sglang/actions/runs/26127262792) [8](https://github.com/sgl-project/sglang/actions/runs/26127265423) [9](https://github.com/sgl-project/sglang/actions/runs/26127267840) [10 fail](https://github.com/sgl-project/sglang/actions/runs/26127270312)

### Flakiness check (10 runs @ add831c) — 10/10 pass

[1](https://github.com/sgl-project/sglang/actions/runs/26128158692) [2](https://github.com/sgl-project/sglang/actions/runs/26128161100) [3](https://github.com/sgl-project/sglang/actions/runs/26128163495) [4](https://github.com/sgl-project/sglang/actions/runs/26128165884) [5](https://github.com/sgl-project/sglang/actions/runs/26128168170) [6](https://github.com/sgl-project/sglang/actions/runs/26128171112) [7](https://github.com/sgl-project/sglang/actions/runs/26128173600) [8](https://github.com/sgl-project/sglang/actions/runs/26128175896) [9](https://github.com/sgl-project/sglang/actions/runs/26128178129) [10](https://github.com/sgl-project/sglang/actions/runs/26128180335)









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26128523367](https://github.com/sgl-project/sglang/actions/runs/26128523367)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26128523222](https://github.com/sgl-project/sglang/actions/runs/26128523222)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
