### PR TITLE
[diffusion] Add index-native VSA forward path

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -286,7 +286,7 @@ def flash_attn_varlen_func_op_lse(
     )
 
 
-from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
+from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (  # noqa: E402
     AttentionBackend,
     AttentionImpl,
     AttentionMetadata,
@@ -381,8 +381,12 @@ class FlashAttentionImpl(AttentionImpl):
         *,
         return_softmax_lse: bool = False,
     ):
-        attn_metadata: FlashAttentionMetadata = get_forward_context().attn_metadata
-        if attn_metadata is not None and attn_metadata.max_seqlen_q is None:
+        attn_metadata = get_forward_context().attn_metadata
+        if (
+            attn_metadata is not None
+            and hasattr(attn_metadata, "max_seqlen_q")
+            and attn_metadata.max_seqlen_q is None
+        ):
             attn_metadata.max_seqlen_q = query.shape[1]
             attn_metadata.max_seqlen_k = key.shape[1]
             max_seqlen_q = attn_metadata.max_seqlen_q

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
@@ -8,9 +8,15 @@ from dataclasses import dataclass
 import torch
 
 try:
-    from vsa import video_sparse_attn
+    from vsa import torch_attention, video_sparse_attn
+
+    from vsa.block_sparse_attn_triton import triton_block_sparse_attn_forward
 except ImportError:
+    torch_attention = None
+    triton_block_sparse_attn_forward = None
     video_sparse_attn = None
+
+from collections.abc import Callable
 
 from typing import Any
 
@@ -121,6 +127,86 @@ def get_non_pad_index(
         < variable_block_sizes[:, None]
     )
     return index_pad[index_mask]
