### PR TITLE
[Bugfix] batch_invariant_ops: triton fallback for DeepGEMM-failing shapes

### DIFF
--- a/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+++ b/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
@@ -1,9 +1,10 @@
 # Adapted from https://github.com/thinking-machines-lab/batch_invariant_ops/blob/main/batch_invariant_ops/batch_invariant_ops.py
 
 import contextlib
+import logging
 from collections import namedtuple
 from collections.abc import Callable
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Set, Tuple
 
 import torch
 import triton
@@ -33,6 +34,10 @@ _ENABLE_MM_COMPARISON_TEST = get_bool_env_var(
 
 if not _ENABLE_MM_DEEPGEMM:
     print("Disable DeepGEMM in batch invariant ops. Performance may be suboptimal.")
+
+logger = logging.getLogger(__name__)
+
+_DEEPGEMM_FAILING_SHAPES: Set[Tuple[int, int, int, torch.dtype]] = set()
 
 __all__ = [
     "set_batch_invariant_mode",
@@ -252,13 +257,22 @@ def _matmul_persistent_deepgemm(
 
     try:
         deep_gemm.bf16_gemm_nn(a, b, out)
+    except torch.cuda.OutOfMemoryError:
+        raise
     except RuntimeError as e:
-        raise RuntimeError(
-            f"DeepGEMM failed for matrix shapes M={M}, N={N}, K={K}. "
-            f"This typically occurs when dimensions are too small for DeepGEMM's TMA descriptors. "
-            f"Consider increasing MIN_DEEPGEMM_DIM in matmul_persistent() or disabling DeepGEMM "
-            f"for small matrices. Original error: {e}"
-        ) from e
+        if _ENABLE_MM_COMPARISON_TEST:
+            raise
+        _DEEPGEMM_FAILING_SHAPES.add((M, N, K, dtype))
+        logger.warning(
+            "DeepGEMM matmul failed for (M=%d, N=%d, K=%d, dtype=%s); "
+            "shape cached, falling back to triton. Error: %s",
+            M,
+            N,
+            K,
+            dtype,
+            e,
+        )
+        return _matmul_persistent_triton(a=a, b=b, bias=bias)
 
     # TODO can this be put in DeepGEMM's `c`?
     if bias is not None:
@@ -270,10 +284,13 @@ def _matmul_persistent_deepgemm(
 def matmul_persistent(
     a: torch.Tensor, b: torch.Tensor, bias: torch.Tensor | None = None
 ):
-    K, N = b.shape
+    M, K = a.shape
+    _, N = b.shape
 
     # DeepGEMM has minimum dimension requirements for TMA descriptors
     MIN_DEEPGEMM_DIM = 16
+
+    shape_key = (M, N, K, a.dtype)
 
     if (
         _ENABLE_MM_DEEPGEMM
@@ -283,6 +300,7 @@ def matmul_persistent(
         and a.is_contiguous()
         and b.transpose(0, 1).is_contiguous()
         and N >= MIN_DEEPGEMM_DIM
+        and shape_key not in _DEEPGEMM_FAILING_SHAPES
     ):
         if _ENABLE_MM_COMPARISON_TEST:
             out_triton = _matmul_persistent_triton(a=a, b=b, bias=bias)


### PR DESCRIPTION
## Motivation

close #25823

With `--enable-deterministic-inference --attention-backend flashinfer` on Qwen3-VL on sm_100 (B200), `_matmul_persistent_deepgemm` crashes the scheduler at warmup. The Qwen3-VL vision encoder's `linear_fc1` produces matmul shapes (`M=256, N=1076, K=1152` and `M=256, N=1152, K=1076`) that pass the existing `MIN_DEEPGEMM_DIM=16` gate from #13226 but still fail DeepGEMM's TMA-descriptor setup with `CUDA_ERROR_INVALID_VALUE`. The existing handler re-raises and the TP worker dies with SIGQUIT ~6s into warmup.

This PR does not change DeepGEMM itself; it makes the sglang caller recover gracefully when DeepGEMM rejects a shape, so the scheduler stays up and the model runs through the existing triton path for those shapes.

The catch here fires once per unique `(M, N, K, dtype)` per process via a small in-process cache, so the hot path is unaffected.

## Test

Vanilla scheduler crashes 6s into warmup; with patch server boots in 74s. 8 warmup fallback warnings (2 shapes × 4 TP ranks), 0 new warnings during follow-up inference (cache hits). Under `--enable-deterministic-inference`, 4 identical-prompt requests produce byte-identical `routed_experts` + `output_ids`. Sustained throughput 91.5 ± 0.1 tok/s.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26140205631](https://github.com/sgl-project/sglang/actions/runs/26140205631)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26140205598](https://github.com/sgl-project/sglang/actions/runs/26140205598)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->