### PR TITLE
Optimize get_load via shared memory

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -648,7 +648,7 @@ async def server_info():
 async def get_load():
     """Get load metrics (deprecated - use /v1/loads instead).
 
-    Legacy shim backed by /v1/loads. Projects GetLoadsReqOutput down to the
+    Legacy shim backed by /v1/loads. Projects load snapshots down to the
     historical field shape (dp_rank, num_reqs, num_waiting_reqs, num_tokens,
     num_pending_tokens, ts_tic) so existing clients keep working.
     """

--- a/python/sglang/srt/entrypoints/v1_loads.py
+++ b/python/sglang/srt/entrypoints/v1_loads.py
@@ -18,7 +18,6 @@ This module provides the /v1/loads endpoint which returns detailed scheduler
 metrics for load balancing, monitoring, and capacity planning.
 """
 
-import dataclasses
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -26,25 +25,9 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
-from sglang.srt.managers.io_struct import (
-    DisaggregationMetrics,
-    GetLoadsReqOutput,
-    LoRAMetrics,
-    MemoryMetrics,
-    QueueMetrics,
-    SpeculativeMetrics,
-)
 from sglang.version import __version__
 
 router = APIRouter()
-
-_OPTIONAL_METRIC_SECTIONS = {
-    "memory": ("memory", MemoryMetrics),
-    "speculative": ("spec", SpeculativeMetrics),
-    "lora": ("lora", LoRAMetrics),
-    "disaggregation": ("disagg", DisaggregationMetrics),
-    "queues": ("queues", QueueMetrics),
-}
 
 
 def _get_tokenizer_manager():
@@ -52,11 +35,6 @@ def _get_tokenizer_manager():
     from sglang.srt.entrypoints.http_server import get_global_state
 
     return get_global_state().tokenizer_manager
-
-
-def _loads_dict_factory(items):
-    """Factory for dataclasses.asdict() that excludes None values and timestamp."""
-    return {k: v for k, v in items if v is not None and k != "timestamp"}
 
 
 def _compute_aggregate(load_dicts: list) -> dict:
@@ -89,42 +67,30 @@ def _compute_aggregate(load_dicts: list) -> dict:
 
 
 def _format_loads_prometheus(load_results) -> Response:
-    """Format load metrics in Prometheus text exposition format.
+    """Format load metrics in Prometheus text exposition format."""
+    section_prefixes = {"speculative": "spec", "disaggregation": "disagg"}
+    metric_samples = {}
 
