### PR TITLE
pr-test: schedule 3x -> 2x; fix extra gate skipped on schedule

### DIFF
--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -117,7 +117,7 @@ jobs:
     needs: [check-changes, call-gate]
     if: |
       needs.check-changes.result == 'success' &&
-      needs.call-gate.result == 'success' &&
+      (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') &&
       needs.check-changes.outputs.sgl_kernel == 'true'
     uses: ./.github/workflows/_pr-test-sgl-kernel-build.yml
     with:
@@ -130,7 +130,7 @@ jobs:
   # =============================================== extra-a (1-/2-gpu) ===============================================
   extra-a-test-1-gpu-small:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-a-test-1-gpu-small
@@ -143,7 +143,7 @@ jobs:
 
   extra-a-test-1-gpu-large:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-a-test-1-gpu-large
@@ -157,7 +157,7 @@ jobs:
 
   extra-a-test-2-gpu-large:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-a-test-2-gpu-large
@@ -171,7 +171,7 @@ jobs:
   # =============================================== extra-b (4-/8-gpu) ===============================================
   extra-b-test-4-gpu-h100:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-4-gpu-h100
@@ -184,7 +184,7 @@ jobs:
 
   extra-b-test-4-gpu-b200:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-4-gpu-b200
@@ -198,7 +198,7 @@ jobs:
 
   extra-b-test-8-gpu-h200:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-8-gpu-h200
@@ -211,7 +211,7 @@ jobs:
 
   extra-b-test-deepep-8-gpu-h200:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && needs.call-gate.result == 'success' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-deepep-8-gpu-h200

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,7 +9,7 @@ run-name: >-
 
 on:
   schedule:
-    - cron: '0 1,9,17 * * *'  # Run 3x daily: 2am / 10am / 6pm Pacific (PDT)
+    - cron: '0 11,23 * * *'  # Run 2x daily, 12h apart, off PR-push peaks
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
Two related changes to the scheduled CI cadence.

## 1. Reduce schedule frequency from 3x/day to 2x/day

Last 30 scheduled runs of \`pr-test.yml\`:

| Metric | Value |
|---|---|
| \`cancelled\` | 9 / 30 (30%) |
| Required retry (\`attempt > 1\`) | 10 / 30 (33%) |
| Median runtime | ~6h |
| Current cadence | 8h |

Cadence (8h) is barely above runtime (~6h, often pushed past by GHA scheduling delay + GPU queue), so each new scheduled run lands while the previous one is still mid-execution. \`concurrency.cancel-in-progress: true\` then kills the prior run, wasting GPU runner time and forcing retries.

Between two adjacent 8h slots \`main\` typically accumulates only a handful of commits — three runs/day end up largely re-validating the same code while consuming a full fresh GPU runner suite each time.

PR push activity by hour (last ~1000 PR runs, UTC):

| Hour | PR runs/h | Slot |
|---|---|---|
| 01 | **82** | current |
| 09 | 65 | current |
| 17 | 20 | current |
| 11 | 20 | **new** |
| 23 | 28 | **new** |

New cron \`0 11,23 * * *\`:
- 12h cadence comfortably exceeds runtime → 0 overlap, 0 cancel-induced waste
- Both slots land in low PR-push hours → minimizes contention with developer pushes
- ~33% fewer scheduled GPU runner hours, plus elimination of retry/cancel waste

## 2. Fix: \`pr-test-extra.yml\` whole suite skipped on schedule path

Introduced by #25465: \`call-gate\` is intentionally skipped on \`schedule\` (no PR context for label check), but downstream test jobs gate on \`needs.call-gate.result == 'success'\`, treating \`skipped\` as failure and skipping the entire extra suite.

Example: https://github.com/sgl-project/sglang/actions/runs/26136273640

Fix: relax downstream \`if\` to \`(success || skipped)\` in all extra stage jobs and \`sgl-kernel-build-wheels\`. \`!failure() && !cancelled()\` still blocks the PR-path gate-failure case.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26158094311](https://github.com/sgl-project/sglang/actions/runs/26158094311)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26158094235](https://github.com/sgl-project/sglang/actions/runs/26158094235)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->