### PR TITLE
[Revert] nvidia-cutlass-dsl[cu13] 4.5.1 -> 4.5.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "ninja",
   "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "numpy",
-  "nvidia-cutlass-dsl[cu13]==4.5.1",
+  "nvidia-cutlass-dsl[cu13]==4.5.0",
   "nvidia-ml-py",
   "openai-harmony==0.0.4",
   "openai==2.6.1",

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -335,6 +335,58 @@ download_flashinfer_cache() {
     mark_step_done "${FUNCNAME[0]}"
 }
 
+fix_cutlass_dsl_libs() {
+    # nvidia-cutlass-dsl[cu13] has additive extras on PyPI: both -libs-base AND
+    # -libs-cu13 are installed when [cu13] is requested. They write to the same
+    # site-packages paths with conflicting content. At 4.5.0 the two .so files
+    # expose a compatible Python binding so the conflict is silent; at 4.5.1+
+    # -libs-cu13's binding changed without a wrapper bump and the conflict
+    # surfaces as a GPUModuleOp TypeError at kernel-compile time
+    # (see vllm-project/vllm#40082).
+    #
+    # Independent of the API mismatch, the two .so files target different GPU
+    # families. Pick the right one per runner:
+    #
+    #   Blackwell (IS_BLACKWELL=1, CU13):
+    #     -libs-cu13 must win. It provides the sm_110 arch alias that the
+    #     CUDA-12.9-built -libs-base wheel lacks. Remove -libs-base and
+    #     force-reinstall -libs-cu13 so its files take precedence.
+    #
+    #   Non-Blackwell CU13 (H100, H200, …):
+    #     -libs-base must win. Keeping only -libs-cu13 causes a
+    #     CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS regression in LoRA CUDA-graph
+    #     capture on H100 (#25743). Remove -libs-cu13 and force-reinstall
+    #     -libs-base so the original bindings are intact.
+    #
+    #   Non-CU13:
+    #     Only -libs-base is installed (no [cu13] extra) — no conflict.
+    #
+    if [ "$CU_MAJOR" != "13" ]; then
+        return
+    fi
+
+    CUTLASS_DSL_VERSION=$(grep -Po -m1 'nvidia-cutlass-dsl(\[[^]]+\])?==\K[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
+    if [ -z "$CUTLASS_DSL_VERSION" ]; then
+        echo "WARNING: could not detect nvidia-cutlass-dsl version from pyproject.toml; skipping libs fix"
+        return
+    fi
+
+    if [ "$IS_BLACKWELL" = "1" ]; then
+        # Blackwell: -libs-cu13 must win for sm_110 support.
+        echo "fix_cutlass_dsl_libs: Blackwell runner — purging -libs-base, reinstalling -libs-cu13==${CUTLASS_DSL_VERSION}"
+        $PIP_UNINSTALL_CMD nvidia-cutlass-dsl-libs-base $PIP_UNINSTALL_SUFFIX || true
+        $PIP_CMD install --force-reinstall --no-deps "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}" $PIP_INSTALL_SUFFIX
+    else
+        # Non-Blackwell CU13 (H100, H200): -libs-base must win to avoid LoRA
+        # CUDA-graph regression and GPUModuleOp TypeError.
+        echo "fix_cutlass_dsl_libs: non-Blackwell CU13 runner — purging -libs-cu13, reinstalling -libs-base==${CUTLASS_DSL_VERSION}"
+        $PIP_UNINSTALL_CMD nvidia-cutlass-dsl-libs-cu13 $PIP_UNINSTALL_SUFFIX || true
+        $PIP_CMD install --force-reinstall --no-deps "nvidia-cutlass-dsl-libs-base==${CUTLASS_DSL_VERSION}" $PIP_INSTALL_SUFFIX
+    fi
+
+    mark_step_done "${FUNCNAME[0]}"
+}
+
 stabilize_flashinfer_jit_paths() {
     # In venv mode, FlashInfer JIT writes build.ninja with hardcoded -isystem
     # paths. Per-job venvs get unique paths, but the JIT cache is shared on the
@@ -488,6 +540,7 @@ main() {
     install_sglang_kernel
     install_sglang_router
     download_flashinfer_cache
+    fix_cutlass_dsl_libs
     stabilize_flashinfer_jit_paths
     install_extra_deps
     install_test_tools


### PR DESCRIPTION
## Problem

`nvidia-cutlass-dsl[cu13]` has **additive extras** on PyPI: both `-libs-base` AND `-libs-cu13` are installed together when `[cu13]` is requested. They write to the same `site-packages` paths with different content, causing a `GPUModuleOp TypeError` at kernel-compile time ([vllm-project/vllm#40082](https://github.com/vllm-project/vllm/issues/40082)).

The correct libs package to keep depends on GPU family:

| Runner | Required libs | Why |
|--------|--------------|-----|
| Blackwell (IS_BLACKWELL=1, CU13) | `-libs-cu13` wins | Provides sm_110 arch alias missing in CUDA-12.9-built `-libs-base` |
| Non-Blackwell CU13 (H100, H200) | `-libs-base` wins | `-libs-cu13` causes `CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS` in LoRA CUDA-graph capture ([#25743](https://github.com/sgl-project/sglang/issues/25743)) |
| Non-CU13 | No-op | Only `-libs-base` installed, no conflict |

## History

- **#25690** added `purge_cutlass_libs_base()` (remove `-libs-base`, reinstall `-libs-cu13`) — fixed GB300 but caused H100 LoRA regression
- **#25756** removed the purge to fix H100 LoRA — re-introduced the `GPUModuleOp` TypeError
- **#25576** bumped to 4.5.1 hoping the new version would fix the conflict — did not help (packaging issue, version-independent)
- **#25935** reverted to 4.5.0 — also does not fix it (same root cause in both versions)

## Changes

Add `fix_cutlass_dsl_libs()` called from `main()` after `download_flashinfer_cache`:

- **IS_BLACKWELL=1, CU13**: purge `-libs-base`, force-reinstall `-libs-cu13` → sm_110 support
- **IS_BLACKWELL=0, CU13**: purge `-libs-cu13`, force-reinstall `-libs-base` → no TypeError, no LoRA regression
- **Non-CU13**: early return, no-op

## Test Plan

- H100 CI (`base-b-test-*-gpu-large`): eagle tests should pass (no more `GPUModuleOp` TypeError), LoRA tests should remain green
- B200/GB300 CI (`base-b-test-*-gpu-b200`): sm_110 alias supported, cutlass import works

🤖 Generated with [Claude Code](https://claude.com/claude-code)





































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26208799937](https://github.com/sgl-project/sglang/actions/runs/26208799937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26208799771](https://github.com/sgl-project/sglang/actions/runs/26208799771)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->