### PR TITLE
[diffusion] Async output finalization

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -7,6 +7,7 @@ import multiprocessing as mp
 import os
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Union
@@ -16,6 +17,7 @@ import torch
 from setproctitle import setproctitle
 
 from sglang.multimodal_gen import envs
+from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 from sglang.multimodal_gen.runtime.distributed import (
     get_sp_group,
     get_tp_rank,
@@ -121,6 +123,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         # FIXME: should we use tcp as distribute init method?
         self.server_args = server_args
         self.pipeline: ComposedPipelineBase = None
+        self._output_save_executor: ThreadPoolExecutor | None = None
 
         self.init_device_and_model()
         self.sp_group = get_sp_group()
@@ -577,6 +580,73 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         )
         return np.asarray(materialized.frames)
 
+    def _can_async_save_output_paths(self, req: Req) -> bool:
+        return (
+            self.server_args.disagg_role == RoleType.MONOLITHIC
+            and not current_platform.is_cpu()
+            and req.save_output
+            and req.return_file_paths_only
+            and not req.enable_frame_interpolation
+            and not req.enable_upscaling
+        )
+
+    def _get_output_save_executor(self) -> ThreadPoolExecutor:
+        if self._output_save_executor is None:
+            self._output_save_executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix=f"sgl-diffusion-output-save-r{self.rank}",
+            )
+        return self._output_save_executor
+
+    @staticmethod
+    def _materialize_audio_for_async_save(audio: Any) -> Any:
+        if isinstance(audio, torch.Tensor):
+            return audio.detach().cpu()
+        return audio
+
+    def _submit_async_output_save(
+        self,
+        output_batch: OutputBatch,
+        req: Req,
+        output_paths: list[str],
+    ) -> None:
+        outputs = [
+            self._materialize_frame_output(output, output_batch, req)
+            for output in output_batch.output
+        ]
+        audio = self._materialize_audio_for_async_save(output_batch.audio)
+        data_type = req.data_type
+        fps = req.fps
+        audio_sample_rate = output_batch.audio_sample_rate
+        output_compression = req.output_compression
+
+        def save_task() -> list[str]:
+            return save_outputs(
+                outputs,
+                data_type,
+                fps,
+                True,
+                lambda idx: output_paths[idx],
+                audio=audio,
+                audio_sample_rate=audio_sample_rate,
+                output_compression=output_compression,
+                enable_frame_interpolation=False,
+                enable_upscaling=False,
+            )
+
+        output_batch.output_save_future = self._get_output_save_executor().submit(
+            save_task
+        )
+        output_batch.output_file_paths = output_paths
+        output_batch.output = None
+        output_batch.audio = None
+        output_batch.audio_sample_rate = None
+
+    def shutdown_output_save_executor(self) -> None:
+        if self._output_save_executor is not None:
+            self._output_save_executor.shutdown(wait=True)
+            self._output_save_executor = None
+
     def _record_output_peak_memory(self, output_batch: OutputBatch) -> None:
         if self.rank != 0 or current_platform.is_cpu():
             return
@@ -619,12 +689,19 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             def build_output_path(idx: int) -> str:
                 return req.output_file_path(num_outputs, idx)
 
+        output_paths = [
+            build_output_path(idx) for idx in range(len(output_batch.output))
+        ]
+        if self._can_async_save_output_paths(req):
+            self._submit_async_output_save(output_batch, req, output_paths)
+            return
+
         output_batch.output_file_paths = save_outputs(
             output_batch.output,
             req.data_type,
             req.fps,
             True,
-            build_output_path,
+            lambda idx: output_paths[idx],
             audio=output_batch.audio,
             audio_sample_rate=output_batch.audio_sample_rate,
             output_compression=req.output_compression,
@@ -650,12 +727,17 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             )
 
         first_req = reqs[0]
