### PR TITLE
feat(model_runner): introduce pool_context for process-global KV pool access

### DIFF
--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -14,6 +14,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_cp_size,
     is_allocation_symmetric,
 )
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.server_args import get_global_server_args
 
 
@@ -342,7 +343,7 @@ def cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size):
         v, cp_size, forward_batch, torch.cuda.current_stream()
     )
 
-    forward_batch.token_to_kv_pool.set_kv_buffer(
+    get_token_to_kv_pool().set_kv_buffer(
         layer,
         cache_loc,
         key_cache_full,

--- a/python/sglang/srt/mem_cache/base_swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/base_swa_memory_pool.py
@@ -30,3 +30,12 @@ class BaseSWAKVPool(KVCache):
     @abc.abstractmethod
     def get_state_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         raise NotImplementedError()
+
+    def invalidate_loc_cache(self) -> None:
+        """Invalidate any cached full→SWA location translation.
+
+        Default is a no-op; subclasses that maintain a location-translation
+        cache (e.g. SWAKVPool) override this to discard the cached result.
+        Called by SWATokenToKVPoolAllocator before every alloc/free/clear that
+        modifies full_to_swa_index_mapping.
+        """

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -493,6 +493,10 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping
 
+    def invalidate_loc_cache(self) -> None:
+        """Discard the cached SWA location translation (cached_loc)."""
+        self.cached_loc = None
+
     def get_ring_size(self, compress_ratio: int) -> int:
         server_args = get_global_server_args()
         is_speculative = server_args.speculative_algorithm is not None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -741,6 +741,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Init memory pool and attention backends
         self.init_memory_pool(pre_model_load_memory)
 
+        from sglang.srt.model_executor.pool_context import set_kv_pools
+
+        set_kv_pools(self.req_to_token_pool, self.token_to_kv_pool)
+
         # Init ngram embedding token table
         self.maybe_init_ngram_embedding()
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -154,6 +154,7 @@ from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
     PiecewiseCudaGraphRunner,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
+from sglang.srt.model_executor.pool_context import set_kv_pools
 from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
 from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
@@ -740,8 +741,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Init memory pool and attention backends
         self.init_memory_pool(pre_model_load_memory)
-
-        from sglang.srt.model_executor.pool_context import set_kv_pools
 
         set_kv_pools(self.req_to_token_pool, self.token_to_kv_pool)
 
@@ -3201,6 +3200,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         reinit_attn_backend: bool = False,
         split_forward_count: int = 1,
     ) -> ModelRunnerOutput:
+        # Ensure the correct pools are active for this runner. Necessary when
+        # multiple ModelRunner instances exist (e.g. multi-layer Eagle draft +
+        # target) because each runner has its own token_to_kv_pool.
+        set_kv_pools(self.req_to_token_pool, self.token_to_kv_pool)
+
         # Check whether can run cuda graph
         mode_check = (
             forward_batch.forward_mode.is_cpu_graph

--- a/python/sglang/srt/model_executor/pool_context.py
+++ b/python/sglang/srt/model_executor/pool_context.py
@@ -1,0 +1,45 @@
+# python/sglang/srt/model_executor/pool_context.py
+"""Process-lifetime KV pool global context.
+
+Provides set_kv_pools() / get_token_to_kv_pool() / get_req_to_token_pool()
+as module-level globals, following the same pattern as get_global_server_args().
+
+Call set_kv_pools() once in ModelRunner.__init__ after init_memory_pool().
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+
+_req_to_token_pool: Optional["ReqToTokenPool"] = None
+_token_to_kv_pool: Optional["KVCache"] = None
+
+
+def set_kv_pools(
+    req_to_token_pool: "ReqToTokenPool",
+    token_to_kv_pool: "KVCache",
+) -> None:
+    """Set process-lifetime pool refs. Called once after ModelRunner.init_memory_pool()."""
+    global _req_to_token_pool, _token_to_kv_pool
+    _req_to_token_pool = req_to_token_pool
+    _token_to_kv_pool = token_to_kv_pool
+
+
+def get_token_to_kv_pool() -> "KVCache":
+    """Return the process-lifetime token-to-KV pool."""
+    assert _token_to_kv_pool is not None, (
+        "token_to_kv_pool not initialized. "
+        "Call set_kv_pools() in ModelRunner.__init__ after init_memory_pool()."
+    )
+    return _token_to_kv_pool
+
+
+def get_req_to_token_pool() -> "ReqToTokenPool":
+    """Return the process-lifetime request-to-token pool."""
+    assert _req_to_token_pool is not None, (
+        "req_to_token_pool not initialized. "
+        "Call set_kv_pools() in ModelRunner.__init__ after init_memory_pool()."
+    )
+    return _req_to_token_pool

--- a/python/sglang/srt/model_executor/pool_context.py
+++ b/python/sglang/srt/model_executor/pool_context.py
@@ -6,6 +6,7 @@ as module-level globals, following the same pattern as get_global_server_args().
 
 Call set_kv_pools() once in ModelRunner.__init__ after init_memory_pool().
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.attention.utils import concat_and_cast_mha_k_triton
 from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.models.deepseek_common.utils import (
     _is_cuda,
     _is_hip,
@@ -431,12 +432,12 @@ class DeepseekMHAForwardMixin:
     ):
         if _is_cuda or _use_aiter_gfx95:
             # Save latent cache
-            forward_batch.token_to_kv_pool.set_mla_kv_buffer(
+            get_token_to_kv_pool().set_mla_kv_buffer(
                 self.attn_mha, forward_batch.out_cache_loc, kv_a.unsqueeze(1), k_pe
             )
         elif _is_npu:
             # To reduce a time-costing split operation
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            get_token_to_kv_pool().set_kv_buffer(
                 self.attn_mha, forward_batch.out_cache_loc, kv_a.unsqueeze(1), k_pe
             )
         else:
@@ -444,7 +445,7 @@ class DeepseekMHAForwardMixin:
             latent_cache[:, :, self.kv_lora_rank :] = k_pe.clone()
 
             # Save latent cache
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            get_token_to_kv_pool().set_kv_buffer(
                 self.attn_mha, forward_batch.out_cache_loc, latent_cache, None
             )
 
@@ -455,12 +456,12 @@ class DeepseekMHAForwardMixin:
         forward_batch: ForwardBatch,
     ):
         if _is_cuda or _use_aiter_gfx95:
-            kv_a, k_pe = forward_batch.token_to_kv_pool.get_mla_kv_buffer(
+            kv_a, k_pe = get_token_to_kv_pool().get_mla_kv_buffer(
                 self.attn_mha, kv_indices, dst_dtype
             )
             kv_a = kv_a.squeeze(1)
         else:
-            latent_cache_buf = forward_batch.token_to_kv_pool.get_key_buffer(
+            latent_cache_buf = get_token_to_kv_pool().get_key_buffer(
                 self.attn_mha.layer_id
             )
             latent_cache = latent_cache_buf[kv_indices].contiguous().to(dst_dtype)
@@ -488,9 +489,7 @@ class DeepseekMHAForwardMixin:
             kv_indices is not None
         ), "page_table_1_flattened should have been generated for FP8 MHA path"
 
-        kv_cache_fp8 = forward_batch.token_to_kv_pool.get_key_buffer(
-            self.attn_mha.layer_id
-        )
+        kv_cache_fp8 = get_token_to_kv_pool().get_key_buffer(self.attn_mha.layer_id)
 
         kv_latent_bf16 = dequantize_k_cache_paged(kv_cache_fp8, kv_indices)
 
@@ -526,7 +525,7 @@ class DeepseekMHAForwardMixin:
                 self.current_attention_backend == "fa3"
                 and self.kv_cache_dtype != "auto"
             ):
-                attn_dtype = forward_batch.token_to_kv_pool.dtype
+                attn_dtype = get_token_to_kv_pool().dtype
             else:
                 attn_dtype = k_nope.dtype
             k = k_nope.new_empty(*k_shape, dtype=attn_dtype)

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -23,6 +23,7 @@ from sglang.srt.lora.deepseek_mla_correction import (
     is_kv_b_lora_active,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.models.deepseek_common.utils import (
     FORWARD_ABSORB_CORE_ATTENTION_BACKENDS,
     _is_cpu,
@@ -420,9 +421,7 @@ class DeepseekMLAForwardMixin:
                     q_pe,
                     k_nope,
                     k_pe,
-                    forward_batch.token_to_kv_pool.get_key_buffer(
-                        self.attn_mqa.layer_id
-                    ),
+                    get_token_to_kv_pool().get_key_buffer(self.attn_mqa.layer_id),
                     forward_batch.out_cache_loc,
                     positions,
                     cos,
@@ -516,9 +515,7 @@ class DeepseekMLAForwardMixin:
                     q_pe,
                     k_nope,
                     k_pe,
-                    forward_batch.token_to_kv_pool.get_key_buffer(
-                        self.attn_mqa.layer_id
-                    ),
+                    get_token_to_kv_pool().get_key_buffer(self.attn_mqa.layer_id),
                     forward_batch.out_cache_loc,
                     positions,
                     cos,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_fused_rope_rocm.py
@@ -7,6 +7,7 @@ import torch
 
 from sglang.srt.layers.quantization.fp8_kernel import per_tensor_quant_mla_fp8
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.models.deepseek_common.utils import (
     _is_cuda,
     _is_hip,
@@ -126,12 +127,10 @@ class DeepseekMLARocmForwardMixin:
             )
 
         # save current latent cache.
-        forward_batch.token_to_kv_pool.set_kv_buffer(
+        get_token_to_kv_pool().set_kv_buffer(
             self.attn_mqa, forward_batch.out_cache_loc, k_input, None
         )
-        key_cache_buf = forward_batch.token_to_kv_pool.get_key_buffer(
-            self.attn_mqa.layer_id
-        )
+        key_cache_buf = get_token_to_kv_pool().get_key_buffer(self.attn_mqa.layer_id)
         val_cache_buf = key_cache_buf[..., : self.kv_lora_rank]
 
         return (
@@ -194,7 +193,7 @@ class DeepseekMLARocmForwardMixin:
 
         if enable_rope_fusion:
             k_input[..., self.kv_lora_rank :] = k_pe_output
-            forward_batch.token_to_kv_pool.set_kv_buffer(
+            get_token_to_kv_pool().set_kv_buffer(
                 self.attn_mqa, forward_batch.out_cache_loc, k_input, None
             )
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -77,6 +77,7 @@ from sglang.srt.model_executor.cuda_graph_runner import (
     get_is_capture_mode,
 )
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.model_loader.utils import maybe_executor_submit, should_async_load
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dbrx import ReplicatedLinear
@@ -397,7 +398,7 @@ class MQALayer(nn.Module):
             kv = qkv_a[..., self.q_lora_rank :]
         else:
             kv, _ = self.wkv(x)
-        token_to_kv_pool = forward_batch.token_to_kv_pool
+        token_to_kv_pool = get_token_to_kv_pool()
         if TYPE_CHECKING:
             assert isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
         token_to_kv_pool.set_swa_key_buffer_radix_fused_norm_rope(

--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -40,6 +40,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import get_req_to_token_pool
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
@@ -263,12 +264,10 @@ class Lfm2ShortConv(nn.Module):
         if forward_batch.forward_mode.is_idle():
             return hidden_states
 
-        layer_cache = forward_batch.req_to_token_pool.mamba2_layer_cache(self.layer_idx)
+        layer_cache = get_req_to_token_pool().mamba2_layer_cache(self.layer_idx)
         conv_state = layer_cache.conv[0]
         req_pool_indices = forward_batch.req_pool_indices
-        mamba_indices = forward_batch.req_to_token_pool.get_mamba_indices(
-            req_pool_indices
-        )
+        mamba_indices = get_req_to_token_pool().get_mamba_indices(req_pool_indices)
 
         # Project and split into gates: B (pre-conv), C (post-conv), x (input)
         proj, _ = self.in_proj(hidden_states)

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -42,6 +42,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import get_req_to_token_pool
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
@@ -326,12 +327,10 @@ class Lfm2MoeShortConv(nn.Module):
         if forward_batch.forward_mode.is_idle():
             return hidden_states
 
-        layer_cache = forward_batch.req_to_token_pool.mamba2_layer_cache(self.layer_idx)
+        layer_cache = get_req_to_token_pool().mamba2_layer_cache(self.layer_idx)
         conv_state = layer_cache.conv[0]
         req_pool_indices = forward_batch.req_pool_indices
-        mamba_indices = forward_batch.req_to_token_pool.get_mamba_indices(
-            req_pool_indices
-        )
+        mamba_indices = get_req_to_token_pool().get_mamba_indices(req_pool_indices)
 
         proj, _ = self.in_proj(hidden_states)
         B_gate, C_gate, x = proj.chunk(3, dim=-1)

--- a/python/sglang/srt/models/mindspore.py
+++ b/python/sglang/srt/models/mindspore.py
@@ -14,6 +14,10 @@ from sglang.srt.distributed import (
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import (
+    get_req_to_token_pool,
+    get_token_to_kv_pool,
+)
 from sglang.srt.models.registry import import_model_classes
 from sglang.srt.utils import is_npu
 
@@ -221,9 +225,9 @@ class MindSporeForCausalLM(torch.nn.Module):
         def prepare_cache(cache_list, is_key_cache):
             for i in range(self.config.num_hidden_layers):
                 if is_key_cache:
-                    cache = forward_batch.token_to_kv_pool.get_key_buffer(i)
+                    cache = get_token_to_kv_pool().get_key_buffer(i)
                 else:
-                    cache = forward_batch.token_to_kv_pool.get_value_buffer(i)
+                    cache = get_token_to_kv_pool().get_value_buffer(i)
                 cache_ms = tensor_torch2ms(cache)
                 if self.use_mla and cache_ms.ndim == 3:
                     cache_ms = mint.unsqueeze(cache_ms, 2)
@@ -275,10 +279,10 @@ class MindSporeForCausalLM(torch.nn.Module):
             if forward_batch.forward_mode.is_target_verify():
                 q_seq_lens = q_seq_lens * forward_batch.spec_info.num_tokens_per_req
 
-        page_size = forward_batch.token_to_kv_pool.page_size
+        page_size = get_token_to_kv_pool().page_size
         block_tables = tensor_torch2ms(
             (
-                forward_batch.req_to_token_pool.req_to_token[
+                get_req_to_token_pool().req_to_token[
                     forward_batch.req_pool_indices, : batch_valid_length.max()
                 ][:, ::page_size]
                 // page_size

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -23,6 +23,7 @@ from sglang.srt.layers.rotary_embedding.mrope import MRotaryEmbedding
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
@@ -214,7 +215,7 @@ class Qwen3Attention(nn.Module):
 
         qkv_3d = qkv.view(num_tokens, -1, self.head_dim)
 
-        token_to_kv_pool = forward_batch.token_to_kv_pool
+        token_to_kv_pool = get_token_to_kv_pool()
         k_cache, v_cache = token_to_kv_pool.get_kv_buffer(self.attn.layer_id)
         slot_mapping = forward_batch.out_cache_loc
 

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -54,6 +54,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.bailing_moe import BailingMoEForCausalLM
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
@@ -605,7 +606,7 @@ class SarvamMoEMLAAttention(nn.Module):
                 self.current_attention_backend == "fa3"
                 and self.kv_cache_dtype != "auto"
             ):
-                attn_dtype = forward_batch.token_to_kv_pool.dtype
+                attn_dtype = get_token_to_kv_pool().dtype
             else:
                 attn_dtype = k_nope.dtype
             k = k_nope.new_empty(*k_shape, dtype=attn_dtype)
@@ -671,7 +672,7 @@ class SarvamMoEMLAAttention(nn.Module):
         q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
         q[..., self.qk_nope_head_dim :] = q_pe
 
-        forward_batch.token_to_kv_pool.set_mla_kv_buffer(
+        get_token_to_kv_pool().set_mla_kv_buffer(
             self.attn_mha,
             forward_batch.out_cache_loc,
             k_nope,

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -31,6 +31,7 @@ from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_current_device_stream_fast, is_cuda, is_hip
@@ -277,9 +278,8 @@ def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
     """Enable fused set_kv_buffer only on CUDA with bfloat16 KV cache."""
     return (
         _is_cuda
-        and hasattr(forward_batch.token_to_kv_pool, "dtype")
-        and forward_batch.token_to_kv_pool.dtype == torch.bfloat16
-        and not isinstance(forward_batch.token_to_kv_pool, SWAKVPool)
+        and get_token_to_kv_pool().dtype == torch.bfloat16
+        and not isinstance(get_token_to_kv_pool(), SWAKVPool)
         and not is_prefill_context_parallel_enabled()
     ) or (_is_hip and not is_prefill_context_parallel_enabled())
 
@@ -292,7 +292,7 @@ def create_fused_set_kv_buffer_arg(
     from sglang.jit_kernel.rope import FusedSetKVBufferArg
 
     layer_id = layer.layer_id
-    token_to_kv_pool = forward_batch.token_to_kv_pool
+    token_to_kv_pool = get_token_to_kv_pool()
 
     k_buffer = token_to_kv_pool.get_key_buffer(layer_id)
     v_buffer = token_to_kv_pool.get_value_buffer(layer_id)

--- a/python/sglang/srt/speculative/frozen_kv_mtp_utils.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_utils.py
@@ -21,6 +21,11 @@ import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.pool_context import (
+    get_req_to_token_pool,
+    get_token_to_kv_pool,
+    set_kv_pools,
+)
 from sglang.srt.speculative.frozen_kv_mtp_info import (
     FrozenKVMTPContext,
     FrozenKVMTPDraftExtendInput,
@@ -38,14 +43,15 @@ def frozen_kv_target_view(forward_batch: ForwardBatch, kv_context: FrozenKVMTPCo
             "bind the frozen KV context first."
         )
     saved_spec_info = forward_batch.spec_info
-    saved_kv_pool = forward_batch.token_to_kv_pool
+    saved_req_pool = get_req_to_token_pool()
+    saved_token_pool = get_token_to_kv_pool()
     forward_batch.spec_info = None
-    forward_batch.token_to_kv_pool = kv_context.target_token_to_kv_pool
+    set_kv_pools(saved_req_pool, kv_context.target_token_to_kv_pool)
     try:
         yield
     finally:
         forward_batch.spec_info = saved_spec_info
-        forward_batch.token_to_kv_pool = saved_kv_pool
+        set_kv_pools(saved_req_pool, saved_token_pool)
 
 
 @contextmanager
@@ -55,12 +61,13 @@ def target_kv_pool_view(forward_batch: ForwardBatch, kv_context: FrozenKVMTPCont
             "Frozen-KV MTP target KV pool view called before the model was bound; "
             "bind the frozen KV context first."
         )
-    saved_kv_pool = forward_batch.token_to_kv_pool
-    forward_batch.token_to_kv_pool = kv_context.target_token_to_kv_pool
+    saved_req_pool = get_req_to_token_pool()
+    saved_token_pool = get_token_to_kv_pool()
+    set_kv_pools(saved_req_pool, kv_context.target_token_to_kv_pool)
     try:
         yield
     finally:
-        forward_batch.token_to_kv_pool = saved_kv_pool
+        set_kv_pools(saved_req_pool, saved_token_pool)
 
 
 def set_frozen_kv_positions(forward_batch: ForwardBatch, topk: int) -> None:

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -41,6 +41,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
 )
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
+from sglang.srt.model_executor.pool_context import get_req_to_token_pool
 from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 from sglang.srt.speculative.multi_layer_eagle_utils import assign_new_state_triton
 from sglang.srt.speculative.spec_utils import fast_topk
@@ -491,7 +492,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
                     forward_batch.batch_size,
                     self.step,
                     forward_batch.req_pool_indices,
-                    forward_batch.req_to_token_pool.req_to_token,
+                    get_req_to_token_pool().req_to_token,
                     self.eagle_worker.req_to_hidden_states_pool,
                 )
                 next_buffers.swa_out_cache_loc.copy_(

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -32,6 +32,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
 )
+from sglang.srt.model_executor.pool_context import get_token_to_kv_pool, set_kv_pools
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -419,9 +420,10 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         topk_p_list = []
         topk_index_list = []
         for step in range(self.speculative_num_steps):
-            forward_batch.req_to_token_pool = self.draft_runner_list[
-                step
-            ].req_to_token_pool
+            set_kv_pools(
+                self.draft_runner_list[step].req_to_token_pool,
+                get_token_to_kv_pool(),
+            )
             output: ModelRunnerOutput = self.draft_runner_list[step].forward(
                 forward_batch
             )
@@ -526,9 +528,10 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
                     draft_logits_output.topk_index,
                 )
             else:
-                forward_batch.req_to_token_pool = self.draft_runner_list[
-                    step
-                ].req_to_token_pool
+                set_kv_pools(
+                    self.draft_runner_list[step].req_to_token_pool,
+                    get_token_to_kv_pool(),
+                )
                 draft_logits_output = self.draft_runner_list[step].forward(
                     forward_batch, skip_attn_backend_init=True
                 )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -32,7 +32,6 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
 )
-from sglang.srt.model_executor.pool_context import get_token_to_kv_pool, set_kv_pools
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -420,10 +419,6 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         topk_p_list = []
         topk_index_list = []
         for step in range(self.speculative_num_steps):
-            set_kv_pools(
-                self.draft_runner_list[step].req_to_token_pool,
-                get_token_to_kv_pool(),
-            )
             output: ModelRunnerOutput = self.draft_runner_list[step].forward(
                 forward_batch
             )
@@ -528,10 +523,6 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
                     draft_logits_output.topk_index,
                 )
             else:
-                set_kv_pools(
-                    self.draft_runner_list[step].req_to_token_pool,
-                    get_token_to_kv_pool(),
-                )
                 draft_logits_output = self.draft_runner_list[step].forward(
                     forward_batch, skip_attn_backend_init=True
                 )


### PR DESCRIPTION
## Summary

- Add `pool_context.py` exporting three helpers — `set_kv_pools()`, `get_token_to_kv_pool()`, `get_req_to_token_pool()` — so model-layer code can access the process KV pools without threading them through `ForwardBatch`
- Replace `forward_batch.token_to_kv_pool.*` reads in model-layer code (`forward_mha.py`, `forward_mla.py`, `forward_mla_fused_rope_rocm.py`, `deepseek_v4.py`, `qwen3.py`, `mindspore.py`, `lfm2.py`, `lfm2_moe.py`, `sarvam_moe.py`, `cp_utils.py`, `utils.py`) with `get_token_to_kv_pool()`
- Replace `forward_batch.token_to_kv_pool` pool-swap save/restore in speculative decoding (`frozen_kv_mtp_utils.py`) with `set_kv_pools()` context manager pattern; remove no-op `set_kv_pools` calls from the Eagle multi-layer draft worker loop (draft runners share the same `req_to_token_pool` as the target)
- Call `set_kv_pools()` at the top of `ModelRunner._forward_raw()` so that multi-runner setups (e.g. multi-layer Eagle draft + target) always have the correct `token_to_kv_pool` active — draft and target share `req_to_token_pool` but own separate `token_to_kv_pool` instances, so without this fix whichever runner initializes last silently wins for all subsequent `get_token_to_kv_pool()` calls
- Fix latent bug: `BaseSWAKVPool` and `DeepSeekV4TokenToKVPool` were missing `invalidate_loc_cache()`, causing `AttributeError` when `SWATokenToKVPoolAllocator.clear()` called it on non-`SWAKVPool` subclasses

## Test plan

- [ ] `grep -rn "forward_batch\.\(token_to_kv_pool\|req_to_token_pool\)" python/sglang/srt/ --include="*.py" | grep -v forward_batch_info.py | grep -v layers/attention/ | grep -v hardware_backend/` → zero matches
- [ ] Server startup + generate: DSV4, Qwen3
- [ ] DSV3 + MTP speculative (`--speculative-algorithm NEXTN`) — exercises `frozen_kv_mtp_utils.py` pool-swap context managers
- [ ] Multi-layer Eagle speculative — exercises `multi_layer_eagle_worker_v2.py` and `multi_layer_eagle_draft_extend_cuda_graph_runner.py`; verify draft and target each use their own `token_to_kv_pool` with no cross-contamination
- [ ] Context-parallel run (`--context-parallel-size > 1`) — exercises `cp_utils.py` callsite

🤖 Generated with [Claude Code](https://claude.com/claude-code)