### PR TITLE
fix: rustfmt service_discovery.rs warn! line length

### DIFF
--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -115,7 +115,9 @@ impl PodInfo {
         if config.pd_mode {
             if config.prefill_selector.is_empty() && config.decode_selector.is_empty() {
                 if !(config.igw_mode && !config.selector.is_empty()) {
-                    warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
+                    warn!(
+                        "PD mode enabled but both prefill_selector and decode_selector are empty"
+                    );
                     return false;
                 }
             }


### PR DESCRIPTION
## Summary

- Reformats a `warn!` macro call in `sgl-model-gateway/src/service_discovery.rs` to satisfy `rustfmt` line-length rules. Introduced by #25294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26201599680](https://github.com/sgl-project/sglang/actions/runs/26201599680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26201599645](https://github.com/sgl-project/sglang/actions/runs/26201599645)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->