### PR TITLE
perf(dsv4): add MHC token-count prewarm

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -593,6 +593,8 @@ class Envs:
     SGLANG_OPT_DEEPGEMM_HC_PRENORM = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_PRE = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_POST = EnvBool(True)
+    # Comma-separated token-count shapes for opt-in DeepSeek V4 MHC prewarm.
+    SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS = EnvTuple(tuple())
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -595,6 +595,8 @@ class Envs:
     SGLANG_OPT_USE_TILELANG_MHC_POST = EnvBool(True)
     # Comma-separated token-count shapes for opt-in DeepSeek V4 MHC prewarm.
     SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS = EnvTuple(tuple())
+    # Backward-compatible alias used by earlier experimental recipes.
+    SGLANG_DSV4_MHC_PREWARM_TOKENS = EnvTuple(tuple())
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -593,8 +593,6 @@ class Envs:
     SGLANG_OPT_DEEPGEMM_HC_PRENORM = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_PRE = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_POST = EnvBool(True)
-    # Max token count for opt-in DeepSeek V4 MHC bucket prewarm.
-    SGLANG_DSV4_MHC_PREWARM_MAX_TOKENS = EnvInt(0)
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -593,10 +593,8 @@ class Envs:
     SGLANG_OPT_DEEPGEMM_HC_PRENORM = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_PRE = EnvBool(True)
     SGLANG_OPT_USE_TILELANG_MHC_POST = EnvBool(True)
-    # Comma-separated token-count shapes for opt-in DeepSeek V4 MHC prewarm.
-    SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS = EnvTuple(tuple())
-    # Backward-compatible alias used by earlier experimental recipes.
-    SGLANG_DSV4_MHC_PREWARM_TOKENS = EnvTuple(tuple())
+    # Max token count for opt-in DeepSeek V4 MHC bucket prewarm.
+    SGLANG_DSV4_MHC_PREWARM_MAX_TOKENS = EnvInt(0)
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)

