### PR TITLE
[Spec] Route seq_lens through FutureMap; drop verify_done.wait

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -180,9 +180,8 @@ class ScheduleBatchDisaggregationDecodeMixin:
                 from sglang.srt.managers.overlap_utils import FutureIndices
 
                 spec_info.future_indices = FutureIndices(indices=self.req_pool_indices)
-                future_map.store_to_map_for_new_batch(
-                    spec_info.future_indices, spec_info
-                )
+                future_map.publish(spec_info.future_indices, spec_info.new_seq_lens)
+                future_map.stash(spec_info.future_indices, spec_info)
             self.spec_info = spec_info
         else:
             # Non-spec: input_ids feeds the next decode forward directly.

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -10,7 +10,6 @@ from sglang.srt.utils import is_cuda, is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import ScheduleBatch
-    from sglang.srt.managers.scheduler import GenerationBatchResult
     from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
     from sglang.srt.speculative.eagle_info import EagleDraftInput
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -61,11 +60,13 @@ class FutureMap:
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
         else:
-            # Schedule-consumed bufs: eagerly allocated with fixed shape/dtype
-            # so store_post_verify can write unconditionally from iter 1.
+            # Schedule-consumed buf (new_seq_lens_buf): eager, fixed shape /
+            # dtype so publish() can write unconditionally from iter 1.
             self.new_seq_lens_buf = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
+            # bonus_tokens_buf is forward-only but its dtype is fixed —
+            # eagerly allocate so stash() doesn't need to peek shape.
             self.bonus_tokens_buf = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
@@ -139,80 +140,51 @@ class FutureMap:
             self._post_verify_buf_ready = torch.get_device_module(self.device).Event()
         self._post_verify_buf_ready.record()
 
-    def store_post_verify(
+    def publish(
         self,
         future_indices: FutureIndices,
         new_seq_lens: torch.Tensor,
-        bonus_tokens: torch.Tensor,
     ) -> None:
-        """Forward stream. Writes the schedule-consumed buf fields and records
-        the fence at verify-end. Fired by both extend and decode branches
-        between target/verify and draft_extend."""
+        """Forward stream. Writes schedule-consumed buf (new_seq_lens_buf)
+        and records the fence — making the write visible to schedule stream.
+        Fired by worker callback at sample-end (verify-end for decode,
+        target-end for extend). Spec only — non-spec has no schedule
+        consumer."""
         if self.spec_algo.is_none():
             return
         indices = future_indices.indices
         if indices.shape[0] == 0:
             return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
-        self.bonus_tokens_buf[indices] = bonus_tokens.to(self.bonus_tokens_buf.dtype)
         self._record_post_verify_buf_ready()
 
-    def store_to_map(
-        self, future_indices: FutureIndices, batch_result: GenerationBatchResult
-    ):
-        """Forward stream. Writes the forward-only buf fields (topk /
-        hidden_states). Next iter's resolve_future reads them on forward
-        stream — same-stream FIFO covers, no fence needed."""
+    def stash(self, future_indices: FutureIndices, payload) -> None:
+        """Forward stream. Writes forward-only buf fields. Next iter's
+        resolve_future reads them on forward stream — same-stream FIFO covers,
+        no fence needed.
+
+        payload is `next_token_ids` tensor for non-spec, EagleDraftInput for
+        spec (the disagg bootstrap path passes the spec_info directly)."""
+        indices = future_indices.indices
+        if indices.shape[0] == 0:
+            return  # DP idle
         if self.spec_algo.is_none():
-            indices = future_indices.indices
-            if indices.shape[0] == 0:
-                return  # DP idle: next_token_ids carries sibling-rank padding.
             # next_token_ids is int32; buf is int64. Advanced indexing requires
             # an explicit cast.
-            self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
+            self.token_ids_buf[indices] = payload.to(torch.int64)
             return
 
-        draft_input: EagleDraftInput = batch_result.next_draft_input
-        indices = future_indices.indices
-        if indices.shape[0] == 0:
-            # DP idle: draft_input fields are empty stubs; _lazy_init_forward_buf's
-            # shape peek would IndexError. Defer init until a real batch.
-            return
-
+        draft_input: EagleDraftInput = payload
         if not self._forward_buf_initialized:
             self._lazy_init_forward_buf(draft_input)
-
-        self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
-        self.topk_index_buf[indices] = draft_input.topk_index.to(
-            self.topk_index_buf.dtype
-        )
-        if spec_need_hidden_states():
-            self.hidden_states_buf[indices] = draft_input.hidden_states.to(
-                self.hidden_states_buf.dtype
-            )
-
-    def store_to_map_for_new_batch(
-        self, future_indices: FutureIndices, draft_input: EagleDraftInput
-    ) -> None:
-        """Disagg-decode bootstrap: seed buf from a fully populated draft_input
-        + record the fence."""
-        indices = future_indices.indices
-        if indices.shape[0] == 0:
-            return
-        if not self._forward_buf_initialized:
-            self._lazy_init_forward_buf(draft_input)
-        self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
-        self.topk_index_buf[indices] = draft_input.topk_index.to(
-            self.topk_index_buf.dtype
-        )
-        self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
-            self.new_seq_lens_buf.dtype
-        )
         self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
             self.bonus_tokens_buf.dtype
         )
+        self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
+        self.topk_index_buf[indices] = draft_input.topk_index.to(
+            self.topk_index_buf.dtype
+        )
         if spec_need_hidden_states():
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
-        self._record_post_verify_buf_ready()

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -118,6 +118,10 @@ class FutureMap:
             draft_input.topk_index = self.topk_index_buf[indices]
             draft_input.bonus_tokens = self.bonus_tokens_buf[indices]
             draft_input.new_seq_lens = self.new_seq_lens_buf[indices]
+            # Resolve placeholder batch.seq_lens (set to -indices at end of
+            # previous run_batch) to post-verify GPU values from the buf.
+            # Mirrors the input_ids placeholder pattern.
+            batch.seq_lens = draft_input.new_seq_lens
             if spec_need_hidden_states():
                 draft_input.hidden_states = self.hidden_states_buf[indices]
 

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -232,27 +232,32 @@ class FutureMap:
         # Slice assignment used to coerce src dtype to buf dtype implicitly;
         # advanced index requires an explicit cast. bonus_tokens / new_seq_lens
         # in particular differ across disagg (int64) and forward (int32) paths.
-        # Write all fields unconditionally — for decode-branch iters the
-        # new_seq_lens / bonus_tokens writes are redundant (post_verify already
-        # wrote them) but idempotent; for extend-branch iters they're the only
-        # writes and must happen to keep buf slots valid.
+        # topk_p / topk_index / hidden_states are forward-only buf fields
+        # (consumed by next iter's resolve_future on forward stream — FIFO
+        # ordering covers them, no fence needed).
         self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
         self.topk_index_buf[indices] = draft_input.topk_index.to(
             self.topk_index_buf.dtype
-        )
-        self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
-            self.new_seq_lens_buf.dtype
-        )
-        self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
-            self.bonus_tokens_buf.dtype
         )
         if spec_need_hidden_states():
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
-        # Fence: skip if post_verify already recorded (keeps fence at verify-end
-        # for overlap). Reset flag for next iter.
+        # new_seq_lens / bonus_tokens are schedule-consumed (resolve_seq_lens_cpu
+        # reads new_seq_lens_buf via cross-stream D2H). Two write sites:
+        #   - decode-branch iter: store_post_verify wrote them already; the
+        #     fence is already at verify-end. Skip here to avoid a redundant
+        #     write that would race with schedule-stream reads guarded only by
+        #     the verify-end fence.
+        #   - extend-branch iter (and disagg bootstrap): no post_verify ran,
+        #     so write them here and record the fence.
         if not self._fence_done_by_post_verify:
+            self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
+                self.new_seq_lens_buf.dtype
+            )
+            self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
+                self.bonus_tokens_buf.dtype
+            )
             self._record_store_done()
         self._fence_done_by_post_verify = False
 

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -57,28 +57,30 @@ class FutureMap:
         self.req_pool_size = req_to_token_pool.req_to_token.shape[0]
 
         if self.spec_algo.is_none():
-            self.buf_initialized = True
             self.token_ids_buf = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
         else:
-            self.buf_initialized = False
+            # Schedule-consumed bufs: eagerly allocated with fixed shape/dtype
+            # so store_post_verify can write unconditionally from iter 1.
+            self.new_seq_lens_buf = torch.empty(
+                (self.req_pool_size,), dtype=torch.int64, device=self.device
+            )
+            self.bonus_tokens_buf = torch.empty(
+                (self.req_pool_size,), dtype=torch.int64, device=self.device
+            )
+            # Forward-only bufs: lazy because per-req shape depends on worker
+            # (topk * num_steps for multi-layer EAGLE) and hidden dtype.
+            self._forward_buf_initialized = False
 
-        # Fences the buf fields that schedule stream reads (new_seq_lens_buf,
-        # bonus_tokens_buf). Recorded by store_post_verify at verify-end
-        # (both extend and decode branches fire it); store_to_map records it
-        # only on the first iter, where post_verify is a no-op pending lazy
-        # buf init.
+        # Fences the schedule-consumed buf fields.
         self._post_verify_buf_ready: Optional[torch.cuda.Event] = None
 
-    def _lazy_init_buf(self, draft_input: EagleDraftInput):
-        self.buf_initialized = True
+    def _lazy_init_forward_buf(self, draft_input: EagleDraftInput):
+        self._forward_buf_initialized = True
 
         topk_p0 = draft_input.topk_p[0]
         topk_index0 = draft_input.topk_index[0]
-        bonus_token0 = draft_input.bonus_tokens[0]
-        new_seq_lens0 = draft_input.new_seq_lens[0]
-
         self.topk_p_buf = torch.empty(
             (self.req_pool_size, *topk_p0.shape),
             dtype=topk_p0.dtype,
@@ -89,17 +91,6 @@ class FutureMap:
             dtype=topk_index0.dtype,
             device=self.device,
         )
-        self.bonus_tokens_buf = torch.empty(
-            (self.req_pool_size, *bonus_token0.shape),
-            dtype=bonus_token0.dtype,
-            device=self.device,
-        )
-        self.new_seq_lens_buf = torch.empty(
-            (self.req_pool_size, *new_seq_lens0.shape),
-            dtype=new_seq_lens0.dtype,
-            device=self.device,
-        )
-
         if spec_need_hidden_states():
             hidden_states0 = draft_input.hidden_states[0]
             self.hidden_states_buf = torch.empty(
@@ -155,12 +146,9 @@ class FutureMap:
         bonus_tokens: torch.Tensor,
     ) -> None:
         """Forward stream. Writes the schedule-consumed buf fields and records
-        the fence at verify-end so schedule consumers unblock before
-        draft_extend. Fired by both extend and decode branches.
-
-        No-op on the first iter (buf not yet allocated). The first iter's
-        store_to_map lazy-inits and catches up the fence."""
-        if self.spec_algo.is_none() or not self.buf_initialized:
+        the fence at verify-end. Fired by both extend and decode branches
+        between target/verify and draft_extend."""
+        if self.spec_algo.is_none():
             return
         indices = future_indices.indices
         if indices.shape[0] == 0:
@@ -173,9 +161,8 @@ class FutureMap:
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
     ):
         """Forward stream. Writes the forward-only buf fields (topk /
-        hidden_states; FIFO covers them, no fence needed). On the first iter
-        — where store_post_verify was a no-op pending lazy init — also writes
-        the schedule-consumed fields and records the fence."""
+        hidden_states). Next iter's resolve_future reads them on forward
+        stream — same-stream FIFO covers, no fence needed."""
         if self.spec_algo.is_none():
             indices = future_indices.indices
             if indices.shape[0] == 0:
