### PR TITLE
[Test] Add fwd_occupancy sanity kit

### DIFF
--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -42,14 +42,14 @@ _METRICS_REQUEST_TIMEOUT = 10
 class FwdOccupancyMixin:
     """Assert steady-state ``sglang:fwd_occupancy`` for single-batch decode.
 
-    Threshold is a percentage in [0, 100]. Default is conservative for
-    overlap scheduler + cuda graph on a decent GPU; saturated multi-batch
-    decode on H100/H200 reaches 95+, so this kit's value lives in the
-    single-batch regime where CPU overhead dominates.
+    Threshold is a percentage in [0, 100]. Default 95.0 -- single-batch
+    decode with overlap scheduler + cuda graph on a healthy GPU should
+    hold steady-state 95+; falling below this points at CPU-side
+    regressions even when batched throughput still looks fine.
     """
 
     # Threshold + detection
-    fwd_occupancy_threshold: float = 80.0
+    fwd_occupancy_threshold: float = 95.0
     fwd_occupancy_min_samples: int = 5
     fwd_occupancy_scrape_interval: float = 0.5
 

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -1,0 +1,216 @@
+"""GPU forward-pass occupancy sanity kit.
+
+Probes the ``sglang:fwd_occupancy`` Prometheus gauge under sustained
+``/generate`` load and asserts the steady-state value clears a
+threshold. Catches CPU-side regressions (overlap scheduler hiccups,
+metadata copy bloat, host-side syncs) that don't break correctness but
+starve the GPU.
+
+The gauge is a percentage in [0, 100] -- ``gpu_busy / wall_clock * 100``
+over the most recent ``decode_log_interval`` batches. It cycles back to
+NaN on every window reset, so the probe filters NaN samples.
+
+Prerequisites on the server launched by the consuming test class:
+    env:          SGLANG_ENABLE_METRICS_DEVICE_TIMER=1
+    server flag:  --enable-metrics
+
+Without both, ``sglang:fwd_occupancy`` is either not exposed or
+permanently NaN, and the probe fails fast with a clear message.
+
+Mix into any ``CustomTestCase`` subclass that exposes ``self.base_url``.
+"""
+
+import re
+import statistics
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+_FWD_OCCUPANCY_RE = re.compile(
+    r"^sglang:fwd_occupancy(?:\{[^}]*\})?\s+(\S+)", re.MULTILINE
+)
+_GENERATE_REQUEST_TIMEOUT = 300
+_METRICS_REQUEST_TIMEOUT = 10
+
+
+class FwdOccupancyMixin:
+    """Assert steady-state ``sglang:fwd_occupancy`` under sustained load.
+
+    Threshold is a percentage in [0, 100]. Default is conservative for
+    single-batch decode with overlap scheduler + cuda graph on a
+    mid-size model; saturated multi-batch decode on H100/H200 should
+    reach 95+.
+    """
+
+    # Threshold + detection
+    fwd_occupancy_threshold: float = 85.0
+    fwd_occupancy_min_samples: int = 5
+    fwd_occupancy_scrape_interval: float = 0.5
+
+    # Warmup phase -- fires synchronously before measurement starts
+    fwd_occupancy_warmup_requests: int = 8
+    fwd_occupancy_warmup_max_new_tokens: int = 64
+    fwd_occupancy_warmup_settle_seconds: float = 1.0
+
+    # Measurement load
+    fwd_occupancy_workers: int = 32
+    fwd_occupancy_total_requests: int = 128
+    fwd_occupancy_max_new_tokens: int = 256
+    fwd_occupancy_prompt: str = "Write a long, detailed, multi-paragraph story about "
+
+    def _scrape_fwd_occupancy(self):
+        """Return the max non-NaN ``sglang:fwd_occupancy`` value across
+        exposed labels (e.g. dp ranks); None on transient scrape failure
+        or no non-NaN sample."""
+        try:
+            resp = requests.get(
+                self.base_url + "/metrics", timeout=_METRICS_REQUEST_TIMEOUT
+            )
+        except requests.RequestException:
+            return None
+        if resp.status_code != 200:
+            return None
+        vals = []
+        for raw in _FWD_OCCUPANCY_RE.findall(resp.text):
+            try:
+                v = float(raw)
+            except ValueError:
+                continue
+            if v == v:  # NaN filter (gauge resets to NaN on window boundary)
+                vals.append(v)
+        return max(vals) if vals else None
+
+    def _assert_metrics_device_timer_enabled(self):
+        """Fail loudly if --enable-metrics or
+        SGLANG_ENABLE_METRICS_DEVICE_TIMER aren't in effect; otherwise
+        a missing gauge would look like a real occupancy regression."""
+        resp = requests.get(
+            self.base_url + "/metrics", timeout=_METRICS_REQUEST_TIMEOUT
+        )
+        assert resp.status_code == 200, (
+            f"/metrics returned {resp.status_code}; the test class's server "
+            "must be launched with --enable-metrics"
+        )
+        assert "sglang:fwd_occupancy" in resp.text, (
+            "sglang:fwd_occupancy gauge not exposed; set "
+            "SGLANG_ENABLE_METRICS_DEVICE_TIMER=1 in the server's env and "
+            "pass --enable-metrics"
+        )
+
+    def _fwd_occupancy_fire(self, prompt: str, max_new_tokens: int):
+        try:
+            requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {
+                        "temperature": 0.0,
+                        "max_new_tokens": max_new_tokens,
+                    },
+                },
+                timeout=_GENERATE_REQUEST_TIMEOUT,
+            )
+        except requests.RequestException:
+            # Individual fire failure is not the probe's concern; the
+            # final stats-vs-threshold check is the signal.
+            pass
+
+    def _fwd_occupancy_warmup(self):
+        """Fire a few requests synchronously to drive the server into
+        steady-state before sampling. The device-timer window also needs
+        a few batches of activity before the gauge produces non-NaN
+        values."""
+        prompts = [
+            f"warmup#{i} {self.fwd_occupancy_prompt}"
+            for i in range(self.fwd_occupancy_warmup_requests)
+        ]
+        with ThreadPoolExecutor(
+            max_workers=self.fwd_occupancy_warmup_requests
+        ) as executor:
+            futures = [
+                executor.submit(
+                    self._fwd_occupancy_fire,
+                    p,
+                    self.fwd_occupancy_warmup_max_new_tokens,
+                )
+                for p in prompts
+            ]
+            for f in futures:
+                f.result()
+        # Give the scheduler a beat to settle before measurement starts.
+        time.sleep(self.fwd_occupancy_warmup_settle_seconds)
+
+    def _fwd_occupancy_measure(self):
+        """Fire concurrent load + scrape /metrics in a background
+        thread; return the list of non-NaN occupancy samples observed
+        while the load was in-flight."""
+        samples = []
+        samples_lock = threading.Lock()
+        scraping_done = threading.Event()
+
+        def scrape_loop():
+            while not scraping_done.is_set():
+                v = self._scrape_fwd_occupancy()
+                if v is not None:
+                    with samples_lock:
+                        samples.append(v)
+                time.sleep(self.fwd_occupancy_scrape_interval)
+
+        scraper = threading.Thread(target=scrape_loop, daemon=True)
+        scraper.start()
+
+        prompts = [
+            f"#{i} {self.fwd_occupancy_prompt}"
+            for i in range(self.fwd_occupancy_total_requests)
+        ]
+        try:
+            with ThreadPoolExecutor(max_workers=self.fwd_occupancy_workers) as executor:
+                futures = [
+                    executor.submit(
+                        self._fwd_occupancy_fire,
+                        p,
+                        self.fwd_occupancy_max_new_tokens,
+                    )
+                    for p in prompts
+                ]
+                for f in futures:
+                    f.result()
+        finally:
+            scraping_done.set()
+            scraper.join(timeout=5.0)
+
+        return samples
+
+    def test_fwd_occupancy(self):
+        self._assert_metrics_device_timer_enabled()
+        self._fwd_occupancy_warmup()
+        samples = self._fwd_occupancy_measure()
+
+        self.assertGreaterEqual(
+            len(samples),
+            self.fwd_occupancy_min_samples,
+            f"only {len(samples)} non-NaN occupancy samples collected "
+            f"(need >= {self.fwd_occupancy_min_samples}); the measurement "
+            "window may be too short or the gauge stuck at NaN",
+        )
+
+        # Median is the steady-state signal; peak / p10 included in the
+        # assertion message for triage.
+        samples_sorted = sorted(samples)
+        median = statistics.median(samples_sorted)
+        peak = samples_sorted[-1]
+        p10 = samples_sorted[max(0, len(samples_sorted) // 10 - 1)]
+        print(
+            f"fwd_occupancy samples (n={len(samples)}): "
+            f"median={median:.2f} peak={peak:.2f} p10={p10:.2f}"
+        )
+
+        self.assertGreater(
+            median,
+            self.fwd_occupancy_threshold,
+            f"sglang:fwd_occupancy median={median:.2f} did not exceed "
+            f"threshold {self.fwd_occupancy_threshold} "
+            f"(peak={peak:.2f}, p10={p10:.2f}, n={len(samples)})",
+        )

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -1,10 +1,15 @@
-"""GPU forward-pass occupancy sanity kit.
+"""GPU forward-pass occupancy sanity kit (single-batch decode).
 
-Probes the ``sglang:fwd_occupancy`` Prometheus gauge under sustained
-``/generate`` load and asserts the steady-state value clears a
-threshold. Catches CPU-side regressions (overlap scheduler hiccups,
-metadata copy bloat, host-side syncs) that don't break correctness but
-starve the GPU.
+Probes the ``sglang:fwd_occupancy`` Prometheus gauge while a single
+long ``/generate`` request is in flight (batch_size = 1 decode) and
+asserts the steady-state value clears a threshold.
+
+Single-batch decode is the worst case for CPU overhead: each decode
+step produces just one token, so per-step host-side work (kernel
+dispatch, sampling, metadata bookkeeping) competes with a single tiny
+forward pass. If the overlap scheduler or cuda graph capture stalls,
+GPU idle ratio shoots up here before anything shows in batched
+throughput numbers.
 
 The gauge is a percentage in [0, 100] -- ``gpu_busy / wall_clock * 100``
 over the most recent ``decode_log_interval`` batches. It cycles back to
@@ -24,40 +29,39 @@ import re
 import statistics
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
 _FWD_OCCUPANCY_RE = re.compile(
     r"^sglang:fwd_occupancy(?:\{[^}]*\})?\s+(\S+)", re.MULTILINE
 )
-_GENERATE_REQUEST_TIMEOUT = 300
+_GENERATE_REQUEST_TIMEOUT = 600
 _METRICS_REQUEST_TIMEOUT = 10
 
 
 class FwdOccupancyMixin:
-    """Assert steady-state ``sglang:fwd_occupancy`` under sustained load.
+    """Assert steady-state ``sglang:fwd_occupancy`` for single-batch decode.
 
     Threshold is a percentage in [0, 100]. Default is conservative for
-    single-batch decode with overlap scheduler + cuda graph on a
-    mid-size model; saturated multi-batch decode on H100/H200 should
-    reach 95+.
+    overlap scheduler + cuda graph on a decent GPU; saturated multi-batch
+    decode on H100/H200 reaches 95+, so this kit's value lives in the
+    single-batch regime where CPU overhead dominates.
     """
 
     # Threshold + detection
-    fwd_occupancy_threshold: float = 85.0
+    fwd_occupancy_threshold: float = 80.0
     fwd_occupancy_min_samples: int = 5
     fwd_occupancy_scrape_interval: float = 0.5
 
-    # Warmup phase -- fires synchronously before measurement starts
-    fwd_occupancy_warmup_requests: int = 8
+    # Warmup phase -- one short request to fill cuda graphs and let the
+    # device-timer window emit its first non-NaN sample.
     fwd_occupancy_warmup_max_new_tokens: int = 64
     fwd_occupancy_warmup_settle_seconds: float = 1.0
 
-    # Measurement load
-    fwd_occupancy_workers: int = 32
-    fwd_occupancy_total_requests: int = 128
-    fwd_occupancy_max_new_tokens: int = 256
+    # Measurement load -- one long single-batch request. max_new_tokens
+    # must cover many decode_log_interval windows worth of decode steps
+    # so the scraper collects enough samples.
+    fwd_occupancy_max_new_tokens: int = 2048
     fwd_occupancy_prompt: str = "Write a long, detailed, multi-paragraph story about "
 
     def _scrape_fwd_occupancy(self):
@@ -100,6 +104,9 @@ class FwdOccupancyMixin:
         )
 
     def _fwd_occupancy_fire(self, prompt: str, max_new_tokens: int):
+        """Synchronously fire one /generate request. Single batch_size=1
+        decode -- this method must never be called concurrently if the
+        probe's single-batch invariant is to hold."""
         try:
             requests.post(
                 self.base_url + "/generate",
@@ -118,69 +125,43 @@ class FwdOccupancyMixin:
             pass
 
     def _fwd_occupancy_warmup(self):
-        """Fire a few requests synchronously to drive the server into
-        steady-state before sampling. The device-timer window also needs
-        a few batches of activity before the gauge produces non-NaN
-        values."""
-        prompts = [
-            f"warmup#{i} {self.fwd_occupancy_prompt}"
-            for i in range(self.fwd_occupancy_warmup_requests)
-        ]
-        with ThreadPoolExecutor(
-            max_workers=self.fwd_occupancy_warmup_requests
-        ) as executor:
-            futures = [
-                executor.submit(
-                    self._fwd_occupancy_fire,
-                    p,
-                    self.fwd_occupancy_warmup_max_new_tokens,
-                )
-                for p in prompts
-            ]
-            for f in futures:
-                f.result()
-        # Give the scheduler a beat to settle before measurement starts.
+        """Fire one short request synchronously to fill cuda graphs and
+        let the device-timer window emit its first non-NaN sample before
+        measurement starts."""
+        self._fwd_occupancy_fire(
+            "warmup " + self.fwd_occupancy_prompt,
+            self.fwd_occupancy_warmup_max_new_tokens,
+        )
         time.sleep(self.fwd_occupancy_warmup_settle_seconds)
 
     def _fwd_occupancy_measure(self):
-        """Fire concurrent load + scrape /metrics in a background
-        thread; return the list of non-NaN occupancy samples observed
-        while the load was in-flight."""
+        """Fire one long single-batch request in a background thread and
+        scrape /metrics from the main thread while it's in flight;
+        return the list of non-NaN occupancy samples observed."""
         samples = []
         samples_lock = threading.Lock()
-        scraping_done = threading.Event()
+        request_done = threading.Event()
 
-        def scrape_loop():
-            while not scraping_done.is_set():
-                v = self._scrape_fwd_occupancy()
-                if v is not None:
-                    with samples_lock:
-                        samples.append(v)
-                time.sleep(self.fwd_occupancy_scrape_interval)
+        def fire_one():
+            try:
+                self._fwd_occupancy_fire(
+                    self.fwd_occupancy_prompt,
+                    self.fwd_occupancy_max_new_tokens,
+                )
+            finally:
+                request_done.set()
 
-        scraper = threading.Thread(target=scrape_loop, daemon=True)
-        scraper.start()
+        firer = threading.Thread(target=fire_one, daemon=True)
+        firer.start()
 
-        prompts = [
-            f"#{i} {self.fwd_occupancy_prompt}"
-            for i in range(self.fwd_occupancy_total_requests)
-        ]
-        try:
-            with ThreadPoolExecutor(max_workers=self.fwd_occupancy_workers) as executor:
-                futures = [
-                    executor.submit(
-                        self._fwd_occupancy_fire,
-                        p,
-                        self.fwd_occupancy_max_new_tokens,
-                    )
-                    for p in prompts
-                ]
-                for f in futures:
-                    f.result()
-        finally:
-            scraping_done.set()
-            scraper.join(timeout=5.0)
+        while not request_done.is_set():
+            v = self._scrape_fwd_occupancy()
+            if v is not None:
+                with samples_lock:
+                    samples.append(v)
+            time.sleep(self.fwd_occupancy_scrape_interval)
 
+        firer.join(timeout=_GENERATE_REQUEST_TIMEOUT)
         return samples
 
     def test_fwd_occupancy(self):

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -31,6 +31,7 @@ import threading
 import time
 
 import requests
+import tabulate
 
 _FWD_OCCUPANCY_RE = re.compile(
     r"^sglang:fwd_occupancy(?:\{[^}]*\})?\s+(\S+)", re.MULTILINE
@@ -184,8 +185,18 @@ class FwdOccupancyMixin:
         peak = samples_sorted[-1]
         p10 = samples_sorted[max(0, len(samples_sorted) // 10 - 1)]
         print(
-            f"fwd_occupancy samples (n={len(samples)}): "
-            f"median={median:.2f} peak={peak:.2f} p10={p10:.2f}"
+            "\n"
+            + tabulate.tabulate(
+                [
+                    ["samples (n)", len(samples)],
+                    ["median", f"{median:.2f}"],
+                    ["peak", f"{peak:.2f}"],
+                    ["p10", f"{p10:.2f}"],
+                    ["threshold", f"{self.fwd_occupancy_threshold:.2f}"],
+                ],
+                headers=["fwd_occupancy", "value"],
+                tablefmt="github",
+            )
         )
 
         self.assertGreater(

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -38,9 +38,10 @@ class FwdOccupancyMixin:
 
     # Spec-decoding accept-length floor. Only enforced when the server
     # is running with a spec algorithm (avg_spec_accept_length present
-    # in /server_info); silently skipped otherwise. Below ~2.0 means
-    # spec barely accepts -- effectively falling back to vanilla.
-    spec_accept_length_threshold: float = 2.0
+    # in /server_info); silently skipped otherwise. EAGLE3 3/1/4 on
+    # 5090 + Llama-3.1-8B measured ~2.0 in CI; 1.8 leaves a small
+    # buffer while still catching silent fallback to vanilla (~1.0).
+    spec_accept_length_threshold: float = 1.8
 
     # Warmup: one short request to fill cuda graphs + get the
     # device-timer past its first NaN window.
@@ -122,7 +123,6 @@ class FwdOccupancyMixin:
         """Background-fire one long single-batch request, scrape
         /metrics on the foreground; return non-NaN samples."""
         samples = []
-        samples_lock = threading.Lock()
         request_done = threading.Event()
 
         def fire_one():
@@ -140,8 +140,7 @@ class FwdOccupancyMixin:
         while not request_done.is_set():
             v = self._scrape_fwd_occupancy()
             if v is not None:
-                with samples_lock:
-                    samples.append(v)
+                samples.append(v)
             time.sleep(self.fwd_occupancy_scrape_interval)
 
         firer.join(timeout=_GENERATE_REQUEST_TIMEOUT)

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -36,6 +36,12 @@ class FwdOccupancyMixin:
     fwd_occupancy_min_samples: int = 5
     fwd_occupancy_scrape_interval: float = 0.5
 
+    # Spec-decoding accept-length floor. Only enforced when the server
+    # is running with a spec algorithm (avg_spec_accept_length present
+    # in /server_info); silently skipped otherwise. Below ~2.0 means
+    # spec barely accepts -- effectively falling back to vanilla.
+    spec_accept_length_threshold: float = 2.0
+
     # Warmup: one short request to fill cuda graphs + get the
     # device-timer past its first NaN window.
     fwd_occupancy_warmup_max_new_tokens: int = 64
@@ -182,3 +188,23 @@ class FwdOccupancyMixin:
             f"threshold {self.fwd_occupancy_threshold} "
             f"(peak={peak:.2f}, p10={p10:.2f}, n={len(samples)})",
         )
+
+        # The 2048-token decode above populates the spec running average
+        # if a spec algorithm is enabled; absent otherwise (vanilla
+        # decode skips this check).
+        try:
+            info = requests.get(
+                self.base_url + "/server_info", timeout=_METRICS_REQUEST_TIMEOUT
+            ).json()
+            avg_accept = info["internal_states"][0].get("avg_spec_accept_length")
+        except (requests.RequestException, KeyError, IndexError):
+            avg_accept = None
+        if avg_accept is not None:
+            print(f"avg_spec_accept_length = {avg_accept:.3f}")
+            self.assertGreater(
+                avg_accept,
+                self.spec_accept_length_threshold,
+                f"avg_spec_accept_length={avg_accept:.3f} did not exceed "
+                f"threshold {self.spec_accept_length_threshold} -- spec "
+                "barely accepted, possibly degraded to vanilla decode",
+            )

--- a/python/sglang/test/kits/fwd_occupancy_kit.py
+++ b/python/sglang/test/kits/fwd_occupancy_kit.py
@@ -1,28 +1,17 @@
-"""GPU forward-pass occupancy sanity kit (single-batch decode).
+"""Single-batch decode GPU occupancy sanity kit.
 
-Probes the ``sglang:fwd_occupancy`` Prometheus gauge while a single
-long ``/generate`` request is in flight (batch_size = 1 decode) and
-asserts the steady-state value clears a threshold.
+Probes ``sglang:fwd_occupancy`` (a 0-100 percentage averaged over the
+last ``decode_log_interval`` batches; resets to NaN at window
+boundaries) under one long single-batch ``/generate`` request, and
+asserts median above a threshold. Single-batch is where CPU overhead
+dominates -- overlap scheduler / cuda graph regressions surface here
+before batched throughput moves.
 
-Single-batch decode is the worst case for CPU overhead: each decode
-step produces just one token, so per-step host-side work (kernel
-dispatch, sampling, metadata bookkeeping) competes with a single tiny
-forward pass. If the overlap scheduler or cuda graph capture stalls,
-GPU idle ratio shoots up here before anything shows in batched
-throughput numbers.
-
-The gauge is a percentage in [0, 100] -- ``gpu_busy / wall_clock * 100``
-over the most recent ``decode_log_interval`` batches. It cycles back to
-NaN on every window reset, so the probe filters NaN samples.
-
-Prerequisites on the server launched by the consuming test class:
+Prerequisites on the consuming server:
     env:          SGLANG_ENABLE_METRICS_DEVICE_TIMER=1
     server flag:  --enable-metrics
 
-Without both, ``sglang:fwd_occupancy`` is either not exposed or
-permanently NaN, and the probe fails fast with a clear message.
-
-Mix into any ``CustomTestCase`` subclass that exposes ``self.base_url``.
+Mix into a ``CustomTestCase`` subclass exposing ``self.base_url``.
 """
 
 import re
@@ -41,34 +30,25 @@ _METRICS_REQUEST_TIMEOUT = 10
 
 
 class FwdOccupancyMixin:
-    """Assert steady-state ``sglang:fwd_occupancy`` for single-batch decode.
+    """Assert single-batch ``sglang:fwd_occupancy`` median > threshold."""
 
-    Threshold is a percentage in [0, 100]. Default 95.0 -- single-batch
-    decode with overlap scheduler + cuda graph on a healthy GPU should
-    hold steady-state 95+; falling below this points at CPU-side
-    regressions even when batched throughput still looks fine.
-    """
-
-    # Threshold + detection
     fwd_occupancy_threshold: float = 95.0
     fwd_occupancy_min_samples: int = 5
     fwd_occupancy_scrape_interval: float = 0.5
 
-    # Warmup phase -- one short request to fill cuda graphs and let the
-    # device-timer window emit its first non-NaN sample.
+    # Warmup: one short request to fill cuda graphs + get the
+    # device-timer past its first NaN window.
     fwd_occupancy_warmup_max_new_tokens: int = 64
     fwd_occupancy_warmup_settle_seconds: float = 1.0
 
-    # Measurement load -- one long single-batch request. max_new_tokens
-    # must cover many decode_log_interval windows worth of decode steps
-    # so the scraper collects enough samples.
+    # Measurement: one long single-batch request -- max_new_tokens must
+    # span several decode_log_interval windows for enough samples.
     fwd_occupancy_max_new_tokens: int = 2048
     fwd_occupancy_prompt: str = "Write a long, detailed, multi-paragraph story about "
 
     def _scrape_fwd_occupancy(self):
-        """Return the max non-NaN ``sglang:fwd_occupancy`` value across
-        exposed labels (e.g. dp ranks); None on transient scrape failure
-        or no non-NaN sample."""
+        """Max non-NaN gauge value across exposed labels (e.g. dp ranks);
+        None on transient scrape failure."""
         try:
             resp = requests.get(
                 self.base_url + "/metrics", timeout=_METRICS_REQUEST_TIMEOUT
@@ -88,9 +68,8 @@ class FwdOccupancyMixin:
         return max(vals) if vals else None
 
     def _assert_metrics_device_timer_enabled(self):
-        """Fail loudly if --enable-metrics or
-        SGLANG_ENABLE_METRICS_DEVICE_TIMER aren't in effect; otherwise
-        a missing gauge would look like a real occupancy regression."""
+        """Fail loudly on missing flag/env -- otherwise a NaN-only gauge
+        looks like a real occupancy regression."""
         resp = requests.get(
             self.base_url + "/metrics", timeout=_METRICS_REQUEST_TIMEOUT
         )
@@ -105,9 +84,8 @@ class FwdOccupancyMixin:
         )
 
     def _fwd_occupancy_fire(self, prompt: str, max_new_tokens: int):
-        """Synchronously fire one /generate request. Single batch_size=1
-        decode -- this method must never be called concurrently if the
-        probe's single-batch invariant is to hold."""
+        """Fire one /generate. Must not be called concurrently -- that
+        would break the single-batch invariant."""
         try:
             requests.post(
                 self.base_url + "/generate",
@@ -121,14 +99,13 @@ class FwdOccupancyMixin:
                 timeout=_GENERATE_REQUEST_TIMEOUT,
             )
         except requests.RequestException:
-            # Individual fire failure is not the probe's concern; the
-            # final stats-vs-threshold check is the signal.
+            # Final stats-vs-threshold is the signal; individual fire
+            # failure isn't.
             pass
 
     def _fwd_occupancy_warmup(self):
-        """Fire one short request synchronously to fill cuda graphs and
-        let the device-timer window emit its first non-NaN sample before
-        measurement starts."""
+        """Fill cuda graphs + step the device-timer past its first NaN
+        window before measurement starts."""
         self._fwd_occupancy_fire(
             "warmup " + self.fwd_occupancy_prompt,
             self.fwd_occupancy_warmup_max_new_tokens,
@@ -136,9 +113,8 @@ class FwdOccupancyMixin:
         time.sleep(self.fwd_occupancy_warmup_settle_seconds)
 
     def _fwd_occupancy_measure(self):
-        """Fire one long single-batch request in a background thread and
-        scrape /metrics from the main thread while it's in flight;
-        return the list of non-NaN occupancy samples observed."""
+        """Background-fire one long single-batch request, scrape
+        /metrics on the foreground; return non-NaN samples."""
         samples = []
         samples_lock = threading.Lock()
         request_done = threading.Event()

--- a/python/sglang/test/kits/hellaswag_kit.py
+++ b/python/sglang/test/kits/hellaswag_kit.py
@@ -1,0 +1,29 @@
+"""Hellaswag sanity kit.
+
+Runs hellaswag via the sgl frontend DSL bound to ``self.base_url`` and
+asserts accuracy above a threshold. Catches systematic regressions that
+pass every cheap single-prompt probe but tank multi-choice reasoning.
+
+Mix into a ``CustomTestCase`` subclass exposing ``self.base_url``.
+"""
+
+
+class HellaswagMixin:
+    """Assert hellaswag accuracy > threshold."""
+
+    hellaswag_accuracy_threshold: float = 0.60
+
+    def test_accuracy_floor(self):
+        import sglang as sgl
+        from sglang.test.test_programs import test_hellaswag_select
+
+        sgl.set_default_backend(sgl.RuntimeEndpoint(self.base_url))
+        try:
+            accuracy, _ = test_hellaswag_select()
+        finally:
+            sgl.set_default_backend(None)
+        self.assertGreater(
+            accuracy,
+            self.hellaswag_accuracy_threshold,
+            f"hellaswag accuracy floor breached: {accuracy:.3f}",
+        )

--- a/python/sglang/test/test_programs.py
+++ b/python/sglang/test/test_programs.py
@@ -582,9 +582,12 @@ def test_hellaswag_select():
 
     # Compute accuracy
     accuracy_gen = np.mean(np.array(preds_gen) == np.array(labels))
-    print(f"{accuracy=}, {accuracy_gen=}")
+    print(f"{accuracy=}, {accuracy_gen=} {latency=:.2f}s {latency_gen=:.2f}s")
     assert np.abs(accuracy_gen - accuracy) < 0.1
-    assert np.abs(latency_gen - latency) < 1 if not _is_hip else 2
+    # Note: latency comparison removed -- the second run hits the radix
+    # prefix cache populated by the first run, so its wall-clock is
+    # consistently a small fraction of the first run regardless of
+    # generator_style.
 
     return accuracy, latency
 

--- a/python/sglang/test/test_programs.py
+++ b/python/sglang/test/test_programs.py
@@ -584,10 +584,7 @@ def test_hellaswag_select():
     accuracy_gen = np.mean(np.array(preds_gen) == np.array(labels))
     print(f"{accuracy=}, {accuracy_gen=} {latency=:.2f}s {latency_gen=:.2f}s")
     assert np.abs(accuracy_gen - accuracy) < 0.1
-    # Note: latency comparison removed -- the second run hits the radix
-    # prefix cache populated by the first run, so its wall-clock is
-    # consistently a small fraction of the first run regardless of
-    # generator_style.
+    # No latency assert: the 2nd run hits the radix cache the 1st filled.
 
     return accuracy, latency
 

--- a/test/registered/core/test_basic_sanity.py
+++ b/test/registered/core/test_basic_sanity.py
@@ -30,9 +30,9 @@ class TestBasicSanity(
     CustomTestCase,
 ):
     served_model_name = DEFAULT_MODEL_NAME_FOR_TEST
-    # Conservative for 5090 + Llama-3.1-8B single-batch decode; saturated
-    # multi-batch runners on H100/H200 can push the default 95.0.
-    fwd_occupancy_threshold = 90.0
+    # 5090 + Llama-3.1-8B single-batch decode with overlap scheduler +
+    # cuda graph measured ~99 median in CI; keep ~2pp headroom.
+    fwd_occupancy_threshold = 97.0
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/core/test_basic_sanity.py
+++ b/test/registered/core/test_basic_sanity.py
@@ -9,6 +9,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.basic_api_contract_kit import BasicAPIContractMixin
 from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
 from sglang.test.kits.basic_scheduler_stress_kit import BasicSchedulerStressMixin
+from sglang.test.kits.fwd_occupancy_kit import FwdOccupancyMixin
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -17,17 +18,21 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=120, stage="base-a", runner_config="1-gpu-small")
-register_amd_ci(est_time=120, suite="stage-a-test-1-gpu-small-amd")
+register_cuda_ci(est_time=160, stage="base-a", runner_config="1-gpu-small")
+register_amd_ci(est_time=160, suite="stage-a-test-1-gpu-small-amd")
 
 
 class TestBasicSanity(
     BasicAPIContractMixin,
     BasicDecodeCorrectnessMixin,
     BasicSchedulerStressMixin,
+    FwdOccupancyMixin,
     CustomTestCase,
 ):
     served_model_name = DEFAULT_MODEL_NAME_FOR_TEST
+    # Conservative for 5090 + Llama-3.1-8B single-batch decode; saturated
+    # multi-batch runners on H100/H200 can push the default 95.0.
+    fwd_occupancy_threshold = 90.0
 
     @classmethod
     def setUpClass(cls):
@@ -43,6 +48,7 @@ class TestBasicSanity(
                 "0.7",
                 "--enable-metrics",
             ],
+            env={"SGLANG_ENABLE_METRICS_DEVICE_TIMER": "1"},
         )
 
     @classmethod

--- a/test/registered/core/test_basic_sanity.py
+++ b/test/registered/core/test_basic_sanity.py
@@ -1,6 +1,7 @@
-"""Basic sanity: small-but-broad server smoke that downstream stages
-depend on. Three sanity kits, one shared server, covering protocol
-contract, decode correctness, and scheduler stress paths."""
+"""Stage-a basic sanity: small-but-broad server smoke that downstream
+stages depend on. Multiple sanity-kit mixins driving one shared server,
+covering protocol, decode correctness, scheduler stress, occupancy, and
+hellaswag accuracy."""
 
 import unittest
 
@@ -10,6 +11,7 @@ from sglang.test.kits.basic_api_contract_kit import BasicAPIContractMixin
 from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
 from sglang.test.kits.basic_scheduler_stress_kit import BasicSchedulerStressMixin
 from sglang.test.kits.fwd_occupancy_kit import FwdOccupancyMixin
+from sglang.test.kits.hellaswag_kit import HellaswagMixin
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -27,6 +29,7 @@ class TestBasicSanity(
     BasicDecodeCorrectnessMixin,
     BasicSchedulerStressMixin,
     FwdOccupancyMixin,
+    HellaswagMixin,
     CustomTestCase,
 ):
     served_model_name = DEFAULT_MODEL_NAME_FOR_TEST
@@ -54,23 +57,6 @@ class TestBasicSanity(
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
-
-    def test_accuracy_floor(self):
-        # Stage-a's own accuracy gate -- catches systematic regressions
-        # that pass every cheap probe but tank multi-choice reasoning.
-        import sglang as sgl
-        from sglang.test.test_programs import test_hellaswag_select
-
-        sgl.set_default_backend(sgl.RuntimeEndpoint(self.base_url))
-        try:
-            accuracy, _ = test_hellaswag_select()
-        finally:
-            sgl.set_default_backend(None)
-        self.assertGreater(
-            accuracy,
-            0.60,
-            f"hellaswag accuracy floor breached: {accuracy:.3f}",
-        )
 
 
 if __name__ == "__main__":

--- a/test/registered/core/test_basic_sanity.py
+++ b/test/registered/core/test_basic_sanity.py
@@ -56,11 +56,8 @@ class TestBasicSanity(
         kill_process_tree(cls.process.pid)
 
     def test_accuracy_floor(self):
-        # Stage-a-private accuracy guard: hellaswag via the frontend DSL
-        # bound to this server. Catches systematic regressions that pass
-        # every cheap probe in the mixed-in kits but tank multi-choice
-        # reasoning. Not part of any reusable mixin -- accuracy gating
-        # is the gate test's own responsibility.
+        # Stage-a's own accuracy gate -- catches systematic regressions
+        # that pass every cheap probe but tank multi-choice reasoning.
         import sglang as sgl
         from sglang.test.test_programs import test_hellaswag_select
 

--- a/test/registered/core/test_basic_sanity_eagle3.py
+++ b/test/registered/core/test_basic_sanity_eagle3.py
@@ -1,6 +1,5 @@
-"""Basic sanity for stage-a with EAGLE3 spec decoding. Mirrors
-test_basic_sanity.py but launches the same target model with EAGLE3
-draft so the gate covers the spec-decoding path."""
+"""Stage-a basic sanity with EAGLE3 spec decoding enabled. Mirrors
+test_basic_sanity.py with the spec-decoding path active."""
 
 import unittest
 
@@ -10,6 +9,7 @@ from sglang.test.kits.basic_api_contract_kit import BasicAPIContractMixin
 from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
 from sglang.test.kits.basic_scheduler_stress_kit import BasicSchedulerStressMixin
 from sglang.test.kits.fwd_occupancy_kit import FwdOccupancyMixin
+from sglang.test.kits.hellaswag_kit import HellaswagMixin
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE3,
     DEFAULT_TARGET_MODEL_EAGLE3,
@@ -28,12 +28,12 @@ class TestBasicSanityEagle3(
     BasicDecodeCorrectnessMixin,
     BasicSchedulerStressMixin,
     FwdOccupancyMixin,
+    HellaswagMixin,
     CustomTestCase,
 ):
     served_model_name = DEFAULT_TARGET_MODEL_EAGLE3
-    # EAGLE3 spec decoding does more GPU work per wall-clock step than
-    # vanilla decode -- threshold can stay tight. Start at 97 like the
-    # vanilla gate; adjust per CI calibration.
+    # Match vanilla gate at 97; EAGLE3 spec should sustain similar
+    # single-batch occupancy. Adjust per CI calibration.
     fwd_occupancy_threshold = 97.0
 
     @classmethod
@@ -73,23 +73,6 @@ class TestBasicSanityEagle3(
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
-
-    def test_accuracy_floor(self):
-        # Stage-a's own accuracy gate -- catches systematic regressions
-        # that pass every cheap probe but tank multi-choice reasoning.
-        import sglang as sgl
-        from sglang.test.test_programs import test_hellaswag_select
-
-        sgl.set_default_backend(sgl.RuntimeEndpoint(self.base_url))
-        try:
-            accuracy, _ = test_hellaswag_select()
-        finally:
-            sgl.set_default_backend(None)
-        self.assertGreater(
-            accuracy,
-            0.60,
-            f"hellaswag accuracy floor breached: {accuracy:.3f}",
-        )
 
 
 if __name__ == "__main__":

--- a/test/registered/core/test_basic_sanity_eagle3.py
+++ b/test/registered/core/test_basic_sanity_eagle3.py
@@ -1,0 +1,89 @@
+"""Basic sanity for stage-a with EAGLE3 spec decoding. Mirrors
+test_basic_sanity.py but launches the same target model with EAGLE3
+draft so the gate covers the spec-decoding path."""
+
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.kits.basic_api_contract_kit import BasicAPIContractMixin
+from sglang.test.kits.basic_decode_correctness_kit import BasicDecodeCorrectnessMixin
+from sglang.test.kits.basic_scheduler_stress_kit import BasicSchedulerStressMixin
+from sglang.test.kits.fwd_occupancy_kit import FwdOccupancyMixin
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE3,
+    DEFAULT_TARGET_MODEL_EAGLE3,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=200, stage="base-a", runner_config="1-gpu-small")
+register_amd_ci(est_time=200, suite="stage-a-test-1-gpu-small-amd")
+
+
+class TestBasicSanityEagle3(
+    BasicAPIContractMixin,
+    BasicDecodeCorrectnessMixin,
+    BasicSchedulerStressMixin,
+    FwdOccupancyMixin,
+    CustomTestCase,
+):
+    served_model_name = DEFAULT_TARGET_MODEL_EAGLE3
+    # EAGLE3 spec decoding does more GPU work per wall-clock step than
+    # vanilla decode -- threshold can stay tight. Start at 97 like the
+    # vanilla gate; adjust per CI calibration.
+    fwd_occupancy_threshold = 97.0
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            DEFAULT_TARGET_MODEL_EAGLE3,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--speculative-algorithm",
+                "EAGLE3",
+                "--speculative-draft-model-path",
+                DEFAULT_DRAFT_MODEL_EAGLE3,
+                "--speculative-num-steps",
+                "3",
+                "--speculative-eagle-topk",
+                "1",
+                "--speculative-num-draft-tokens",
+                "4",
+                "--cuda-graph-max-bs",
+                "4",
+                "--mem-fraction-static",
+                "0.7",
+                "--enable-metrics",
+            ],
+            env={"SGLANG_ENABLE_METRICS_DEVICE_TIMER": "1"},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_accuracy_floor(self):
+        # Stage-a's own accuracy gate -- catches systematic regressions
+        # that pass every cheap probe but tank multi-choice reasoning.
+        import sglang as sgl
+        from sglang.test.test_programs import test_hellaswag_select
+
+        sgl.set_default_backend(sgl.RuntimeEndpoint(self.base_url))
+        try:
+            accuracy, _ = test_hellaswag_select()
+        finally:
+            sgl.set_default_backend(None)
+        self.assertGreater(
+            accuracy,
+            0.60,
+            f"hellaswag accuracy floor breached: {accuracy:.3f}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/core/test_basic_sanity_eagle3.py
+++ b/test/registered/core/test_basic_sanity_eagle3.py
@@ -44,6 +44,13 @@ class TestBasicSanityEagle3(
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
+                # Canonical EAGLE3 sglang config: fp16 + triton attention.
+                # bf16 + flashinfer cutlass RMSNorm hits a SM120 dtype
+                # mismatch on the draft model's input_layernorm.
+                "--dtype",
+                "float16",
+                "--attention-backend",
+                "triton",
                 "--speculative-algorithm",
                 "EAGLE3",
                 "--speculative-draft-model-path",


### PR DESCRIPTION
New mixin `FwdOccupancyMixin` in `python/sglang/test/kits/fwd_occupancy_kit.py` that fires sustained concurrent `/generate` load + scrapes the `sglang:fwd_occupancy` Prometheus gauge, asserting steady-state median above a threshold (default 85%). Phases: precondition check (`--enable-metrics` + `SGLANG_ENABLE_METRICS_DEVICE_TIMER=1`), warmup, measurement. No consumer test class yet; this PR is just the kit.

























































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26156631640](https://github.com/sgl-project/sglang/actions/runs/26156631640)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26156631409](https://github.com/sgl-project/sglang/actions/runs/26156631409)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->