### PR TITLE
[MoE] Default-on CUDA-graph pad-token mask for fused_moe_triton path

### DIFF
--- a/python/sglang/jit_kernel/dsv4/moe.py
+++ b/python/sglang/jit_kernel/dsv4/moe.py
@@ -9,6 +9,7 @@ from sglang.jit_kernel.utils import (
     load_jit,
     make_cpp_args,
 )
+from sglang.srt.utils.custom_op import register_custom_op
 
 from .utils import make_name
 
@@ -102,8 +103,9 @@ def _jit_silu_and_mul_clamp_module(dtype: torch.dtype):
     )
 
 
-def mask_topk_ids(topk_ids: torch.Tensor, num_token_non_padded: torch.Tensor):
-    return _jit_mask_topk_module().run(topk_ids, num_token_non_padded)
+@register_custom_op(mutates_args=["topk_ids"])
+def mask_topk_ids(topk_ids: torch.Tensor, num_token_non_padded: torch.Tensor) -> None:
+    _jit_mask_topk_module().run(topk_ids, num_token_non_padded)
 
 
 def hash_topk(

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -246,6 +246,10 @@ class FusedMoE(torch.nn.Module):
             hidden_size = round_up(hidden_size, 256)
         self.hidden_size = hidden_size
 
+        from sglang.srt.model_executor.forward_batch_info import (
+            enable_num_token_non_padded,
+        )
+
         self.moe_runner_config = MoeRunnerConfig(
             num_experts=num_experts,
             num_local_experts=self.num_local_experts,
@@ -265,6 +269,9 @@ class FusedMoE(torch.nn.Module):
             swiglu_limit=swiglu_limit,
             is_gated=is_gated,
             routing_method_type=routing_method_type,
+            # Quantized kernels can't skip -1 sentinels; only enable for unquantized.
+            enable_pad_token_mask=enable_num_token_non_padded()
+            and quant_config is None,
         )
 
         self.quant_method: Optional[FusedMoEMethodBase] = None

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -66,6 +66,8 @@ class MoeRunnerConfig:
     gemm1_clamp_limit: Optional[float] = None
     swiglu_limit: Optional[float] = None
 
+    enable_pad_token_mask: bool = False
+
 
 @dataclass
 class RunnerInput(ABC):

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -237,9 +237,11 @@ def fused_experts(
     block_shape: Optional[List[int]] = None,
 ):
     topk_weights, topk_ids, _ = topk_output
+    # Kernel skips sentinel (-1) blocks; needed for EP filtering and pad mask.
     filter_expert = (
         moe_runner_config.num_experts is None
         or moe_runner_config.num_experts != moe_runner_config.num_local_experts
+        or moe_runner_config.enable_pad_token_mask
     )
     if moe_runner_config.inplace:
         assert not moe_runner_config.no_combine, "no combine + inplace makes no sense"

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1061,7 +1061,8 @@ def _mask_topk_ids_padded_region(
         mask_topk_ids(topk_ids, num_token_non_padded)
     else:
         indices = torch.arange(0, topk_ids.shape[0], device=topk_ids.device)
-        topk_ids[indices >= num_token_non_padded, :] = -1
+        mask = (indices >= num_token_non_padded).unsqueeze(-1)
+        topk_ids.masked_fill_(mask, -1)
 
 
 @torch.compile(dynamic=True, backend=get_compiler_backend())

--- a/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
+++ b/python/sglang/srt/model_executor/cuda_graph_buffer_registry.py
@@ -760,6 +760,7 @@ def build_prefill_registry(
     hidden_size: int = 0,
     embed_dtype: Optional[torch.dtype] = None,
     enable_mamba_track: bool = False,
+    enable_num_token_non_padded: bool = False,
     share_pool: bool = True,
     source: Optional[Any] = None,
 ) -> CudaGraphBufferRegistry:
@@ -842,6 +843,25 @@ def build_prefill_registry(
         slots.append(GraphSlot("mamba_track_indices", _bs, torch.int64, axis="bs"))
         slots.append(GraphSlot("mamba_track_mask", _bs, torch.bool, axis="bs"))
         slots.append(GraphSlot("mamba_track_seqlens", _bs, torch.int32, axis="bs"))
+
+    if enable_num_token_non_padded:
+
+        def _num_token_non_padded_post_fill(buf, fb, ctx):
+            if fb.num_token_non_padded is not None:
+                buf.copy_(fb.num_token_non_padded.view(1))
+            else:
+                buf.fill_(ctx.raw_num_tokens)
+
+        slots.append(
+            GraphSlot(
+                "num_token_non_padded",
+                lambda _bs2, _mt: (1,),
+                torch.int32,
+                axis="none",
+                copy_from_fb=False,
+                post_fill=_num_token_non_padded_post_fill,
+            )
+        )
 
     for slot in slots:
         bind = None

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1331,7 +1331,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
 
 def enable_num_token_non_padded():
-    return get_moe_expert_parallel_world_size() > 1
+    return get_moe_expert_parallel_world_size() > 1 or (
+        not get_global_server_args().disable_cuda_graph
+        and not get_global_server_args().enable_dp_attention
+    )
 
 
 def build_inner_fb_view(

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -57,6 +57,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
     PPProxyTensors,
+    enable_num_token_non_padded,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.utils import (
@@ -241,6 +242,7 @@ class PiecewiseCudaGraphRunner:
             hidden_size=self.model_runner.model_config.hidden_size,
             embed_dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
+            enable_num_token_non_padded=enable_num_token_non_padded(),
             share_pool=not is_npu(),
             source=None,
         )
@@ -367,7 +369,11 @@ class PiecewiseCudaGraphRunner:
                 spec_algorithm=None,
                 spec_info=None,
                 capture_hidden_mode=CaptureHiddenMode.NULL,
-                num_token_non_padded=None,
+                num_token_non_padded=(
+                    _slot("num_token_non_padded")
+                    if registry.has_slot("num_token_non_padded")
+                    else None
+                ),
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
                 lora_ids=None,
@@ -538,7 +544,11 @@ class PiecewiseCudaGraphRunner:
                 spec_algorithm=None,
                 spec_info=None,
                 capture_hidden_mode=CaptureHiddenMode.NULL,
-                num_token_non_padded=None,
+                num_token_non_padded=(
+                    _slot("num_token_non_padded")
+                    if registry.has_slot("num_token_non_padded")
+                    else None
+                ),
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
                 lora_ids=None,
@@ -699,7 +709,11 @@ class PiecewiseCudaGraphRunner:
             spec_algorithm=forward_batch.spec_algorithm,
             spec_info=forward_batch.spec_info,
             capture_hidden_mode=forward_batch.capture_hidden_mode,
-            num_token_non_padded=forward_batch.num_token_non_padded,
+            num_token_non_padded=(
+                _slot("num_token_non_padded")
+                if registry.has_slot("num_token_non_padded")
+                else None
+            ),
             num_token_non_padded_cpu=forward_batch.num_token_non_padded_cpu,
             global_forward_mode=pcg_global_forward_mode,
             lora_ids=forward_batch.lora_ids,

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -47,7 +47,10 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    PPProxyTensors,
+)
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
 
@@ -105,13 +108,28 @@ class MixtralMoE(nn.Module):
             prefix=add_prefix("experts", prefix),
         )
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        self._enable_pad_token_mask: bool = bool(
+            self.experts.moe_runner_config.enable_pad_token_mask
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: Optional[ForwardBatch] = None,
+    ) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
         orig_shape = hidden_states.shape
         hidden_states = hidden_states.view(-1, self.hidden_size)
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        topk_output = self.topk(hidden_states, router_logits)
+        num_token_non_padded = None
+        if forward_batch is not None and self._enable_pad_token_mask:
+            num_token_non_padded = forward_batch.num_token_non_padded
+        topk_output = self.topk(
+            hidden_states,
+            router_logits,
+            num_token_non_padded=num_token_non_padded,
+        )
         final_hidden_states = self.experts(hidden_states, topk_output)
         if self.tp_size > 1:
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
@@ -256,7 +274,7 @@ class MixtralDecoderLayer(nn.Module):
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.block_sparse_moe(hidden_states)
+        hidden_states = self.block_sparse_moe(hidden_states, forward_batch)
         return hidden_states, residual
 
 

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -69,7 +69,10 @@ from sglang.srt.layers.utils.cp_utils import (
     prepare_context_parallel_metadata,
 )
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    PPProxyTensors,
+)
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2_moe import Qwen2MoeMLP as Qwen3MoeMLP
 from sglang.srt.models.qwen2_moe import Qwen2MoeModel
@@ -289,6 +292,10 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             )
             self.top_k = config.num_experts_per_tok
 
