### PR TITLE
Fix DSV4 topk invalid raw-index CUDA OOB access

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh
@@ -48,6 +48,13 @@ constexpr uint32_t kClusterSize = Large::kClusterSize;
 constexpr uint32_t kMax2PassLength = Small::kMax2PassLength;
 constexpr uint32_t kMaxSupportedLength = Large::kMaxLength;
 
+SGL_DEVICE void init_topk_indices(int32_t* indices) {
+  if (threadIdx.x < K) {
+    indices[threadIdx.x] = -1;
+  }
+  __syncthreads();
+}
+
 /// Common metadata lives at metadata[0] (first row of the [batch_size+1, 4] tensor).
 /// Per-item metadata starts at metadata[1..batch_size]. The plan kernel writes both.
 struct alignas(16) GlobalMetadata {
@@ -238,6 +245,7 @@ topk_short_transform(const __grid_constant__ TopKParams params) {
   if (seq_len <= K) {
     impl::trivial_transform(transform, seq_len, K);
   } else {
+    init_topk_indices(s_topk_indices);
     Small::run(params.get_scores(batch_id), s_topk_indices, seq_len, smem, /*use_pdl=*/true);
     device::PDLTriggerSecondary<true>();
     Small::transform(transform);
@@ -284,6 +292,7 @@ topk_combine_preprocess(const __grid_constant__ TopKParams params) {
     const auto transform = params.get_transform(batch_id, s_topk_indices);
     const auto ws = params.workspace + batch_id * params.workspace_stride;
     if (need_prefetch) prefetch_metadata();
+    init_topk_indices(s_topk_indices);
     Large::stage1(s_topk_indices, this_length, smem, /*reuse=*/true);
     if (need_prefetch) launch_prologue();
     Large::stage1_epilogue(transform, this_offset, ws, smem);
@@ -302,6 +311,7 @@ topk_combine_transform(const __grid_constant__ TopKParams params) {
   if (seq_len <= K) {
     impl::trivial_transform(transform, seq_len, K);
   } else if (seq_len <= kMax2PassLength) {
+    init_topk_indices(s_topk_indices);
     if (seq_len <= Small::kMax1PassLength) {
       Small::run(params.get_scores(batch_id), s_topk_indices, seq_len, smem);
     } else {
@@ -310,6 +320,7 @@ topk_combine_transform(const __grid_constant__ TopKParams params) {
     }
     Small::transform(transform);
   } else if (seq_len <= cluster_threshold) {
+    init_topk_indices(s_topk_indices);
     Medium::run(params.get_scores(batch_id), seq_len, s_topk_indices, smem);
     Medium::transform(transform, smem);
   } else {
@@ -332,11 +343,13 @@ topk_fused_transform(const __grid_constant__ TopKParams params) {
     impl::trivial_transform(transform, seq_len, K);
   } else if (seq_len <= Small::kMax1PassLength) {
     if (cluster_rank != 0) return;  // only first rank work
+    init_topk_indices(s_topk_indices);
     Small::run(params.get_scores(batch_id), s_topk_indices, seq_len, smem, /*use_pdl=*/true);
     Small::transform(transform);
   } else {
     const auto [offset, length] = partition_work(seq_len, cluster_rank);
     const auto ws = params.workspace + batch_id * params.workspace_stride;
+    init_topk_indices(s_topk_indices);
     Large::stage1_init(smem);
     device::PDLWaitPrimary<true>();
     Large::stage1_prologue(params.get_scores(batch_id) + offset, length, smem);

--- a/python/sglang/jit_kernel/include/sgl_kernel/deepseek_v4/topk/common.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/deepseek_v4/topk/common.cuh
@@ -30,7 +30,8 @@ struct TransformParams {
   uint32_t page_bits;
 
   SGL_DEVICE void transform(const uint32_t idx) const {
-    indices_out[idx] = page_to_indices(page_table, indices_in[idx], page_bits);
+    const auto src = indices_in[idx];
+    indices_out[idx] = src < 0 ? -1 : page_to_indices(page_table, static_cast<uint32_t>(src), page_bits);
   }
   SGL_DEVICE void write(const uint32_t dst, const uint32_t src) const {
     indices_out[dst] = page_to_indices(page_table, src, page_bits);


### PR DESCRIPTION
  ## Motivation
  
  DSV4 topk transforms convert raw topk positions into physical page indices through the compressed-attention page table.
  
  For non-trivial topk v2 paths, raw indices are first written into a shared scratch buffer and later translated into page indices. If an entry in this scratch buffer is not populated by
  the topk path, it should remain an invalid sentinel instead of being interpreted as a valid raw index. Otherwise, a negative invalid raw index may be converted to an unsigned value
  during page-index translation, which can lead to an out-of-bounds page-table access.
  
  The trivial transform path is not affected by this issue because it writes output indices directly and does not read the shared scratch buffer.
  
  ## Modifications
  
  This PR adds two correctness guards:
  
  1. Initialize the topk v2 shared scratch index buffer with `-1` on paths that consume `s_topk_indices`:
  
     - `topk_short_transform`
       - Initializes before the non-trivial `Small::run(...)` path.
       - Does not initialize the trivial path because `trivial_transform(...)` writes outputs directly and does not read `s_topk_indices`.
  
     - `topk_combine_preprocess`
       - Initializes inside the persistent loop before each `Large::stage1(...)`.
       - This kernel can process multiple items in one persistent launch, so the scratch buffer is initialized per item, not just once before the loop.
  
     - `topk_combine_transform`
       - Initializes before the `Small` path.
       - Initializes before the `Medium` path.
       - Does not initialize the trivial path because it does not read `s_topk_indices`.
       - Does not initialize the final `Large::transform(...)` path because it reads from the workspace produced by stage 1, not from `s_topk_indices`.
  
     - `topk_fused_transform`
       - Initializes before the `Small` path after non-working cluster ranks return.
       - Initializes before the fused `Large::stage1(...)` path.
       - Does not initialize the trivial path because it does not read `s_topk_indices`.
  
  2. Preserve the invalid `-1` sentinel in `TransformParams::transform()` instead of passing it to `page_to_indices()`.
  
  This PR is intentionally limited to invalid raw-index handling. It does not include the separate PDL trigger fix or debug/oracle utilities.
  
  ## Accuracy Tests
  
  Tested locally:
  
  - `git diff --check`
  - `pre-commit run clang-format --files python/sglang/jit_kernel/csrc/deepseek_v4/topk_v2.cuh python/sglang/jit_kernel/include/sgl_kernel/deepseek_v4/topk/common.cuh`
  - CUDA smoke test comparing `topk_transform_512_v2` with the torch oracle by sorted output equality.
  
  Smoke test cases:
  
  ```text
  PASS bs=1 width=1024 seq_lens=[677]
  PASS bs=2 width=4096 seq_lens=[2097, 2571]
  PASS bs=8 width=8192 seq_lens=[8166, 5814, 6937, 4197, 7185, 5124, 5761, 7046]
  PASS bs=1 width=65536 seq_lens=[52174]
  PASS bs=8 width=65536 seq_lens=[54253, 55345, 39092, 63581, 47798, 35667, 59462, 35343]
  topk v2 vs torch oracle smoke passed
  
  Speed Tests and Profiling
  
  A focused topk v2 microbenchmark was run to check for obvious regressions, including trivial, small, long fused, and two-stage paths.
  
  Environment:
  - Warmup: 50 iterations
  - Measured iterations: 500
  - Metric: CUDA event elapsed time per topk_transform_512_v2 call
  
  ┌────────────────┬─────┬───────┬──────────────┬─────────────────┐
  │      Path      │ bs  │ width │ main cuda_ms │ this PR cuda_ms │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial        │   1 │   128 │     0.008596 │        0.008267 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial edge   │   1 │   512 │     0.007511 │        0.007848 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   1 │   516 │     0.007232 │        0.007959 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   1 │  1024 │     0.007203 │        0.007921 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial edge   │   8 │   512 │     0.007290 │        0.007863 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   8 │  1024 │     0.007322 │        0.008046 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ long fused     │   1 │ 65536 │     0.009583 │        0.009611 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ long fused     │   8 │ 65536 │     0.010281 │        0.010339 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ long two-stage │  16 │ 65536 │     0.015607 │        0.015852 │
  └────────────────┴─────┴───────┴──────────────┴─────────────────┘
  
  ```text
  PASS bs=1 width=1024 seq_lens=[677]
  PASS bs=2 width=4096 seq_lens=[2097, 2571]
  PASS bs=8 width=8192 seq_lens=[8166, 5814, 6937, 4197, 7185, 5124, 5761, 7046]
  PASS bs=1 width=65536 seq_lens=[52174]
  PASS bs=8 width=65536 seq_lens=[54253, 55345, 39092, 63581, 47798, 35667, 59462, 35343]
  topk v2 vs torch oracle smoke passed

  Speed Tests and Profiling

  A focused topk v2 microbenchmark was run to check for obvious regressions, including trivial, small, long fused, and two-stage paths.

  Environment:
  - Warmup: 50 iterations
  - Measured iterations: 500
  - Metric: CUDA event elapsed time per topk_transform_512_v2 call

  ┌────────────────┬─────┬───────┬──────────────┬─────────────────┐
  │      Path      │ bs  │ width │ main cuda_ms │ this PR cuda_ms │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial        │   1 │   128 │     0.008596 │        0.008267 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial edge   │   1 │   512 │     0.007511 │        0.007848 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   1 │   516 │     0.007232 │        0.007959 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   1 │  1024 │     0.007203 │        0.007921 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial edge   │   1 │   512 │     0.007511 │        0.007848 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   1 │   516 │     0.007232 │        0.007959 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   1 │  1024 │     0.007203 │        0.007921 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ trivial edge   │   8 │   512 │     0.007290 │        0.007863 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ small          │   8 │  1024 │     0.007322 │        0.008046 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ long fused     │   1 │ 65536 │     0.009583 │        0.009611 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ long fused     │   8 │ 65536 │     0.010281 │        0.010339 │
  ├────────────────┼─────┼───────┼──────────────┼─────────────────┤
  │ long two-stage │  16 │ 65536 │     0.015607 │        0.015852 │
  └────────────────┴─────┴───────┴──────────────┴─────────────────┘

  No obvious performance regression was observed. The trivial path does not consume s_topk_indices, so this PR avoids scratch-buffer initialization on that path.

  Checklist

  - Format your code according to the Format code with pre-commit (https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - Add unit tests according to the Run and add unit tests (https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - Update documentation according to Write documentations (https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - Provide accuracy and speed benchmark results according to Test the accuracy (https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and Benchmark the speed
  (https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - Follow the SGLang code style guidance (https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).








<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26139458384](https://github.com/sgl-project/sglang/actions/runs/26139458384)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26139458363](https://github.com/sgl-project/sglang/actions/runs/26139458363)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->