-    Metrics are derived from dataclass field metadata, providing a single source of truth.
-    """
+    for load in load_results:
+        load_dict = load.to_dict()
+        dp_rank = load_dict.pop("dp_rank")
+
+        for key, value in load_dict.items():
+            if isinstance(value, dict):
+                prefix = section_prefixes.get(key, key)
+                for sub_key, sub_value in value.items():
+                    if isinstance(sub_value, (int, float)):
+                        metric_samples.setdefault(
+                            f"sglang_{prefix}_{sub_key}", []
+                        ).append((dp_rank, sub_value))
+            elif isinstance(value, (int, float)):
+                metric_samples.setdefault(f"sglang_{key}", []).append((dp_rank, value))
+
     lines = []
-
-    for f in dataclasses.fields(GetLoadsReqOutput):
-        if "metric" not in f.metadata:
-            continue
-        metric_type, description = f.metadata["metric"]
-        metric_name = f"sglang_{f.name}"
-        lines.append(f"# HELP {metric_name} {description}")
-        lines.append(f"# TYPE {metric_name} {metric_type}")
-        for load in load_results:
-            value = getattr(load, f.name, None)
-            if value is not None:
-                lines.append(f'{metric_name}{{dp_rank="{load.dp_rank}"}} {value}')
-
-    for attr_name, (prefix, dataclass_type) in _OPTIONAL_METRIC_SECTIONS.items():
-        if not any(getattr(load, attr_name, None) for load in load_results):
-            continue
-        for f in dataclasses.fields(dataclass_type):
-            if "metric" not in f.metadata:
-                continue
-            metric_type, description = f.metadata["metric"]
-            metric_name = f"sglang_{prefix}_{f.name}"
-            lines.append(f"# HELP {metric_name} {description}")
-            lines.append(f"# TYPE {metric_name} {metric_type}")
-            for load in load_results:
-                section = getattr(load, attr_name, None)
-                if section:
-                    value = getattr(section, f.name, None)
-                    if value is not None:
-                        lines.append(
-                            f'{metric_name}{{dp_rank="{load.dp_rank}"}} {value}'
-                        )
+    for metric_name, samples in metric_samples.items():
+        lines.append(f"# TYPE {metric_name} gauge")
+        for dp_rank, value in samples:
+            lines.append(f'{metric_name}{{dp_rank="{dp_rank}"}} {value}')
 
     return Response(
         content="\n".join(lines) + "\n",
@@ -174,7 +140,7 @@ async def get_loads(
 
     loads = []
     for load in load_results:
-        d = dataclasses.asdict(load, dict_factory=_loads_dict_factory)
+        d = load.to_dict()
         d["num_total_reqs"] = d["num_running_reqs"] + d["num_waiting_reqs"]
         loads.append(d)
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -36,8 +36,8 @@ from sglang.srt.managers.io_struct import (
     ProfileReq,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
-    WatchLoadUpdateReq,
 )
+from sglang.srt.managers.load_snapshot import LoadSnapshotReader, shm_path_for
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
@@ -91,10 +91,14 @@ class DPBudget:
         self.dp_size = dp_size
         self.total_requests = [0] * dp_size
         self.total_tokens = [0] * dp_size
+        self.last_timestamp = [0.0] * dp_size
 
-    def update_budget(self, load_update: WatchLoadUpdateReq):
-        """Update the budget."""
-        for load in load_update.loads:
+    def update_budget(self, loads):
+        """Update budget from shm snapshots, skipping stale reads."""
+        for load in loads:
+            if load.timestamp == self.last_timestamp[load.dp_rank]:
+                continue
+            self.last_timestamp[load.dp_rank] = load.timestamp
             self.total_requests[load.dp_rank] = (
                 load.num_running_reqs + load.num_waiting_reqs
             )
@@ -151,9 +155,17 @@ class DataParallelController:
             LoadBalanceMethod.TOTAL_TOKENS: self.total_tokens_scheduler,
         }
         self.dispatching = dispatch_lookup[self.load_balance_method]
+        self.refresh_load_budget_on_dispatch = self.load_balance_method in (
+            LoadBalanceMethod.TOTAL_REQUESTS,
+            LoadBalanceMethod.TOTAL_TOKENS,
+        )
 
         # Load balance budget
         self.dp_budget = DPBudget(server_args.dp_size)
+        self.load_snapshot_reader = LoadSnapshotReader(
+            shm_path_for(port_args.scheduler_input_ipc_name),
+            server_args.dp_size,
+        )
 
         # To protect changing env vars to set CUDA_VISIBLE_DEVICES.
         self.env_lock = threading.Lock()
@@ -198,13 +210,16 @@ class DataParallelController:
         for worker in self.workers[:: self.control_message_step]:
             worker.send_pyobj(obj)
 
-    def handle_load_update_req(self, obj):
-        self.dp_budget.update_budget(obj)
-
     def update_active_ranks(self, ranks: ActiveRanksOutput):
         self.status = ranks.status
 
-    def dispatching_with_trace(self, req: Req):
+    def refresh_load_budget(self):
+        self.dp_budget.update_budget(self.load_snapshot_reader.read_all())
+
+    def dispatching_with_trace(self, req: Req, refresh_load_budget: bool = True):
+        if refresh_load_budget and self.refresh_load_budget_on_dispatch:
+            self.refresh_load_budget()
+
         req.time_stats = DPControllerReqTimeStats.new_from_obj(req.time_stats)
 
         req.time_stats.set_dp_dispatch_time()
@@ -212,12 +227,16 @@ class DataParallelController:
         req.time_stats.set_dp_dispatch_finish_time()
 
     def dispatch_batch_generate(self, batch_req: BatchTokenizedGenerateReqInput):
+        if self.refresh_load_budget_on_dispatch:
+            self.refresh_load_budget()
         for req in batch_req:
-            self.dispatching_with_trace(req)
+            self.dispatching_with_trace(req, refresh_load_budget=False)
 
     def dispatch_batch_embedding(self, batch_req: BatchTokenizedEmbeddingReqInput):
+        if self.refresh_load_budget_on_dispatch:
+            self.refresh_load_budget()
         for req in batch_req:
-            self.dispatching_with_trace(req)
+            self.dispatching_with_trace(req, refresh_load_budget=False)
 
     def init_dispatcher(self):
         self._request_dispatcher = TypeBasedDispatcher(
@@ -228,7 +247,6 @@ class DataParallelController:
                 (BatchTokenizedEmbeddingReqInput, self.dispatch_batch_embedding),
                 (BlockReqInput, self.send_to_all_workers),
                 (ProfileReq, self.send_to_all_workers),
-                (WatchLoadUpdateReq, self.handle_load_update_req),
                 (ActiveRanksOutput, self.update_active_ranks),
             ]
         )

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -396,7 +396,6 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             placeholder_tokens_val=None,
             retraction_counts=recv_obj.retraction_counts,
             token_steps=recv_obj.token_steps,
-            load=recv_obj.load,
             dp_ranks=recv_obj.dp_ranks,
             time_stats=recv_obj.time_stats,
         )

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1128,8 +1128,6 @@ class BatchTokenIDOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: List[List[int]] = None
 
-    # Load for DP balance
-    load: GetLoadsReqOutput = None
     # Customized info
     customized_info: Optional[Dict[str, List[Any]]] = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
@@ -1192,9 +1190,6 @@ class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
 
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: List[List[int]] = None
-
-    # Load for DP balance
-    load: GetLoadsReqOutput = None
 
     # Customized info
     customized_info: Optional[Dict[str, List[Any]]] = None
@@ -1936,158 +1931,51 @@ class BlockReqInput(BaseReq):
 class MemoryMetrics:
     """Memory breakdown metrics."""
 
-    weight_gb: float = field(
-        metadata={"metric": ("gauge", "Model weight memory in GB")}
-    )
-    kv_cache_gb: float = field(metadata={"metric": ("gauge", "KV cache memory in GB")})
-    graph_gb: float = field(metadata={"metric": ("gauge", "CUDA graph memory in GB")})
-    token_capacity: int = field(
-        metadata={"metric": ("gauge", "Max tokens in KV cache")}
-    )
+    weight_gb: float
+    kv_cache_gb: float
+    graph_gb: float
+    token_capacity: int
 
 
 @dataclass
 class SpeculativeMetrics:
     """Speculative decoding metrics."""
 
-    accept_length: float = field(
-        metadata={
-            "metric": (
-                "gauge",
-                "Mean acceptance length (accepted drafts + bonus token per forward)",
-            )
-        }
-    )
-    accept_rate: float = field(
-        metadata={"metric": ("gauge", "Speculative acceptance rate")}
-    )
+    accept_length: float
+    accept_rate: float
 
 
 @dataclass
 class LoRAMetrics:
     """LoRA adapter pool metrics."""
 
-    slots_used: int = field(metadata={"metric": ("gauge", "LoRA adapter slots in use")})
-    slots_total: int = field(metadata={"metric": ("gauge", "Total LoRA adapter slots")})
-    utilization: float = field(
-        metadata={"metric": ("gauge", "LoRA pool utilization ratio")}
-    )
+    slots_used: int
+    slots_total: int
+    utilization: float
 
 
 @dataclass
 class DisaggregationMetrics:
     """PD disaggregation metrics."""
 
-    mode: str  # "prefill", "decode", or "null" - not a metric
-    prefill_bootstrap_queue_reqs: int = field(
-        default=0, metadata={"metric": ("gauge", "Prefill bootstrap queue requests")}
-    )
-    prefill_inflight_queue_reqs: int = field(
-        default=0, metadata={"metric": ("gauge", "Prefill inflight queue requests")}
-    )
-    decode_prealloc_queue_reqs: int = field(
-        default=0, metadata={"metric": ("gauge", "Decode prealloc queue requests")}
-    )
-    decode_transfer_queue_reqs: int = field(
-        default=0, metadata={"metric": ("gauge", "Decode transfer queue requests")}
-    )
-    decode_retracted_queue_reqs: int = field(
-        default=0, metadata={"metric": ("gauge", "Decode retracted queue requests")}
-    )
-    kv_transfer_speed_gb_s: float = field(
-        default=0.0, metadata={"metric": ("gauge", "KV transfer speed in GB/s")}
-    )
-    kv_transfer_latency_ms: float = field(
-        default=0.0, metadata={"metric": ("gauge", "KV transfer latency in ms")}
-    )
+    mode: str
+    prefill_bootstrap_queue_reqs: int = 0
+    prefill_inflight_queue_reqs: int = 0
+    decode_prealloc_queue_reqs: int = 0
+    decode_transfer_queue_reqs: int = 0
+    decode_retracted_queue_reqs: int = 0
+    kv_transfer_speed_gb_s: float = 0.0
+    kv_transfer_latency_ms: float = 0.0
 
 
 @dataclass
 class QueueMetrics:
     """Detailed queue breakdown."""
 
-    waiting: int = field(metadata={"metric": ("gauge", "Main waiting queue size")})
-    grammar: int = field(
-        metadata={"metric": ("gauge", "Grammar compilation queue size")}
-    )
-    paused: int = field(
-        metadata={"metric": ("gauge", "Requests paused by weight sync")}
-    )
-    retracted: int = field(metadata={"metric": ("gauge", "Retracted requests count")})
-
-
-@dataclass
-class GetLoadsReqInput(BaseReq):
-    """Request for /v1/loads endpoint."""
-
-    VALID_SECTIONS = frozenset(
-        {"core", "memory", "spec", "lora", "disagg", "queues", "all"}
-    )
-
-    include: List[str] = field(default_factory=lambda: ["all"])
-    dp_rank: Optional[int] = None
-
-    def __post_init__(self):
-        """Validate include sections."""
-        if self.include:
-            invalid = set(self.include) - self.VALID_SECTIONS
-            if invalid:
-                raise ValueError(
-                    f"Invalid include sections: {invalid}. "
-                    f"Valid options: {sorted(self.VALID_SECTIONS)}"
-                )
-
-
-@dataclass
-class GetLoadsReqOutput(BaseReq):
-    """Per-DP-rank load metrics for /v1/loads endpoint."""
-
-    dp_rank: int
-    timestamp: float
-
-    num_running_reqs: int = field(
-        metadata={"metric": ("gauge", "Number of running requests")}
-    )
-    num_waiting_reqs: int = field(
-        metadata={"metric": ("gauge", "Number of waiting requests")}
-    )
-    num_used_tokens: int = field(
-        metadata={"metric": ("gauge", "Number of tokens in use")}
-    )
-    # num_used_tokens + pending prefill tokens (waiting-queue seqlen, incl.
-    # disagg bootstrap/prealloc/transfer queues). Used for DP balance.
-    num_total_tokens: int = field(
-        metadata={"metric": ("gauge", "Used tokens plus pending prefill tokens")}
-    )
-    max_total_num_tokens: int = field(
-        metadata={"metric": ("gauge", "Maximum token capacity")}
-    )
-    # FIXME: token_usage is actually max usage across all pools (KV, SWA, mamba),
-    # not just KV token usage. Rename requires API deprecation.
-    token_usage: float = field(metadata={"metric": ("gauge", "Token pool usage ratio")})
-    gen_throughput: float = field(
-        metadata={"metric": ("gauge", "Generation throughput tokens/sec")}
-    )
-    cache_hit_rate: float = field(
-        metadata={"metric": ("gauge", "Prefix cache hit rate")}
-    )
-    utilization: float = field(
-        metadata={"metric": ("gauge", "Overall utilization ratio")}
-    )
-    max_running_requests: int = field(
-        metadata={"metric": ("gauge", "Maximum running requests capacity")}
-    )
-
-    memory: Optional[MemoryMetrics] = None
-    speculative: Optional[SpeculativeMetrics] = None
-    lora: Optional[LoRAMetrics] = None
-    disaggregation: Optional[DisaggregationMetrics] = None
-    queues: Optional[QueueMetrics] = None
-
-
-@dataclass
-class WatchLoadUpdateReq(BaseReq):
-    loads: List[GetLoadsReqOutput]
+    waiting: int
+    grammar: int
+    paused: int
+    retracted: int
 
 
 @dataclass

--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import logging
+import mmap
+import os
+import struct
+from contextlib import contextmanager
+from dataclasses import dataclass, field, fields, replace
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+MAGIC = b"SLNS"
+VERSION = 1
+HEADER_STRUCT = struct.Struct("<4sHHI")
+
+DISAGG_MODE_TO_INT = {"null": 0, "prefill": 1, "decode": 2}
+INT_TO_DISAGG_MODE = {v: k for k, v in DISAGG_MODE_TO_INT.items()}
+
+
+def i64(default: int = 0):
+    return field(default=default, metadata={"fmt": "q"})
+
+
+def f64(default: float = 0.0):
+    return field(default=default, metadata={"fmt": "d"})
+
+
+@dataclass
+class LoadSnapshot:
+    timestamp: float = f64()
+    dp_rank: int = i64()
+    num_running_reqs: int = i64()
+    num_waiting_reqs: int = i64()
+    num_used_tokens: int = i64()
+    num_total_tokens: int = i64()
+    max_total_num_tokens: int = i64()
+    max_running_requests: int = i64()
+    token_usage: float = f64()
+    gen_throughput: float = f64()
+    cache_hit_rate: float = f64()
+    utilization: float = f64()
+
+    has_memory: int = i64()
+    memory_weight_gb: float = f64()
+    memory_kv_cache_gb: float = f64()
+    memory_graph_gb: float = f64()
+    memory_token_capacity: int = i64()
+
+    has_speculative: int = i64()
+    speculative_accept_length: float = f64()
+    speculative_accept_rate: float = f64()
+
+    has_lora: int = i64()
+    lora_slots_used: int = i64()
+    lora_slots_total: int = i64()
+    lora_utilization: float = f64()
+
+    has_disaggregation: int = i64()
+    disagg_mode: int = i64()
+    prefill_bootstrap_queue_reqs: int = i64()
+    prefill_inflight_queue_reqs: int = i64()
+    decode_prealloc_queue_reqs: int = i64()
+    decode_transfer_queue_reqs: int = i64()
+    decode_retracted_queue_reqs: int = i64()
+    kv_transfer_speed_gb_s: float = f64()
+    kv_transfer_latency_ms: float = f64()
+
+    has_queues: int = i64()
+    queue_waiting: int = i64()
+    queue_grammar: int = i64()
+    queue_paused: int = i64()
+    queue_retracted: int = i64()
+
+    @classmethod
+    def from_metrics(cls, **metrics) -> "LoadSnapshot":
+        snapshot = {name: metrics[name] for name in CORE_METRIC_FIELDS}
+
+        for include_key, section_name, present_attr, attrs in SECTION_FIELDS:
+            section = metrics.get(section_name)
+            snapshot[present_attr] = int(section is not None)
+            if section is None:
+                continue
+
+            for section_attr, snapshot_attr in attrs:
+                value = getattr(section, section_attr)
+                if snapshot_attr == "disagg_mode":
+                    value = DISAGG_MODE_TO_INT.get(value, 0)
+                snapshot[snapshot_attr] = value
+
+        return cls(**snapshot)
+
+    def with_sections(self, include: list[str]) -> "LoadSnapshot":
+        if not include or "all" in include:
+            return self
+
+        include = set(include)
+        updates = {}
+        for section, defaults in SECTION_FIELD_DEFAULTS.items():
+            if section not in include:
+                updates.update(defaults)
+        return replace(self, **updates) if updates else self
+
+    def to_dict(self) -> dict:
+        load = {
+            name: getattr(self, name)
+            for name in CORE_METRIC_FIELDS
+            if name != "timestamp"
+        }
+
+        for include_key, section_name, present_attr, attrs in SECTION_FIELDS:
+            if not getattr(self, present_attr):
+                continue
+
+            section = {}
+            for section_attr, snapshot_attr in attrs:
+                value = getattr(self, snapshot_attr)
+                if snapshot_attr == "disagg_mode":
+                    value = INT_TO_DISAGG_MODE.get(value, "null")
+                section[section_attr] = value
+            load[section_name] = section
+
+        return load
+
+
+CORE_METRIC_FIELDS = (
+    "timestamp",
+    "dp_rank",
+    "num_running_reqs",
+    "num_waiting_reqs",
+    "num_used_tokens",
+    "num_total_tokens",
+    "max_total_num_tokens",
+    "max_running_requests",
+    "token_usage",
+    "gen_throughput",
+    "cache_hit_rate",
+    "utilization",
+)
+SECTION_FIELDS = (
+    (
+        "memory",
+        "memory",
+        "has_memory",
+        (
+            ("weight_gb", "memory_weight_gb"),
+            ("kv_cache_gb", "memory_kv_cache_gb"),
+            ("graph_gb", "memory_graph_gb"),
+            ("token_capacity", "memory_token_capacity"),
+        ),
+    ),
+    (
+        "spec",
+        "speculative",
+        "has_speculative",
+        (
+            ("accept_length", "speculative_accept_length"),
+            ("accept_rate", "speculative_accept_rate"),
+        ),
+    ),
+    (
+        "lora",
+        "lora",
+        "has_lora",
+        (
+            ("slots_used", "lora_slots_used"),
+            ("slots_total", "lora_slots_total"),
+            ("utilization", "lora_utilization"),
+        ),
+    ),
+    (
+        "disagg",
+        "disaggregation",
+        "has_disaggregation",
+        (
+            ("mode", "disagg_mode"),
+            ("prefill_bootstrap_queue_reqs", "prefill_bootstrap_queue_reqs"),
+            ("prefill_inflight_queue_reqs", "prefill_inflight_queue_reqs"),
+            ("decode_prealloc_queue_reqs", "decode_prealloc_queue_reqs"),
+            ("decode_transfer_queue_reqs", "decode_transfer_queue_reqs"),
+            ("decode_retracted_queue_reqs", "decode_retracted_queue_reqs"),
+            ("kv_transfer_speed_gb_s", "kv_transfer_speed_gb_s"),
+            ("kv_transfer_latency_ms", "kv_transfer_latency_ms"),
+        ),
+    ),
+    (
+        "queues",
+        "queues",
+        "has_queues",
+        (
+            ("waiting", "queue_waiting"),
+            ("grammar", "queue_grammar"),
+            ("paused", "queue_paused"),
+            ("retracted", "queue_retracted"),
+        ),
+    ),
+)
+
+SNAPSHOT_FIELDS = fields(LoadSnapshot)
+PAYLOAD_STRUCT = struct.Struct(
+    "<" + "".join(snapshot_field.metadata["fmt"] for snapshot_field in SNAPSHOT_FIELDS)
+)
+# 64-byte aligned so each slot starts on a cache-line boundary.
+SLOT_SIZE = (PAYLOAD_STRUCT.size + 63) & ~63
+FIELD_DEFAULTS = {
+    snapshot_field.name: snapshot_field.default for snapshot_field in SNAPSHOT_FIELDS
+}
+SECTION_FIELD_DEFAULTS = {
+    include_key: {
+        name: FIELD_DEFAULTS[name]
+        for name in (present_attr, *(snapshot_attr for _, snapshot_attr in attrs))
+    }
+    for include_key, section_name, present_attr, attrs in SECTION_FIELDS
+}
+
+
+def snapshot_values(snapshot: LoadSnapshot) -> tuple:
+    return tuple(
+        getattr(snapshot, snapshot_field.name) for snapshot_field in SNAPSHOT_FIELDS
+    )
+
+
+def snapshot_from_values(values: tuple) -> LoadSnapshot:
+    return LoadSnapshot(
+        **dict(
+            zip(
+                (snapshot_field.name for snapshot_field in SNAPSHOT_FIELDS),
+                values,
+                strict=True,
+            )
+        )
+    )
+
+
+@contextmanager
+def file_lock(fd: int, lock_type: int):
+    fcntl.flock(fd, lock_type)
+    try:
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def shm_path_for(ipc_name: str) -> str:
+    name = os.path.basename(ipc_name.rstrip("/")) or "default"
+    safe_name = "".join(c if c.isalnum() or c in "._-" else "_" for c in name)
+    digest = hashlib.blake2s(ipc_name.encode(), digest_size=4).hexdigest()
+    return f"/dev/shm/sglang_loads_{safe_name}_{digest}.shm"
+
+
+def file_size(dp_size: int) -> int:
+    return HEADER_STRUCT.size + dp_size * SLOT_SIZE
+
+
+def slot_offset(dp_rank: int) -> int:
+    return HEADER_STRUCT.size + dp_rank * SLOT_SIZE
+
+
+class LoadSnapshotWriter:
+    def __init__(
+        self, path: str, dp_size: int, dp_rank: int, publish_interval: int = 1
+    ):
+        if dp_rank < 0 or dp_rank >= dp_size:
+            raise ValueError(f"invalid dp_rank={dp_rank} for dp_size={dp_size}")
+        self.publish_interval = max(1, publish_interval)
+        self.publish_counter = 0
+
+        self.path = path
+        self.dp_size = dp_size
+        self.dp_rank = dp_rank
+        self.fd = -1
+        size = file_size(dp_size)
+
+        self.fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            with file_lock(self.fd, fcntl.LOCK_EX):
+                os.ftruncate(self.fd, size)
+                self.mmap = mmap.mmap(self.fd, size, access=mmap.ACCESS_WRITE)
+                HEADER_STRUCT.pack_into(
+                    self.mmap, 0, MAGIC, VERSION, dp_size, SLOT_SIZE
+                )
+                self._write_payload(LoadSnapshot(dp_rank=dp_rank))
+        except Exception:
+            if self.fd >= 0:
+                os.close(self.fd)
+            raise
+
+    def write(self, snapshot: LoadSnapshot) -> None:
+        if snapshot.dp_rank != self.dp_rank:
+            raise ValueError(
+                f"snapshot dp_rank={snapshot.dp_rank} does not match writer dp_rank={self.dp_rank}"
+            )
+
+        with file_lock(self.fd, fcntl.LOCK_EX):
+            self._write_payload(snapshot)
+
+    def _write_payload(self, snapshot: LoadSnapshot) -> None:
+        PAYLOAD_STRUCT.pack_into(
+            self.mmap,
+            slot_offset(self.dp_rank),
+            *snapshot_values(snapshot),
+        )
+
+    def close(self) -> None:
+        self.mmap.close()
+        os.close(self.fd)
+
+
+class LoadSnapshotReader:
+    def __init__(self, path: str, dp_size: int):
+        self.path = path
+        self.dp_size = dp_size
+        self.mmap: Optional[mmap.mmap] = None
+        self.fd: Optional[int] = None
+        self.header_warning_logged = False
+
+    def attach(self) -> bool:
+        if self.mmap is not None:
+            return True
+
+        size = file_size(self.dp_size)
+        try:
+            fd = os.open(self.path, os.O_RDONLY)
+        except FileNotFoundError:
+            return False
+
+        try:
+            with file_lock(fd, fcntl.LOCK_SH):
+                mapped = mmap.mmap(fd, size, access=mmap.ACCESS_READ)
+                magic, version, dp_size, slot_size = HEADER_STRUCT.unpack_from(
+                    mapped, 0
+                )
+        except (OSError, ValueError):
+            os.close(fd)
+            return False
+
+        if (
+            magic != MAGIC
+            or version != VERSION
+            or dp_size != self.dp_size
+            or slot_size != SLOT_SIZE
+        ):
+            mapped.close()
+            os.close(fd)
+            if not self.header_warning_logged:
+                logger.warning("load shm header mismatch at %s", self.path)
+                self.header_warning_logged = True
+            return False
+
+        self.mmap = mapped
+        self.fd = fd
+        return True
+
+    def read(self, dp_rank: int) -> Optional[LoadSnapshot]:
+        if dp_rank < 0 or dp_rank >= self.dp_size:
+            return None
+        if not self.attach():
+            return None
+
+        assert self.fd is not None
+        with file_lock(self.fd, fcntl.LOCK_SH):
+            return self._read_slot(dp_rank)
+
+    def _read_slot(self, dp_rank: int) -> LoadSnapshot:
+        assert self.mmap is not None
+        values = PAYLOAD_STRUCT.unpack_from(self.mmap, slot_offset(dp_rank))
+        return snapshot_from_values(values)
+
+    def read_all(self) -> list[LoadSnapshot]:
+        if not self.attach():
+            return []
+
+        assert self.fd is not None
+        with file_lock(self.fd, fcntl.LOCK_SH):
+            return [self._read_slot(r) for r in range(self.dp_size)]
+
+    def close(self) -> None:
+        if self.mmap is not None:
+            self.mmap.close()
+            self.mmap = None
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -106,7 +106,6 @@ from sglang.srt.managers.io_struct import (
     FreezeGCReq,
     GetInternalStateReq,
     GetInternalStateReqOutput,
-    GetLoadsReqInput,
     GetWeightsByNameReqInput,
     HealthCheckOutput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
@@ -142,6 +141,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromIPCReqInput,
     UpdateWeightsFromTensorReqInput,
 )
+from sglang.srt.managers.load_snapshot import LoadSnapshotWriter, shm_path_for
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.prefill_delayer import (
     PrefillDelayer,
@@ -662,6 +662,23 @@ class Scheduler(
             get_spec_total_num_forward_ct=lambda: self.metrics_reporter.spec_total_num_forward_ct,
         )
 
+        self.load_snapshot_writer = None
+        if (
+            self.ps.pp_rank == 0
+            and self.ps.attn_tp_rank == 0
+            and self.ps.attn_cp_rank == 0
+        ):
+            dp_rank = self.ps.dp_rank if self.ps.dp_rank is not None else 0
+            try:
+                self.load_snapshot_writer = LoadSnapshotWriter(
+                    shm_path_for(port_args.scheduler_input_ipc_name),
+                    self.ps.dp_size,
+                    dp_rank,
+                    publish_interval=self.server_args.load_snapshot_publish_interval,
+                )
+            except Exception as e:
+                logger.warning("load snapshot writer init failed: %s", e)
+
         self.output_streamer = SchedulerOutputStreamer(
             send_to_detokenizer=self.ipc_channels.send_to_detokenizer,
             tree_cache=self.tree_cache,
@@ -671,7 +688,6 @@ class Scheduler(
             spec_algorithm=self.spec_algorithm,
             disaggregation_mode=self.disaggregation_mode,
             enable_hicache_storage=lambda: self.enable_hicache_storage,
-            load_inquirer_get_loads=lambda req: self.load_inquirer.get_loads(req),
         )
 
         self.batch_result_processor = SchedulerBatchResultProcessor(
@@ -1432,10 +1448,6 @@ class Scheduler(
                     self.load_lora_adapter_from_tensors,
                 ),
                 (UnloadLoRAAdapterReqInput, self.unload_lora_adapter),
-                (
-                    GetLoadsReqInput,
-                    lambda req: self.load_inquirer.get_loads(req),
-                ),
                 (PauseGenerationReqInput, self.pause_generation),
                 (ContinueGenerationReqInput, self.continue_generation),
                 (DumperControlReqInput, self.handle_dumper_control),
@@ -2975,11 +2987,27 @@ class Scheduler(
         if batch_result.logits_output is not None:
             batch_result.logits_output.next_token_logits = None
 
+    def publish_load_snapshot(self, force: bool = False):
+        writer = self.load_snapshot_writer
+        if writer is None:
+            return
+        if not force:
+            writer.publish_counter += 1
+            if writer.publish_counter < writer.publish_interval:
+                return
+        writer.publish_counter = 0
+        try:
+            writer.write(self.load_inquirer.get_loads(include=["all"]))
+        except Exception as e:
+            logger.debug("load snapshot publish failed: %s", e)
+
     def process_batch_result(
         self,
         batch: ScheduleBatch,
         result: Union[GenerationBatchResult, EmbeddingBatchResult],
     ):
+        self.publish_load_snapshot(force=batch.forward_mode.is_extend())
+
         if batch.forward_mode.is_decode():
             self.batch_result_processor.process_batch_result_decode(batch, result)
         elif batch.forward_mode.is_extend():
@@ -3084,6 +3112,9 @@ class Scheduler(
 
         # reset device timer window so idle time isn't counted
         self.metrics_reporter.reset_device_timer_window()
+
+        # publish load snapshot so /v1/loads and DP balancing see the idle state
+        self.publish_load_snapshot(force=True)
 
         # sleep until next event
         self.maybe_sleep_on_idle()

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -3,18 +3,17 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import (
     DisaggregationMetrics,
-    GetLoadsReqInput,
-    GetLoadsReqOutput,
     LoRAMetrics,
     MemoryMetrics,
     QueueMetrics,
     SpeculativeMetrics,
 )
+from sglang.srt.managers.load_snapshot import LoadSnapshot
 
 if TYPE_CHECKING:
     from sglang.srt.distributed.parallel_state_wrapper import ParallelState
@@ -72,20 +71,17 @@ class SchedulerLoadInquirer:
             num_pending_tokens += req.seqlen - len(req.prefix_indices) - chunk_deduct
         return num_pending_tokens
 
-    def get_loads(self, req: GetLoadsReqInput = None) -> GetLoadsReqOutput:
+    def get_loads(self, include: Optional[List[str]] = None) -> LoadSnapshot:
         """
         Get comprehensive load metrics for /v1/loads endpoint.
 
         Args:
