### PR TITLE
[BugFix] disaggregation: balance inc_lock_ref in decode KV offload release

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -254,7 +254,16 @@ class DecodeKVCacheOffloadManager:
             self.token_to_kv_pool_allocator.free(overalloc_indices)
 
         self.req_to_token_pool.free(req)
-        self.tree_cache.protected_size_ -= len(req.prefix_indices)
+        # When --disaggregation-decode-enable-radix-cache is on,
+        # _match_prefix_and_lock called inc_lock_ref(req.last_node) at request
+        # entry, bumping protected_size_ via per-node 0->1 ref-count transitions.
+        # Balance it with the symmetric dec_lock_ref API instead of mutating
+        # protected_size_ by hand: the previous flat subtraction of
+        # len(req.prefix_indices) used raw-token accounting incompatible with
+        # inc_lock_ref semantics, leaving protected_size_ negative after the
+        # first finished request and tripping the pool-leak guard.
+        if getattr(req, "last_node", None) is not None and len(req.prefix_indices) > 0:
+            self.tree_cache.dec_lock_ref(req.last_node)
         if req.rid in self.offloaded_state:
             del self.offloaded_state[req.rid]
 


### PR DESCRIPTION
## Summary

When PD-disaggregation is run with **both** `--disaggregation-decode-enable-radix-cache` and `--disaggregation-decode-enable-offload-kvcache`, the decode scheduler trips the pool memory leak guard (`[pool memory leak detected ... protected=-N]`) and aborts via SIGQUIT **after the first finished request**, killing the decode server. Repro is deterministic.

The root cause is an accounting mismatch in `DecodeKVCacheOffloadManager._release_finished_req`: it decrements `tree_cache.protected_size_` by hand using `len(req.prefix_indices)` (a flat raw-token count), while the matching increment comes from `inc_lock_ref(last_device_node)` in `_match_prefix_and_lock`, which only adds on per-node 0→1 ref-count transitions over the matched radix subtree. The two counts do not agree, so `protected_size_` drifts negative immediately after the first release.

This PR replaces the manual subtraction with the symmetric `dec_lock_ref(req.last_node)` call, mirroring the existing failure-path balancers at `disaggregation/decode.py:870/874/892`.

## Reproduction

Setup: any PD-disagg pair with mooncake (or NIXL) transfer. Tested on Kimi-K2.6, TP=8 per side, page_size=64.

Decode-side flags that reproduce:

```
--disaggregation-mode decode
--disaggregation-transfer-backend mooncake
--disaggregation-decode-enable-radix-cache
--disaggregation-decode-enable-offload-kvcache
--enable-hierarchical-cache (via hicache-* flags)
```

Send a single chat completion. Decode log:

```
ValueError: pool memory leak detected! [full] total=614400, available=614400,
            evictable=0, protected=-27, session_held=0, uncached=0
[SIGQUIT received. signum=None, frame=None. It usually means one child failed.]
```

`protected=-N` magnitude depends on the matched prefix length.

## Root cause

Two code paths touch `tree_cache.protected_size_` when decode-side radix cache is active:

1. **Entry — ref-count based (correct)**
   `disaggregation/decode.py::_match_prefix_and_lock`:
   ```python
   self.tree_cache.inc_lock_ref(last_device_node)
   ```
   `inc_lock_ref` walks from `last_device_node` to root and adds a node's page count to `protected_size_` **only on ref_count 0→1 transitions**.

2. **Exit — raw-token based (incorrect)**
   `disaggregation/decode_kvcache_offload_manager.py::_release_finished_req`:
   ```python
   self.tree_cache.protected_size_ -= len(req.prefix_indices)
   ```

When `disaggregation_decode_enable_offload_kvcache` is on, `scheduler_output_processor_mixin._handle_finished_req` **skips** the normal `release_kv_cache(req, self.tree_cache) → cache_finished_req → dec_lock_ref` chain in favor of the offload manager's release path. The flat subtraction above is the only thing standing in for the proper `dec_lock_ref`, and it does not have the same arithmetic as `inc_lock_ref`:

