### PR TITLE
[CI] Fix bot-cherry-pick auth: GITHUB_TOKEN for push, dedicated PAT for PR

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -131,7 +131,7 @@ jobs:
       - name: Create Pull Request
         if: steps.cherry_pick.outputs.cherry_pick_success == 'true' && github.event.inputs.create_pr == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_CHERRY_PICK }}
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
           SHORT_SHA: ${{ steps.commit_info.outputs.short_sha }}
           COMMIT_TITLE: ${{ steps.commit_info.outputs.commit_title }}

--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -115,7 +115,9 @@ impl PodInfo {
         if config.pd_mode {
             if config.prefill_selector.is_empty() && config.decode_selector.is_empty() {
                 if !(config.igw_mode && !config.selector.is_empty()) {
-                    warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
+                    warn!(
+                        "PD mode enabled but both prefill_selector and decode_selector are empty"
+                    );
                     return false;
                 }
             }


### PR DESCRIPTION
## Summary

`bot-cherry-pick.yml` has 403'd at `git push` on every single run since at least Feb 2026 (e.g. [run #23996058016](https://github.com/sgl-project/sglang/actions/runs/23996058016)). Root cause:

```
remote: Permission to sgl-project/sglang.git denied to sglang-bot.
fatal: unable to access 'https://github.com/sgl-project/sglang/': The requested URL returned error: 403
```

Checkout was authenticated with `GH_PAT_FOR_PULL_REQUEST` (owned by `sglang-bot`), so the later `git push` reused that PAT — but `sglang-bot` only has `Pull requests: Write`, not `Contents: Write`, so the branch push is denied.

## Fix

Two-line workflow change — adopt the same pattern already used by `bot-bump-flashinfer-version.yml`, `bot-bump-sglang-version.yml`, etc.:

- **Checkout uses `secrets.GITHUB_TOKEN`** → `git push` of the new cherry-pick branch is authenticated by the job's own token, which can push because the workflow already declares `permissions: contents: write`.
- **`gh pr create` uses a new dedicated PAT `secrets.GH_PAT_FOR_CHERRY_PICK`** → keeps the property that PRs opened by the workflow trigger downstream CI (PRs opened with `GITHUB_TOKEN` deliberately don't, per GitHub's anti-recursion design).

## Required follow-up (repo admin)

Before merging, add a repo secret named `GH_PAT_FOR_CHERRY_PICK` (preferably in the `prod` environment that this job already pins to). The PAT only needs:

| Permission | Level |
|---|---|
| Contents | Read |
| Pull requests | Write |
| Metadata | Read (default) |

Scoping the PAT this narrowly (no `Contents: Write`) means a leak can't push commits to the repo, only open PRs.

If you'd rather reuse the existing `GH_PAT_FOR_PULL_REQUEST` secret, just revert the second hunk — the first hunk alone unbreaks the workflow, since the push will then use `GITHUB_TOKEN`.

## Test plan

- [ ] Repo admin: create `GH_PAT_FOR_CHERRY_PICK` secret (see permissions above).
- [ ] After secrets land, manually dispatch `Bot Cherry Pick to Release Branch` against a recent benign commit and a real release branch.
- [ ] Confirm: new `cherry-pick/<sha>-to-<release>-<rand>` branch is pushed, a PR is opened, and the PR triggers `pr-test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26201687702](https://github.com/sgl-project/sglang/actions/runs/26201687702)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26201687626](https://github.com/sgl-project/sglang/actions/runs/26201687626)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->