### PR TITLE
Unify overlap transition input paths via future_map

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -185,5 +185,13 @@ class ScheduleBatchDisaggregationDecodeMixin:
                 )
             self.spec_info = spec_info
         else:
-            # Non-spec: input_ids feeds the next decode forward directly.
-            self.input_ids = last_tokens_tensor
+            if self.enable_overlap:
+                # Route via future_map; resolve_future gathers uniformly (mirrors
+                # the spec branch above).
+                future_map.token_ids_buf[self.req_pool_indices] = last_tokens_tensor.to(
+                    torch.int64
+                )
+                self.input_ids = -self.req_pool_indices
+            else:
+                # Non-spec, non-overlap: input_ids feeds the next decode forward.
+                self.input_ids = last_tokens_tensor

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2244,9 +2244,16 @@ class Scheduler(
         batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
         batch.orig_seq_lens = torch.tensor(seq_lens, dtype=torch.int32, device=device)
         batch.seq_lens_sum = sum(seq_lens)
-        batch.input_ids = torch.tensor(
+        last_tokens = torch.tensor(
             [r.output_ids[-1] for r in reqs], dtype=torch.int64, device=device
         )
+        if self.enable_overlap:
+            # Route via future_map; resolve_future gathers uniformly (matches the
+            # spec V2 disagg arrival path established by #25862).
+            self.future_map.token_ids_buf[batch.req_pool_indices] = last_tokens
+            batch.input_ids = -batch.req_pool_indices
+        else:
+            batch.input_ids = last_tokens
 
         if batch.return_logprob:
             batch.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]


### PR DESCRIPTION
## Why

#25862 keyed `future_map.token_ids_buf` by `req_pool_idx` and migrated the
spec V2 disagg arrival path to write through `store_to_map_for_new_batch`.
Two overlap-mode transition paths still bypass `future_map` and write
positive `batch.input_ids` directly:

- hisparse staging → decode rejoin (`_build_hisparse_decode_batch`)
- non-spec disagg arrival (`process_prebuilt` non-spec branch)

These bypasses leave `batch.input_ids` with mixed provenance (positive
real tokens vs. the standard negative placeholder used by the main path).

## Change

Route both transition paths through `future_map.token_ids_buf` before the
batch enters `run_batch`. Each pre-writes the last-known token into the
slot and sets `batch.input_ids = -req_pool_indices`. `resolve_future`'s
where-kernel then gathers uniformly.

After this PR, every overlap-mode input source — main decode loop,
hisparse rejoin, disagg arrival (both spec and non-spec) — flows through
`future_map`. Non-overlap mode is unchanged.

## Behavior

No semantic change. Token sequences bit-exact under deterministic seed.

## Risk

Low. The spec V2 disagg path has been in production since #25862 with
the same mechanism; this PR extends the pattern to the two remaining
bypass paths.