### PR TITLE
[Model] Add debug logging and error tracking for async weight loading

### DIFF
--- a/python/sglang/srt/models/afmoe.py
+++ b/python/sglang/srt/models/afmoe.py
@@ -24,6 +24,7 @@ AfMoE is a Mixture-of-Experts model with:
 from __future__ import annotations
 
 import functools
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -60,6 +61,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, is_npu
 
+logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 
 if _is_npu:
@@ -602,6 +604,9 @@ class AfmoeForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Skip rotary embedding inverse frequencies
             if "rotary_emb.inv_freq" in name:
                 continue

--- a/python/sglang/srt/models/apertus.py
+++ b/python/sglang/srt/models/apertus.py
@@ -585,6 +585,9 @@ class ApertusForCausalLM(nn.Module):
                 params_dict[name] = buffer
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/arcee.py
+++ b/python/sglang/srt/models/arcee.py
@@ -479,6 +479,9 @@ class ArceeForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/baichuan.py
+++ b/python/sglang/srt/models/baichuan.py
@@ -23,6 +23,7 @@
 # limitations under the License.
 """Inference-only BaiChuan model compatible with HuggingFace weights."""
 
+import logging
 import math
 from typing import Iterable, Optional, Tuple
 
@@ -53,6 +54,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, is_npu
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 
@@ -402,6 +405,9 @@ class BaiChuanBaseForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if name == "lm_head.weight":

--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -929,6 +929,9 @@ class BailingMoEForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if (
                 ("v_head" in name)
                 or ("inv_freq" in name)

--- a/python/sglang/srt/models/bailing_moe_linear.py
+++ b/python/sglang/srt/models/bailing_moe_linear.py
@@ -1399,6 +1399,9 @@ class BailingMoELinearForCausalLM(nn.Module):
         cached_a_proj = {} if fuse_qkv_a_proj else None
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("model.mtp"):
                 continue
             layer_idx = None

--- a/python/sglang/srt/models/bert.py
+++ b/python/sglang/srt/models/bert.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import logging
 from typing import Iterable, Optional, Set, Tuple
 
 import torch
@@ -19,6 +20,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 BertConfig = None
 
@@ -412,6 +415,9 @@ class BertModel(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = name.replace("self", "self_attn")
             if not self.use_bert_pooler and "pooler" in name:
                 continue

--- a/python/sglang/srt/models/chatglm.py
+++ b/python/sglang/srt/models/chatglm.py
@@ -16,6 +16,7 @@
 # https://github.com/THUDM/ChatGLM2-6B
 """Inference-only ChatGLM model compatible with THUDM weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -42,6 +43,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 LoraConfig = None
 
@@ -408,6 +411,9 @@ class ChatGLMForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_pos_emb.inv_freq" in name:
                 continue
             if "word_embeddings" in name:

--- a/python/sglang/srt/models/clip.py
+++ b/python/sglang/srt/models/clip.py
@@ -1,6 +1,7 @@
 # Adapted from
 # https://github.com/huggingface/transformers/blob/af9b2eaa54c150741f298d6db939af6328e1dc38/src/transformers/models/clip/modeling_clip.py
 
+import logging
 from functools import partial
 from typing import Iterable, List, Optional, Tuple, Type, Union
 
@@ -19,6 +20,8 @@ from sglang.srt.managers.schedule_batch import MultimodalInputs
 from sglang.srt.model_executor.model_runner import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, flatten_nested_list
+
+logger = logging.getLogger(__name__)
 
 
 class CLIPVisionEmbeddings(nn.Module):
@@ -484,6 +487,9 @@ class CLIPModel(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "position_ids" in name:
                 continue
             if "out_proj" in name:

--- a/python/sglang/srt/models/commandr.py
+++ b/python/sglang/srt/models/commandr.py
@@ -41,6 +41,7 @@
 # This file is based on the LLama model definition file in transformers
 """PyTorch Cohere model."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -70,6 +71,8 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.utils import add_prefix, get_compiler_backend, set_weight_attrs
+
+logger = logging.getLogger(__name__)
 
 
 @torch.compile(backend=get_compiler_backend())
@@ -399,6 +402,9 @@ class CohereForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, shard_name, shard_id in stacked_params_mapping:
                 if shard_name not in name:
                     continue

--- a/python/sglang/srt/models/dbrx.py
+++ b/python/sglang/srt/models/dbrx.py
@@ -18,6 +18,7 @@
 # Adapted from:
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/models/dbrx.py#L1
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -55,6 +56,8 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.utils import add_prefix, is_npu, set_weight_attrs
+
+logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 
@@ -447,6 +450,9 @@ class DbrxForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, weight_name in expert_params_mapping:
                 if weight_name not in name:
                     continue

--- a/python/sglang/srt/models/deepseek.py
+++ b/python/sglang/srt/models/deepseek.py
@@ -18,6 +18,7 @@
 # https://github.com/vllm-project/vllm/blob/14f91fe67c2342f2fe859dc6a5c40810df0e1c61/vllm/model_executor/models/deepseek.py
 """Inference-only Deepseek model."""
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -57,6 +58,8 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 if _is_cpu and _is_cpu_amx_available:
     import sgl_kernel  # noqa: F401
+
+logger = logging.getLogger(__name__)
 
 
 class DeepseekMLP(nn.Module):
@@ -478,6 +481,9 @@ class DeepseekForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -151,11 +151,19 @@ class DeepseekV2WeightLoaderMixin:
             assert self.num_fused_shared_experts == 1
             log_info_on_rank0(logger, "Shared experts fusion optimization enabled.")
 
+        def track_future(name):
+            if futures and id(futures[-1]) not in future_to_name:
+                future_to_name[id(futures[-1])] = name
+
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []
             params_dict = dict(self.named_parameters())
             weight_names = []
+            future_to_name = {}
             for name, loaded_weight in weights:
+                logger.debug(
+                    f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+                )
                 use_async_loading = should_async_load(loaded_weight)
                 layer_id = get_layer_id(name)
                 if (
@@ -234,6 +242,7 @@ class DeepseekV2WeightLoaderMixin:
                         func=weight_loader,
                         func_args=(param, loaded_weight, shard_id),
                     )
+                    track_future(name)
                     break
                 else:
                     for mapping in expert_params_mapping:
@@ -262,6 +271,7 @@ class DeepseekV2WeightLoaderMixin:
                                 "expert_id": expert_id,
                             },
                         )
+                        track_future(name)
                         break
                     else:
                         # Skip loading extra bias for GPTQ models.
@@ -337,6 +347,7 @@ class DeepseekV2WeightLoaderMixin:
                                     func=weight_loader,
                                     func_args=(param, fused_weight),
                                 )
+                                track_future(param_name)
                                 cached_a_proj.pop(q_a_proj_name)
                                 cached_a_proj.pop(kv_a_proj_name)
                         else:
@@ -367,10 +378,19 @@ class DeepseekV2WeightLoaderMixin:
                                 func=weight_loader,
                                 func_args=(param, loaded_weight),
                             )
+                            track_future(name)
 
             # Wait for all tasks to complete and raise any exceptions.
-            for future in concurrent.futures.as_completed(futures):
-                future.result()
+            for i, future in enumerate(concurrent.futures.as_completed(futures)):
+                try:
+                    future.result()
+                except Exception as e:
+                    idx = futures.index(future) if future in futures else -1
+                    fname = future_to_name.get(id(future), "unknown")
+                    logger.error(
+                        f"Async weight loading failed: name={fname}, future_index={idx}"
+                    )
+                    raise
 
         self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)
 

--- a/python/sglang/srt/models/deepseek_janus_pro.py
+++ b/python/sglang/srt/models/deepseek_janus_pro.py
@@ -2018,6 +2018,9 @@ class MultiModalityCausalLM(MultiModalityPreTrainedModel):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq~" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/deepseek_ocr.py
+++ b/python/sglang/srt/models/deepseek_ocr.py
@@ -1779,6 +1779,9 @@ class DeepseekOCRForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             is_qwen2_weight = "qwen2_model." in name

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1354,6 +1354,10 @@ class DeepseekV4ForCausalLM(nn.Module):
         def auto_weight_loader(module):
             return getattr(module, "weight_loader", default_weight_loader)
 
