### PR TITLE
fix: align logprobs.content with message.content in /v1/chat/completions for reasoning models

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -927,11 +927,6 @@ class OpenAIServingChat(OpenAIServingBase):
             )
 
         for idx, ret_item in enumerate(ret):
-            # Process logprobs
-            choice_logprobs = None
-            if request.logprobs:
-                choice_logprobs = self._process_response_logprobs(ret_item)
-
             # Handle hidden states
             hidden_states = process_hidden_states_from_ret(ret_item, request)
 
@@ -961,6 +956,19 @@ class OpenAIServingChat(OpenAIServingBase):
                         err_type="InternalServerError",
                         status_code=500,
                     )
+
+            # Process logprobs after reasoning parsing so logprobs.content describes
+            # the same visible text as message.content, not the raw reasoning stream.
+            choice_logprobs = None
+            if request.logprobs:
+                choice_logprobs = self._process_response_logprobs(
+                    ret_item,
+                    parsed_content=(
+                        text
+                        if reasoning_parser and request.separate_reasoning
+                        else None
+                    ),
+                )
 
             # Handle tool calls
             tool_calls = None
@@ -1056,11 +1064,127 @@ class OpenAIServingChat(OpenAIServingBase):
 
         return token_logprobs
 
-    def _process_response_logprobs(self, ret_item: Dict[str, Any]) -> ChoiceLogprobs:
-        """Process logprobs for non-streaming response"""
+    def _slice_response_logprobs_to_content(
+        self,
+        output_token_logprobs: List[Any],
+        output_top_logprobs: Optional[List[Any]],
+        content: Optional[str],
+    ) -> tuple[List[Any], Optional[List[Any]]]:
+        """Slice non-streaming logprobs so joining tokens equals message.content."""
+        if content is None:
+            return output_token_logprobs, output_top_logprobs
+        if not content:
+            return [], [] if output_top_logprobs is not None else None
+
+        token_texts = [token_logprob[2] for token_logprob in output_token_logprobs]
+        raw_text = "".join(token_texts)
+
+        token_offsets = [0]
+        boundaries = {0: 0}
+        offset = 0
+        for token_index, token_text in enumerate(token_texts, start=1):
+            offset += len(token_text)
+            token_offsets.append(offset)
+            boundaries[offset] = token_index
+
+        content_start = raw_text.rfind(content)
+        while content_start != -1:
+            content_end = content_start + len(content)
+            start_index = boundaries.get(content_start)
+            end_index = boundaries.get(content_end)
+            if start_index is not None and end_index is not None:
+                sliced_top_logprobs = (
+                    output_top_logprobs[start_index:end_index]
+                    if output_top_logprobs is not None
+                    else None
+                )
+                return (
+                    output_token_logprobs[start_index:end_index],
+                    sliced_top_logprobs,
+                )
+
+            # The reasoning parser trims the final text. If that trim cuts into a
+            # decoded token, keep the token logprob but trim only whitespace from
+            # the displayed token text so the public invariant still holds:
+            # "".join(t.token for t in logprobs.content) == message.content.
+            start_index = 0
+            while (
+                start_index + 1 < len(token_offsets)
+                and token_offsets[start_index + 1] <= content_start
+            ):
+                start_index += 1
+            end_index = start_index + 1
+            while (
+                end_index < len(token_offsets)
+                and token_offsets[end_index] < content_end
+            ):
+                end_index += 1
+
+            prefix = raw_text[token_offsets[start_index] : content_start]
+            suffix = raw_text[content_end : token_offsets[end_index]]
+            if not prefix.strip() and not suffix.strip():
+                sliced_token_logprobs = list(
+                    output_token_logprobs[start_index:end_index]
+                )
+                if start_index == end_index - 1:
+                    sliced_token_logprobs[0] = self._replace_token_logprob_text(
+                        sliced_token_logprobs[0],
+                        content,
+                    )
+                else:
+                    first_token_text = token_texts[start_index][
+                        content_start - token_offsets[start_index] :
+                    ]
+                    last_token_text = token_texts[end_index - 1][
+                        : content_end - token_offsets[end_index - 1]
+                    ]
+                    sliced_token_logprobs[0] = self._replace_token_logprob_text(
+                        sliced_token_logprobs[0],
+                        first_token_text,
+                    )
+                    sliced_token_logprobs[-1] = self._replace_token_logprob_text(
+                        sliced_token_logprobs[-1],
+                        last_token_text,
+                    )
+
+                sliced_top_logprobs = (
+                    output_top_logprobs[start_index:end_index]
+                    if output_top_logprobs is not None
+                    else None
+                )
+                return sliced_token_logprobs, sliced_top_logprobs
+            content_start = raw_text.rfind(content, 0, content_start)
+
+        logger.warning(
+            "Failed to align chat completion logprobs with parsed message content; "
+            "returning unsliced logprobs."
+        )
+        return output_token_logprobs, output_top_logprobs
+
+    @staticmethod
+    def _replace_token_logprob_text(token_logprob: Any, token_text: str) -> Any:
+        values = list(token_logprob)
+        values[2] = token_text
+        return tuple(values) if isinstance(token_logprob, tuple) else values
+
+    def _process_response_logprobs(
+        self,
+        ret_item: Dict[str, Any],
+        parsed_content: Optional[str] = None,
+    ) -> ChoiceLogprobs:
+        """Process logprobs for non-streaming response."""
+        output_token_logprobs = ret_item["meta_info"]["output_token_logprobs"]
+        output_top_logprobs = ret_item["meta_info"].get("output_top_logprobs", None)
+        output_token_logprobs, output_top_logprobs = (
+            self._slice_response_logprobs_to_content(
+                output_token_logprobs,
+                output_top_logprobs,
+                parsed_content,
+            )
+        )
         logprobs = to_openai_style_logprobs(
-            output_token_logprobs=ret_item["meta_info"]["output_token_logprobs"],
-            output_top_logprobs=ret_item["meta_info"].get("output_top_logprobs", None),
+            output_token_logprobs=output_token_logprobs,
+            output_top_logprobs=output_top_logprobs,
         )
 
         token_logprobs = self._process_logprobs_tokens(logprobs, use_token_index=True)


