### PR TITLE
Fix FlashInfer A2A token cap sizing

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -101,9 +101,12 @@ class FlashinferDispatcher(BaseDispatcher):
         self.payload_in_workspace = get_moe_runner_backend().is_flashinfer_cutlass()
 
         # TODO: Can this be a server arg and shared with deepep/mooncakeep?
-        self.max_num_tokens = (
-            get_int_env_var("SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 1024)
-            * self.ep_size
+        # FlashInfer sizes the workspace from the maximum dispatched tokens per
+        # EP rank. See FlashInfer's moe_a2a_get_workspace_size_per_rank(),
+        # which reserves ep_size * max_num_tokens * payload bytes, and the C++
+        # dispatch op's epSize * runtimeMaxTokensPerRank payload buffer.
+        self.max_num_tokens = get_int_env_var(
+            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 16384
         )
 
         # Calculate workspace size. For eagle mode, use the larger workspace size since nextn layer will be unquantized.

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -106,7 +106,7 @@ class FlashinferDispatcher(BaseDispatcher):
         # which reserves ep_size * max_num_tokens * payload bytes, and the C++
         # dispatch op's epSize * runtimeMaxTokensPerRank payload buffer.
         self.max_num_tokens = get_int_env_var(
-            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 16384
+            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 4096
         )
 
         # Calculate workspace size. For eagle mode, use the larger workspace size since nextn layer will be unquantized.


### PR DESCRIPTION
## Summary

- Fix `max_num_tokens` in `FlashinferDispatcher`: the previous code multiplied the per-rank env var by `ep_size`, double-counting the scaling already done inside FlashInfer's workspace sizing (`moe_a2a_get_workspace_size_per_rank()`).
- Raise the default from 1024 to 16384 tokens per rank.

## Original commits

- `9b4258cdc`

## Test plan

- [ ] Verify FlashInfer A2A dispatch works correctly with the new default on an EP setup
- [ ] Confirm custom `SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK` values are respected































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26204297059](https://github.com/sgl-project/sglang/actions/runs/26204297059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26204296992](https://github.com/sgl-project/sglang/actions/runs/26204296992)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->