### PR TITLE
Update GLM-5 H200 FP8

### DIFF
--- a/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
+++ b/docs_new/cookbook/autoregressive/GLM/GLM-5.mdx
@@ -109,6 +109,7 @@ sglang serve \
   --speculative-num-steps 3 \
   --speculative-eagle-topk 1 \
   --speculative-num-draft-tokens 4 \
+  --enable-flashinfer-allreduce-fusion \
   --mem-fraction-static 0.85 \
   --host 0.0.0.0 \
   --port 30000

--- a/docs_new/src/snippets/autoregressive/glm-5-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/glm-5-deployment.jsx
@@ -206,6 +206,11 @@ export const GLM5Deployment = () => {
       cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
     }
 
+    // H200 FP8: flashinfer allreduce fusion.
+    if (hardware === 'h200' && effectiveQuant === 'fp8') {
+      cmd += ' \\\n  --enable-flashinfer-allreduce-fusion';
+    }
+
     cmd += ` \\\n  --mem-fraction-static ${memFraction}`;
     return cmd;
   };


### PR DESCRIPTION
Add --enable-flashinfer-allreduce-fusion to the GLM-5 H200 FP8 SGLang serve command for improved allreduce performance. Based on SemiAnalysisAI/InferenceX#1033.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26129406123](https://github.com/sgl-project/sglang/actions/runs/26129406123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26129406007](https://github.com/sgl-project/sglang/actions/runs/26129406007)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->