### PR TITLE
[diffusion] Batch standard CFG text encoding

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -104,17 +104,9 @@ class TextEncodingStage(PipelineStage):
     def get_or_compute_negative_text_embedding(
         self, batch: Req, server_args: ServerArgs, all_indices: list[int]
     ):
-        negative_cache_key = self._build_negative_text_cache_key(
+        cached_negative = self._get_cached_negative_text_embedding(
             batch, server_args, all_indices
         )
-        use_negative_cache = not batch.is_warmup
-        cached_negative = None
-        if use_negative_cache:
-            cached_negative = (
-                self._negative_text_cache_value
-                if self._negative_text_cache_key == negative_cache_key
-                else None
-            )
         if cached_negative is None:
             (
                 neg_embeds_list,
@@ -129,14 +121,16 @@ class TextEncodingStage(PipelineStage):
                 return_attention_mask=True,
             )
 
-            if use_negative_cache:
-                self._negative_text_cache_key = negative_cache_key
-                self._negative_text_cache_value = (
-                    tuple(neg_embeds_list),
-                    tuple(neg_masks_list),
-                    tuple(neg_pooler_embeds_list),
-                    tuple(neg_embeds_masks_list),
-                    tuple(neg_seq_lens_list),
+            if self._should_cache_negative_text_embedding(batch):
+                self._cache_negative_text_embedding(
+                    batch,
+                    server_args,
+                    all_indices,
+                    neg_embeds_list,
+                    neg_masks_list,
+                    neg_pooler_embeds_list,
+                    neg_embeds_masks_list,
+                    neg_seq_lens_list,
                 )
         else:
             (
@@ -154,6 +148,43 @@ class TextEncodingStage(PipelineStage):
             neg_seq_lens_list,
         )
 
+    def _should_cache_negative_text_embedding(self, batch: Req) -> bool:
+        return not batch.is_warmup
+
+    def _get_cached_negative_text_embedding(
+        self, batch: Req, server_args: ServerArgs, encoder_indices: list[int]
+    ):
+        if batch.is_warmup:
+            return None
+        negative_cache_key = self._build_negative_text_cache_key(
+            batch, server_args, encoder_indices
+        )
+        if self._negative_text_cache_key == negative_cache_key:
+            return self._negative_text_cache_value
+        return None
+
+    def _cache_negative_text_embedding(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+        encoder_indices: list[int],
+        neg_embeds_list,
+        neg_masks_list,
+        neg_pooler_embeds_list,
+        neg_embeds_masks_list,
+        neg_seq_lens_list,
+    ) -> None:
+        self._negative_text_cache_key = self._build_negative_text_cache_key(
+            batch, server_args, encoder_indices
+        )
+        self._negative_text_cache_value = (
+            tuple(neg_embeds_list),
+            tuple(neg_masks_list),
+            tuple(neg_pooler_embeds_list),
+            tuple(neg_embeds_masks_list),
+            tuple(neg_seq_lens_list),
+        )
+
     def _build_negative_text_cache_key(
         self, batch: Req, server_args: ServerArgs, encoder_indices: list[int]
     ):
@@ -166,6 +197,185 @@ class TextEncodingStage(PipelineStage):
             self.freeze_for_dedup(batch.prompt_template),
             batch.max_sequence_length,
         )
+
+    def _split_cfg_text_outputs(
+        self,
+        *,
+        prompt_count: int,
+        prompt_embeds_list,
+        prompt_masks_list,
+        pooler_embeds_list,
+        prompt_embeds_masks_list,
+        prompt_seq_lens_list,
+    ):
+        prompt_embeds = [tensor[:prompt_count] for tensor in prompt_embeds_list]
+        negative_prompt_embeds = [tensor[prompt_count:] for tensor in prompt_embeds_list]
+        prompt_masks = [tensor[:prompt_count] for tensor in prompt_masks_list]
+        negative_masks = [tensor[prompt_count:] for tensor in prompt_masks_list]
+        prompt_embeds_masks = [
+            tensor[:prompt_count] for tensor in prompt_embeds_masks_list
+        ]
+        negative_prompt_embeds_masks = [
+            tensor[prompt_count:] for tensor in prompt_embeds_masks_list
+        ]
+        prompt_seq_lens = [seq_lens[:prompt_count] for seq_lens in prompt_seq_lens_list]
+        negative_prompt_seq_lens = [
+            seq_lens[prompt_count:] for seq_lens in prompt_seq_lens_list
+        ]
+
+        pooled_embeds = [tensor[:prompt_count] for tensor in pooler_embeds_list]
+        negative_pooled_embeds = [
+            tensor[prompt_count:] for tensor in pooler_embeds_list
+        ]
+
+        return (
+            prompt_embeds,
+            prompt_masks,
+            pooled_embeds,
+            prompt_embeds_masks,
+            prompt_seq_lens,
+            negative_prompt_embeds,
+            negative_masks,
+            negative_pooled_embeds,
+            negative_prompt_embeds_masks,
+            negative_prompt_seq_lens,
+        )
+
+    def _append_positive_text_outputs(
+        self,
+        batch: Req,
+        prompt_embeds_list,
+        prompt_masks_list,
+        pooler_embeds_list,
+        prompt_embeds_masks_list,
+        prompt_seq_lens_list,
+    ) -> None:
+        for pe in prompt_embeds_list:
+            batch.prompt_embeds.append(pe)
+
+        for pe in pooler_embeds_list:
+            batch.pooled_embeds.append(pe)
+
+        if batch.prompt_attention_mask is None:
+            batch.prompt_attention_mask = []
+            for am in prompt_masks_list:
+                batch.prompt_attention_mask.append(am)
+
+        batch.prompt_embeds_mask = []
+        batch.prompt_seq_lens = []
+        for mask in prompt_embeds_masks_list:
+            batch.prompt_embeds_mask.append(mask)
+        for seq_lens in prompt_seq_lens_list:
+            batch.prompt_seq_lens.append(seq_lens)
+
+    def _append_negative_text_outputs(
+        self,
+        batch: Req,
+        prompt_embeds_list,
+        neg_embeds_list,
+        neg_masks_list,
+        neg_pooler_embeds_list,
+        neg_embeds_masks_list,
+        neg_seq_lens_list,
+    ) -> None:
+        assert batch.negative_prompt_embeds is not None
+
+        # a single negative prompt can be shared across positive prompts
+        target_batch_sizes = [pe.shape[0] for pe in prompt_embeds_list]
+
+        def align_negative_batch_dim(
+            tensor: torch.Tensor, target_batch: int, name: str
+        ) -> torch.Tensor:
+            if tensor.shape[0] == target_batch:
+                return tensor
+            if tensor.shape[0] == 1 and target_batch > 1:
+                return tensor.expand(target_batch, *tensor.shape[1:])
+            raise ValueError(
+                f"{name} batch dimension mismatch: got {tensor.shape[0]}, expected 1 or {target_batch}"
+            )
+
+        def align_negative_seq_lens(
+            seq_lens: list[int], target_batch: int, name: str
+        ) -> list[int]:
+            if len(seq_lens) == target_batch:
+                return [int(x) for x in seq_lens]
+            if len(seq_lens) == 1 and target_batch > 1:
+                return [int(seq_lens[0])] * target_batch
+            raise ValueError(
+                f"{name} batch dimension mismatch: got {len(seq_lens)}, expected 1 or {target_batch}"
+            )
+
+        for idx, ne in enumerate(neg_embeds_list):
+            target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
+            ne = align_negative_batch_dim(ne, target_batch, "negative_prompt_embeds")
+            batch.negative_prompt_embeds.append(ne)
+
+        for idx, pe in enumerate(neg_pooler_embeds_list):
+            target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
+            pe = align_negative_batch_dim(pe, target_batch, "negative_pooled_embeds")
+            batch.neg_pooled_embeds.append(pe)
+        if batch.negative_attention_mask is None:
+            batch.negative_attention_mask = []
+            for idx, nm in enumerate(neg_masks_list):
+                target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
+                nm = align_negative_batch_dim(
+                    nm, target_batch, "negative_attention_mask"
+                )
+                batch.negative_attention_mask.append(nm)
+
+        batch.negative_prompt_embeds_mask = []
+        batch.negative_prompt_seq_lens = []
+        for idx, nm in enumerate(neg_embeds_masks_list):
+            target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
+            nm = align_negative_batch_dim(
+                nm, target_batch, "negative_prompt_embeds_mask"
+            )
+            batch.negative_prompt_embeds_mask.append(nm)
+        for idx, seq_lens in enumerate(neg_seq_lens_list):
+            target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
+            batch.negative_prompt_seq_lens.append(
+                align_negative_seq_lens(
+                    seq_lens, target_batch, "negative_prompt_seq_lens"
+                )
+            )
+
+    def _encode_cfg_text_batch(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+        prompt_text: str | list[str],
+        all_indices: list[int],
+        max_seq_length: int | None,
+    ):
+        assert isinstance(batch.negative_prompt, str)
+        prompts = [prompt_text] if isinstance(prompt_text, str) else list(prompt_text)
+        combined_text = prompts + [batch.negative_prompt]
+        outputs = self.encode_text(
+            combined_text,
+            server_args,
+            encoder_index=all_indices,
+            return_attention_mask=True,
+            max_length=max_seq_length,
+        )
+        return self._split_cfg_text_outputs(
+            prompt_count=len(prompts),
+            prompt_embeds_list=outputs[0],
+            prompt_masks_list=outputs[1],
+            pooler_embeds_list=outputs[2],
+            prompt_embeds_masks_list=outputs[3],
+            prompt_seq_lens_list=outputs[4],
+        )
+
+    def _should_encode_cfg_text_batch(
+        self, batch: Req, server_args: ServerArgs
+    ) -> bool:
+        if not batch.do_classifier_free_guidance:
+            return False
+        if not isinstance(batch.negative_prompt, str):
+            return False
+        # TurboWan/DMD output changed in validation when positive/negative text
+        # were encoded in the same batch; keep that path on separated encoding
+        return not hasattr(server_args.pipeline_config, "dmd_denoising_steps")
 
     @torch.no_grad()
     def forward(
@@ -190,117 +400,104 @@ class TextEncodingStage(PipelineStage):
         # Get max_sequence_length from batch if available
         max_seq_length = getattr(batch, "max_sequence_length", None)
 
-        (
-            prompt_embeds_list,
-            prompt_masks_list,
-            pooler_embeds_list,
-            prompt_embeds_masks_list,
-            prompt_seq_lens_list,
-        ) = self.encode_text(
-            prompt_text,
-            server_args,
-            encoder_index=all_indices,
-            return_attention_mask=True,
-            max_length=max_seq_length,
-        )
-
-        for pe in prompt_embeds_list:
-            batch.prompt_embeds.append(pe)
-
-        for pe in pooler_embeds_list:
-            batch.pooled_embeds.append(pe)
-
-        if batch.prompt_attention_mask is None:
-            batch.prompt_attention_mask = []
-            for am in prompt_masks_list:
-                batch.prompt_attention_mask.append(am)
-
-        batch.prompt_embeds_mask = []
-        batch.prompt_seq_lens = []
-        for mask in prompt_embeds_masks_list:
-            batch.prompt_embeds_mask.append(mask)
-        for seq_lens in prompt_seq_lens_list:
-            batch.prompt_seq_lens.append(seq_lens)
-
-        # Encode negative prompt if CFG is enabled
+        cached_negative = None
         if batch.do_classifier_free_guidance:
-            assert isinstance(batch.negative_prompt, str)
+            cached_negative = self._get_cached_negative_text_embedding(
+                batch, server_args, all_indices
+            )
+
+        if cached_negative is not None:
+            (
+                prompt_embeds_list,
+                prompt_masks_list,
+                pooler_embeds_list,
+                prompt_embeds_masks_list,
+                prompt_seq_lens_list,
+            ) = self.encode_text(
+                prompt_text,
+                server_args,
+                encoder_index=all_indices,
+                return_attention_mask=True,
+                max_length=max_seq_length,
+            )
             (
                 neg_embeds_list,
                 neg_masks_list,
                 neg_pooler_embeds_list,
                 neg_embeds_masks_list,
                 neg_seq_lens_list,
-            ) = self.get_or_compute_negative_text_embedding(
-                batch, server_args, all_indices
+            ) = cached_negative
+        elif self._should_encode_cfg_text_batch(batch, server_args):
+            (
+                prompt_embeds_list,
+                prompt_masks_list,
+                pooler_embeds_list,
+                prompt_embeds_masks_list,
+                prompt_seq_lens_list,
+                neg_embeds_list,
+                neg_masks_list,
+                neg_pooler_embeds_list,
+                neg_embeds_masks_list,
+                neg_seq_lens_list,
+            ) = self._encode_cfg_text_batch(
+                batch, server_args, prompt_text, all_indices, max_seq_length
             )
-
-            assert batch.negative_prompt_embeds is not None
-
-            # A single negative prompt can be shared across positive prompts.
-            target_batch_sizes = [pe.shape[0] for pe in prompt_embeds_list]
-
-            def align_negative_batch_dim(
-                tensor: torch.Tensor, target_batch: int, name: str
-            ) -> torch.Tensor:
-                if tensor.shape[0] == target_batch:
-                    return tensor
-                if tensor.shape[0] == 1 and target_batch > 1:
-                    return tensor.expand(target_batch, *tensor.shape[1:])
-                raise ValueError(
-                    f"{name} batch dimension mismatch: got {tensor.shape[0]}, expected 1 or {target_batch}"
+            if self._should_cache_negative_text_embedding(batch):
+                self._cache_negative_text_embedding(
+                    batch,
+                    server_args,
+                    all_indices,
+                    neg_embeds_list,
+                    neg_masks_list,
+                    neg_pooler_embeds_list,
+                    neg_embeds_masks_list,
+                    neg_seq_lens_list,
+                )
+        else:
+            (
+                prompt_embeds_list,
+                prompt_masks_list,
+                pooler_embeds_list,
+                prompt_embeds_masks_list,
+                prompt_seq_lens_list,
+            ) = self.encode_text(
+                prompt_text,
+                server_args,
+                encoder_index=all_indices,
+                return_attention_mask=True,
+                max_length=max_seq_length,
+            )
+            if batch.do_classifier_free_guidance:
+                (
+                    neg_embeds_list,
+                    neg_masks_list,
+                    neg_pooler_embeds_list,
+                    neg_embeds_masks_list,
+                    neg_seq_lens_list,
+                ) = self.get_or_compute_negative_text_embedding(
+                    batch, server_args, all_indices
                 )
 
-            def align_negative_seq_lens(
-                seq_lens: list[int], target_batch: int, name: str
-            ) -> list[int]:
-                if len(seq_lens) == target_batch:
-                    return [int(x) for x in seq_lens]
-                if len(seq_lens) == 1 and target_batch > 1:
-                    return [int(seq_lens[0])] * target_batch
-                raise ValueError(
-                    f"{name} batch dimension mismatch: got {len(seq_lens)}, expected 1 or {target_batch}"
-                )
+        self._append_positive_text_outputs(
+            batch,
+            prompt_embeds_list,
+            prompt_masks_list,
+            pooler_embeds_list,
+            prompt_embeds_masks_list,
+            prompt_seq_lens_list,
+        )
 
-            for idx, ne in enumerate(neg_embeds_list):
-                target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
-                ne = align_negative_batch_dim(
-                    ne, target_batch, "negative_prompt_embeds"
-                )
-                batch.negative_prompt_embeds.append(ne)
-
-            for idx, pe in enumerate(neg_pooler_embeds_list):
-                target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
-                pe = align_negative_batch_dim(
-                    pe, target_batch, "negative_pooled_embeds"
-                )
-                batch.neg_pooled_embeds.append(pe)
-            if batch.negative_attention_mask is None:
-                batch.negative_attention_mask = []
-                for idx, nm in enumerate(neg_masks_list):
-                    target_batch = target_batch_sizes[
-                        min(idx, len(target_batch_sizes) - 1)
-                    ]
-                    nm = align_negative_batch_dim(
-                        nm, target_batch, "negative_attention_mask"
-                    )
-                    batch.negative_attention_mask.append(nm)
-
-            batch.negative_prompt_embeds_mask = []
-            batch.negative_prompt_seq_lens = []
-            for idx, nm in enumerate(neg_embeds_masks_list):
-                target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
-                nm = align_negative_batch_dim(
-                    nm, target_batch, "negative_prompt_embeds_mask"
-                )
-                batch.negative_prompt_embeds_mask.append(nm)
-            for idx, seq_lens in enumerate(neg_seq_lens_list):
-                target_batch = target_batch_sizes[min(idx, len(target_batch_sizes) - 1)]
-                batch.negative_prompt_seq_lens.append(
-                    align_negative_seq_lens(
-                        seq_lens, target_batch, "negative_prompt_seq_lens"
-                    )
-                )
+        # Encode negative prompt if CFG is enabled
+        if batch.do_classifier_free_guidance:
+            self._append_negative_text_outputs(
+                batch,
+                prompt_embeds_list,
+                neg_embeds_list,
+                neg_masks_list,
+                neg_pooler_embeds_list,
+                neg_embeds_masks_list,
+                neg_seq_lens_list,
+            )
 
         return batch
 

--- a/python/sglang/multimodal_gen/test/unit/test_text_encoding_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_text_encoding_cache.py
@@ -21,14 +21,18 @@ class DummyTextEncodingStage(TextEncodingStage):
 
     def encode_text(self, *args, **kwargs):
         self.calls += 1
-        embeds = torch.full((1, 1, 1), float(self.calls))
-        mask = torch.ones((1, 1), dtype=torch.int64)
-        return [embeds], [mask], [], [mask], [[1]]
+        text = args[0]
+        batch_size = len(text) if isinstance(text, list) else 1
+        embeds = torch.full((batch_size, 1, 1), float(self.calls))
+        mask = torch.ones((batch_size, 1), dtype=torch.int64)
+        return [embeds], [mask], [], [mask], [[1] * batch_size]
 
 
 def make_req(**kwargs):
     defaults = {
+        "prompt": "hello",
         "negative_prompt": "bad quality",
+        "do_classifier_free_guidance": True,
         "prompt_template": {"template": "{}"},
         "max_sequence_length": 1024,
         "is_warmup": False,
@@ -37,9 +41,37 @@ def make_req(**kwargs):
     return SimpleNamespace(**defaults)
 
 
+def make_forward_req(**kwargs):
+    defaults = {
+        "prompt_embeds": [],
+        "pooled_embeds": [],
+        "prompt_attention_mask": None,
+        "prompt_embeds_mask": None,
+        "prompt_seq_lens": None,
+        "negative_prompt_embeds": [],
+        "neg_pooled_embeds": [],
+        "negative_attention_mask": None,
+        "negative_prompt_embeds_mask": None,
+        "negative_prompt_seq_lens": None,
+    }
+    defaults.update(make_req(**kwargs).__dict__)
+    return SimpleNamespace(**defaults)
+
+
+def make_server_args(**kwargs):
+    defaults = {
+        "pipeline_class_name": "LTX2TwoStagePipeline",
+        "pipeline_config": SimpleNamespace(text_encoder_configs=[]),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(
+        **defaults,
+    )
+
+
 def test_negative_text_cache_key_tracks_encode_options():
     stage = DummyTextEncodingStage()
-    server_args = SimpleNamespace(pipeline_class_name="LTX2TwoStagePipeline")
+    server_args = make_server_args()
 
     stage.get_or_compute_negative_text_embedding(make_req(), server_args, [0])
     stage.get_or_compute_negative_text_embedding(make_req(), server_args, [0])
@@ -58,11 +90,37 @@ def test_negative_text_cache_key_tracks_encode_options():
 
 def test_negative_text_cache_skips_warmup():
     stage = DummyTextEncodingStage()
-    server_args = SimpleNamespace(pipeline_class_name="LTX2TwoStagePipeline")
+    server_args = make_server_args()
 
     stage.get_or_compute_negative_text_embedding(
         make_req(is_warmup=True), server_args, [0]
     )
     stage.get_or_compute_negative_text_embedding(make_req(), server_args, [0])
+
+    assert stage.calls == 2
+
+
+def test_cfg_text_batch_encodes_positive_and_negative_once():
+    stage = DummyTextEncodingStage()
+    server_args = make_server_args()
+    batch = make_forward_req()
+
+    stage.forward(batch, server_args)
+
+    assert stage.calls == 1
+    assert batch.prompt_embeds[0].shape[0] == 1
+    assert batch.negative_prompt_embeds[0].shape[0] == 1
+
+
+def test_cfg_text_batch_skips_dmd_pipeline():
+    stage = DummyTextEncodingStage()
+    server_args = make_server_args(
+        pipeline_config=SimpleNamespace(
+            text_encoder_configs=[],
+            dmd_denoising_steps=1,
+        )
+    )
+
+    stage.forward(make_forward_req(), server_args)
 
     assert stage.calls == 2


### PR DESCRIPTION
## Summary
- Batch standard CFG positive and negative prompt text into one encoder forward when the pipeline supports it.
- Keep the existing negative prompt cache behavior, with helpers shared by batched and separated encoding paths.
- Leave TurboWan/DMD on separated positive/negative encoding because validation changed when those paths were batched.

## CFG Scope and Impact
This change is path-based rather than model-name-based. It applies only when a request uses standard CFG, `negative_prompt` is a string, and the pipeline config does not expose `dmd_denoising_steps`.

Model examples:
- Qwen-Image: the default sampling params use a string `negative_prompt` and `guidance_scale > 1`, so Qwen-Image T2I/Edit requests normally take this path. The Qwen text encoder sees positive and negative prompts in one batch, then the postprocessed embeddings, masks, and sequence lengths are split back into the original positive/negative fields.
- Flux v1 / Flux 2: the default sampling params use `negative_prompt=None` (and Flux 2 Klein also defaults `guidance_scale=1`), so default Flux requests normally do not take this path. If a request explicitly provides a string negative prompt with CFG enabled, Flux uses the same batched text-encoding path. For Flux v1 this batches both CLIP and T5 text encoders; for Flux 2 it batches the single text encoder.

Accuracy / precision impact:
- Standard CFG pipelines still use the same tokenizer, encoder, and postprocess functions. The positive and negative outputs are split back into the original fields before denoising, so the expected model behavior is unchanged.
- Qwen-Image keeps the same embedding-aligned attention masks and text sequence lengths after the split, so variable-length text conditioning should preserve the same denoising contract.
- Flux keeps the same fixed-length text conditioning contract after the split; default non-CFG Flux requests are unchanged.
- TurboWan/DMD-style pipelines are explicitly kept on the old separated positive/negative encoding path because batching changed validation output in testing. They should have no accuracy change from this PR.
- Non-CFG requests, requests using precomputed negative embeddings, and non-string negative prompt paths are unchanged.

Performance impact:
- Cold standard CFG negative prompt: reduces text encoding from separate positive and negative `encode_text` calls to one batched call. This can reduce tokenizer/encoder launch overhead and TextEncodingStage latency.
- Qwen-Image is expected to be the main default beneficiary among these examples because it uses CFG by default.
- Flux default requests are expected to see no change because they normally do not enable standard CFG. Flux requests with an explicit negative prompt can benefit on the same cold CFG path.
- Warm standard CFG negative prompt: no expected speedup, because the existing negative text cache already skips the negative encoder forward.
- End-to-end speedup is model- and request-dependent. It is most visible when TextEncodingStage is a meaningful part of request latency, and small or zero when DiT/VAE dominates or the negative cache is already warm.
- This PR does not include request-warmup full text-output caching; that is split into the stacked follow-up PR.
- Peak final text output memory is unchanged. During the encoder call, the text encoder sees a larger combined batch, so transient text-encoder activation memory can be slightly higher on the affected cold CFG path.

## Validation
- `python3 -m pytest -q python/sglang/multimodal_gen/test/unit/test_text_encoding_cache.py --tb=short`


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26201729290](https://github.com/sgl-project/sglang/actions/runs/26201729290)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26201729208](https://github.com/sgl-project/sglang/actions/runs/26201729208)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
