### PR TITLE
[Deps] cherry-pick #25576 onto release/v0.5.12

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "ninja",
   "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "numpy",
-  "nvidia-cutlass-dsl==4.5.0",
+  "nvidia-cutlass-dsl[cu13]==4.5.1",
   "nvidia-ml-py",
   "openai-harmony==0.0.4",
   "openai==2.6.1",


### PR DESCRIPTION
## Summary

Cherry-pick of #25576 (commit a449ee4822eed379d510a381badc39e5cba6280e) onto `release/v0.5.12`.

Switches `nvidia-cutlass-dsl` to the `[cu13]` extra at version `4.5.1`, matching what is already on `main`. This is needed on CUDA 13 images (e.g. GB300) where the non-`[cu13]` wheel ships CUDA-12.9 binaries that miss the `sm_110` → `sm_101` alias and crash FlashAttention 4 / cute kernels at runtime.

## Changes

- `python/pyproject.toml`: `nvidia-cutlass-dsl==4.5.0` → `nvidia-cutlass-dsl[cu13]==4.5.1`

## Conflict resolution

The source commit on `main` was a pure version bump (`[cu13]==4.5.0` → `[cu13]==4.5.1`) because `main` already had the `[cu13]` extra from a prior commit. On `release/v0.5.12` the `[cu13]` extra was never picked up, so the line still read `nvidia-cutlass-dsl==4.5.0`. Took the incoming line so this branch ends up with the same final state as `main` (`[cu13]==4.5.1`), which is the intent of the original PR title ("Use cu13 extra for nvidia cutlass dsl").

## Test Plan

- Install on a CUDA 13 environment (GB300) and confirm `nvidia-cutlass-dsl` resolves to `4.5.1` with the `cu13` extra, and that FA4 / cute kernels no longer crash on `sm_110`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->