+        self._enable_pad_token_mask: bool = bool(
+            self.experts.moe_runner_config.enable_pad_token_mask
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -302,7 +309,10 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             and not get_moe_a2a_backend().is_ascend_fuseep()
         ):
             return self.forward_normal(
-                hidden_states, should_allreduce_fusion, use_reduce_scatter
+                hidden_states,
+                forward_batch,
+                should_allreduce_fusion,
+                use_reduce_scatter,
             )
         else:
             return self.forward_deepep(hidden_states, forward_batch)
@@ -320,6 +330,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
     def forward_normal(
         self,
         hidden_states: torch.Tensor,
+        forward_batch: Optional[ForwardBatch] = None,
         should_allreduce_fusion: bool = False,
         use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
@@ -328,7 +339,14 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        topk_output = self.topk(hidden_states, router_logits)
+        num_token_non_padded = None
+        if forward_batch is not None and self._enable_pad_token_mask:
+            num_token_non_padded = forward_batch.num_token_non_padded
+        topk_output = self.topk(
+            hidden_states,
+            router_logits,
+            num_token_non_padded=num_token_non_padded,
+        )
         final_hidden_states = self.experts(hidden_states, topk_output)
 
         if self.ep_size > 1 and not should_skip_post_experts_all_reduce(


### PR DESCRIPTION
## Motivation

In the default (TP-only) `fused_moe_triton` path, CUDA-graph padded tokens go through the full router and activate extra experts they shouldn't, which adds wasted expert-weight loads per decode step at low real batch sizes. The DeepEP/EP path already mitigates this via `num_token_non_padded` (see `topk._mask_topk_ids_padded_region`); this PR wires the same mechanism into the default path and makes it on by default.

When the running batch sits above a captured-bs cliff (e.g. real BS=5 padded to captured BS=8), the masking sets the 3 padded rows' `topk_ids = -1` (the sentinel slot reserved by `sgl_moe_align_block_size`) and the Triton fused-MoE kernel skips those blocks. The optimization is fully PCG-compatible: `num_token_non_padded` is maintained in a persistent buffer inside `PrefillInputBuffers` so the captured PCG cudagraph reads a stable tensor identity across replays, and the value is refreshed each step via `copy_/fill_` in `replay_prepare`.

Key changes: `enable_num_token_non_padded` now returns True when EP > 1 or decode CUDA graph is on (so the default path also populates the field); `MoeRunnerConfig.enable_pad_token_mask` forces the Triton kernel's `filter_expert` branch on so it safely skips blocks routed to `expert_id == -1`; `qwen3_moe.Qwen3MoeSparseMoeBlock` and `mixtral.MixtralMoE` plumb `forward_batch` into the MoE forward and pass `num_token_non_padded` to TopK; `_mask_topk_ids_padded_region` uses `masked_fill_` instead of boolean fancy indexing for a static output shape; and `PiecewiseCudaGraphRunner.PrefillInputBuffers` gains a persistent `num_token_non_padded` buffer refreshed in `replay_prepare`.

## Accuracy Tests

H200, TP=1, default sglang config (decode CUDA graph and PCG both on, no flags). Throughput/latency workload: `bench_serving --dataset-name random-ids`, input_len=128, output_len=512, 60 prompts, concurrency=5, `ignore_eos`; numbers are the mean of 2 fresh-restart runs per cell. GSM8K is 200 questions (5-shot), `--parallel 5`.

### Qwen3-30B-A3B

| Config | Decode tok/s | TTFT p50 | TPOT p50 | GSM8K |
|---|---:|---:|---:|---:|
| Baseline | 705.3 | 45.4 ms | 7.10 ms | 0.920 |
| This PR | **758.1** | **41.3 ms** | **6.60 ms** | 0.920 |
| Δ | **+7.5%** | -9.0% | **-7.0%** | parity |

### Mixtral-8x7B-v0.1

| Config | Decode tok/s | TTFT p50 | TPOT p50 | GSM8K |
|---|---:|---:|---:|---:|
| Baseline | 284.5 | 60.6 ms | 17.22 ms | 0.600 |
| This PR | **308.0** | **58.7 ms** | **15.75 ms** | 0.600 |
| Δ | **+8.3%** | -3.1% | **-8.5%** | exact match |

### Launch

```bash
python -m sglang.launch_server \
    --model-path /path/to/Qwen3-30B-A3B \
    --port 30000 --tp 1 --random-seed 0
```

Equivalently for `mistralai/Mixtral-8x7B-v0.1`. No special flag required — the optimization is on by default.

### Bench

```bash
# Decode throughput / TTFT / TPOT
python -m sglang.bench_serving \
    --backend sglang --host 127.0.0.1 --port 30000 \
    --tokenizer /path/to/model \
    --dataset-name random-ids --num-prompts 60 --max-concurrency 5 \
    --random-input-len 128 --random-output-len 512 --random-range-ratio 1 --seed 0

# Accuracy
python benchmark/gsm8k/bench_sglang.py \
    --data-path /path/to/gsm8k/test.jsonl \
    --num-questions 200 --parallel 5 \
    --host 127.0.0.1 --port 30000
```






































































































































































































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27000497850](https://github.com/sgl-project/sglang/actions/runs/27000497850)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27000497720](https://github.com/sgl-project/sglang/actions/runs/27000497720)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->