### PR TITLE
Revert "[AMD]fix: use CUDA event for targeted draft-to-verify sync in…

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -803,13 +803,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
             ):
                 verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
             assert verify_input.is_verify_input()
-            # Record a CUDA event after draft() GPU work is dispatched.
-            # This event will be waited on by plan_stream in verify()
-            # to ensure draft CUDA graph kernels finish before plan_stream
-            # begins metadata preparation.
-            if self.plan_stream:
-                self._draft_done_event = torch.get_device_module(self.device).Event()
-                self._draft_done_event.record()
             batch.spec_info = verify_input
             batch_output = self.verify(batch)
             with (
@@ -975,12 +968,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # Batch 1: Target verify
         # Prepare for target verify in a separate stream
         with self.plan_stream_ctx:
-            # Wait for the draft CUDA graph to finish before plan_stream
-            # begins its work. Using an event is more targeted than
-            # wait_stream(main_stream) — it only waits for draft GPU
-            # work, not all queued main_stream operations.
-            if self.plan_stream and hasattr(self, "_draft_done_event"):
-                self.plan_stream.wait_event(self._draft_done_event)
             verify_forward_batch, can_run_cuda_graph = (
                 verify_input.prepare_for_v2_verify(
                     self.req_to_token_pool,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -704,10 +704,6 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                 )
             verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
             assert verify_input.is_verify_input()
-            # Record a CUDA event after draft() GPU work is dispatched.
-            if self.plan_stream:
-                self._draft_done_event = torch.get_device_module(self.device).Event()
-                self._draft_done_event.record()
             batch.spec_info = verify_input
             batch_output = self.verify(batch)
             self.draft_worker._draft_extend_for_decode(batch, batch_output)
@@ -726,10 +722,6 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         # Batch 1: Target verify
         # Prepare for target verify in a separate stream
         with self.plan_stream_ctx:
-            # Wait for the draft CUDA graph to finish before plan_stream
-            # begins its work.
-            if self.plan_stream and hasattr(self, "_draft_done_event"):
-                self.plan_stream.wait_event(self._draft_done_event)
             verify_forward_batch, can_run_cuda_graph = (
                 verify_input.prepare_for_v2_verify(
                     self.req_to_token_pool,


### PR DESCRIPTION
… EAGLE overlap (#21940)"

This reverts commit 5141d8ae21f2e446a0022cb7d009d56702d34744.

The commit is essentially hardcoding `SGLANG_ENABLE_OVERLAP_PLAN_STREAM=0`. The user should just use `SGLANG_ENABLE_OVERLAP_PLAN_STREAM=0` instead.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26194867984](https://github.com/sgl-project/sglang/actions/runs/26194867984)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26195695407](https://github.com/sgl-project/sglang/actions/runs/26195695407)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->