### PR TITLE
[XPU] Fix FP8 KV cache support for ModelOpt quantized models (e.g. Llama-3.3-70B-FP8)

### DIFF
--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -510,6 +510,15 @@ class XPUAttentionBackend(AttentionBackend):
             value_cache = value_cache.view(
                 -1, self.page_size, layer.tp_v_head_num, layer.head_dim
             )
+            # XPU flash-attn does not support fp8 inputs; cast fp8 kv cache
+            # back to the compute dtype (bf16/fp16) before calling flash_attn.
+            # This only fires when kv_cache_quant_algo=FP8 is set in the model
+            # config (e.g. nvidia/Llama-3.3-70B-Instruct-FP8).  All other models
+            # have key_cache.dtype == q.dtype already so the branch is skipped.
+            _prefill_compute_dtype = q.dtype
+            if key_cache.dtype != _prefill_compute_dtype:
+                key_cache = key_cache.to(_prefill_compute_dtype)
+                value_cache = value_cache.to(_prefill_compute_dtype)
             if layer.is_cross_attention:
                 page_table = metadata.encoder_page_table
                 cache_seqlens = metadata.encoder_lens_int32
@@ -754,6 +763,8 @@ class XPUAttentionBackend(AttentionBackend):
             kwargs["sinks"] = sinks
 
         k_descale, v_descale = None, None
+        # Save compute dtype before any fp8 cast (XPU flash-attn does not support fp8 natively)
+        compute_dtype = q.dtype
         # only use kv scaling if: 1) fp8 kv is explicitly enabled, 2) RadixAttention
         # has corresponding quantization method so that layer.k_scale is not None,
         # 3) layer.head_dim <= 256 since fa3 kernel require fp16 and bf16 data type in this case.
@@ -777,6 +788,15 @@ class XPUAttentionBackend(AttentionBackend):
             value_cache = value_cache.view(
                 -1, self.page_size, layer.tp_v_head_num, layer.head_dim
             )
+
+            # XPU flash-attn does not support fp8 inputs; cast fp8 kv cache
+            # and q back to compute dtype before any flash_attn call.
+            # compute_dtype was saved before q was cast to kv_cache_dtype above.
+            # Only fires for models with kv_cache_quant_algo=FP8 (e.g. Llama-3.3-FP8).
+            if key_cache.dtype != compute_dtype or q.dtype != compute_dtype:
+                key_cache = key_cache.to(compute_dtype)
+                value_cache = value_cache.to(compute_dtype)
+                q = q.to(compute_dtype)
 
             if layer.is_cross_attention:
                 # Always use non-chunked logic for cross-attention

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -40,6 +40,7 @@ from sglang.srt.utils import (
     is_musa,
     is_sm100_supported,
     is_sm120_supported,
+    is_xpu,
     log_info_on_rank0,
 )
 from sglang.srt.utils.custom_op import register_custom_op
@@ -49,6 +50,7 @@ _is_hip = is_hip()
 _is_cuda = is_cuda()
 _is_cpu = is_cpu()
 _is_musa = is_musa()
+_is_xpu = is_xpu()
 _is_sm100_supported = is_sm100_supported()
 _is_sm120_supported = is_sm120_supported()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
@@ -1735,6 +1737,64 @@ if _is_hip:
                 torch.ops._C.static_scaled_fp8_quant(output, input, scale)
             else:
                 _native_static_quant_fp8(output, input, scale)
+
+        return output, scale
+
+elif _is_xpu:
+    try:
+        from sgl_kernel import sgl_per_tensor_quant_fp8 as _sgl_per_tensor_quant_fp8_xpu
+        from sgl_kernel import sgl_per_token_quant_fp8 as _sgl_per_token_quant_fp8_xpu
+
+        _has_sgl_kernel_xpu = True
+    except ImportError:
+        _has_sgl_kernel_xpu = False
+
+    def scaled_fp8_quant(
+        input: torch.Tensor,
+        scale: Optional[torch.Tensor] = None,
+        num_token_padding: Optional[int] = None,
+        use_per_token_if_dynamic: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """XPU path: use sgl-kernel-xpu SYCL kernels when available, else pure PyTorch."""
+        assert input.ndim == 2, f"Expected 2D input tensor, got {input.ndim}D"
+        shape = input.shape
+        if num_token_padding:
+            shape = (max(num_token_padding, input.shape[0]), shape[1])
+        output = torch.empty(shape, device=input.device, dtype=fp8_dtype)
+
+        if scale is None:
+            # Dynamic scaling
+            if use_per_token_if_dynamic:
+                if _has_sgl_kernel_xpu:
+                    scale = torch.empty(
+                        (shape[0], 1), device=input.device, dtype=torch.float32
+                    )
+                    _sgl_per_token_quant_fp8_xpu(input, output, scale)
+                else:
+                    absmax = input.abs().max(dim=1, keepdim=True).values
+                    scale = torch.clamp(absmax, min=1e-12) / fp8_max
+                    output.copy_(
+                        torch.clamp(input / scale, fp8_min, fp8_max).to(fp8_dtype)
+                    )
+            else:
+                scale = torch.zeros(1, device=input.device, dtype=torch.float32)
+                if _has_sgl_kernel_xpu:
+                    _sgl_per_tensor_quant_fp8_xpu(input, output, scale, is_static=False)
+                else:
+                    absmax = input.abs().max()
+                    scale.fill_(torch.clamp(absmax, min=1e-12).item() / fp8_max)
+                    output.copy_(
+                        torch.clamp(input / scale, fp8_min, fp8_max).to(fp8_dtype)
+                    )
+        else:
+            # Static scaling
+            assert (
+                scale.numel() == 1
+            ), f"Expected scalar scale, got numel={scale.numel()}"
+            if _has_sgl_kernel_xpu:
+                _sgl_per_tensor_quant_fp8_xpu(input, output, scale, is_static=True)
+            else:
+                output.copy_(torch.clamp(input / scale, fp8_min, fp8_max).to(fp8_dtype))
 
         return output, scale
 


### PR DESCRIPTION
Models with kv_cache_quant_algo=FP8 in hf_quant_config.json (e.g.
nvidia/Llama-3.3-70B-Instruct-FP8) cause sglang to store KV cache as
float8_e4m3fn. XPU flash attention only supports bf16/fp16 inputs.

Two fixes in xpu_backend.py:
- Prefill: cast fp8 KV cache back to compute dtype before flash_attn
- Decode: save compute dtype before q is cast to fp8, then cast q and
  KV cache back before all flash_attn branches

One fix in fp8_kernel.py:
- Add elif _is_xpu branch for scaled_fp8_quant using sgl-kernel-xpu
  SYCL kernels (avoids NameError on CUDA-only sgl_per_tensor_quant_fp8),
  using PyTorch fallback if sgl_kernel is not available















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26197192401](https://github.com/sgl-project/sglang/actions/runs/26197192401)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26197192336](https://github.com/sgl-project/sglang/actions/runs/26197192336)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->