### PR TITLE
eagle: inherit dtype from target

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -56,6 +56,7 @@ from sglang.srt.speculative.eagle_utils import (
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
+    TORCH_DTYPE_TO_STR,
     assign_draft_cache_locs,
     draft_tp_context,
     fast_topk,
@@ -126,11 +127,9 @@ class EAGLEWorker(TpModelWorker):
 
         # Match draft dtype to target. EAGLE-3 / MTP drafts share target's embed/lm_head
         # weights and aux hidden states; dtype divergence trips strict norm kernels.
-        server_args.dtype = {
-            torch.bfloat16: "bfloat16",
-            torch.float16: "float16",
-            torch.float32: "float32",
-        }[target_worker.model_runner.model_config.dtype]
+        server_args.dtype = TORCH_DTYPE_TO_STR[
+            target_worker.model_runner.model_config.dtype
+        ]
 
         # Do not capture cuda graph in `super().__init__()`
         # It will be captured later.

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -124,6 +124,14 @@ class EAGLEWorker(TpModelWorker):
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
 
+        # Match draft dtype to target. EAGLE-3 / MTP drafts share target's embed/lm_head
+        # weights and aux hidden states; dtype divergence trips strict norm kernels.
+        server_args.dtype = {
+            torch.bfloat16: "bfloat16",
+            torch.float16: "float16",
+            torch.float32: "float32",
+        }[target_worker.model_runner.model_config.dtype]
+
         # Do not capture cuda graph in `super().__init__()`
         # It will be captured later.
         backup_disable_cuda_graph = server_args.disable_cuda_graph

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -55,6 +55,7 @@ from sglang.srt.speculative.eagle_info_v2 import (
 from sglang.srt.speculative.eagle_utils import TreeMaskMode, build_tree_kernel_efficient
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
+    TORCH_DTYPE_TO_STR,
     draft_tp_context,
     generate_token_bitmask,
     load_token_map,
@@ -689,6 +690,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
+
+        # Match draft dtype to target. EAGLE-3 / MTP drafts share target's embed/lm_head
+        # weights and aux hidden states; dtype divergence trips strict norm kernels.
+        server_args.dtype = TORCH_DTYPE_TO_STR[
+            target_worker.model_runner.model_config.dtype
+        ]
 
         self._draft_worker = EagleDraftWorker(
             server_args,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -66,6 +66,7 @@ from sglang.srt.speculative.frozen_kv_mtp_utils import (
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
+    TORCH_DTYPE_TO_STR,
     draft_tp_context,
     fast_topk,
     generate_token_bitmask,
@@ -116,6 +117,12 @@ class FrozenKVMTPWorker(TpModelWorker):
 
         # Assistant reads target KV directly, so its context length must match the target.
         server_args.context_length = target_worker.model_runner.model_config.context_len
+
+        # Match draft dtype to target. EAGLE-3 / MTP drafts share target's embed/lm_head
+        # weights and aux hidden states; dtype divergence trips strict norm kernels.
+        server_args.dtype = TORCH_DTYPE_TO_STR[
+            target_worker.model_runner.model_config.dtype
+        ]
 
         # Defer cuda graph capture; we do it ourselves below.
         backup_disable_cuda_graph = server_args.disable_cuda_graph

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -49,6 +49,7 @@ from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner imp
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
+    TORCH_DTYPE_TO_STR,
     draft_tp_context,
     fast_topk,
     generate_token_bitmask,
@@ -99,6 +100,12 @@ class MultiLayerEagleWorker(TpModelWorker):
 
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
+
+        # Match draft dtype to target. EAGLE-3 / MTP drafts share target's embed/lm_head
+        # weights and aux hidden states; dtype divergence trips strict norm kernels.
+        server_args.dtype = TORCH_DTYPE_TO_STR[
+            target_worker.model_runner.model_config.dtype
+        ]
 
         # Do not capture cuda graph in `super().__init__()`
         # It will be captured later.

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -47,6 +47,7 @@ from sglang.srt.speculative.multi_layer_eagle_utils import (
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
+    TORCH_DTYPE_TO_STR,
     draft_tp_context,
     maybe_detect_nan,
     maybe_detect_oob,
@@ -636,6 +637,12 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
 
         # Override the context length of the draft model to be the same as the target model.
         server_args.context_length = target_worker.model_runner.model_config.context_len
+
+        # Match draft dtype to target. EAGLE-3 / MTP drafts share target's embed/lm_head
+        # weights and aux hidden states; dtype divergence trips strict norm kernels.
+        server_args.dtype = TORCH_DTYPE_TO_STR[
+            target_worker.model_runner.model_config.dtype
+        ]
 
         self._draft_worker = MultiLayerEagleDraftWorker(
             server_args,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -52,6 +52,16 @@ TREE_SPEC_KERNEL_AVAILABLE = (
 )  # This kernel is only available for CUDA and MUSA now
 
 
+# Inverse of model_config._STR_DTYPE_TO_TORCH_DTYPE, restricted to the canonical
+# names accepted by server_args. Used by spec workers to align draft dtype with
+# target's already-resolved dtype.
+TORCH_DTYPE_TO_STR = {
+    torch.bfloat16: "bfloat16",
+    torch.float16: "float16",
+    torch.float32: "float32",
+}
+
+
 def record_stream_each(tensors, stream):
     """Call record_stream(stream) on each cuda tensor in `tensors`, skipping
     non-tensor / non-cuda entries. Tells the caching allocator that the


### PR DESCRIPTION
Match draft dtype to target's resolved dtype in EAGLEWorker init (same place as the existing context_length override). EAGLE-3 / MTP drafts splice target embed/lm_head weights and feed target aux hidden states into draft norm layers; when draft HF config's torch_dtype differs from target's resolved dtype, strict kernels (e.g. flashinfer rmsnorm_cute) reject the dtype mismatch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26158320217](https://github.com/sgl-project/sglang/actions/runs/26158320217)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26158320169](https://github.com/sgl-project/sglang/actions/runs/26158320169)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->