-            req: Request containing include list and optional dp_rank filter
+            include: Sections to include in the output.
 
         Returns:
-            GetLoadsReqOutput with core metrics and optional detailed sections
+            LoadSnapshot with core metrics and optional detailed sections
         """
-        if req is None:
-            req = GetLoadsReqInput()
-
-        include = set(req.include) if req.include else {"core"}
+        include = set(include) if include else {"core"}
         include_all = "all" in include
 
         num_running_reqs = len(self.get_running_batch().reqs)
@@ -188,8 +184,8 @@ class SchedulerLoadInquirer:
                 retracted=self.get_stats().num_retracted_reqs,
             )
 
-        return GetLoadsReqOutput(
-            dp_rank=self.ps.dp_rank,
+        return LoadSnapshot.from_metrics(
+            dp_rank=self.ps.dp_rank if self.ps.dp_rank is not None else 0,
             timestamp=time.time(),
             num_running_reqs=num_running_reqs,
             num_waiting_reqs=num_waiting_reqs,

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -18,7 +18,6 @@ from sglang.srt.environ import envs
 from sglang.srt.managers.io_struct import (
     BatchEmbeddingOutput,
     BatchTokenIDOutput,
-    GetLoadsReqInput,
 )
 from sglang.srt.managers.schedule_batch import (
     BaseFinishReason,
@@ -44,7 +43,6 @@ class SchedulerOutputStreamer:
     spec_algorithm: SpeculativeAlgorithm
     disaggregation_mode: DisaggregationMode
     enable_hicache_storage: Callable[[], bool]
-    load_inquirer_get_loads: Callable[..., Any]
     _test_stream_output_count: int = 0
 
     def _get_storage_backend_type(self) -> str:
@@ -129,8 +127,6 @@ class SchedulerOutputStreamer:
             default_force_stream_interval=DEFAULT_FORCE_STREAM_INTERVAL,
             get_cached_tokens_details=self.get_cached_tokens_details,
         )
-        load = self.load_inquirer_get_loads(GetLoadsReqInput(include=["core"]))
-
         for req in reqs:
             if req is skip_req:
                 continue
@@ -144,7 +140,6 @@ class SchedulerOutputStreamer:
 
         # Send to detokenizer
         payload = acc.to_payload(
-            load=load,
             dp_rank=self.ps.dp_rank,
             is_idle_batch=is_idle_batch,
             has_reqs=bool(reqs),
@@ -448,7 +443,7 @@ class _GenerationStreamAccumulator:
                 self.customized_info[k].append(v[send_token_offset : len(output_ids_)])
 
     def to_payload(
-        self, *, load, dp_rank: int, is_idle_batch: bool, has_reqs: bool
+        self, *, dp_rank: int, is_idle_batch: bool, has_reqs: bool
     ) -> Optional[BatchTokenIDOutput]:
         if not (has_reqs or is_idle_batch):
             return None
@@ -493,6 +488,5 @@ class _GenerationStreamAccumulator:
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,
             retraction_counts=self.retraction_counts,
-            load=load,
             dp_ranks=dp_ranks,
         )

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -39,8 +39,6 @@ from sglang.srt.managers.io_struct import (
     FlushCacheReqOutput,
     GetInternalStateReq,
     GetInternalStateReqOutput,
-    GetLoadsReqInput,
-    GetLoadsReqOutput,
     GetWeightsByNameReqInput,
     GetWeightsByNameReqOutput,
     InitWeightsSendGroupForRemoteInstanceReqInput,
@@ -79,6 +77,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
+from sglang.srt.managers.load_snapshot import LoadSnapshot
 from sglang.srt.server_args import LoRARef, ServerArgs
 from sglang.srt.utils import get_bool_env_var
 from sglang.utils import TypeBasedDispatcher
@@ -119,7 +118,6 @@ _COMMUNICATOR_SPECS = [
     ("set_internal_state", SetInternalStateReqOutput),
     ("expert_distribution", ExpertDistributionReqOutput),
     ("update_lora_adapter", LoRAUpdateOutput),
-    ("get_loads", GetLoadsReqOutput, "watching"),
     ("dumper_control", DumperControlReqOutput),
 ]
 
@@ -809,7 +807,7 @@ class TokenizerControlMixin:
         self: TokenizerManager,
         include: Optional[List[str]] = None,
         dp_rank: Optional[int] = None,
-    ) -> List[GetLoadsReqOutput]:
+    ) -> List[LoadSnapshot]:
         """
         Get comprehensive load metrics for /v1/loads endpoint.
 
