### PR TITLE
[AMD] Fix AMD stage-a-test-small-1-gpu

### DIFF
--- a/test/registered/core/test_basic_sanity_eagle3.py
+++ b/test/registered/core/test_basic_sanity_eagle3.py
@@ -33,16 +33,11 @@ class TestBasicSanityEagle3(
     CustomTestCase,
 ):
     served_model_name = DEFAULT_TARGET_MODEL_EAGLE3
-    # Match vanilla gate at 97; EAGLE3 spec should sustain similar
-    # single-batch occupancy. Adjust per CI calibration.
-    fwd_occupancy_threshold = 97.0
-
-    @unittest.skipIf(
-        is_in_amd_ci(),
-        "EAGLE3 fwd_occupancy threshold is calibrated for CUDA, not AMD CI yet",
-    )
-    def test_fwd_occupancy(self):
-        super().test_fwd_occupancy()
+    # CUDA 5090 + Llama-3.1-8B measured ~99 median in CI. AMD EAGLE3
+    # currently sustains lower single-batch occupancy and needs a longer
+    # measurement window to avoid too few non-NaN samples.
+    fwd_occupancy_threshold = 82.0 if is_in_amd_ci() else 97.0
+    fwd_occupancy_max_new_tokens = 4096 if is_in_amd_ci() else 2048
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/core/test_basic_sanity_eagle3.py
+++ b/test/registered/core/test_basic_sanity_eagle3.py
@@ -16,6 +16,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_in_amd_ci,
     popen_launch_server,
 )
 
@@ -35,6 +36,13 @@ class TestBasicSanityEagle3(
     # Match vanilla gate at 97; EAGLE3 spec should sustain similar
     # single-batch occupancy. Adjust per CI calibration.
     fwd_occupancy_threshold = 97.0
+
+    @unittest.skipIf(
+        is_in_amd_ci(),
+        "EAGLE3 fwd_occupancy threshold is calibrated for CUDA, not AMD CI yet",
+    )
+    def test_fwd_occupancy(self):
+        super().test_fwd_occupancy()
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/core/test_basic_sanity_eagle3.py
+++ b/test/registered/core/test_basic_sanity_eagle3.py
@@ -36,7 +36,7 @@ class TestBasicSanityEagle3(
     # CUDA 5090 + Llama-3.1-8B measured ~99 median in CI. AMD EAGLE3
     # currently sustains lower single-batch occupancy and needs a longer
     # measurement window to avoid too few non-NaN samples.
-    fwd_occupancy_threshold = 82.0 if is_in_amd_ci() else 97.0
+    fwd_occupancy_threshold = 80.0 if is_in_amd_ci() else 97.0
     fwd_occupancy_max_new_tokens = 4096 if is_in_amd_ci() else 2048
 
     @classmethod


### PR DESCRIPTION
## Summary
- Calibrate the EAGLE3 `fwd_occupancy` gate for AMD CI instead of skipping the test.
- Keep CUDA threshold unchanged at `97.0`, while using `80.0` for AMD based on observed MI runner results.
- Extend AMD EAGLE3 occupancy measurement from `2048` to `4096` generated tokens to reduce non-NaN sample flakiness.
## Motivation
AMD stage-a CI was failing in `TestBasicSanityEagle3.test_fwd_occupancy` after the new occupancy sanity kit landed. The failing run showed valid AMD EAGLE3 samples with median occupancy around `86.26`, below the CUDA-calibrated `97.0` threshold, and a retry later collected too few non-NaN samples.
This keeps the regression check active on AMD while calibrating it to current AMD EAGLE3 behavior.

## Accuracy Tests

skip https://github.com/sgl-project/sglang/actions/runs/26202382619
thres relaxing https://github.com/sgl-project/sglang/actions/runs/26203217313

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26204013661](https://github.com/sgl-project/sglang/actions/runs/26204013661)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26204013621](https://github.com/sgl-project/sglang/actions/runs/26204013621)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->