### PR TITLE
[DSA] Make MQA logits free memory ratio configurable

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -474,6 +474,7 @@ class Envs:
     SGLANG_DSA_HIP_DISABLE_PRESHUFFLE = EnvBoolWithAlias(
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
+    SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
     SGLANG_USE_FUSED_METADATA_COPY = EnvBool(True)
 
     # sgl-kernel

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -178,9 +178,12 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
 class Indexer(MultiPlatformOp):
     _MQA_LOGITS_BYTES_PER_ELEM = 4
     _MQA_LOGITS_STATIC_SKIP_ELEMS = 8_000_000
-    _MQA_LOGITS_FREE_MEM_FRACTION = 0.5
     _MQA_LOGITS_TOTAL_MEM_FRACTION = 0.3
     _mqa_logits_budget_bytes: Dict[int, int] = {}
+
+    @staticmethod
+    def _mqa_logits_free_mem_fraction() -> float:
+        return envs.SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION.get()
 
     def __init__(
         self,
@@ -559,6 +562,7 @@ class Indexer(MultiPlatformOp):
         return topk_result
 
     def _get_mqa_logits_budget_bytes(self, device_index: int) -> int:
+        free_mem_fraction = self._mqa_logits_free_mem_fraction()
         cached_budget = self._mqa_logits_budget_bytes.get(device_index)
         if cached_budget is not None:
             return cached_budget
@@ -572,7 +576,7 @@ class Indexer(MultiPlatformOp):
         else:
             static_free_mem = int(total_mem * max(0.0, 1.0 - mem_fraction_static))
             static_budget = min(
-                int(static_free_mem * self._MQA_LOGITS_FREE_MEM_FRACTION),
+                int(static_free_mem * free_mem_fraction),
                 total_mem_budget,
             )
         static_budget = max(1, static_budget)
@@ -587,9 +591,7 @@ class Indexer(MultiPlatformOp):
         # torch.cuda.mem_get_info synchronizes the host, so cache the result,
         # capped by the workload-independent serving-memory headroom.
         free_mem, _ = torch.cuda.mem_get_info(device_index)
-        budget_bytes = min(
-            int(free_mem * self._MQA_LOGITS_FREE_MEM_FRACTION), static_budget
-        )
+        budget_bytes = min(int(free_mem * free_mem_fraction), static_budget)
 
         budget_bytes = max(1, budget_bytes)
         self._mqa_logits_budget_bytes[device_index] = budget_bytes


### PR DESCRIPTION
## Motivation

The cached DSA MQA logits budget can be too loose on memory-tight H200 runs. Make the free-memory fraction configurable and use a more conservative default so the logits path chunks earlier instead of relying on a stale cached budget.

## Modifications

- Rebase on the NSA to DSA rename and move the change to `dsa_indexer.py`.
- Add `SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION` with default `0.2`.
- Fetch the env value inside the budget helper instead of freezing it at import time.
- Use this env value for the MQA logits free-memory budget instead of the previous hardcoded `0.5`.

## Accuracy Tests

Manual H200 stress run, intended to reproduce the core workload from the optional CI failure in `TestDeepseekV32IndexTopkPattern.test_a_gsm8k`.

Setup matched with CI:

- Hardware: H200 8-GPU node.
- Model: DeepSeek-V3.2, TP8.
- Args: `--trust-remote-code`, `--tp 8`, `--enable-dp-attention`, and the same `index_topk_pattern` override used by the CI test.
- Effective `enable_dp_attention=False`, because `dp_size=1`; this matches the CI log behavior.
- Eval shape: GSM8K with `num_questions=1400`, `parallel=1400`, `max_new_tokens=512`.
- Patch env: `SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION=0.2`.

Differences from CI harness:

- This was run as a manual server + eval stress test, not through the pytest harness.
- The model was loaded from a mounted local DeepSeek-V3.2 checkpoint instead of the HF id.
- I did not keep CI's `model-loader-extra-config={"enable_multithread_load": true, "num_threads": 64}` because that loader setup hung during weight-loading finalization on this shared filesystem. This should only affect startup/loading, not the serving/eval path being validated.
- This H200 node required `NCCL_P2P_DISABLE=1` for stable NCCL initialization.

Result:

- Accuracy: `0.956`
- Invalid: `0.000`
- Latency: `130.721 s`
- Output throughput: `981.223 token/s`
- Server log check: `out of memory` / `fp8_mqa_logits` / traceback count = `0`
- Stress evidence: capture finished with about `12.99 GB` available GPU memory, and the eval reached `#running-req` around `1200+` during the high-concurrency prefill burst without OOM.

## Speed Tests and Profiling

Not a speed optimization. This changes the default safety headroom for the cached MQA logits budget.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26150384190](https://github.com/sgl-project/sglang/actions/runs/26150384190)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26150384188](https://github.com/sgl-project/sglang/actions/runs/26150384188)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->