@@ -818,32 +816,22 @@ class TokenizerControlMixin:
             dp_rank: Optional filter for specific DP rank
 
         Returns:
-            List of GetLoadsReqOutput, one per scheduler (filtered by dp_rank if specified)
+            List of LoadSnapshot, one per scheduler (filtered by dp_rank if specified)
         """
         self.auto_create_handle_loop()
-        # Always request all sections from scheduler — watching mode shares
-        # results across concurrent callers, so we fetch full data and filter here.
-        req = GetLoadsReqInput(include=["all"], dp_rank=None)
-        results = await self.get_loads_communicator(req)
+        if dp_rank is not None and (dp_rank < 0 or dp_rank >= self.server_args.dp_size):
+            return []
 
-        # Filter by dp_rank if specified
+        reader = self.load_snapshot_reader
+
         if dp_rank is not None:
-            results = [r for r in results if r.dp_rank == dp_rank]
+            load = reader.read(dp_rank)
+            results = [load] if load is not None else []
+        else:
+            results = reader.read_all()
 
-        # Filter optional sections client-side (scheduler always returns all)
         if include and "all" not in include:
-            include_set = set(include)
-            _section_attrs = {
-                "memory": "memory",
-                "spec": "speculative",
-                "lora": "lora",
-                "disagg": "disaggregation",
-                "queues": "queues",
-            }
-            for r in results:
-                for key, attr in _section_attrs.items():
-                    if key not in include_set:
-                        setattr(r, attr, None)
+            results = [r.with_sections(include) for r in results]
 
         return results
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -70,8 +70,8 @@ from sglang.srt.managers.io_struct import (
     TokenizedGenerateReqInput,
     UpdateWeightFromDiskReqInput,
     UpdateWeightFromDiskReqOutput,
-    WatchLoadUpdateReq,
 )
+from sglang.srt.managers.load_snapshot import LoadSnapshotReader, shm_path_for
 from sglang.srt.managers.mm_utils import TensorTransportMode, wrap_shm_features
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.schedule_batch import MultimodalDataItem
@@ -360,6 +360,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             # Make sure that each request carries the tokenizer_ipc_name for response routing
             self.send_to_scheduler = SenderWrapper(port_args, send_to_scheduler)
+
+        self.load_snapshot_reader = LoadSnapshotReader(
+            shm_path_for(port_args.scheduler_input_ipc_name),
+            self.server_args.dp_size,
+        )
 
     def init_running_status(self):
         # Request states
@@ -1919,16 +1924,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # handle_loop awaits next recv immediately
         for s in pending_notify.values():
             s.event.set()
-
-        # When skip_tokenizer_init is enabled, tokensizer_manager receives
-        # BatchTokenIDOutput.
-        if (
-            self.server_args.dp_size > 1
-            and isinstance(recv_obj, (BatchStrOutput, BatchTokenIDOutput))
-            and recv_obj.load is not None
-        ):
-            load_update_req = WatchLoadUpdateReq(loads=[recv_obj.load])
-            self.send_to_scheduler.send_pyobj(load_update_req)
 
     def add_logprob_to_meta_info(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -434,6 +434,7 @@ class ServerArgs:
     base_gpu_id: int = 0
     gpu_id_step: int = 1
     sleep_on_idle: bool = False
+    load_snapshot_publish_interval: int = 10
     use_ray: bool = False
     custom_sigquit_handler: Optional[Callable] = None
 
@@ -4802,6 +4803,12 @@ class ServerArgs:
             "--sleep-on-idle",
             action="store_true",
             help="Reduce CPU usage when sglang is idle.",
+        )
+        parser.add_argument(
+            "--load-snapshot-publish-interval",
+            type=int,
+            default=ServerArgs.load_snapshot_publish_interval,
+            help="Publish load snapshot to shared memory every N decode iterations. Prefill and idle always publish immediately.",
         )
         parser.add_argument(
             "--use-ray",

--- a/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
+++ b/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
@@ -5,9 +5,23 @@ Narrow scope: lock in the semantic of new aggregate keys added by this PR
 zero-init branch) are not covered — they would just restate Python.
 """
 
