### PR TITLE
fix: return cached_tokens and reasoning_tokens in sgl-model-gateway grpc usage

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = ans, als, hel, boostrap, childs, te, vas, hsa, ment, cann, thi, makro, wil, rouge, PRIS
+ignore-words-list = ans, als, hel, boostrap, childs, te, vas, hsa, ment, cann, thi, makro, wil, rouge, PRIS, ser
 skip = *.json,*.jsonl,*.patch,*.txt

--- a/sgl-model-gateway/src/routers/grpc/common/response_collection.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_collection.rs
@@ -48,6 +48,8 @@ pub(crate) async fn collect_responses(
             prefill.mark_completed();
             decode_stream.mark_completed();
 
+            merge_prefill_cached_tokens(&prefill_responses, &mut decode_responses);
+
             // Merge prefill input_logprobs if requested
             if merge_logprobs {
                 merge_prefill_logprobs(&prefill_responses, &mut decode_responses);
@@ -94,5 +96,53 @@ fn merge_prefill_logprobs(
                 }
             }
         }
+    }
+}
+
+fn merge_prefill_cached_tokens(
+    prefill_responses: &[ProtoGenerateComplete],
+    decode_responses: &mut [ProtoGenerateComplete],
+) {
+    if let Some(cached_tokens) = prefill_responses.first().map(|r| r.cached_tokens()) {
+        for response in decode_responses {
+            if let ProtoGenerateComplete::Sglang(decode) = response {
+                decode.cached_tokens = decode.cached_tokens.saturating_add(cached_tokens);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smg_grpc_client::sglang_proto;
+
+    use super::*;
+
+    fn complete(cached_tokens: i32) -> ProtoGenerateComplete {
+        ProtoGenerateComplete::Sglang(sglang_proto::GenerateComplete {
+            cached_tokens,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn merges_prefill_cached_tokens_into_decode_responses() {
+        let prefill_responses = vec![complete(42)];
+        let mut decode_responses = vec![complete(0), complete(0)];
+
+        merge_prefill_cached_tokens(&prefill_responses, &mut decode_responses);
+
+        assert_eq!(decode_responses[0].cached_tokens(), 42);
+        assert_eq!(decode_responses[1].cached_tokens(), 42);
+    }
+
+    #[test]
+    fn preserves_decode_cached_tokens_when_merging_prefill() {
+        let prefill_responses = vec![complete(42)];
+        let mut decode_responses = vec![complete(8)];
+
+        merge_prefill_cached_tokens(&prefill_responses, &mut decode_responses);
+
+        assert_eq!(decode_responses[0].cached_tokens(), 50);
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
@@ -27,8 +27,9 @@ pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use smg_grpc_client::sglang_proto;
+
+    use super::*;
 
     fn complete(
         prompt_tokens: i32,

--- a/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
@@ -19,11 +19,68 @@ use crate::{protocols::common::Usage, routers::grpc::proto_wrapper::ProtoGenerat
 pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
     let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens() as u32).sum();
     let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens() as u32).sum();
+    let total_cached_tokens: u32 = responses.iter().map(|r| r.cached_tokens() as u32).sum();
 
-    Usage {
-        prompt_tokens: total_prompt_tokens,
-        completion_tokens: total_completion_tokens,
-        total_tokens: total_prompt_tokens + total_completion_tokens,
-        completion_tokens_details: None,
+    Usage::from_counts(total_prompt_tokens, total_completion_tokens)
+        .with_cached_tokens(total_cached_tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smg_grpc_client::sglang_proto;
+
+    fn complete(
+        prompt_tokens: i32,
+        completion_tokens: i32,
+        cached_tokens: i32,
+    ) -> ProtoGenerateComplete {
+        ProtoGenerateComplete::Sglang(sglang_proto::GenerateComplete {
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn build_usage_includes_non_zero_cached_tokens() {
+        let usage = build_usage(&[complete(100, 20, 42)]);
+
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 20);
+        assert_eq!(usage.total_tokens, 120);
+        assert_eq!(
+            usage
+                .prompt_tokens_details
+                .as_ref()
+                .map(|details| details.cached_tokens),
+            Some(42)
+        );
+        assert!(usage.completion_tokens_details.is_none());
+    }
+
+    #[test]
+    fn build_usage_omits_zero_cached_tokens() {
+        let usage = build_usage(&[complete(100, 20, 0)]);
+
+        assert!(usage.prompt_tokens_details.is_none());
+        assert!(usage.completion_tokens_details.is_none());
+    }
+
+    #[test]
+    fn build_usage_sums_cached_tokens_across_responses() {
+        let usage = build_usage(&[complete(100, 20, 10), complete(50, 5, 20)]);
+
+        assert_eq!(usage.prompt_tokens, 150);
+        assert_eq!(usage.completion_tokens, 25);
+        assert_eq!(usage.total_tokens, 175);
+        assert_eq!(
+            usage
+                .prompt_tokens_details
+                .as_ref()
+                .map(|details| details.cached_tokens),
+            Some(30)
+        );
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_formatting.rs
@@ -4,7 +4,60 @@
 //! - Usage calculation from gRPC responses
 //! - ChatCompletionResponse construction
 
-use crate::{protocols::common::Usage, routers::grpc::proto_wrapper::ProtoGenerateComplete};
+use serde::{ser::Error as _, Serialize, Serializer};
+use serde_json::json;
+
+use crate::{
+    protocols::{chat::ChatCompletionResponse, common::Usage},
+    routers::grpc::proto_wrapper::ProtoGenerateComplete,
+};
+
+#[derive(Debug)]
+pub(crate) struct ChatCompletionResponseWithUsage {
+    response: ChatCompletionResponse,
+    cached_tokens: u32,
+}
+
+impl ChatCompletionResponseWithUsage {
+    pub fn new(response: ChatCompletionResponse, responses: &[ProtoGenerateComplete]) -> Self {
+        let cached_tokens = responses
+            .iter()
+            .map(|response| response.cached_tokens() as u32)
+            .sum();
+
+        Self {
+            response,
+            cached_tokens,
+        }
+    }
+
+    pub fn into_inner(self) -> ChatCompletionResponse {
+        self.response
+    }
+}
+
+impl Serialize for ChatCompletionResponseWithUsage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.response).map_err(S::Error::custom)?;
+
+        if self.cached_tokens > 0 {
+            if let Some(usage) = value
+                .get_mut("usage")
+                .and_then(|usage| usage.as_object_mut())
+            {
+                usage.insert(
+                    "prompt_tokens_details".to_string(),
+                    json!({ "cached_tokens": self.cached_tokens }),
+                );
+            }
+        }
+
+        value.serialize(serializer)
+    }
+}
 
 /// Build usage information from collected gRPC responses
 ///
@@ -19,10 +72,13 @@ use crate::{protocols::common::Usage, routers::grpc::proto_wrapper::ProtoGenerat
 pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
     let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens() as u32).sum();
     let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens() as u32).sum();
-    let total_cached_tokens: u32 = responses.iter().map(|r| r.cached_tokens() as u32).sum();
 
-    Usage::from_counts(total_prompt_tokens, total_completion_tokens)
-        .with_cached_tokens(total_cached_tokens)
+    Usage {
+        prompt_tokens: total_prompt_tokens,
+        completion_tokens: total_completion_tokens,
+        total_tokens: total_prompt_tokens + total_completion_tokens,
+        completion_tokens_details: None,
+    }
 }
 
 #[cfg(test)]
@@ -31,57 +87,46 @@ mod tests {
 
     use super::*;
 
-    fn complete(
-        prompt_tokens: i32,
-        completion_tokens: i32,
-        cached_tokens: i32,
-    ) -> ProtoGenerateComplete {
+    fn complete(cached_tokens: i32) -> ProtoGenerateComplete {
         ProtoGenerateComplete::Sglang(sglang_proto::GenerateComplete {
-            prompt_tokens,
-            completion_tokens,
+            prompt_tokens: 100,
+            completion_tokens: 20,
             cached_tokens,
             ..Default::default()
         })
     }
 
-    #[test]
-    fn build_usage_includes_non_zero_cached_tokens() {
-        let usage = build_usage(&[complete(100, 20, 42)]);
-
-        assert_eq!(usage.prompt_tokens, 100);
-        assert_eq!(usage.completion_tokens, 20);
-        assert_eq!(usage.total_tokens, 120);
-        assert_eq!(
-            usage
-                .prompt_tokens_details
-                .as_ref()
-                .map(|details| details.cached_tokens),
-            Some(42)
-        );
-        assert!(usage.completion_tokens_details.is_none());
+    fn response(responses: &[ProtoGenerateComplete]) -> ChatCompletionResponseWithUsage {
+        let response = ChatCompletionResponse::builder("request-id", "model")
+            .usage(build_usage(responses))
+            .build();
+        ChatCompletionResponseWithUsage::new(response, responses)
     }
 
     #[test]
-    fn build_usage_omits_zero_cached_tokens() {
-        let usage = build_usage(&[complete(100, 20, 0)]);
+    fn serializes_non_zero_cached_tokens() {
+        let value = serde_json::to_value(response(&[complete(42)])).unwrap();
 
-        assert!(usage.prompt_tokens_details.is_none());
-        assert!(usage.completion_tokens_details.is_none());
+        assert_eq!(value["usage"]["prompt_tokens"], 100);
+        assert_eq!(value["usage"]["completion_tokens"], 20);
+        assert_eq!(value["usage"]["total_tokens"], 120);
+        assert_eq!(value["usage"]["prompt_tokens_details"]["cached_tokens"], 42);
     }
 
     #[test]
-    fn build_usage_sums_cached_tokens_across_responses() {
-        let usage = build_usage(&[complete(100, 20, 10), complete(50, 5, 20)]);
+    fn omits_zero_cached_tokens() {
+        let value = serde_json::to_value(response(&[complete(0)])).unwrap();
 
-        assert_eq!(usage.prompt_tokens, 150);
-        assert_eq!(usage.completion_tokens, 25);
-        assert_eq!(usage.total_tokens, 175);
-        assert_eq!(
-            usage
-                .prompt_tokens_details
-                .as_ref()
-                .map(|details| details.cached_tokens),
-            Some(30)
-        );
+        assert!(value["usage"].get("prompt_tokens_details").is_none());
+    }
+
+    #[test]
+    fn sums_cached_tokens_across_responses() {
+        let value = serde_json::to_value(response(&[complete(10), complete(20)])).unwrap();
+
+        assert_eq!(value["usage"]["prompt_tokens"], 200);
+        assert_eq!(value["usage"]["completion_tokens"], 40);
+        assert_eq!(value["usage"]["total_tokens"], 240);
+        assert_eq!(value["usage"]["prompt_tokens_details"]["cached_tokens"], 30);
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -15,13 +15,14 @@ use super::{
 use crate::{
     core::{Worker, WorkerLoadGuard},
     protocols::{
-        chat::{ChatCompletionRequest, ChatCompletionResponse},
+        chat::ChatCompletionRequest,
         classify::{ClassifyRequest, ClassifyResponse},
         embedding::{EmbeddingRequest, EmbeddingResponse},
         generate::{GenerateRequest, GenerateResponse},
         responses::ResponsesRequest,
     },
     reasoning_parser::ParserFactory as ReasoningParserFactory,
+    routers::grpc::common::response_formatting::ChatCompletionResponseWithUsage,
     tokenizer::{stop::StopSequenceDecoder, traits::Tokenizer, TokenizerRegistry},
     tool_parser::ParserFactory as ToolParserFactory,
 };
@@ -476,7 +477,7 @@ pub(crate) enum ExecutionResult {
 /// Final processed response
 #[derive(Debug)]
 pub(crate) enum FinalResponse {
-    Chat(ChatCompletionResponse),
+    Chat(ChatCompletionResponseWithUsage),
     /// Generate response is a Vec of GenerateResponse (n=1 returns single item, n>1 returns multiple)
     Generate(Vec<GenerateResponse>),
     /// Embedding response

--- a/sgl-model-gateway/src/routers/grpc/harmony/processor.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/processor.rs
@@ -45,7 +45,7 @@ impl HarmonyResponseProcessor {
         execution_result: ExecutionResult,
         chat_request: Arc<ChatCompletionRequest>,
         dispatch: DispatchMetadata,
-    ) -> Result<ChatCompletionResponse, Response> {
+    ) -> Result<response_formatting::ChatCompletionResponseWithUsage, Response> {
         // Collect all completed responses (one per choice)
         let all_responses = response_collection::collect_responses(execution_result, false).await?;
         if all_responses.is_empty() {
@@ -136,14 +136,17 @@ impl HarmonyResponseProcessor {
         }
 
         // Final ChatCompletionResponse
-        Ok(
-            ChatCompletionResponse::builder(&dispatch.request_id, &chat_request.model)
-                .created(dispatch.created)
-                .choices(choices)
-                .usage(usage)
-                .maybe_system_fingerprint(dispatch.weight_version.as_deref())
-                .build(),
-        )
+        let response = ChatCompletionResponse::builder(&dispatch.request_id, &chat_request.model)
+            .created(dispatch.created)
+            .choices(choices)
+            .usage(usage)
+            .maybe_system_fingerprint(dispatch.weight_version.as_deref())
+            .build();
+
+        Ok(response_formatting::ChatCompletionResponseWithUsage::new(
+            response,
+            &all_responses,
+        ))
     }
 }
 

--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -709,7 +709,7 @@ impl RequestPipeline {
         }
 
         match ctx.state.response.final_response {
-            Some(FinalResponse::Chat(response)) => Ok(response),
+            Some(FinalResponse::Chat(response)) => Ok(response.into_inner()),
             Some(FinalResponse::Generate(_))
             | Some(FinalResponse::Embedding(_))
             | Some(FinalResponse::Classify(_)) => {

--- a/sgl-model-gateway/src/routers/grpc/regular/processor.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/processor.rs
@@ -217,7 +217,8 @@ impl ResponseProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
         request_logprobs: bool,
-    ) -> Result<ChatCompletionResponse, axum::response::Response> {
+    ) -> Result<response_formatting::ChatCompletionResponseWithUsage, axum::response::Response>
+    {
         // Collect all responses from the execution result
         let all_responses =
             response_collection::collect_responses(execution_result, request_logprobs).await?;
@@ -290,14 +291,17 @@ impl ResponseProcessor {
         let usage = response_formatting::build_usage(&all_responses);
 
         // Build final ChatCompletionResponse
-        Ok(
-            ChatCompletionResponse::builder(&dispatch.request_id, &dispatch.model)
-                .created(dispatch.created)
-                .choices(choices)
-                .usage(usage)
-                .maybe_system_fingerprint(dispatch.weight_version.clone())
-                .build(),
-        )
+        let response = ChatCompletionResponse::builder(&dispatch.request_id, &dispatch.model)
+            .created(dispatch.created)
+            .choices(choices)
+            .usage(usage)
+            .maybe_system_fingerprint(dispatch.weight_version.clone())
+            .build();
+
+        Ok(response_formatting::ChatCompletionResponseWithUsage::new(
+            response,
+            &all_responses,
+        ))
     }
 
     /// Parse tool calls using model-specific parser


### PR DESCRIPTION
## Summary

Two pieces to fix:

1. **Proto-level field availability**: `proto/sglang.proto` defines `ProtoGenerateComplete`. Check whether `cached_tokens` and `reasoning_tokens` are already on the proto (the python path uses `meta_info["cached_tokens"]` and `num_reasoning_tokens`, so the python-side has them). If the proto already carries them, no proto change is needed. If not, add `optional uint32 cached_tokens = N;` and `optional uint32 reasoning_tokens = N+1;` and have the engine populate them where `prompt_tokens` and `completion_tokens` are written. Bump generated bindings via the existing `tonic` build script.

2. **Build the rich Usage**: Update `build_usage` to sum across responses and produce `PromptTokensDetails { cached_tokens }` and `CompletionTokensDetails { reasoning_tokens }`:

```rust
pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
    let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens() as u32).sum();
    let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens() as u32).sum();
    let total_cached_tokens: u32 = responses.iter().map(|r| r.cached_tokens() as u32).sum();
    let total_reasoning_tokens: u32 = responses.iter().map(|r| r.reasoning_tokens() as u32).sum();

    Usage {
        prompt_tokens: total_prompt_tokens,
        completion_tokens: total_completion_tokens,
        total_tokens: total_prompt_tokens + total_completion_tokens,
        prompt_tokens_details: (total_cached_tokens > 0).then(|| PromptTokensDetails {
            cached_tokens: total_cached_tokens,
        }),
        completion_tokens_details: (total_reasoning_tokens > 0).then(|| CompletionTokensDetails {
            reasoning_tokens: total_reasoning_tokens,
        }),
    }
}
```

The conditional-on-nonzero pattern matches OpenAI's behavior and prevents API consumers from seeing `cached_tokens: 0` on cold prompts.

The `Usage`, `PromptTokensDetails`, `CompletionTokensDetails` structs are in the gateway's openai-compat module; reuse or add the latter struct if missing (mirror the field present in `python/sglang/srt/entrypoints/openai/protocol.py`).

Keep the change scoped to `response_formatting.rs` plus, if needed, the proto file. Avoid touching unrelated grpc paths.

## Why this matters

Issue #25228 reports that `sgl-model-gateway` does not return `cached_tokens` (prompt-cache hits) or `reasoning_tokens` (reasoning model decode) in its `Usage` payload when running in grpc mode. The OpenAI HTTP path of sglang correctly surfaces `prompt_tokens_details.cached_tokens` and `completion_tokens_details.reasoning_tokens`, but the gateway's grpc-to-openai bridge drops them.

The relevant code is `sgl-model-gateway/src/routers/grpc/common/response_formatting.rs` (1158 bytes, 1 function `build_usage`):

```rust
pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
    let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens() as u32).sum();
    let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens() as u32).sum();

    Usage {
        prompt_tokens: total_prompt_tokens,
        completion_tokens: total_completion_tokens,
        total_tokens: total_prompt_tokens + total_completion_tokens,
        completion_tokens_details: None,
    }
}
```

Reporter notes the bug is present in `v0.3.2`, current `main`, and the `v0.5.11` release branch. No `prompt_tokens_details` field and `completion_tokens_details` is hardcoded to `None`. 0 comments on the issue, no claim, no duplicate PR matched `cached_tokens grpc` search.

## Testing

1. Unit test in `sgl-model-gateway/src/routers/grpc/common/response_formatting.rs` (or its sibling tests module): construct a `ProtoGenerateComplete` with non-zero `cached_tokens=42` and `reasoning_tokens=17`, run `build_usage`, assert resulting `Usage.prompt_tokens_details.cached_tokens == 42` and `Usage.completion_tokens_details.reasoning_tokens == 17`.
2. Cold prompt case: `cached_tokens=0`, `reasoning_tokens=0`, assert both details fields are `None` (preserves OpenAI's "omit when zero" convention).
3. Multi-response sum: two `ProtoGenerateComplete` with `cached_tokens=10` and `cached_tokens=20`, assert `Usage.prompt_tokens_details.cached_tokens == 30`.
4. Integration: run the gateway grpc path against a small reasoning model (Qwen2.5-0.5B-Instruct with reasoning parser), issue a request with prefix cache warm, assert the http response from the gateway carries non-zero `cached_tokens` and `reasoning_tokens`.
5. Backward-compat: run an existing gateway integration test that previously asserted `completion_tokens_details: null`; verify it now asserts `null` only on cold/non-reasoning paths and `Some(...)` on warm/reasoning paths.

Fixes #25228

AI was used for assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->