### PR TITLE
[Disagg] Support fake prefill disaggregation backend

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -615,7 +615,6 @@ class SchedulerDisaggregationPrefillMixin:
         undone_reqs: List[Req] = []
         # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-
             if rids_to_check is not None:
                 if req.rid not in rids_to_check:
                     undone_reqs.append(req)
@@ -804,8 +803,9 @@ class SchedulerDisaggregationPrefillMixin:
 
             def _swa_payload():
                 window_size = self.sliding_window_size
+                state_page_size = getattr(self.token_to_kv_pool_allocator.get_kvcache(), "swa_page_size", page_size)
                 window_start = max(0, seq_len - window_size)
-                window_start = (window_start // page_size) * page_size
+                window_start = (window_start // state_page_size) * state_page_size
                 window_kv_indices_full = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, window_start:seq_len
                 ]
@@ -815,7 +815,7 @@ class SchedulerDisaggregationPrefillMixin:
                     )
                 )
                 return kv_to_page_indices(
-                    window_kv_indices_swa.cpu().numpy(), page_size
+                    window_kv_indices_swa.cpu().numpy(), state_page_size
                 )
 
             def _nsa_payload():

--- a/python/sglang/srt/managers/disagg_service.py
+++ b/python/sglang/srt/managers/disagg_service.py
@@ -19,6 +19,9 @@ def start_disagg_service(
     transfer_backend = TransferBackend(server_args.disaggregation_transfer_backend)
 
     if disagg_mode == DisaggregationMode.PREFILL:
+        if transfer_backend == TransferBackend.FAKE:
+            return None
+
         # only start bootstrap server on prefill tm
         kv_bootstrap_server_class = get_kv_class(
             transfer_backend, KVClassType.BOOTSTRAP_SERVER

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -44,7 +44,7 @@ def page_align_floor(length: int, page_size: int) -> int:
 
 
 def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
-    if getattr(req, "skip_radix_cache_insert", False):
+    if getattr(req, "skip_radix_cache_insert", False) and not kwargs.get("chunked", False):
         return
 
     tree_cache.cache_unfinished_req(req, **kwargs)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3695,9 +3695,6 @@ class ServerArgs:
                     self.mamba_scheduler_strategy = "no_buffer"
 
         elif self.disaggregation_mode == "prefill":
-            assert (
-                self.disaggregation_transfer_backend != "fake"
-            ), "Prefill server does not support 'fake' as the transfer backend"
 
             if self.disable_piecewise_cuda_graph:
                 self.disable_cuda_graph = True


### PR DESCRIPTION
# [Disagg] Support fake transfer backend for prefill benchmarking

## Motivation

This PR enables fake disaggregation prefill benchmarking for a standalone prefill server.

When serving DeepSeek-V4-Pro with prefill disaggregation and the fake transfer backend:

```bash
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256 sglang serve \
  --trust-remote-code \
  --model-path DeepSeek-V4-Pro \
  --tp 8 --dp 8 --enable-dp-attention \
  --moe-a2a-backend deepep \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend fake \
  --disaggregation-ib-device mlx5_7 \
  --dist-init-addr 127.0.0.1:30435 \
  --max-running-requests 256 \
  --mem-fraction-static 0.85 \
  --host 0.0.0.0 --port 30001
```

and benchmarking it by sending concurrent fake-bootstrap `/generate` requests:

```bash
curl -N -X POST http://127.0.0.1:30001/generate \
  -H 'Content-Type: application/json' \
  -d '{
    "text": "<32k-token prompt>",
    "sampling_params": {
      "temperature": 0,
      "min_new_tokens": 1000,
      "max_new_tokens": 1000,
      "ignore_eos": false
    },
    "stream": true,
    "bootstrap_host": "2.2.2.2",
    "bootstrap_port": 30201,
    "bootstrap_room": 1,
    "id": "fake-prefill-req-0"
  }'
```

there were three issues:

1. The prefill server failed during argument handling:

```text
AssertionError: Prefill server does not support 'fake' as the transfer backend
```

2. After allowing the argument combination, startup still failed because the fake backend does not provide a real `KVClassType.BOOTSTRAP_SERVER`, while prefill mode always tried to create one.

3. After startup, long prompts such as 32k tokens could hang during chunked prefill. Logs showed the same chunk being processed repeatedly and empty / regressed KV send ranges, for example:

```text
fake-prefill send_kv_chunk: start=2048 end=2048 num_pages=0
send_kv_chunk skip: start_send_idx=2048 end_idx=1280
```

## Root Cause

A fake-bootstrap request sets `bootstrap_host = FAKE_BOOTSTRAP_HOST`, which makes SGLang set:

```python
req.skip_radix_cache_insert = True
```

This is correct for fake benchmark requests because they should not pollute the normal radix / prefix cache.

However, chunked prefill also relies on unfinished-request cache entries to carry progress from one chunk to the next. Before this PR, `maybe_cache_unfinished_req()` skipped all requests with `skip_radix_cache_insert=True`, including calls with `chunked=True`.

As a result, a 32k prompt could prefill the first 2048-token chunk, but the next scheduling round could not match the unfinished prefix. The scheduler then treated the request as if no prefix had been computed and repeatedly scheduled the first chunk, while the fake KV sender had already advanced `start_send_idx`.

For hybrid SWA models such as DeepSeek-V4-Pro, the SWA state payload also needs to use the SWA cache page size. Reusing the normal KV `page_size` can misalign the SWA window and produce incorrect state page indices.

## Modifications

**`python/sglang/srt/server_args.py`**
- Allow `--disaggregation-mode prefill --disaggregation-transfer-backend fake` by removing the prefill-side fake backend assertion.

**`python/sglang/srt/managers/disagg_service.py`**
- Skip bootstrap server creation for `DisaggregationMode.PREFILL` + `TransferBackend.FAKE`.
- Real backends still create their bootstrap server as before.

**`python/sglang/srt/mem_cache/common.py`**
- Keep skipping normal cache insertion for fake-bootstrap requests.
- Allow `maybe_cache_unfinished_req(..., chunked=True)` so chunked prefill can record intermediate progress and advance across chunks.

**`python/sglang/srt/disaggregation/prefill.py`**
- Use `kvcache.swa_page_size` when building SWA state payloads, falling back to the normal `page_size` when unavailable.

## Tests

The server starts successfully and prints that it is ready. A benchmark with 16 concurrent 32k-token fake-bootstrap prefill requests completes instead of hanging:

```text
16 requests succeed, 0 requests failed
Total Time:        23.2187
Input Tokens:      512000
Avg Input:         32000
Generated Tokens:  16
Num Requests:      16
Num Succeed:       16
Num Failed:        0
Input Throughput:  22051.1667
Qps:               0.6891
Median Ttft:       4.6823
Mean Ttft:         5.0493
Std Ttft:          1.3083
Percentiles Ttft:  [(80.0, 6.163), (99.0, 8.028)]
```

Debug logs also confirm that fake prefill KV send ranges advance normally across chunks:

```text
start=0     end=2048
start=2048  end=4096
start=4096  end=6144
...
start=30720 end=32000 last=True
```

## Checklist

- [x] Verified prefill server startup with fake transfer backend.
- [x] Verified 32k fake-bootstrap chunked prefill requests complete successfully.
- [x] Verified the fix keeps fake requests from inserting normal radix cache entries.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26146868586](https://github.com/sgl-project/sglang/actions/runs/26146868586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26146868376](https://github.com/sgl-project/sglang/actions/runs/26146868376)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->