### PR TITLE
Fix/dsv4 flash eagle dummy ima

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1198,8 +1198,40 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
             )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+        orig_out_cache_loc = forward_batch.out_cache_loc
+        orig_seq_lens = forward_batch.seq_lens
+        orig_seq_lens_cpu = forward_batch.seq_lens_cpu
+
+        step_out_cache_locs = None
+        if (
+            orig_out_cache_loc is not None
+            and self.topk > 0
+            and orig_out_cache_loc.numel()
+            == forward_batch.batch_size * self.topk * self.speculative_num_steps
+        ):
+            step_out_cache_locs = (
+                orig_out_cache_loc.reshape(
+                    forward_batch.batch_size, self.topk, self.speculative_num_steps
+                )
+                .permute((2, 0, 1))
+                .reshape(self.speculative_num_steps, -1)
+            )
+
+        try:
+            for i in range(self.speculative_num_steps - 1):
+                if step_out_cache_locs is not None:
+                    forward_batch.out_cache_loc = step_out_cache_locs[i]
+                    forward_batch.seq_lens = orig_seq_lens + i + 1
+                    forward_batch.seq_lens_cpu = (
+                        None
+                        if orig_seq_lens_cpu is None
+                        else orig_seq_lens_cpu + i + 1
+                    )
+                self.attn_backends[i].init_forward_metadata(forward_batch)
+        finally:
+            forward_batch.out_cache_loc = orig_out_cache_loc
+            forward_batch.seq_lens = orig_seq_lens
+            forward_batch.seq_lens_cpu = orig_seq_lens_cpu
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1198,42 +1198,8 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
             )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        orig_out_cache_loc = forward_batch.out_cache_loc
-        orig_seq_lens = forward_batch.seq_lens
-        orig_seq_lens_cpu = forward_batch.seq_lens_cpu
-
-        step_out_cache_locs = None
-        if (
-            orig_out_cache_loc is not None
-            and self.topk > 0
-            and orig_out_cache_loc.numel()
-            == forward_batch.batch_size * self.topk * self.speculative_num_steps
-        ):
-            # EAGLE allocates cache locations for all draft steps up front, but
-            # each DSV4 decode metadata plan expects only this step's locations.
-            step_out_cache_locs = (
-                orig_out_cache_loc.reshape(
-                    forward_batch.batch_size, self.topk, self.speculative_num_steps
-                )
-                .permute((2, 0, 1))
-                .reshape(self.speculative_num_steps, -1)
-            )
-
-        try:
-            for i in range(self.speculative_num_steps - 1):
-                if step_out_cache_locs is not None:
-                    forward_batch.out_cache_loc = step_out_cache_locs[i]
-                    forward_batch.seq_lens = orig_seq_lens + i + 1
-                    forward_batch.seq_lens_cpu = (
-                        None
-                        if orig_seq_lens_cpu is None
-                        else orig_seq_lens_cpu + i + 1
-                    )
-                self.attn_backends[i].init_forward_metadata(forward_batch)
-        finally:
-            forward_batch.out_cache_loc = orig_out_cache_loc
-            forward_batch.seq_lens = orig_seq_lens
-            forward_batch.seq_lens_cpu = orig_seq_lens_cpu
+        for i in range(self.speculative_num_steps - 1):
+            self.attn_backends[i].init_forward_metadata(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1209,6 +1209,8 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
             and orig_out_cache_loc.numel()
             == forward_batch.batch_size * self.topk * self.speculative_num_steps
         ):
+            # EAGLE allocates cache locations for all draft steps up front, but
+            # each DSV4 decode metadata plan expects only this step's locations.
             step_out_cache_locs = (
                 orig_out_cache_loc.reshape(
                     forward_batch.batch_size, self.topk, self.speculative_num_steps

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -50,6 +50,8 @@ class HashTopK(nn.Module):
         if topk == 0:
             return
 
+        # DummyModelLoader only initializes floating tensors, so keep this int
+        # lookup table valid until real checkpoints overwrite it.
         token_ids = torch.arange(
             self.tid2eid.shape[0], dtype=torch.int64, device=self.tid2eid.device
         ).unsqueeze(1)

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -41,8 +41,24 @@ class HashTopK(nn.Module):
             torch.empty(vocab_size, topk - num_fused_shared_experts, dtype=torch.int32),
             requires_grad=False,
         )
+        self._init_default_tid2eid()
 
         assert not apply_routed_scaling_factor_on_output, "not implemented"
+
+    def _init_default_tid2eid(self) -> None:
+        topk = self.tid2eid.shape[1]
+        if topk == 0:
+            return
+
+        token_ids = torch.arange(
+            self.tid2eid.shape[0], dtype=torch.int64, device=self.tid2eid.device
+        ).unsqueeze(1)
+        expert_offsets = torch.arange(
+            topk, dtype=torch.int64, device=self.tid2eid.device
+        ).unsqueeze(0)
+        tid2eid = (token_ids + expert_offsets) % self.num_experts
+        with torch.no_grad():
+            self.tid2eid.copy_(tid2eid.to(self.tid2eid.dtype))
 
     def empty_topk_output(self, device: torch.device):
         topk = self.topk - self.num_fused_shared_experts

--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -53,10 +53,10 @@ class HashTopK(nn.Module):
         # DummyModelLoader only initializes floating tensors, so keep this int
         # lookup table valid until real checkpoints overwrite it.
         token_ids = torch.arange(
-            self.tid2eid.shape[0], dtype=torch.int64, device=self.tid2eid.device
+            self.tid2eid.shape[0], dtype=self.tid2eid.dtype, device=self.tid2eid.device
         ).unsqueeze(1)
         expert_offsets = torch.arange(
-            topk, dtype=torch.int64, device=self.tid2eid.device
+            topk, dtype=self.tid2eid.dtype, device=self.tid2eid.device
         ).unsqueeze(0)
         tid2eid = (token_ids + expert_offsets) % self.num_experts
         with torch.no_grad():


### PR DESCRIPTION
## Motivation

Closes https://github.com/sgl-project/sglang/issues/25767

`--load-format dummy` only initializes floating-point tensors, leaving `HashTopK.tid2eid` uninitialized because it is an integer lookup table. For DeepSeek-V4-Flash with `flashinfer_mxfp4`, this can produce invalid expert ids and trigger CUDA illegal memory accesses during hash top-k execution, including CUDA graph capture.

## Modifications

Initialize `HashTopK.tid2eid` with a deterministic valid default mapping when the layer is constructed. This keeps dummy-loaded models within valid expert-id bounds while preserving normal checkpoint behavior, since real weights still overwrite `tid2eid` during loading.
















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26156702416](https://github.com/sgl-project/sglang/actions/runs/26156702416)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26156702147](https://github.com/sgl-project/sglang/actions/runs/26156702147)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->