+        def track_future(name):
+            if futures and id(futures[-1]) not in future_to_name:
+                future_to_name[id(futures[-1])] = name
+
         if is_nextn:
             nextn_layer_prefix = f"model.layers.{nextn_layer_id}"
             nextn_spec_weight_names_out_of_layer = [
@@ -1376,7 +1380,11 @@ class DeepseekV4ForCausalLM(nn.Module):
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []
             weight_names = []
+            future_to_name = {}
             for name, loaded_weight in weights:
+                logger.debug(
+                    f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+                )
                 try:
                     use_async_loading = should_async_load(loaded_weight)
 
@@ -1461,6 +1469,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                             func=weight_loader,
                             func_args=(param, loaded_weight, shard_id),
                         )
+                        track_future(name)
                         loaded_params.add(name)
                         break
                     else:
@@ -1490,6 +1499,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                     "expert_id": expert_id,
                                 },
                             )
+                            track_future(name)
                             loaded_params.add(name)
                             break
                         else:
@@ -1540,6 +1550,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                         func=weight_loader,
                                         func_args=(param, fused_weight),
                                     )
+                                    track_future(param_name)
                                     loaded_params.add(param_name)
                                     cache_compressor_weight.pop(key)
                             elif fuse_wqa_wkv and (
@@ -1571,6 +1582,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                         func=weight_loader,
                                         func_args=(param, fused_weight),
                                     )
+                                    track_future(param_name)
                                     loaded_params.add(param_name)
                                     cache_wqkv_a_weight.pop(param_name)
                             else:
@@ -1599,13 +1611,22 @@ class DeepseekV4ForCausalLM(nn.Module):
                                     func=weight_loader,
                                     func_args=(param, loaded_weight),
                                 )
+                                track_future(name)
                                 loaded_params.add(name)
                 except Exception as e:
                     e.add_note(f"{name=} {loaded_weight.shape=}")
                     raise
 
-            for future in concurrent.futures.as_completed(futures):
-                future.result()
+            for i, future in enumerate(concurrent.futures.as_completed(futures)):
+                try:
+                    future.result()
+                except Exception as e:
+                    idx = futures.index(future) if future in futures else -1
+                    fname = future_to_name.get(id(future), "unknown")
+                    logger.error(
+                        f"Async weight loading failed: name={fname}, future_index={idx}"
+                    )
+                    raise
 
         assert len(cache_compressor_weight) == 0
         assert len(cache_wqkv_a_weight) == 0, cache_wqkv_a_weight.keys()

--- a/python/sglang/srt/models/deepseek_vl2.py
+++ b/python/sglang/srt/models/deepseek_vl2.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, List, Optional, Tuple
 
 import torch
@@ -20,6 +21,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.deepseek import DeepseekForCausalLM
 from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
+
+logger = logging.getLogger(__name__)
 
 
 class DeepseekVL2MlpProjector(nn.Module):
@@ -245,6 +248,9 @@ class DeepseekVL2ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         weights = list(weights)
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "language" in name:
                 name = name.replace("language.", "")
                 self.language_model.load_weights([(name, loaded_weight)])

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -365,6 +365,9 @@ class DFlashDraftModel(nn.Module):
             return None
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if f".{weight_name}." not in name:
                     continue

--- a/python/sglang/srt/models/dots_ocr.py
+++ b/python/sglang/srt/models/dots_ocr.py
@@ -140,6 +140,9 @@ class DotsOCRForCausalLM(nn.Module):
         language_weights = []
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("vision_tower."):
                 vision_name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
 

