### PR TITLE
Simplify Mamba2 SSD

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -548,28 +548,24 @@ class MambaMixer2(torch.nn.Module):
             # NOTE: final output is an in-place update of out tensor
             varlen_state = mamba_chunk_scan_combined(
                 hidden_states_p.view(
-                    1, num_prefill_tokens, self.num_heads // self.tp_size, self.head_dim
+                    num_prefill_tokens, self.num_heads // self.tp_size, self.head_dim
                 ),
-                dt_p.unsqueeze(0),
+                dt_p,
                 self.A,
-                B_p.view(1, num_prefill_tokens, self.n_groups // self.tp_size, -1),
-                C_p.view(1, num_prefill_tokens, self.n_groups // self.tp_size, -1),
+                B_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
+                C_p.view(num_prefill_tokens, self.n_groups // self.tp_size, -1),
                 chunk_size=mixed_metadata.chunk_size,
                 D=self.D,
                 z=None,
                 dt_bias=self.dt_bias,
-                seq_idx=mixed_metadata.seq_idx,
-                chunk_indices=mixed_metadata.chunk_indices,
-                chunk_offsets=mixed_metadata.chunk_offsets,
                 cu_seqlens=query_start_loc_p,
+                cu_chunk_seqlens=mixed_metadata.cu_chunk_seqlens,
+                last_chunk_indices=mixed_metadata.last_chunk_indices,
+                seq_idx=mixed_metadata.seq_idx,
                 initial_states=initial_states,
-                return_varlen_states=True,
-                return_final_states=False,
                 dt_softplus=True,
                 dt_limit=(0.0, float("inf")),
-                out=preallocated_ssm_out_p.view(
-                    1, num_prefill_tokens, -1, self.head_dim
-                ),
+                out=preallocated_ssm_out_p.view(num_prefill_tokens, -1, self.head_dim),
                 state_dtype=ssm_state.dtype,
             )
 

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -16,13 +16,13 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/2c58742dff8613a3bd7496f2008ce927e18d38d1/vllm/model_executor/layers/mamba/mamba2_metadata.py
 
 
-import math
 from dataclasses import dataclass
 from typing import Optional
 
 import torch
 
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.utils.common import is_pin_memory_available
 
 
 @dataclass(kw_only=True)
@@ -63,9 +63,9 @@ class Mamba2Metadata(ForwardMetadata):
         prep_initial_states: bool
 
         chunk_size: int
+        cu_chunk_seqlens: torch.Tensor
         seq_idx: torch.Tensor
-        chunk_indices: torch.Tensor
-        chunk_offsets: torch.Tensor
+        last_chunk_indices: torch.Tensor
 
         extend_seq_lens_cpu: list[int]
 
@@ -73,88 +73,63 @@ class Mamba2Metadata(ForwardMetadata):
     """`mixed_metadata` is used for extend/mixed requests"""
 
     @staticmethod
-    def _query_start_loc_to_chunk_indices_offsets(
-        query_start_loc: torch.Tensor, chunk_size: int, total_seqlens: int
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Args:
-            query_start_loc (torch.Tensor): 1D tensor of cumulative sequence
-                lengths, shape (num_seqs + 1,).
-                The first element should be 0. Each entry represents the starting
-                index of a sequence in the flattened token array.
-            chunk_size (int): The size of each physical mamba chunk
-                (number of tokens per chunk).
-            total_seqlens (int): The total number of tokens in the batch.
-
-        Returns:
-            Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
-                - chunk_indices (torch.Tensor): 1D tensor of indices
-                    indicating the physical chunk for each logical chunk.
-                - chunk_offsets (torch.Tensor): 1D tensor of offsets
-                    indicating the starting index of each logical chunk within
-                    its physical chunk.
-
-        This function computes the chunk indices and offsets for the given
-        query_start_loc and chunk_size. Both are tensors of integers with length N,
-        where N is the number of logical (pseudo) chunks.
-        A logical chunk is a sequence of tokens that are all part of the same
-        sequence and are all in the same physical mamba chunk.
-        In other words, a logical chunk changes every time we cross a sequence
-        boundary or a physical mamba chunk boundary.
-        Logical chunks are needed to handle batched requests with initial states
-        (see _state_passing_fwd and _chunk_scan_fwd).
-        The chunk_indices tensor contains the index of the physical chunk for each
-        logical chunk.
-        The chunk_offsets tensor contains the offset (AKA starting index) of the
-        logical chunk in the physical chunk.
-
-        Example:
-        query_start_loc = [0, 5, 10]
-        chunk_size = 8
-        total_seqlens = 10
-        -> chunk_indices = [0, 0, 1]
-        -> chunk_offsets = [0, 5, 0]
-
-        In this example, we have 2 sequences, each with 5 tokens. The physical
-        chunk size is 8 tokens.
-        We have three logical chunks:
-        - the first logical chunk starts at token 0 in the first physical chunk
-            and contains all 5 tokens from the first sequence
-        - the second logical chunk starts at token 5 in the first physical chunk
-            and contains first 3 tokens from the second sequence
-        - the third logical chunk starts at token 0 in the second physical chunk
-            and contains the remaining 2 tokens from the second sequence
-        """
-
-        cu_seqlens = query_start_loc[1:]  # remove prepended 0
-
-        # outputs will have length expansion of chunks that do not divide
-        # chunk_size
-        N = (
-            math.ceil(total_seqlens / chunk_size)
-            + (cu_seqlens[:-1] % chunk_size > 0).sum()
+    def _async_tensor_h2d(data: list[int], device: torch.device) -> torch.Tensor:
+        t = torch.tensor(
+            data,
+            dtype=torch.int32,
+            device="cpu",
+            pin_memory=is_pin_memory_available(device),
         )
-        chunk_indices = torch.arange(N, dtype=torch.int, device=query_start_loc.device)
-        chunk_offsets = torch.zeros(
-            (N,), dtype=torch.int, device=query_start_loc.device
+        return t.to(device=device, non_blocking=True)
+
+    @staticmethod
+    def _seq_lens_to_logical_chunks(
+        extend_seq_lens_cpu: list[int],
+        chunk_size: int,
+        device: torch.device,
+        extend_prefix_lens_cpu: Optional[list[int]] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        cu_chunk_seqlens: list[int] = [0]
+        seq_idx: list[int] = []
+        last_chunk_indices: list[int] = []
+
+        if extend_prefix_lens_cpu is None:
+            extend_prefix_lens_cpu = [0] * len(extend_seq_lens_cpu)
+
+        start = 0
+        for seq_i, (prefix_len, seq_len) in enumerate(
+            zip(extend_prefix_lens_cpu, extend_seq_lens_cpu, strict=True)
+        ):
+            remaining_len = seq_len
+            chunk_start = start
+            first_chunk_len = chunk_size - (prefix_len % chunk_size)
+            if first_chunk_len == 0:
+                first_chunk_len = chunk_size
+
+            while remaining_len > 0:
+                chunk_len = min(first_chunk_len, remaining_len)
+                seq_idx.append(seq_i)
+                chunk_start += chunk_len
+                remaining_len -= chunk_len
+                first_chunk_len = chunk_size
+                cu_chunk_seqlens.append(chunk_start)
+
+            last_chunk_indices.append(len(cu_chunk_seqlens) - 2)
+            start += seq_len
+
+        return (
+            Mamba2Metadata._async_tensor_h2d(cu_chunk_seqlens, device),
+            Mamba2Metadata._async_tensor_h2d(seq_idx, device),
+            Mamba2Metadata._async_tensor_h2d(last_chunk_indices, device),
         )
 
-        p = 0  # num of insertions
-        for s, e in zip(cu_seqlens[:-1], cu_seqlens[1:]):
-
-            # if does not divide chunk_size, then there is one chunk insertion
-            p += s % chunk_size > 0
-
-            # get the dimensions
-            # - the + 1 for _e is to shift the boundary by one chunk
-            # - this shifting is not needed if chunk_size divides e
-            _s, _e = s // chunk_size + p, e // chunk_size + p + (e % chunk_size > 0)
-
-            # adjust indices and offsets
-            chunk_indices[_s:_e] -= p
-            chunk_offsets[_s] = s % chunk_size
-
-        return chunk_indices, chunk_offsets
+    @staticmethod
+    def _to_cpu_len_list(seq_lens: list[int] | torch.Tensor | None) -> list[int]:
+        assert seq_lens is not None
+        if isinstance(seq_lens, torch.Tensor):
+            assert seq_lens.device.type == "cpu"
+            return seq_lens.tolist()
+        return seq_lens
 
     @staticmethod
     def prepare_decode(
@@ -203,30 +178,23 @@ class Mamba2Metadata(ForwardMetadata):
         num_decodes = len(forward_batch.seq_lens) - num_prefills
         context_lens_tensor = forward_batch.extend_prefix_lens
         assert context_lens_tensor is not None
+        extend_seq_lens_cpu = cls._to_cpu_len_list(forward_batch.extend_seq_lens_cpu)
+        extend_prefix_lens_cpu = cls._to_cpu_len_list(
+            forward_batch.extend_prefix_lens_cpu
+        )
         # precompute flag to avoid device syncs later
         has_initial_states = context_lens_tensor > 0
-        prep_initial_states = torch.any(has_initial_states[:num_prefills]).item()
+        prep_initial_states = any(
+            prefix_len > 0 for prefix_len in extend_prefix_lens_cpu
+        )
 
         query_start_loc = forward_metadata.query_start_loc[: num_prefills + 1]
-        seq_idx = torch.repeat_interleave(
-            torch.arange(
-                num_prefills, dtype=torch.int32, device=query_start_loc.device
-            ),
-            query_start_loc.diff(),
-            output_size=num_prefill_tokens,
+        cu_chunk_seqlens, seq_idx, last_chunk_indices = cls._seq_lens_to_logical_chunks(
+            extend_seq_lens_cpu,
+            chunk_size,
+            query_start_loc.device,
+            extend_prefix_lens_cpu,
         )
-        seq_idx.unsqueeze_(0)
-
-        # We compute metadata for chunked prefill once at the top level model
-        # forward and reuse them in mamba layers. If not needed, they will be
-        # ignored inside mamba kernels.
-        chunk_offsets, chunk_indices = None, None
-        if prep_initial_states:
-            chunk_indices, chunk_offsets = (
-                cls._query_start_loc_to_chunk_indices_offsets(
-                    query_start_loc, chunk_size, num_prefill_tokens
-                )
-            )
 
         draft_token_num = (
             getattr(forward_batch.spec_info, "draft_token_num", 1)
@@ -248,9 +216,9 @@ class Mamba2Metadata(ForwardMetadata):
                 has_initial_states=has_initial_states,
                 prep_initial_states=prep_initial_states,
                 chunk_size=chunk_size,
+                cu_chunk_seqlens=cu_chunk_seqlens,
                 seq_idx=seq_idx,
-                chunk_indices=chunk_indices,
-                chunk_offsets=chunk_offsets,
-                extend_seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+                last_chunk_indices=last_chunk_indices,
+                extend_seq_lens_cpu=extend_seq_lens_cpu,
             ),
         )

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_bmm.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_bmm.py
@@ -8,8 +8,6 @@
 
 # ruff: noqa: E501,SIM102
 
-import math
-
 import torch
 import triton
 import triton.language as tl
@@ -21,37 +19,31 @@ def _bmm_chunk_fwd_kernel(
     a_ptr,
     b_ptr,
     out_ptr,
-    seq_idx_ptr,
+    cu_chunk_seqlens_ptr,
     # Matrix dimensions
     seqlen,
     chunk_size,
     K,
     ngroups,
-    stride_a_batch,
+    # Strides
     stride_a_seqlen,
     stride_a_head,
     stride_ak,
-    stride_b_batch,
     stride_b_seqlen,
     stride_b_head,
     stride_bk,
-    stride_out_batch,
     stride_out_chunk,
     stride_out_head,
     stride_outm,
     stride_outn,
-    stride_seq_idx_batch,
-    stride_seq_idx_seqlen,
     # Meta-parameters
     IS_CAUSAL: tl.constexpr,
     dot_dtype: tl.constexpr,
-    HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr = 16,
     BLOCK_SIZE_N: tl.constexpr = 16,
     BLOCK_SIZE_K: tl.constexpr = 16,
 ):
-    pid_b = tl.program_id(axis=1)
-    pid_ch = tl.program_id(axis=2).to(tl.int64)
+    pid_ch = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_ch // ngroups
     pid_h = pid_ch - pid_c * ngroups
     num_pid_n = tl.cdiv(chunk_size, BLOCK_SIZE_N)
@@ -60,27 +52,19 @@ def _bmm_chunk_fwd_kernel(
     if IS_CAUSAL:
         if pid_n * BLOCK_SIZE_N >= (pid_m + 1) * BLOCK_SIZE_M:
             return
-    a_ptr += (
-        pid_b * stride_a_batch
-        + pid_c * chunk_size * stride_a_seqlen
-        + pid_h * stride_a_head
-    )
-    b_ptr += (
-        pid_b * stride_b_batch
-        + pid_c * chunk_size * stride_b_seqlen
-        + pid_h * stride_b_head
-    )
-    if HAS_SEQ_IDX:
-        seq_idx_ptr += (
-            pid_b * stride_seq_idx_batch + pid_c * chunk_size * stride_seq_idx_seqlen
-        )
+
+    chunk_start = tl.load(cu_chunk_seqlens_ptr + pid_c).to(tl.int64)
+    chunk_end = tl.load(cu_chunk_seqlens_ptr + pid_c + 1).to(tl.int64)
+    chunk_size_limit = chunk_end - chunk_start
+
+    a_ptr += chunk_start * stride_a_seqlen + pid_h * stride_a_head
+    b_ptr += chunk_start * stride_b_seqlen + pid_h * stride_b_head
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
     a_ptrs = a_ptr + (offs_m[:, None] * stride_a_seqlen + offs_k[None, :] * stride_ak)
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_b_seqlen)
-    chunk_size_limit = min(chunk_size, seqlen - pid_c * chunk_size)
 
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -100,26 +84,8 @@ def _bmm_chunk_fwd_kernel(
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
-    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    if HAS_SEQ_IDX:
-        chunk_size_limit = min(chunk_size, seqlen - pid_c * chunk_size)
-        seq_idx_m = tl.load(
-            seq_idx_ptr + offs_m * stride_seq_idx_seqlen,
-            mask=offs_m < chunk_size_limit,
-            other=-1,
-        )
-        seq_idx_n = tl.load(
-            seq_idx_ptr + offs_n * stride_seq_idx_seqlen,
-            mask=offs_n < chunk_size_limit,
-            other=-2,
-        )
-        acc = tl.where(seq_idx_m[:, None] == seq_idx_n[None, :], acc, 0.0)
     out = acc.to(out_ptr.dtype.element_ty)
-
-    out_ptr += (
-        pid_b * stride_out_batch + pid_c * stride_out_chunk + pid_h * stride_out_head
-    )
+    out_ptr += pid_c * stride_out_chunk + pid_h * stride_out_head
     out_ptrs = out_ptr + (stride_outm * offs_m[:, None] + offs_n[None, :] * stride_outn)
     tl.store(
         out_ptrs,
@@ -128,41 +94,29 @@ def _bmm_chunk_fwd_kernel(
     )
 
 
-def _bmm_chunk_fwd(a, b, chunk_size, seq_idx=None, causal=False, output_dtype=None):
+def _bmm_chunk_fwd(a, b, chunk_size, cu_chunk_seqlens, causal=False, output_dtype=None):
     """
     Argument:
-        a: (batch, seqlen, k) or (batch, seqlen, ngroups, k)
-        b: (batch, seqlen, k) or (batch, seqlen, ngroups, k)
-        seq_idx: (batch, seqlen) or None. out[i, j] for seq_idx[i] != seq_idx[j] will be zeroed out.
+        a: (seqlen, ngroups, k)
+        b: (seqlen, ngroups, k)
+        chunk_size: int
+        cu_chunk_seq_lens: (nchunks + 1,)
         causal: if True, then out[i, j] for i > j will be arbitrary, only out[i, j] for i <= j are
             guaranteed to be correct.
     Return:
-        out: (batch, nchunks, chunk_size, chunk_size) or (batch, nchunks, ngroups, chunk_size, chunk_size)
+        out: (nchunks, ngroups, chunk_size, chunk_size)
     """
-    # Check constraints.
-    has_groups = a.dim() == 4
-    if not has_groups:
-        batch, seqlen, k = a.shape
-    else:
-        batch, seqlen, ngroups, k = a.shape
+    seqlen, ngroups, k = a.shape
     assert b.shape == a.shape
-    if seq_idx is not None:
-        assert seq_idx.shape == (batch, seqlen)
-    if a.stride(-1) != 1 and a.stride(1) != 1:
+    if a.stride(-1) != 1 and a.stride(0) != 1:
         a = a.contiguous()
-    if b.stride(-1) != 1 and b.stride(1) != 1:
+    if b.stride(-1) != 1 and b.stride(0) != 1:
         b = b.contiguous()
-    nchunks = math.ceil(seqlen / chunk_size)
-    # Allocates output.
+
+    nchunks = cu_chunk_seqlens.shape[0] - 1
     out_dtype = a.dtype if output_dtype is None else output_dtype
     out = torch.empty(
-        (
-            (batch, nchunks, chunk_size, chunk_size)
-            if not has_groups
-            else (batch, nchunks, ngroups, chunk_size, chunk_size)
-        ),
-        device=a.device,
-        dtype=out_dtype,
+        (nchunks, ngroups, chunk_size, chunk_size), device=a.device, dtype=out_dtype
     )
     dot_dtype = (
         tl.bfloat16
@@ -176,39 +130,29 @@ def _bmm_chunk_fwd(a, b, chunk_size, seq_idx=None, causal=False, output_dtype=No
     grid = lambda META: (
         triton.cdiv(chunk_size, META["BLOCK_SIZE_M"])
         * triton.cdiv(chunk_size, META["BLOCK_SIZE_N"]),
-        batch,
-        nchunks if not has_groups else nchunks * ngroups,
+        nchunks * ngroups,
     )
     with torch.get_device_module(a.device).device(a.device.index):
         _bmm_chunk_fwd_kernel[grid](
             a,
             b,
             out,
-            seq_idx,
+            cu_chunk_seqlens,
             seqlen,
             chunk_size,
             k,
-            ngroups if has_groups else 1,
+            ngroups,
             a.stride(0),
             a.stride(1),
-            0 if not has_groups else a.stride(2),
-            a.stride(-1),
+            a.stride(2),
             b.stride(0),
             b.stride(1),
-            0 if not has_groups else b.stride(2),
-            b.stride(-1),
+            b.stride(2),
             out.stride(0),
             out.stride(1),
-            0 if not has_groups else out.stride(2),
-            out.stride(-2),
-            out.stride(-1),
-            *(
-                (seq_idx.stride(0), seq_idx.stride(1))
-                if seq_idx is not None
-                else (0, 0)
-            ),
+            out.stride(2),
+            out.stride(3),
             causal,
             dot_dtype,
-            HAS_SEQ_IDX=seq_idx is not None,
         )
     return out

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
@@ -8,7 +8,6 @@
 
 # ruff: noqa: E501,SIM102
 
-import torch
 import triton
 import triton.language as tl
 from packaging import version
@@ -23,7 +22,6 @@ def _chunk_scan_fwd_kernel(
     x_ptr,
     z_ptr,
     out_ptr,
-    out_x_ptr,
     dt_ptr,
     dA_cumsum_ptr,
     seq_idx_ptr,
@@ -31,49 +29,37 @@ def _chunk_scan_fwd_kernel(
     states_ptr,
     D_ptr,
     initstates_ptr,
-    chunk_indices_ptr,
-    chunk_offsets_ptr,
-    chunk_meta_num,
+    cu_chunk_seqlens_ptr,
     # Matrix dimensions
     chunk_size,
     hdim,
     dstate,
-    batch,
     seqlen,
     nheads_ngroups_ratio,
     # Strides
-    stride_cb_batch,
     stride_cb_chunk,
     stride_cb_head,
     stride_cb_csize_m,
     stride_cb_csize_k,
-    stride_x_batch,
     stride_x_seqlen,
     stride_x_head,
     stride_x_hdim,
-    stride_z_batch,
     stride_z_seqlen,
     stride_z_head,
     stride_z_hdim,
-    stride_out_batch,
     stride_out_seqlen,
     stride_out_head,
     stride_out_hdim,
-    stride_dt_batch,
     stride_dt_chunk,
     stride_dt_head,
     stride_dt_csize,
-    stride_dA_cs_batch,
     stride_dA_cs_chunk,
     stride_dA_cs_head,
     stride_dA_cs_csize,
-    stride_seq_idx_batch,
-    stride_seq_idx_seqlen,
-    stride_C_batch,
+    stride_seq_idx_chunk,
     stride_C_seqlen,
     stride_C_head,
     stride_C_dstate,
-    stride_states_batch,
     stride_states_chunk,
     stride_states_head,
     stride_states_hdim,
@@ -88,7 +74,6 @@ def _chunk_scan_fwd_kernel(
     HAS_D: tl.constexpr,
     D_HAS_HDIM: tl.constexpr,
     HAS_Z: tl.constexpr,
-    HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
     IS_TRITON_22: tl.constexpr,
     HAS_INITSTATES: tl.constexpr,
@@ -96,209 +81,106 @@ def _chunk_scan_fwd_kernel(
     BLOCK_SIZE_N: tl.constexpr = 16,
     BLOCK_SIZE_K: tl.constexpr = 16,
 ):
-    pid_bc = tl.program_id(axis=1).to(tl.int64)
-    pid_c = pid_bc // batch
-    pid_b = pid_bc - pid_c * batch
-    if not HAS_INITSTATES:
-        c_idx = pid_c
-        c_off = 0
-    else:
-        c_idx = tl.load(chunk_indices_ptr + pid_c, mask=pid_c > -1, other=0)
-        c_off = tl.load(chunk_offsets_ptr + pid_c, mask=pid_c > -1, other=0)
-
+    pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     num_pid_n = tl.cdiv(hdim, BLOCK_SIZE_N)
     pid_m = tl.program_id(axis=0) // num_pid_n
     pid_n = tl.program_id(axis=0) % num_pid_n
-    cb_ptr += (
-        pid_b * stride_cb_batch
-        + c_idx * stride_cb_chunk
-        + (pid_h // nheads_ngroups_ratio) * stride_cb_head
-    )
-    x_ptr += (
-        pid_b * stride_x_batch
-        + c_idx * chunk_size * stride_x_seqlen
-        + pid_h * stride_x_head
-    )
-    dt_ptr += pid_b * stride_dt_batch + c_idx * stride_dt_chunk + pid_h * stride_dt_head
-    dA_cumsum_ptr += (
-        pid_b * stride_dA_cs_batch
-        + c_idx * stride_dA_cs_chunk
-        + pid_h * stride_dA_cs_head
-    )
+
+    cb_ptr += pid_c * stride_cb_chunk + (pid_h // nheads_ngroups_ratio) * stride_cb_head
+    chunk_start = tl.load(cu_chunk_seqlens_ptr + pid_c).to(tl.int64)
+    chunk_end = tl.load(cu_chunk_seqlens_ptr + pid_c + 1).to(tl.int64)
+    chunk_size_limit = chunk_end - chunk_start
+    x_ptr += chunk_start * stride_x_seqlen + pid_h * stride_x_head
+    dt_ptr += pid_c * stride_dt_chunk + pid_h * stride_dt_head
+    dA_cumsum_ptr += pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
     C_ptr += (
-        pid_b * stride_C_batch
-        + c_idx * chunk_size * stride_C_seqlen
-        + (pid_h // nheads_ngroups_ratio) * stride_C_head
+        chunk_start * stride_C_seqlen + (pid_h // nheads_ngroups_ratio) * stride_C_head
     )
 
-    # M-block offsets and prev states
-    #  - logic in next block may override these if there is an active offset
-    offs_m = pid_m * BLOCK_SIZE_M + c_off + tl.arange(0, BLOCK_SIZE_M)
-    prev_states_ptr = (
-        states_ptr
-        + pid_b * stride_states_batch
-        + c_idx * stride_states_chunk
-        + pid_h * stride_states_head
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+
+    seq_idx_ptr += pid_c * stride_seq_idx_chunk
+    seq_idx = tl.load(seq_idx_ptr)
+    seq_idx_prev = tl.load(
+        seq_idx_ptr - stride_seq_idx_chunk, mask=pid_c >= 1, other=-1
     )
-    prev_states_hdim = stride_states_hdim
-    prev_states_dstate = stride_states_dstate
 
-    chunk_size_limit = min(chunk_size, seqlen - c_idx * chunk_size)
-    if HAS_SEQ_IDX:
-        seq_idx_ptr += (
-            pid_b * stride_seq_idx_batch + c_idx * chunk_size * stride_seq_idx_seqlen
+    if HAS_INITSTATES and (seq_idx != seq_idx_prev):
+        prev_states_ptr = (
+            initstates_ptr
+            + seq_idx * stride_init_states_batch
+            + pid_h * stride_init_states_head
         )
-
-        # - we only need seq_idx_prev to be aligned to chunk boundary
-        seq_idx_prev = tl.load(
-            seq_idx_ptr - stride_seq_idx_seqlen, mask=c_idx >= 1, other=0
+        prev_states_hdim = stride_init_states_hdim
+        prev_states_dstate = stride_init_states_dstate
+    else:
+        prev_states_ptr = (
+            states_ptr + (pid_c - 1) * stride_states_chunk + pid_h * stride_states_head
         )
-
-        if HAS_INITSTATES:
-            # if there are init states, we only need seq_idx_m to point
-            # what is the current seq_idx
-
-            # get current seq idx
-            if (pid_m * BLOCK_SIZE_M + c_off) < chunk_size_limit:
-                seq_idx_m = tl.load(
-                    seq_idx_ptr
-                    + (pid_m * BLOCK_SIZE_M + c_off) * stride_seq_idx_seqlen,
-                )
-
-                # - recall that in ssd_state_passing, for the case c_off == 0
-                # i.e., the very first sequence, we made states_ptr hold its initial state
-                # so this edge case is taken care of
-                if (
-                    (c_off == 0)
-                    and (
-                        seq_idx_prev != seq_idx_m
-                    )  # if a seq is changed exactly on boundary
-                    or (c_off > 0)  # implies a new example (pseudo chunk)
-                ):
-
-                    # - replace prev_states_ptr with init_states
-                    prev_states_ptr = (
-                        initstates_ptr
-                        + seq_idx_m * stride_init_states_batch
-                        + pid_h * stride_init_states_head
-                    )
-                    prev_states_hdim = stride_init_states_hdim  # override strides
-                    prev_states_dstate = stride_init_states_dstate
+        prev_states_hdim = stride_states_hdim
+        prev_states_dstate = stride_states_dstate
 
     offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     dA_cs_m = tl.load(
         dA_cumsum_ptr + offs_m * stride_dA_cs_csize, mask=offs_m < chunk_size, other=0.0
     ).to(tl.float32)
 
-    # - handle chunk state limit
-    if HAS_INITSTATES:
-
-        # have to split this if otherwise compilation will have problems
-        dA_cs_m_boundary = 0.0
-
-        # get the c_idx for the next (logica) chunk
-        c_idx_n = tl.load(
-            chunk_indices_ptr + (pid_c + 1),
-            mask=pid_c > -1 and (pid_c + 1) < chunk_meta_num,
-            other=-1,  # to trigger different chunk
-        )
-
-        # - there are things to consider
-        # A. if c_off > 0 then we need to move the dA_cs boundary to ensure correct
-        #    contribution of past states
-        # B. if c_off_n < chunk_size_limit, then we need to adjust this so as not to
-        #    encroach into the next sequence, where c_off_n is the offset of the next
-        #    (logical) chunk.
-        # An equivalent check for B is c_idx == c_idx_n, where there is repetition in
-        # (logical) chunk indices.
-
-        if (c_idx == c_idx_n) or c_off > 0:
-
-            # get the next offset
-            c_off_n = tl.load(
-                chunk_offsets_ptr + (pid_c + 1),
-                mask=pid_c > -1 and (pid_c + 1) < chunk_meta_num,
-                other=chunk_size,
-            )
-
-            # in this case, adjust down the chunk_size_limit
-            if c_idx == c_idx_n:
-                chunk_size_limit = min(c_off_n, chunk_size_limit)
-
-            # get the cs at the offset boundary
-            # - c_off == 0 is a passthrough
-            # - We need dA_cs at the boundary, defined by c_off - no need
-            #   to increase pointer by pid_m (it is a constant offset,
-            #   i.e. the same for all blocks)
-            dA_cs_m_boundary = tl.load(
-                dA_cumsum_ptr + (c_off - 1) * stride_dA_cs_csize,
-                mask=(((c_off - 1) > -1) and ((c_off) < chunk_size)),
-                other=0.0,
-            ).to(tl.float32)
-
-    if HAS_SEQ_IDX:
-        # - handle seq idx when HAS_INITSTATES==False
-        if not HAS_INITSTATES:
-            seq_idx_m = tl.load(
-                seq_idx_ptr + offs_m * stride_seq_idx_seqlen,
-                mask=offs_m < chunk_size_limit,
-                other=-1,
-            )
-
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
-    # Without the if (pid_c > -1), with Triton 2.1.0, I get
-    # Assertion `!(srcMmaLayout && dstMmaLayout) && "Unexpected mma -> mm a layout conversion"' failed.
-    # With Triton 2.2.0, this works
-    if IS_TRITON_22 or c_idx > -1:
-        # Faster to just do 1 iteration with larger BLOCK_SIZE_K, up to block size 128
-        offs_k_dstate = tl.arange(
-            0, BLOCK_SIZE_DSTATE if BLOCK_SIZE_DSTATE <= 128 else BLOCK_SIZE_K
-        )
-        C_ptrs = C_ptr + (
-            offs_m[:, None] * stride_C_seqlen + offs_k_dstate[None, :] * stride_C_dstate
+    offs_k_dstate = tl.arange(
+        0, BLOCK_SIZE_DSTATE if BLOCK_SIZE_DSTATE <= 128 else BLOCK_SIZE_K
+    )
+    C_ptrs = C_ptr + (
+        offs_m[:, None] * stride_C_seqlen + offs_k_dstate[None, :] * stride_C_dstate
+    )
+
+    scale_m = tl.exp(dA_cs_m)
+    if BLOCK_SIZE_DSTATE <= 128:
+        C = tl.load(
+            C_ptrs,
+            mask=(offs_m[:, None] < chunk_size_limit)
+            & (offs_k_dstate[None, :] < dstate),
+            other=0.0,
         )
 
-        prev_states_ptrs = prev_states_ptr + (
-            offs_n[None, :] * prev_states_hdim
-            + offs_k_dstate[:, None] * prev_states_dstate
-        )
-        if HAS_SEQ_IDX:
-
-            if not HAS_INITSTATES:
-                # - this is for continuous batching where there is no init states
-                scale_m = tl.where(seq_idx_m == seq_idx_prev, tl.exp(dA_cs_m), 0.0)
-            else:
-                # - if there is initstates, we will rely on prev_states, no zeroing
-                #   required.
-                scale_m = tl.exp(dA_cs_m - dA_cs_m_boundary)
-        else:
-            scale_m = tl.exp(dA_cs_m)
-        if BLOCK_SIZE_DSTATE <= 128:
-            C = tl.load(
-                C_ptrs,
-                mask=(offs_m[:, None] < chunk_size_limit)
-                & (offs_k_dstate[None, :] < dstate),
-                other=0.0,
+        if not HAS_INITSTATES and (seq_idx != seq_idx_prev):
+            prev_states = tl.zeros(
+                (BLOCK_SIZE_DSTATE, BLOCK_SIZE_N), dtype=C_ptr.dtype.element_ty
             )
-
+        else:
+            prev_states_ptrs = (
+                prev_states_ptr
+                + offs_n[None, :] * prev_states_hdim
+                + offs_k_dstate[:, None] * prev_states_dstate
+            )
             prev_states = tl.load(
                 prev_states_ptrs,
                 mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
                 other=0.0,
             )
             prev_states = prev_states.to(C_ptr.dtype.element_ty)
-            acc = tl.dot(C, prev_states) * scale_m[:, None]
-        else:
-            for k in range(0, dstate, BLOCK_SIZE_K):
-                C = tl.load(
-                    C_ptrs,
-                    mask=(offs_m[:, None] < chunk_size_limit)
-                    & (offs_k_dstate[None, :] < dstate - k),
-                    other=0.0,
+
+        acc = tl.dot(C, prev_states) * scale_m[:, None]
+
+    else:
+        prev_states_ptrs = (
+            prev_states_ptr
+            + offs_n[None, :] * prev_states_hdim
+            + offs_k_dstate[:, None] * prev_states_dstate
+        )
+        for k in range(0, dstate, BLOCK_SIZE_K):
+            C = tl.load(
+                C_ptrs,
+                mask=(offs_m[:, None] < chunk_size_limit)
+                & (offs_k_dstate[None, :] < dstate - k),
+                other=0.0,
+            )
+            if not HAS_INITSTATES and (seq_idx != seq_idx_prev):
+                prev_states = tl.zeros(
+                    (BLOCK_SIZE_K, BLOCK_SIZE_N), dtype=C_ptr.dtype.element_ty
                 )
-                # C = (C * scale_m[:, None]).to(C_ptr.dtype.element_ty)
+            else:
                 prev_states = tl.load(
                     prev_states_ptrs,
                     mask=(offs_k_dstate[:, None] < dstate - k)
@@ -306,12 +188,12 @@ def _chunk_scan_fwd_kernel(
                     other=0.0,
                 )
                 prev_states = prev_states.to(C_ptr.dtype.element_ty)
-                acc += tl.dot(C, prev_states)
-                C_ptrs += BLOCK_SIZE_K
-                prev_states_ptrs += BLOCK_SIZE_K
-            acc *= scale_m[:, None]
+            acc += tl.dot(C, prev_states)
+            C_ptrs += BLOCK_SIZE_K
+            prev_states_ptrs += BLOCK_SIZE_K
+        acc *= scale_m[:, None]
 
-    offs_k = tl.arange(0, BLOCK_SIZE_K) + c_off
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
     cb_ptrs = cb_ptr + (
         offs_m[:, None] * stride_cb_csize_m + offs_k[None, :] * stride_cb_csize_k
     )
@@ -334,9 +216,7 @@ def _chunk_scan_fwd_kernel(
         dA_cs_k = tl.load(dA_cumsum_ptrs, mask=offs_k < chunk_size - k, other=0.0).to(
             tl.float32
         )
-        # If there's seq_idx, we already set cb[i, j] = 0 for seq_idx[i] != seq_idx[j].
-        # So we don't need masking wrt seq_idx here.
-        cb *= tl.exp(dA_cs_m[:, None] - dA_cs_k[None, :])
+        cb *= tl.exp(tl.minimum(dA_cs_m[:, None] - dA_cs_k[None, :], 0.0))
         dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size - k, other=0.0).to(tl.float32)
         cb *= dt_k
         if IS_CAUSAL:
@@ -354,7 +234,7 @@ def _chunk_scan_fwd_kernel(
         dt_ptrs += BLOCK_SIZE_K * stride_dt_csize
         dA_cumsum_ptrs += BLOCK_SIZE_K * stride_dA_cs_csize
 
-    offs_out_m = pid_m * BLOCK_SIZE_M + c_off + tl.arange(0, BLOCK_SIZE_M)
+    offs_out_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_out_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
 
     if HAS_D:
@@ -373,26 +253,7 @@ def _chunk_scan_fwd_kernel(
         acc += x_residual * D
 
     if HAS_Z:
-        out_x_ptr += (
-            pid_b * stride_out_batch
-            + c_idx * chunk_size * stride_out_seqlen
-            + pid_h * stride_out_head
-        )
-        out_x_ptrs = out_x_ptr + (
-            stride_out_seqlen * offs_out_m[:, None] + offs_out_n[None, :]
-        )
-        tl.store(
-            out_x_ptrs,
-            acc,
-            mask=(offs_out_m[:, None] < chunk_size_limit)
-            & (offs_out_n[None, :] < hdim),
-        )
-
-        z_ptr += (
-            pid_b * stride_z_batch
-            + c_idx * chunk_size * stride_z_seqlen
-            + pid_h * stride_z_head
-        )
+        z_ptr += chunk_start * stride_z_seqlen + pid_h * stride_z_head
         z_ptrs = z_ptr + (
             stride_z_seqlen * offs_out_m[:, None] + stride_z_hdim * offs_out_n[None, :]
         )
@@ -404,11 +265,7 @@ def _chunk_scan_fwd_kernel(
         ).to(tl.float32)
         acc *= z * tl.sigmoid(z)
 
-    out_ptr += (
-        pid_b * stride_out_batch
-        + c_idx * chunk_size * stride_out_seqlen
-        + pid_h * stride_out_head
-    )
+    out_ptr += chunk_start * stride_out_seqlen + pid_h * stride_out_head
     out_ptrs = out_ptr + (
         stride_out_seqlen * offs_out_m[:, None] + offs_out_n[None, :] * stride_out_hdim
     )
@@ -426,68 +283,55 @@ def _chunk_scan_fwd(
     dA_cumsum,
     C,
     states,
+    cu_chunk_seqlens,
+    out,
+    seq_idx,
     D=None,
     z=None,
-    seq_idx=None,
-    chunk_indices=None,
-    chunk_offsets=None,
     initial_states=None,
-    out=None,
 ):
-    batch, seqlen, nheads, headdim = x.shape
-    _, _, nchunks, chunk_size = dt.shape
-    _, _, ngroups, dstate = C.shape
+    assert seq_idx is not None, "this implementation requires seq_idx"
+
+    seqlen, nheads, headdim = x.shape
+    _, nchunks, chunk_size = dt.shape
+    _, ngroups, dstate = C.shape
     assert nheads % ngroups == 0
-    assert C.shape == (batch, seqlen, ngroups, dstate)
-    assert cb.shape == (batch, nchunks, ngroups, chunk_size, chunk_size)
-    if z is not None:
-        assert z.shape == x.shape
+    assert C.shape == (seqlen, ngroups, dstate)
+    assert cb.shape == (nchunks, ngroups, chunk_size, chunk_size)
     if D is not None:
         assert D.shape == (nheads, headdim) or D.shape == (nheads,)
-    assert dt.shape == (batch, nheads, nchunks, chunk_size)
-    assert dA_cumsum.shape == (batch, nheads, nchunks, chunk_size)
-    assert states.shape == (batch, nchunks, nheads, headdim, dstate)
-
-    if seq_idx is not None:
-        assert seq_idx.shape == (batch, seqlen)
-
-        if initial_states is not None:
-            # with initial states, we need to take care of how
-            # seq_idx crosses the boundaries
-            assert batch == 1, "chunk scan only supports initial states with batch 1"
-            assert (
-                chunk_indices is not None and chunk_offsets is not None
-            ), "chunk_indices and chunk_offsets should have been set"
-        else:
-            chunk_indices, chunk_offsets = None, None
-    else:
-        chunk_indices, chunk_offsets = None, None
-
-    assert out.shape == x.shape
-
     if z is not None:
-        out_x = torch.empty_like(x)
-        assert out_x.stride() == out.stride()
-    else:
-        out_x = None
+        assert z.shape == x.shape
+    assert dt.shape == (nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == (nheads, nchunks, chunk_size)
+    assert states.shape == (nchunks, nheads, headdim, dstate)
+    assert seq_idx.shape == (nchunks,)
+    assert out.shape == x.shape
 
     grid = lambda META: (
         triton.cdiv(chunk_size, META["BLOCK_SIZE_M"])
         * triton.cdiv(headdim, META["BLOCK_SIZE_N"]),
-        batch * nchunks if chunk_offsets is None else len(chunk_offsets),
+        nchunks,
         nheads,
     )
-    z_strides = (
-        (z.stride(0), z.stride(1), z.stride(2), z.stride(3))
-        if z is not None
+
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+    initial_states_strides = (
+        (
+            initial_states.stride(0),
+            initial_states.stride(1),
+            initial_states.stride(2),
+            initial_states.stride(3),
+        )
+        if initial_states is not None
         else (0, 0, 0, 0)
     )
+
     _chunk_scan_fwd_kernel[grid](
         cb,
         x,
         z,
         out,
-        out_x,
         dt,
         dA_cumsum,
         seq_idx,
@@ -495,68 +339,50 @@ def _chunk_scan_fwd(
         states,
         D,
         initial_states,
-        chunk_indices,
-        chunk_offsets,
-        len(chunk_indices) if chunk_indices is not None else 0,
+        cu_chunk_seqlens,
         chunk_size,
         headdim,
         dstate,
-        batch,
         seqlen,
         nheads // ngroups,
         cb.stride(0),
         cb.stride(1),
         cb.stride(2),
         cb.stride(3),
-        cb.stride(4),
         x.stride(0),
         x.stride(1),
         x.stride(2),
-        x.stride(3),
         z_strides[0],
         z_strides[1],
         z_strides[2],
-        z_strides[3],
         out.stride(0),
         out.stride(1),
         out.stride(2),
-        out.stride(3),
+        dt.stride(1),
         dt.stride(0),
         dt.stride(2),
-        dt.stride(1),
-        dt.stride(3),
+        dA_cumsum.stride(1),
         dA_cumsum.stride(0),
         dA_cumsum.stride(2),
-        dA_cumsum.stride(1),
-        dA_cumsum.stride(3),
-        *((seq_idx.stride(0), seq_idx.stride(1)) if seq_idx is not None else (0, 0)),
+        seq_idx.stride(0),
         C.stride(0),
         C.stride(1),
         C.stride(2),
-        C.stride(3),
         states.stride(0),
         states.stride(1),
         states.stride(2),
         states.stride(3),
-        states.stride(4),
-        *(
-            (
-                initial_states.stride(0),
-                initial_states.stride(1),
-                initial_states.stride(2),
-                initial_states.stride(3),
-            )
-            if initial_states is not None
-            else (0, 0, 0, 0)
-        ),
+        initial_states_strides[0],
+        initial_states_strides[1],
+        initial_states_strides[2],
+        initial_states_strides[3],
         D.stride(0) if D is not None else 0,
         True,
         D is not None,
         D.dim() == 2 if D is not None else True,
-        BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
         HAS_Z=z is not None,
-        HAS_SEQ_IDX=seq_idx is not None,
+        BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
         IS_TRITON_22=TRITON_22,
         HAS_INITSTATES=initial_states is not None,
     )
-    return out_x
+    return

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_scan.py
@@ -24,11 +24,9 @@ def _chunk_scan_fwd_kernel(
     out_ptr,
     dt_ptr,
     dA_cumsum_ptr,
-    seq_idx_ptr,
     C_ptr,
     states_ptr,
     D_ptr,
-    initstates_ptr,
     cu_chunk_seqlens_ptr,
     # Matrix dimensions
     chunk_size,
@@ -56,7 +54,6 @@ def _chunk_scan_fwd_kernel(
     stride_dA_cs_chunk,
     stride_dA_cs_head,
     stride_dA_cs_csize,
-    stride_seq_idx_chunk,
     stride_C_seqlen,
     stride_C_head,
     stride_C_dstate,
@@ -64,10 +61,6 @@ def _chunk_scan_fwd_kernel(
     stride_states_head,
     stride_states_hdim,
     stride_states_dstate,
-    stride_init_states_batch,
-    stride_init_states_head,
-    stride_init_states_hdim,
-    stride_init_states_dstate,
     stride_D_head,
     # Meta-parameters
     IS_CAUSAL: tl.constexpr,
@@ -76,7 +69,6 @@ def _chunk_scan_fwd_kernel(
     HAS_Z: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
     IS_TRITON_22: tl.constexpr,
-    HAS_INITSTATES: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr = 16,
     BLOCK_SIZE_N: tl.constexpr = 16,
     BLOCK_SIZE_K: tl.constexpr = 16,
@@ -98,29 +90,14 @@ def _chunk_scan_fwd_kernel(
         chunk_start * stride_C_seqlen + (pid_h // nheads_ngroups_ratio) * stride_C_head
     )
 
-    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-
-    seq_idx_ptr += pid_c * stride_seq_idx_chunk
-    seq_idx = tl.load(seq_idx_ptr)
-    seq_idx_prev = tl.load(
-        seq_idx_ptr - stride_seq_idx_chunk, mask=pid_c >= 1, other=-1
+    # state_passing has already placed the correct start-of-chunk state at
+    # states_ptr[pid_c] (init_state for first chunk of a sequence, otherwise
+    # the end-of-previous-chunk state). No init_states / seq_idx branching needed.
+    prev_states_ptr = (
+        states_ptr + pid_c * stride_states_chunk + pid_h * stride_states_head
     )
 
-    if HAS_INITSTATES and (seq_idx != seq_idx_prev):
-        prev_states_ptr = (
-            initstates_ptr
-            + seq_idx * stride_init_states_batch
-            + pid_h * stride_init_states_head
-        )
-        prev_states_hdim = stride_init_states_hdim
-        prev_states_dstate = stride_init_states_dstate
-    else:
-        prev_states_ptr = (
-            states_ptr + (pid_c - 1) * stride_states_chunk + pid_h * stride_states_head
-        )
-        prev_states_hdim = stride_states_hdim
-        prev_states_dstate = stride_states_dstate
-
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     dA_cs_m = tl.load(
         dA_cumsum_ptr + offs_m * stride_dA_cs_csize, mask=offs_m < chunk_size, other=0.0
@@ -143,31 +120,24 @@ def _chunk_scan_fwd_kernel(
             & (offs_k_dstate[None, :] < dstate),
             other=0.0,
         )
-
-        if not HAS_INITSTATES and (seq_idx != seq_idx_prev):
-            prev_states = tl.zeros(
-                (BLOCK_SIZE_DSTATE, BLOCK_SIZE_N), dtype=C_ptr.dtype.element_ty
-            )
-        else:
-            prev_states_ptrs = (
-                prev_states_ptr
-                + offs_n[None, :] * prev_states_hdim
-                + offs_k_dstate[:, None] * prev_states_dstate
-            )
-            prev_states = tl.load(
-                prev_states_ptrs,
-                mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
-                other=0.0,
-            )
-            prev_states = prev_states.to(C_ptr.dtype.element_ty)
-
+        prev_states_ptrs = (
+            prev_states_ptr
+            + offs_n[None, :] * stride_states_hdim
+            + offs_k_dstate[:, None] * stride_states_dstate
+        )
+        prev_states = tl.load(
+            prev_states_ptrs,
+            mask=(offs_k_dstate[:, None] < dstate) & (offs_n[None, :] < hdim),
+            other=0.0,
+        )
+        prev_states = prev_states.to(C_ptr.dtype.element_ty)
         acc = tl.dot(C, prev_states) * scale_m[:, None]
 
     else:
         prev_states_ptrs = (
             prev_states_ptr
-            + offs_n[None, :] * prev_states_hdim
-            + offs_k_dstate[:, None] * prev_states_dstate
+            + offs_n[None, :] * stride_states_hdim
+            + offs_k_dstate[:, None] * stride_states_dstate
         )
         for k in range(0, dstate, BLOCK_SIZE_K):
             C = tl.load(
@@ -176,18 +146,12 @@ def _chunk_scan_fwd_kernel(
                 & (offs_k_dstate[None, :] < dstate - k),
                 other=0.0,
             )
-            if not HAS_INITSTATES and (seq_idx != seq_idx_prev):
-                prev_states = tl.zeros(
-                    (BLOCK_SIZE_K, BLOCK_SIZE_N), dtype=C_ptr.dtype.element_ty
-                )
-            else:
-                prev_states = tl.load(
-                    prev_states_ptrs,
-                    mask=(offs_k_dstate[:, None] < dstate - k)
-                    & (offs_n[None, :] < hdim),
-                    other=0.0,
-                )
-                prev_states = prev_states.to(C_ptr.dtype.element_ty)
+            prev_states = tl.load(
+                prev_states_ptrs,
+                mask=(offs_k_dstate[:, None] < dstate - k) & (offs_n[None, :] < hdim),
+                other=0.0,
+            )
+            prev_states = prev_states.to(C_ptr.dtype.element_ty)
             acc += tl.dot(C, prev_states)
             C_ptrs += BLOCK_SIZE_K
             prev_states_ptrs += BLOCK_SIZE_K
@@ -285,13 +249,9 @@ def _chunk_scan_fwd(
     states,
     cu_chunk_seqlens,
     out,
-    seq_idx,
     D=None,
     z=None,
-    initial_states=None,
 ):
-    assert seq_idx is not None, "this implementation requires seq_idx"
-
     seqlen, nheads, headdim = x.shape
     _, nchunks, chunk_size = dt.shape
     _, ngroups, dstate = C.shape
@@ -305,7 +265,6 @@ def _chunk_scan_fwd(
     assert dt.shape == (nheads, nchunks, chunk_size)
     assert dA_cumsum.shape == (nheads, nchunks, chunk_size)
     assert states.shape == (nchunks, nheads, headdim, dstate)
-    assert seq_idx.shape == (nchunks,)
     assert out.shape == x.shape
 
     grid = lambda META: (
@@ -316,16 +275,6 @@ def _chunk_scan_fwd(
     )
 
     z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
-    initial_states_strides = (
-        (
-            initial_states.stride(0),
-            initial_states.stride(1),
-            initial_states.stride(2),
-            initial_states.stride(3),
-        )
-        if initial_states is not None
-        else (0, 0, 0, 0)
-    )
 
     _chunk_scan_fwd_kernel[grid](
         cb,
@@ -334,11 +283,9 @@ def _chunk_scan_fwd(
         out,
         dt,
         dA_cumsum,
-        seq_idx,
         C,
         states,
         D,
-        initial_states,
         cu_chunk_seqlens,
         chunk_size,
         headdim,
@@ -364,7 +311,6 @@ def _chunk_scan_fwd(
         dA_cumsum.stride(1),
         dA_cumsum.stride(0),
         dA_cumsum.stride(2),
-        seq_idx.stride(0),
         C.stride(0),
         C.stride(1),
         C.stride(2),
@@ -372,10 +318,6 @@ def _chunk_scan_fwd(
         states.stride(1),
         states.stride(2),
         states.stride(3),
-        initial_states_strides[0],
-        initial_states_strides[1],
-        initial_states_strides[2],
-        initial_states_strides[3],
         D.stride(0) if D is not None else 0,
         True,
         D is not None,
@@ -383,6 +325,5 @@ def _chunk_scan_fwd(
         HAS_Z=z is not None,
         BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
         IS_TRITON_22=TRITON_22,
-        HAS_INITSTATES=initial_states is not None,
     )
     return

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -8,8 +8,6 @@
 
 # ruff: noqa: E501
 
-import math
-
 import torch
 import triton
 import triton.language as tl
@@ -25,26 +23,23 @@ def _chunk_cumsum_fwd_kernel(
     dt_bias_ptr,
     dt_out_ptr,
     dA_cumsum_ptr,
+    cu_chunk_seqlens_ptr,
     # Matrix dimension
-    batch,
     seqlen,
     nheads,
     chunk_size,
     dt_min,
     dt_max,
     # Strides
-    stride_dt_batch,
     stride_dt_seqlen,
     stride_dt_head,
     stride_A_head,
     stride_dt_bias_head,
-    stride_dt_out_batch,
-    stride_dt_out_chunk,
     stride_dt_out_head,
+    stride_dt_out_chunk,
     stride_dt_out_csize,
-    stride_dA_cs_batch,
-    stride_dA_cs_chunk,
     stride_dA_cs_head,
+    stride_dA_cs_chunk,
     stride_dA_cs_csize,
     # Meta-parameters
     DT_SOFTPLUS: tl.constexpr,
@@ -52,15 +47,18 @@ def _chunk_cumsum_fwd_kernel(
     BLOCK_SIZE_CHUNK: tl.constexpr,
     BLOCK_SIZE_H: tl.constexpr = 16,
 ):
-    pid_b = tl.program_id(axis=0)
-
     # if dt is long, may cause problems, so use 64 bit
     # https://github.com/triton-lang/triton/issues/1058
-    pid_c = tl.program_id(axis=1).to(tl.int64)
-    pid_h = tl.program_id(axis=2)
-    dt_ptr += pid_b * stride_dt_batch + pid_c * chunk_size * stride_dt_seqlen
-    dt_out_ptr += pid_b * stride_dt_out_batch + pid_c * stride_dt_out_chunk
-    dA_cumsum_ptr += pid_b * stride_dA_cs_batch + pid_c * stride_dA_cs_chunk
+    pid_c = tl.program_id(axis=0).to(tl.int64)
+    pid_h = tl.program_id(axis=1)
+
+    chunk_start = tl.load(cu_chunk_seqlens_ptr + pid_c).to(tl.int64)
+    chunk_end = tl.load(cu_chunk_seqlens_ptr + pid_c + 1).to(tl.int64)
+    chunk_size_limit = chunk_end - chunk_start
+
+    dt_ptr += chunk_start * stride_dt_seqlen
+    dt_out_ptr += pid_c * stride_dt_out_chunk
+    dA_cumsum_ptr += pid_c * stride_dA_cs_chunk
 
     offs_h = pid_h * BLOCK_SIZE_H + tl.arange(0, BLOCK_SIZE_H)
     offs_c = tl.arange(0, BLOCK_SIZE_CHUNK)
@@ -74,8 +72,6 @@ def _chunk_cumsum_fwd_kernel(
     dA_cs_ptrs = dA_cumsum_ptr + (
         offs_h[:, None] * stride_dA_cs_head + offs_c[None, :] * stride_dA_cs_csize
     )
-    chunk_size_limit = min(chunk_size, seqlen - pid_c * chunk_size)
-
     dt = tl.load(
         dt_ptrs,
         mask=(offs_h[:, None] < nheads) & (offs_c[None, :] < chunk_size_limit),
@@ -88,8 +84,7 @@ def _chunk_cumsum_fwd_kernel(
         dt += dt_bias[:, None]
     if DT_SOFTPLUS:
         dt = tl.where(dt <= 20.0, softplus(dt), dt)
-    # As of Triton 2.2.0, tl.clamp is not available yet
-    # dt = tl.clamp(dt, dt_min, dt_max)
+    # As of Triton 2.2.0, tl.clamp is not available yet.
     dt = tl.minimum(tl.maximum(dt, dt_min), dt_max)
     dt = tl.where(
         (offs_h[:, None] < nheads) & (offs_c[None, :] < chunk_size_limit), dt, 0.0
@@ -117,71 +112,50 @@ def _chunk_state_fwd_kernel(
     states_ptr,
     dt_ptr,
     dA_cumsum_ptr,
-    seq_idx_ptr,
+    cu_chunk_seqlens_ptr,
     # Matrix dimensions
     hdim,
     dstate,
     chunk_size,
-    batch,
     seqlen,
     nheads_ngroups_ratio,
     # Strides
-    stride_x_batch,
     stride_x_seqlen,
     stride_x_head,
     stride_x_hdim,
-    stride_b_batch,
     stride_b_seqlen,
     stride_b_head,
     stride_b_dstate,
-    stride_states_batch,
     stride_states_chunk,
     stride_states_head,
     stride_states_hdim,
     stride_states_dstate,
-    stride_dt_batch,
-    stride_dt_chunk,
     stride_dt_head,
+    stride_dt_chunk,
     stride_dt_csize,
-    stride_dA_cs_batch,
-    stride_dA_cs_chunk,
     stride_dA_cs_head,
+    stride_dA_cs_chunk,
     stride_dA_cs_csize,
-    stride_seq_idx_batch,
-    stride_seq_idx_seqlen,
     # Meta-parameters
-    HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr = 16,
     BLOCK_SIZE_N: tl.constexpr = 16,
     BLOCK_SIZE_K: tl.constexpr = 16,
 ):
-    pid_bc = tl.program_id(axis=1).to(tl.int64)
-    pid_c = pid_bc // batch
-    pid_b = pid_bc - pid_c * batch
+    pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     num_pid_n = tl.cdiv(dstate, BLOCK_SIZE_N)
     pid_m = tl.program_id(axis=0) // num_pid_n
     pid_n = tl.program_id(axis=0) % num_pid_n
+    chunk_start = tl.load(cu_chunk_seqlens_ptr + pid_c).to(tl.int64)
+    chunk_end = tl.load(cu_chunk_seqlens_ptr + pid_c + 1).to(tl.int64)
+    chunk_size_limit = chunk_end - chunk_start
+
     b_ptr += (
-        pid_b * stride_b_batch
-        + pid_c * chunk_size * stride_b_seqlen
-        + (pid_h // nheads_ngroups_ratio) * stride_b_head
+        chunk_start * stride_b_seqlen + (pid_h // nheads_ngroups_ratio) * stride_b_head
     )
-    x_ptr += (
-        pid_b * stride_x_batch
-        + pid_c * chunk_size * stride_x_seqlen
-        + pid_h * stride_x_head
-    )
-    dt_ptr += pid_b * stride_dt_batch + pid_c * stride_dt_chunk + pid_h * stride_dt_head
-    dA_cumsum_ptr += (
-        pid_b * stride_dA_cs_batch
-        + pid_c * stride_dA_cs_chunk
-        + pid_h * stride_dA_cs_head
-    )
-    if HAS_SEQ_IDX:
-        seq_idx_ptr += (
-            pid_b * stride_seq_idx_batch + pid_c * chunk_size * stride_seq_idx_seqlen
-        )
+    x_ptr += chunk_start * stride_x_seqlen + pid_h * stride_x_head
+    dt_ptr += pid_c * stride_dt_chunk + pid_h * stride_dt_head
+    dA_cumsum_ptr += pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
@@ -197,14 +171,6 @@ def _chunk_state_fwd_kernel(
         tl.float32
     )
     dA_cumsum_ptrs = dA_cumsum_ptr + offs_k * stride_dA_cs_csize
-    if HAS_SEQ_IDX:
-        seq_idx_ptrs = seq_idx_ptr + offs_k * stride_seq_idx_seqlen
-
-    chunk_size_limit = min(chunk_size, seqlen - pid_c * chunk_size)
-    if HAS_SEQ_IDX:
-        seq_idx_last = tl.load(
-            seq_idx_ptr + (chunk_size_limit - 1) * stride_seq_idx_seqlen
-        )
 
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, chunk_size_limit, BLOCK_SIZE_K):
@@ -221,217 +187,22 @@ def _chunk_state_fwd_kernel(
         dA_cs_k = tl.load(
             dA_cumsum_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0
         ).to(tl.float32)
-        if HAS_SEQ_IDX:
-            seq_idx_k = tl.load(
-                seq_idx_ptrs, mask=offs_k < chunk_size_limit - k, other=-1
-            )
         dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0).to(
             tl.float32
         )
-        if not HAS_SEQ_IDX:
-            scale = tl.exp(dA_cs_last - dA_cs_k) * dt_k
-        else:
-            scale = tl.where(
-                seq_idx_k == seq_idx_last, tl.exp(dA_cs_last - dA_cs_k) * dt_k, 0.0
-            )
+        scale = tl.exp(tl.minimum(dA_cs_last - dA_cs_k, 0.0)) * dt_k
         b *= scale[:, None]
         b = b.to(x_ptr.dtype.element_ty)
         acc += tl.dot(x, b)
-        x_ptrs += BLOCK_SIZE_K * stride_x_seqlen
-        b_ptrs += BLOCK_SIZE_K * stride_b_seqlen
-        dt_ptrs += BLOCK_SIZE_K * stride_dt_csize
-        dA_cumsum_ptrs += BLOCK_SIZE_K * stride_dA_cs_csize
-        if HAS_SEQ_IDX:
-            seq_idx_ptrs += BLOCK_SIZE_K * stride_seq_idx_seqlen
-    states = acc.to(states_ptr.dtype.element_ty)
 
-    states_ptr += (
-        pid_b * stride_states_batch
-        + pid_c * stride_states_chunk
-        + pid_h * stride_states_head
-    )
-    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    states_ptrs = states_ptr + (
-        offs_m[:, None] * stride_states_hdim + offs_n[None, :] * stride_states_dstate
-    )
-    c_mask = (offs_m[:, None] < hdim) & (offs_n[None, :] < dstate)
-    tl.store(states_ptrs, states, mask=c_mask)
-
-
-@triton.jit
-def _chunk_state_varlen_kernel(
-    # Pointers to matrices
-    x_ptr,
-    b_ptr,
-    dt_ptr,
-    dA_cumsum_ptr,
-    chunk_states_ptr,
-    cu_seqlens_ptr,
-    states_ptr,
-    initstates_ptr,
-    # Matrix dimensions
-    hdim,
-    dstate,
-    chunk_size,
-    seqlen,
-    nheads_ngroups_ratio,
-    # Strides
-    stride_x_seqlen,
-    stride_x_head,
-    stride_x_hdim,
-    stride_b_seqlen,
-    stride_b_head,
-    stride_b_dstate,
-    stride_dt_chunk,
-    stride_dt_head,
-    stride_dt_csize,
-    stride_dA_cs_chunk,
-    stride_dA_cs_head,
-    stride_dA_cs_csize,
-    stride_chunk_states_chunk,
-    stride_chunk_states_head,
-    stride_chunk_states_hdim,
-    stride_chunk_states_dstate,
-    stride_states_batch,
-    stride_states_head,
-    stride_states_hdim,
-    stride_states_dstate,
-    stride_init_states_batch,
-    stride_init_states_head,
-    stride_init_states_hdim,
-    stride_init_states_dstate,
-    # Meta-parameters
-    HAS_INITSTATES: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr = 16,
-    BLOCK_SIZE_N: tl.constexpr = 16,
-    BLOCK_SIZE_K: tl.constexpr = 16,
-):
-    pid_b = tl.program_id(axis=1)
-    pid_h = tl.program_id(axis=2)
-    num_pid_n = tl.cdiv(dstate, BLOCK_SIZE_N)
-    pid_m = tl.program_id(axis=0) // num_pid_n
-    pid_n = tl.program_id(axis=0) % num_pid_n
-    end_idx = tl.load(cu_seqlens_ptr + pid_b + 1)
-    pid_c = (end_idx - 1) // chunk_size
-    b_ptr += (
-        pid_c * chunk_size * stride_b_seqlen
-        + (pid_h // nheads_ngroups_ratio) * stride_b_head
-    )
-    x_ptr += pid_c * chunk_size * stride_x_seqlen + pid_h * stride_x_head
-    dt_ptr += pid_c * stride_dt_chunk + pid_h * stride_dt_head
-    dA_cumsum_ptr += pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
-    chunk_states_ptr += (
-        pid_c * stride_chunk_states_chunk + pid_h * stride_chunk_states_head
-    )
-
-    if HAS_INITSTATES:
-        # if there are init states provided, we differentiate between states (which
-        # are boundary conditions at a chunk boundary) and initstates (which are boundary
-        # conditions when a new example in a cont batch starts)
-        initstates_ptr += pid_h * stride_init_states_head
-
-    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
-    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    offs_k = tl.arange(0, BLOCK_SIZE_K)
-    x_ptrs = x_ptr + (
-        offs_m[:, None] * stride_x_hdim + offs_k[None, :] * stride_x_seqlen
-    )
-    b_ptrs = b_ptr + (
-        offs_n[None, :] * stride_b_dstate + offs_k[:, None] * stride_b_seqlen
-    )
-    dt_ptrs = dt_ptr + offs_k * stride_dt_csize
-    dA_cs_last = tl.load(
-        dA_cumsum_ptr + (end_idx - pid_c * chunk_size - 1) * stride_dA_cs_csize
-    ).to(tl.float32)
-    dA_cumsum_ptrs = dA_cumsum_ptr + offs_k * stride_dA_cs_csize
-
-    chunk_size_limit = end_idx - pid_c * chunk_size
-    start_idx = tl.load(cu_seqlens_ptr + pid_b)
-    start_idx_cur = tl.maximum(start_idx - pid_c * chunk_size, 0)
-
-    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, chunk_size_limit, BLOCK_SIZE_K):
-        x = tl.load(
-            x_ptrs,
-            mask=(offs_m[:, None] < hdim)
-            & (offs_k[None, :] < chunk_size_limit - k)
-            & (offs_k[None, :] >= start_idx_cur - k),
-            other=0.0,
-        )
-        b = tl.load(
-            b_ptrs,
-            mask=(offs_k[:, None] < chunk_size_limit - k)
-            & (offs_n[None, :] < dstate)
-            & (offs_k[:, None] >= start_idx_cur - k),
-            other=0.0,
-        ).to(tl.float32)
-        dA_cs_k = tl.load(
-            dA_cumsum_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0
-        ).to(tl.float32)
-        dt_k = tl.load(dt_ptrs, mask=offs_k < chunk_size_limit - k, other=0.0).to(
-            tl.float32
-        )
-        scale = tl.where(
-            (offs_k >= start_idx_cur - k) & (offs_k < chunk_size_limit - k),
-            tl.exp(dA_cs_last - dA_cs_k) * dt_k,
-            0.0,
-        )
-        b *= scale[:, None]
-        b = b.to(x_ptr.dtype.element_ty)
-        acc += tl.dot(x, b)
         x_ptrs += BLOCK_SIZE_K * stride_x_seqlen
         b_ptrs += BLOCK_SIZE_K * stride_b_seqlen
         dt_ptrs += BLOCK_SIZE_K * stride_dt_csize
         dA_cumsum_ptrs += BLOCK_SIZE_K * stride_dA_cs_csize
 
-    # If the sequence starts after the last chunk idx, we don't need to add the contribution from the last chunk
-    # If HAS_INITSTATES==True need to consider two possibilities
-    # - if start_idx < pid_c * chunk_size, then we need to take the past_states_ptrs
-    # - if state_idx >= pid * chunk_size, then we need to insert initstates
-    if (start_idx < pid_c * chunk_size) or (HAS_INITSTATES):  # first chunk
-
-        dA_cs_boundary = 0.0  # default
-
-        if not HAS_INITSTATES:
-            past_states_ptrs = chunk_states_ptr + (
-                offs_m[:, None] * stride_chunk_states_hdim
-                + offs_n[None, :] * stride_chunk_states_dstate
-            )
-        else:
-
-            # - this seems repetitive, buts its to help the compiler
-            if start_idx < pid_c * chunk_size:
-                past_states_ptrs = chunk_states_ptr + (
-                    offs_m[:, None] * stride_chunk_states_hdim
-                    + offs_n[None, :] * stride_chunk_states_dstate
-                )
-            else:
-                past_states_ptrs = initstates_ptr + (
-                    pid_b * stride_init_states_batch
-                    + offs_m[:, None] * stride_init_states_hdim
-                    + offs_n[None, :] * stride_init_states_dstate
-                )
-
-                # need to adjust the boundary
-                if start_idx > pid_c * chunk_size:
-                    dA_cs_boundary = tl.load(
-                        dA_cumsum_ptr
-                        + (start_idx - pid_c * chunk_size - 1) * stride_dA_cs_csize
-                    ).to(tl.float32)
-
-        past_states = tl.load(
-            past_states_ptrs,
-            mask=(offs_m[:, None] < hdim) & (offs_n[None, :] < dstate),
-            other=0.0,
-        ).to(tl.float32)
-
-        scale = tl.exp(dA_cs_last - dA_cs_boundary)
-        acc += past_states * scale
-
     states = acc.to(states_ptr.dtype.element_ty)
 
-    states_ptr += pid_b * stride_states_batch + pid_h * stride_states_head
+    states_ptr += pid_c * stride_states_chunk + pid_h * stride_states_head
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     states_ptrs = states_ptr + (
@@ -442,24 +213,26 @@ def _chunk_state_varlen_kernel(
 
 
 def _chunk_cumsum_fwd(
-    dt, A, chunk_size, dt_bias=None, dt_softplus=False, dt_limit=(0.0, float("inf"))
+    dt,
+    A,
+    chunk_size,
+    cu_chunk_seqlens,
+    dt_bias=None,
+    dt_softplus=False,
+    dt_limit=(0.0, float("inf")),
 ):
-    batch, seqlen, nheads = dt.shape
+    seqlen, nheads = dt.shape
     assert A.shape == (nheads,)
     if dt_bias is not None:
         assert dt_bias.shape == (nheads,)
-    nchunks = math.ceil(seqlen / chunk_size)
+    nchunks = cu_chunk_seqlens.shape[0] - 1
     dt_out = torch.empty(
-        batch, nheads, nchunks, chunk_size, device=dt.device, dtype=torch.float32
+        nheads, nchunks, chunk_size, device=dt.device, dtype=torch.float32
     )
     dA_cumsum = torch.empty(
-        batch, nheads, nchunks, chunk_size, device=dt.device, dtype=torch.float32
+        nheads, nchunks, chunk_size, device=dt.device, dtype=torch.float32
     )
-    grid_chunk_cs = lambda META: (
-        batch,
-        nchunks,
-        triton.cdiv(nheads, META["BLOCK_SIZE_H"]),
-    )
+    grid_chunk_cs = lambda META: (nchunks, triton.cdiv(nheads, META["BLOCK_SIZE_H"]))
     with torch.get_device_module(dt.device).device(dt.device.index):
         _chunk_cumsum_fwd_kernel[grid_chunk_cs](
             dt,
@@ -467,7 +240,7 @@ def _chunk_cumsum_fwd(
             dt_bias,
             dt_out,
             dA_cumsum,
-            batch,
+            cu_chunk_seqlens,
             seqlen,
             nheads,
             chunk_size,
@@ -475,17 +248,14 @@ def _chunk_cumsum_fwd(
             dt_limit[1],
             dt.stride(0),
             dt.stride(1),
-            dt.stride(2),
             A.stride(0),
             dt_bias.stride(0) if dt_bias is not None else 0,
             dt_out.stride(0),
-            dt_out.stride(2),
             dt_out.stride(1),
-            dt_out.stride(3),
+            dt_out.stride(2),
             dA_cumsum.stride(0),
-            dA_cumsum.stride(2),
             dA_cumsum.stride(1),
-            dA_cumsum.stride(3),
+            dA_cumsum.stride(2),
             dt_softplus,
             HAS_DT_BIAS=dt_bias is not None,
             BLOCK_SIZE_CHUNK=triton.next_power_of_2(chunk_size),
@@ -494,30 +264,34 @@ def _chunk_cumsum_fwd(
 
 
 def _chunk_state_fwd(
-    B, x, dt, dA_cumsum, seq_idx=None, states=None, states_in_fp32=True
+    B,
+    x,
+    dt,
+    dA_cumsum,
+    cu_chunk_seqlens,
+    states=None,
+    states_in_fp32=True,
 ):
-    batch, seqlen, nheads, headdim = x.shape
-    _, _, nchunks, chunk_size = dt.shape
-    _, _, ngroups, dstate = B.shape
+    seqlen, nheads, headdim = x.shape
+    _, nchunks, chunk_size = dt.shape
+    _, ngroups, dstate = B.shape
     assert nheads % ngroups == 0
-    assert B.shape == (batch, seqlen, ngroups, dstate)
-    assert dt.shape == (batch, nheads, nchunks, chunk_size)
+    assert B.shape == (seqlen, ngroups, dstate)
+    assert dt.shape == (nheads, nchunks, chunk_size)
     assert dA_cumsum.shape == dt.shape
-    if seq_idx is not None:
-        assert seq_idx.shape == (batch, seqlen)
+
     if states is not None:
-        assert states.shape == (batch, nchunks, nheads, headdim, dstate)
+        assert states.shape == (nchunks, nheads, headdim, dstate)
     else:
         states_dtype = torch.float32 if states_in_fp32 else B.dtype
         states = torch.empty(
-            (batch, nchunks, nheads, headdim, dstate),
-            device=x.device,
-            dtype=states_dtype,
+            (nchunks, nheads, headdim, dstate), device=x.device, dtype=states_dtype
         )
+
     grid = lambda META: (
         triton.cdiv(headdim, META["BLOCK_SIZE_M"])
         * triton.cdiv(dstate, META["BLOCK_SIZE_N"]),
-        batch * nchunks,
+        nchunks,
         nheads,
     )
     with torch.get_device_module(x.device).device(x.device.index):
@@ -527,120 +301,27 @@ def _chunk_state_fwd(
             states,
             dt,
             dA_cumsum,
-            seq_idx,
+            cu_chunk_seqlens,
             headdim,
             dstate,
             chunk_size,
-            batch,
             seqlen,
             nheads // ngroups,
             x.stride(0),
             x.stride(1),
             x.stride(2),
-            x.stride(3),
             B.stride(0),
             B.stride(1),
             B.stride(2),
-            B.stride(-1),
             states.stride(0),
             states.stride(1),
             states.stride(2),
             states.stride(3),
-            states.stride(4),
             dt.stride(0),
-            dt.stride(2),
             dt.stride(1),
-            dt.stride(3),
-            dA_cumsum.stride(0),
-            dA_cumsum.stride(2),
-            dA_cumsum.stride(1),
-            dA_cumsum.stride(3),
-            *(
-                (seq_idx.stride(0), seq_idx.stride(1))
-                if seq_idx is not None
-                else (0, 0)
-            ),
-            HAS_SEQ_IDX=seq_idx is not None,
-        )
-    return states
-
-
-def chunk_state_varlen(
-    B, x, dt, dA_cumsum, cu_seqlens, chunk_states, initial_states=None
-):
-    total_seqlen, nheads, headdim = x.shape
-    _, nchunks, chunk_size = dt.shape
-    _, ngroups, dstate = B.shape
-    batch = cu_seqlens.shape[0] - 1
-    cu_seqlens = cu_seqlens.contiguous()
-    assert nheads % ngroups == 0
-    assert B.shape == (total_seqlen, ngroups, dstate)
-    assert dt.shape == (nheads, nchunks, chunk_size)
-    assert dA_cumsum.shape == dt.shape
-    assert chunk_states.shape == (nchunks, nheads, headdim, dstate)
-
-    if initial_states is not None:
-        assert initial_states.shape == (batch, nheads, headdim, dstate)
-
-    states = torch.empty(
-        batch,
-        nheads,
-        headdim,
-        dstate,
-        dtype=chunk_states.dtype,
-        device=chunk_states.device,
-    )
-    grid = lambda META: (
-        triton.cdiv(headdim, META["BLOCK_SIZE_M"])
-        * triton.cdiv(dstate, META["BLOCK_SIZE_N"]),
-        batch,
-        nheads,
-    )
-    with torch.get_device_module(x.device).device(x.device.index):
-        _chunk_state_varlen_kernel[grid](
-            x,
-            B,
-            dt,
-            dA_cumsum,
-            chunk_states,
-            cu_seqlens,
-            states,
-            initial_states,
-            headdim,
-            dstate,
-            chunk_size,
-            total_seqlen,
-            nheads // ngroups,
-            x.stride(0),
-            x.stride(1),
-            x.stride(2),
-            B.stride(0),
-            B.stride(1),
-            B.stride(2),
-            dt.stride(1),
-            dt.stride(0),
             dt.stride(2),
-            dA_cumsum.stride(1),
             dA_cumsum.stride(0),
+            dA_cumsum.stride(1),
             dA_cumsum.stride(2),
-            chunk_states.stride(0),
-            chunk_states.stride(1),
-            chunk_states.stride(2),
-            chunk_states.stride(3),
-            states.stride(0),
-            states.stride(1),
-            states.stride(2),
-            states.stride(3),
-            *(
-                (
-                    initial_states.stride(0),
-                    initial_states.stride(1),
-                    initial_states.stride(2),
-                    initial_states.stride(3),
-                )
-                if initial_states is not None
-                else (0, 0, 0, 0)
-            ),
-            HAS_INITSTATES=initial_states is not None,
         )
     return states

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -96,9 +96,10 @@ def _mamba_chunk_scan_combined_fwd(
         states_in_fp32=True,
     )
 
-    # 3. Compute the inter-chunk SSM recurrence. The returned states are
-    # post-chunk states, so final per-sequence states are a gather below.
-    states = _state_passing_fwd(
+    # 3. Compute the inter-chunk SSM recurrence. Returns start-of-chunk states
+    # (init_state or end-of-previous-chunk) in `states`, and per-sequence
+    # final states for the SSM cache.
+    states, final_states = _state_passing_fwd(
         rearrange(states, "... p n -> ... (p n)"),
         dA_cumsum,
         last_chunk_indices,
@@ -110,6 +111,7 @@ def _mamba_chunk_scan_combined_fwd(
         out_dtype=state_dtype if state_dtype is not None else C.dtype,
     )
     states = rearrange(states, "... (p n) -> ... p n", n=dstate)
+    final_states = rearrange(final_states, "... (p n) -> ... p n", n=dstate)
 
     # 4. Compute batched matrix multiply for C_j^T B_i terms.
     CB = _bmm_chunk_fwd(
@@ -120,8 +122,9 @@ def _mamba_chunk_scan_combined_fwd(
         output_dtype=torch.float32,
     )
 
-    # 5. Scan and compute diagonal blocks using either initial states at
-    # sequence boundaries or the previous chunk's post-state.
+    # 5. Scan and compute diagonal blocks. chunk_scan reads
+    # `states[pid_c]` directly as prev_state (start-of-chunk state) — no
+    # init_state / seq_idx branching needed inside the kernel.
     _chunk_scan_fwd(
         CB,
         x,
@@ -131,15 +134,13 @@ def _mamba_chunk_scan_combined_fwd(
         states,
         cu_chunk_seqlens,
         out,
-        seq_idx,
         D=D,
         z=z,
-        initial_states=initial_states,
     )
 
     if return_intermediate_states:
-        return states
-    return states[last_chunk_indices]
+        return states, final_states
+    return final_states
 
 
 def mamba_chunk_scan_combined(
@@ -183,8 +184,8 @@ def mamba_chunk_scan_combined(
         dt_softplus: Whether to apply softplus to dt
         state_dtype: The data type of the SSM state
     Return:
-        final_states: (num_sequences, nheads, headdim, dstate), or all
-        post-chunk states when return_intermediate_states=True.
+        final_states: (num_sequences, nheads, headdim, dstate), or
+        (start-of-chunk states, final_states) when return_intermediate_states=True.
     """
     return _mamba_chunk_scan_combined_fwd(
         x,

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_combined.py
@@ -9,16 +9,12 @@
 # ruff: noqa: E501
 
 import torch
-import triton
 from einops import rearrange
-from packaging import version
 
 from .ssd_bmm import _bmm_chunk_fwd
 from .ssd_chunk_scan import _chunk_scan_fwd
-from .ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd, chunk_state_varlen
+from .ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd
 from .ssd_state_passing import _state_passing_fwd
-
-TRITON_22 = version.parse(triton.__version__) >= version.parse("2.2.0")
 
 
 def is_int_pow_2(n):
@@ -32,150 +28,118 @@ def _mamba_chunk_scan_combined_fwd(
     B,
     C,
     chunk_size,
+    out,
     D=None,
     z=None,
     dt_bias=None,
     initial_states=None,
+    return_intermediate_states=False,
     seq_idx=None,
-    chunk_indices=None,
-    chunk_offsets=None,
     cu_seqlens=None,
+    cu_chunk_seqlens=None,
+    last_chunk_indices=None,
     dt_softplus=False,
     dt_limit=(0.0, float("inf")),
     state_dtype=None,
-    out=None,
 ):
     assert is_int_pow_2(chunk_size), "chunk_size must be integer power of 2"
-    batch, seqlen, nheads, headdim = x.shape
-    _, _, ngroups, dstate = B.shape
+    seqlen, nheads, headdim = x.shape
+    _, ngroups, dstate = B.shape
     assert nheads % ngroups == 0
-    assert B.shape == (batch, seqlen, ngroups, dstate)
-    assert dt.shape == (batch, seqlen, nheads)
+    assert B.shape == (seqlen, ngroups, dstate)
+    assert dt.shape == (seqlen, nheads)
     assert A.shape == (nheads,)
     assert C.shape == B.shape
+    assert out.shape == x.shape
+    assert cu_seqlens is not None, "cu_seqlens must be provided for varlen input"
+    assert cu_chunk_seqlens is not None, "cu_chunk_seqlens must be provided"
+    assert last_chunk_indices is not None, "last_chunk_indices must be provided"
+    assert seq_idx is not None, "seq_idx must be provided"
+    assert seq_idx.shape == (cu_chunk_seqlens.shape[0] - 1,)
+    assert last_chunk_indices.shape == (cu_seqlens.shape[0] - 1,)
     if z is not None:
         assert z.shape == x.shape
     if D is not None:
         assert D.shape == (nheads, headdim) or D.shape == (nheads,)
-    if seq_idx is not None:
-        assert seq_idx.shape == (batch, seqlen)
+    if initial_states is not None:
+        assert initial_states.shape == (len(cu_seqlens) - 1, nheads, headdim, dstate)
+
     if B.stride(-1) != 1:
         B = B.contiguous()
     if C.stride(-1) != 1:
         C = C.contiguous()
-    if (
-        x.stride(-1) != 1 and x.stride(1) != 1
-    ):  # Either M or K dimension should be contiguous
+    if x.stride(-1) != 1 and x.stride(0) != 1:
         x = x.contiguous()
-    if (
-        z is not None and z.stride(-1) != 1 and z.stride(1) != 1
-    ):  # Either M or K dimension should be contiguous
+    if z is not None and z.stride(-1) != 1 and z.stride(0) != 1:
         z = z.contiguous()
     if D is not None and D.stride(-1) != 1:
         D = D.contiguous()
-    if initial_states is not None:
-        if cu_seqlens is None:
-            assert initial_states.shape == (batch, nheads, headdim, dstate)
-        else:
-            assert initial_states.shape == (
-                len(cu_seqlens) - 1,
-                nheads,
-                headdim,
-                dstate,
-            )
 
-    # This function executes 5 sub-functions for computing mamba
-    # - a good resource is the blog https://goombalab.github.io/blog/2024/mamba2-part3-algorithm/
-    #   which has a minimal implementation to understand the below operations
-    # - as explained by the blog, mamba is a special case of causal attention
-    # - the idea is to chunk the attention matrix and compute each
-    #   submatrix separately using different optimizations.
-    # - see the blog and paper for a visualization of the submatrices
-    #   which we refer to in the comments below
-
-    # 1. Compute chunked cumsum of A * dt
-    # - here dt may go through a softplus activation
+    # 1. Compute chunked cumsum of A * dt.
     dA_cumsum, dt = _chunk_cumsum_fwd(
-        dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=dt_softplus, dt_limit=dt_limit
+        dt,
+        A,
+        chunk_size,
+        cu_chunk_seqlens,
+        dt_bias=dt_bias,
+        dt_softplus=dt_softplus,
+        dt_limit=dt_limit,
     )
 
-    # 2. Compute the state for each intra-chunk
-    # (right term of low-rank factorization of off-diagonal blocks; B terms)
-    states = _chunk_state_fwd(B, x, dt, dA_cumsum, seq_idx=seq_idx, states_in_fp32=True)
+    # 2. Compute the state for each intra-chunk.
+    states = _chunk_state_fwd(
+        B,
+        x,
+        dt,
+        dA_cumsum,
+        cu_chunk_seqlens,
+        states_in_fp32=True,
+    )
 
-    # 3. Compute the inter-chunk SSM recurrence; produces correct SSM states at chunk boundaries
-    # (middle term of factorization of off-diag blocks; A terms)
-    # - for handling chunked prefill, this requires i) initial_states
-    #   ii) seq_idx iii) is_cont_batched and (iv) chunk_offsets to be all specified.
-    # - When a new seq_idx is detected, we will stop passing the prev_state
-    #   and switch accordingly to the init_state corresponding to the new seq_idx.
-    # - We will also make sure that the dA_cumsum is taken only from the start of the
-    #   sequence (hence we need the full dA_cumsum tensor and not just the values at chunk boundaries)
-    # - this will ensure that states will be updated with the rightmost flushed seq_idx
-    #   of the previous chunk. This implies that the first chunk of states is either 0
-    #   or equal to init_states of the first example.
-    states, final_states = _state_passing_fwd(
+    # 3. Compute the inter-chunk SSM recurrence. The returned states are
+    # post-chunk states, so final per-sequence states are a gather below.
+    states = _state_passing_fwd(
         rearrange(states, "... p n -> ... (p n)"),
         dA_cumsum,
+        last_chunk_indices,
         initial_states=(
             rearrange(initial_states, "... p n -> ... (p n)")
             if initial_states is not None
             else None
         ),
-        seq_idx=seq_idx,
-        chunk_size=chunk_size,
         out_dtype=state_dtype if state_dtype is not None else C.dtype,
-        is_cont_batched=cu_seqlens is not None,
-        chunk_offsets=chunk_offsets,
     )
-    states, final_states = (
-        rearrange(t, "... (p n) -> ... p n", n=dstate) for t in [states, final_states]
+    states = rearrange(states, "... (p n) -> ... p n", n=dstate)
+
+    # 4. Compute batched matrix multiply for C_j^T B_i terms.
+    CB = _bmm_chunk_fwd(
+        C,
+        B,
+        chunk_size,
+        cu_chunk_seqlens,
+        output_dtype=torch.float32,
     )
 
-    # 4. Compute batched matrix multiply for C_j^T B_i terms
-    CB = _bmm_chunk_fwd(C, B, chunk_size, seq_idx=seq_idx, output_dtype=torch.float32)
-
-    # 5. Scan and compute the diagonal blocks, taking into
-    #    account past causal states.
-    # - if initial states are provided, then states information will be
-    #   augmented with initial_states.
-    # - to do this properly, we need to account for example changes in
-    #   the continuous batch, therefore we introduce pseudo chunks, which is
-    #   a chunk that is split up each time an example changes.
-    # - in each (pseudo) chunk, we detect if the previous (pseudo) chunk had
-    #   a seq_idx change, in which case we take states information from
-    #   init_states.
-    out_x = _chunk_scan_fwd(
+    # 5. Scan and compute diagonal blocks using either initial states at
+    # sequence boundaries or the previous chunk's post-state.
+    _chunk_scan_fwd(
         CB,
         x,
         dt,
         dA_cumsum,
         C,
         states,
+        cu_chunk_seqlens,
+        out,
+        seq_idx,
         D=D,
         z=z,
-        seq_idx=seq_idx,
-        chunk_indices=chunk_indices,
-        chunk_offsets=chunk_offsets,
         initial_states=initial_states,
-        out=out,
     )
-    if cu_seqlens is None:
-        return out_x, dt, dA_cumsum, states, final_states
-    else:
-        assert (
-            batch == 1
-        ), "passing cu_seqlens to get the varlen states is only supported if batch dimension is 1"
-        varlen_states = chunk_state_varlen(
-            B.squeeze(0),
-            x.squeeze(0),
-            dt.squeeze(0),
-            dA_cumsum.squeeze(0),
-            cu_seqlens,
-            states.squeeze(0),
-            initial_states=initial_states,
-        )
-        return out_x, dt, dA_cumsum, states, final_states, varlen_states
+
+    if return_intermediate_states:
+        return states
+    return states[last_chunk_indices]
 
 
 def mamba_chunk_scan_combined(
@@ -185,91 +149,61 @@ def mamba_chunk_scan_combined(
     B,
     C,
     chunk_size,
+    cu_seqlens,
+    cu_chunk_seqlens,
+    last_chunk_indices,
+    seq_idx,
+    out,
     D=None,
     z=None,
     dt_bias=None,
     initial_states=None,
-    seq_idx=None,
-    chunk_indices=None,
-    chunk_offsets=None,
-    cu_seqlens=None,
     dt_softplus=False,
     dt_limit=(0.0, float("inf")),
-    out=None,
-    return_final_states=False,
-    return_varlen_states=False,
     return_intermediate_states=False,
     state_dtype=None,
 ):
     """
     Argument:
-        x: (batch, seqlen, nheads, headdim)
-        dt: (batch, seqlen, nheads)
-        A: (nheads)
-        B: (batch, seqlen, ngroups, dstate)
-        C: (batch, seqlen, ngroups, dstate)
+        x: (seqlen, nheads, headdim)
+        dt: (seqlen, nheads)
+        A: (nheads,)
+        B: (seqlen, ngroups, dstate)
+        C: (seqlen, ngroups, dstate)
         chunk_size: int
+        cu_seqlens: (num_sequences + 1,)
+        cu_chunk_seqlens: (nchunks + 1,)
+        last_chunk_indices: (num_sequences,)
+        seq_idx: (nchunks,)
+        out: (seqlen, nheads, headdim) preallocated output tensor
         D: (nheads, headdim) or (nheads,)
-        z: (batch, seqlen, nheads, headdim)
+        z: (seqlen, nheads, headdim)
         dt_bias: (nheads,)
-        initial_states: (batch, nheads, headdim, dstate)
-        seq_idx: (batch, seqlen)
-        cu_seqlens: (num_sequences + 1) or None, only used if return_varlen_states is True
+        initial_states: (num_sequences, nheads, headdim, dstate)
         dt_softplus: Whether to apply softplus to dt
-        out: Preallocated output tensor
-        state_dtype: The data type of the ssm state
+        state_dtype: The data type of the SSM state
+    Return:
+        final_states: (num_sequences, nheads, headdim, dstate), or all
+        post-chunk states when return_intermediate_states=True.
     """
-
-    if not return_varlen_states:
-        cu_seqlens = None
-    else:
-        assert (
-            cu_seqlens is not None
-        ), "cu_seqlens must be provided if return_varlen_states is True"
-    out_x, dt_out, dA_cumsum, states, final_states, *rest = (
-        _mamba_chunk_scan_combined_fwd(
-            x,
-            dt,
-            A,
-            B,
-            C,
-            chunk_size,
-            D=D,
-            z=z,
-            dt_bias=dt_bias,
-            initial_states=initial_states,
-            seq_idx=seq_idx,
-            chunk_indices=chunk_indices,
-            chunk_offsets=chunk_offsets,
-            cu_seqlens=cu_seqlens,
-            dt_softplus=dt_softplus,
-            dt_limit=dt_limit,
-            out=out,
-            state_dtype=state_dtype,
-        )
+    return _mamba_chunk_scan_combined_fwd(
+        x,
+        dt,
+        A,
+        B,
+        C,
+        chunk_size,
+        out,
+        D=D,
+        z=z,
+        dt_bias=dt_bias,
+        initial_states=initial_states,
+        return_intermediate_states=return_intermediate_states,
+        seq_idx=seq_idx,
+        cu_seqlens=cu_seqlens,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        dt_softplus=dt_softplus,
+        dt_limit=dt_limit,
+        state_dtype=state_dtype,
     )
-    if return_intermediate_states:
-        if return_varlen_states:
-            varlen_states = rest[0]
-            if return_final_states:
-                return states, final_states, varlen_states
-            else:
-                return states, varlen_states
-        else:
-            if return_final_states:
-                return states, final_states
-            else:
-                return states
-
-    if not return_varlen_states:
-        if not return_final_states:
-            return
-        else:
-            return final_states
-    else:
-        varlen_states = rest[0]
-        return (
-            (varlen_states)
-            if not return_final_states
-            else (final_states, varlen_states)
-        )

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_state_passing.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_state_passing.py
@@ -132,7 +132,7 @@ def _state_passing_fwd(
     out_dtype = states.dtype if out_dtype is None else out_dtype
     out = torch.empty((nchunks, nheads, dim), device=states.device, dtype=out_dtype)
     final_states = torch.empty(
-        (batch, nheads, dim), device=states.device, dtype=torch.float32
+        (batch, nheads, dim), device=states.device, dtype=out_dtype
     )
 
     initial_states_strides = (

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_state_passing.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_state_passing.py
@@ -18,151 +18,67 @@ def _state_passing_fwd_kernel(
     # Pointers to matrices
     states_ptr,
     out_ptr,
-    final_states_ptr,
     dA_cs_ptr,
     initstates_ptr,
-    seq_idx_ptr,
-    chunk_offsets_ptr,
-    chunk_meta_num,
+    last_chunk_indices_ptr,
     # Matrix dimensions
     dim,
-    nchunks,
-    seqlen,
     chunk_size,
     # Strides
-    stride_states_batch,
     stride_states_chunk,
     stride_states_head,
     stride_states_dim,
-    stride_out_batch,
     stride_out_chunk,
     stride_out_head,
     stride_out_dim,
-    stride_final_states_batch,
-    stride_final_states_head,
-    stride_final_states_dim,
-    stride_dA_cs_batch,
-    stride_dA_cs_chunk,
     stride_dA_cs_head,
+    stride_dA_cs_chunk,
     stride_dA_cs_csize,
     stride_initstates_batch,
     stride_initstates_head,
     stride_initstates_dim,
-    stride_seq_idx_batch,
-    stride_seq_idx_seqlen,
     # Meta-parameters
     HAS_INITSTATES: tl.constexpr,
-    HAS_SEQ_IDX: tl.constexpr,
-    IS_CONT_BATCHED: tl.constexpr,
     BLOCK_SIZE: tl.constexpr = 16,
 ):
+    pid_m = tl.program_id(axis=0)
     pid_b = tl.program_id(axis=1)
     pid_h = tl.program_id(axis=2)
-    pid_m = tl.program_id(axis=0)
-    states_ptr += pid_b * stride_states_batch + pid_h * stride_states_head
+
+    chunk_end = tl.load(last_chunk_indices_ptr + pid_b) + 1
+    chunk_start = (
+        tl.load(last_chunk_indices_ptr + pid_b - 1, mask=pid_b > 0, other=-1) + 1
+    )
+
+    states_ptr += chunk_start * stride_states_chunk + pid_h * stride_states_head
     dA_cs_ptr += (
-        pid_b * stride_dA_cs_batch
-        + pid_h * stride_dA_cs_head
+        pid_h * stride_dA_cs_head
+        + chunk_start * stride_dA_cs_chunk
         + (chunk_size - 1) * stride_dA_cs_csize
     )
-    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
-    final_states_ptr += (
-        pid_b * stride_final_states_batch + pid_h * stride_final_states_head
-    )
-    if HAS_INITSTATES:
-        initstates_ptr += pid_h * stride_initstates_head
-        if not IS_CONT_BATCHED:
-            initstates_ptr += pid_b * stride_initstates_batch
-
-    if HAS_SEQ_IDX:
-        seq_idx_ptr += pid_b * stride_seq_idx_batch
+    out_ptr += chunk_start * stride_out_chunk + pid_h * stride_out_head
 
     offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     states_ptrs = states_ptr + offs_m * stride_states_dim
     out_ptrs = out_ptr + offs_m * stride_out_dim
-    final_states_ptrs = final_states_ptr + offs_m * stride_final_states_dim
 
-    # - states will be the past state of the sequence that continues on the current check
-    if not HAS_INITSTATES:
-        states = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
-    else:
-        initstates_ptr += offs_m * stride_initstates_dim
-        initstates_ptrs = initstates_ptr
-        # - for cont batches, for the first chunk mean it will be the first batch's
-        #   init state
+    if HAS_INITSTATES:
+        initstates_ptrs = (
+            initstates_ptr
+            + pid_b * stride_initstates_batch
+            + pid_h * stride_initstates_head
+            + offs_m * stride_initstates_dim
+        )
         states = tl.load(initstates_ptrs, mask=offs_m < dim, other=0.0).to(tl.float32)
+    else:
+        states = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
 
-    tl.store(out_ptrs, states, mask=offs_m < dim)
-    out_ptrs += stride_out_chunk
-    prev_seq_idx_chunk_end = 0
-    logical_chunk_idx = 0
-    for c in range(nchunks):
+    for _ in range(chunk_end - chunk_start):
         new_states = tl.load(states_ptrs, mask=offs_m < dim, other=0.0).to(tl.float32)
         dA_cs = tl.load(dA_cs_ptr).to(tl.float32)
-        scale_mask = True
-        if HAS_SEQ_IDX:
-            # - the seq to pass forward is the one that is flushed to the right
-            #   boundary.
-            # - that is given by seq_idx_chunk_end below: the sequence index at the end of the chunk.
-            seq_idx_chunk_end = tl.load(
-                seq_idx_ptr
-                + (min((c + 1) * chunk_size, seqlen) - 1) * stride_seq_idx_seqlen
-            )
-            if HAS_INITSTATES:
-                if IS_CONT_BATCHED and prev_seq_idx_chunk_end != seq_idx_chunk_end:
-                    # this means in the current chunk the rightmost flushed seq
-                    # has changed.
-                    # - so we do not propagate the state from previous chunk
-                    # - but rather we load that sequence's init state
-                    initstates_ptrs = (
-                        initstates_ptr + seq_idx_chunk_end * stride_initstates_batch
-                    )
+        states = tl.exp(dA_cs) * states + new_states
+        tl.store(out_ptrs, states, mask=offs_m < dim)
 
-                    # - update state with seq_idx_new's init state
-                    states = tl.load(initstates_ptrs, mask=offs_m < dim, other=0.0).to(
-                        tl.float32
-                    )
-
-                    # - we need to consider the cumsum only of the last sequence in the chunk
-                    # - find its starting position (given by c_off of the logical chunk index)
-                    # - and subtract the cumsum just before that position from the total cumsum
-                    # - first, update the logical chunk index (add the number of sequences in the current physical chunk):
-                    # sequence index at the start of the current chunk
-                    seq_idx_chunk_start = tl.load(
-                        seq_idx_ptr
-                        + min(c * chunk_size, seqlen) * stride_seq_idx_seqlen
-                    )
-                    logical_chunk_idx += seq_idx_chunk_end - seq_idx_chunk_start
-                    # - load the chunk offset:
-                    c_off = tl.load(
-                        chunk_offsets_ptr + logical_chunk_idx,
-                        mask=logical_chunk_idx < chunk_meta_num,
-                        other=0,
-                    )
-                    # - if offset is 0, then the sequence starts at the beginning of the chunk, and we don't need to subtract anything
-                    if c_off > 0:
-                        # - dA_cs_ptr currently points to the cumsum at the end of the chunk - subtract the chunk size and add the offset
-                        dA_cs_boundary = tl.load(
-                            dA_cs_ptr
-                            - (chunk_size - 1) * stride_dA_cs_csize
-                            + (c_off - 1) * stride_dA_cs_csize,
-                            mask=(c_off - 1) > -1 and c_off < chunk_size,
-                            other=0.0,
-                        )
-                        dA_cs -= dA_cs_boundary
-
-                # - increment logical chunk index for every physical chunk
-                logical_chunk_idx += 1
-            else:
-                scale_mask = seq_idx_chunk_end == prev_seq_idx_chunk_end
-            prev_seq_idx_chunk_end = seq_idx_chunk_end
-
-        scale = tl.where(scale_mask, tl.exp(dA_cs), 0.0)
-        states = scale * states + new_states
-        if c < nchunks - 1:
-            tl.store(out_ptrs, states, mask=offs_m < dim)
-        else:
-            tl.store(final_states_ptrs, states, mask=offs_m < dim)
         states_ptrs += stride_states_chunk
         dA_cs_ptr += stride_dA_cs_chunk
         out_ptrs += stride_out_chunk
@@ -171,94 +87,48 @@ def _state_passing_fwd_kernel(
 def _state_passing_fwd(
     states,
     dA_cumsum,
+    last_chunk_indices,
     initial_states=None,
-    seq_idx=None,
-    chunk_size=None,
     out_dtype=None,
-    is_cont_batched=False,
-    chunk_offsets=None,
 ):
-    batch, nchunks, nheads, dim = states.shape
-    if chunk_size is None:
-        chunk_size = dA_cumsum.shape[-1]
-    else:
-        assert chunk_size == dA_cumsum.shape[-1]
-    assert dA_cumsum.shape == (batch, nheads, nchunks, chunk_size)
+    nchunks, nheads, dim = states.shape
+    chunk_size = dA_cumsum.shape[-1]
+    batch = last_chunk_indices.shape[0]
+    assert dA_cumsum.shape == (nheads, nchunks, chunk_size)
     if initial_states is not None:
-        if is_cont_batched:
-            # - if cu_seqlens is provided, then the initial states
-            #   are used for continuous batching. In which case we
-            #   require seq_idx to be provided
-            assert (
-                seq_idx is not None
-            ), "seq_idx must be provided for continuous batching"
-            # - we also need chunk_offsets to be provided, to account
-            #   for computation of dA_cumsum from the start of the
-            #   sequence
-            assert (
-                chunk_offsets is not None
-            ), "chunk_offsets must be provided for continuous batching"
-        else:
-            # - this is the regular batching case, where initial
-            #   states are used are for each example of the batch.
-            assert initial_states.shape == (batch, nheads, dim)
+        assert initial_states.shape == (batch, nheads, dim)
 
-    if seq_idx is not None:
-        seqlen = seq_idx.shape[-1]
-        assert seq_idx.shape == (batch, seqlen)
     out_dtype = states.dtype if out_dtype is None else out_dtype
-    out = torch.empty(
-        (batch, nchunks, nheads, dim), device=states.device, dtype=out_dtype
+    out = torch.empty((nchunks, nheads, dim), device=states.device, dtype=out_dtype)
+
+    initial_states_strides = (
+        (initial_states.stride(0), initial_states.stride(1), initial_states.stride(2))
+        if initial_states is not None
+        else (0, 0, 0)
     )
-    final_states = torch.empty(
-        (batch, nheads, dim), device=states.device, dtype=torch.float32
-    )
+
     grid = lambda META: (triton.cdiv(dim, META["BLOCK_SIZE"]), batch, nheads)
     with torch.get_device_module(states.device).device(states.device.index):
         _state_passing_fwd_kernel[grid](
             states,
             out,
-            final_states,
             dA_cumsum,
             initial_states,
-            seq_idx,
-            chunk_offsets,
-            len(chunk_offsets) if chunk_offsets is not None else 0,
+            last_chunk_indices,
             dim,
-            nchunks,
-            seqlen if seq_idx is not None else 0,
             chunk_size,
             states.stride(0),
             states.stride(1),
             states.stride(2),
-            states.stride(3),
             out.stride(0),
             out.stride(1),
             out.stride(2),
-            out.stride(3),
-            final_states.stride(0),
-            final_states.stride(1),
-            final_states.stride(2),
             dA_cumsum.stride(0),
-            dA_cumsum.stride(2),
             dA_cumsum.stride(1),
-            dA_cumsum.stride(3),
-            *(
-                (
-                    initial_states.stride(0),
-                    initial_states.stride(1),
-                    initial_states.stride(2),
-                )
-                if initial_states is not None
-                else (0, 0, 0)
-            ),
-            *(
-                (seq_idx.stride(0), seq_idx.stride(1))
-                if seq_idx is not None
-                else (0, 0)
-            ),
+            dA_cumsum.stride(2),
+            initial_states_strides[0],
+            initial_states_strides[1],
+            initial_states_strides[2],
             HAS_INITSTATES=initial_states is not None,
-            HAS_SEQ_IDX=seq_idx is not None,
-            IS_CONT_BATCHED=is_cont_batched,
         )
-    return out, final_states
+    return out

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_state_passing.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_state_passing.py
@@ -18,6 +18,7 @@ def _state_passing_fwd_kernel(
     # Pointers to matrices
     states_ptr,
     out_ptr,
+    final_states_ptr,
     dA_cs_ptr,
     initstates_ptr,
     last_chunk_indices_ptr,
@@ -31,6 +32,9 @@ def _state_passing_fwd_kernel(
     stride_out_chunk,
     stride_out_head,
     stride_out_dim,
+    stride_final_states_batch,
+    stride_final_states_head,
+    stride_final_states_dim,
     stride_dA_cs_head,
     stride_dA_cs_chunk,
     stride_dA_cs_csize,
@@ -49,6 +53,7 @@ def _state_passing_fwd_kernel(
     chunk_start = (
         tl.load(last_chunk_indices_ptr + pid_b - 1, mask=pid_b > 0, other=-1) + 1
     )
+    n_chunks_in_seq = chunk_end - chunk_start
 
     states_ptr += chunk_start * stride_states_chunk + pid_h * stride_states_head
     dA_cs_ptr += (
@@ -61,6 +66,12 @@ def _state_passing_fwd_kernel(
     offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     states_ptrs = states_ptr + offs_m * stride_states_dim
     out_ptrs = out_ptr + offs_m * stride_out_dim
+    final_states_ptrs = (
+        final_states_ptr
+        + pid_b * stride_final_states_batch
+        + pid_h * stride_final_states_head
+        + offs_m * stride_final_states_dim
+    )
 
     if HAS_INITSTATES:
         initstates_ptrs = (
@@ -69,15 +80,25 @@ def _state_passing_fwd_kernel(
             + pid_h * stride_initstates_head
             + offs_m * stride_initstates_dim
         )
-        states = tl.load(initstates_ptrs, mask=offs_m < dim, other=0.0).to(tl.float32)
+        state = tl.load(initstates_ptrs, mask=offs_m < dim, other=0.0).to(tl.float32)
     else:
-        states = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+        state = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
 
-    for _ in range(chunk_end - chunk_start):
-        new_states = tl.load(states_ptrs, mask=offs_m < dim, other=0.0).to(tl.float32)
+    # Write the start-of-chunk state for the first chunk of this sequence
+    # (= init_state). Subsequent iterations write start-of-chunk states for
+    # following chunks (= end-of-previous-chunk states). The last chunk's
+    # post-state goes to final_states for the SSM cache.
+    tl.store(out_ptrs, state, mask=offs_m < dim)
+    out_ptrs += stride_out_chunk
+
+    for c in range(n_chunks_in_seq):
+        new_state = tl.load(states_ptrs, mask=offs_m < dim, other=0.0).to(tl.float32)
         dA_cs = tl.load(dA_cs_ptr).to(tl.float32)
-        states = tl.exp(dA_cs) * states + new_states
-        tl.store(out_ptrs, states, mask=offs_m < dim)
+        state = tl.exp(dA_cs) * state + new_state
+        if c < n_chunks_in_seq - 1:
+            tl.store(out_ptrs, state, mask=offs_m < dim)
+        else:
+            tl.store(final_states_ptrs, state, mask=offs_m < dim)
 
         states_ptrs += stride_states_chunk
         dA_cs_ptr += stride_dA_cs_chunk
@@ -91,6 +112,16 @@ def _state_passing_fwd(
     initial_states=None,
     out_dtype=None,
 ):
+    """Run inter-chunk SSM recurrence.
+
+    Returns:
+        out: (nchunks, nheads, dim) start-of-chunk states. For each sequence,
+            out[chunk_start] is the initial state (init_state or zero), and
+            out[c] for chunk_start < c < chunk_end is the post-state of the
+            previous chunk (which equals the start state of chunk c).
+        final_states: (num_seqs, nheads, dim) post-state of the last chunk of
+            each sequence, used to update the SSM cache.
+    """
     nchunks, nheads, dim = states.shape
     chunk_size = dA_cumsum.shape[-1]
     batch = last_chunk_indices.shape[0]
@@ -100,6 +131,9 @@ def _state_passing_fwd(
 
     out_dtype = states.dtype if out_dtype is None else out_dtype
     out = torch.empty((nchunks, nheads, dim), device=states.device, dtype=out_dtype)
+    final_states = torch.empty(
+        (batch, nheads, dim), device=states.device, dtype=torch.float32
+    )
 
     initial_states_strides = (
         (initial_states.stride(0), initial_states.stride(1), initial_states.stride(2))
@@ -112,6 +146,7 @@ def _state_passing_fwd(
         _state_passing_fwd_kernel[grid](
             states,
             out,
+            final_states,
             dA_cumsum,
             initial_states,
             last_chunk_indices,
@@ -123,6 +158,9 @@ def _state_passing_fwd(
             out.stride(0),
             out.stride(1),
             out.stride(2),
+            final_states.stride(0),
+            final_states.stride(1),
+            final_states.stride(2),
             dA_cumsum.stride(0),
             dA_cumsum.stride(1),
             dA_cumsum.stride(2),
@@ -131,4 +169,4 @@ def _state_passing_fwd(
             initial_states_strides[2],
             HAS_INITSTATES=initial_states is not None,
         )
-    return out
+    return out, final_states

--- a/test/registered/layers/mamba/test_mamba_ssm_ssd.py
+++ b/test/registered/layers/mamba/test_mamba_ssm_ssd.py
@@ -102,6 +102,31 @@ def ssd_minimal_discrete(
     return Y, final_state
 
 
+def ssd_minimal_discrete_packed(
+    X,
+    A,
+    B,
+    C,
+    block_len,
+    initial_states=None,
+    return_intermediate_states=False,
+):
+    result = ssd_minimal_discrete(
+        X.unsqueeze(0),
+        A.unsqueeze(0),
+        B.unsqueeze(0),
+        C.unsqueeze(0),
+        block_len,
+        initial_states=initial_states,
+        return_intermediate_states=return_intermediate_states,
+    )
+    if return_intermediate_states:
+        Y, final_state, states = result
+        return Y.squeeze(0), final_state, states.squeeze(0)
+    Y, final_state = result
+    return Y.squeeze(0), final_state
+
+
 def cu_seqlens_to_logical_chunks(cu_seqlens, chunk_size, prefix_lens_cpu=None):
     extend_seq_lens_cpu = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
     return Mamba2Metadata._seq_lens_to_logical_chunks(
@@ -112,7 +137,9 @@ def cu_seqlens_to_logical_chunks(cu_seqlens, chunk_size, prefix_lens_cpu=None):
     )
 
 
-def generate_random_inputs(batch_size, seqlen, n_heads, d_head, itype, device=None):
+def generate_random_batched_inputs(
+    batch_size, seqlen, n_heads, d_head, itype, device=None
+):
 
     if device is None:
         device = get_device()
@@ -129,6 +156,19 @@ def generate_random_inputs(batch_size, seqlen, n_heads, d_head, itype, device=No
     C = torch.randn((batch_size, seqlen, n_heads, d_head), dtype=itype, device=device)
 
     return A, dt, X, B, C
+
+
+def generate_random_inputs(batch_size, seqlen, n_heads, d_head, itype, device=None):
+    A, dt, X, B, C = generate_random_batched_inputs(
+        batch_size, seqlen, n_heads, d_head, itype, device
+    )
+    return (
+        A,
+        dt.reshape(batch_size * seqlen, n_heads),
+        X.reshape(batch_size * seqlen, n_heads, d_head),
+        B.reshape(batch_size * seqlen, n_heads, d_head),
+        C.reshape(batch_size * seqlen, n_heads, d_head),
+    )
 
 
 def generate_continuous_batched_examples(
@@ -152,7 +192,7 @@ def generate_continuous_batched_examples(
     # reference output.
 
     # generate the full-length example
-    A, dt, X, B, C = generate_random_inputs(
+    A, dt, X, B, C = generate_random_batched_inputs(
         num_examples, full_length, n_heads, d_head, itype, device
     )
     # Capture the resolved device from the tensors
@@ -177,7 +217,7 @@ def generate_continuous_batched_examples(
             exhausted[i] = last_taken[i] == 0
 
         return (
-            torch.concat([x[i, s:e] for i, (s, e) in enumerate(indices)]).unsqueeze(0)
+            torch.concat([x[i, s:e] for i, (s, e) in enumerate(indices)])
             for x in (dt, X, B, C)
         )
 
@@ -275,7 +315,7 @@ def test_mamba_chunk_scan_single_example(d_head, n_heads, seq_len_chunk_size, it
 
     A, dt, X, B, C = generate_random_inputs(batch_size, seqlen, n_heads, d_head, itype)
 
-    Y_min, final_state_min = ssd_minimal_discrete(
+    Y_min, final_state_min = ssd_minimal_discrete_packed(
         X * dt.unsqueeze(-1), A * dt, B, C, chunk_size
     )
     cu_seqlens = torch.tensor([0, seqlen], dtype=torch.int32, device=X.device)
@@ -284,22 +324,22 @@ def test_mamba_chunk_scan_single_example(d_head, n_heads, seq_len_chunk_size, it
     )
     Y = torch.empty_like(X)
     final_state = mamba_chunk_scan_combined(
-        X[0],
-        dt[0],
+        X,
+        dt,
         A,
-        B[0],
-        C[0],
+        B,
+        C,
         chunk_size,
         cu_seqlens=cu_seqlens,
         cu_chunk_seqlens=cu_chunk_seqlens,
         last_chunk_indices=last_chunk_indices,
         seq_idx=seq_idx,
         D=None,
-        out=Y[0],
+        out=Y,
     )
 
     # just test the last in sequence
-    torch.testing.assert_close(Y[:, -1], Y_min[:, -1], atol=atol, rtol=rtol)
+    torch.testing.assert_close(Y[-1], Y_min[-1], atol=atol, rtol=rtol)
 
     # just test the last head
     torch.testing.assert_close(
@@ -394,11 +434,11 @@ def test_mamba_chunk_scan_cont_batch(d_head, n_heads, seq_len_chunk_size_cases, 
 
         Y = torch.empty_like(X)
         new_states = mamba_chunk_scan_combined(
-            X[0],
-            dt[0],
+            X,
+            dt,
             A,
-            B[0],
-            C[0],
+            B,
+            C,
             chunk_size,
             D=None,
             cu_seqlens=cu_seqlens,
@@ -406,14 +446,14 @@ def test_mamba_chunk_scan_cont_batch(d_head, n_heads, seq_len_chunk_size_cases, 
             last_chunk_indices=last_chunk_indices,
             seq_idx=seq_idx,
             initial_states=states,
-            out=Y[0],
+            out=Y,
         )
 
         # just test the last in sequence
         for i in range(num_examples):
 
             # just test one dim and dstate
-            Y_eg = Y[0, cu_seqlens[i] : cu_seqlens[i + 1], 0, 0]
+            Y_eg = Y[cu_seqlens[i] : cu_seqlens[i + 1], 0, 0]
             Y_min_eg = Y_min[i][:, 0, 0]
             torch.testing.assert_close(Y_eg, Y_min_eg, atol=atol, rtol=rtol)
 
@@ -446,14 +486,9 @@ def test_mamba_chunk_scan_packed_initial_states_without_varlen_return(
         device=device,
     )
 
-    torch.manual_seed(0)
-    A = -torch.exp(torch.rand(n_heads, dtype=itype, device=device))
-    dt = F.softplus(
-        torch.randn(1, total_seqlen, n_heads, dtype=itype, device=device) - 4
+    A, dt, X, B, C = generate_random_inputs(
+        1, total_seqlen, n_heads, d_head, itype, device=device
     )
-    X = torch.randn((1, total_seqlen, n_heads, d_head), dtype=itype, device=device)
-    B = torch.randn((1, total_seqlen, n_heads, d_head), dtype=itype, device=device)
-    C = torch.randn((1, total_seqlen, n_heads, d_head), dtype=itype, device=device)
     initial_states = torch.randn(
         (num_sequences, n_heads, d_head, d_head), dtype=itype, device=device
     )
@@ -464,27 +499,27 @@ def test_mamba_chunk_scan_packed_initial_states_without_varlen_return(
 
     Y_ref = torch.empty_like(X)
     final_states_ref = mamba_chunk_scan_combined(
-        X[0],
-        dt[0],
+        X,
+        dt,
         A,
-        B[0],
-        C[0],
+        B,
+        C,
         chunk_size,
         cu_seqlens=cu_seqlens,
         cu_chunk_seqlens=cu_chunk_seqlens,
         last_chunk_indices=last_chunk_indices,
         seq_idx=seq_idx,
         initial_states=initial_states,
-        out=Y_ref[0],
+        out=Y_ref,
     )
 
     Y = torch.empty_like(X)
     _, final_states = mamba_chunk_scan_combined(
-        X[0],
-        dt[0],
+        X,
+        dt,
         A,
-        B[0],
-        C[0],
+        B,
+        C,
         chunk_size,
         cu_seqlens=cu_seqlens,
         cu_chunk_seqlens=cu_chunk_seqlens,
@@ -492,7 +527,7 @@ def test_mamba_chunk_scan_packed_initial_states_without_varlen_return(
         seq_idx=seq_idx,
         initial_states=initial_states,
         return_intermediate_states=True,
-        out=Y[0],
+        out=Y,
     )
 
     torch.testing.assert_close(Y, Y_ref, atol=5e-3, rtol=5e-3)
@@ -562,11 +597,11 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     )
     Y_ref = torch.empty_like(X)
     state_ref = mamba_chunk_scan_combined(
-        X[0],
-        dt[0],
+        X,
+        dt,
         A,
-        B[0],
-        C[0],
+        B,
+        C,
         chunk_size,
         D=None,
         cu_seqlens=cu_seqlens,
@@ -574,7 +609,7 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
         last_chunk_indices=last_chunk_indices,
         seq_idx=seq_idx,
         initial_states=None,
-        out=Y_ref[0],
+        out=Y_ref,
     )
 
     ## chunked seqlen computation
@@ -584,18 +619,18 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
         [torch.tensor([0], device=device), torch.cumsum(chunked_seqlens, dim=0)], dim=0
     )
     chunked_input_seq_len = chunked_cu_seqlens[-1]
-    X_chunked = torch.zeros_like(X)[:, :chunked_input_seq_len, ...]
-    dt_chunked = torch.zeros_like(dt)[:, :chunked_input_seq_len, ...]
-    B_chunked = torch.zeros_like(B)[:, :chunked_input_seq_len, ...]
-    C_chunked = torch.zeros_like(C)[:, :chunked_input_seq_len, ...]
+    X_chunked = torch.zeros_like(X)[:chunked_input_seq_len, ...]
+    dt_chunked = torch.zeros_like(dt)[:chunked_input_seq_len, ...]
+    B_chunked = torch.zeros_like(B)[:chunked_input_seq_len, ...]
+    C_chunked = torch.zeros_like(C)[:chunked_input_seq_len, ...]
     for i in range(num_sequences):
         # fmt: off
-        chunk_f = lambda x, i: x[:, cu_seqlens[i]:cu_seqlens[i] + chunked_seqlens[i], ...]  # noqa: E501
+        chunk_f = lambda x, i: x[cu_seqlens[i]:cu_seqlens[i] + chunked_seqlens[i], ...]  # noqa: E501
 
-        X_chunked[:, chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(X, i)  # noqa: E501
-        dt_chunked[:, chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(dt, i)  # noqa: E501
-        B_chunked[:, chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(B, i)  # noqa: E501
-        C_chunked[:, chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(C, i)  # noqa: E501
+        X_chunked[chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(X, i)  # noqa: E501
+        dt_chunked[chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(dt, i)  # noqa: E501
+        B_chunked[chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(B, i)  # noqa: E501
+        C_chunked[chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(C, i)  # noqa: E501
         # fmt: on
 
     cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
@@ -603,11 +638,11 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     )
     Y_partial = torch.empty_like(X_chunked)
     partial_state = mamba_chunk_scan_combined(
-        X_chunked[0],
-        dt_chunked[0],
+        X_chunked,
+        dt_chunked,
         A,
-        B_chunked[0],
-        C_chunked[0],
+        B_chunked,
+        C_chunked,
         chunk_size,
         D=None,
         cu_seqlens=chunked_cu_seqlens,
@@ -615,7 +650,7 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
         last_chunk_indices=last_chunk_indices,
         seq_idx=seq_idx,
         initial_states=None,
-        out=Y_partial[0],
+        out=Y_partial,
     )
 
     # remaining chunk
@@ -629,25 +664,25 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     )
     remaining_chunked_input_seq_len = remaining_chunked_cu_seqlens[-1]
     # fmt: off
-    remaining_X_chunked = torch.zeros_like(X)[:, :remaining_chunked_input_seq_len, ...]  # noqa: E501
-    remaining_dt_chunked = torch.zeros_like(dt)[:, :remaining_chunked_input_seq_len, ...]  # noqa: E501
-    remaining_B_chunked = torch.zeros_like(B)[:, :remaining_chunked_input_seq_len, ...]  # noqa: E501
-    remaining_C_chunked = torch.zeros_like(C)[:, :remaining_chunked_input_seq_len, ...]  # noqa: E501
+    remaining_X_chunked = torch.zeros_like(X)[:remaining_chunked_input_seq_len, ...]  # noqa: E501
+    remaining_dt_chunked = torch.zeros_like(dt)[:remaining_chunked_input_seq_len, ...]  # noqa: E501
+    remaining_B_chunked = torch.zeros_like(B)[:remaining_chunked_input_seq_len, ...]  # noqa: E501
+    remaining_C_chunked = torch.zeros_like(C)[:remaining_chunked_input_seq_len, ...]  # noqa: E501
     for i in range(num_sequences):
-        remaining_chunk_f = lambda x, i: x[:, cu_seqlens[i] + chunked_seqlens[i]:cu_seqlens[i+1], ...]  # noqa: E501
+        remaining_chunk_f = lambda x, i: x[cu_seqlens[i] + chunked_seqlens[i]:cu_seqlens[i+1], ...]  # noqa: E501
 
-        remaining_X_chunked[:, remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(X, i)  # noqa: E501
-        remaining_dt_chunked[:, remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(dt, i)  # noqa: E501
-        remaining_B_chunked[:, remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(B, i)  # noqa: E501
-        remaining_C_chunked[:, remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(C, i)  # noqa: E501
+        remaining_X_chunked[remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(X, i)  # noqa: E501
+        remaining_dt_chunked[remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(dt, i)  # noqa: E501
+        remaining_B_chunked[remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(B, i)  # noqa: E501
+        remaining_C_chunked[remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1], ...] = remaining_chunk_f(C, i)  # noqa: E501
 
     # assert input chunking is correct
     concat_chunk_f = lambda pt1, pt2, i: torch.cat([
-        pt1[:,chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1],...],
-        pt2[:,remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1],...],
+        pt1[chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1],...],
+        pt2[remaining_chunked_cu_seqlens[i]:remaining_chunked_cu_seqlens[i+1],...],
         ],
-        dim=1)
-    concat_batch_f = lambda pt1, pt2: torch.cat([concat_chunk_f(pt1, pt2, i) for i in range(num_sequences)], dim=1)  # noqa: E501
+        dim=0)
+    concat_batch_f = lambda pt1, pt2: torch.cat([concat_chunk_f(pt1, pt2, i) for i in range(num_sequences)], dim=0)  # noqa: E501
     # fmt: on
 
     assert concat_batch_f(X_chunked, remaining_X_chunked).equal(X)
@@ -663,11 +698,11 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
 
     Y_chunked = torch.empty_like(remaining_X_chunked)
     state_chunked = mamba_chunk_scan_combined(
-        remaining_X_chunked[0],
-        remaining_dt_chunked[0],
+        remaining_X_chunked,
+        remaining_dt_chunked,
         A,
-        remaining_B_chunked[0],
-        remaining_C_chunked[0],
+        remaining_B_chunked,
+        remaining_C_chunked,
         chunk_size,
         D=None,
         cu_seqlens=remaining_chunked_cu_seqlens,
@@ -675,24 +710,24 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
         last_chunk_indices=last_chunk_indices,
         seq_idx=seq_idx,
         initial_states=partial_state,
-        out=Y_chunked[0],
+        out=Y_chunked,
     )
     Y = concat_batch_f(Y_partial, Y_chunked)
 
     # kernel chunked is same as kernel overall
     for i in range(num_sequences):
-        Y_seq = Y[:, cu_seqlens[i] : cu_seqlens[i + 1], ...]
-        Y_ref_seq = Y_ref[:, cu_seqlens[i] : cu_seqlens[i + 1], ...]
+        Y_seq = Y[cu_seqlens[i] : cu_seqlens[i + 1], ...]
+        Y_ref_seq = Y_ref[cu_seqlens[i] : cu_seqlens[i + 1], ...]
         torch.testing.assert_close(
-            Y_seq[:, : chunked_seqlens[i], ...],
-            Y_ref_seq[:, : chunked_seqlens[i], ...],
+            Y_seq[: chunked_seqlens[i], ...],
+            Y_ref_seq[: chunked_seqlens[i], ...],
             atol=atol,
             rtol=rtol,
             msg=lambda x: f"seq{i} output part1 " + x,
         )  # noqa: B023
         torch.testing.assert_close(
-            Y_seq[:, chunked_seqlens[i] :, ...],
-            Y_ref_seq[:, chunked_seqlens[i] :, ...],
+            Y_seq[chunked_seqlens[i] :, ...],
+            Y_ref_seq[chunked_seqlens[i] :, ...],
             atol=atol,
             rtol=rtol,
             msg=lambda x: f"seq{i} output part2 " + x,
@@ -733,7 +768,7 @@ def test_mamba_chunk_scan_intermediate_states(
 
     A, dt, X, B, C = generate_random_inputs(batch_size, seqlen, n_heads, d_head, itype)
 
-    _, ref_final_state, ref_states = ssd_minimal_discrete(
+    _, ref_final_state, ref_states = ssd_minimal_discrete_packed(
         X * dt.unsqueeze(-1), A * dt, B, C, chunk_size, return_intermediate_states=True
     )
 
@@ -743,11 +778,11 @@ def test_mamba_chunk_scan_intermediate_states(
     )
     Y = torch.empty_like(X)
     states, final_state = mamba_chunk_scan_combined(
-        X[0],
-        dt[0],
+        X,
+        dt,
         A,
-        B[0],
-        C[0],
+        B,
+        C,
         chunk_size,
         cu_seqlens=cu_seqlens,
         cu_chunk_seqlens=cu_chunk_seqlens,
@@ -755,12 +790,12 @@ def test_mamba_chunk_scan_intermediate_states(
         seq_idx=seq_idx,
         D=None,
         return_intermediate_states=True,
-        out=Y[0],
+        out=Y,
     )
 
     num_chunks = seqlen // chunk_size
     assert states.shape == (num_chunks, n_heads, d_head, d_head)
-    assert ref_states.shape == (batch_size, num_chunks, n_heads, d_head, d_head)
+    assert ref_states.shape == states.shape
 
     torch.testing.assert_close(
         final_state[:, -1].to(torch.float32),
@@ -772,7 +807,7 @@ def test_mamba_chunk_scan_intermediate_states(
     for chunk_idx in range(num_chunks):
         torch.testing.assert_close(
             states[chunk_idx, -1],
-            ref_states[0, chunk_idx, -1].to(states.dtype),
+            ref_states[chunk_idx, -1].to(states.dtype),
             atol=atol,
             rtol=rtol,
             msg=lambda x: f"chunk {chunk_idx} " + x,

--- a/test/registered/layers/mamba/test_mamba_ssm_ssd.py
+++ b/test/registered/layers/mamba/test_mamba_ssm_ssd.py
@@ -88,7 +88,6 @@ def ssd_minimal_discrete(
     decay_chunk = torch.exp(segsum(F.pad(A_cumsum[:, :, :, -1], (1, 0))))
     new_states = torch.einsum("bhzc,bchpn->bzhpn", decay_chunk, states)
     states, final_state = new_states[:, :-1], new_states[:, -1]
-    post_chunk_states = new_states[:, 1:]
 
     # 4. Compute state -> output conversion per chunk
     # (left term of low-rank factorization of off-diagonal blocks; C terms)
@@ -99,7 +98,7 @@ def ssd_minimal_discrete(
     # (diagonal and off-diagonal blocks)
     Y = rearrange(Y_diag + Y_off, "b c l h p -> b (c l) h p")
     if return_intermediate_states:
-        return Y, final_state, post_chunk_states
+        return Y, final_state, states
     return Y, final_state
 
 
@@ -480,7 +479,7 @@ def test_mamba_chunk_scan_packed_initial_states_without_varlen_return(
     )
 
     Y = torch.empty_like(X)
-    states = mamba_chunk_scan_combined(
+    _, final_states = mamba_chunk_scan_combined(
         X[0],
         dt[0],
         A,
@@ -495,7 +494,6 @@ def test_mamba_chunk_scan_packed_initial_states_without_varlen_return(
         return_intermediate_states=True,
         out=Y[0],
     )
-    final_states = states[last_chunk_indices]
 
     torch.testing.assert_close(Y, Y_ref, atol=5e-3, rtol=5e-3)
     torch.testing.assert_close(final_states, final_states_ref, atol=5e-3, rtol=5e-3)
@@ -744,7 +742,7 @@ def test_mamba_chunk_scan_intermediate_states(
         cu_seqlens, chunk_size
     )
     Y = torch.empty_like(X)
-    states = mamba_chunk_scan_combined(
+    states, final_state = mamba_chunk_scan_combined(
         X[0],
         dt[0],
         A,
@@ -759,7 +757,6 @@ def test_mamba_chunk_scan_intermediate_states(
         return_intermediate_states=True,
         out=Y[0],
     )
-    final_state = states[last_chunk_indices]
 
     num_chunks = seqlen // chunk_size
     assert states.shape == (num_chunks, n_heads, d_head, d_head)

--- a/test/registered/layers/mamba/test_mamba_ssm_ssd.py
+++ b/test/registered/layers/mamba/test_mamba_ssm_ssd.py
@@ -88,6 +88,7 @@ def ssd_minimal_discrete(
     decay_chunk = torch.exp(segsum(F.pad(A_cumsum[:, :, :, -1], (1, 0))))
     new_states = torch.einsum("bhzc,bchpn->bzhpn", decay_chunk, states)
     states, final_state = new_states[:, :-1], new_states[:, -1]
+    post_chunk_states = new_states[:, 1:]
 
     # 4. Compute state -> output conversion per chunk
     # (left term of low-rank factorization of off-diagonal blocks; C terms)
@@ -98,8 +99,18 @@ def ssd_minimal_discrete(
     # (diagonal and off-diagonal blocks)
     Y = rearrange(Y_diag + Y_off, "b c l h p -> b (c l) h p")
     if return_intermediate_states:
-        return Y, final_state, states
+        return Y, final_state, post_chunk_states
     return Y, final_state
+
+
+def cu_seqlens_to_logical_chunks(cu_seqlens, chunk_size, prefix_lens_cpu=None):
+    extend_seq_lens_cpu = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+    return Mamba2Metadata._seq_lens_to_logical_chunks(
+        extend_seq_lens_cpu,
+        chunk_size,
+        cu_seqlens.device,
+        extend_prefix_lens_cpu=prefix_lens_cpu,
+    )
 
 
 def generate_random_inputs(batch_size, seqlen, n_heads, d_head, itype, device=None):
@@ -185,18 +196,7 @@ def generate_continuous_batched_examples(
         # get the (maybe partial) example seen in this cont batch
         dt2, X2, B2, C2 = get_continuous_batch(spec)
 
-        # get the metadata
         cu_seqlens = torch.tensor((0,) + spec, device=device).cumsum(dim=0)
-        seq_idx = torch.zeros(
-            cu_seqlens[-1], dtype=torch.int32, device=cu_seqlens.device
-        )
-        for i, (srt, end) in enumerate(
-            zip(
-                cu_seqlens,
-                cu_seqlens[1:],
-            )
-        ):
-            seq_idx[srt:end] = i
 
         # for cont batch
         if IND_E is None:
@@ -212,7 +212,6 @@ def generate_continuous_batched_examples(
                 else None
             ),
             cu_seqlens,
-            seq_idx.unsqueeze(0),
             (A, dt2, X2, B2, C2),
         )
 
@@ -227,6 +226,27 @@ if is_in_ci():
     SINGLE_NHEADS = [3, 32]
     SINGLE_DHEAD = [5, 128]
     SINGLE_SEQ_LEN_CHUNK_SIZE = [(112, 16)]
+
+
+def test_mamba2_metadata_logical_chunks_use_prefix_lens():
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = (
+        Mamba2Metadata._seq_lens_to_logical_chunks(
+            extend_seq_lens_cpu=[10, 7, 8],
+            chunk_size=8,
+            device=torch.device("cpu"),
+            extend_prefix_lens_cpu=[5, 16, 31],
+        )
+    )
+
+    torch.testing.assert_close(
+        cu_chunk_seqlens, torch.tensor([0, 3, 10, 17, 18, 25], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        seq_idx, torch.tensor([0, 0, 1, 2, 2], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        last_chunk_indices, torch.tensor([1, 2, 4], dtype=torch.int32)
+    )
 
 
 @pytest.mark.parametrize("itype", SINGLE_ITYPE)
@@ -259,18 +279,32 @@ def test_mamba_chunk_scan_single_example(d_head, n_heads, seq_len_chunk_size, it
     Y_min, final_state_min = ssd_minimal_discrete(
         X * dt.unsqueeze(-1), A * dt, B, C, chunk_size
     )
+    cu_seqlens = torch.tensor([0, seqlen], dtype=torch.int32, device=X.device)
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+        cu_seqlens, chunk_size
+    )
     Y = torch.empty_like(X)
     final_state = mamba_chunk_scan_combined(
-        X, dt, A, B, C, chunk_size, D=None, return_final_states=True, out=Y
+        X[0],
+        dt[0],
+        A,
+        B[0],
+        C[0],
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        seq_idx=seq_idx,
+        D=None,
+        out=Y[0],
     )
 
     # just test the last in sequence
     torch.testing.assert_close(Y[:, -1], Y_min[:, -1], atol=atol, rtol=rtol)
 
     # just test the last head
-    # NOTE, in the kernel we always cast states to fp32
     torch.testing.assert_close(
-        final_state[:, -1],
+        final_state[:, -1].to(torch.float32),
         final_state_min[:, -1].to(torch.float32),
         atol=atol,
         rtol=rtol,
@@ -351,34 +385,29 @@ def test_mamba_chunk_scan_cont_batch(d_head, n_heads, seq_len_chunk_size_cases, 
     for (
         Y_min,
         cu_seqlens,
-        seq_idx,
         (A, dt, X, B, C),
     ) in generate_continuous_batched_examples(
         cases, num_examples, seqlen, last_taken, exhausted, n_heads, d_head, itype
     ):
-
-        chunk_indices, chunk_offsets = (
-            Mamba2Metadata._query_start_loc_to_chunk_indices_offsets(
-                cu_seqlens, chunk_size, cu_seqlens[-1]
-            )
+        cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+            cu_seqlens, chunk_size
         )
 
         Y = torch.empty_like(X)
         new_states = mamba_chunk_scan_combined(
-            X,
-            dt,
+            X[0],
+            dt[0],
             A,
-            B,
-            C,
+            B[0],
+            C[0],
             chunk_size,
             D=None,
             cu_seqlens=cu_seqlens,
+            cu_chunk_seqlens=cu_chunk_seqlens,
+            last_chunk_indices=last_chunk_indices,
             seq_idx=seq_idx,
-            chunk_indices=chunk_indices,
-            chunk_offsets=chunk_offsets,
-            return_varlen_states=True,
             initial_states=states,
-            out=Y,
+            out=Y[0],
         )
 
         # just test the last in sequence
@@ -395,6 +424,81 @@ def test_mamba_chunk_scan_cont_batch(d_head, n_heads, seq_len_chunk_size_cases, 
             if clear:
                 states[i].fill_(0.0)
                 exhausted[i] = False
+
+
+@pytest.mark.parametrize("chunk_size", [8, 32])
+@pytest.mark.parametrize("seqlens", [(16, 12, 20), (16, 20)])
+def test_mamba_chunk_scan_packed_initial_states_without_varlen_return(
+    chunk_size, seqlens
+):
+    """Regression: packed initial_states return final states from chunk states."""
+    device = get_device()
+    if device not in ["cuda", "xpu"]:
+        pytest.skip("Test only supports CUDA and XPU devices")
+
+    itype = torch.float32
+    n_heads = 4
+    d_head = 32
+    num_sequences = len(seqlens)
+    total_seqlen = sum(seqlens)
+    cu_seqlens = torch.tensor(
+        [0, *torch.cumsum(torch.tensor(seqlens), dim=0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    torch.manual_seed(0)
+    A = -torch.exp(torch.rand(n_heads, dtype=itype, device=device))
+    dt = F.softplus(
+        torch.randn(1, total_seqlen, n_heads, dtype=itype, device=device) - 4
+    )
+    X = torch.randn((1, total_seqlen, n_heads, d_head), dtype=itype, device=device)
+    B = torch.randn((1, total_seqlen, n_heads, d_head), dtype=itype, device=device)
+    C = torch.randn((1, total_seqlen, n_heads, d_head), dtype=itype, device=device)
+    initial_states = torch.randn(
+        (num_sequences, n_heads, d_head, d_head), dtype=itype, device=device
+    )
+
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+        cu_seqlens, chunk_size
+    )
+
+    Y_ref = torch.empty_like(X)
+    final_states_ref = mamba_chunk_scan_combined(
+        X[0],
+        dt[0],
+        A,
+        B[0],
+        C[0],
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        seq_idx=seq_idx,
+        initial_states=initial_states,
+        out=Y_ref[0],
+    )
+
+    Y = torch.empty_like(X)
+    states = mamba_chunk_scan_combined(
+        X[0],
+        dt[0],
+        A,
+        B[0],
+        C[0],
+        chunk_size,
+        cu_seqlens=cu_seqlens,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        seq_idx=seq_idx,
+        initial_states=initial_states,
+        return_intermediate_states=True,
+        out=Y[0],
+    )
+    final_states = states[last_chunk_indices]
+
+    torch.testing.assert_close(Y, Y_ref, atol=5e-3, rtol=5e-3)
+    torch.testing.assert_close(final_states, final_states_ref, atol=5e-3, rtol=5e-3)
 
 
 @pytest.mark.parametrize("chunk_size", [8, 256])
@@ -438,7 +542,7 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     # example has been exhausted and needs to cycle
     last_taken: dict = {}  # map: eg -> pointer to last taken sample
     exhausted: dict = {}  # map: eg -> boolean indicating example is exhausted
-    _, cu_seqlens, seq_idx, (A, dt, X, B, C) = next(
+    _, cu_seqlens, (A, dt, X, B, C) = next(
         generate_continuous_batched_examples(
             [seqlens],
             num_sequences,
@@ -455,27 +559,24 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     device = X.device
 
     ## full seqlen computation
-    chunk_indices, chunk_offsets = (
-        Mamba2Metadata._query_start_loc_to_chunk_indices_offsets(
-            cu_seqlens, chunk_size, cu_seqlens[-1]
-        )
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+        cu_seqlens, chunk_size
     )
     Y_ref = torch.empty_like(X)
     state_ref = mamba_chunk_scan_combined(
-        X,
-        dt,
+        X[0],
+        dt[0],
         A,
-        B,
-        C,
+        B[0],
+        C[0],
         chunk_size,
         D=None,
         cu_seqlens=cu_seqlens,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
         seq_idx=seq_idx,
-        chunk_indices=chunk_indices,
-        chunk_offsets=chunk_offsets,
-        return_varlen_states=True,
         initial_states=None,
-        out=Y_ref,
+        out=Y_ref[0],
     )
 
     ## chunked seqlen computation
@@ -483,15 +584,6 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     chunked_seqlens = seqlens // 2
     chunked_cu_seqlens = torch.cat(
         [torch.tensor([0], device=device), torch.cumsum(chunked_seqlens, dim=0)], dim=0
-    )
-    chunked_seq_idx = (
-        torch.repeat_interleave(
-            torch.arange(len(chunked_seqlens), device=device),
-            chunked_seqlens,
-            output_size=chunked_cu_seqlens[-1],
-        )
-        .unsqueeze(0)
-        .to(torch.int32)
     )
     chunked_input_seq_len = chunked_cu_seqlens[-1]
     X_chunked = torch.zeros_like(X)[:, :chunked_input_seq_len, ...]
@@ -508,27 +600,24 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
         C_chunked[:, chunked_cu_seqlens[i]:chunked_cu_seqlens[i+1], ...] = chunk_f(C, i)  # noqa: E501
         # fmt: on
 
-    chunk_indices, chunk_offsets = (
-        Mamba2Metadata._query_start_loc_to_chunk_indices_offsets(
-            chunked_cu_seqlens, chunk_size, chunked_cu_seqlens[-1]
-        )
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+        chunked_cu_seqlens, chunk_size
     )
     Y_partial = torch.empty_like(X_chunked)
     partial_state = mamba_chunk_scan_combined(
-        X_chunked,
-        dt_chunked,
+        X_chunked[0],
+        dt_chunked[0],
         A,
-        B_chunked,
-        C_chunked,
+        B_chunked[0],
+        C_chunked[0],
         chunk_size,
         D=None,
         cu_seqlens=chunked_cu_seqlens,
-        seq_idx=chunked_seq_idx,
-        chunk_indices=chunk_indices,
-        chunk_offsets=chunk_offsets,
-        return_varlen_states=True,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        seq_idx=seq_idx,
         initial_states=None,
-        out=Y_partial,
+        out=Y_partial[0],
     )
 
     # remaining chunk
@@ -539,15 +628,6 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
             torch.cumsum(remaining_chunked_seqlens, dim=0),
         ],
         dim=0,
-    )
-    remaining_chunked_seq_idx = (
-        torch.repeat_interleave(
-            torch.arange(len(remaining_chunked_seqlens), device=device),
-            remaining_chunked_seqlens,
-            output_size=remaining_chunked_cu_seqlens[-1],
-        )
-        .unsqueeze(0)
-        .to(torch.int32)
     )
     remaining_chunked_input_seq_len = remaining_chunked_cu_seqlens[-1]
     # fmt: off
@@ -577,28 +657,27 @@ def test_mamba_chunk_scan_cont_batch_prefill_chunking(chunk_size, seqlens):
     assert concat_batch_f(B_chunked, remaining_B_chunked).equal(B)
     assert concat_batch_f(C_chunked, remaining_C_chunked).equal(C)
 
-    chunk_indices, chunk_offsets = (
-        Mamba2Metadata._query_start_loc_to_chunk_indices_offsets(
-            remaining_chunked_cu_seqlens, chunk_size, remaining_chunked_cu_seqlens[-1]
-        )
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+        remaining_chunked_cu_seqlens,
+        chunk_size,
+        prefix_lens_cpu=chunked_seqlens.cpu().tolist(),
     )
 
     Y_chunked = torch.empty_like(remaining_X_chunked)
     state_chunked = mamba_chunk_scan_combined(
-        remaining_X_chunked,
-        remaining_dt_chunked,
+        remaining_X_chunked[0],
+        remaining_dt_chunked[0],
         A,
-        remaining_B_chunked,
-        remaining_C_chunked,
+        remaining_B_chunked[0],
+        remaining_C_chunked[0],
         chunk_size,
         D=None,
         cu_seqlens=remaining_chunked_cu_seqlens,
-        seq_idx=remaining_chunked_seq_idx,
-        chunk_indices=chunk_indices,
-        chunk_offsets=chunk_offsets,
-        return_varlen_states=True,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        seq_idx=seq_idx,
         initial_states=partial_state,
-        out=Y_chunked,
+        out=Y_chunked[0],
     )
     Y = concat_batch_f(Y_partial, Y_chunked)
 
@@ -660,26 +739,34 @@ def test_mamba_chunk_scan_intermediate_states(
         X * dt.unsqueeze(-1), A * dt, B, C, chunk_size, return_intermediate_states=True
     )
 
+    cu_seqlens = torch.tensor([0, seqlen], dtype=torch.int32, device=X.device)
+    cu_chunk_seqlens, seq_idx, last_chunk_indices = cu_seqlens_to_logical_chunks(
+        cu_seqlens, chunk_size
+    )
     Y = torch.empty_like(X)
-    states, final_state = mamba_chunk_scan_combined(
-        X,
-        dt,
+    states = mamba_chunk_scan_combined(
+        X[0],
+        dt[0],
         A,
-        B,
-        C,
+        B[0],
+        C[0],
         chunk_size,
+        cu_seqlens=cu_seqlens,
+        cu_chunk_seqlens=cu_chunk_seqlens,
+        last_chunk_indices=last_chunk_indices,
+        seq_idx=seq_idx,
         D=None,
         return_intermediate_states=True,
-        return_final_states=True,
-        out=Y,
+        out=Y[0],
     )
+    final_state = states[last_chunk_indices]
 
     num_chunks = seqlen // chunk_size
-    assert states.shape == (batch_size, num_chunks, n_heads, d_head, d_head)
-    assert ref_states.shape == states.shape
+    assert states.shape == (num_chunks, n_heads, d_head, d_head)
+    assert ref_states.shape == (batch_size, num_chunks, n_heads, d_head, d_head)
 
     torch.testing.assert_close(
-        final_state[:, -1],
+        final_state[:, -1].to(torch.float32),
         ref_final_state[:, -1].to(torch.float32),
         atol=atol,
         rtol=rtol,
@@ -687,8 +774,8 @@ def test_mamba_chunk_scan_intermediate_states(
 
     for chunk_idx in range(num_chunks):
         torch.testing.assert_close(
-            states[:, chunk_idx, -1],
-            ref_states[:, chunk_idx, -1].to(states.dtype),
+            states[chunk_idx, -1],
+            ref_states[0, chunk_idx, -1].to(states.dtype),
             atol=atol,
             rtol=rtol,
             msg=lambda x: f"chunk {chunk_idx} " + x,

--- a/test/registered/layers/mamba/test_mamba_ssm_ssd.py
+++ b/test/registered/layers/mamba/test_mamba_ssm_ssd.py
@@ -796,6 +796,7 @@ def test_mamba_chunk_scan_intermediate_states(
     num_chunks = seqlen // chunk_size
     assert states.shape == (num_chunks, n_heads, d_head, d_head)
     assert ref_states.shape == states.shape
+    assert final_state.dtype == itype
 
     torch.testing.assert_close(
         final_state[:, -1].to(torch.float32),


### PR DESCRIPTION
Refactors Mamba2 SSD prefill to use prefix-aware logical chunk metadata and packed varlen kernel inputs, removing the older batch/token-level chunk indexing path while preserving final-state updates for continuous and chunked prefill.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The mamba code has been ported from vLLM a while back. In the meantime, vLLM introduced a major simplification to it's mamba implementation (https://github.com/vllm-project/vllm/pull/24683). The stated reasons for the change were:

- It dramatically simplifies the kernels
- It can improve performance, because we can entirely skip the final call to the "varlen" kernel that is used to align the final states for each sequence.

To which I can add:

- makes it possible to provide deterministic computation for mamba layers, due to predictable chunk boundaries in batched inputs (but not sufficient by itself)


## Modifications

This PR ports, at least in spirit, the vLLM changes described above to SGLang, with one intentional deviation: state passing, not chunk_scan, owns initial-state and previous-state selection. This preserves the original start-of-chunk state semantics while letting chunk_scan read precomputed boundary states directly. In my testing, the exact vLLM approach regressed performance, especially at TP > 1.

## Accuracy Tests

few_shot_gsm8k results for Nemotron 3 Nano BF16 with the changes:
```
Accuracy: 0.465
Invalid: 0.000
Latency: 73.302 s
Output throughput: 761.428 token/s
```
and without:
```
Accuracy: 0.465
Invalid: 0.005
Latency: 74.771 s
Output throughput: 751.290 token/s
```

## Speed Tests and Profiling
  2× H100 NVL · 400 requests · 50 warmup · max throughput · fixed-length inputs

  | Config | Tput (req/s) | Out (tok/s) | TTFT (ms) | ITL (ms) |
  |--------|:---:|:---:|:---:|:---:|
  | Baseline TP=1 Chat (1024→512)  |  8.37 |  2194 | 11215 |  73.0 |
  | **Modified TP=1 Chat (1024→512)**  |  **8.80** |  **2307** | **10723** | **69.7** |
  | Baseline TP=1 Summ (4096→512)  |  5.04 |  1322 | 26340 | 118.9 |
  | **Modified TP=1 Summ (4096→512)**  |  **5.36** |  **1405** | **24583** | **112.0** |
  | Baseline TP=2 Chat (1024→512)  | 19.21 |  5035 |  3366 |  44.4 |
  | **Modified TP=2 Chat (1024→512)**  | **19.49** |  **5108** |  **3178** | **43.9** |
  | Baseline TP=2 Summ (4096→512)  | 10.27 |  2693 | 12463 |  78.5 |
  | **Modified TP=2 Summ (4096→512)**  | **10.61** |  **2782** | **11828** | **76.3** |

  **Δ vs baseline:** TP=1 Chat +5.1% tput / +4.4% TTFT · TP=1 Summ +6.2% tput / +6.7% TTFT · TP=2 Chat +1.5% tput / +5.6% TTFT · TP=2 Summ +3.3% tput / +5.1% TTFT

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26165240198](https://github.com/sgl-project/sglang/actions/runs/26165240198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26165240183](https://github.com/sgl-project/sglang/actions/runs/26165240183)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->