@@ -183,19 +170,17 @@ class FutureMap:
             # next_token_ids is int32; buf is int64. Advanced indexing requires
             # an explicit cast.
             self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
-            self._record_post_verify_buf_ready()
             return
 
         draft_input: EagleDraftInput = batch_result.next_draft_input
         indices = future_indices.indices
         if indices.shape[0] == 0:
-            # DP idle: draft_input fields are empty stubs; _lazy_init_buf's
+            # DP idle: draft_input fields are empty stubs; _lazy_init_forward_buf's
             # shape peek would IndexError. Defer init until a real batch.
             return
 
-        first_iter = not self.buf_initialized
-        if first_iter:
-            self._lazy_init_buf(draft_input)
+        if not self._forward_buf_initialized:
+            self._lazy_init_forward_buf(draft_input)
 
         self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
         self.topk_index_buf[indices] = draft_input.topk_index.to(
@@ -205,26 +190,17 @@ class FutureMap:
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
-        if first_iter:
-            # Catch up for store_post_verify's no-op (buf wasn't allocated).
-            self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
-                self.new_seq_lens_buf.dtype
-            )
-            self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
-                self.bonus_tokens_buf.dtype
-            )
-            self._record_post_verify_buf_ready()
 
     def store_to_map_for_new_batch(
         self, future_indices: FutureIndices, draft_input: EagleDraftInput
     ) -> None:
-        """Disagg-decode bootstrap: seed buf in one shot from a fully
-        populated draft_input + record the fence."""
+        """Disagg-decode bootstrap: seed buf from a fully populated draft_input
+        + record the fence."""
         indices = future_indices.indices
         if indices.shape[0] == 0:
             return
-        if not self.buf_initialized:
-            self._lazy_init_buf(draft_input)
+        if not self._forward_buf_initialized:
+            self._lazy_init_forward_buf(draft_input)
         self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
         self.topk_index_buf[indices] = draft_input.topk_index.to(
             self.topk_index_buf.dtype

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -64,16 +64,11 @@ class FutureMap:
         else:
             self.buf_initialized = False
 
-        # Single cross-stream fence covering "all buf writes dispatched so far".
-        # Recorded on forward stream at the tail of every store_to_map; waited
-        # on by schedule-stream consumers (e.g. resolve_seq_lens_cpu) before
-        # reading the buf. Lives on FutureMap so callers can't forget to
-        # propagate it through filter/merge/etc.
+        # Forward-stream fence covering all buf writes dispatched so far.
+        # Waited on by schedule-stream consumers before reading the buf.
         self._last_store_done: Optional[torch.cuda.Event] = None
-        # Per-iter flag: did store_post_verify record the fence already? If so,
-        # store_to_map skips its own record so the fence stays at verify-end
-        # (preserving schedule prep / draft_extend overlap). Reset by every
-        # store_to_map call.
+        # Set by store_post_verify so store_to_map skips its own record and
+        # the fence stays at verify-end (for draft_extend overlap).
         self._fence_done_by_post_verify: bool = False
 
     def _lazy_init_buf(self, draft_input: EagleDraftInput):
@@ -130,21 +125,14 @@ class FutureMap:
             draft_input.topk_index = self.topk_index_buf[indices]
             draft_input.bonus_tokens = self.bonus_tokens_buf[indices]
             draft_input.new_seq_lens = self.new_seq_lens_buf[indices]
-            # Resolve placeholder batch.seq_lens (set to -indices at end of
-            # previous run_batch) to post-verify GPU values from the buf.
-            # Mirrors the input_ids placeholder pattern.
+            # Resolve seq_lens placeholder (-indices) to the post-verify view.
             batch.seq_lens = draft_input.new_seq_lens
             if spec_need_hidden_states():
                 draft_input.hidden_states = self.hidden_states_buf[indices]
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
-        """Schedule-stream counterpart of resolve_future for the CPU mirror.
-
-        Reads post-verify seq_lens from new_seq_lens_buf into batch.seq_lens_cpu
-        and recomputes batch.seq_lens_sum. Waits on _last_store_done so the
-        D2H sees all forward-stream buf writes dispatched so far. No-op for
-        paths without future state (first iter / no spec_info).
-        """
+        """Schedule-stream D2H from new_seq_lens_buf into batch.seq_lens_cpu,
+        gated on _last_store_done. No-op when there's no future state yet."""
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
@@ -154,11 +142,8 @@ class FutureMap:
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
     def _record_store_done(self) -> None:
-        # Must be called on forward stream right after a buf write that
-        # produces values consumed by schedule stream. Reuses one Event across
-        # iters; record() repositions it to the current forward-stream point.
-        # Forward-stream FIFO guarantees the new position is at-or-past every
-        # prior write recorded on this event.
+        # Forward-stream only. record() repositions the event to the current
+        # stream point; FIFO covers all prior writes on this stream.
         if self._last_store_done is None:
             self._last_store_done = torch.get_device_module(self.device).Event()
         self._last_store_done.record()
@@ -169,25 +154,15 @@ class FutureMap:
         new_seq_lens: torch.Tensor,
         bonus_tokens: torch.Tensor,
     ) -> None:
-        """Forward stream. Writes the buf fields produced at verify-end
-        (new_seq_lens, bonus_tokens) and records the cross-stream fence here.
-
-        The fence lands at verify-end rather than at store_to_map (which runs
-        after draft_extend), so schedule-stream consumers (resolve_seq_lens_cpu)
-        unblock as soon as verify is done — preserving the schedule prep /
-        draft_extend overlap window on forward stream.
-
-        First iter (buf not yet allocated): no-op. The subsequent store_to_map
-        will write these fields and record the fence.
-        """
+        """Forward stream. Writes verify-end buf fields and records the fence
+        here so schedule consumers unblock at verify-end (before draft_extend).
+        No-op on the first iter (buf not yet allocated); store_to_map handles
+        it then."""
         if self.spec_algo.is_none() or not self.buf_initialized:
             return
         indices = future_indices.indices
         if indices.shape[0] == 0:
-            # DP idle: nothing to store for this rank.
-            return
-        # Advanced indexing requires explicit dtype cast (slice assignment
-        # used to coerce implicitly).
+            return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
         self.bonus_tokens_buf[indices] = bonus_tokens.to(self.bonus_tokens_buf.dtype)
         self._record_store_done()
@@ -196,22 +171,15 @@ class FutureMap:
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
     ):
-        """Forward stream. Writes all buf fields. Records the cross-stream
-        fence only if store_post_verify did not already record it for this
-        iter (decode-branch). Extend-branch iters (prefill / mixed) never fire
-        the post_verify callback, so this method must write new_seq_lens /
-        bonus_tokens here too — otherwise their buf slots stay uninitialized
-        (`torch.empty` garbage) and a downstream `.cpu()` overflows int32.
-        """
+        """Forward stream. Writes the post-draft_extend buf fields (topk /
+        hidden), plus new_seq_lens / bonus_tokens when post_verify didn't run
+        (extend branch). Records the fence iff post_verify didn't."""
         if self.spec_algo.is_none():
             indices = future_indices.indices
             if indices.shape[0] == 0:
-                # DP attention idle rank: indices is empty but next_token_ids
-                # may carry padded values from sibling ranks. Nothing to store
-                # for this rank.
-                return
-            # next_token_ids is int32; buf is int64. Slice assignment used to
-            # cast implicitly, but advanced indexing requires an explicit match.
+                return  # DP idle: next_token_ids carries sibling-rank padding.
+            # next_token_ids is int32; buf is int64. Advanced indexing requires
+            # an explicit cast.
             self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
             if not self._fence_done_by_post_verify:
                 self._record_store_done()
@@ -221,20 +189,15 @@ class FutureMap:
         draft_input: EagleDraftInput = batch_result.next_draft_input
         indices = future_indices.indices
         if indices.shape[0] == 0:
-            # DP idle rank: draft_input fields are empty stubs without a usable
-            # shape, so _lazy_init_buf's shape peek (draft_input.topk_p[0])
-            # would IndexError. Defer init until a real batch arrives.
+            # DP idle: draft_input fields are empty stubs; _lazy_init_buf's
+            # shape peek would IndexError. Defer init until a real batch.
             return
 
         if not self.buf_initialized:
             self._lazy_init_buf(draft_input)
 