--- a/python/sglang/srt/models/dots_vlm.py
+++ b/python/sglang/srt/models/dots_vlm.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 """Inference-only Dots-VL model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, List, Optional, Tuple
 
 import torch
@@ -35,6 +36,8 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
 
 from .dots_vlm_vit import DotsVisionTransformer
+
+logger = logging.getLogger(__name__)
 
 
 class DotsVLMForCausalLM(nn.Module):
@@ -97,6 +100,9 @@ class DotsVLMForCausalLM(nn.Module):
         language_weights = []
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("vision_tower."):
                 vision_name = name.replace(r"attn.qkv.", r"attn.qkv_proj.")
                 vision_weights.append((vision_name, loaded_weight))

--- a/python/sglang/srt/models/ernie4.py
+++ b/python/sglang/srt/models/ernie4.py
@@ -14,6 +14,7 @@
 
 """Inference-only Ernie4.5 model compatible with baidu/ERNIE-4.5-*-PT weights."""
 
+import logging
 from typing import Iterable, List, Optional, Tuple, Union
 
 import torch
@@ -44,6 +45,8 @@ from sglang.srt.models.deepseek_v2 import DeepseekV2MLP as Ernie4MLP
 from sglang.srt.models.llama import LlamaAttention as Ernie4Attention
 from sglang.srt.utils import add_prefix, make_layers
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class MoEGate(nn.Module):
@@ -336,6 +339,9 @@ class Ernie4_5_ForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 continue
             for param_name, weight_name, shard_id in self.stacked_params_mapping:
@@ -370,6 +376,9 @@ class Ernie4_5_MoeForCausalLM(Ernie4_5_ForCausalLM):
         )
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 continue
             if name.startswith("model.mtp_"):

--- a/python/sglang/srt/models/ernie45_vl.py
+++ b/python/sglang/srt/models/ernie45_vl.py
@@ -336,6 +336,9 @@ class VariableResolutionResamplerModel(nn.Module):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name not in params_dict:
                 continue
             param = params_dict[name]
@@ -752,6 +755,9 @@ class Ernie4_5_VLMoeForConditionalGeneration(nn.Module):
         )
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if self.config.tie_word_embeddings and "lm_head.weight" in name:

--- a/python/sglang/srt/models/ernie4_eagle.py
+++ b/python/sglang/srt/models/ernie4_eagle.py
@@ -14,6 +14,7 @@
 
 """Ernie4.5 MTP model compatible with baidu/ERNIE-4.5-*-PT weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -33,6 +34,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.ernie4 import Ernie4_5_ForCausalLM, Ernie4DecoderLayer
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class Ernie4ModelMTP(nn.Module):
@@ -150,6 +153,9 @@ class Ernie4_5_MoeForCausalLMMTP(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Only name matched patterns should be loaded
             for layer_pattern in mtp_weight_patterns:
                 if layer_pattern in name:

--- a/python/sglang/srt/models/exaone.py
+++ b/python/sglang/srt/models/exaone.py
@@ -16,6 +16,7 @@
 # Adapted from llama2.py
 """Inference-only Exaone model compatible with HuggingFace weights."""
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -41,6 +42,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class ExaoneGatedMLP(nn.Module):
@@ -344,6 +347,9 @@ class ExaoneForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/exaone4.py
+++ b/python/sglang/srt/models/exaone4.py
@@ -558,6 +558,9 @@ class Exaone4ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/exaone_moe.py
+++ b/python/sglang/srt/models/exaone_moe.py
@@ -787,6 +787,9 @@ class ExaoneMoEForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if is_mtp:
                 if "mtp" not in name:
                     continue

--- a/python/sglang/srt/models/falcon_h1.py
+++ b/python/sglang/srt/models/falcon_h1.py
@@ -526,6 +526,9 @@ class FalconH1ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
 
             if "rotary_emb.inv_freq" in name:
                 continue

--- a/python/sglang/srt/models/gemma.py
+++ b/python/sglang/srt/models/gemma.py
@@ -19,6 +19,7 @@
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/models/gemma.py#L1
 """Inference-only Gemma model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -41,6 +42,8 @@ from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class GemmaMLP(nn.Module):
@@ -381,6 +384,9 @@ class GemmaForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, shard_name, shard_id in stacked_params_mapping:
                 if shard_name not in name:
                     continue

--- a/python/sglang/srt/models/gemma2.py
+++ b/python/sglang/srt/models/gemma2.py
@@ -18,6 +18,7 @@
 # Adapted from:
 # https://github.com/vllm-project/vllm/blob/56b325e977435af744f8b3dca7af0ca209663558/vllm/model_executor/models/gemma2.py
 
+import logging
 from typing import Iterable, Optional, Set, Tuple
 
 import torch
@@ -43,6 +44,8 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.utils import add_prefix, is_npu, make_layers
+
+logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 
@@ -469,6 +472,9 @@ class Gemma2ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, shard_name, shard_id in stacked_params_mapping:
                 if shard_name not in name:
                     continue

--- a/python/sglang/srt/models/gemma3_causal.py
+++ b/python/sglang/srt/models/gemma3_causal.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 import copy
+import logging
 from typing import Iterable, List, Optional, Set, Tuple
 
 import einops
@@ -48,6 +49,8 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.utils import add_prefix, cpu_has_amx_support, is_cpu, make_layers
+
+logger = logging.getLogger(__name__)
 
 _is_cpu = is_cpu()
 _is_cpu_amx_available = cpu_has_amx_support()
@@ -857,6 +860,9 @@ class Gemma3ForCausalLM(PreTrainedModel):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, shard_name, shard_id in stacked_params_mapping:
                 # if param_name in name:
                 # print(f"{param_name} is already in {name}")

--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -439,6 +439,9 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
         loaded_params: Set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "language_model" in name:
                 # Gemma3ForCausalLM.load_weights(self, [(name.replace("language_model.", ""), loaded_weight)])
                 causal_loaded_params = Gemma3ForCausalLM.load_weights(

--- a/python/sglang/srt/models/gemma3n_causal.py
+++ b/python/sglang/srt/models/gemma3n_causal.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, Optional, Set, Tuple
 
 import torch
@@ -27,6 +28,8 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.models.gemma3_causal import Gemma3TextScaledWordEmbedding
 from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
 
 
 # Aligned with HF's implementation, using sliding window inclusive with the last token
@@ -970,6 +973,9 @@ class Gemma3nForCausalLM(PreTrainedModel):
         loaded_params: Set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = name.replace("model.language_model.", "model.")
             for param_name, shard_name, shard_id in stacked_params_mapping:
                 if shard_name not in name:

--- a/python/sglang/srt/models/gemma3n_mm.py
+++ b/python/sglang/srt/models/gemma3n_mm.py
@@ -462,6 +462,9 @@ class Gemma3nForConditionalGeneration(PreTrainedModel):
         loaded_params: Set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = re.sub(r"^model\.", "", name)
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:

--- a/python/sglang/srt/models/gemma4_causal.py
+++ b/python/sglang/srt/models/gemma4_causal.py
@@ -1160,6 +1160,9 @@ class Gemma4ForCausalLM(PreTrainedModel):
 
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = name.replace("model.language_model.", "model.")
 
             # HF has router.per_expert_scale and experts.* on the decoder layer;

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -832,6 +832,9 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         loaded_params: Set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "embed_vision.embedding." in name or "embed_audio.embedding." in name:
                 continue
             if self.audio_tower is None and (

--- a/python/sglang/srt/models/glm4.py
+++ b/python/sglang/srt/models/glm4.py
@@ -568,6 +568,9 @@ class Glm4ForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -1341,6 +1341,9 @@ class Glm4MoeForCausalLM(nn.Module):
 
         weight_names = []
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             weight_names.append(name)
 
             if not is_nextn:

--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -619,6 +619,9 @@ class Glm4MoeLiteForCausalLM(DeepseekV2ForCausalLM):
 
         weight_names = []
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             weight_names.append(name)
 
             if not is_nextn:

--- a/python/sglang/srt/models/glm4v.py
+++ b/python/sglang/srt/models/glm4v.py
@@ -754,6 +754,9 @@ class Glm4vForConditionalGeneration(nn.Module):
         # If this name does not exist in the current rank’s params_dict,
         # it does not belong to this pipeline stage, thus we simply continue.
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "language_model" in name:

--- a/python/sglang/srt/models/glm4v_moe.py
+++ b/python/sglang/srt/models/glm4v_moe.py
@@ -158,6 +158,9 @@ class Glm4vMoeForConditionalGeneration(Glm4vForConditionalGeneration):
         params_dict = dict(self.named_parameters())
         weight_names = []
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "language_model." in name:
                 name = name.replace("language_model.", "")
             if "model.visual." in name:

--- a/python/sglang/srt/models/glm_ocr.py
+++ b/python/sglang/srt/models/glm_ocr.py
@@ -357,6 +357,9 @@ class GlmOcrForConditionalGeneration(Glm4vForConditionalGeneration):
         # it does not belong to this pipeline stage, thus we simply continue.
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "language_model" in name:

--- a/python/sglang/srt/models/glmasr.py
+++ b/python/sglang/srt/models/glmasr.py
@@ -136,6 +136,9 @@ class GlmAsrForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/gpt2.py
+++ b/python/sglang/srt/models/gpt2.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 """Inference-only GPT-2 model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple, Type
 
 import torch
@@ -38,6 +39,8 @@ from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class GPT2Attention(nn.Module):
@@ -261,6 +264,9 @@ class GPT2LMHeadModel(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "lm_head.weight" in name:
                 # GPT-2 ties the weights of the embedding layer and the final
                 # linear layer.

--- a/python/sglang/srt/models/gpt_bigcode.py
+++ b/python/sglang/srt/models/gpt_bigcode.py
@@ -19,6 +19,7 @@
 # https://github.com/vllm-project/vllm/blob/07eb6f19f3b0ee9f7adf6eb689607028aa40bfd5/vllm/model_executor/models/gpt_bigcode.py
 """Inference-only GPTBigCode model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -39,6 +40,8 @@ from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class GPTBigCodeAttention(nn.Module):
@@ -287,6 +290,9 @@ class GPTBigCodeForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "lm_head.weight" in name:
                 continue
             if ".attn.bias" in name:

--- a/python/sglang/srt/models/gpt_j.py
+++ b/python/sglang/srt/models/gpt_j.py
@@ -19,6 +19,7 @@
 # https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gpt_j.py
 """Inference-only GPT-J model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -46,6 +47,8 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class GPTJAttention(nn.Module):
@@ -288,6 +291,9 @@ class GPTJForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "attn.bias" in name or "attn.masked_bias" in name:
                 continue
 

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -1097,6 +1097,9 @@ class GptOssForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             loaded_weight = _WeightCreator.maybe_materialize(loaded_weight)
 
             # Apply weight name mapping if provided

--- a/python/sglang/srt/models/granite.py
+++ b/python/sglang/srt/models/granite.py
@@ -392,6 +392,9 @@ class GraniteForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/grok.py
+++ b/python/sglang/srt/models/grok.py
@@ -835,6 +835,9 @@ class Grok1ForCausalLM(nn.Module):
             self.loaded_param_names.add(original_name)
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/hunyuan.py
+++ b/python/sglang/srt/models/hunyuan.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Inference-only HunYuan model compatible with HuggingFace weights."""
 
+import logging
 import re
 from typing import Any, Dict, Iterable, Optional, Tuple
 
@@ -54,6 +55,8 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.utils import is_hip
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 expert_distribution_recorder = ExpertDistributionRecorder()
 
@@ -676,6 +679,9 @@ class HunYuanMoEV1ForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "gate_proj_bias" in name:

--- a/python/sglang/srt/models/hunyuan_v3.py
+++ b/python/sglang/srt/models/hunyuan_v3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -49,6 +50,8 @@ from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import is_cuda
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class HYV3FeedForward(nn.Module):
@@ -531,6 +534,9 @@ class HYV3ForCausalLM(nn.Module):
         num_nextn_layers = getattr(self.config, "num_nextn_predict_layers", 0)
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "lm_head.weight" in name and getattr(
                 self.config, "tie_word_embeddings", False
             ):

--- a/python/sglang/srt/models/hunyuan_v3_nextn.py
+++ b/python/sglang/srt/models/hunyuan_v3_nextn.py
@@ -181,6 +181,9 @@ class HYV3ForCausalLMNextN(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith(nextn_prefix):
                 subname = name[len(nextn_prefix) :]
                 if any(subname.startswith(s) for s in spec_weight_names):

--- a/python/sglang/srt/models/internlm2.py
+++ b/python/sglang/srt/models/internlm2.py
@@ -17,6 +17,7 @@
 
 # Adapted from https://raw.githubusercontent.com/vllm-project/vllm/7f62077af5159c625fe3ad1c812e6c1a2b93ba3b/vllm/model_executor/models/internlm2.py
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -42,6 +43,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class InternLM2MLP(nn.Module):
@@ -317,6 +320,9 @@ class InternLM2ForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/interns1.py
+++ b/python/sglang/srt/models/interns1.py
@@ -217,6 +217,9 @@ class InternS1ForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             name = self._mapping_interns1_name(name)

--- a/python/sglang/srt/models/interns1pro.py
+++ b/python/sglang/srt/models/interns1pro.py
@@ -240,6 +240,9 @@ class InternS1ProForConditionalGeneration(Qwen3VLMoeForConditionalGeneration):
         params_dict = self._cached_params_dict
         other_weights = dict()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "sin_coef" in name or "cos_coef" in name:
                 name = name.replace(r"model.language_model.", r"model.")
                 self._load_fope_weights(name, loaded_weight, params_dict)

--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -714,6 +714,9 @@ class InternVLChatModel(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/iquest_loopcoder.py
+++ b/python/sglang/srt/models/iquest_loopcoder.py
@@ -448,6 +448,9 @@ class IQuestLoopCoderForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/jet_vlm.py
+++ b/python/sglang/srt/models/jet_vlm.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from collections.abc import Iterable
 
@@ -23,6 +24,8 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.jet_nemotron import JetNemotronForCausalLM
+
+logger = logging.getLogger(__name__)
 
 MM_HIDDEN_SIZE = 1152
 
@@ -124,6 +127,9 @@ class JetVLMForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("llm."):
                 self.llm.load_weights([(name[len("llm.") :], loaded_weight)])
             else:

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -761,6 +761,9 @@ class KimiK25ForConditionalGeneration(nn.Module):
 
         def stream_language_weights():
             for name, loaded_weight in weights:
+                logger.debug(
+                    f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+                )
                 if "vision_tower" in name or "mm_projector" in name:
                     if vision_params is None:
                         continue

--- a/python/sglang/srt/models/kimi_k25_eagle3.py
+++ b/python/sglang/srt/models/kimi_k25_eagle3.py
@@ -383,6 +383,9 @@ class Eagle3DeepseekV2ForCausalLM(nn.Module):
         cached_a_proj: dict[str, torch.Tensor] = {}
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name == "d2t" or name.endswith(".d2t"):
                 # d2t stores diffs between draft id and target id; absent in
                 # checkpoints whose draft_vocab_size equals vocab_size.

--- a/python/sglang/srt/models/laguna.py
+++ b/python/sglang/srt/models/laguna.py
@@ -683,6 +683,9 @@ class LagunaForCausalLM(nn.Module):
         ]
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if layer_id is not None and (
                 layer_id < self.start_layer or layer_id >= self.end_layer

--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -510,6 +510,9 @@ class Lfm2ForCausalLM(nn.Module):
         embed_tokens_weight = None
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -12,6 +12,7 @@ Key MoE characteristics:
 - Post-hoc normalization of top-k weights
 """
 
+import logging
 from typing import Iterable, Optional, Set, Tuple
 
 import torch
@@ -47,6 +48,8 @@ from sglang.srt.model_loader.weight_utils import (
     sharded_weight_loader,
 )
 from sglang.srt.utils import add_prefix, make_layers, set_weight_attrs
+
+logger = logging.getLogger(__name__)
 
 
 class Lfm2MoeMLP(nn.Module):
@@ -596,6 +599,9 @@ class Lfm2MoeForCausalLM(nn.Module):
         embed_tokens_weight = None
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/lfm2_vl.py
+++ b/python/sglang/srt/models/lfm2_vl.py
@@ -297,6 +297,9 @@ class Lfm2VlForConditionalGeneration(nn.Module):
         lm_weights = []
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("model.vision_tower."):
                 # model.vision_tower.* → * (strip model.vision_tower. prefix)
                 # siglip2.py expects names like "vision_model.embeddings.patch_embedding.weight"

--- a/python/sglang/srt/models/llada2.py
+++ b/python/sglang/srt/models/llada2.py
@@ -864,6 +864,9 @@ class LLaDA2MoeModelLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if (
                 ("v_head" in name)
                 or ("inv_freq" in name)

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -625,6 +625,9 @@ class LlamaForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.endswith(".activation_scale"):
                 name = name.replace(".activation_scale", ".input_scale")
             if name.endswith(".weight_scale_inv"):

--- a/python/sglang/srt/models/llama_classification.py
+++ b/python/sglang/srt/models/llama_classification.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -29,6 +30,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaForCausalLM, LlamaModel
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class LlamaForClassification(nn.Module):
@@ -76,6 +79,9 @@ class LlamaForClassification(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "classification_head" in name:
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/python/sglang/srt/models/llama_eagle.py
+++ b/python/sglang/srt/models/llama_eagle.py
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
+
 from sglang.srt.utils import add_prefix
 
 # Adapted from
@@ -34,6 +36,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.models.llama import LlamaDecoderLayer, LlamaForCausalLM
+
+logger = logging.getLogger(__name__)
 
 
 class LlamaDecoderLayer(LlamaDecoderLayer):
@@ -141,6 +145,9 @@ class LlamaForCausalLMEagle(LlamaForCausalLM):
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "lm_head" not in name:
                 name = "model." + name
                 super().load_weights([(name, loaded_weight)])

--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
+
 from sglang.srt.utils import add_prefix
 
 # Adapted from
@@ -39,6 +41,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTe
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaDecoderLayer, LlamaForCausalLM, LlamaMLP
 from sglang.srt.server_args import get_global_server_args
+
+logger = logging.getLogger(__name__)
 
 
 class LlamaDecoderLayer(LlamaDecoderLayer):
@@ -314,6 +318,9 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
         }
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for legacy, new in legacy_name_map.items():
                 if legacy in name:
                     name = name.replace(legacy, new)

--- a/python/sglang/srt/models/llama_embedding.py
+++ b/python/sglang/srt/models/llama_embedding.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, Tuple
 
 import torch
@@ -9,6 +10,8 @@ from sglang.srt.model_executor.model_runner import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaModel
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class LlamaEmbeddingModel(nn.Module):
@@ -51,6 +54,9 @@ class LlamaEmbeddingModel(nn.Module):
         params_dict = dict(self.model.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 return
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -512,6 +512,9 @@ class LlavaBaseForCausalLM(nn.Module):
         }
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "projector" in name or "vision_tower" in name or "image_newline" in name:
                 for weight_name, param_name in projector_weights.items():
                     if weight_name in name:
@@ -869,6 +872,9 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
 
         # Load weights directly without remapping
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for part in ("language_model", "vision_tower"):
                 if name.startswith(part):
                     name = name[len(part + ".") :]

--- a/python/sglang/srt/models/llavavid.py
+++ b/python/sglang/srt/models/llavavid.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """Inference-only LLaVa video model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, List, Optional, Tuple
 
 import numpy as np
@@ -27,6 +28,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaForCausalLM
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class LlavaVidForCausalLM(nn.Module):
@@ -263,6 +266,9 @@ class LlavaVidForCausalLM(nn.Module):
         }
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # FIXME: why projector weights read two times?
             if "projector" in name or "vision_tower" in name or "image_newline" in name:
                 for weight_name, param_name in projector_weights.items():

--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -878,11 +878,20 @@ class LongcatFlashForCausalLM(nn.Module):
             self.config.q_lora_rank is not None
         )
         cached_a_proj = {} if fuse_qkv_a_proj else None
+
+        def track_future(name):
+            if futures and id(futures[-1]) not in future_to_name:
+                future_to_name[id(futures[-1])] = name
+
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []
             params_dict = dict(self.named_parameters())
             weight_names = []
+            future_to_name = {}
             for name, loaded_weight in weights:
+                logger.debug(
+                    f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+                )
                 use_async_loading = should_async_load(loaded_weight)
                 if "mtp" in name:
                     continue
@@ -920,6 +929,7 @@ class LongcatFlashForCausalLM(nn.Module):
                         func=weight_loader,
                         func_args=(param, loaded_weight, shard_id),
                     )
+                    track_future(name)
                     break
                 else:
                     for mapping in expert_params_mapping:
@@ -940,6 +950,7 @@ class LongcatFlashForCausalLM(nn.Module):
                                 "expert_id": expert_id,
                             },
                         )
+                        track_future(name)
                         break
                     else:
                         # Skip loading extra bias for GPTQ models.
@@ -999,6 +1010,7 @@ class LongcatFlashForCausalLM(nn.Module):
                                     func=weight_loader,
                                     func_args=(param, fused_weight),
                                 )
+                                track_future(param_name)
                                 cached_a_proj.pop(q_a_proj_name)
                                 cached_a_proj.pop(kv_a_proj_name)
                         else:
@@ -1029,10 +1041,19 @@ class LongcatFlashForCausalLM(nn.Module):
                                 func=weight_loader,
                                 func_args=(param, loaded_weight),
                             )
+                            track_future(name)
 
             # Wait for all tasks to complete and raise any exceptions.
-            for future in concurrent.futures.as_completed(futures):
-                future.result()
+            for i, future in enumerate(concurrent.futures.as_completed(futures)):
+                try:
+                    future.result()
+                except Exception as e:
+                    idx = futures.index(future) if future in futures else -1
+                    fname = future_to_name.get(id(future), "unknown")
+                    logger.error(
+                        f"Async weight loading failed: name={fname}, future_index={idx}"
+                    )
+                    raise
 
         self.post_load_weights(weight_names=weight_names)
 

--- a/python/sglang/srt/models/longcat_flash_nextn.py
+++ b/python/sglang/srt/models/longcat_flash_nextn.py
@@ -541,11 +541,20 @@ class LongcatFlashForCausalLMNextN(LongcatFlashForCausalLM):
             "model.mtp.layers.0.transformer_layer.mlp.up_proj.weight_scale_inv": "layers.0.mlp.up_proj.weight_scale_inv",
             "model.mtp.norm.weight": "layers.0.final_layernorm.weight",
         }
+
+        def track_future(name):
+            if futures and id(futures[-1]) not in future_to_name:
+                future_to_name[id(futures[-1])] = name
+
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []
             params_dict = dict(self.named_parameters())
             weight_names = []
+            future_to_name = {}
             for name, loaded_weight in weights:
+                logger.debug(
+                    f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+                )
                 if ".mtp." not in name:
                     continue
                 if name in weight_names_mapping:
@@ -600,6 +609,7 @@ class LongcatFlashForCausalLMNextN(LongcatFlashForCausalLM):
                     futures.append(
                         executor.submit(weight_loader, param, loaded_weight, shard_id)
                     )
+                    track_future(name)
                     break
                 else:
                     # Skip loading extra bias for GPTQ models.
@@ -653,6 +663,7 @@ class LongcatFlashForCausalLMNextN(LongcatFlashForCausalLM):
                             futures.append(
                                 executor.submit(weight_loader, param, fused_weight)
                             )
+                            track_future(param_name)
                             cached_a_proj.pop(q_a_proj_name)
                             cached_a_proj.pop(kv_a_proj_name)
                     else:
@@ -677,6 +688,20 @@ class LongcatFlashForCausalLMNextN(LongcatFlashForCausalLM):
                         futures.append(
                             executor.submit(weight_loader, param, loaded_weight)
                         )
+                        track_future(name)
+
+            # Wait for all tasks to complete and raise any exceptions.
+            for i, future in enumerate(concurrent.futures.as_completed(futures)):
+                try:
+                    future.result()
+                except Exception as e:
+                    idx = futures.index(future) if future in futures else -1
+                    fname = future_to_name.get(id(future), "unknown")
+                    logger.error(
+                        f"Async weight loading failed: name={fname}, future_index={idx}"
+                    )
+                    raise
+
         self.post_load_weights()
 
 

--- a/python/sglang/srt/models/midashenglm.py
+++ b/python/sglang/srt/models/midashenglm.py
@@ -614,6 +614,9 @@ class MiDashengLMModel(nn.Module):
         skipped_weights = []
         decoder_weights = []
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/mimo.py
+++ b/python/sglang/srt/models/mimo.py
@@ -1,5 +1,6 @@
 # Adapted from qwen2.py
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -13,6 +14,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2DecoderLayer, Qwen2Model
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 MiMoConfig = None
 
@@ -108,6 +111,9 @@ class MiMoForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if (
                 "rotary_emb.inv_freq" in name
                 or "projector" in name

--- a/python/sglang/srt/models/mimo_mtp.py
+++ b/python/sglang/srt/models/mimo_mtp.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://github.com/vllm-project/vllm/pull/17433/files  and deepseek_nextn.py
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -19,6 +20,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2DecoderLayer
+
+logger = logging.getLogger(__name__)
 
 
 class MiMoMultiTokenPredictorLayer(nn.Module):
@@ -129,6 +132,9 @@ class MiMoMTP(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/mimo_v2.py
+++ b/python/sglang/srt/models/mimo_v2.py
@@ -1281,6 +1281,9 @@ class MiMoV2ForCausalLM(nn.Module):
             )
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if not self._is_multimodal and _is_vision_audio_weight(name):
                 continue
 

--- a/python/sglang/srt/models/mimo_v2_nextn.py
+++ b/python/sglang/srt/models/mimo_v2_nextn.py
@@ -290,6 +290,9 @@ class MiMoV2MTP(MiMoV2ForCausalLM):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/minicpm.py
+++ b/python/sglang/srt/models/minicpm.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """Inference-only MiniCPM model compatible with HuggingFace weights."""
 
+import logging
 import math
 from typing import Any, Dict, Iterable, Optional, Tuple
 
@@ -39,6 +40,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class MiniCPMMLP(nn.Module):
@@ -354,6 +357,9 @@ class MiniCPMForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/minicpm3.py
+++ b/python/sglang/srt/models/minicpm3.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """Inference-only MiniCPM3 model compatible with HuggingFace weights."""
 
+import logging
 import math
 from typing import Any, Dict, Iterable, Optional, Tuple
 
@@ -69,6 +70,9 @@ if is_cuda():
             )
         _bmm_fp8_op(A, B, out, A_scale, B_scale)
         return out
+
+
+logger = logging.getLogger(__name__)
 
 
 class MiniCPM3MLP(nn.Module):
@@ -488,6 +492,9 @@ class MiniCPM3ForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/minicpmo.py
+++ b/python/sglang/srt/models/minicpmo.py
@@ -1875,6 +1875,9 @@ class MiniCPMO(MiniCPMBaseModel):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
 
             if "rotary_emb.inv_freq~" in name or "projector" in name:
                 continue

--- a/python/sglang/srt/models/minicpmv.py
+++ b/python/sglang/srt/models/minicpmv.py
@@ -21,6 +21,7 @@
 # limitations under the License.
 """Inference-only MiniCPM-V model compatible with HuggingFace weights."""
 
+import logging
 import types
 from functools import partial
 from itertools import chain
@@ -70,6 +71,7 @@ from sglang.srt.models.qwen3 import Qwen3Config, Qwen3ForCausalLM
 from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM
 from sglang.srt.utils import add_prefix, flatten_nested_list
 
+logger = logging.getLogger(__name__)
 RawImageType = Union[Image.Image, torch.Tensor]
 
 
@@ -1706,6 +1708,9 @@ class MiniCPMV:
 
         params_dict = dict(self.minicpmv.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq~" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -1300,6 +1300,9 @@ class MiniMaxM2ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/mistral.py
+++ b/python/sglang/srt/models/mistral.py
@@ -64,6 +64,9 @@ class MistralForCausalLMMistralFormat(MistralForCausalLM):
     ) -> Iterable[tuple[str, torch.Tensor]]:
         """Remap Mistral native format weight names to HF/Llama format."""
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Pass through weights already in HF/Llama layout so this loader
             # tolerates mixed-format checkpoints (e.g. native body + HF-style
             # multi_modal_projector weights spliced in by a parent class).

--- a/python/sglang/srt/models/mistral_eagle.py
+++ b/python/sglang/srt/models/mistral_eagle.py
@@ -187,6 +187,9 @@ class MistralForCausalLMEagle(LlamaForCausalLMEagle):
         self, weights: Iterable[Tuple[str, torch.Tensor]]
     ) -> Iterable[Tuple[str, torch.Tensor]]:
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("model.") or name.startswith("lm_head."):
                 yield name, loaded_weight
                 continue

--- a/python/sglang/srt/models/mistral_large_3.py
+++ b/python/sglang/srt/models/mistral_large_3.py
@@ -1,12 +1,15 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/mistral_large_3.py
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
 from collections.abc import Iterable
 
 import regex as re
 import torch
 
 from sglang.srt.models.deepseek_v2 import DeepseekV3ForCausalLM
+
+logger = logging.getLogger(__name__)
 
 
 class MistralLarge3ForCausalLM(DeepseekV3ForCausalLM):
@@ -51,6 +54,9 @@ class MistralLarge3ForCausalLM(DeepseekV3ForCausalLM):
     ) -> Iterable[tuple[str, torch.Tensor]]:
         """Remap Mistral parameters to DeepseekV2 parameters."""
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for k, v in self.remapping.items():
                 match = re.fullmatch(k, name)
                 if match:

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -406,6 +406,9 @@ class MixtralForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/mixtral_quant.py
+++ b/python/sglang/srt/models/mixtral_quant.py
@@ -18,6 +18,7 @@
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/models/mixtral_quant.py#L1
 """Inference-only Mixtral model."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import numpy as np
@@ -48,6 +49,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class MixtralMLP(nn.Module):
@@ -400,6 +403,9 @@ class QuantMixtralForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/mllama.py
+++ b/python/sglang/srt/models/mllama.py
@@ -4,6 +4,7 @@
 # https://github.com/vllm-project/vllm/blob/7193774b1ff8603ad5bf4598e5efba0d9a39b436/vllm/model_executor/models/mllama.py
 """PyTorch Mllama model."""
 
+import logging
 import math
 from typing import Iterable, List, Optional, Tuple, Union
 
@@ -41,6 +42,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaDecoderLayer, LlamaMLP
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class ColumnParallelConv2dPatch(torch.nn.Module):
@@ -1021,6 +1024,9 @@ class MllamaForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters())
         updated_params = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "patch_embedding.weight" in name:
                 name = name.replace(
                     "patch_embedding.weight", "patch_embedding._linear.weight"

--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -648,6 +648,9 @@ class Llama4ForConditionalGeneration(nn.Module):
         loaded_params = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if self._should_skip_weight(name):
                 continue
 

--- a/python/sglang/srt/models/moss_vl.py
+++ b/python/sglang/srt/models/moss_vl.py
@@ -443,6 +443,9 @@ class MossVLVisionModel(nn.Module):
         loaded_params: set = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue
@@ -1544,6 +1547,9 @@ class MossVLForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -912,6 +912,9 @@ class NemotronHForCausalLM(nn.Module):
         # memory systems (e.g. DGX Spark, 119 GB) the old buffered path
         # caused OOM: skeleton 81.6 GB + buffer 75 GB = 157 GB peak.
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = replace_prefix(name, self.remap_prefix)
             name = replace_substrings(name, self.remap_substr)
             if is_mtp:

--- a/python/sglang/srt/models/nemotron_nas.py
+++ b/python/sglang/srt/models/nemotron_nas.py
@@ -384,6 +384,9 @@ class DeciLMForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/nvila.py
+++ b/python/sglang/srt/models/nvila.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import math
 from collections.abc import Iterable
 from typing import Any
@@ -26,6 +27,8 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+
+logger = logging.getLogger(__name__)
 
 MM_HIDDEN_SIZE = 3456
 
@@ -207,6 +210,9 @@ class NVILAForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("llm."):
                 self.llm.load_weights([(name[len("llm.") :], loaded_weight)])
             else:

--- a/python/sglang/srt/models/nvila_lite.py
+++ b/python/sglang/srt/models/nvila_lite.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from collections.abc import Iterable
 from typing import Any
@@ -25,6 +26,8 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+
+logger = logging.getLogger(__name__)
 
 MM_HIDDEN_SIZE = 1152
 
@@ -165,6 +168,9 @@ class NVILALiteForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("llm."):
                 self.llm.load_weights([(name[len("llm.") :], loaded_weight)])
             else:

--- a/python/sglang/srt/models/olmo.py
+++ b/python/sglang/srt/models/olmo.py
@@ -19,6 +19,7 @@
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/models/olmo.py#L1
 """Inference-only OLMo model compatible with HuggingFace weights."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -43,6 +44,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
 
 
 class OlmoAttention(nn.Module):
@@ -351,6 +354,9 @@ class OlmoForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -18,6 +18,7 @@
 # https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/olmo2.py
 """Inference-only OLMo2 model compatible with HuggingFace weights."""
 
+import logging
 from functools import partial
 from typing import Iterable, Optional, Tuple
 
@@ -50,6 +51,8 @@ from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, is_cuda, make_layers
+
+logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 
@@ -452,6 +455,9 @@ class Olmo2ForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/olmoe.py
+++ b/python/sglang/srt/models/olmoe.py
@@ -19,6 +19,7 @@
 
 """Inference-only OLMoE model compatible with HuggingFace weights."""
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -45,6 +46,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers, print_warning_once
+
+logger = logging.getLogger(__name__)
 
 
 class OlmoeMoE(nn.Module):
@@ -367,6 +370,9 @@ class OlmoeForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/opt.py
+++ b/python/sglang/srt/models/opt.py
@@ -466,6 +466,9 @@ class OPTForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if name.startswith("decoder"):
                 name = name.replace("decoder.", "model.decoder.")
             layer_id = get_layer_id(name)

--- a/python/sglang/srt/models/orion.py
+++ b/python/sglang/srt/models/orion.py
@@ -8,6 +8,7 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/orion.py
 """Inference-only Orion-14B model compatible with HuggingFace weights."""
 
+import logging
 from collections.abc import Iterable
 from typing import Any, Optional, Tuple
 
@@ -36,6 +37,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTe
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class OrionMLP(nn.Module):
@@ -336,6 +339,9 @@ class OrionForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/paddleocr_vl.py
+++ b/python/sglang/srt/models/paddleocr_vl.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import logging
 from collections.abc import Iterable
 from typing import List, Optional, Set, Tuple, Union
 
@@ -38,6 +39,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.ernie4 import Ernie4_5_ForCausalLM
 from sglang.srt.utils import add_prefix, is_npu
+
+logger = logging.getLogger(__name__)
 
 
 class Projector(nn.Module):
@@ -693,6 +696,9 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5_ForCausalLM):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "head.attention" in name or "head.layernorm" in name:

--- a/python/sglang/srt/models/persimmon.py
+++ b/python/sglang/srt/models/persimmon.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable
 from typing import Optional
 
@@ -24,6 +25,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
 
 
 class PersimmonMLP(nn.Module):
@@ -303,6 +306,9 @@ class PersimmonForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if name not in params_dict:

--- a/python/sglang/srt/models/phi3_small.py
+++ b/python/sglang/srt/models/phi3_small.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from typing import Iterable, Optional, Tuple, Union
 
@@ -26,6 +27,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
 
 
 @torch.jit.script
@@ -461,6 +464,9 @@ class Phi3SmallForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if name.endswith(".bias") and name not in params_dict:

--- a/python/sglang/srt/models/phi4mm.py
+++ b/python/sglang/srt/models/phi4mm.py
@@ -506,6 +506,9 @@ class Phi4MMForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Skip the last layer
             if _should_skip(name):
                 continue

--- a/python/sglang/srt/models/phimoe.py
+++ b/python/sglang/srt/models/phimoe.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, Optional, Tuple, Union
 
 import torch
@@ -29,6 +30,8 @@ from sglang.srt.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
 
 
 class PhiMoEConfig(PretrainedConfig):
@@ -515,6 +518,9 @@ class PhiMoEForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue

--- a/python/sglang/srt/models/pixtral.py
+++ b/python/sglang/srt/models/pixtral.py
@@ -16,6 +16,7 @@
 Using mistral-community/pixtral-12b as reference.
 """
 
+import logging
 from dataclasses import dataclass, fields
 from typing import Iterable, List, Optional, Set, Tuple, Union
 
@@ -48,6 +49,7 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.mistral import MistralForCausalLMMistralFormat
 from sglang.srt.models.mistral_large_3 import MistralLarge3ForCausalLM
 
+logger = logging.getLogger(__name__)
 USE_XFORMERS_OPS = False
 PATCH_MERGE = "patch_merge"
 
@@ -1011,6 +1013,9 @@ class PixtralHFVisionModel(nn.Module):
 
         # Process each weight
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name in name:
                     # Replace the weight name part with the combined parameter name

--- a/python/sglang/srt/models/points_v15_chat.py
+++ b/python/sglang/srt/models/points_v15_chat.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from typing import Iterable, List, Optional, Set, Tuple
 
 import torch
@@ -21,6 +22,8 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
 from sglang.srt.models.qwen2_vl import Qwen2VisionPatchMerger, Qwen2VisionTransformer
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class Qwen2VisionTransformerForNavitPOINTS(Qwen2VisionTransformer):
@@ -150,6 +153,9 @@ class POINTSV15ChatModel(nn.Module):
         loaded_params: Set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/qwen.py
+++ b/python/sglang/srt/models/qwen.py
@@ -17,6 +17,7 @@
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/models/qwen.py#L1
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -43,6 +44,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class QWenMLP(nn.Module):
@@ -332,6 +335,9 @@ class QWenLMHeadModel(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -569,6 +569,9 @@ class Qwen2ForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -800,6 +800,9 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/qwen2_audio.py
+++ b/python/sglang/srt/models/qwen2_audio.py
@@ -150,6 +150,9 @@ class Qwen2AudioForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/qwen2_eagle.py
+++ b/python/sglang/srt/models/qwen2_eagle.py
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import logging
+
 from sglang.srt.utils import add_prefix
 
 # Adapted from
@@ -33,6 +35,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.models.qwen2 import Qwen2DecoderLayer, Qwen2ForCausalLM
+
+logger = logging.getLogger(__name__)
 
 Qwen2Config = None
 
@@ -138,6 +142,9 @@ class Qwen2ForCausalLMEagle(Qwen2ForCausalLM):
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "lm_head" not in name:
                 name = "model." + name
                 super().load_weights([(name, loaded_weight)])

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -993,6 +993,9 @@ class Qwen2MoeForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -581,6 +581,9 @@ class Qwen2VLForConditionalGeneration(nn.Module):
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if self.config.tie_word_embeddings and "lm_head.weight" in name:

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -601,6 +601,9 @@ class Qwen3ForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if not name.startswith("model.") and (
                 name.startswith("layers.")
                 or name.startswith("embed_tokens.")

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1172,6 +1172,9 @@ class Qwen3_5ForCausalLM(nn.Module):
         loaded_params: Set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
@@ -1315,6 +1318,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
@@ -1518,6 +1524,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         loaded_params: Set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
@@ -1765,6 +1774,9 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -247,6 +247,9 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/python/sglang/srt/models/qwen3_asr.py
+++ b/python/sglang/srt/models/qwen3_asr.py
@@ -143,6 +143,9 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/qwen3_classification.py
+++ b/python/sglang/srt/models/qwen3_classification.py
@@ -86,6 +86,9 @@ class Qwen3ForPooledOutput(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Skip lm_head weights (pooled output models don't have lm_head)
             if name.startswith("lm_head"):
                 continue

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -1127,6 +1127,9 @@ class Qwen3MoeForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -1068,6 +1068,9 @@ class Qwen3NextForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
 
             if is_mtp:
 

--- a/python/sglang/srt/models/qwen3_omni_moe.py
+++ b/python/sglang/srt/models/qwen3_omni_moe.py
@@ -552,6 +552,9 @@ class Qwen3OmniMoeForConditionalGeneration(PreTrainedModel):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = name.replace(r"model.language_model.", r"model.")
 
             if ("talker" in name or "code2wav" in name) and not self.enable_talker:

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -915,6 +915,9 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue
@@ -1318,6 +1321,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "language_model" in name:

--- a/python/sglang/srt/models/qwen3_vl_moe.py
+++ b/python/sglang/srt/models/qwen3_vl_moe.py
@@ -230,6 +230,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = name.replace(r"model.language_model.", r"model.")
             layer_id = get_layer_id(name)
             if (

--- a/python/sglang/srt/models/roberta.py
+++ b/python/sglang/srt/models/roberta.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 from typing import Iterable, Optional, Tuple
 
@@ -14,6 +15,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.bert import BertEncoder
 from sglang.srt.utils.hf_transformers_utils import download_from_hf
+
+logger = logging.getLogger(__name__)
 
 RobertaConfig = None
 
@@ -166,6 +169,9 @@ class XLMRobertaBaseModel(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             name = name.replace("self", "self_attn")
             if self.pooler is None and "pooler" in name:
                 continue

--- a/python/sglang/srt/models/sarashina2_vision.py
+++ b/python/sglang/srt/models/sarashina2_vision.py
@@ -183,6 +183,9 @@ class Sarashina2VisionForCausalLM(nn.Module):
         gate_up_weights = {}
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Handle weight name mappings
 
             # Map visual attention weights: qkv -> qkv_proj

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -3,6 +3,7 @@
 - SarvamMoEForCausalLM (30B)
 """
 
+import logging
 import math
 from enum import IntEnum, auto
 from typing import Any, Dict, Iterable, Optional, Tuple
@@ -95,6 +96,9 @@ else:
     concat_mla_k = None
     merge_state_v2 = None
     per_tensor_quant_mla_fp8 = None
+
+
+logger = logging.getLogger(__name__)
 
 
 class AttnForwardMethod(IntEnum):
@@ -1360,6 +1364,9 @@ class SarvamMLAForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             layer_id = get_layer_id(name)
             if layer_id is not None and (
                 layer_id < self.start_layer or layer_id >= self.end_layer

--- a/python/sglang/srt/models/sdar.py
+++ b/python/sglang/srt/models/sdar.py
@@ -522,6 +522,9 @@ class SDARForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if not name.startswith("model.") and (
                 name.startswith("layers.")
                 or name.startswith("embed_tokens.")

--- a/python/sglang/srt/models/sdar_moe.py
+++ b/python/sglang/srt/models/sdar_moe.py
@@ -628,6 +628,9 @@ class SDARMoeForCausalLM(nn.Module):
         params_dict = self._cached_params_dict
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if not name.startswith("model.") and (
                 name.startswith("layers.")
                 or name.startswith("embed_tokens.")

--- a/python/sglang/srt/models/siglip2.py
+++ b/python/sglang/srt/models/siglip2.py
@@ -21,6 +21,7 @@
 # Unlike Siglip v1 which uses fixed-size images, Siglip2 handles images of different
 # sizes by packing them into sequences and using cu_seqlens for attention.
 
+import logging
 from collections.abc import Iterable
 from typing import Optional
 
@@ -38,6 +39,8 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class Siglip2VisionEmbeddings(nn.Module):
@@ -545,6 +548,9 @@ class Siglip2Model(nn.Module):
         layer_count = len(self.vision_model.encoder.layers)
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # post_layernorm is optional in Siglip2Model
             if (
                 name.startswith("vision_model.post_layernorm")

--- a/python/sglang/srt/models/solar.py
+++ b/python/sglang/srt/models/solar.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
+
 # Adapted from
 # https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
 # Copyright 2023 The vLLM team.
@@ -56,6 +58,8 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.utils import add_prefix, make_layers
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class SolarMLP(nn.Module):
@@ -474,6 +478,9 @@ class SolarForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
 
             is_packed = False
             for packed_name, sources in self.packed_modules_mapping.items():

--- a/python/sglang/srt/models/stablelm.py
+++ b/python/sglang/srt/models/stablelm.py
@@ -22,6 +22,7 @@ Inference-only StableLM-2 (https://huggingface.co/stabilityai/stablelm-2-1_6b)
 model compatible with HuggingFace weights.
 """
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -46,6 +47,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, is_npu
+
+logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 
@@ -321,6 +324,9 @@ class StableLmForCausalLM(nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/starcoder2.py
+++ b/python/sglang/srt/models/starcoder2.py
@@ -22,6 +22,7 @@
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/starcoder2.py
 """PyTorch Starcoder2 model."""
 
+import logging
 from collections.abc import Iterable
 from typing import Optional, Tuple
 
@@ -48,6 +49,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
+
+logger = logging.getLogger(__name__)
 
 
 class Starcoder2Attention(nn.Module):
@@ -330,6 +333,9 @@ class Starcoder2ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freqs" in name:
                 continue
 

--- a/python/sglang/srt/models/step3_vl.py
+++ b/python/sglang/srt/models/step3_vl.py
@@ -912,6 +912,9 @@ class Step3VLForConditionalGeneration(nn.Module):
             return shard_id_matches
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "vision_model" in name:
                 name = name.replace("self_attn", "self_attn.attn")
                 name = name.replace("out_proj", "proj")

--- a/python/sglang/srt/models/step3_vl_10b.py
+++ b/python/sglang/srt/models/step3_vl_10b.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """This is basically a copy from perception_models/core/vision_encoder/pe.py"""
 
+import logging
 from functools import partial
 from typing import Callable, Iterable, List, Optional, Tuple
 
@@ -29,6 +30,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_NORM_LAYER = partial(nn.LayerNorm, eps=1e-5)
 
@@ -552,6 +555,9 @@ class StepVLForConditionalGeneration(nn.Module):
         language_weights = []
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "vision_model" in name or "vit_large_projector" in name:
                 name = name.replace(r".attn.in_proj_weight", r".attn.qkv_proj.weight")
                 name = name.replace(r".attn.in_proj_bias", r".attn.qkv_proj.bias")

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 import torch
@@ -52,6 +53,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTe
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, is_cuda, is_non_idle_and_non_empty, make_layers
+
+logger = logging.getLogger(__name__)
 
 Step3p5Config = None
 
@@ -933,6 +936,9 @@ class Step3p5ForCausalLM(nn.Module):
             return shard_id_matches
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             # Filter nextn layer weights.
             if hasattr(self.config, "num_nextn_predict_layers"):
                 num_nextn_layers = getattr(self.config, "num_nextn_predict_layers", 0)

--- a/python/sglang/srt/models/step3p5_mtp.py
+++ b/python/sglang/srt/models/step3p5_mtp.py
@@ -203,6 +203,9 @@ class Step3p5MTP(Step3p5ForCausalLM):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)

--- a/python/sglang/srt/models/torch_native_llama.py
+++ b/python/sglang/srt/models/torch_native_llama.py
@@ -25,6 +25,7 @@ Reference: https://pytorch.org/docs/stable/distributed.tensor.parallel.html
 Here is a quick example to enable TP:
 ```python
 from sglang.srt.layers.model_parallel import tensor_parallel
+import logging
 
 device_mesh = torch.distributed.init_device_mesh("cuda", (tp_size,))
 tensor_parallel(model, device_mesh)
@@ -42,6 +43,7 @@ $ python3 -m sglang.bench_one_batch --correct \
 We will enable CUDA Graph support soon.
 """
 
+import logging
 import types
 from typing import Any, Dict, Iterable, Optional, Tuple
 
@@ -67,6 +69,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
 
 tp_size: Optional[int] = None
 tp_rank: Optional[int] = None
@@ -464,6 +468,9 @@ class TorchNativeLlamaForCausalLM(nn.Module):
         params_dict = dict(module.named_parameters(prefix=fqn, recurse=False))
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -425,6 +425,9 @@ class TransformersFusedMoE(nn.Module):
         loaded: set[str] = set()
         param_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             matched = False
             for param_name, weight_name, expert_id, shard_id in self._expert_mapping:
                 if weight_name not in name:

--- a/python/sglang/srt/models/xverse.py
+++ b/python/sglang/srt/models/xverse.py
@@ -18,6 +18,7 @@
 # https://github.com/vllm-project/vllm/blob/c7f2cf2b7f67bce5842fedfdba508440fe257375/vllm/model_executor/models/xverse.py#L1
 """Inference-only XVERSE model compatible with HuggingFace weights."""
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -44,6 +45,8 @@ from sglang.srt.model_executor.model_runner import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class XverseMLP(nn.Module):
@@ -376,6 +379,9 @@ class XverseForCausalLM(nn.Module):
 
         if name is None or loaded_weight is None:
             for name, loaded_weight in weights:
+                logger.debug(
+                    f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+                )
                 load_weights_per_param(name, loaded_weight)
         else:
             load_weights_per_param(name, loaded_weight)

--- a/python/sglang/srt/models/xverse_moe.py
+++ b/python/sglang/srt/models/xverse_moe.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """Inference-only XVERSE MoE model."""
 
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import torch
@@ -50,6 +51,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, is_npu
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+logger = logging.getLogger(__name__)
 
 
 class XverseMLP(nn.Module):
@@ -447,6 +450,9 @@ class XverseMoeForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "rotary_emb.inv_freq" in name:
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/python/sglang/srt/models/yivl.py
+++ b/python/sglang/srt/models/yivl.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """Inference-only Yi-VL model."""
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -22,6 +23,8 @@ from transformers import CLIPVisionModel, LlavaConfig
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llava import LlavaLlamaForCausalLM
+
+logger = logging.getLogger(__name__)
 
 
 class YiVLForCausalLM(LlavaLlamaForCausalLM):
@@ -80,6 +83,9 @@ class YiVLForCausalLM(LlavaLlamaForCausalLM):
         params_dict = dict(self.named_parameters())
         weights = list(weights)
         for name, loaded_weight in weights:
+            logger.debug(
+                f"Loading weight: {name}, dtype={loaded_weight.dtype}, shape={loaded_weight.shape}"
+            )
             if "projector" in name or "vision_tower" in name:
                 for weight_name, param_name in projector_weights.items():
                     if weight_name in name:


### PR DESCRIPTION
## Motivation

When async weight loading fails during model initialization, the error traceback only shows the low-level exception (e.g., shape mismatch, dtype error) without indicating which specific weight triggered the failure. This makes debugging weight loading issues time-consuming, especially for large models with hundreds of parameters loaded concurrently via `ThreadPoolExecutor`.

### Real-world Example

When deploying DeepSeek-V4/DeepSeek-V4-Flash-FP8 with `export SGLANG_DSV4_FP4_EXPERTS=0` but without setting `export SGLANG_OPT_FP8_WO_A_GEMM=0`, the server crashes with:

```
ValueError: Downcasting not allowed: target.dtype=torch.float8_e4m3fn, loaded_weight.dtype=torch.bfloat16
```

**Before this PR:** The error gives no indication of which weight failed. With hundreds of weights loading concurrently, it's nearly impossible to pinpoint the root cause.

**After this PR:** The enhanced error tracking immediately prints:

```
ERROR - Async weight loading failed: name=model.layers.6.self_attn.wo_a.weight, future_index=9409
```

This directly points to `wo_a.weight`, guiding the developer to analyze the `wo_a` weight handling logic and quickly discover that `SGLANG_OPT_FP8_WO_A_GEMM=0` is needed to disable the FP8 path for this weight.

## Modifications

1. **Add `logger.debug` for weight loading across all model files (142 files)**
   - Every `for name, loaded_weight in weights:` loop now logs the weight name, dtype, and shape at debug level.
   - This provides a complete loading trace when `--log-level debug` is enabled, without impacting normal runtime performance.

2. **Add `track_future` error tracking for async weight loaders (4 files)**
   - Files: `deepseek_v4.py`, `longcat_flash.py`, `longcat_flash_nextn.py`, `deepseek_common/deepseek_weight_loader.py`
   - Introduces a `future_to_name` dict that maps each submitted future to its corresponding weight name.
   - Enhanced `as_completed` error handling: on failure, logs the exact weight name and submission index before re-raising.

3. **Add missing `import logging` and `logger` definitions**
   - 64 model files that previously lacked a `logger` instance now have proper `import logging` and `logger = logging.getLogger(__name__)`.

## Accuracy Tests

No model forward logic is changed. All modifications are limited to logging and error reporting in the weight loading path. No accuracy impact.

## Speed Tests and Profiling

`logger.debug(...)` is a no-op when log level is INFO or above (the default). No measurable performance impact on weight loading or inference.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26165837063](https://github.com/sgl-project/sglang/actions/runs/26165837063)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26165836305](https://github.com/sgl-project/sglang/actions/runs/26165836305)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->