+import asyncio
+import os
+import tempfile
 import unittest
+from types import SimpleNamespace
 
 from sglang.srt.entrypoints.v1_loads import _compute_aggregate
+from sglang.srt.managers.io_struct import (
+    DisaggregationMetrics,
+    QueueMetrics,
+)
+from sglang.srt.managers.load_snapshot import (
+    LoadSnapshot,
+    LoadSnapshotReader,
+    LoadSnapshotWriter,
+)
+from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -37,6 +51,22 @@ def _load(
     }
 
 
+def _temp_path() -> str:
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(path)
+    return path
+
+
+class _FakeTokenizerManager(TokenizerControlMixin):
+    def __init__(self, reader, dp_size: int):
+        self.load_snapshot_reader = reader
+        self.server_args = SimpleNamespace(dp_size=dp_size)
+
+    def auto_create_handle_loop(self):
+        pass
+
+
 class TestComputeAggregate(CustomTestCase):
     def test_multi_dp_rank_sums(self):
         agg = _compute_aggregate(
@@ -64,12 +94,60 @@ class TestComputeAggregate(CustomTestCase):
         self.assertAlmostEqual(agg["avg_utilization"], 0.6)
 
     def test_total_tokens_differs_from_total_used_tokens(self):
-        # Regression: total_tokens sums num_total_tokens, NOT num_used_tokens.
-        # Gateway reads aggregate.total_tokens for DP load estimation, so a
-        # silent swap would under-report load.
         agg = _compute_aggregate([_load(used=10, total=30), _load(used=20, total=45)])
         self.assertEqual(agg["total_used_tokens"], 30)
         self.assertEqual(agg["total_tokens"], 75)
+
+
+class TestGetLoads(CustomTestCase):
+    def test_reads_snapshot_and_filters_sections(self):
+        path = _temp_path()
+        writer = LoadSnapshotWriter(path, dp_size=1, dp_rank=0)
+        reader = LoadSnapshotReader(path, dp_size=1)
+        try:
+            initial_load = reader.read(0)
+            self.assertIsNotNone(initial_load)
+            self.assertEqual(initial_load.num_total_tokens, 0)
+
+            writer.write(
+                LoadSnapshot.from_metrics(
+                    dp_rank=0,
+                    timestamp=1.25,
+                    num_running_reqs=3,
+                    num_waiting_reqs=2,
+                    num_used_tokens=128,
+                    num_total_tokens=256,
+                    max_total_num_tokens=4096,
+                    token_usage=0.125,
+                    gen_throughput=99.5,
+                    cache_hit_rate=0.75,
+                    utilization=0.5,
+                    max_running_requests=128,
+                    disaggregation=DisaggregationMetrics(
+                        mode="decode",
+                        decode_transfer_queue_reqs=4,
+                    ),
+                    queues=QueueMetrics(
+                        waiting=2,
+                        grammar=1,
+                        paused=0,
+                        retracted=3,
+                    ),
+                )
+            )
+
+            manager = _FakeTokenizerManager(reader, dp_size=1)
+            loads = asyncio.run(manager.get_loads(include=["core"], dp_rank=0))
+
+            self.assertEqual(len(loads), 1)
+            self.assertEqual(loads[0].num_total_tokens, 256)
+            self.assertFalse(loads[0].has_disaggregation)
+            self.assertFalse(loads[0].has_queues)
+        finally:
+            reader.close()
+            writer.close()
+            if os.path.exists(path):
+                os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_dp_budget.py
+++ b/test/registered/unit/managers/test_dp_budget.py
@@ -1,7 +1,7 @@
 """Unit tests for DPBudget — field mapping regression guard.
 
 This PR changed DPBudget.update_budget to read num_running_reqs +
-num_waiting_reqs and num_total_tokens from the new GetLoadsReqOutput.
+num_waiting_reqs and num_total_tokens from LoadSnapshot.
 These tests lock in that mapping. Pre-existing dispatch logic is not
 retested here — it's covered by DP balance integration tests.
 """
@@ -9,34 +9,25 @@ retested here — it's covered by DP balance integration tests.
 import dataclasses
 import unittest
 
+from sglang.srt.managers.data_parallel_controller import DPBudget, LoadBalanceMethod
+from sglang.srt.managers.load_snapshot import LoadSnapshot
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.data_parallel_controller import DPBudget
-from sglang.srt.managers.io_struct import GetLoadsReqOutput, WatchLoadUpdateReq
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 
-_BASE_LOAD = GetLoadsReqOutput(
-    dp_rank=0,
-    timestamp=0.0,
-    num_running_reqs=0,
-    num_waiting_reqs=0,
-    num_used_tokens=0,
-    num_total_tokens=0,
+_BASE_LOAD = dataclasses.replace(
+    LoadSnapshot(dp_rank=0),
     max_total_num_tokens=4096,
-    token_usage=0.0,
-    gen_throughput=0.0,
-    cache_hit_rate=0.0,
-    utilization=0.0,
     max_running_requests=128,
 )
 
 
-def _load(**overrides) -> GetLoadsReqOutput:
+def _load(**overrides) -> LoadSnapshot:
     return dataclasses.replace(_BASE_LOAD, **overrides)
 
 
@@ -44,47 +35,93 @@ class TestDPBudgetUpdateBudget(CustomTestCase):
     def test_maps_running_plus_waiting_to_total_requests(self):
         budget = DPBudget(dp_size=2)
         budget.update_budget(
-            WatchLoadUpdateReq(
-                loads=[
-                    _load(dp_rank=0, num_running_reqs=3, num_waiting_reqs=2),
-                    _load(dp_rank=1, num_running_reqs=5, num_waiting_reqs=1),
-                ]
-            )
+            [
+                _load(dp_rank=0, timestamp=1.0, num_running_reqs=3, num_waiting_reqs=2),
+                _load(dp_rank=1, timestamp=1.0, num_running_reqs=5, num_waiting_reqs=1),
+            ]
         )
         self.assertEqual(budget.total_requests, [5, 6])
 
     def test_maps_num_total_tokens_not_num_used_tokens(self):
-        # Reads num_total_tokens (used + pending prefill), NOT num_used_tokens.
-        # A silent swap here would break DP balance for long-prompt workloads.
         budget = DPBudget(dp_size=2)
         budget.update_budget(
-            WatchLoadUpdateReq(
-                loads=[
-                    _load(dp_rank=0, num_used_tokens=100, num_total_tokens=150),
-                    _load(dp_rank=1, num_used_tokens=80, num_total_tokens=80),
-                ]
-            )
+            [
+                _load(
+                    dp_rank=0, timestamp=1.0, num_used_tokens=100, num_total_tokens=150
+                ),
+                _load(
+                    dp_rank=1, timestamp=1.0, num_used_tokens=80, num_total_tokens=80
+                ),
+            ]
         )
         self.assertEqual(budget.total_tokens, [150, 80])
 
     def test_partial_update_only_affects_reported_rank(self):
         budget = DPBudget(dp_size=3)
-        budget.total_requests = [10, 20, 30]
-        budget.total_tokens = [100, 200, 300]
         budget.update_budget(
-            WatchLoadUpdateReq(
-                loads=[
-                    _load(
-                        dp_rank=1,
-                        num_running_reqs=1,
-                        num_waiting_reqs=1,
-                        num_total_tokens=50,
-                    )
-                ]
-            )
+            [
+                _load(
+                    dp_rank=0, timestamp=1.0, num_running_reqs=10, num_total_tokens=100
+                ),
+                _load(
+                    dp_rank=1, timestamp=1.0, num_running_reqs=20, num_total_tokens=200
+                ),
+                _load(
+                    dp_rank=2, timestamp=1.0, num_running_reqs=30, num_total_tokens=300
+                ),
+            ]
+        )
+        budget.update_budget(
+            [
+                _load(
+                    dp_rank=1,
+                    timestamp=2.0,
+                    num_running_reqs=1,
+                    num_waiting_reqs=1,
+                    num_total_tokens=50,
+                )
+            ]
         )
         self.assertEqual(budget.total_requests, [10, 2, 30])
         self.assertEqual(budget.total_tokens, [100, 50, 300])
+
+    def test_stale_reread_preserves_speculative_increments(self):
+        budget = DPBudget(dp_size=2)
+        budget.update_budget(
+            [
+                _load(dp_rank=0, timestamp=1.0, num_running_reqs=0, num_waiting_reqs=0),
+                _load(dp_rank=1, timestamp=1.0, num_running_reqs=0, num_waiting_reqs=0),
+            ]
+        )
+        budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
+        self.assertEqual(budget.total_requests, [1, 0])
+
+        # Re-read same stale snapshot (same timestamp) — increment survives
+        budget.update_budget(
+            [
+                _load(dp_rank=0, timestamp=1.0, num_running_reqs=0, num_waiting_reqs=0),
+                _load(dp_rank=1, timestamp=1.0, num_running_reqs=0, num_waiting_reqs=0),
+            ]
+        )
+        self.assertEqual(budget.total_requests, [1, 0])
+
+    def test_fresh_snapshot_overwrites_speculative_increments(self):
+        budget = DPBudget(dp_size=2)
+        budget.update_budget(
+            [
+                _load(dp_rank=0, timestamp=1.0, num_running_reqs=0, num_waiting_reqs=0),
+                _load(dp_rank=1, timestamp=1.0, num_running_reqs=0, num_waiting_reqs=0),
+            ]
+        )
+        budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
+        budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
+        self.assertEqual(budget.total_requests, [1, 1])
+
+        # Fresh snapshot from scheduler (new timestamp) overwrites
+        budget.update_budget(
+            [_load(dp_rank=0, timestamp=2.0, num_running_reqs=1, num_waiting_reqs=0)]
+        )
+        self.assertEqual(budget.total_requests, [1, 1])
 
 
 if __name__ == "__main__":

--- a/test/registered/utils/test_type_based_dispatcher.py
+++ b/test/registered/utils/test_type_based_dispatcher.py
@@ -33,7 +33,6 @@ class TestTypeBasedDispatcher(unittest.TestCase):
             FlushCacheReqInput,
             FreezeGCReq,
             GetInternalStateReq,
-            GetLoadsReqInput,
             GetWeightsByNameReqInput,
             InitWeightsSendGroupForRemoteInstanceReqInput,
             InitWeightsUpdateGroupReqInput,
@@ -113,7 +112,6 @@ class TestTypeBasedDispatcher(unittest.TestCase):
             (ExpertDistributionReq, lambda req: "expert_distribution_handled"),
             (LoadLoRAAdapterReqInput, lambda req: "load_lora_adapter_handled"),
             (UnloadLoRAAdapterReqInput, lambda req: "unload_lora_adapter_handled"),
-            (GetLoadsReqInput, lambda req: "get_loads_handled"),
         ]
 
         # Create requests that conforms to the real distribution
@@ -204,7 +202,6 @@ class TestTypeBasedDispatcher(unittest.TestCase):
         test_requests.append(GetWeightsByNameReqInput(name=""))
         test_requests.append(ReleaseMemoryOccupationReqInput())
         test_requests.append(RpcReqInput(method=""))
-        test_requests.append(GetLoadsReqInput())
 
         dispatcher = TypeBasedDispatcher(mapping)
 


### PR DESCRIPTION
## Motivation

`/get_loads` currently sends a `GetLoadsReqInput` to the scheduler via ZMQ and waits for the response, adding latency to every load query. 

## Solution

Replace the ZMQ request-response path with a shared-memory region (`/dev/shm`). Each scheduler writes its `LoadSnapshot` to a fixed-size mmap slot; the tokenizer_manager and DP controller read directly without IPC.

- New `LoadSnapshot` flat dataclass + `LoadSnapshotWriter`/`LoadSnapshotReader` using mmap + flock
- Scheduler publishes on every prefill/idle and every N decodes (`--load-snapshot-publish-interval`, default 10)
- DP controller reads shm on dispatch; `DPBudget` skips stale re-reads via timestamp comparison
- Remove `GetLoadsReqInput`/`GetLoadsReqOutput`/`WatchLoadUpdateReq` and `load` field from batch outputs















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26140516948](https://github.com/sgl-project/sglang/actions/runs/26140516948)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26140516911](https://github.com/sgl-project/sglang/actions/runs/26140516911)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->