+        output_paths = [req.output_file_path(1, 0) for req in reqs]
+        if self._can_async_save_output_paths(first_req):
+            self._submit_async_output_save(output_batch, first_req, output_paths)
+            return
+
         output_batch.output_file_paths = save_outputs(
             output_batch.output,
             first_req.data_type,
             first_req.fps,
             True,
-            lambda idx: reqs[idx].output_file_path(1, 0),
+            lambda idx: output_paths[idx],
             audio=output_batch.audio,
             audio_sample_rate=output_batch.audio_sample_rate,
             output_compression=first_req.output_compression,

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -582,7 +582,8 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
     def _can_async_save_output_paths(self, req: Req) -> bool:
         return (
-            self.server_args.disagg_role == RoleType.MONOLITHIC
+            req.allow_async_output_save
+            and self.server_args.disagg_role == RoleType.MONOLITHIC
             and not current_platform.is_cpu()
             and req.save_output
             and req.return_file_paths_only
@@ -692,7 +693,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         output_paths = [
             build_output_path(idx) for idx in range(len(output_batch.output))
         ]
-        if self._can_async_save_output_paths(req):
+        if req.allow_async_output_save and self._can_async_save_output_paths(req):
             self._submit_async_output_save(output_batch, req, output_paths)
             return
 
@@ -728,7 +729,9 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
         first_req = reqs[0]
         output_paths = [req.output_file_path(1, 0) for req in reqs]
-        if self._can_async_save_output_paths(first_req):
+        if first_req.allow_async_output_save and self._can_async_save_output_paths(
+            first_req
+        ):
             self._submit_async_output_save(output_batch, first_req, output_paths)
             return
 

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -236,6 +236,41 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return reqs[0]
         return reqs
 
+    @staticmethod
+    def _set_async_output_save_hint(req_or_group: Any, allow_async: bool) -> None:
+        if isinstance(req_or_group, Req):
+            req_or_group.allow_async_output_save = allow_async
+            return
+
+        if isinstance(req_or_group, list):
+            for req in req_or_group:
+                if isinstance(req, Req):
+                    req.allow_async_output_save = allow_async
+
+    @staticmethod
+    def _generation_req_count(req_or_group: Any) -> int:
+        if isinstance(req_or_group, Req):
+            return 1
+        if isinstance(req_or_group, list):
+            return sum(1 for req in req_or_group if isinstance(req, Req))
+        return 0
+
+    def _enable_async_output_save_for_queued_burst(self) -> None:
+        if not self.waiting_queue:
+            return
+        if len(self.waiting_queue) == 1 and isinstance(self.waiting_queue[0][1], Req):
+            return
+
+        generation_req_count = sum(
+            self._generation_req_count(req_or_group)
+            for _, req_or_group, _ in self.waiting_queue
+        )
+        if generation_req_count <= 1:
+            return
+
+        for _, req_or_group, _ in self.waiting_queue:
+            self._set_async_output_save_hint(req_or_group, True)
+
     def _dispatch_single_request(self, req_or_group: Any) -> OutputBatch:
         if isinstance(req_or_group, list):
             if not all(isinstance(req, Req) for req in req_or_group):
@@ -1035,6 +1070,10 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 self.waiting_queue.extend(
                     [(identity, req, now) for identity, req in new_reqs]
                 )
+                if len(self.waiting_queue) > 1 or any(
+                    isinstance(req, list) for _, req in new_reqs
+                ):
+                    self._enable_async_output_save_for_queued_burst()
                 # Reset error count on success
                 self._consecutive_error_count = 0
             except Exception as e:

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -151,9 +151,9 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._batch_metrics_enabled = server_args.enable_batching_metrics
         self._batch_metrics_window = BatchMetricsWindow()
         self._batch_admission = BatchAdmissionController(server_args, gpu_id=local_rank)
-        self._pending_output_results: deque[
-            tuple[bytes | None, OutputBatch, bool]
-        ] = deque()
+        self._pending_output_results: deque[tuple[bytes | None, OutputBatch, bool]] = (
+            deque()
+        )
         self._poller = zmq.Poller()
         if self.receiver is not None:
             self._poller.register(self.receiver, zmq.POLLIN)

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -151,6 +151,9 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._batch_metrics_enabled = server_args.enable_batching_metrics
         self._batch_metrics_window = BatchMetricsWindow()
         self._batch_admission = BatchAdmissionController(server_args, gpu_id=local_rank)
+        self._pending_output_results: deque[
+            tuple[bytes | None, OutputBatch, bool]
+        ] = deque()
         self._poller = zmq.Poller()
         if self.receiver is not None:
             self._poller.register(self.receiver, zmq.POLLIN)
@@ -571,6 +574,59 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
     ) -> List[OutputBatch]:
         return [OutputBatch(error=error_msg) for _ in reqs]
 
+    def _finish_output_save_if_ready(
+        self, output_batch: OutputBatch, *, wait: bool = False
+    ) -> bool:
+        future = output_batch.output_save_future
+        if future is None:
+            return True
+        if not wait and not future.done():
+            return False
+
+        try:
+            output_paths = future.result()
+            if output_paths is not None and output_batch.output_file_paths is None:
+                output_batch.output_file_paths = output_paths
+        except Exception as e:
+            logger.error("Async output save failed: %s", e, exc_info=True)
+            output_batch.error = f"Async output save failed: {e}"
+            output_batch.output_file_paths = None
+        finally:
+            output_batch.output_save_future = None
+        return True
+
+    def _return_or_defer_result(
+        self,
+        output_batch: OutputBatch,
+        identity: bytes | None,
+        *,
+        should_not_return: bool,
+    ) -> None:
+        if self._finish_output_save_if_ready(output_batch):
+            self.return_result(
+                output_batch, identity, should_not_return=should_not_return
+            )
+            return
+        self._pending_output_results.append((identity, output_batch, should_not_return))
+
+    def _drain_pending_output_results(self, *, wait: bool = False) -> None:
+        pending = self._pending_output_results
+        self._pending_output_results = deque()
+
+        while pending:
+            identity, output_batch, should_not_return = pending.popleft()
+            if not self._finish_output_save_if_ready(output_batch, wait=wait):
+                self._pending_output_results.append(
+                    (identity, output_batch, should_not_return)
+                )
+                continue
+            try:
+                self.return_result(
+                    output_batch, identity, should_not_return=should_not_return
+                )
+            except zmq.ZMQError as e:
+                logger.error(f"ZMQ error sending delayed reply: {e}")
+
     def return_result(
         self,
         output_batch: OutputBatch,
@@ -738,6 +794,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 output_file_paths=self._slice_batched_value(
                     output_batch.output_file_paths, start, end, total_items
                 ),
+                output_save_future=output_batch.output_save_future,
                 metrics=deepcopy(output_batch.metrics),
                 noise_pred=self._slice_batched_value(
                     output_batch.noise_pred, start, end, total_items
@@ -965,6 +1022,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         )
 
         while self._running:
+            self._drain_pending_output_results()
             # Update queue depth for metrics
             if self._disagg_metrics:
                 self._disagg_metrics.update_queue_depth(len(self.waiting_queue))
@@ -1051,19 +1109,21 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     if is_warmup and should_return_warmup_result(processed_req):
                         # only keep the necessary lightweight payloads
                         output_batch.drop_payload_for_warmup()
-                        self.return_result(
-                            output_batch, identity, should_not_return=False
-                        )
+                        should_not_return = False
                     else:
-                        self.return_result(
-                            output_batch, identity, should_not_return=is_warmup
-                        )
+                        should_not_return = is_warmup
+
+                    self._return_or_defer_result(
+                        output_batch, identity, should_not_return=should_not_return
+                    )
             except zmq.ZMQError as e:
                 # Reply failed; log and keep loop alive to accept future requests
                 logger.error(f"ZMQ error sending reply: {e}")
                 continue
 
+        self._drain_pending_output_results(wait=True)
         self._log_batch_metrics_summary()
+        self.worker.shutdown_output_save_executor()
 
         if self.receiver is not None:
             self.receiver.close()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -199,6 +199,10 @@ class Req:
     # stage logging
     metrics: Optional[RequestMetrics] = None
 
+    # scheduler-owned hint; async output save only helps when file finalization
+    # can overlap with follow-up work
+    allow_async_output_save: bool = False
+
     # tracing context (TraceReqContext or TraceNullContext)
     trace_ctx: Union[TraceReqContext, TraceNullContext] = field(
         default_factory=TraceNullContext

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -420,6 +420,7 @@ class OutputBatch:
     trajectory_decoded: list[torch.Tensor] | None = None
     error: str | None = None
     output_file_paths: list[str] | None = None
+    output_save_future: Any | None = field(default=None, repr=False, compare=False)
 
     # logged metrics info, directly from Req.timings
     metrics: Optional[RequestMetrics] = None

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -6,11 +6,32 @@ import zmq
 import zmq.asyncio
 
 from sglang.multimodal_gen.runtime.ipc_array import materialize_file_refs
-from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
+    OutputBatch,
+    Req,
+)
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
+
+
+def _set_async_output_save_hint_for_batch(batch: Any, allow_async: bool) -> None:
+    if isinstance(batch, Req):
+        batch.allow_async_output_save = allow_async
+        return
+
+    if isinstance(batch, list):
+        for item in batch:
+            _set_async_output_save_hint_for_batch(item, allow_async)
+
+
+def _generation_req_count_in_batch(batch: Any) -> int:
+    if isinstance(batch, Req):
+        return 1
+    if isinstance(batch, list):
+        return sum(_generation_req_count_in_batch(item) for item in batch)
+    return 0
 
 
 async def run_zeromq_broker(server_args: ServerArgs):
@@ -142,6 +163,7 @@ class AsyncSchedulerClient:
     def __init__(self):
         self.context = None
         self.server_args = None
+        self._active_forward_batches: list[Any] = []
 
     def initialize(self, server_args: ServerArgs):
         if self.context is not None and not self.context.closed:
@@ -152,7 +174,19 @@ class AsyncSchedulerClient:
 
         self.server_args = server_args
         self.context = zmq.asyncio.Context()
+        self._active_forward_batches = []
         logger.debug("AsyncSchedulerClient initialized with zmq.asyncio.Context")
+
+    def _mark_active_forward_batches_for_async_output_save(self) -> None:
+        active_generation_reqs = sum(
+            _generation_req_count_in_batch(batch)
+            for batch in self._active_forward_batches
+        )
+        if active_generation_reqs <= 1:
+            return
+
+        for batch in self._active_forward_batches:
+            _set_async_output_save_hint_for_batch(batch, True)
 
     async def forward(self, batch: Any) -> Any:
         """Sends a batch or request to the scheduler and waits for the response."""
@@ -161,16 +195,20 @@ class AsyncSchedulerClient:
                 "AsyncSchedulerClient is not initialized. Call initialize() first."
             )
 
-        # Create a temporary REQ socket for this request to allow concurrency
-        socket = self.context.socket(zmq.REQ)
-        socket.setsockopt(zmq.LINGER, 0)
-        # 100 minute timeout
-        socket.setsockopt(zmq.RCVTIMEO, 6000000)
-
-        endpoint = self.server_args.scheduler_endpoint
-        socket.connect(endpoint)
-
+        self._active_forward_batches.append(batch)
+        socket = None
         try:
+            self._mark_active_forward_batches_for_async_output_save()
+
+            # Create a temporary REQ socket for this request to allow concurrency
+            socket = self.context.socket(zmq.REQ)
+            socket.setsockopt(zmq.LINGER, 0)
+            # 100 minute timeout
+            socket.setsockopt(zmq.RCVTIMEO, 6000000)
+
+            endpoint = self.server_args.scheduler_endpoint
+            socket.connect(endpoint)
+
             await socket.send(pickle.dumps(batch))
             payload = await socket.recv()
             output_batch = pickle.loads(payload)
@@ -180,7 +218,13 @@ class AsyncSchedulerClient:
             logger.error("Timeout waiting for response from scheduler.")
             raise TimeoutError("Scheduler did not respond in time.")
         finally:
-            socket.close()
+            if socket is not None:
+                socket.close()
+            self._active_forward_batches = [
+                active_batch
+                for active_batch in self._active_forward_batches
+                if active_batch is not batch
+            ]
 
     async def ping(self) -> bool:
         """
@@ -211,6 +255,7 @@ class AsyncSchedulerClient:
         if self.context:
             self.context.term()
             self.context = None
+        self._active_forward_batches = []
 
 
 # Singleton instances for easy access

--- a/python/sglang/multimodal_gen/test/unit/test_async_output_save.py
+++ b/python/sglang/multimodal_gen/test/unit/test_async_output_save.py
@@ -1,0 +1,102 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+from sglang.multimodal_gen.runtime.managers.gpu_worker import GPUWorker
+from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.scheduler_client import (
+    AsyncSchedulerClient,
+    _set_async_output_save_hint_for_batch,
+)
+
+
+class TestAsyncOutputSaveHint(unittest.TestCase):
+    def test_req_defaults_to_sync_output_save(self):
+        req = Req(prompt="x")
+
+        self.assertIs(req.allow_async_output_save, False)
+
+    def test_scheduler_keeps_single_queued_req_sync(self):
+        scheduler = object.__new__(Scheduler)
+        req = Req(prompt="x")
+        scheduler.waiting_queue = [(None, req, 0.0)]
+
+        scheduler._enable_async_output_save_for_queued_burst()
+
+        self.assertIs(req.allow_async_output_save, False)
+
+    def test_scheduler_marks_entire_queued_burst_async(self):
+        scheduler = object.__new__(Scheduler)
+        reqs = [Req(prompt="a"), Req(prompt="b"), Req(prompt="c")]
+        scheduler.waiting_queue = [(None, req, 0.0) for req in reqs]
+
+        scheduler._enable_async_output_save_for_queued_burst()
+
+        self.assertTrue(all(req.allow_async_output_save for req in reqs))
+
+    def test_scheduler_marks_grouped_req_async(self):
+        scheduler = object.__new__(Scheduler)
+        reqs = [Req(prompt="a"), Req(prompt="b")]
+        scheduler.waiting_queue = [(None, reqs, 0.0)]
+
+        scheduler._enable_async_output_save_for_queued_burst()
+
+        self.assertTrue(all(req.allow_async_output_save for req in reqs))
+
+    def test_scheduler_client_hint_marks_nested_req_batch(self):
+        reqs = [Req(prompt="a"), Req(prompt="b")]
+
+        _set_async_output_save_hint_for_batch([reqs[0], [reqs[1]]], True)
+
+        self.assertTrue(all(req.allow_async_output_save for req in reqs))
+
+    def test_scheduler_client_marks_all_active_forward_batches(self):
+        client = object.__new__(AsyncSchedulerClient)
+        reqs = [Req(prompt="a"), Req(prompt="b")]
+        client._active_forward_batches = [[reqs[0]], [reqs[1]]]
+
+        client._mark_active_forward_batches_for_async_output_save()
+
+        self.assertTrue(all(req.allow_async_output_save for req in reqs))
+
+    def test_gpu_worker_requires_scheduler_hint(self):
+        req = Req(
+            prompt="x",
+            save_output=True,
+            return_file_paths_only=True,
+            enable_frame_interpolation=False,
+            enable_upscaling=False,
+        )
+        worker = object.__new__(GPUWorker)
+        worker.server_args = SimpleNamespace(disagg_role=RoleType.MONOLITHIC)
+
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.gpu_worker.current_platform.is_cpu",
+            return_value=False,
+        ):
+            self.assertIs(worker._can_async_save_output_paths(req), False)
+            req.allow_async_output_save = True
+            self.assertIs(worker._can_async_save_output_paths(req), True)
+
+    def test_gpu_worker_short_circuits_without_scheduler_hint(self):
+        req = Req(
+            prompt="x",
+            save_output=True,
+            return_file_paths_only=True,
+            enable_frame_interpolation=False,
+            enable_upscaling=False,
+        )
+        worker = object.__new__(GPUWorker)
+
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.gpu_worker.current_platform.is_cpu",
+            return_value=False,
+        ) as is_cpu:
+            self.assertIs(worker._can_async_save_output_paths(req), False)
+            is_cpu.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds adaptive async output finalization for eligible diffusion file-path outputs.
- Keeps isolated single requests on the synchronous save path: no background save submit, no output-save future, no future wait.
- Enables async save only when the scheduler/client observes overlapping generation work, so queued/burst requests can overlap file encode/write with later work.
- Scope is limited to monolithic, non-CPU, file-path-only outputs without frame interpolation or upscaling.

## Implementation

- `Req.allow_async_output_save` defaults to `False`.
- `Scheduler` marks queued generation bursts for async output save.
- `AsyncSchedulerClient` marks same-tick concurrent HTTP forwards before serialization, preserving burst behavior for concurrent HTTP requests.
- `GPUWorker` checks `allow_async_output_save` before async-save capability checks. False-hint requests directly use the synchronous save path.
- The async path intentionally pre-materializes frames before submitting the save task, then offloads file encode/write. A follow-up profile showed that moving CUDA-to-CPU materialization into the background thread worsens tail latency and should not be merged.

## Validation

Current PR head: `f64163f86f12e7c4327553c4de4ee604228c33ca`.

- `pre-commit run --files python/sglang/multimodal_gen/runtime/managers/gpu_worker.py python/sglang/multimodal_gen/runtime/managers/scheduler.py python/sglang/multimodal_gen/runtime/scheduler_client.py python/sglang/multimodal_gen/test/unit/test_async_output_save.py`
- Remote unit test: `PYTHONPATH=/sgl-workspace/sglang/python python3 -m pytest -q python/sglang/multimodal_gen/test/unit/test_async_output_save.py` -> `8 passed`

## Full-Server Request Matrix: Three-Way Rerun

This is the stricter real HTTP request validation. It compares no-async baseline, the previous always-async behavior, and this PR on the same devbox/GPU.

Setup:

- GPU: 1x B200
- Server: `--batching-max-size 4 --batching-delay-ms 5 --num-gpus 1`
- Baseline/no-async: `c6a7c98ae4`
- Always-async: `8095abebbc`
- PR/adaptive: `f64163f86f`

| model case | request mode | baseline | always-async | PR |
| --- | --- | ---: | ---: | ---: |
| Z-Image-Turbo 1024 url, 4 steps | single p50 | 0.442 s | 0.451 s | 0.441 s |
| Z-Image-Turbo 1024 url, 4 steps | c8 makespan p50 | 2.478 s | 2.474 s | 2.466 s |
| Wan2.1 T2V 1.3B 832x480 17f, 4 steps | single p50 | 2.005 s | 2.005 s | 2.006 s |
| Wan2.1 T2V 1.3B 832x480 17f, 4 steps | c4 makespan p50 | 5.017 s | 5.021 s | 5.018 s |

Interpretation:

- The stricter same-GPU three-way full-server rerun does not show a material real HTTP E2E speedup for either the measured image or video case.
- For the Z-Image case, all c8 makespan deltas are below `0.5%`.
- For the Wan2.1 17f case, baseline, always-async, and PR all land around `5.02s` c4 makespan.
- Do not claim real E2E speedup from this PR. The defensible claim is narrower: single requests avoid async/future overhead, queued synthetic workloads can benefit, and the measured real HTTP image/video cases are neutral.

## Output-Finalization Critical-Path Profile

This profile isolates CUDA-to-CPU/frame materialization from local encode/write, and compares the current PR boundary with an experimental variant that also offloads materialization.

Setup:

- GPU: 1x B200
- PR head: `f64163f86f`
- `current_async`: current PR behavior, pre-materialize frames on the worker path and offload encode/write.
- `full_materialize_offload`: experimental patch that moves raw tensor materialization into the background save thread.

| model case | variant | single p50 | single p95 | concurrent makespan p50 | concurrent makespan p95 | pre-materialize p50 | async save task p50 | encode/write p50 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Z-Image-Turbo 1024 url, 4 steps | current_async | 0.444 s | 0.447 s | 2.485 s | 2.498 s | 0.83 ms | 41.8 ms | 8.4 ms |
| Z-Image-Turbo 1024 url, 4 steps | full_materialize_offload | 0.442 s | 1.303 s | 2.530 s | 3.738 s | n/a | 540.2 ms | 3.2 ms |
| Wan2.1 T2V 1.3B 832x480 49f, 4 steps | current_async | 3.007 s | 3.008 s | 10.023 s | 10.026 s | 65.7 ms | 1.742 s | 471.1 ms |
| Wan2.1 T2V 1.3B 832x480 49f, 4 steps | full_materialize_offload | 3.007 s | 3.007 s | 10.026 s | 10.026 s | n/a | 2.466 s | 469.3 ms |

Interpretation:

- CUDA-to-CPU/frame materialization remains on the critical path in the current PR, but it is small for image and tens of milliseconds for 49-frame video.
- Local video encode/write is the actual large cost: about `0.47s` p50 per 49-frame mp4, and about `1.74-2.04s` per 4-output dynamic batch in the background task.
- Moving raw tensor materialization into the background thread is not worth merging. It significantly worsens image tail latency and makes the video background task longer without improving E2E makespan.
- The current PR boundary is the right one: offload only the expensive and overlapable encode/write portion, not CUDA-to-CPU materialization.
- Cloud upload is separate API-layer work. It is awaited when S3 storage is enabled because response URL semantics may depend on it, so it is intentionally not folded into this worker-level async-save PR.

## Synthetic Scheduler Matrix: No-Async Baseline vs PR

This matrix is not a real HTTP/model-server request benchmark. It is a scheduler-level synthetic workload used to isolate output tensor size, save/finalization cost, and scheduler overlap behavior.

Setup:

- GPU: 1x B200
- Benchmark: fake generation plus CUDA fp16 video tensors and real `GPUWorker._save_output_paths()`
- Baseline: `c6a7c98ae4` with no async output finalization
- PR: `f64163f86f`
- Small tensor: `480p24f`, raw fp16 `54.8 MB`, materialized uint8 `27.4 MB`
- Large tensor: `720p48f`, raw fp16 `253.1 MB`, materialized uint8 `126.6 MB`
- Single req: p50 over 20 isolated synthetic requests
- Multi req: 8 queued synthetic requests, 500ms simulated generation per request, total makespan

| request mode | tensor size | baseline | PR | PR / baseline | result |
| --- | --- | ---: | ---: | ---: | --- |
| single req | small tensor | 683.199 ms | 688.619 ms | 1.0079x | neutral; no async/future path |
| single req | large tensor | 918.768 ms | 922.575 ms | 1.0041x | neutral; no async/future path |
| multi req | small tensor | 5.452 s | 4.235 s | 0.7768x | 1.29x faster |
| multi req | large tensor | 7.500 s | 4.749 s | 0.6332x | 1.58x faster |

## Synthetic Burst Guardrail: Always-Async vs PR

This is also scheduler-level synthetic data. It checks that the adaptive policy does not materially lose the burst benefit of the original always-async implementation.

| request mode | tensor size | always-async | PR | PR / always-async |
| --- | --- | ---: | ---: | ---: |
| multi req | small tensor | 4.234 s | 4.235 s | 1.0004x |
| multi req | large tensor | 4.663 s | 4.749 s | 1.0185x |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28463113171](https://github.com/sgl-project/sglang/actions/runs/28463113171)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28463113008](https://github.com/sgl-project/sglang/actions/runs/28463113008)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
