### PR TITLE
Add DevashishLal-CB to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -97,6 +97,13 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "DevashishLal-CB": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
     "Edwardf0t1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- Add DevashishLal-CB to `.github/CI_PERMISSIONS.json` with custom override permissions and 60-minute cooldown

## Test plan
- [x] Entry is in correct alphabetical order (between DarkSharpness and Edwardf0t1)
- [x] JSON is valid











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26181298844](https://github.com/sgl-project/sglang/actions/runs/26181298844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26181298711](https://github.com/sgl-project/sglang/actions/runs/26181298711)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->