-        # Slice assignment used to coerce src dtype to buf dtype implicitly;
-        # advanced index requires an explicit cast. bonus_tokens / new_seq_lens
-        # in particular differ across disagg (int64) and forward (int32) paths.
-        # topk_p / topk_index / hidden_states are forward-only buf fields
-        # (consumed by next iter's resolve_future on forward stream — FIFO
-        # ordering covers them, no fence needed).
+        # Forward-only fields (next iter's resolve_future reads them on
+        # forward stream — FIFO covers them, no fence needed).
         self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
         self.topk_index_buf[indices] = draft_input.topk_index.to(
             self.topk_index_buf.dtype
@@ -243,14 +206,9 @@ class FutureMap:
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
-        # new_seq_lens / bonus_tokens are schedule-consumed (resolve_seq_lens_cpu
-        # reads new_seq_lens_buf via cross-stream D2H). Two write sites:
-        #   - decode-branch iter: store_post_verify wrote them already; the
-        #     fence is already at verify-end. Skip here to avoid a redundant
-        #     write that would race with schedule-stream reads guarded only by
-        #     the verify-end fence.
-        #   - extend-branch iter (and disagg bootstrap): no post_verify ran,
-        #     so write them here and record the fence.
+        # Schedule-consumed fields: skip when post_verify already wrote them
+        # — a redundant write here would race the schedule-stream read gated
+        # on the verify-end fence.
         if not self._fence_done_by_post_verify:
             self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
                 self.new_seq_lens_buf.dtype
@@ -264,11 +222,8 @@ class FutureMap:
     def store_to_map_for_new_batch(
         self, future_indices: FutureIndices, draft_input: EagleDraftInput
     ) -> None:
-        """Bootstrap helper for disagg-decode prebuilt batches. The caller
-        constructs a fully-populated EagleDraftInput (all post-verify and
-        post-draft_extend fields) and asks FutureMap to seed the buf in one
-        shot, recording the fence so subsequent resolve_seq_lens_cpu sees
-        valid data. Equivalent to the first-iter path in store_to_map."""
+        """Disagg-decode bootstrap: seed buf in one shot from a fully
+        populated draft_input + record the fence."""
         indices = future_indices.indices
         if indices.shape[0] == 0:
             return

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -68,7 +68,7 @@ class FutureMap:
             self._forward_buf_initialized = False
 
         # Fences the schedule-consumed buf fields.
-        self._post_verify_buf_ready: Optional[torch.cuda.Event] = None
+        self.publish_ready: Optional[torch.cuda.Event] = None
 
     def _lazy_init_forward_buf(self, draft_input: EagleDraftInput):
         self._forward_buf_initialized = True
@@ -120,21 +120,14 @@ class FutureMap:
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
         """Schedule-stream D2H from new_seq_lens_buf into batch.seq_lens_cpu,
-        gated on _post_verify_buf_ready. No-op when there's no future state yet."""
+        gated on publish_ready. No-op when there's no future state yet."""
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
-        if self._post_verify_buf_ready is not None:
-            self._post_verify_buf_ready.wait()
+        if self.publish_ready is not None:
+            self.publish_ready.wait()
         batch.seq_lens_cpu = self.new_seq_lens_buf[fi.indices].cpu()
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
-
-    def _record_post_verify_buf_ready(self) -> None:
-        # Forward-stream only. record() repositions the event to the current
-        # stream point; FIFO covers all prior writes on this stream.
-        if self._post_verify_buf_ready is None:
-            self._post_verify_buf_ready = torch.get_device_module(self.device).Event()
-        self._post_verify_buf_ready.record()
 
     def publish(
         self,
@@ -152,7 +145,9 @@ class FutureMap:
         if indices.shape[0] == 0:
             return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
-        self._record_post_verify_buf_ready()
+        if self.publish_ready is None:
+            self.publish_ready = torch.get_device_module(self.device).Event()
+        self.publish_ready.record()
 
     def stash(self, future_indices: FutureIndices, payload) -> None:
         """Forward stream. Writes forward-only buf fields. Next iter's

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -149,17 +149,53 @@ class FutureMap:
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
     def _record_store_done(self) -> None:
-        # Must be called on forward stream right after a store_to_map write.
-        # Reuses the same Event across iters; record() repositions it to the
-        # current forward-stream point. FIFO of forward stream guarantees the
-        # new position is at-or-past every prior store_to_map.
+        # Must be called on forward stream right after a buf write that
+        # produces values consumed by schedule stream. Reuses one Event across
+        # iters; record() repositions it to the current forward-stream point.
+        # Forward-stream FIFO guarantees the new position is at-or-past every
+        # prior write recorded on this event.
         if self._last_store_done is None:
             self._last_store_done = torch.get_device_module(self.device).Event()
         self._last_store_done.record()
 
+    def store_post_verify(
+        self,
+        future_indices: FutureIndices,
+        new_seq_lens: torch.Tensor,
+        bonus_tokens: torch.Tensor,
+    ) -> None:
+        """Forward stream. Writes the buf fields produced at verify-end
+        (new_seq_lens, bonus_tokens) and records the cross-stream fence here.
+
+        The fence lands at verify-end rather than at store_to_map (which runs
+        after draft_extend), so schedule-stream consumers (resolve_seq_lens_cpu)
+        unblock as soon as verify is done — preserving the schedule prep /
+        draft_extend overlap window on forward stream.
+
+        First iter (buf not yet allocated): no-op. The subsequent store_to_map
+        will lazy-init, write these fields too, and record the fence.
+        """
+        if self.spec_algo.is_none() or not self.buf_initialized:
+            return
+        indices = future_indices.indices
+        if indices.shape[0] == 0:
+            # DP idle: nothing to store for this rank.
+            return
+        # Advanced indexing requires explicit dtype cast (slice assignment
+        # used to coerce implicitly).
+        self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
+        self.bonus_tokens_buf[indices] = bonus_tokens.to(self.bonus_tokens_buf.dtype)
+        self._record_store_done()
+
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
     ):
+        """Forward stream. Writes the buf fields produced at draft_extend-end
+        (topk_p, topk_index, hidden_states). new_seq_lens / bonus_tokens are
+        written earlier by store_post_verify on steady-state iters; this
+        method also writes them on the first iter (where post_verify was a
+        no-op pre-lazy-init) and records the fence then.
+        """
         if self.spec_algo.is_none():
             indices = future_indices.indices
             if indices.shape[0] == 0:
@@ -170,14 +206,10 @@ class FutureMap:
             # next_token_ids is int32; buf is int64. Slice assignment used to
             # cast implicitly, but advanced indexing requires an explicit match.
             self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
-        else:
-            draft_input: EagleDraftInput = batch_result.next_draft_input
-            self.store_to_map_for_new_batch(future_indices, draft_input)
-        self._record_store_done()
+            self._record_store_done()
+            return
 
-    def store_to_map_for_new_batch(
-        self, future_indices: FutureIndices, draft_input: EagleDraftInput
-    ):
+        draft_input: EagleDraftInput = batch_result.next_draft_input
         indices = future_indices.indices
         if indices.shape[0] == 0:
             # DP idle rank: draft_input fields are empty stubs without a usable
@@ -185,7 +217,8 @@ class FutureMap:
             # would IndexError. Defer init until a real batch arrives.
             return
 
-        if not self.buf_initialized:
+        first_iter = not self.buf_initialized
+        if first_iter:
             self._lazy_init_buf(draft_input)
 
         # Slice assignment used to coerce src dtype to buf dtype implicitly;
@@ -195,13 +228,46 @@ class FutureMap:
         self.topk_index_buf[indices] = draft_input.topk_index.to(
             self.topk_index_buf.dtype
         )
-        self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
-            self.bonus_tokens_buf.dtype
+        if first_iter:
+            # store_post_verify was a no-op (buf not allocated then). Catch up
+            # on its writes here and record the fence.
+            self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
+                self.new_seq_lens_buf.dtype
+            )
+            self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
+                self.bonus_tokens_buf.dtype
+            )
+            self._record_store_done()
+        if spec_need_hidden_states():
+            self.hidden_states_buf[indices] = draft_input.hidden_states.to(
+                self.hidden_states_buf.dtype
+            )
+
+    def store_to_map_for_new_batch(
+        self, future_indices: FutureIndices, draft_input: EagleDraftInput
+    ) -> None:
+        """Bootstrap helper for disagg-decode prebuilt batches. The caller
+        constructs a fully-populated EagleDraftInput (all post-verify and
+        post-draft_extend fields) and asks FutureMap to seed the buf in one
+        shot, recording the fence so subsequent resolve_seq_lens_cpu sees
+        valid data. Equivalent to the first-iter path in store_to_map."""
+        indices = future_indices.indices
+        if indices.shape[0] == 0:
+            return
+        if not self.buf_initialized:
+            self._lazy_init_buf(draft_input)
+        self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
+        self.topk_index_buf[indices] = draft_input.topk_index.to(
+            self.topk_index_buf.dtype
         )
         self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
             self.new_seq_lens_buf.dtype
+        )
+        self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
+            self.bonus_tokens_buf.dtype
         )
         if spec_need_hidden_states():
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
+        self._record_store_done()

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -40,11 +40,6 @@ else:
 @dataclass
 class FutureIndices:
     indices: torch.Tensor
-    # Cross-stream barrier event signaling that forward stream has finished
-    # producing this future (i.e., the buf slots at `indices` are written).
-    # Consumers on schedule stream wait on this before reading the buf.
-    # Recorded by Scheduler AFTER store_to_map on the forward stream.
-    done: Optional["torch.cuda.Event"] = None
 
 
 class FutureMap:
@@ -68,6 +63,13 @@ class FutureMap:
             )
         else:
             self.buf_initialized = False
+
+        # Single cross-stream fence covering "all buf writes dispatched so far".
+        # Recorded on forward stream at the tail of every store_to_map; waited
+        # on by schedule-stream consumers (e.g. resolve_seq_lens_cpu) before
+        # reading the buf. Lives on FutureMap so callers can't forget to
+        # propagate it through filter/merge/etc.
+        self._last_store_done: Optional[torch.cuda.Event] = None
 
     def _lazy_init_buf(self, draft_input: EagleDraftInput):
         self.buf_initialized = True
@@ -134,18 +136,26 @@ class FutureMap:
         """Schedule-stream counterpart of resolve_future for the CPU mirror.
 
         Reads post-verify seq_lens from new_seq_lens_buf into batch.seq_lens_cpu
-        and recomputes batch.seq_lens_sum. future_indices.done provides the
-        cross-stream barrier — Scheduler records it AFTER store_to_map, so the
-        wait ensures the buf write is visible from schedule stream. No-op for
+        and recomputes batch.seq_lens_sum. Waits on _last_store_done so the
+        D2H sees all forward-stream buf writes dispatched so far. No-op for
         paths without future state (first iter / no spec_info).
         """
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
-        if fi.done is not None:
-            fi.done.wait()
+        if self._last_store_done is not None:
+            self._last_store_done.wait()
         batch.seq_lens_cpu = self.new_seq_lens_buf[fi.indices].cpu()
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+
+    def _record_store_done(self) -> None:
+        # Must be called on forward stream right after a store_to_map write.
+        # Reuses the same Event across iters; record() repositions it to the
+        # current forward-stream point. FIFO of forward stream guarantees the
+        # new position is at-or-past every prior store_to_map.
+        if self._last_store_done is None:
+            self._last_store_done = torch.get_device_module(self.device).Event()
+        self._last_store_done.record()
 
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
@@ -163,6 +173,7 @@ class FutureMap:
         else:
             draft_input: EagleDraftInput = batch_result.next_draft_input
             self.store_to_map_for_new_batch(future_indices, draft_input)
+        self._record_store_done()
 
     def store_to_map_for_new_batch(
         self, future_indices: FutureIndices, draft_input: EagleDraftInput

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -40,6 +40,11 @@ else:
 @dataclass
 class FutureIndices:
     indices: torch.Tensor
+    # Cross-stream barrier event signaling that forward stream has finished
+    # producing this future (i.e., the buf slots at `indices` are written).
+    # Consumers on schedule stream wait on this before reading the buf.
+    # Recorded by Scheduler AFTER store_to_map on the forward stream.
+    done: Optional["torch.cuda.Event"] = None
 
 
 class FutureMap:
@@ -129,18 +134,17 @@ class FutureMap:
         """Schedule-stream counterpart of resolve_future for the CPU mirror.
 
         Reads post-verify seq_lens from new_seq_lens_buf into batch.seq_lens_cpu
-        and recomputes batch.seq_lens_sum. spec_info.verify_done provides the
+        and recomputes batch.seq_lens_sum. future_indices.done provides the
         cross-stream barrier — Scheduler records it AFTER store_to_map, so the
         wait ensures the buf write is visible from schedule stream. No-op for
         paths without future state (first iter / no spec_info).
         """
-        spec_info = batch.spec_info
-        if spec_info is None or spec_info.future_indices is None:
+        fi = batch.spec_info.future_indices if batch.spec_info is not None else None
+        if fi is None:
             return
-        if spec_info.verify_done is not None:
-            spec_info.verify_done.wait()
-        indices = spec_info.future_indices.indices
-        batch.seq_lens_cpu = self.new_seq_lens_buf[indices].cpu()
+        if fi.done is not None:
+            fi.done.wait()
+        batch.seq_lens_cpu = self.new_seq_lens_buf[fi.indices].cpu()
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
     def store_to_map(

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -64,11 +64,7 @@ class FutureMap:
             self.new_seq_lens_buf = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
-            # Forward-only buf, eager fixed dtype.
-            self.bonus_tokens_buf = torch.empty(
-                (self.req_pool_size,), dtype=torch.int64, device=self.device
-            )
-            # Remaining forward-only bufs are lazy (worker-dependent shape).
+            # Forward-only bufs are lazy (worker-dependent shape).
             self._forward_buf_initialized = False
 
         # Fences the schedule-consumed buf fields.
@@ -88,6 +84,9 @@ class FutureMap:
             (self.req_pool_size, *topk_index0.shape),
             dtype=topk_index0.dtype,
             device=self.device,
+        )
+        self.bonus_tokens_buf = torch.empty(
+            (self.req_pool_size,), dtype=torch.int64, device=self.device
         )
         if spec_need_hidden_states():
             hidden_states0 = draft_input.hidden_states[0]

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -125,6 +125,24 @@ class FutureMap:
             if spec_need_hidden_states():
                 draft_input.hidden_states = self.hidden_states_buf[indices]
 
+    def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
+        """Schedule-stream counterpart of resolve_future for the CPU mirror.
+
+        Reads post-verify seq_lens from new_seq_lens_buf into batch.seq_lens_cpu
+        and recomputes batch.seq_lens_sum. spec_info.verify_done provides the
+        cross-stream barrier — Scheduler records it AFTER store_to_map, so the
+        wait ensures the buf write is visible from schedule stream. No-op for
+        paths without future state (first iter / no spec_info).
+        """
+        spec_info = batch.spec_info
+        if spec_info is None or spec_info.future_indices is None:
+            return
+        if spec_info.verify_done is not None:
+            spec_info.verify_done.wait()
+        indices = spec_info.future_indices.indices
+        batch.seq_lens_cpu = self.new_seq_lens_buf[indices].cpu()
+        batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
     ):

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -66,10 +66,10 @@ class FutureMap:
 
         # Forward-stream fence covering all buf writes dispatched so far.
         # Waited on by schedule-stream consumers before reading the buf.
+        # Recorded by store_post_verify at verify-end (both extend and decode
+        # branches fire it); store_to_map only records on the first iter,
+        # where post_verify is a no-op pending lazy buf init.
         self._last_store_done: Optional[torch.cuda.Event] = None
-        # Set by store_post_verify so store_to_map skips its own record and
-        # the fence stays at verify-end (for draft_extend overlap).
-        self._fence_done_by_post_verify: bool = False
 
     def _lazy_init_buf(self, draft_input: EagleDraftInput):
         self.buf_initialized = True
@@ -154,10 +154,12 @@ class FutureMap:
         new_seq_lens: torch.Tensor,
         bonus_tokens: torch.Tensor,
     ) -> None:
-        """Forward stream. Writes verify-end buf fields and records the fence
-        here so schedule consumers unblock at verify-end (before draft_extend).
-        No-op on the first iter (buf not yet allocated); store_to_map handles
-        it then."""
+        """Forward stream. Writes the schedule-consumed buf fields and records
+        the fence at verify-end so schedule consumers unblock before
+        draft_extend. Fired by both extend and decode branches.
+
+        No-op on the first iter (buf not yet allocated). The first iter's
+        store_to_map lazy-inits and catches up the fence."""
         if self.spec_algo.is_none() or not self.buf_initialized:
             return
         indices = future_indices.indices
@@ -166,14 +168,14 @@ class FutureMap:
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
         self.bonus_tokens_buf[indices] = bonus_tokens.to(self.bonus_tokens_buf.dtype)
         self._record_store_done()
-        self._fence_done_by_post_verify = True
 
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
     ):
-        """Forward stream. Writes the post-draft_extend buf fields (topk /
-        hidden), plus new_seq_lens / bonus_tokens when post_verify didn't run
-        (extend branch). Records the fence iff post_verify didn't."""
+        """Forward stream. Writes the forward-only buf fields (topk /
+        hidden_states; FIFO covers them, no fence needed). On the first iter
+        — where store_post_verify was a no-op pending lazy init — also writes
+        the schedule-consumed fields and records the fence."""
         if self.spec_algo.is_none():
             indices = future_indices.indices
             if indices.shape[0] == 0:
@@ -181,9 +183,7 @@ class FutureMap:
             # next_token_ids is int32; buf is int64. Advanced indexing requires
             # an explicit cast.
             self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
-            if not self._fence_done_by_post_verify:
-                self._record_store_done()
-            self._fence_done_by_post_verify = False
+            self._record_store_done()
             return
 
         draft_input: EagleDraftInput = batch_result.next_draft_input
@@ -193,11 +193,10 @@ class FutureMap:
             # shape peek would IndexError. Defer init until a real batch.
             return
 
-        if not self.buf_initialized:
+        first_iter = not self.buf_initialized
+        if first_iter:
             self._lazy_init_buf(draft_input)
 
-        # Forward-only fields (next iter's resolve_future reads them on
-        # forward stream — FIFO covers them, no fence needed).
         self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
         self.topk_index_buf[indices] = draft_input.topk_index.to(
             self.topk_index_buf.dtype
@@ -206,10 +205,8 @@ class FutureMap:
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
-        # Schedule-consumed fields: skip when post_verify already wrote them
-        # — a redundant write here would race the schedule-stream read gated
-        # on the verify-end fence.
-        if not self._fence_done_by_post_verify:
+        if first_iter:
+            # Catch up for store_post_verify's no-op (buf wasn't allocated).
             self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
                 self.new_seq_lens_buf.dtype
             )
@@ -217,7 +214,6 @@ class FutureMap:
                 self.bonus_tokens_buf.dtype
             )
             self._record_store_done()
-        self._fence_done_by_post_verify = False
 
     def store_to_map_for_new_batch(
         self, future_indices: FutureIndices, draft_input: EagleDraftInput

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -60,18 +60,15 @@ class FutureMap:
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
         else:
-            # Schedule-consumed buf (new_seq_lens_buf): eager, fixed shape /
-            # dtype so publish() can write unconditionally from iter 1.
+            # Schedule-consumed buf, eager fixed dtype.
             self.new_seq_lens_buf = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
-            # bonus_tokens_buf is forward-only but its dtype is fixed —
-            # eagerly allocate so stash() doesn't need to peek shape.
+            # Forward-only buf, eager fixed dtype.
             self.bonus_tokens_buf = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
-            # Forward-only bufs: lazy because per-req shape depends on worker
-            # (topk * num_steps for multi-layer EAGLE) and hidden dtype.
+            # Remaining forward-only bufs are lazy (worker-dependent shape).
             self._forward_buf_initialized = False
 
         # Fences the schedule-consumed buf fields.

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -64,12 +64,12 @@ class FutureMap:
         else:
             self.buf_initialized = False
 
-        # Forward-stream fence covering all buf writes dispatched so far.
-        # Waited on by schedule-stream consumers before reading the buf.
-        # Recorded by store_post_verify at verify-end (both extend and decode
-        # branches fire it); store_to_map only records on the first iter,
-        # where post_verify is a no-op pending lazy buf init.
-        self._last_store_done: Optional[torch.cuda.Event] = None
+        # Fences the buf fields that schedule stream reads (new_seq_lens_buf,
+        # bonus_tokens_buf). Recorded by store_post_verify at verify-end
+        # (both extend and decode branches fire it); store_to_map records it
+        # only on the first iter, where post_verify is a no-op pending lazy
+        # buf init.
+        self._post_verify_buf_ready: Optional[torch.cuda.Event] = None
 
     def _lazy_init_buf(self, draft_input: EagleDraftInput):
         self.buf_initialized = True
@@ -132,21 +132,21 @@ class FutureMap:
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
         """Schedule-stream D2H from new_seq_lens_buf into batch.seq_lens_cpu,
-        gated on _last_store_done. No-op when there's no future state yet."""
+        gated on _post_verify_buf_ready. No-op when there's no future state yet."""
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
-        if self._last_store_done is not None:
-            self._last_store_done.wait()
+        if self._post_verify_buf_ready is not None:
+            self._post_verify_buf_ready.wait()
         batch.seq_lens_cpu = self.new_seq_lens_buf[fi.indices].cpu()
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
-    def _record_store_done(self) -> None:
+    def _record_post_verify_buf_ready(self) -> None:
         # Forward-stream only. record() repositions the event to the current
         # stream point; FIFO covers all prior writes on this stream.
-        if self._last_store_done is None:
-            self._last_store_done = torch.get_device_module(self.device).Event()
-        self._last_store_done.record()
+        if self._post_verify_buf_ready is None:
+            self._post_verify_buf_ready = torch.get_device_module(self.device).Event()
+        self._post_verify_buf_ready.record()
 
     def store_post_verify(
         self,
@@ -167,7 +167,7 @@ class FutureMap:
             return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
         self.bonus_tokens_buf[indices] = bonus_tokens.to(self.bonus_tokens_buf.dtype)
-        self._record_store_done()
+        self._record_post_verify_buf_ready()
 
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
@@ -183,7 +183,7 @@ class FutureMap:
             # next_token_ids is int32; buf is int64. Advanced indexing requires
             # an explicit cast.
             self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
-            self._record_store_done()
+            self._record_post_verify_buf_ready()
             return
 
         draft_input: EagleDraftInput = batch_result.next_draft_input
@@ -213,7 +213,7 @@ class FutureMap:
             self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
                 self.bonus_tokens_buf.dtype
             )
-            self._record_store_done()
+            self._record_post_verify_buf_ready()
 
     def store_to_map_for_new_batch(
         self, future_indices: FutureIndices, draft_input: EagleDraftInput
@@ -239,4 +239,4 @@ class FutureMap:
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
-        self._record_store_done()
+        self._record_post_verify_buf_ready()

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -119,8 +119,6 @@ class FutureMap:
                 draft_input.hidden_states = self.hidden_states_buf[indices]
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
-        """Schedule-stream D2H from new_seq_lens_buf into batch.seq_lens_cpu,
-        gated on publish_ready. No-op when there's no future state yet."""
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
         if fi is None:
             return
@@ -130,15 +128,9 @@ class FutureMap:
         batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
     def publish(
-        self,
-        future_indices: FutureIndices,
-        new_seq_lens: torch.Tensor,
+        self, future_indices: FutureIndices, new_seq_lens: torch.Tensor
     ) -> None:
-        """Forward stream. Writes schedule-consumed buf (new_seq_lens_buf)
-        and records the fence — making the write visible to schedule stream.
-        Fired by worker callback at sample-end (verify-end for decode,
-        target-end for extend). Spec only — non-spec has no schedule
-        consumer."""
+        """Store schedule-consumed fields and signal publish_ready."""
         if self.spec_algo.is_none():
             return
         indices = future_indices.indices
@@ -150,12 +142,7 @@ class FutureMap:
         self.publish_ready.record()
 
     def stash(self, future_indices: FutureIndices, payload) -> None:
-        """Forward stream. Writes forward-only buf fields. Next iter's
-        resolve_future reads them on forward stream — same-stream FIFO covers,
-        no fence needed.
-
-        payload is `next_token_ids` tensor for non-spec, EagleDraftInput for
-        spec (the disagg bootstrap path passes the spec_info directly)."""
+        """Store forward-only fields for the next forward batch to pick up."""
         indices = future_indices.indices
         if indices.shape[0] == 0:
             return  # DP idle

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -70,6 +70,11 @@ class FutureMap:
         # reading the buf. Lives on FutureMap so callers can't forget to
         # propagate it through filter/merge/etc.
         self._last_store_done: Optional[torch.cuda.Event] = None
+        # Per-iter flag: did store_post_verify record the fence already? If so,
+        # store_to_map skips its own record so the fence stays at verify-end
+        # (preserving schedule prep / draft_extend overlap). Reset by every
+        # store_to_map call.
+        self._fence_done_by_post_verify: bool = False
 
     def _lazy_init_buf(self, draft_input: EagleDraftInput):
         self.buf_initialized = True
@@ -173,7 +178,7 @@ class FutureMap:
         draft_extend overlap window on forward stream.
 
         First iter (buf not yet allocated): no-op. The subsequent store_to_map
-        will lazy-init, write these fields too, and record the fence.
+        will write these fields and record the fence.
         """
         if self.spec_algo.is_none() or not self.buf_initialized:
             return
@@ -186,15 +191,17 @@ class FutureMap:
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
         self.bonus_tokens_buf[indices] = bonus_tokens.to(self.bonus_tokens_buf.dtype)
         self._record_store_done()
+        self._fence_done_by_post_verify = True
 
     def store_to_map(
         self, future_indices: FutureIndices, batch_result: GenerationBatchResult
     ):
-        """Forward stream. Writes the buf fields produced at draft_extend-end
-        (topk_p, topk_index, hidden_states). new_seq_lens / bonus_tokens are
-        written earlier by store_post_verify on steady-state iters; this
-        method also writes them on the first iter (where post_verify was a
-        no-op pre-lazy-init) and records the fence then.
+        """Forward stream. Writes all buf fields. Records the cross-stream
+        fence only if store_post_verify did not already record it for this
+        iter (decode-branch). Extend-branch iters (prefill / mixed) never fire
+        the post_verify callback, so this method must write new_seq_lens /
+        bonus_tokens here too — otherwise their buf slots stay uninitialized
+        (`torch.empty` garbage) and a downstream `.cpu()` overflows int32.
         """
         if self.spec_algo.is_none():
             indices = future_indices.indices
@@ -206,7 +213,9 @@ class FutureMap:
             # next_token_ids is int32; buf is int64. Slice assignment used to
             # cast implicitly, but advanced indexing requires an explicit match.
             self.token_ids_buf[indices] = batch_result.next_token_ids.to(torch.int64)
-            self._record_store_done()
+            if not self._fence_done_by_post_verify:
+                self._record_store_done()
+            self._fence_done_by_post_verify = False
             return
 
         draft_input: EagleDraftInput = batch_result.next_draft_input
@@ -217,31 +226,35 @@ class FutureMap:
             # would IndexError. Defer init until a real batch arrives.
             return
 
-        first_iter = not self.buf_initialized
-        if first_iter:
+        if not self.buf_initialized:
             self._lazy_init_buf(draft_input)
 
         # Slice assignment used to coerce src dtype to buf dtype implicitly;
         # advanced index requires an explicit cast. bonus_tokens / new_seq_lens
         # in particular differ across disagg (int64) and forward (int32) paths.
+        # Write all fields unconditionally — for decode-branch iters the
+        # new_seq_lens / bonus_tokens writes are redundant (post_verify already
+        # wrote them) but idempotent; for extend-branch iters they're the only
+        # writes and must happen to keep buf slots valid.
         self.topk_p_buf[indices] = draft_input.topk_p.to(self.topk_p_buf.dtype)
         self.topk_index_buf[indices] = draft_input.topk_index.to(
             self.topk_index_buf.dtype
         )
-        if first_iter:
-            # store_post_verify was a no-op (buf not allocated then). Catch up
-            # on its writes here and record the fence.
-            self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
-                self.new_seq_lens_buf.dtype
-            )
-            self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
-                self.bonus_tokens_buf.dtype
-            )
-            self._record_store_done()
+        self.new_seq_lens_buf[indices] = draft_input.new_seq_lens.to(
+            self.new_seq_lens_buf.dtype
+        )
+        self.bonus_tokens_buf[indices] = draft_input.bonus_tokens.to(
+            self.bonus_tokens_buf.dtype
+        )
         if spec_need_hidden_states():
             self.hidden_states_buf[indices] = draft_input.hidden_states.to(
                 self.hidden_states_buf.dtype
             )
+        # Fence: skip if post_verify already recorded (keeps fence at verify-end
+        # for overlap). Reset flag for next iter.
+        if not self._fence_done_by_post_verify:
+            self._record_store_done()
+        self._fence_done_by_post_verify = False
 
     def store_to_map_for_new_batch(
         self, future_indices: FutureIndices, draft_input: EagleDraftInput

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -109,6 +109,7 @@ if TYPE_CHECKING:
 
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.overlap_utils import FutureMap
     from sglang.srt.managers.scheduler_components.metrics_reporter import PrefillStats
     from sglang.srt.session.session_controller import Session
     from sglang.srt.speculative.eagle_info import EagleDraftInput
@@ -2447,23 +2448,28 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 .to(device=self.device, non_blocking=True)
             )
 
-    def maybe_wait_verify_done(self):
-        # Use event.wait() (stream-level wait) instead of .synchronize()
-        # (CPU block). Schedule-stream prep ops following this call get
-        # ordered after the forward-stream verify via the wait; CPU is not
-        # blocked. Subsequent .cpu()/.item() naturally sync the stream.
-        if self.is_spec_v2:
-            draft_input: EagleDraftInput = self.spec_info
-            if draft_input.verify_done is not None:
-                draft_input.verify_done.wait()
-
-    def refresh_seq_lens_cpu(self, sync: bool = True):
-        # sync=True: D2H from seq_lens (needed when seq_lens_cpu is stale
-        # relative to seq_lens, i.e. spec v2's mid-forward GPU rebind).
-        # sync=False: caller asserts seq_lens_cpu already fresh — skip D2H,
-        # only recompute the cached sum.
-        if sync and self.is_spec_v2:
-            self.seq_lens_cpu = self.seq_lens.cpu()
+    def refresh_seq_lens_cpu(self, future_map: Optional["FutureMap"] = None):
+        # Standalone sync point for seq_lens_cpu / seq_lens_sum.
+        # When future_map is passed (spec v2, post-first-iter), D2H reads
+        # post-verify seq_lens from new_seq_lens_buf. The buf is written by the
+        # previous iter's forward stream (store_to_map), so we need an explicit
+        # cross-stream wait — .cpu() alone is NOT a cross-stream sync. The wait
+        # is encapsulated here: spec_info.verify_done is recorded by Scheduler
+        # AFTER store_to_map, so waiting on it covers the buf write.
+        # Otherwise (first iter / non-spec / lazy-fallback paths), the CPU mirror
+        # is already eagerly maintained — just recompute the cached sum.
+        # In handle mode batch.seq_lens is a placeholder between iters; never
+        # D2H from it directly here.
+        if (
+            future_map is not None
+            and self.is_spec_v2
+            and self.spec_info is not None
+            and self.spec_info.future_indices is not None
+        ):
+            if self.spec_info.verify_done is not None:
+                self.spec_info.verify_done.wait()
+            indices = self.spec_info.future_indices.indices
+            self.seq_lens_cpu = future_map.new_seq_lens_buf[indices].cpu()
         self.seq_lens_sum = int(self.seq_lens_cpu.sum())
 
     def filter_batch(
@@ -2473,10 +2479,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # FIXME(lsyin): deprecate this API after spec v1 is deprecated
         v1_spec_info_filtered: Optional[bool] = False,
     ):
-        # FIXME(lsyin): used here to get the correct seq_lens
-        # The batch has been launched but we need it verified to get correct next batch info
-        self.maybe_wait_verify_done()
-
         if keep_indices is None:
             if isinstance(chunked_req_to_exclude, Req):
                 chunked_req_to_exclude = [chunked_req_to_exclude]
@@ -2553,15 +2555,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
     def merge_batch(self, other: "ScheduleBatch"):
-        # In the regular scheduler path:
-        # 1) self is always prefill, whose seq_lens is not a future
-        # 2) other is always decode, which is finished in previous step
-        # so verify_done is already synced and this is a no-op.
-        # In disagg decode + overlap, merge_batch can be called before
-        # filter_batch, so running_batch.seq_lens may still be a forward_stream
-        # future. Synchronize here to avoid a cross-stream data race.
-        self.maybe_wait_verify_done()
-
         # Penalizer orchestrator must be merged before Batch.reqs is merged. This is because
         # orchestrator.merge() depends on Batch.reqs during preparation of each penalizers, so it
         # needs to be called with pre-merged Batch.reqs.

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -109,7 +109,6 @@ if TYPE_CHECKING:
 
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
-    from sglang.srt.managers.overlap_utils import FutureMap
     from sglang.srt.managers.scheduler_components.metrics_reporter import PrefillStats
     from sglang.srt.session.session_controller import Session
     from sglang.srt.speculative.eagle_info import EagleDraftInput
@@ -2448,28 +2447,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 .to(device=self.device, non_blocking=True)
             )
 
