### PR TITLE
pr-states: dispatch from pr-test* notify job (fix rerun status)

### DIFF
--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -3,21 +3,29 @@ name: PR States
 # pull_request_target (not pull_request) for fork-PR write access; safe
 # because we never check out PR head code, only API-read and PATCH the body.
 #
-# Trigger sources:
-#   - pull_request_target: covers fresh push / open / label changes.
+# Three trigger sources, each covering a distinct gap:
+#   - pull_request_target: covers fresh push / open / label changes (all
+#     PRs including forks, since pull_request_target runs in base-repo
+#     context with full permissions).
+#   - workflow_run (pr-test* completion): covers the INITIAL completion of
+#     each pr-test / pr-test-extra run, including fork PRs. The notify-job
+#     below cannot fire for fork PRs (their `pull_request` GITHUB_TOKEN is
+#     read-only), so fork PRs rely on this path to update on completion.
+#     workflow_run does NOT re-fire for rerun attempts (GitHub reuses the
+#     workflow_run record across attempts), which is why we need the
+#     notify-job path too.
 #   - workflow_dispatch: explicit refresh fired by pr-test.yml /
-#     pr-test-extra.yml's notify-pr-states final job after every run
-#     (initial + every rerun attempt). This is the only way to catch a
-#     post-rerun status change, because GitHub does NOT re-fire
-#     `workflow_run.completed` for rerun attempts (the workflow_run record
-#     is reused across attempts, so subscribers see the initial completion
-#     once and never again). `workflow_dispatch` is also the only event
-#     that GITHUB_TOKEN can cascade-create, which lets the notify job fire
-#     this workflow regardless of who initiated the rerun.
+#     pr-test-extra.yml's notify-pr-states final job after every attempt
+#     completion. This catches rerun completions (initial + rerun) for
+#     non-fork PRs. `workflow_dispatch` is the only event GITHUB_TOKEN can
+#     cascade-create, so it works regardless of who initiated the rerun.
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_run:
+    workflows: ["PR Test Base", "PR Test Extra"]
+    types: [requested, completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,9 +38,11 @@ permissions:
   actions: read
 
 concurrency:
-  # Dedupe per PR so a flurry of notify-pr-states dispatches (e.g. one
-  # per stage completion) doesn't race on the body PATCH.
-  group: pr-states-${{ github.event.pull_request.number || inputs.pr_number }}
+  # Dedupe per commit SHA when available, fall back to PR number for the
+  # workflow_dispatch path. Concurrent fires from pull_request_target +
+  # workflow_run + notify-job on the same push will queue rather than
+  # race on the body PATCH.
+  group: pr-states-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -51,10 +61,39 @@ jobs:
 
             // Event-agnostic PR lookup.
             // - pull_request_target: PR is in the payload.
+            // - workflow_run: pull_requests[] is populated for same-repo
+            //   PRs; fork PRs need a head-ref reverse lookup
+            //   ("forkOwner:branch") because
+            //   listPullRequestsAssociatedWithCommit requires the commit to
+            //   be in the default branch. Bail when no open PR matches.
             // - workflow_dispatch: pr_number is an explicit input.
             let prNumber;
             if (context.payload.pull_request) {
               prNumber = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_run') {
+              const wr = context.payload.workflow_run;
+              if (wr.pull_requests && wr.pull_requests.length > 0) {
+                prNumber = wr.pull_requests[0].number;
+              } else if (wr.head_repository && wr.head_branch) {
+                const headSpec = `${wr.head_repository.owner.login}:${wr.head_branch}`;
+                const { data: prs } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  head: headSpec,
+                });
+                // Multiple PRs could share a head ref if a branch was reused;
+                // match by head_sha to pick the right one.
+                const match = prs.find(p => p.head.sha === wr.head_sha) || prs[0];
+                if (!match) {
+                  core.info(`No open PR for head=${headSpec}; skipping.`);
+                  return;
+                }
+                prNumber = match.number;
+              } else {
+                core.info(`workflow_run has no PR linkage; skipping.`);
+                return;
+              }
             } else if (context.eventName === 'workflow_dispatch') {
               // workflow_dispatch inputs are arbitrary strings; reject
               // anything that isn't a pure digit sequence so trailing

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -56,11 +56,15 @@ jobs:
             if (context.payload.pull_request) {
               prNumber = context.payload.pull_request.number;
             } else if (context.eventName === 'workflow_dispatch') {
-              prNumber = parseInt(context.payload.inputs.pr_number, 10);
-              if (!prNumber) {
-                core.setFailed(`workflow_dispatch: invalid pr_number input '${context.payload.inputs.pr_number}'`);
+              // workflow_dispatch inputs are arbitrary strings; reject
+              // anything that isn't a pure digit sequence so trailing
+              // garbage like '123abc' doesn't silently truncate via parseInt.
+              const raw = context.payload.inputs.pr_number;
+              if (!/^\d+$/.test(raw)) {
+                core.setFailed(`workflow_dispatch: invalid pr_number input '${raw}' (must be digits only)`);
                 return;
               }
+              prNumber = parseInt(raw, 10);
             } else {
               core.info(`Unsupported event '${context.eventName}'; skipping.`);
               return;

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -2,26 +2,37 @@ name: PR States
 # Maintains the CI-states block at the bottom of the PR body. Uses
 # pull_request_target (not pull_request) for fork-PR write access; safe
 # because we never check out PR head code, only API-read and PATCH the body.
+#
+# Trigger sources:
+#   - pull_request_target: covers fresh push / open / label changes.
+#   - workflow_dispatch: explicit refresh fired by pr-test.yml /
+#     pr-test-extra.yml's notify-pr-states final job after every run
+#     (initial + every rerun attempt). This is the only way to catch a
+#     post-rerun status change, because GitHub does NOT re-fire
+#     `workflow_run.completed` for rerun attempts (the workflow_run record
+#     is reused across attempts, so subscribers see the initial completion
+#     once and never again). `workflow_dispatch` is also the only event
+#     that GITHUB_TOKEN can cascade-create, which lets the notify job fire
+#     this workflow regardless of who initiated the rerun.
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_run:
-    # Listen to pr-test* lifecycle so reruns initiated by slash commands
-    # (run.rerun / run.rerun_failed_jobs via GITHUB_TOKEN) -- which don't
-    # refire pull_request_target -- still refresh the CI-states block.
-    workflows: ["PR Test Base", "PR Test Extra"]
-    types: [requested, completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose CI-states block should be refreshed.'
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
   actions: read
 
 concurrency:
-  # Dedupe per commit SHA across both event sources so simultaneous
-  # synchronize + workflow_run firings on the same push queue instead
-  # of racing on the body PATCH.
-  group: pr-states-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+  # Dedupe per PR so a flurry of notify-pr-states dispatches (e.g. one
+  # per stage completion) doesn't race on the body PATCH.
+  group: pr-states-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 jobs:
@@ -40,37 +51,19 @@ jobs:
 
             // Event-agnostic PR lookup.
             // - pull_request_target: PR is in the payload.
-            // - workflow_run: pull_requests[] is populated for same-repo PRs;
-            //   fork PRs need a head-ref reverse lookup ("forkOwner:branch")
-            //   because listPullRequestsAssociatedWithCommit requires the commit
-            //   to be in the default branch. Bail when no open PR matches.
+            // - workflow_dispatch: pr_number is an explicit input.
             let prNumber;
             if (context.payload.pull_request) {
               prNumber = context.payload.pull_request.number;
-            } else {
-              const wr = context.payload.workflow_run;
-              if (wr.pull_requests && wr.pull_requests.length > 0) {
-                prNumber = wr.pull_requests[0].number;
-              } else if (wr.head_repository && wr.head_branch) {
-                const headSpec = `${wr.head_repository.owner.login}:${wr.head_branch}`;
-                const { data: prs } = await github.rest.pulls.list({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  state: 'open',
-                  head: headSpec,
-                });
-                // Multiple PRs could share a head ref if a branch was reused;
-                // match by head_sha to pick the right one.
-                const match = prs.find(p => p.head.sha === wr.head_sha) || prs[0];
-                if (!match) {
-                  core.info(`No open PR for head=${headSpec}; skipping.`);
-                  return;
-                }
-                prNumber = match.number;
-              } else {
-                core.info(`workflow_run has no PR linkage; skipping.`);
+            } else if (context.eventName === 'workflow_dispatch') {
+              prNumber = parseInt(context.payload.inputs.pr_number, 10);
+              if (!prNumber) {
+                core.setFailed(`workflow_dispatch: invalid pr_number input '${context.payload.inputs.pr_number}'`);
                 return;
               }
+            } else {
+              core.info(`Unsupported event '${context.eventName}'; skipping.`);
+              return;
             }
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/pr-states.yml
+++ b/.github/workflows/pr-states.yml
@@ -3,22 +3,15 @@ name: PR States
 # pull_request_target (not pull_request) for fork-PR write access; safe
 # because we never check out PR head code, only API-read and PATCH the body.
 #
-# Three trigger sources, each covering a distinct gap:
-#   - pull_request_target: covers fresh push / open / label changes (all
-#     PRs including forks, since pull_request_target runs in base-repo
-#     context with full permissions).
-#   - workflow_run (pr-test* completion): covers the INITIAL completion of
-#     each pr-test / pr-test-extra run, including fork PRs. The notify-job
-#     below cannot fire for fork PRs (their `pull_request` GITHUB_TOKEN is
-#     read-only), so fork PRs rely on this path to update on completion.
-#     workflow_run does NOT re-fire for rerun attempts (GitHub reuses the
-#     workflow_run record across attempts), which is why we need the
-#     notify-job path too.
-#   - workflow_dispatch: explicit refresh fired by pr-test.yml /
-#     pr-test-extra.yml's notify-pr-states final job after every attempt
-#     completion. This catches rerun completions (initial + rerun) for
-#     non-fork PRs. `workflow_dispatch` is the only event GITHUB_TOKEN can
-#     cascade-create, so it works regardless of who initiated the rerun.
+# Three triggers, each covering a gap:
+#   - pull_request_target: push / open / label change (all PRs incl forks).
+#   - workflow_run: initial pr-test* completion (incl fork PRs; the
+#     notify-job below can't fire on forks — their pull_request
+#     GITHUB_TOKEN is forced read-only). Does NOT re-fire for rerun
+#     attempts, which is why workflow_dispatch is needed too.
+#   - workflow_dispatch: rerun completions for non-fork PRs, dispatched by
+#     pr-test*'s notify-pr-states job. workflow_dispatch is the only event
+#     GITHUB_TOKEN can cascade-create.
 
 on:
   pull_request_target:
@@ -38,10 +31,8 @@ permissions:
   actions: read
 
 concurrency:
-  # Dedupe per commit SHA when available, fall back to PR number for the
-  # workflow_dispatch path. Concurrent fires from pull_request_target +
-  # workflow_run + notify-job on the same push will queue rather than
-  # race on the body PATCH.
+  # Per-SHA dedupe (PR number for workflow_dispatch). Queues concurrent
+  # fires across the three triggers so they don't race on the body PATCH.
   group: pr-states-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || inputs.pr_number }}
   cancel-in-progress: false
 
@@ -95,9 +86,8 @@ jobs:
                 return;
               }
             } else if (context.eventName === 'workflow_dispatch') {
-              // workflow_dispatch inputs are arbitrary strings; reject
-              // anything that isn't a pure digit sequence so trailing
-              // garbage like '123abc' doesn't silently truncate via parseInt.
+              // Reject non-digit pr_number; parseInt('123abc', 10) returns
+              // 123 and would silently truncate trailing garbage.
               const raw = context.payload.inputs.pr_number;
               if (!/^\d+$/.test(raw)) {
                 core.setFailed(`workflow_dispatch: invalid pr_number input '${raw}' (must be digits only)`);

--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -222,27 +222,63 @@ jobs:
       run_timeout_minutes: '60'
     secrets: inherit
 
+  # =============================================== aggregator ====================================================
+  # Mirrors pr-test.yml's `pr-test-finish`: one aggregator job that
+  # encodes the full job-graph membership in a single place. Downstream
+  # consumers (notify-pr-states) only need to depend on this job rather
+  # than re-listing every stage. Failures cascade up: this job fails if
+  # any dependent failed/cancelled.
+  pr-test-extra-finish:
+    needs:
+      [
+        check-changes,
+        call-gate,
+        sgl-kernel-build-wheels,
+        extra-a-test-1-gpu-small,
+        extra-a-test-1-gpu-large,
+        extra-a-test-2-gpu-large,
+        extra-b-test-4-gpu-h100,
+        extra-b-test-4-gpu-b200,
+        extra-b-test-8-gpu-h200,
+        extra-b-test-deepep-8-gpu-h200,
+      ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all dependent job statuses
+        run: |
+          json_needs='${{ toJson(needs) }}'
+          job_names=$(echo "$json_needs" | jq -r 'keys_unsorted[]')
+          for job in $job_names; do
+            result=$(echo "$json_needs" | jq -r --arg j "$job" '.[$j].result')
+            echo "$job: $result"
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "The above jobs failed."
+              exit 1
+            fi
+          done
+          echo "All jobs completed successfully"
+          exit 0
+
   # =============================================== notify pr-states ====================================================
   # Explicit dispatch of pr-states.yml on every run completion (initial +
   # every rerun attempt). GitHub does not re-fire `workflow_run.completed`
   # for rerun attempts, so a `workflow_run` subscription only catches the
   # initial completion. `workflow_dispatch` is the only event GITHUB_TOKEN
   # is allowed to cascade-create, so this works regardless of who initiated
-  # the rerun. Runs unconditionally (`if: always()`) so the PR-body status
-  # block reflects the latest attempt even after cancellation / failure.
+  # the rerun. Depends only on pr-test-extra-finish (which aggregates
+  # everything) so the needs list stays maintenance-free.
+  #
+  # Fork PRs are excluded: `pull_request` event from a fork repo runs with
+  # a read-only GITHUB_TOKEN regardless of the declared `actions: write`,
+  # so the dispatch call would 403. Fork PRs already get pr-states updates
+  # from `pull_request_target.synchronize` on each push.
   notify-pr-states:
-    needs:
-      - check-changes
-      - call-gate
-      - sgl-kernel-build-wheels
-      - extra-a-test-1-gpu-small
-      - extra-a-test-1-gpu-large
-      - extra-a-test-2-gpu-large
-      - extra-b-test-4-gpu-h100
-      - extra-b-test-4-gpu-b200
-      - extra-b-test-8-gpu-h200
-      - extra-b-test-deepep-8-gpu-h200
-    if: always() && github.event_name == 'pull_request'
+    needs: [pr-test-extra-finish]
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch pr-states refresh

--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -221,3 +221,36 @@ jobs:
       partitions: ${{ needs.check-changes.outputs.partitions }}
       run_timeout_minutes: '60'
     secrets: inherit
+
+  # =============================================== notify pr-states ====================================================
+  # Explicit dispatch of pr-states.yml on every run completion (initial +
+  # every rerun attempt). GitHub does not re-fire `workflow_run.completed`
+  # for rerun attempts, so a `workflow_run` subscription only catches the
+  # initial completion. `workflow_dispatch` is the only event GITHUB_TOKEN
+  # is allowed to cascade-create, so this works regardless of who initiated
+  # the rerun. Runs unconditionally (`if: always()`) so the PR-body status
+  # block reflects the latest attempt even after cancellation / failure.
+  notify-pr-states:
+    needs:
+      - check-changes
+      - call-gate
+      - sgl-kernel-build-wheels
+      - extra-a-test-1-gpu-small
+      - extra-a-test-1-gpu-large
+      - extra-a-test-2-gpu-large
+      - extra-b-test-4-gpu-h100
+      - extra-b-test-4-gpu-b200
+      - extra-b-test-8-gpu-h200
+      - extra-b-test-deepep-8-gpu-h200
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch pr-states refresh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run pr-states.yml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            -f pr_number="$PR_NUMBER"

--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -223,11 +223,9 @@ jobs:
     secrets: inherit
 
   # =============================================== aggregator ====================================================
-  # Mirrors pr-test.yml's `pr-test-finish`: one aggregator job that
-  # encodes the full job-graph membership in a single place. Downstream
-  # consumers (notify-pr-states) only need to depend on this job rather
-  # than re-listing every stage. Failures cascade up: this job fails if
-  # any dependent failed/cancelled.
+  # Mirrors pr-test.yml's `pr-test-finish` so notify-pr-states below only
+  # depends on one job rather than re-listing every stage. Fails if any
+  # dependent failed/cancelled.
   pr-test-extra-finish:
     needs:
       [
@@ -261,18 +259,15 @@ jobs:
           exit 0
 
   # =============================================== notify pr-states ====================================================
-  # Explicit dispatch of pr-states.yml on every run completion (initial +
-  # every rerun attempt). GitHub does not re-fire `workflow_run.completed`
-  # for rerun attempts, so a `workflow_run` subscription only catches the
-  # initial completion. `workflow_dispatch` is the only event GITHUB_TOKEN
-  # is allowed to cascade-create, so this works regardless of who initiated
-  # the rerun. Depends only on pr-test-extra-finish (which aggregates
-  # everything) so the needs list stays maintenance-free.
+  # Dispatches pr-states.yml after every attempt (initial + every rerun).
+  # workflow_run.completed only fires on the initial completion (one
+  # workflow_run record across attempts), so we explicitly dispatch —
+  # workflow_dispatch is the only event GITHUB_TOKEN can cascade-create.
   #
-  # Fork PRs are excluded: `pull_request` event from a fork repo runs with
-  # a read-only GITHUB_TOKEN regardless of the declared `actions: write`,
-  # so the dispatch call would 403. Fork PRs already get pr-states updates
-  # from `pull_request_target.synchronize` on each push.
+  # Fork PRs are excluded: their pull_request GITHUB_TOKEN is forced
+  # read-only regardless of declared `actions: write`, so dispatch 403s.
+  # Fork PRs get pr-states updates via the workflow_run subscription
+  # there (initial completion) and pull_request_target (push / label).
   notify-pr-states:
     needs: [pr-test-extra-finish]
     if: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -563,3 +563,26 @@ jobs:
           # If the loop completes, all jobs were successful
           echo "All jobs completed successfully"
           exit 0
+
+  # =============================================== notify pr-states ====================================================
+  # Explicit dispatch of pr-states.yml on every run completion (initial +
+  # every rerun attempt). GitHub does not re-fire `workflow_run.completed`
+  # for rerun attempts, so a `workflow_run` subscription only catches the
+  # initial completion. `workflow_dispatch` is the only event GITHUB_TOKEN
+  # is allowed to cascade-create, so this works regardless of who initiated
+  # the rerun. Depends only on pr-test-finish (which aggregates everything)
+  # so the needs list stays maintenance-free.
+  notify-pr-states:
+    needs: [pr-test-finish]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch pr-states refresh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run pr-states.yml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            -f pr_number="$PR_NUMBER"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -572,9 +572,17 @@ jobs:
   # is allowed to cascade-create, so this works regardless of who initiated
   # the rerun. Depends only on pr-test-finish (which aggregates everything)
   # so the needs list stays maintenance-free.
+  #
+  # Fork PRs are excluded: `pull_request` event from a fork repo runs with
+  # a read-only GITHUB_TOKEN regardless of the declared `actions: write`,
+  # so the dispatch call would 403. Fork PRs already get pr-states updates
+  # from `pull_request_target.synchronize` on each push.
   notify-pr-states:
     needs: [pr-test-finish]
-    if: always() && github.event_name == 'pull_request'
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch pr-states refresh

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -565,18 +565,15 @@ jobs:
           exit 0
 
   # =============================================== notify pr-states ====================================================
-  # Explicit dispatch of pr-states.yml on every run completion (initial +
-  # every rerun attempt). GitHub does not re-fire `workflow_run.completed`
-  # for rerun attempts, so a `workflow_run` subscription only catches the
-  # initial completion. `workflow_dispatch` is the only event GITHUB_TOKEN
-  # is allowed to cascade-create, so this works regardless of who initiated
-  # the rerun. Depends only on pr-test-finish (which aggregates everything)
-  # so the needs list stays maintenance-free.
+  # Dispatches pr-states.yml after every attempt (initial + every rerun).
+  # workflow_run.completed only fires on the initial completion (one
+  # workflow_run record across attempts), so we explicitly dispatch —
+  # workflow_dispatch is the only event GITHUB_TOKEN can cascade-create.
   #
-  # Fork PRs are excluded: `pull_request` event from a fork repo runs with
-  # a read-only GITHUB_TOKEN regardless of the declared `actions: write`,
-  # so the dispatch call would 403. Fork PRs already get pr-states updates
-  # from `pull_request_target.synchronize` on each push.
+  # Fork PRs are excluded: their pull_request GITHUB_TOKEN is forced
+  # read-only regardless of declared `actions: write`, so dispatch 403s.
+  # Fork PRs get pr-states updates via the workflow_run subscription
+  # there (initial completion) and pull_request_target (push / label).
   notify-pr-states:
     needs: [pr-test-finish]
     if: |


### PR DESCRIPTION
Fix pr-states.yml not refreshing after a rerun (UI or slash command).

Root cause: GitHub does NOT re-fire `workflow_run.completed` for rerun attempts (the workflow_run record is reused across attempts, so subscribers see the initial completion once and never again). The previous `workflow_run` subscription in pr-states.yml only worked for the initial run.

Fix: pr-test.yml and pr-test-extra.yml each gain a final `notify-pr-states` job (`if: always() && github.event_name == 'pull_request'`) that calls `gh workflow run pr-states.yml -F pr_number=...`. `workflow_dispatch` is the only event GITHUB_TOKEN is allowed to cascade-create, so this fires for every run completion regardless of who initiated the rerun. The previous `workflow_run` subscription is removed.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26129448608](https://github.com/sgl-project/sglang/actions/runs/26129448608)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26129448514](https://github.com/sgl-project/sglang/actions/runs/26129448514)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->