### PR DESCRIPTION
## Summary

The handler that builds the chat completion response lives in `python/sglang/srt/entrypoints/openai/serving_chat.py`. When `separate_reasoning` is set, the reasoning parser splits the raw output into `reasoning_content` and `content`. The fix needs to:

1. Locate the spot where `ChatCompletionMessage.content` is assembled from parsed output (post-reasoning-parser) and where `logprobs.content` is assembled from `meta_info.output_token_logprobs`.
2. Compute the number of leading tokens that belong to the reasoning span (and the trailing `</think>` or close-marker token) by re-tokenizing `reasoning_content` plus the close marker through the same tokenizer the engine used, OR by counting the prefix length up to and including the reasoning-end token id used by the parser.
3. Slice `output_token_logprobs` to start from the first content token and end at the last content token before any trailing stop-marker, then build `logprobs.content` from that slice only.
4. Guard the slice: when `separate_reasoning=False` (or there is no reasoning parser), keep current behavior.
5. Guard the case where reasoning consumes all `max_tokens` and `content` is empty: emit an empty `logprobs.content` list (not the reasoning tokens) so the invariant holds.

The reasoning parser objects expose the boundary token id (e.g. `THINKING_END_TOKEN_ID` for Qwen3, equivalent for DeepSeek-R1 and GLM-4.5). Reuse the same parser instance that was used to split text so we don't re-implement the boundary detection. Cleanest hook: after the parser returns `(reasoning_text, final_text)`, return also the prefix token count it consumed; then the caller slices `output_token_logprobs[prefix_count:]`.

If touching every parser is too broad for one PR, the narrower fix is to re-tokenize `final_text` with the model tokenizer, find the suffix of `output_token_logprobs` whose decoded text equals `final_text`, and use that slice. This is local to `serving_chat.py` and keeps parser interfaces unchanged.

Document the new invariant in a docstring near the response construction so future contributors don't drift the streaming path away again.

## Why this matters

Issue #25055 reports that when `/v1/chat/completions` is called against a reasoning model (DeepSeek-R1/V3, Qwen3, GLM-4.5, Kimi, etc.) with `logprobs=true` and `separate_reasoning=true`, the returned `logprobs.content` contains token logprobs for the entire raw output stream including the `<think>...</think>` reasoning span and marker tokens, while `message.content` correctly contains only the post-parser final answer.

OpenAI's reference spec and Aliyun Bailian emit `logprobs.content` aligned with `message.content`. The invariant should be:

```
"".join(t.token for t in logprobs.content) == message.content
```

SGLang violates that invariant whenever the reasoning parser strips a leading thinking span. Token-level consumers (scoring, visualization, audit) cannot align logprob entries to the user-visible content.

The bug is in the non-streaming branch of the chat completions handler. PR #23954 fixed an analogous streaming issue but did not cover this path. Issue has 0 comments and no maintainer claim, no open PR matched the search "logprobs reasoning" or "logprobs.content reasoning" against the repo.

## Testing

1. Reasoning model with non-empty `content` and non-empty `reasoning_content`. Set `logprobs=true`, assert `"".join(t.token for t in resp.choices[0].logprobs.content) == resp.choices[0].message.content`.
2. Reasoning model where `content` is empty (reasoning consumed `max_tokens`, related to bug #25267): assert `logprobs.content == []` and not the reasoning token stream.
3. Non-reasoning model (Llama-3, base Qwen2-Instruct): assert `logprobs.content` length and token sequence match `message.content` (regression guard, must equal previous behavior).
4. `top_logprobs > 0`: verify each `logprobs.content[i].top_logprobs` entry survives slicing and aligns with the post-slice token.
5. Streaming run with same model and prompt: confirm streaming `logprobs.content` chunks already align (PR #23954) and that non-streaming now matches streaming concatenation.

Existing tests live under `test/srt/openai_server/` and reasoning-parser tests under `test/srt/test_reasoning_parser.py`. Add the new assertions to the chat-completions test module that already exercises `separate_reasoning`.

Fixes #25055

AI was used for assistance.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26129927477](https://github.com/sgl-project/sglang/actions/runs/26129927477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26129927310](https://github.com/sgl-project/sglang/actions/runs/26129927310)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->