### PR TITLE
amd/deepseek_v4 29/N Optimize Triton sparse MLA kernel dispatch for prefill, from separate gather+attention path to 1 fused kernel

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_fused.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_fused.py
@@ -1206,6 +1206,10 @@ def _prune_splitk_configs(configs, named_args, **kwargs):
         triton.Config({"BLOCK_H": 64, "BLOCK_N": 128}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 128, "BLOCK_N": 64}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_H": 128, "BLOCK_N": 128}, num_warps=4, num_stages=1),
+        # BLOCK_H=32: critical for cc=32 with h_q=128 (gives 256 blocks with split_k=2)
+        triton.Config({"BLOCK_H": 32, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 32, "BLOCK_N": 128}, num_warps=4, num_stages=1),
+
     ],
     key=["total_tokens_bucket", "h_q", "topk_per_split"],
     prune_configs_by={"early_config_prune": _prune_splitk_configs},
@@ -1588,6 +1592,7 @@ def fused_gather_attn_decode_dsv4_dual_scope(
     topk_length_extra: Optional[torch.Tensor] = None,
     attn_sink: Optional[torch.Tensor] = None,
     s_q: int = 1,
+    force_no_splitk: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Fused gather+dequant+attention for DSV4 with dual scope (main + extra).
@@ -1606,6 +1611,9 @@ def fused_gather_attn_decode_dsv4_dual_scope(
         topk_length_extra: Optional per-batch topk length for extra [b]
         attn_sink: Optional attention sink values [h_q]
         s_q: Sequence length per batch
+        force_no_splitk: If True, skip split-K and use the non-splitk kernel
+            directly. Used by the dispatch layer for large batch prefill where
+            the non-splitk fused kernel avoids intermediate buffer allocation.
 
     Returns:
         output: Attention output [total_tokens, h_q, d_v]
@@ -1645,6 +1653,10 @@ def fused_gather_attn_decode_dsv4_dual_scope(
         or kv_cache_size_extra > BUFFER_OPS_DISABLE_THRESHOLD
     )
 
+    # When force_no_splitk is set, skip the split-K decision and fall
+    # through to the non-splitk kernel path below.
+    use_splitk = not force_no_splitk
+
     # Use Split-K for dual scope in these cases:
     # 1. Small batch sizes with h_q=128 or large topk to increase GPU parallelism
     # 2. Large topk (>= 2048) with medium/large batch sizes
@@ -1663,7 +1675,7 @@ def fused_gather_attn_decode_dsv4_dual_scope(
     # For h_q > 64 (e.g. h_q=128), the non-splitk grid has very few blocks
     # in the H dimension, leading to low GPU utilization at medium batch sizes.
     use_splitk_for_large_hq = h_q > 64 and total_tokens > 8 and total_topk >= 256
-    if (
+    if use_splitk and (
         use_splitk_for_small_bs
         or use_splitk_for_h64_large_topk
         or use_splitk_for_large_topk

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_optimized.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_optimized.py
@@ -28,6 +28,7 @@ from .triton_mla_kernels_decode_dsv4 import (
 )
 from .triton_mla_kernels_decode_fused import (
     fused_gather_attn_decode_dsv4,
+    fused_gather_attn_decode_dsv4_dual_scope,
     fused_gather_attn_decode_dsv4_dual_scope_low_overhead,
 )
 
@@ -56,14 +57,8 @@ def triton_sparse_attn_decode(
 def _should_use_fused_dual_scope(total_tokens: int, h_q: int, total_topk: int) -> bool:
     """Determine whether to use fused kernel for dual-scope cases.
 
-    The fused kernel avoids allocating a large intermediate gathered_kv
-    buffer and eliminates a separate gather kernel launch.  However, for
-    h_q > 64 with medium-to-large batch sizes and larger topk, the
-    non-splitk fused kernel suffers from low GPU utilization (the grid
-    has only cdiv(h_q, BLOCK_H) blocks in the H dimension).  In those
-    cases the fallback (separate gather + attention) can be faster on
-    the GPU, though it incurs extra torch.empty() overhead in CUDA
-    graphs.
+    Returns True if the fused kernel (with splitk for small bs) should be used.
+    For large batch sizes (>= 256), use _should_use_fused_nosplitk instead.
 
     The thresholds below were determined empirically on MI355X (256 CUs).
     """
@@ -74,15 +69,41 @@ def _should_use_fused_dual_scope(total_tokens: int, h_q: int, total_topk: int) -
     if h_q <= 64 and total_topk >= 1024:
         return total_tokens <= 128
     # h_q > 64 (e.g. h_q=128 when q is padded to full n_heads).
-    # For small topk (c128 layers, topk~192), fused always wins.
-    # For larger topk (c4 layers, topk~640), fused wins at small bs
-    # but the fallback catches up at bs>=16 due to better GPU utilization.
-    # However, the fallback has 4 extra torch.empty() calls that add
-    # ~30us CUDA-graph replay overhead, roughly cancelling the GPU gain.
-    # So we route to fused for all practical batch sizes.
     if h_q > 64:
-        return total_tokens <= 256
+        if total_topk >= 400:
+            return total_tokens <= 32
+        else:
+            return total_tokens <= 128
     return True
+
+
+def _should_use_fused_nosplitk(total_tokens: int, h_q: int, total_topk: int) -> bool:
+    """Determine whether to use the fused no-splitk kernel for large batches.
+
+    Kernel-level benchmarking on MI355X shows that for large batch sizes
+    (total_tokens >= 256), the fused dual-scope kernel WITHOUT split-K
+    is ~10% faster than the separate gather+attention path:
+
+      total_tokens=256:  fused-noSK=169us vs separate=194us (14% faster)
+      total_tokens=512:  fused-noSK=350us vs separate=408us (14% faster)
+      total_tokens=1024: fused-noSK=700us vs separate=777us (10% faster)
+      total_tokens=4096: fused-noSK=2761us vs separate=3063us (10% faster)
+
+    The fused no-splitk kernel avoids:
+    1. Materializing the large intermediate gathered_kv buffer
+    2. The separate gather kernel launch
+    3. The split-K combine overhead
+
+    For total_tokens < 256, the separate path is faster because the
+    fused kernel has insufficient parallelism.
+    """
+    if h_q <= 64:
+        return False  # Not benchmarked for h_q <= 64
+    if total_topk < 200:
+        return False  # Small topk doesn't benefit
+    # For h_q > 64 and total_topk >= 200:
+    # Fused no-splitk wins for total_tokens >= 256
+    return total_tokens >= 256
 
 
 def _triton_sparse_attn_decode_dsv4(
@@ -135,7 +156,43 @@ def _triton_sparse_attn_decode_dsv4(
     topk_extra = extra_kv_scope.indices_in_kvcache.shape[-1]
     total_topk = topk_main + topk_extra
 
-    # Check if chunking needed (fall back to original implementation)
+    # For large batch sizes, use fused no-splitk kernel (10% faster than separate).
+    # This check is BEFORE the chunking check because the fused kernel does NOT
+    # allocate the intermediate gathered_kv buffer, so buffer size limits don't apply.
+    if _should_use_fused_nosplitk(total_tokens, h_q, total_topk):
+        q_reshaped = q.reshape(total_tokens, h_q, d_qk)
+        if not q_reshaped.is_contiguous():
+            q_reshaped = q_reshaped.contiguous()
+
+        indices_main = kv_scope.indices_in_kvcache.reshape(total_tokens, topk_main)
+        if not indices_main.is_contiguous():
+            indices_main = indices_main.contiguous()
+
+        block_size_extra = extra_kv_scope.blocked_k.shape[1]
+        indices_extra = extra_kv_scope.indices_in_kvcache.reshape(
+            total_tokens, topk_extra
+        )
+        if not indices_extra.is_contiguous():
+            indices_extra = indices_extra.contiguous()
+
+        output, lse = fused_gather_attn_decode_dsv4_dual_scope(
+            q_reshaped,
+            kv_quantized_main,
+            indices_main,
+            block_size_main,
+            extra_kv_scope.blocked_k_quantized,
+            indices_extra,
+            block_size_extra,
+            sm_scale,
+            topk_length_main=kv_scope.topk_length,
+            topk_length_extra=extra_kv_scope.topk_length,
+            attn_sink=attn_sink,
+            s_q=s_q,
+            force_no_splitk=True,
+        )
+        return output.view(b, s_q, h_q, d_v), lse.view(b, s_q, h_q).transpose(1, 2)
+
+    # Check if chunking needed for separate path (fall back to original implementation)
     token_ranges = compute_token_ranges(total_tokens, total_topk, d_qk)
     if len(token_ranges) > 1:
         from .triton_mla_kernels_decode_dsv4 import triton_sparse_attn_decode_dsv4

--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_optimized.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_optimized.py
@@ -160,20 +160,14 @@ def _triton_sparse_attn_decode_dsv4(
     # This check is BEFORE the chunking check because the fused kernel does NOT
     # allocate the intermediate gathered_kv buffer, so buffer size limits don't apply.
     if _should_use_fused_nosplitk(total_tokens, h_q, total_topk):
-        q_reshaped = q.reshape(total_tokens, h_q, d_qk)
-        if not q_reshaped.is_contiguous():
-            q_reshaped = q_reshaped.contiguous()
+        q_reshaped = q.reshape(total_tokens, h_q, d_qk).contiguous()
 
-        indices_main = kv_scope.indices_in_kvcache.reshape(total_tokens, topk_main)
-        if not indices_main.is_contiguous():
-            indices_main = indices_main.contiguous()
+        indices_main = kv_scope.indices_in_kvcache.reshape(total_tokens, topk_main).contiguous()
 
         block_size_extra = extra_kv_scope.blocked_k.shape[1]
         indices_extra = extra_kv_scope.indices_in_kvcache.reshape(
             total_tokens, topk_extra
-        )
-        if not indices_extra.is_contiguous():
-            indices_extra = indices_extra.contiguous()
+        ).contiguous()
 
         output, lse = fused_gather_attn_decode_dsv4_dual_scope(
             q_reshaped,
@@ -203,20 +197,14 @@ def _triton_sparse_attn_decode_dsv4(
 
     # Use fused dual-scope kernel with low-overhead buffer pool
     if _should_use_fused_dual_scope(total_tokens, h_q, total_topk):
-        q_reshaped = q.reshape(total_tokens, h_q, d_qk)
-        if not q_reshaped.is_contiguous():
-            q_reshaped = q_reshaped.contiguous()
+        q_reshaped = q.reshape(total_tokens, h_q, d_qk).contiguous()
 
-        indices_main = kv_scope.indices_in_kvcache.reshape(total_tokens, topk_main)
-        if not indices_main.is_contiguous():
-            indices_main = indices_main.contiguous()
+        indices_main = kv_scope.indices_in_kvcache.reshape(total_tokens, topk_main).contiguous()
 
         block_size_extra = extra_kv_scope.blocked_k.shape[1]
         indices_extra = extra_kv_scope.indices_in_kvcache.reshape(
             total_tokens, topk_extra
-        )
-        if not indices_extra.is_contiguous():
-            indices_extra = indices_extra.contiguous()
+        ).contiguous()
 
         output, lse = fused_gather_attn_decode_dsv4_dual_scope_low_overhead(
             q_reshaped,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
During DeepSeek V4 prefill with `chunked_prefill_size=8192`, the c4 attention layers (30 out of 61 layers, `total_topk=640`) previously required allocating a ~5 GB intermediate `gathered_kv` buffer for the separate gather+attention path. This exceeded the 2 GB chunking limit, forcing **3-chunk processing** with repeated buffer allocations, kernel launches, and result concatenation.

## Modifications

<!-- Detail the changes made in this pull request. -->
This PR optimizes the Triton sparse MLA kernel dispatch by routing large-batch dual-scope attention through the fused no-splitk kernel, which performs gather and attention in a single kernel **without materializing the intermediate buffer**.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Accuracy test on GMS8K shows that it can keep aligned with before, ~0.936.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
<img width="793" height="526" alt="image" src="https://github.com/user-attachments/assets/5ea8e929-0789-4218-ab8a-02a3a9aa6d43" />

- TTFT improvement is consistent across all concurrency levels
The 13-15% TTFT gain comes primarily from **eliminating chunking**:
**Before**: 5 GB buffer → exceeds 2 GB limit → 3 chunks × (buffer alloc + gather kernel + attention kernel) + Python loop + tensor concat
**After**: single fused kernel, zero intermediate buffer, no chunking
- ITL (decode latency) is unaffected

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->