### PR TITLE
fix(gateway): do not trip circuit breaker on 4xx client errors

### DIFF
--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -321,7 +321,10 @@ impl Router {
         // mask "200-then-broken" workers — every request would tick a
         // success before the stream had a chance to error out.
         if !is_stream {
-            worker.record_outcome(status.is_success());
+            // 4xx responses are client/request errors — the worker is healthy.
+            // Only 5xx and transport errors should trip the circuit breaker.
+            // (Mirrors the logic already in pd_router.rs.)
+            worker.record_outcome(status.is_success() || status.is_client_error());
         }
 
         // Record worker errors for server errors (5xx)
@@ -622,17 +625,21 @@ impl Router {
             // no spawned task or channel needed. `BreakerTrackedStream`
             // updates the worker's circuit breaker exactly once on drop:
             // success on clean end, failure on stream error, neither on
-            // client disconnect. For non-2xx responses we pre-mark the
+            // client disconnect. For 5xx responses we pre-mark the
             // wrapper as Errored — otherwise the small error body would
             // stream cleanly to `None` and Drop would record a spurious
-            // success (and the streaming branch also skips the eager
+            // success. 4xx responses are client-side errors and do not
+            // constitute a worker failure, so we leave the tracker unmarked
+            // (and the streaming branch also skips the eager
             // `record_outcome` above).
             let mut tracked = BreakerTrackedStream::new(
                 res.bytes_stream(),
                 worker.clone(),
                 worker_url.to_string(),
             );
-            if !status.is_success() {
+            // Only pre-mark as errored for 5xx/transport failures; 4xx errors
+            // are the client's fault and should not trip the circuit breaker.
+            if !(status.is_success() || status.is_client_error()) {
                 tracked.mark_errored();
             }
             let body = Body::from_stream(tracked);

--- a/sgl-model-gateway/src/routers/openai/responses/non_streaming.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/non_streaming.rs
@@ -116,8 +116,12 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             }
         };
 
-        if !response.status().is_success() {
+        // 4xx = client/request error — the worker is healthy.
+        // Only trip the circuit breaker for 5xx / transport failures.
+        if !response.status().is_success() && !response.status().is_client_error() {
             worker.circuit_breaker().record_failure();
+        }
+        if !response.status().is_success() {
             let status = StatusCode::from_u16(response.status().as_u16())
                 .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
             let body = response.text().await.unwrap_or_default();

--- a/sgl-model-gateway/src/routers/openai/responses/streaming.rs
+++ b/sgl-model-gateway/src/routers/openai/responses/streaming.rs
@@ -525,8 +525,12 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let status_code =
         StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-    if !status.is_success() {
+    // 4xx = client/request error — the worker is healthy.
+    // Only trip the circuit breaker for 5xx / transport failures.
+    if !status.is_success() && !status.is_client_error() {
         worker.circuit_breaker().record_failure();
+    }
+    if !status.is_success() {
         let error_body = response
             .text()
             .await

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -600,7 +600,8 @@ impl crate::routers::RouterTrait for OpenAIRouter {
                     if !is_streaming {
                         // Non-streaming: record the breaker outcome inline
                         // once the body is fully read.
-                        if !status.is_success() {
+                        // 4xx = client/request error; worker is healthy.
+                        if !status.is_success() && !status.is_client_error() {
                             worker.circuit_breaker().record_failure();
                         }
                         let content_type = resp.headers().get(CONTENT_TYPE).cloned();
@@ -639,7 +640,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
                             Arc::clone(&worker),
                             url.clone(),
                         );
-                        if !status.is_success() {
+                        if !(status.is_success() || status.is_client_error()) {
                             tracked.mark_errored();
                         }
                         let mut response = Response::new(Body::from_stream(tracked));


### PR DESCRIPTION
## Problem

Fixes #25811.

The HTTP router and OpenAI router in `sgl-model-gateway` treated **any non-2xx response** as a worker failure and incremented the circuit-breaker failure counter. This means a burst of malformed client requests (e.g. an unsupported model name → 400, missing auth → 401, rate-limit → 429) would open the breaker and cause **all subsequent valid requests** to be rejected with 503 until the half-open timeout expires — a pure client mistake cascading into a service outage.

## Root cause

Four router paths used `!status.is_success()` as the "worker is sick" signal:

```rust
// http/router.rs, openai/router.rs,
// responses/non_streaming.rs, responses/streaming.rs (before)
if !status.is_success() {
    worker.circuit_breaker().record_failure(); // 4xx → failure!
}
```

`pd_router.rs` already had the correct logic (`is_success() || is_client_error()`) and carried a comment explaining the intent; the other routers were simply missed.

## Fix

Apply the same `is_client_error()` exemption to all affected paths:

| File | Change |
|------|--------|
| `routers/http/router.rs` | `record_outcome(is_success() \|\| is_client_error())` + streaming pre-mark guard |
| `routers/openai/router.rs` | `record_failure` guard + streaming `mark_errored` guard |
| `routers/openai/responses/non_streaming.rs` | `record_failure` guard |
| `routers/openai/responses/streaming.rs` | `record_failure` guard |

`pd_router.rs` and `streaming_utils.rs` are **unchanged** — they already handle this correctly.

## Testing

- `rustfmt --check` passes on all four changed files.
- Build environment on this dev machine is missing `protoc` (required for gRPC codegen), so full `cargo build` was not run locally; the CI environment provides `protoc`.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26690709952](https://github.com/sgl-project/sglang/actions/runs/26690709952)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26690709904](https://github.com/sgl-project/sglang/actions/runs/26690709904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->