- `inc_lock_ref` only increments on per-node 0→1 transitions, bounded by that subtree's page contribution.
- `len(prefix_indices)` is the request's full matched-prefix length, independent of ref-count state.

After one finished request, `protected_size_` is negative. The next leak-check tick tears the server down.

When decode-side radix cache is **off**, `_match_prefix_and_lock` is never called, `prefix_indices` is empty, and the manual `-= 0` happens to be a no-op — which is why the bug is silent in offload-only mode.

## Fix

```diff
@@ -254,7 +254,16 @@ class DecodeKVCacheOffloadManager:
             self.token_to_kv_pool_allocator.free(overalloc_indices)

         self.req_to_token_pool.free(req)
-        self.tree_cache.protected_size_ -= len(req.prefix_indices)
+        # When --disaggregation-decode-enable-radix-cache is on,
+        # _match_prefix_and_lock called inc_lock_ref(req.last_node) at request
+        # entry, bumping protected_size_ via per-node 0->1 ref-count transitions.
+        # Balance it with the symmetric dec_lock_ref API instead of mutating
+        # protected_size_ by hand: the previous flat subtraction of
+        # len(req.prefix_indices) used raw-token accounting incompatible with
+        # inc_lock_ref semantics, leaving protected_size_ negative after the
+        # first finished request and tripping the pool-leak guard.
+        if getattr(req, "last_node", None) is not None and len(req.prefix_indices) > 0:
+            self.tree_cache.dec_lock_ref(req.last_node)
         if req.rid in self.offloaded_state:
             del self.offloaded_state[req.rid]
```

The guard `len(req.prefix_indices) > 0` mirrors `prefix_len > 0` at the existing failure-path callsites, so the no-radix-cache path remains a no-op.

## Verification

Tested on H200 8×TP / Kimi-K2.6, both `v0.5.12` and `main`, mooncake and NIXL transports. 5 sequential + 20 concurrent requests per cell:

| Branch | radix-cache | offload-kvcache | Before patch | After patch |
|---|---|---|---|---|
| v0.5.12 | on  | on  | leak fires, SIGQUIT after 1st req | clean across 30+ reqs |
| v0.5.12 | on  | off | clean | clean (no-op, guard hits) |
| v0.5.12 | off | on  | clean | clean (no-op, prefix_indices empty) |
| main    | on  | on  | leak fires, SIGQUIT after 1st req | clean across 30+ reqs |
| main    | on  | off | clean | clean (no-op, guard hits) |
| main    | off | on  | clean | clean (no-op, prefix_indices empty) |

No new leak signatures, no SIGQUIT, decode schedulers stay alive. `protected_size_` remains ≥ 0 throughout.

## Scope

- No behavior change when either flag is off (existing balancers and the no-op guard cover those paths).
- Does not touch `inc_lock_ref` callsite, scheduler dispatch, or the release-vs-offload branching.
- No new public API.

## Known related issue (not addressed here)

With both flags on, generation output for streaming + structured output (`response_format=json_object`) is corrupted (e.g. `"░░░░"` repeated) in addition to the leak. The corruption survives this patch and is gated on the same flag interaction. I am still isolating it and will file a separate issue once the mechanism is pinned down. That work is out of scope for this PR, whose sole purpose is to restore correct `protected_size_` accounting so the leak guard stops triggering.

## Test plan

- [x] Reproduce leak on `v0.5.12` (mooncake + NIXL), both flags on
- [x] Reproduce leak on `main`, both flags on
- [x] After patch: no leak on `v0.5.12` + `main`, mooncake + NIXL, both flags on
- [x] After patch: 5 sequential + 20 concurrent requests succeed, no SIGQUIT
- [x] After patch: radix-only and offload-only configs unchanged (no-op behavior preserved)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26138845721](https://github.com/sgl-project/sglang/actions/runs/26138845721)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26138845644](https://github.com/sgl-project/sglang/actions/runs/26138845644)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->