--- a/python/sglang/srt/layers/mhc.py
+++ b/python/sglang/srt/layers/mhc.py
@@ -450,6 +450,24 @@ def _compute_num_split_for_mhc_pre(num_tokens: int, hc_hidden_size: int) -> int:
     return max(1, min(n_sms // max(grid_size, 1), num_block_k // 4))
 
 
+def get_mhc_pre_token_count_representatives(
+    max_num_tokens: int, hc_hidden_size: int
+) -> Tuple[int, ...]:
+    """Return one token-count representative for each MHC pre split bucket."""
+    if max_num_tokens <= 0:
+        return tuple()
+
+    representatives_by_split: dict[int, int] = {}
+    for num_tokens in range(1, max_num_tokens + 1):
+        n_splits = _compute_num_split_for_mhc_pre(num_tokens, hc_hidden_size)
+        representatives_by_split[n_splits] = num_tokens
+
+    return tuple(
+        representatives_by_split[n_splits]
+        for n_splits in sorted(representatives_by_split)
+    )
+
+
 @tilelang.jit(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2299,6 +2299,35 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self._should_run_flashinfer_autotune():
             self._flashinfer_autotune()
 
+        self._deepseek_v4_mhc_prewarm()
+
+    def _deepseek_v4_mhc_prewarm(self):
+        if not self.is_hybrid_swa or not self.model_config.is_deepseek_v4_arch:
+            return
+        if not envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
+            return
+        if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
+            return
+
+        token_values = envs.SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS.get()
+        if not token_values:
+            return
+
+        token_counts = tuple(int(x) for x in token_values)
+        if any(x <= 0 for x in token_counts):
+            raise ValueError(
+                "SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS expects positive integers, "
+                f"got {token_values}"
+            )
+
+        self.model.prewarm_mhc_token_counts(token_counts, self.device)
+        self.tp_group.barrier()
+
+        logger.info(
+            "DeepSeek V4 MHC prewarm completed for token-count shapes: %s",
+            token_counts,
+        )
+
     def _pre_initialize_flashinfer_allreduce_workspace(self):
         """Pre-initialize flashinfer allreduce fusion workspaces.
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2310,6 +2310,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             return
 
         token_values = envs.SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS.get()
+        legacy_token_values = envs.SGLANG_DSV4_MHC_PREWARM_TOKENS.get()
+        if not token_values and legacy_token_values:
+            token_values = legacy_token_values
+            logger.warning(
+                "SGLANG_DSV4_MHC_PREWARM_TOKENS is deprecated; use "
+                "SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS instead."
+            )
         if not token_values:
             return
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2309,14 +2309,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
             return
 
-        max_num_tokens = envs.SGLANG_DSV4_MHC_PREWARM_MAX_TOKENS.get()
-        if max_num_tokens < 0:
-            raise ValueError(
-                "SGLANG_DSV4_MHC_PREWARM_MAX_TOKENS expects a non-negative "
-                f"integer, got {max_num_tokens}"
-            )
-        if max_num_tokens == 0:
-            return
+        max_num_tokens = self.server_args.chunked_prefill_size
+        if max_num_tokens is None or max_num_tokens <= 0:
+            max_num_tokens = 8192
 
         token_counts = self.model.prewarm_mhc_token_count_buckets(
             max_num_tokens, self.device

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2309,29 +2309,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
             return
 
-        token_values = envs.SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS.get()
-        legacy_token_values = envs.SGLANG_DSV4_MHC_PREWARM_TOKENS.get()
-        if not token_values and legacy_token_values:
-            token_values = legacy_token_values
-            logger.warning(
-                "SGLANG_DSV4_MHC_PREWARM_TOKENS is deprecated; use "
-                "SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS instead."
+        max_num_tokens = envs.SGLANG_DSV4_MHC_PREWARM_MAX_TOKENS.get()
+        if max_num_tokens < 0:
+            raise ValueError(
+                "SGLANG_DSV4_MHC_PREWARM_MAX_TOKENS expects a non-negative "
+                f"integer, got {max_num_tokens}"
             )
-        if not token_values:
+        if max_num_tokens == 0:
             return
 
-        token_counts = tuple(int(x) for x in token_values)
-        if any(x <= 0 for x in token_counts):
-            raise ValueError(
-                "SGLANG_DSV4_MHC_PREWARM_TOKEN_COUNTS expects positive integers, "
-                f"got {token_values}"
-            )
-
-        self.model.prewarm_mhc_token_counts(token_counts, self.device)
+        token_counts = self.model.prewarm_mhc_token_count_buckets(
+            max_num_tokens, self.device
+        )
         self.tp_group.barrier()
 
         logger.info(
-            "DeepSeek V4 MHC prewarm completed for token-count shapes: %s",
+            "DeepSeek V4 MHC prewarm completed for representative token-count shapes: %s",
             token_counts,
         )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2291,7 +2291,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def kernel_warmup(self):
         """
         Warmup and tune kernels before cuda graph capture.
-        Currently only doing FlashInfer autotune.
+        Covers framework-level warmups and optional model-specific warmups.
         """
         if self.device != "cuda":
             return
@@ -2299,29 +2299,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if self._should_run_flashinfer_autotune():
             self._flashinfer_autotune()
 
-        self._deepseek_v4_mhc_prewarm()
-
-    def _deepseek_v4_mhc_prewarm(self):
-        if not self.is_hybrid_swa or not self.model_config.is_deepseek_v4_arch:
-            return
-        if not envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
-            return
-        if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
-            return
-
-        max_num_tokens = self.server_args.chunked_prefill_size
-        if max_num_tokens is None or max_num_tokens <= 0:
-            max_num_tokens = 8192
-
-        token_counts = self.model.prewarm_mhc_token_count_buckets(
-            max_num_tokens, self.device
-        )
-        self.tp_group.barrier()
-
-        logger.info(
-            "DeepSeek V4 MHC prewarm completed for representative token-count shapes: %s",
-            token_counts,
-        )
+        # Models may need their own warmup for model-specific kernels or JIT paths.
+        # Register those hooks on the model class so ModelRunner can keep this
+        # warmup entry point generic.
+        model_kernel_warmup = getattr(self.model, "kernel_warmup", None)
+        if model_kernel_warmup is not None:
+            model_kernel_warmup(self)
 
     def _pre_initialize_flashinfer_allreduce_workspace(self):
         """Pre-initialize flashinfer allreduce fusion workspaces.

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import time
 from typing import (
     TYPE_CHECKING,
     Iterable,
@@ -696,6 +697,51 @@ class DeepseekV4DecoderLayer(nn.Module):
         self.rms_norm_eps = config.rms_norm_eps
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
 
+    def prewarm_mhc_token_counts(
+        self, token_counts: Tuple[int, ...], device: torch.device
+    ) -> None:
+        paths = (
+            (
+                "attn",
+                self.hc_attn_fn,
+                self.hc_attn_scale,
+                self.hc_attn_base,
+                self.input_layernorm,
+            ),
+            (
+                "ffn",
+                self.hc_ffn_fn,
+                self.hc_ffn_scale,
+                self.hc_ffn_base,
+                self.post_attention_layernorm,
+            ),
+        )
+
+        with torch.inference_mode():
+            for num_tokens in token_counts:
+                for path_name, hc_fn, hc_scale, hc_base, norm in paths:
+                    tic = time.perf_counter()
+                    residual = torch.empty(
+                        (num_tokens, self.hc_mult, self.hidden_size),
+                        dtype=torch.bfloat16,
+                        device=device,
+                    )
+                    y, post, comb, _ = self.hc_pre(
+                        residual,
+                        hc_fn,
+                        hc_scale,
+                        hc_base,
+                        norm=norm,
+                    )
+                    del residual, y, post, comb
+                    torch.cuda.synchronize()
+                    logger.info(
+                        "DeepSeek V4 MHC prewarm path=%s num_tokens=%s completed in %.3fs",
+                        path_name,
+                        num_tokens,
+                        time.perf_counter() - tic,
+                    )
+
     def hc_pre(
         self,
         x: torch.Tensor,
@@ -983,6 +1029,20 @@ class DeepseekV4Model(nn.Module):
         if self.nsa_enable_prefill_cp:
             self.cp_size = get_attention_cp_size()
 
+    def prewarm_mhc_token_counts(
+        self, token_counts: Tuple[int, ...], device: torch.device
+    ) -> None:
+        tic = time.perf_counter()
+        logger.info(
+            "Running DeepSeek V4 MHC prewarm for token-count shapes: %s",
+            token_counts,
+        )
+        self.layers[self.start_layer].prewarm_mhc_token_counts(token_counts, device)
+        logger.info(
+            "DeepSeek V4 MHC prewarm finished in %.3fs",
+            time.perf_counter() - tic,
+        )
+
     def hc_head(
         self,
         x: torch.Tensor,
@@ -1133,6 +1193,11 @@ class DeepseekV4ForCausalLM(nn.Module):
         if self.nsa_enable_prefill_cp:
             self.cp_rank = get_attention_cp_rank()
             self.cp_size = get_attention_cp_size()
+
+    def prewarm_mhc_token_counts(
+        self, token_counts: Tuple[int, ...], device: torch.device
+    ) -> None:
+        self.model.prewarm_mhc_token_counts(token_counts, device)
 
     @property
     def routed_experts_weights_of_layer(self):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -742,6 +742,25 @@ class DeepseekV4DecoderLayer(nn.Module):
                         time.perf_counter() - tic,
                     )
 
+    def prewarm_mhc_token_count_buckets(
+        self, max_num_tokens: int, device: torch.device
+    ) -> Tuple[int, ...]:
+        from sglang.srt.layers.mhc import get_mhc_pre_token_count_representatives
+
+        token_counts = get_mhc_pre_token_count_representatives(
+            max_num_tokens, self.hc_mult * self.hidden_size
+        )
+        if not token_counts:
+            return token_counts
+
+        logger.info(
+            "DeepSeek V4 MHC prewarm max_num_tokens=%s representative token counts: %s",
+            max_num_tokens,
+            token_counts,
+        )
+        self.prewarm_mhc_token_counts(token_counts, device)
+        return token_counts
+
     def hc_pre(
         self,
         x: torch.Tensor,
@@ -1029,19 +1048,23 @@ class DeepseekV4Model(nn.Module):
         if self.nsa_enable_prefill_cp:
             self.cp_size = get_attention_cp_size()
 
-    def prewarm_mhc_token_counts(
-        self, token_counts: Tuple[int, ...], device: torch.device
-    ) -> None:
+    def prewarm_mhc_token_count_buckets(
+        self, max_num_tokens: int, device: torch.device
+    ) -> Tuple[int, ...]:
         tic = time.perf_counter()
         logger.info(
-            "Running DeepSeek V4 MHC prewarm for token-count shapes: %s",
+            "Running DeepSeek V4 MHC prewarm for max_num_tokens=%s",
+            max_num_tokens,
+        )
+        token_counts = self.layers[self.start_layer].prewarm_mhc_token_count_buckets(
+            max_num_tokens, device
+        )
+        logger.info(
+            "DeepSeek V4 MHC prewarm finished in %.3fs for representative token counts: %s",
+            time.perf_counter() - tic,
             token_counts,
         )
-        self.layers[self.start_layer].prewarm_mhc_token_counts(token_counts, device)
-        logger.info(
-            "DeepSeek V4 MHC prewarm finished in %.3fs",
-            time.perf_counter() - tic,
-        )
+        return token_counts
 
     def hc_head(
         self,
@@ -1194,10 +1217,10 @@ class DeepseekV4ForCausalLM(nn.Module):
             self.cp_rank = get_attention_cp_rank()
             self.cp_size = get_attention_cp_size()
 
-    def prewarm_mhc_token_counts(
-        self, token_counts: Tuple[int, ...], device: torch.device
-    ) -> None:
-        self.model.prewarm_mhc_token_counts(token_counts, device)
+    def prewarm_mhc_token_count_buckets(
+        self, max_num_tokens: int, device: torch.device
+    ) -> Tuple[int, ...]:
+        return self.model.prewarm_mhc_token_count_buckets(max_num_tokens, device)
 
     @property
     def routed_experts_weights_of_layer(self):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1222,6 +1222,28 @@ class DeepseekV4ForCausalLM(nn.Module):
     ) -> Tuple[int, ...]:
         return self.model.prewarm_mhc_token_count_buckets(max_num_tokens, device)
 
+    def kernel_warmup(self, model_runner) -> None:
+        if not model_runner.is_hybrid_swa:
+            return
+        if not envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
+            return
+        if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
+            return
+
+        max_num_tokens = model_runner.server_args.chunked_prefill_size
+        if max_num_tokens is None or max_num_tokens <= 0:
+            max_num_tokens = 8192
+
+        token_counts = self.prewarm_mhc_token_count_buckets(
+            max_num_tokens, model_runner.device
+        )
+        model_runner.tp_group.barrier()
+
+        logger.info(
+            "DeepSeek V4 MHC prewarm completed for representative token-count shapes: %s",
+            token_counts,
+        )
+
     @property
     def routed_experts_weights_of_layer(self):
         return self._routed_experts_weights_of_layer.value

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -108,10 +108,10 @@ class DeepseekV4ModelNextN(nn.Module):
         y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
         return y.to(dtype)
 
-    def prewarm_mhc_token_counts(
-        self, token_counts: Tuple[int, ...], device: torch.device
-    ) -> None:
-        self.decoder.prewarm_mhc_token_counts(token_counts, device)
+    def prewarm_mhc_token_count_buckets(
+        self, max_num_tokens: int, device: torch.device
+    ) -> Tuple[int, ...]:
+        return self.decoder.prewarm_mhc_token_count_buckets(max_num_tokens, device)
 
     def forward(
         self,

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -108,6 +108,11 @@ class DeepseekV4ModelNextN(nn.Module):
         y = torch.sum(pre.unsqueeze(-1) * x.view(shape), dim=1)
         return y.to(dtype)
 
+    def prewarm_mhc_token_counts(
+        self, token_counts: Tuple[int, ...], device: torch.device
+    ) -> None:
+        self.decoder.prewarm_mhc_token_counts(token_counts, device)
+
     def forward(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
## Motivation

DeepSeek V4 MHC pre can hit a large one-time cold cost when a rare token-count bucket first enters the server process. In internal DSV4 profiling runs, the long 20-40s forward stalls aligned with first-seen MHC pre split buckets in sparse mixed/decode tail. This patch moves that first-hit cost into startup warmup so live traffic and benchmark measurement do not pay it at the tail.

## Changes

- Add an optional model-level kernel warmup hook in `ModelRunner.kernel_warmup()`, before CUDA graph capture.
- Implement the DeepSeek V4 MHC prewarm in the DeepSeek V4 model, keeping model-specific logic out of `ModelRunner`.
- Gate the hook narrowly to DeepSeek V4 + hybrid SWA + `SGLANG_OPT_DEEPGEMM_HC_PRENORM=1` + `SGLANG_OPT_USE_TILELANG_MHC_PRE=1`.
- Infer the warmup range from the normalized `server_args.chunked_prefill_size`; if it is unset or invalid, fall back to `8192`.
- Compute one representative token count per MHC pre split bucket under that range, instead of requiring users to manually provide token counts.
- Run both attention and FFN `hc_pre` paths on one local DeepSeek V4 decoder layer for each representative token-count bucket.
- Expose the MHC prewarm path through the DeepSeek V4 NextN wrapper so the inherited model hook can handle that runtime path as well.

## Notes for reviewers

- There is no new user-facing environment variable in the final version. The prewarm range follows the same `chunked_prefill_size` budget used by serving.
- With DP attention enabled, `ServerArgs` already normalizes `chunked_prefill_size` by `dp_size`, so `ModelRunner` sees the local per-DP-rank token budget and should not divide it again.
- Warming one local decoder layer is enough for this purpose because the MHC pre kernel shape is determined by token count and hidden shape, not by layer-specific weights.

## Accuracy

Full GSM8K validation on a B300 DeepSeek V4-Pro DP-attention mixed-chunk setup. The run did not set any `SGLANG_DSV4_MHC_PREWARM_*` env; the prewarm range was derived from `chunked_prefill_size`.

Representative setup:

```bash
export SGLANG_OPT_DEEPGEMM_HC_PRENORM=1
export SGLANG_OPT_USE_TILELANG_MHC_PRE=1
export SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1
export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=2048
export SGLANG_EXPERIMENTAL_ENABLE_PIECEWISE_CUDA_GRAPH_MOE_A2A=1
export SGLANG_OPT_USE_TOPK_V2=1
export SGLANG_OPT_USE_JIT_NORM=1
export SGLANG_OPT_USE_JIT_INDEXER_METADATA=1
export SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1
export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
export SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1

python3 -m dynamo.sglang \
  --model-path /path/to/DeepSeek-V4-Pro \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --host 0.0.0.0 \
  --port 6100 \
  --trust-remote-code \
  --chunked-prefill-size 16384 \
  --max-prefill-tokens 16384 \
  --enable-mixed-chunk \
  --context-length 16384 \
  --tensor-parallel-size 8 \
  --data-parallel-size 8 \
  --expert-parallel-size 8 \
  --enable-dp-attention \
  --moe-a2a-backend deepep \
  --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
  --cuda-graph-max-bs 544 \
  --max-running-requests 4352 \
  --mem-fraction-static 0.835 \
  --swa-full-tokens-ratio 0.075 \
  --stream-interval 30 \
  --tokenizer-worker-num 1 \
  --watchdog-timeout 86400
```

With DP attention, the global `--chunked-prefill-size 16384` is normalized by DP size 8, so each local DP rank sees `max_num_tokens=2048` for this warmup.

The worker log confirmed the local prewarm range and representative buckets:

```text
Running DeepSeek V4 MHC prewarm for max_num_tokens=2048
DeepSeek V4 MHC prewarm max_num_tokens=2048 representative token counts: (2048, 1856, 1536, 1344, 1152, 1024, 896, 832, 768, 704, 640, 576, 512, 448, 384, 320, 256, 192, 128, 64)
DeepSeek V4 MHC prewarm path=attn num_tokens=2048 completed in 28.551s
DeepSeek V4 MHC prewarm path=attn num_tokens=64 completed in 28.014s
Capture cuda graph end. Time elapsed: 247.96 s.
```

Full GSM8K benchmark output:

```text
GSM8K Config: endpoint=http://localhost:8000; num_examples=1319; max_tokens=2048; num_threads=512; num_shots=8; temperature=default; top_p=default; top_k=default
Running GSM8K evaluation...
Total latency: 131.544 s
Score: 0.969
Output throughput: 4405.387 token/s
[METRIC] gsm8k_score=0.9687261632341724 labels={"model": "deepseek-ai/DeepSeek-V4-Pro", "eval": "gsm8k"}
[METRIC] gsm8k_latency=131.54371510795318 labels={"model": "deepseek-ai/DeepSeek-V4-Pro", "eval": "gsm8k"}
{'score:std': np.float64(0.17405684100250698), 'score': np.float64(0.9687261632341724), 'latency': 131.54371510795318, 'output_throughput': 4405.3872092971105}
GSM8K evaluation complete
```

## Benchmark
Before:
<img width="1718" height="401" alt="image" src="https://github.com/user-attachments/assets/615c6c87-56be-4f0f-8d54-f5831a0d8b62" />

After:
<img width="1441" height="329" alt="image" src="https://github.com/user-attachments/assets/97e0673b-7daa-405b-a04b-a82674195e04" />

Total TPS/GPU from 9266.78 to 9644.40 under conc=2048 on B300

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26182953200](https://github.com/sgl-project/sglang/actions/runs/26182953200)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26182953180](https://github.com/sgl-project/sglang/actions/runs/26182953180)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