+
+
+def _use_index_native_vsa(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    gate_compress: torch.Tensor | None,
+) -> bool:
+    if torch_attention is None or triton_block_sparse_attn_forward is None:
+        return False
+    if not torch.is_grad_enabled():
+        return True
+    return not any(
+        tensor is not None and tensor.requires_grad
+        for tensor in (query, key, value, gate_compress)
+    )
+
+
+def _video_sparse_attn_index_native(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    variable_block_sizes: torch.Tensor,
+    topk: int,
+    block_size: int | tuple[int, int, int],
+    compress_attn_weight: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if isinstance(block_size, int):
+        block_size = (block_size, block_size, block_size)
+
+    block_elements = math.prod(block_size)
+    assert block_elements == math.prod(VSA_TILE_SIZE)
+    assert q.shape[2] % block_elements == 0
+
+    batch_size, num_heads, seq_len, head_dim = q.shape
+    num_blocks = seq_len // block_elements
+    block_sizes = variable_block_sizes.view(1, 1, -1, 1)
+    q_compress = (
+        q.view(batch_size, num_heads, num_blocks, block_elements, head_dim)
+        .float()
+        .sum(dim=3)
+        / block_sizes
+    ).to(q.dtype)
+    k_compress = (
+        k.view(batch_size, num_heads, num_blocks, block_elements, head_dim)
+        .float()
+        .sum(dim=3)
+        / block_sizes
+    ).to(k.dtype)
+    v_compress = (
+        v.view(batch_size, num_heads, num_blocks, block_elements, head_dim)
+        .float()
+        .sum(dim=3)
+        / block_sizes
+    ).to(v.dtype)
+
+    output_compress, block_attn_score = torch_attention(q_compress, k_compress, v_compress)
+    output_compress = (
+        output_compress.view(batch_size, num_heads, num_blocks, 1, head_dim)
+        .repeat(1, 1, 1, block_elements, 1)
+        .view(batch_size, num_heads, seq_len, head_dim)
+    )
+
+    q2k_idx = torch.topk(block_attn_score, topk, dim=-1).indices.to(torch.int32)
+    q2k_idx = q2k_idx.contiguous()
+    q2k_num = torch.full(
+        q2k_idx.shape[:-1], topk, dtype=torch.int32, device=q2k_idx.device
+    )
+    output_select, _ = triton_block_sparse_attn_forward(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        q2k_idx,
+        q2k_num,
+        variable_block_sizes.to(torch.int32).contiguous(),
+    )
+
+    if compress_attn_weight is not None:
+        return output_compress * compress_attn_weight + output_select
+    return output_compress + output_select
 
 
 class VideoSparseAttentionBackend(AttentionBackend):
@@ -319,7 +405,12 @@ class VideoSparseAttentionImpl(AttentionImpl):
 
         if video_sparse_attn is None:
             raise NotImplementedError("video_sparse_attn is not installed")
-        hidden_states = video_sparse_attn(
+        attn_fn: Callable[..., torch.Tensor]
+        if _use_index_native_vsa(query, key, value, gate_compress):
+            attn_fn = _video_sparse_attn_index_native
+        else:
+            attn_fn = video_sparse_attn
+        hidden_states = attn_fn(
             query,
             key,
             value,

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -624,6 +624,8 @@ class WanTransformerBlock_VSA(nn.Module):
         added_kv_proj_dim: int | None = None,
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         prefix: str = "",
+        attention_type: str = "original",
+        sla_topk: float = 0.1,
         quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
@@ -937,7 +939,7 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             config.out_channels * math.prod(config.patch_size),
             bias=True,
             gather_output=True,
-            prefix=f"proj_out",
+            prefix="proj_out",
             quant_config=quant_config,
         )
         self.scale_shift_table = nn.Parameter(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -226,6 +226,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 "Using one backend for denoising metadata.",
                 sorted(backend.name.lower() for backend in backends),
             )
+        if AttentionBackendEnum.VIDEO_SPARSE_ATTN in backends:
+            return AttentionBackendEnum.VIDEO_SPARSE_ATTN
         return sorted(backends, key=lambda backend: backend.name)[0]
 
     def component_uses(

--- a/python/sglang/multimodal_gen/test/unit/test_video_sparse_attn_index_native.py
+++ b/python/sglang/multimodal_gen/test/unit/test_video_sparse_attn_index_native.py
@@ -1,0 +1,96 @@
+import unittest
+
+import torch
+
+from sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn import (
+    VSA_TILE_SIZE,
+    _use_index_native_vsa,
+    _video_sparse_attn_index_native,
+    torch_attention,
+    triton_block_sparse_attn_forward,
+    video_sparse_attn,
+)
+
+
+HAS_INDEX_NATIVE_VSA = (
+    torch.cuda.is_available()
+    and video_sparse_attn is not None
+    and torch_attention is not None
+    and triton_block_sparse_attn_forward is not None
+)
+
+
+class TestVideoSparseAttentionIndexNative(unittest.TestCase):
+    def test_grad_path_uses_legacy_wrapper(self):
+        query = torch.ones(1, requires_grad=True)
+        with torch.enable_grad():
+            self.assertFalse(_use_index_native_vsa(query, query, query, None))
+
+    @unittest.skipUnless(HAS_INDEX_NATIVE_VSA, "vsa CUDA kernels are unavailable")
+    def test_index_native_matches_legacy_wrapper(self):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        batch_size = 1
+        num_heads = 2
+        num_blocks = 3
+        head_dim = 64
+        block_elements = VSA_TILE_SIZE[0] * VSA_TILE_SIZE[1] * VSA_TILE_SIZE[2]
+        seq_len = num_blocks * block_elements
+
+        query = torch.randn(
+            batch_size, num_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        variable_block_sizes = torch.full(
+            (num_blocks,), block_elements, device=device, dtype=torch.int32
+        )
+
+        with torch.inference_mode():
+            expected = video_sparse_attn(
+                query,
+                key,
+                value,
+                variable_block_sizes=variable_block_sizes,
+                topk=2,
+                block_size=VSA_TILE_SIZE,
+            )
+            actual = _video_sparse_attn_index_native(
+                query,
+                key,
+                value,
+                variable_block_sizes=variable_block_sizes,
+                topk=2,
+                block_size=VSA_TILE_SIZE,
+            )
+
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+    @unittest.skipUnless(HAS_INDEX_NATIVE_VSA, "vsa CUDA kernels are unavailable")
+    def test_index_native_matches_legacy_wrapper_with_compress_weight(self):
+        torch.manual_seed(1)
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        block_elements = VSA_TILE_SIZE[0] * VSA_TILE_SIZE[1] * VSA_TILE_SIZE[2]
+        query = torch.randn(1, 2, block_elements * 2, 64, device=device, dtype=dtype)
+        key = torch.randn_like(query)
+        value = torch.randn_like(query)
+        compress_weight = torch.rand_like(query)
+        variable_block_sizes = torch.full(
+            (2,), block_elements, device=device, dtype=torch.int32
+        )
+
+        with torch.inference_mode():
+            expected = video_sparse_attn(
+                query, key, value, variable_block_sizes, 1, VSA_TILE_SIZE, compress_weight
+            )
+            actual = _video_sparse_attn_index_native(
+                query, key, value, variable_block_sizes, 1, VSA_TILE_SIZE, compress_weight
+            )
+
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR ports the index-native Video Sparse Attention path from FastVideo PR hao-ai-lab/FastVideo#1243. The old wrapper converts `topk_indices` to a dense boolean block mask and maps that mask back to sparse indices before launching the block-sparse attention kernel. The new path keeps the `topk` result as `q2k_idx` and passes it directly to `triton_block_sparse_attn_forward`, removing the mask round trip.

## Modifications

- Add an index-native VSA forward path that builds `q2k_idx` and `q2k_num` directly from block attention scores.
- Keep the legacy `video_sparse_attn` wrapper for grad-enabled paths and missing VSA Triton dependencies.
- Fix Wan VSA construction for generic Wan block kwargs used by current configs.
- Prefer VSA metadata when Wan blocks contain both VSA self-attn and FA cross-attn, and let FA use q/k lengths when the global metadata belongs to VSA.
- Add unit coverage for index-native dispatch, legacy fallback, and parity with the legacy wrapper.

## Accuracy Tests

Generated on `ion-b200` GPU 1 with `FastVideo/FastWan2.1-T2V-1.3B-Diffusers`, `video_sparse_attn`, `VSA_sparsity=0.8`, `832x480`, 61 frames, 3 denoise steps, `seed=42`, no torch compile.

Prompt: `A red vintage car driving down a sunny coastal road, cinematic motion.`

<table>
  <thead>
    <tr>
      <th>Variant</th>
      <th>Metrics JSON</th>
      <th>Rendered GIF Preview</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>legacy bool-mask VSA wrapper + compatibility fixes</td>
      <td><code>outputs/diffusion_benchmarks/vsa_index_legacy/fastwan_vsa_legacy_no_compile.json</code></td>
      <td><img width="300" alt="legacy VSA" src="https://github.com/BBuf/sglang/releases/download/diffusion-fastvideo-port-validation-20260520/vsa-legacy.gif"></td>
    </tr>
    <tr>
      <td>this PR</td>
      <td><code>outputs/diffusion_benchmarks/vsa_index_branch/fastwan_vsa_index_no_compile.json</code></td>
      <td><img width="300" alt="index-native VSA" src="https://github.com/BBuf/sglang/releases/download/diffusion-fastvideo-port-validation-20260520/vsa-pr.gif"></td>
    </tr>
  </tbody>
</table>

The GIF previews are downsampled from the generated MP4 outputs. The `--enable-torch-compile` variant is not used here because the current VSA Triton sparse kernel hits a TorchInductor compile-time assertion on B200 before denoising starts.

## Speed Tests and Profiling

Command:

```bash
CUDA_VISIBLE_DEVICES=1 \
sglang generate \
  --model-path FastVideo/FastWan2.1-T2V-1.3B-Diffusers \
  --prompt 'A red vintage car driving down a sunny coastal road, cinematic motion.' \
  --seed=42 \
  --width=832 \
  --height=480 \
  --num-frames=61 \
  --attention-backend video_sparse_attn \
  --attention-backend-config VSA_sparsity=0.8 \
  --save-output \
  --warmup \
  --master-port=30107 \
  --scheduler-port=5691 \
  --perf-dump-path outputs/diffusion_benchmarks/vsa_index_branch/fastwan_vsa_index_no_compile.json
```

Comparison command:

```bash
python python/sglang/multimodal_gen/benchmarks/compare_perf.py \
  outputs/diffusion_benchmarks/vsa_index_legacy/fastwan_vsa_legacy_no_compile.json \
  outputs/diffusion_benchmarks/vsa_index_branch/fastwan_vsa_index_no_compile.json
```

| Metric | legacy wrapper | this PR | Diff |
| :--- | ---: | ---: | ---: |
| Warmed request E2E | 2414.21 ms | 2399.13 ms | -15.08 ms (-0.6%) |
| DmdDenoisingStage | 574.93 ms | 556.90 ms | -18.03 ms (-3.1%) |
| DecodingStage | 1025.60 ms | 1029.31 ms | +3.71 ms (+0.4%) |
| Peak memory | 20172 MB | 20172 MB | 0 MB |

B200 microbench for the VSA kernel path, bf16, `H=16`, `D=128`:

| Seq | topk | legacy wrapper | index-native | Diff |
| ---: | ---: | ---: | ---: | ---: |
| 4096 | 4 | 0.3096 ms | 0.2347 ms | -24.2% |
| 4096 | 8 | 0.3081 ms | 0.2521 ms | -18.2% |
| 8192 | 4 | 0.4069 ms | 0.3717 ms | -8.7% |
| 8192 | 8 | 0.4436 ms | 0.4100 ms | -7.6% |
| 16384 | 4 | 0.7826 ms | 0.7035 ms | -10.1% |
| 16384 | 8 | 0.8553 ms | 0.7765 ms | -9.2% |

Tests:

- `CUDA_VISIBLE_DEVICES=1 python -m pytest -q python/sglang/multimodal_gen/test/unit/test_video_sparse_attn_index_native.py` (`3 passed`)
- `uvx ruff check python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py python/sglang/multimodal_gen/test/unit/test_video_sparse_attn_index_native.py`
- B200 FastWan native diffusion validation above

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26143859059](https://github.com/sgl-project/sglang/actions/runs/26143859059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26143858953](https://github.com/sgl-project/sglang/actions/runs/26143858953)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->