-    def refresh_seq_lens_cpu(self, future_map: Optional["FutureMap"] = None):
-        # Standalone sync point for seq_lens_cpu / seq_lens_sum.
-        # When future_map is passed (spec v2, post-first-iter), D2H reads
-        # post-verify seq_lens from new_seq_lens_buf. The buf is written by the
-        # previous iter's forward stream (store_to_map), so we need an explicit
-        # cross-stream wait — .cpu() alone is NOT a cross-stream sync. The wait
-        # is encapsulated here: spec_info.verify_done is recorded by Scheduler
-        # AFTER store_to_map, so waiting on it covers the buf write.
-        # Otherwise (first iter / non-spec / lazy-fallback paths), the CPU mirror
-        # is already eagerly maintained — just recompute the cached sum.
-        # In handle mode batch.seq_lens is a placeholder between iters; never
-        # D2H from it directly here.
-        if (
-            future_map is not None
-            and self.is_spec_v2
-            and self.spec_info is not None
-            and self.spec_info.future_indices is not None
-        ):
-            if self.spec_info.verify_done is not None:
-                self.spec_info.verify_done.wait()
-            indices = self.spec_info.future_indices.indices
-            self.seq_lens_cpu = future_map.new_seq_lens_buf[indices].cpu()
+    def refresh_seq_lens_cpu(self):
+        # Recompute seq_lens_sum from the (eagerly maintained, or freshly
+        # synced via FutureMap.resolve_seq_lens_cpu) CPU mirror.
         self.seq_lens_sum = int(self.seq_lens_cpu.sum())
 
     def filter_batch(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2420,8 +2420,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.seq_lens.add_(1)
             self.seq_lens_cpu.add_(1)
             self.orig_seq_lens.add_(1)
-        # Defer compute to refresh_seq_lens_cpu (either pre-forward in scheduler.py
-        # or lazily in ForwardBatch.init_new).
+        # Sum is recomputed lazily by ForwardBatch.init_new.
         self.seq_lens_sum = None
 
         if self.hisparse_coordinator is not None:
@@ -2446,11 +2445,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 .pin_memory()
                 .to(device=self.device, non_blocking=True)
             )
-
-    def refresh_seq_lens_cpu(self):
-        # Recompute seq_lens_sum from the (eagerly maintained, or freshly
-        # synced via FutureMap.resolve_seq_lens_cpu) CPU mirror.
-        self.seq_lens_sum = int(self.seq_lens_cpu.sum())
 
     def filter_batch(
         self,
@@ -2498,8 +2492,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_cpu = self.seq_lens_cpu[keep_indices]
         self.orig_seq_lens = self.orig_seq_lens[keep_indices_device]
         self.out_cache_loc = None
-        # Defer compute to refresh_seq_lens_cpu (either pre-forward in scheduler.py
-        # or lazily in ForwardBatch.init_new).
+        # Sum is recomputed lazily by ForwardBatch.init_new.
         self.seq_lens_sum = None
 
         if self.input_ids is not None:
@@ -2551,8 +2544,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_cpu = torch.cat([self.seq_lens_cpu, other.seq_lens_cpu])
         self.orig_seq_lens = torch.cat([self.orig_seq_lens, other.orig_seq_lens])
         self.out_cache_loc = None
-        # Defer compute to refresh_seq_lens_cpu (either pre-forward in scheduler.py
-        # or lazily in ForwardBatch.init_new).
+        # Sum is recomputed lazily by ForwardBatch.init_new.
         self.seq_lens_sum = None
         if self.input_ids is not None:
             self.input_ids = torch.cat([self.input_ids, other.input_ids])

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2835,11 +2835,11 @@ class Scheduler(
         if self.is_generation:
             if self.enable_overlap:
                 # Pre-isolation CPU mirror prep. resolve_seq_lens_cpu is the
-                # spec v2 buf-D2H counterpart of resolve_future (no-op for
-                # first iter / non-spec); cross-stream barrier on the future's
-                # `done` event is encapsulated inside.
+                # spec v2 buf-D2H counterpart of resolve_future (no-op when
+                # there's no future state); also sets batch.seq_lens_sum.
+                # For paths it skips, ForwardBatch.init_new lazily computes
+                # the sum from seq_lens_cpu.
                 self.future_map.resolve_seq_lens_cpu(batch)
-                batch.refresh_seq_lens_cpu()
 
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2895,10 +2895,8 @@ class Scheduler(
                 if batch.is_spec_v2:
                     batch.spec_info = batch_result.next_draft_input
                     batch.spec_info.future_indices = future_indices
-                    # Placeholder for next iter's resolve_future; mirrors the
-                    # input_ids handle-mode treatment one line above. Post-verify
-                    # seq_lens lives in future_map.new_seq_lens_buf and is
-                    # resolved back into batch.seq_lens inside isolation.
+                    # Schedule-stream sentinel between iters; next iter's
+                    # resolve_future reassigns batch.seq_lens from new_seq_lens_buf.
                     batch.seq_lens = -future_indices.indices
             elif self.enable_pdmux and batch.forward_mode.is_split_prefill():
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2844,19 +2844,16 @@ class Scheduler(
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
 
-                    # Callback the worker fires between verify and draft_extend
-                    # for spec_v2. Dispatches the buf write whose values are
-                    # consumed by schedule stream (resolve_seq_lens_cpu), so
-                    # the fence event lands at verify-end and schedule prep
-                    # can overlap with draft_extend on forward stream. Only
-                    # spec_v2 workers accept this kwarg.
+                    # Callback the worker fires between sample (target-end /
+                    # verify-end) and draft_extend for spec_v2. Writes
+                    # new_seq_lens_buf and records the cross-stream fence
+                    # early so schedule prep can overlap with draft_extend.
+                    # Only spec_v2 workers accept this kwarg.
                     fwd_kwargs = {}
                     if batch.is_spec_v2:
 
-                        def on_verify_complete(new_seq_lens, bonus_tokens):
-                            self.future_map.store_post_verify(
-                                future_indices, new_seq_lens, bonus_tokens
-                            )
+                        def on_verify_complete(new_seq_lens):
+                            self.future_map.publish(future_indices, new_seq_lens)
 
                         fwd_kwargs["on_verify_complete"] = on_verify_complete
 
@@ -2877,7 +2874,12 @@ class Scheduler(
                         # FIXME(lsyin): maybe move this to forward_batch_generation
                         batch_result.copy_done = self.device_module.Event()
                         if batch_result.delay_sample_func is None:
-                            self.future_map.store_to_map(future_indices, batch_result)
+                            stash_payload = (
+                                batch_result.next_draft_input
+                                if batch.is_spec_v2
+                                else batch_result.next_token_ids
+                            )
+                            self.future_map.stash(future_indices, stash_payload)
                             batch_result.copy_to_cpu(
                                 return_logprob=batch.return_logprob,
                                 return_hidden_states=batch.return_hidden_states,
@@ -2980,7 +2982,10 @@ class Scheduler(
             self.forward_stream.wait_stream(self.schedule_stream)
             _batch_result = batch_result.delay_sample_func()
             assert _batch_result is batch_result
-            self.future_map.store_to_map(batch_result.future_indices, batch_result)
+            # Delay-sample is non-spec only; stash takes next_token_ids tensor.
+            self.future_map.stash(
+                batch_result.future_indices, batch_result.next_token_ids
+            )
             batch_result.copy_to_cpu(
                 return_logprob=self.cur_batch.return_logprob,
                 return_hidden_states=self.cur_batch.return_hidden_states,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2836,8 +2836,8 @@ class Scheduler(
             if self.enable_overlap:
                 # Pre-isolation CPU mirror prep. resolve_seq_lens_cpu is the
                 # spec v2 buf-D2H counterpart of resolve_future (no-op for
-                # first iter / non-spec); cross-stream barrier on
-                # spec_info.verify_done is encapsulated inside.
+                # first iter / non-spec); cross-stream barrier on the future's
+                # `done` event is encapsulated inside.
                 self.future_map.resolve_seq_lens_cpu(batch)
                 batch.refresh_seq_lens_cpu()
 
@@ -2864,17 +2864,14 @@ class Scheduler(
                                 return_logprob=batch.return_logprob,
                                 return_hidden_states=batch.return_hidden_states,
                             )
-                            # Allocate + record verify_done AFTER store_to_map.
-                            # Covers all forward-stream work (incl. buf write);
-                            # next iter's FutureMap.resolve_seq_lens_cpu waits
-                            # on it as the cross-stream barrier.
-                            if (
-                                batch.is_spec_v2
-                                and batch_result.next_draft_input is not None
-                            ):
-                                evt = self.device_module.Event()
-                                evt.record()
-                                batch_result.next_draft_input.verify_done = evt
+                            # Mark the future as ready: record an event on
+                            # forward stream AFTER store_to_map. The event is
+                            # attached to the future handle itself; next iter's
+                            # FutureMap.resolve_seq_lens_cpu waits on it as
+                            # the cross-stream barrier.
+                            if batch.is_spec_v2:
+                                future_indices.done = self.device_module.Event()
+                                future_indices.done.record()
                         else:
                             batch_result.future_indices = future_indices
 
@@ -2978,12 +2975,11 @@ class Scheduler(
                 return_logprob=self.cur_batch.return_logprob,
                 return_hidden_states=self.cur_batch.return_hidden_states,
             )
-            # Allocate + record verify_done AFTER store_to_map for the
-            # delay-sample path too (see Scheduler.run_batch for non-delay).
-            if batch_result.next_draft_input is not None:
-                evt = self.device_module.Event()
-                evt.record()
-                batch_result.next_draft_input.verify_done = evt
+            # Mark the future as ready (delay-sample path; see Scheduler.run_batch
+            # for the non-delay path).
+            if batch_result.future_indices is not None:
+                batch_result.future_indices.done = self.device_module.Event()
+                batch_result.future_indices.done.record()
 
         # Release the closure and large GPU tensors that are no longer needed.
         # The delay_sample_func closure captures forward_batch (which holds

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2864,14 +2864,6 @@ class Scheduler(
                                 return_logprob=batch.return_logprob,
                                 return_hidden_states=batch.return_hidden_states,
                             )
-                            # Mark the future as ready: record an event on
-                            # forward stream AFTER store_to_map. The event is
-                            # attached to the future handle itself; next iter's
-                            # FutureMap.resolve_seq_lens_cpu waits on it as
-                            # the cross-stream barrier.
-                            if batch.is_spec_v2:
-                                future_indices.done = self.device_module.Event()
-                                future_indices.done.record()
                         else:
                             batch_result.future_indices = future_indices
 
@@ -2975,11 +2967,6 @@ class Scheduler(
                 return_logprob=self.cur_batch.return_logprob,
                 return_hidden_states=self.cur_batch.return_hidden_states,
             )
-            # Mark the future as ready (delay-sample path; see Scheduler.run_batch
-            # for the non-delay path).
-            if batch_result.future_indices is not None:
-                batch_result.future_indices.done = self.device_module.Event()
-                batch_result.future_indices.done.record()
 
         # Release the closure and large GPU tensors that are no longer needed.
         # The delay_sample_func closure captures forward_batch (which holds

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2844,11 +2844,29 @@ class Scheduler(
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
 
+                    # Callback the worker fires between verify and draft_extend
+                    # for spec_v2. Dispatches the buf write whose values are
+                    # consumed by schedule stream (resolve_seq_lens_cpu), so
+                    # the fence event lands at verify-end and schedule prep
+                    # can overlap with draft_extend on forward stream. Only
+                    # spec_v2 workers accept this kwarg.
+                    fwd_kwargs = {}
+                    if batch.is_spec_v2:
+
+                        def on_verify_complete(new_seq_lens, bonus_tokens):
+                            self.future_map.store_post_verify(
+                                future_indices, new_seq_lens, bonus_tokens
+                            )
+
+                        fwd_kwargs["on_verify_complete"] = on_verify_complete
+
                     with self.forward_stream_ctx:
                         self.forward_stream.wait_stream(self.schedule_stream)
                         self.future_map.resolve_future(batch)
                         # FIXME: pp is not compatible with overlap
-                        batch_result = self.model_worker.forward_batch_generation(batch)
+                        batch_result = self.model_worker.forward_batch_generation(
+                            batch, **fwd_kwargs
+                        )
                         # Park any refs the worker wants kept alive 2 iters
                         # (cross-stream tensor lifetime; pinned in the same
                         # ring slot as the SB attr snapshot).

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -22,6 +22,7 @@ import sys
 import time
 from collections import deque
 from contextlib import contextmanager, nullcontext
+from functools import partial
 from http import HTTPStatus
 from typing import Any, Deque, Dict, List, Optional, Tuple, Union
 
@@ -2844,18 +2845,18 @@ class Scheduler(
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
 
-                    # Callback the worker fires between sample (target-end /
-                    # verify-end) and draft_extend for spec_v2. Writes
-                    # new_seq_lens_buf and records the cross-stream fence
-                    # early so schedule prep can overlap with draft_extend.
-                    # Only spec_v2 workers accept this kwarg.
-                    fwd_kwargs = {}
-                    if batch.is_spec_v2:
-
-                        def on_verify_complete(new_seq_lens):
-                            self.future_map.publish(future_indices, new_seq_lens)
-
-                        fwd_kwargs["on_verify_complete"] = on_verify_complete
+                    # Spec_v2 worker fires this between sample-end and
+                    # draft_extend; publish moves the fence to verify-end so
+                    # schedule prep can overlap with draft_extend.
+                    fwd_kwargs = (
+                        {
+                            "on_verify_complete": partial(
+                                self.future_map.publish, future_indices
+                            )
+                        }
+                        if batch.is_spec_v2
+                        else {}
+                    )
 
                     with self.forward_stream_ctx:
                         self.forward_stream.wait_stream(self.schedule_stream)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2838,6 +2838,7 @@ class Scheduler(
                 # into batch.seq_lens_cpu + set seq_lens_sum. For non-spec_v2,
                 # ForwardBatch.init_new lazily computes the sum.
                 if batch.is_spec_v2:
+                    # FIXME: make this optional to different backends.
                     self.future_map.resolve_seq_lens_cpu(batch)
 
                 with self._overlap_forward_isolation(batch):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2834,9 +2834,11 @@ class Scheduler(
         # Run forward
         if self.is_generation:
             if self.enable_overlap:
-                # Refresh BEFORE _overlap_forward_isolation so snapshot
-                # captures fresh values and restore preserves them.
-                batch.refresh_seq_lens_cpu()
+                # Single pre-isolation sync site: refresh_seq_lens_cpu owns the
+                # D2H from new_seq_lens_buf (spec v2 placeholder path) AND the
+                # lazy sum recompute. .cpu() to host is itself the cross-stream
+                # sync; no explicit verify_done.wait() needed.
+                batch.refresh_seq_lens_cpu(self.future_map)
 
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
@@ -2861,6 +2863,16 @@ class Scheduler(
                                 return_logprob=batch.return_logprob,
                                 return_hidden_states=batch.return_hidden_states,
                             )
+                            # Record verify_done AFTER store_to_map so the
+                            # event covers the buf write (next iter's
+                            # refresh_seq_lens_cpu waits on it).
+                            if (
+                                batch.is_spec_v2
+                                and batch_result.next_draft_input is not None
+                                and batch_result.next_draft_input.verify_done
+                                is not None
+                            ):
+                                batch_result.next_draft_input.verify_done.record()
                         else:
                             batch_result.future_indices = future_indices
 
@@ -2869,15 +2881,13 @@ class Scheduler(
                 batch.input_ids = -future_indices.indices
 
                 if batch.is_spec_v2:
-                    # FIXME(lsyin): tmp code for spec v2
-                    # We only keep future indices for next draft input
-
                     batch.spec_info = batch_result.next_draft_input
                     batch.spec_info.future_indices = future_indices
-
-                    # The future value, usually for next batch preparation
-                    # Current implementation strictly synchronizes the seq_lens
-                    batch.seq_lens = batch_result.next_draft_input.new_seq_lens
+                    # Placeholder for next iter's resolve_future; mirrors the
+                    # input_ids handle-mode treatment one line above. Post-verify
+                    # seq_lens lives in future_map.new_seq_lens_buf and is
+                    # resolved back into batch.seq_lens inside isolation.
+                    batch.seq_lens = -future_indices.indices
             elif self.enable_pdmux and batch.forward_mode.is_split_prefill():
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)
                 if isinstance(batch_result.next_token_ids, torch.Tensor):
@@ -2966,6 +2976,13 @@ class Scheduler(
                 return_logprob=self.cur_batch.return_logprob,
                 return_hidden_states=self.cur_batch.return_hidden_states,
             )
+            # Record verify_done AFTER store_to_map for the delay-sample path
+            # too (see Scheduler.run_batch for the non-delay path).
+            if (
+                batch_result.next_draft_input is not None
+                and batch_result.next_draft_input.verify_done is not None
+            ):
+                batch_result.next_draft_input.verify_done.record()
 
         # Release the closure and large GPU tensors that are no longer needed.
         # The delay_sample_func closure captures forward_batch (which holds

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2834,12 +2834,11 @@ class Scheduler(
         # Run forward
         if self.is_generation:
             if self.enable_overlap:
-                # Pre-isolation CPU mirror prep. resolve_seq_lens_cpu is the
-                # spec v2 buf-D2H counterpart of resolve_future (no-op when
-                # there's no future state); also sets batch.seq_lens_sum.
-                # For paths it skips, ForwardBatch.init_new lazily computes
-                # the sum from seq_lens_cpu.
-                self.future_map.resolve_seq_lens_cpu(batch)
+                # Spec v2 pre-isolation CPU mirror prep: D2H new_seq_lens_buf
+                # into batch.seq_lens_cpu + set seq_lens_sum. For non-spec_v2,
+                # ForwardBatch.init_new lazily computes the sum.
+                if batch.is_spec_v2:
+                    self.future_map.resolve_seq_lens_cpu(batch)
 
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2834,11 +2834,12 @@ class Scheduler(
         # Run forward
         if self.is_generation:
             if self.enable_overlap:
-                # Single pre-isolation sync site: refresh_seq_lens_cpu owns the
-                # D2H from new_seq_lens_buf (spec v2 placeholder path) AND the
-                # lazy sum recompute. .cpu() to host is itself the cross-stream
-                # sync; no explicit verify_done.wait() needed.
-                batch.refresh_seq_lens_cpu(self.future_map)
+                # Pre-isolation CPU mirror prep. resolve_seq_lens_cpu is the
+                # spec v2 buf-D2H counterpart of resolve_future (no-op for
+                # first iter / non-spec); cross-stream barrier on
+                # spec_info.verify_done is encapsulated inside.
+                self.future_map.resolve_seq_lens_cpu(batch)
+                batch.refresh_seq_lens_cpu()
 
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
@@ -2863,16 +2864,17 @@ class Scheduler(
                                 return_logprob=batch.return_logprob,
                                 return_hidden_states=batch.return_hidden_states,
                             )
-                            # Record verify_done AFTER store_to_map so the
-                            # event covers the buf write (next iter's
-                            # refresh_seq_lens_cpu waits on it).
+                            # Allocate + record verify_done AFTER store_to_map.
+                            # Covers all forward-stream work (incl. buf write);
+                            # next iter's FutureMap.resolve_seq_lens_cpu waits
+                            # on it as the cross-stream barrier.
                             if (
                                 batch.is_spec_v2
                                 and batch_result.next_draft_input is not None
-                                and batch_result.next_draft_input.verify_done
-                                is not None
                             ):
-                                batch_result.next_draft_input.verify_done.record()
+                                evt = self.device_module.Event()
+                                evt.record()
+                                batch_result.next_draft_input.verify_done = evt
                         else:
                             batch_result.future_indices = future_indices
 
@@ -2976,13 +2978,12 @@ class Scheduler(
                 return_logprob=self.cur_batch.return_logprob,
                 return_hidden_states=self.cur_batch.return_hidden_states,
             )
-            # Record verify_done AFTER store_to_map for the delay-sample path
-            # too (see Scheduler.run_batch for the non-delay path).
-            if (
-                batch_result.next_draft_input is not None
-                and batch_result.next_draft_input.verify_done is not None
-            ):
-                batch_result.next_draft_input.verify_done.record()
+            # Allocate + record verify_done AFTER store_to_map for the
+            # delay-sample path too (see Scheduler.run_batch for non-delay).
+            if batch_result.next_draft_input is not None:
+                evt = self.device_module.Event()
+                evt.record()
+                batch_result.next_draft_input.verify_done = evt
 
         # Release the closure and large GPU tensors that are no longer needed.
         # The delay_sample_func closure captures forward_batch (which holds

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -504,7 +504,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             seq_lens_cpu = batch.seq_lens_cpu
 
         if batch.seq_lens_sum is None:
-            batch.refresh_seq_lens_cpu()
+            batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
 
         ret = cls(
             forward_mode=batch.forward_mode,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -504,7 +504,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             seq_lens_cpu = batch.seq_lens_cpu
 
         if batch.seq_lens_sum is None:
-            batch.refresh_seq_lens_cpu(sync=False)
+            batch.refresh_seq_lens_cpu()
 
         ret = cls(
             forward_mode=batch.forward_mode,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -696,7 +696,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     # V2 overlap worker only
     future_indices: Optional[FutureIndices] = None
     new_seq_lens: Optional[torch.Tensor] = None
-    verify_done: Optional[torch.cuda.Event] = None
     # V2 reuses `EagleDraftInput` across phases (V1 has a separate
     # `EagleDraftExtendInput` for these). Set during V2's draft-extend.
     num_correct_drafts: Optional[torch.Tensor] = None

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -228,9 +228,7 @@ class EagleDraftInputV2Mixin:
         batch.input_ids = predict
         batch.seq_lens = batch.seq_lens + num_draft_tokens
         batch.seq_lens_cpu = batch.seq_lens_cpu + num_draft_tokens
-        # seq_lens_cpu was just CPU-updated in tandem — sync=False avoids
-        # a redundant D2H on the draft hot path.
-        batch.refresh_seq_lens_cpu()
+        batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
         batch.extend_lens = [num_draft_tokens for _ in range(len(batch.seq_lens))]
         batch.prefix_lens = seq_lens_cpu_.tolist()
         batch.extend_num_tokens = extend_num_tokens

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -96,9 +96,6 @@ class EagleDraftInputV2Mixin:
 
         bs = batch.batch_size()
 
-        # Now seq_lens is correct
-        batch.maybe_wait_verify_done()
-
         # Accumulate penalty
         # This is a relaxed version of penalties for speculative decoding.
         if batch.sampling_info.penalizer_orchestrator.is_required:
@@ -233,7 +230,7 @@ class EagleDraftInputV2Mixin:
         batch.seq_lens_cpu = batch.seq_lens_cpu + num_draft_tokens
         # seq_lens_cpu was just CPU-updated in tandem — sync=False avoids
         # a redundant D2H on the draft hot path.
-        batch.refresh_seq_lens_cpu(sync=False)
+        batch.refresh_seq_lens_cpu()
         batch.extend_lens = [num_draft_tokens for _ in range(len(batch.seq_lens))]
         batch.prefix_lens = seq_lens_cpu_.tolist()
         batch.extend_num_tokens = extend_num_tokens

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -767,6 +767,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
+            # Same fence point as decode: after target forward + sample, before
+            # draft_extend. new_seq_lens = batch.seq_lens (post-prefill input
+            # length, unchanged by target forward); bonus = next_token_ids.
+            if on_verify_complete is not None:
+                on_verify_complete(batch.seq_lens, batch_output.next_token_ids)
+
             # Draft prefill
             with (
                 self.draft_worker.draft_tp_context(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1098,8 +1098,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             )
 
         next_draft_input = EagleDraftInput(
-            bonus_tokens=bonus_tokens,
-            new_seq_lens=new_seq_lens,
+            bonus_tokens=bonus_tokens, new_seq_lens=new_seq_lens
         )
 
         # verify_forward_batch transitively holds verify-time GPU tensors

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1077,8 +1077,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 batch, verify_input, accept_lens, accept_index, bs
             )
 
+        # verify_done event is allocated here, recorded by Scheduler.run_batch
+        # AFTER store_to_map on the forward stream — so that next iter's
+        # refresh_seq_lens_cpu wait on it covers the buf write, not just verify.
         verify_done = torch.get_device_module(self.device).Event()
-        verify_done.record()
 
         if not batch.forward_mode.is_idle():
             accept_tokens = predict[accept_index]

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1077,11 +1077,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 batch, verify_input, accept_lens, accept_index, bs
             )
 
-        # verify_done event is allocated here, recorded by Scheduler.run_batch
-        # AFTER store_to_map on the forward stream — so that next iter's
-        # refresh_seq_lens_cpu wait on it covers the buf write, not just verify.
-        verify_done = torch.get_device_module(self.device).Event()
-
         if not batch.forward_mode.is_idle():
             accept_tokens = predict[accept_index]
             bonus_tokens = torch.empty_like(accept_lens, dtype=torch.int32)
@@ -1102,7 +1097,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
         next_draft_input = EagleDraftInput(
             bonus_tokens=bonus_tokens,
             new_seq_lens=new_seq_lens,
-            verify_done=verify_done,
         )
 
         # verify_forward_batch transitively holds verify-time GPU tensors

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1101,8 +1101,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # verify_forward_batch transitively holds verify-time GPU tensors
         # (draft_token / out_cache_loc / ...) that must outlive the imminent
-        # batch.input_ids rebind in prepare_for_extend_to_fill_draft_kvcache,
-        # until the next iter's verify_done.synchronize() in filter_batch.
+        # batch.input_ids rebind in prepare_for_extend_to_fill_draft_kvcache.
         # Scheduler pins it in batch_record_buf for the 2-iter window.
         return GenerationBatchResult(
             logits_output=logits_output,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -767,9 +767,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
-            # Same fence point as decode: after target forward + sample,
-            # before draft_extend. new_seq_lens = batch.seq_lens (post-prefill
-            # input length, unchanged by target forward).
+            # Publish before draft_extend so the fence is at target-end.
             if on_verify_complete is not None:
                 on_verify_complete(batch.seq_lens)
 
@@ -815,10 +813,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             assert verify_input.is_verify_input()
             batch.spec_info = verify_input
             batch_output = self.verify(batch)
-            # Dispatch the post-verify buf write on forward stream BEFORE
-            # draft_extend, so the cross-stream fence point lands at verify-end
-            # rather than after draft_extend — preserving schedule prep /
-            # draft_extend overlap.
+            # Publish before draft_extend so the fence is at verify-end.
             if on_verify_complete is not None:
                 on_verify_complete(batch_output.next_draft_input.new_seq_lens)
             with (

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -767,11 +767,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
-            # Same fence point as decode: after target forward + sample, before
-            # draft_extend. new_seq_lens = batch.seq_lens (post-prefill input
-            # length, unchanged by target forward); bonus = next_token_ids.
+            # Same fence point as decode: after target forward + sample,
+            # before draft_extend. new_seq_lens = batch.seq_lens (post-prefill
+            # input length, unchanged by target forward).
             if on_verify_complete is not None:
-                on_verify_complete(batch.seq_lens, batch_output.next_token_ids)
+                on_verify_complete(batch.seq_lens)
 
             # Draft prefill
             with (
@@ -820,10 +820,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             # rather than after draft_extend — preserving schedule prep /
             # draft_extend overlap.
             if on_verify_complete is not None:
-                on_verify_complete(
-                    batch_output.next_draft_input.new_seq_lens,
-                    batch_output.next_draft_input.bonus_tokens,
-                )
+                on_verify_complete(batch_output.next_draft_input.new_seq_lens)
             with (
                 self.draft_worker.draft_tp_context(
                     self.draft_worker.draft_runner.tp_group

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -756,7 +756,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
-    def forward_batch_generation(self, batch: ScheduleBatch):
+    def forward_batch_generation(self, batch: ScheduleBatch, on_verify_complete=None):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             # Target prefill
             target_capture_mode = (
@@ -809,6 +809,15 @@ class EAGLEWorkerV2(BaseSpecWorker):
             assert verify_input.is_verify_input()
             batch.spec_info = verify_input
             batch_output = self.verify(batch)
+            # Dispatch the post-verify buf write on forward stream BEFORE
+            # draft_extend, so the cross-stream fence point lands at verify-end
+            # rather than after draft_extend — preserving schedule prep /
+            # draft_extend overlap.
+            if on_verify_complete is not None:
+                on_verify_complete(
+                    batch_output.next_draft_input.new_seq_lens,
+                    batch_output.next_draft_input.bonus_tokens,
+                )
             with (
                 self.draft_worker.draft_tp_context(
                     self.draft_worker.draft_runner.tp_group

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -680,6 +680,12 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
+            # Same fence point as decode: after target forward + sample, before
+            # draft_extend. new_seq_lens = batch.seq_lens (post-prefill input
+            # length, unchanged by target forward); bonus = next_token_ids.
+            if on_verify_complete is not None:
+                on_verify_complete(batch.seq_lens, batch_output.next_token_ids)
+
             # Chain-style MTP needs FULL to get all-token hidden states;
             # non-chain only needs LAST (the target model's hidden states).
             batch_output.next_draft_input = self.draft_worker._draft_extend_for_prefill(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -775,8 +775,10 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             accept_index,
         ) = verify_input.sample(batch, logits_output)
         new_seq_lens = batch.seq_lens + accept_lens
+        # verify_done event is allocated here, recorded by Scheduler.run_batch
+        # AFTER store_to_map on the forward stream — so that next iter's
+        # refresh_seq_lens_cpu wait on it covers the buf write, not just verify.
         verify_done = torch.get_device_module(self.device).Event()
-        verify_done.record()
 
         if not batch.forward_mode.is_idle():
             accept_tokens = predict[accept_index]

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -669,7 +669,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         # allocator and kv cache pool are shared with target worker, which are cleared in scheduler
         pass
 
-    def forward_batch_generation(self, batch: ScheduleBatch):
+    def forward_batch_generation(self, batch: ScheduleBatch, on_verify_complete=None):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             # Target prefill
             target_capture_mode = (
@@ -706,6 +706,15 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             assert verify_input.is_verify_input()
             batch.spec_info = verify_input
             batch_output = self.verify(batch)
+            # Dispatch the post-verify buf write on forward stream BEFORE
+            # draft_extend, so the cross-stream fence point lands at verify-end
+            # rather than after draft_extend — preserving schedule prep /
+            # draft_extend overlap.
+            if on_verify_complete is not None:
+                on_verify_complete(
+                    batch_output.next_draft_input.new_seq_lens,
+                    batch_output.next_draft_input.bonus_tokens,
+                )
             self.draft_worker._draft_extend_for_decode(batch, batch_output)
             return batch_output
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -680,9 +680,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
-            # Same fence point as decode: after target forward + sample,
-            # before draft_extend. new_seq_lens = batch.seq_lens (post-prefill
-            # input length, unchanged by target forward).
+            # Publish before draft_extend so the fence is at target-end.
             if on_verify_complete is not None:
                 on_verify_complete(batch.seq_lens)
 
@@ -712,10 +710,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             assert verify_input.is_verify_input()
             batch.spec_info = verify_input
             batch_output = self.verify(batch)
-            # Dispatch the post-verify buf write on forward stream BEFORE
-            # draft_extend, so the cross-stream fence point lands at verify-end
-            # rather than after draft_extend — preserving schedule prep /
-            # draft_extend overlap.
+            # Publish before draft_extend so the fence is at verify-end.
             if on_verify_complete is not None:
                 on_verify_complete(batch_output.next_draft_input.new_seq_lens)
             self.draft_worker._draft_extend_for_decode(batch, batch_output)

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -680,11 +680,11 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
-            # Same fence point as decode: after target forward + sample, before
-            # draft_extend. new_seq_lens = batch.seq_lens (post-prefill input
-            # length, unchanged by target forward); bonus = next_token_ids.
+            # Same fence point as decode: after target forward + sample,
+            # before draft_extend. new_seq_lens = batch.seq_lens (post-prefill
+            # input length, unchanged by target forward).
             if on_verify_complete is not None:
-                on_verify_complete(batch.seq_lens, batch_output.next_token_ids)
+                on_verify_complete(batch.seq_lens)
 
             # Chain-style MTP needs FULL to get all-token hidden states;
             # non-chain only needs LAST (the target model's hidden states).
@@ -717,10 +717,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             # rather than after draft_extend — preserving schedule prep /
             # draft_extend overlap.
             if on_verify_complete is not None:
-                on_verify_complete(
-                    batch_output.next_draft_input.new_seq_lens,
-                    batch_output.next_draft_input.bonus_tokens,
-                )
+                on_verify_complete(batch_output.next_draft_input.new_seq_lens)
             self.draft_worker._draft_extend_for_decode(batch, batch_output)
             return batch_output
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -775,10 +775,6 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             accept_index,
         ) = verify_input.sample(batch, logits_output)
         new_seq_lens = batch.seq_lens + accept_lens
-        # verify_done event is allocated here, recorded by Scheduler.run_batch
-        # AFTER store_to_map on the forward stream — so that next iter's
-        # refresh_seq_lens_cpu wait on it covers the buf write, not just verify.
-        verify_done = torch.get_device_module(self.device).Event()
 
         if not batch.forward_mode.is_idle():
             accept_tokens = predict[accept_index]
@@ -800,7 +796,6 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         next_draft_input = EagleDraftInput(
             bonus_tokens=bonus_tokens,
             new_seq_lens=new_seq_lens,
-            verify_done=verify_done,
         )
         # verify_forward_batch transitively holds verify-time GPU tensors that
         # must outlive the imminent batch.input_ids rebind; scheduler pins it


### PR DESCRIPTION
## Summary
- Drop `verify_done.wait()` cross-stream barrier — route `seq_lens` through `FutureMap` so schedule-stream consumers gate on a forward-stream `publish_ready` event instead
- Split `FutureMap` buf writes by consumer: `publish` (schedule-consumed `new_seq_lens_buf`, fence-gated) vs `stash` (forward-only fields, FIFO-covered)
- Fence recorded at verify-end via worker `on_verify_complete` callback (fires between sample and `draft_extend`), preserving schedule prep / `draft_extend` overlap

## Mechanism

**Between iters (schedule stream)**
- `batch.seq_lens = -future_indices.indices` — schedule-stream sentinel
- `FutureMap.resolve_seq_lens_cpu(batch)` pulls `seq_lens_cpu` from `new_seq_lens_buf` via D2H, gated on `publish_ready`

**Inside isolation (forward stream)**
- `resolve_future` reassigns `batch.seq_lens` from `new_seq_lens_buf[indices]`
- Worker fires `on_verify_complete(new_seq_lens)` between sample-end and `draft_extend` → `FutureMap.publish` writes `new_seq_lens_buf` + records `publish_ready`
- After `draft_extend`, `FutureMap.stash` writes forward-only fields (topk / hidden / bonus); same-stream FIFO covers the next iter's `resolve_future` read

## Changes

**`FutureMap` (`overlap_utils.py`)**
- New `publish` / `stash` methods (replace `store_to_map`)
- New `resolve_seq_lens_cpu` for schedule-stream D2H of `new_seq_lens_buf`
- `new_seq_lens_buf` eager-allocated (fixed shape/dtype); forward-only bufs stay lazy
- `publish_ready` event lives on `FutureMap` (no per-`FutureIndices` event)

**Workers (`eagle_worker_v2.py`, `multi_layer_eagle_worker_v2.py`)**
- `forward_batch_generation` accepts `on_verify_complete` kwarg
- Both extend and decode branches fire the callback after sample-end

**Scheduler (`scheduler.py`)**
- Sets `batch.seq_lens = -future_indices.indices` between iters
- Calls `resolve_seq_lens_cpu` pre-isolation, gated by `batch.is_spec_v2`
- Uses `functools.partial` to bind `future_indices` for the callback

**`ScheduleBatch` (`schedule_batch.py`)**
- Drop `refresh_seq_lens_cpu` helper; inline `seq_lens_sum = int(seq_lens_cpu.sum())` at call sites
- Drop `maybe_wait_verify_done` (replaced by the FutureMap fence)

**`EagleDraftInput` (`eagle_info.py`)**
- Drop `verify_done` field (fence moved to `FutureMap`)



































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26205726688](https://github.com/sgl-project/sglang/actions/runs/26205726688)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26205726614](https://github.com/sgl-project/sglang/actions/runs/26205726614)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->