### PR TITLE
[codex] Optimize VLM preprocessed input path

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -83,6 +83,7 @@ dependencies = [
   "xgrammar==0.2.0",
   "smg-grpc-servicer>=0.5.0",
   "kernels",
+  "xxhash",
 ]
 
 [[tool.uv.index]]

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -68,6 +68,7 @@ dependencies = [
   "uvloop",
   "xgrammar==0.2.0",
   "smg-grpc-servicer>=0.5.0",
+  "xxhash",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -64,6 +64,7 @@ dependencies = [
   "uvloop",
   "xgrammar==0.2.0",
   "smg-grpc-servicer>=0.5.0",
+  "xxhash",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -64,6 +64,7 @@ runtime_common = [
   "uvloop",
   "xgrammar==0.2.0",
   "smg-grpc-servicer>=0.5.0",
+  "xxhash",
 ]
 
 diffusion_common = [

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -68,6 +68,7 @@ dependencies = [
   "uvloop",
   # "xgrammar==0.2.0", xgrammar depends on CUDA PyTorch and Triton only
   "smg-grpc-servicer>=0.5.0",
+  "xxhash",
 ]
 
 [project.optional-dependencies]

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -10,17 +10,126 @@ once the gRPC request manager is ready, regardless of whether --enable-metrics
 is set.
 """
 
+import copy
 import inspect
 import json
 import logging
+import os
 import time
 
 from aiohttp import web
 
-from sglang.srt.managers.io_struct import ProfileReq, ProfileReqType
+from sglang.srt.managers.io_struct import (
+    ProfileReq,
+    ProfileReqType,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.managers.schedule_batch import MultimodalProcessorOutput
+from sglang.srt.server_args import set_global_server_args_for_tokenizer
 from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_GRPC_MAX_MESSAGE_MB = 512
+
+
+def _grpc_max_message_bytes() -> int:
+    raw = os.environ.get("SGLANG_GRPC_MAX_MESSAGE_MB")
+    if raw is None:
+        return _DEFAULT_GRPC_MAX_MESSAGE_MB * 1024 * 1024
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid SGLANG_GRPC_MAX_MESSAGE_MB=%r; falling back to %dMB",
+            raw,
+            _DEFAULT_GRPC_MAX_MESSAGE_MB,
+        )
+        value = _DEFAULT_GRPC_MAX_MESSAGE_MB
+    return max(value, 1) * 1024 * 1024
+
+
+def _with_grpc_message_size_options(options, max_message_bytes: int):
+    keys = {"grpc.max_send_message_length", "grpc.max_receive_message_length"}
+    merged = [(k, v) for k, v in (options or []) if k not in keys]
+    merged.extend(
+        [
+            ("grpc.max_send_message_length", max_message_bytes),
+            ("grpc.max_receive_message_length", max_message_bytes),
+        ]
+    )
+    return merged
+
+
+def _patch_grpc_message_size_options() -> None:
+    import grpc
+
+    if getattr(grpc, "_sglang_message_size_options_patched", False):
+        return
+
+    max_message_bytes = _grpc_max_message_bytes()
+    original_aio_server = grpc.aio.server
+    original_insecure_channel = grpc.insecure_channel
+
+    def aio_server_with_message_size(*args, **kwargs):
+        if "options" in kwargs:
+            kwargs["options"] = _with_grpc_message_size_options(
+                kwargs["options"], max_message_bytes
+            )
+        elif len(args) >= 4:
+            args = list(args)
+            args[3] = _with_grpc_message_size_options(args[3], max_message_bytes)
+        else:
+            kwargs["options"] = _with_grpc_message_size_options(
+                None, max_message_bytes
+            )
+        return original_aio_server(*args, **kwargs)
+
+    def insecure_channel_with_message_size(target, options=None, *args, **kwargs):
+        options = _with_grpc_message_size_options(options, max_message_bytes)
+        return original_insecure_channel(target, options, *args, **kwargs)
+
+    grpc.aio.server = aio_server_with_message_size
+    grpc.insecure_channel = insecure_channel_with_message_size
+    grpc._sglang_message_size_options_patched = True
+
+
+def _patch_grpc_request_manager_shm_transport() -> None:
+    from smg_grpc_servicer.sglang import request_manager as grpc_request_manager
+
+    cls = grpc_request_manager.GrpcRequestManager
+    original_send = cls._send_to_scheduler
+    if getattr(original_send, "_sglang_wraps_shm_features", False):
+        return
+
+    from sglang.srt.managers.mm_utils import wrap_shm_features
+
+    def copy_multimodal_request(obj):
+        if not isinstance(obj, TokenizedGenerateReqInput) or obj.mm_inputs is None:
+            return obj
+
+        copied = copy.copy(obj)
+        copied.mm_inputs = copy.copy(obj.mm_inputs)
+        copied.mm_inputs.mm_items = [
+            copy.copy(item) for item in copied.mm_inputs.mm_items
+        ]
+        for item in copied.mm_inputs.mm_items:
+            item.set_pad_value()
+        copied.mm_inputs.padded_input_ids = (
+            MultimodalProcessorOutput.build_padded_input_ids(
+                copied.input_ids, copied.mm_inputs.mm_items
+            )
+        )
+        return copied
+
+    async def send_to_scheduler_with_shm(self, obj):
+        if obj is not None:
+            obj = copy_multimodal_request(obj)
+            obj = wrap_shm_features(obj)
+        return await original_send(self, obj)
+
+    send_to_scheduler_with_shm._sglang_wraps_shm_features = True
+    cls._send_to_scheduler = send_to_scheduler_with_shm
 
 
 async def _start_sidecar_server(host: str, port: int, app):
@@ -164,6 +273,10 @@ async def serve_grpc(server_args, model_info=None):
             "If already installed, there may be a broken import due to a "
             "version mismatch — see the chained exception above for details."
         ) from e
+
+    set_global_server_args_for_tokenizer(server_args)
+    _patch_grpc_message_size_options()
+    _patch_grpc_request_manager_shm_transport()
 
     sidecar_app = web.Application()
     sidecar_runner = None

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -1,4 +1,5 @@
 import contextlib
+import inspect
 import logging
 import platform
 from typing import Optional, Tuple
@@ -29,6 +30,8 @@ logger = logging.getLogger(__name__)
 
 _flashinfer_comm = None
 _TorchDistBackend = None
+_flashinfer_create_workspace_supports_group = False
+_flashinfer_allreduce_supports_trigger_completion = False
 _flashinfer_allreduce_unavailable = False
 _posix_transport_override_logged = False
 
@@ -106,6 +109,15 @@ if is_flashinfer_available():
             comm, "create_allreduce_fusion_workspace"
         ):
             _flashinfer_comm = comm
+            _flashinfer_create_workspace_supports_group = (
+                "group" in inspect.signature(
+                    comm.create_allreduce_fusion_workspace
+                ).parameters
+            )
+            _flashinfer_allreduce_supports_trigger_completion = (
+                "trigger_completion_at_end"
+                in inspect.signature(comm.allreduce_fusion).parameters
+            )
         else:
             _flashinfer_allreduce_unavailable = True
             logger.warning(
@@ -383,12 +395,11 @@ class FlashInferWorkspaceManager:
                 hidden_dim=hidden_dim,
                 dtype=dtype,
                 force_oneshot_support=bool(use_oneshot),
-                # Pin the symmetric-memory rendezvous to the actual
-                # subgroup. Without this, flashinfer >=0.6.10 falls back
-                # to WORLD and TP/EP/CP subgroup peers get addressed
-                # incorrectly (kernel hangs in cuda-graph warmup).
-                group=device_group,
             )
+            if _flashinfer_create_workspace_supports_group:
+                # Pin rendezvous to the actual subgroup on FlashInfer versions
+                # whose workspace API accepts an explicit process group
+                kwargs["group"] = device_group
             if (
                 _TorchDistBackend is not None
                 and device_group is not None
@@ -669,12 +680,11 @@ def flashinfer_allreduce_residual_rmsnorm(
     norm_out = torch.empty_like(input_tensor)
 
     workspace_manager = _get_workspace_manager(use_attn_tp_group)
-    _flashinfer_comm.allreduce_fusion(
+    kwargs = dict(
         input=input_tensor,
         workspace=workspace_manager.workspace,
         pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
         launch_with_pdl=True,
-        trigger_completion_at_end=trigger_completion_at_end,
         residual_out=residual_out,
         norm_out=norm_out,
         residual_in=residual,
@@ -683,6 +693,9 @@ def flashinfer_allreduce_residual_rmsnorm(
         use_oneshot=use_oneshot,
         fp32_acc=fp32_acc,
     )
+    if _flashinfer_allreduce_supports_trigger_completion:
+        kwargs["trigger_completion_at_end"] = trigger_completion_at_end
+    _flashinfer_comm.allreduce_fusion(**kwargs)
 
     return norm_out, residual_out
 

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1582,14 +1582,14 @@ class ShmPointerMMData:
         )
 
     def materialize(self) -> torch.Tensor:
-        """Clone tensor from shm to owned memory, then release shm handle."""
-        tensor = self.tensor.clone()
+        """Return a tensor view backed by shm, then unlink the shared name."""
+        tensor = self.tensor
         if self._shm_handle is not None:
-            self._shm_handle.close()
             try:
                 self._shm_handle.unlink()
             except FileNotFoundError:
                 pass  # Another rank already unlinked
+            tensor._sglang_shm_handle = self._shm_handle
             self._shm_handle = None
         return tensor
 

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -319,10 +319,13 @@ class MultiModalityDataPaddingPatternMultimodalTokens(MultiModalityDataPaddingPa
         Replaces multimodal tokens in input_ids with corresponding pad_values from mm_items.
         Each modality (image, audio, video) is handled separately based on its token_id.
         """
-        if not input_ids or not mm_inputs.mm_items:
+        if input_ids is None or len(input_ids) == 0 or not mm_inputs.mm_items:
             return input_ids
 
-        input_ids_tensor = torch.as_tensor(input_ids)
+        if isinstance(input_ids, torch.Tensor):
+            padded_input_ids = input_ids.flatten().tolist()
+        else:
+            padded_input_ids = list(input_ids)
 
         # Replace multimodal tokens using per-item offsets
         items_by_modality = defaultdict(list)
@@ -343,10 +346,11 @@ class MultiModalityDataPaddingPatternMultimodalTokens(MultiModalityDataPaddingPa
 
             for i, item in enumerate(items):
                 for offset in items[i].offsets:
-                    input_ids_tensor[offset[0] : offset[1] + 1] = item.pad_value
+                    padded_input_ids[offset[0] : offset[1] + 1] = [item.pad_value] * (
+                        offset[1] - offset[0] + 1
+                    )
 
-        ret_input_ids = input_ids_tensor.tolist()
-        return ret_input_ids
+        return padded_input_ids
 
 
 embedding_cache: Optional[MultiModalStaticCache] = None

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -463,21 +463,35 @@ DataEmbeddingFunc = Callable[
 ]
 
 
-def _embedder_handles_feature_device(data_embedding_func: DataEmbeddingFunc) -> bool:
+_QWEN_VL_FEATURE_EMBEDDER_METHOD_NAMES = {"get_image_feature", "get_video_feature"}
+_QWEN_VL_FEATURE_EMBEDDER_OWNER_NAMES = {
+    "Qwen3VLForConditionalGeneration",
+    "Qwen3VLMoeForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+}
+
+
+def _is_qwen_vl_feature_embedder(data_embedding_func: DataEmbeddingFunc) -> bool:
     owner = getattr(data_embedding_func, "__self__", None)
     if owner is None:
         return False
-    if getattr(data_embedding_func, "__name__", None) not in (
-        "get_image_feature",
-        "get_video_feature",
+    if (
+        getattr(data_embedding_func, "__name__", None)
+        not in _QWEN_VL_FEATURE_EMBEDDER_METHOD_NAMES
     ):
         return False
-    return owner.__class__.__name__ in {
-        "Qwen3VLForConditionalGeneration",
-        "Qwen3VLMoeForConditionalGeneration",
-        "Qwen3_5ForConditionalGeneration",
-        "Qwen3_5MoeForConditionalGeneration",
-    }
+    return owner.__class__.__name__ in _QWEN_VL_FEATURE_EMBEDDER_OWNER_NAMES
+
+
+def _embedder_handles_feature_device(data_embedding_func: DataEmbeddingFunc) -> bool:
+    return _is_qwen_vl_feature_embedder(data_embedding_func)
+
+
+def _embedder_supports_offset_placement(
+    data_embedding_func: DataEmbeddingFunc,
+) -> bool:
+    return _is_qwen_vl_feature_embedder(data_embedding_func)
 
 
 def _move_items_to_device(
@@ -519,14 +533,15 @@ def _get_chunked_embedding_full(
 
     if isinstance(embedding_per_req, EVSEmbeddingResult):
         item = embedding_items_per_req[0]
-        input_ids, items_offset = (
-            embedding_per_req.redistribute_pruned_frames_placeholders(
-                input_ids,
-                items_offset,
-                item=item,
-                extend_prefix_len=extend_prefix_len,
-                extend_seq_len=extend_seq_len,
-            )
+        (
+            input_ids,
+            items_offset,
+        ) = embedding_per_req.redistribute_pruned_frames_placeholders(
+            input_ids,
+            items_offset,
+            item=item,
+            extend_prefix_len=extend_prefix_len,
+            extend_seq_len=extend_seq_len,
         )
 
     embedding_per_req_chunk, _, _ = get_embedding_chunk(
@@ -714,6 +729,47 @@ def _adjust_embedding_length(
     return embedding
 
 
+def _get_multimodal_indices_from_offsets(
+    items_size: List[int],
+    prefix_length: List[int],
+    extend_length: List[int],
+    items_offset_list: List[List[Tuple[int, int]]],
+    input_token_starts: Optional[List[int]],
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    if input_token_starts is None:
+        return None
+
+    indices = []
+    max_iterations = min(
+        len(items_size) - 1, len(prefix_length), len(input_token_starts)
+    )
+    for i in range(max_iterations):
+        if items_size[i] == items_size[i + 1]:
+            continue
+
+        extend_len = extend_length[i] if i < len(extend_length) else 0
+        if extend_len <= 0:
+            continue
+
+        chunk_start = prefix_length[i]
+        chunk_end = chunk_start + extend_len - 1
+        token_start = input_token_starts[i]
+        for start, end in items_offset_list[i]:
+            overlap_start = max(start, chunk_start)
+            overlap_end = min(end, chunk_end)
+            if overlap_start > overlap_end:
+                continue
+
+            local_start = token_start + overlap_start - chunk_start
+            local_end = token_start + overlap_end - chunk_start + 1
+            indices.extend(range(local_start, local_end))
+
+    if not indices:
+        return None
+    return torch.tensor(indices, dtype=torch.long, device=device)
+
+
 def get_embedding_and_mask(
     data_embedding_func: DataEmbeddingFunc,
     embedding_items: List[MultimodalDataItem],
@@ -723,7 +779,9 @@ def get_embedding_and_mask(
     prefix_length: List[int],
     extend_length: List[int],
     items_offset_list: List[List[Tuple[int, int]]],
-) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor]:
+    input_token_starts: Optional[List[int]] = None,
+    use_offset_placement: bool = False,
+) -> Tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor, torch.Tensor | None]:
     """
     Generate multimodal embeddings and create a mask for identifying their positions in the input sequence.
 
@@ -758,14 +816,31 @@ def get_embedding_and_mask(
             input_ids,
         )
         if embedding is None:
-            return None, None, input_ids
+            return None, None, input_ids, None
+
+    placement_indices = None
+    if use_offset_placement:
+        placement_indices = _get_multimodal_indices_from_offsets(
+            items_size=items_size,
+            prefix_length=prefix_length,
+            extend_length=extend_length,
+            items_offset_list=items_offset_list,
+            input_token_starts=input_token_starts,
+            device=input_ids.device,
+        )
+        if (
+            placement_indices is not None
+            and placement_indices.shape[0] == embedding.shape[0]
+        ):
+            return embedding, None, input_ids, placement_indices
+
     # 2. Get mask
     if _is_npu:
         torch.npu.current_stream().synchronize()
     special_multimodal_mask = _get_multimodal_mask(input_ids, placeholder_tensor)
     # 3. Adjust embedding length if needed
     embedding = _adjust_embedding_length(embedding, special_multimodal_mask, logger)
-    return embedding, special_multimodal_mask, input_ids
+    return embedding, special_multimodal_mask, input_ids, None
 
 
 def embed_mm_inputs(
@@ -778,6 +853,7 @@ def embed_mm_inputs(
     data_embedding_func_mapping: Dict[Modality, DataEmbeddingFunc] = None,
     placeholder_tokens: dict[Modality, List[int]] = None,
     use_deepstack: Dict[Modality, bool] = {},
+    input_token_starts: Optional[List[int]] = None,
 ) -> Optional[torch.Tensor]:
     """
     Embed multimodal inputs and integrate them with text token embeddings.
@@ -804,7 +880,13 @@ def embed_mm_inputs(
         item_flatten_list += [item for item in mm_inputs.mm_items if item is not None]
 
     # deepstack_embeddings: per-modality
-    modalities, embeddings, masks, deepstack_embeddings = [], [], [], []
+    modalities, embeddings, masks, placement_indices, deepstack_embeddings = (
+        [],
+        [],
+        [],
+        [],
+        [],
+    )
 
     # 2. Get multimodal embedding separately
     # Try get mm embedding if any
@@ -842,7 +924,7 @@ def embed_mm_inputs(
                 )
             items_size = torch.cumsum(items_size, dim=0).tolist()
 
-            embedding, mask, input_ids = get_embedding_and_mask(
+            embedding, mask, input_ids, indices = get_embedding_and_mask(
                 data_embedding_func=embedder,
                 embedding_items=items,
                 placeholder_tensor=placeholder_tensor,
@@ -851,18 +933,22 @@ def embed_mm_inputs(
                 prefix_length=extend_prefix_lens,
                 extend_length=extend_seq_lens,
                 items_offset_list=items_offsets,
+                input_token_starts=input_token_starts,
+                use_offset_placement=_embedder_supports_offset_placement(embedder),
             )
 
             if use_deepstack.get(modality, None) and embedding is not None:
-                embedding, deepstack_embedding = (
-                    multimodal_model.separate_deepstack_embeds(embedding)
-                )
+                (
+                    embedding,
+                    deepstack_embedding,
+                ) = multimodal_model.separate_deepstack_embeds(embedding)
                 deepstack_embeddings += [deepstack_embedding]
             else:
                 deepstack_embeddings += [None]
             modalities += [modality]
             embeddings += [embedding]
             masks += [mask]
+            placement_indices += [indices]
 
     # 3. Get input embeddings
     vocab_size = input_embedding.num_embeddings
@@ -890,14 +976,24 @@ def embed_mm_inputs(
         other_info["input_deepstack_embeds"] = input_deepstack_embeds
 
     # 4. scatter embeddings into input embedding
-    for i, modality, embedding, mask in zip(
-        range(len(embeddings)), modalities, embeddings, masks
+    for i, modality, embedding, mask, indices in zip(
+        range(len(embeddings)), modalities, embeddings, masks, placement_indices
     ):
-        if embedding is None or mask is None:
+        if embedding is None:
+            continue
+        embedding = embedding.to(input_embeds.device, input_embeds.dtype)
+        if indices is not None:
+            input_embeds[indices] = embedding
+            if use_deepstack.get(modality, None):
+                input_deepstack_embeds[indices] = deepstack_embeddings[i].to(
+                    input_embeds.device, input_embeds.dtype
+                )
+            continue
+        if mask is None:
             continue
         # in-place update
         indices = torch.where(mask.squeeze(dim=-1))[0]
-        input_embeds[indices] = embedding.to(input_embeds.device, input_embeds.dtype)
+        input_embeds[indices] = embedding
         if use_deepstack.get(modality, None):
             input_deepstack_embeds[indices] = deepstack_embeddings[i].to(
                 input_embeds.device, input_embeds.dtype
@@ -917,6 +1013,7 @@ def _embed_mm_inputs_with_split(
     data_embedding_func_mapping: Dict[Modality, DataEmbeddingFunc] = None,
     placeholder_tokens: dict[Modality, List[int]] = None,
     use_deepstack: Dict[Modality, bool] = {},
+    input_token_starts: Optional[List[int]] = None,
 ):
     """Split batch into precomputed vs non-precomputed, embed each group, merge back."""
     precomputed_req_indices = []
@@ -944,6 +1041,7 @@ def _embed_mm_inputs_with_split(
             extend_prefix_lens=extend_prefix_lens,
             extend_seq_lens=extend_seq_lens,
             input_ids=input_ids,
+            input_token_starts=input_token_starts,
             **embed_kwargs,
         )
 
@@ -982,12 +1080,18 @@ def _embed_mm_inputs_with_split(
             for bi in group_batch_indices
         ]
         sub_input_ids = torch.cat(sub_slices)
+        sub_token_starts = []
+        sub_token_offset = 0
+        for bi in group_batch_indices:
+            sub_token_starts.append(sub_token_offset)
+            sub_token_offset += all_seq_lens[bi]
 
         sub_embeds, sub_info = embed_mm_inputs(
             mm_inputs_list=sub_mm_inputs,
             extend_prefix_lens=sub_prefix_lens,
             extend_seq_lens=sub_seq_lens,
             input_ids=sub_input_ids,
+            input_token_starts=sub_token_starts,
             **embed_kwargs,
         )
 
@@ -1046,6 +1150,16 @@ def general_mm_embed_routine(
             mm_inputs_list = [
                 mm_input for mm_input in forward_batch.mm_inputs if mm_input is not None
             ]
+            token_starts = []
+            token_offset = 0
+            for seq_len in forward_batch.extend_seq_lens_cpu:
+                token_starts.append(token_offset)
+                token_offset += seq_len
+            mm_input_token_starts = [
+                token_starts[i]
+                for i, mm_input in enumerate(forward_batch.mm_inputs)
+                if mm_input is not None
+            ]
             extend_prefix_lens = [
                 prefix_len
                 for i, prefix_len in enumerate(forward_batch.extend_prefix_lens_cpu)
@@ -1070,6 +1184,7 @@ def general_mm_embed_routine(
                     data_embedding_func_mapping=data_embedding_funcs,
                     placeholder_tokens=placeholder_tokens,
                     use_deepstack=use_deepstack,
+                    input_token_starts=mm_input_token_starts,
                 )
             else:
                 input_embeds, other_info = embed_mm_inputs(
@@ -1082,6 +1197,7 @@ def general_mm_embed_routine(
                     data_embedding_func_mapping=data_embedding_funcs,
                     placeholder_tokens=placeholder_tokens,
                     use_deepstack=use_deepstack,
+                    input_token_starts=mm_input_token_starts,
                 )
 
             # add for qwen3_vl deepstack

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -910,19 +910,18 @@ def embed_mm_inputs(
                 device=input_ids.device,
             )
             # calculate per request items length offset
-            items_size = torch.zeros(len(mm_inputs_list) + 1, dtype=int)
+            items_size = [0]
             items_offsets = []
-            for i, mm_inputs in enumerate(mm_inputs_list):
+            for mm_inputs in mm_inputs_list:
                 mm_items = [
                     item
                     for item in mm_inputs.mm_items
                     if item.is_modality(modality=modality)
                 ]
-                items_size[i + 1] = len(mm_items)
+                items_size.append(items_size[-1] + len(mm_items))
                 items_offsets.append(
                     flatten_nested_list([item.offsets for item in mm_items])
                 )
-            items_size = torch.cumsum(items_size, dim=0).tolist()
 
             embedding, mask, input_ids, indices = get_embedding_and_mask(
                 data_embedding_func=embedder,

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -463,6 +463,23 @@ DataEmbeddingFunc = Callable[
 ]
 
 
+def _embedder_handles_feature_device(data_embedding_func: DataEmbeddingFunc) -> bool:
+    owner = getattr(data_embedding_func, "__self__", None)
+    if owner is None:
+        return False
+    if getattr(data_embedding_func, "__name__", None) not in (
+        "get_image_feature",
+        "get_video_feature",
+    ):
+        return False
+    return owner.__class__.__name__ in {
+        "Qwen3VLForConditionalGeneration",
+        "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+
+
 def _move_items_to_device(
     items: List[MultimodalDataItem], device: torch.device
 ) -> None:
@@ -490,7 +507,8 @@ def _get_chunked_embedding_full(
     embedding_per_req = embedding_cache.get(item_hashes)
 
     if embedding_per_req is None:
-        _move_items_to_device(embedding_items_per_req, device)
+        if not _embedder_handles_feature_device(data_embedding_func):
+            _move_items_to_device(embedding_items_per_req, device)
         embedding = data_embedding_func(embedding_items_per_req)
         embedding_per_req = (
             EmbeddingResult(embedding=embedding)
@@ -563,7 +581,8 @@ def _get_chunked_embedding_by_item(
     # 3. Batch encode all cache-miss items in one ViT call
     if miss_items:
         miss_item_list = [item for _, item, _, _ in miss_items]
-        _move_items_to_device(miss_item_list, device)
+        if not _embedder_handles_feature_device(data_embedding_func):
+            _move_items_to_device(miss_item_list, device)
         all_miss_embedding = data_embedding_func(miss_item_list)
         all_miss_embedding = all_miss_embedding.reshape(
             -1, all_miss_embedding.shape[-1]

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -1297,6 +1297,24 @@ def _slice_value(value, start, end):
         return value
 
 
+def _grid_rows_to_cpu_list(value):
+    if isinstance(value, torch.Tensor):
+        value = value.detach()
+        if value.device.type != "cpu":
+            value = value.cpu()
+        return value.tolist()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    return value
+
+
+def _prod_grid_values(grid):
+    result = 1
+    for value in grid:
+        result *= int(value)
+    return result
+
+
 def _slice_model_data(
     data: dict,
     index: int,
@@ -1382,10 +1400,10 @@ def get_new_expanded_mm_items(original_mm_items):
                         expanded_mm_items.append(item)
                     continue
 
+                image_grid_rows = _grid_rows_to_cpu_list(image_grid_thw)
                 patches_per_item = []
-                for grid in image_grid_thw:
-                    grid_tensor = torch.as_tensor(grid, dtype=torch.long)
-                    patches_per_item.append(int(torch.prod(grid_tensor).item()))
+                for grid in image_grid_rows:
+                    patches_per_item.append(_prod_grid_values(grid))
 
                 cumulative = torch.cumsum(
                     torch.tensor(patches_per_item, dtype=torch.long), dim=0
@@ -1433,17 +1451,14 @@ def get_new_expanded_mm_items(original_mm_items):
                 # grid_len = num_videos, num_items = sum(T for each video) = total frames
                 grid_len = _get_length(video_grid_thw)
                 num_videos = grid_len
+                video_grid_rows = _grid_rows_to_cpu_list(video_grid_thw)
 
                 # Calculate total frames and frames per video
                 frames_per_video = []
                 total_frames = 0
                 for i in range(num_videos):
-                    grid = video_grid_thw[i]
-                    if isinstance(grid, torch.Tensor):
-                        T = int(grid[0].item())  # T is the first element [T, H, W]
-                    else:
-                        grid_tensor = torch.as_tensor(grid, dtype=torch.long)
-                        T = int(grid_tensor[0].item())
+                    grid = video_grid_rows[i]
+                    T = int(grid[0])  # T is the first element [T, H, W]
                     frames_per_video.append(T)
                     total_frames += T
 
@@ -1455,12 +1470,8 @@ def get_new_expanded_mm_items(original_mm_items):
                 # Calculate patches per video: T * H * W for each video
                 patches_per_video = []
                 for i in range(num_videos):
-                    grid = video_grid_thw[i]
-                    if isinstance(grid, torch.Tensor):
-                        patches_per_video.append(int(torch.prod(grid).item()))
-                    else:
-                        grid_tensor = torch.as_tensor(grid, dtype=torch.long)
-                        patches_per_video.append(int(torch.prod(grid_tensor).item()))
+                    grid = video_grid_rows[i]
+                    patches_per_video.append(_prod_grid_values(grid))
 
                 # Calculate cumulative patches to get slice indices for each video
                 cumulative = torch.cumsum(

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -45,6 +45,12 @@ _GPU_FEATURE_BUFFER: Optional[torch.Tensor] = None
 _BUFFER_OFFSET = 0
 
 _is_default_tensor_transport = None
+_SHM_TOP_LEVEL_TENSOR_MIN_BYTES = 4096
+_SHM_MM_INPUT_TENSOR_FIELDS = (
+    "mrope_positions",
+    "vision_position_ids",
+    "visible_frame_counts",
+)
 
 
 def init_feature_buffer(device):
@@ -1747,17 +1753,37 @@ def _get_is_default_transport():
     return _is_default_tensor_transport
 
 
-def _wrap_tensor_or_list(value):
+def _should_wrap_tensor(value, min_nbytes: int) -> bool:
+    return (
+        isinstance(value, torch.Tensor)
+        and value.is_cpu
+        and value.numel() > 0
+        and value.numel() * value.element_size() >= min_nbytes
+    )
+
+
+def _wrap_tensor_or_list(value, min_nbytes: int = 0):
     """Wrap a CPU tensor (or list of CPU tensors) in ShmPointerMMData."""
-    if isinstance(value, torch.Tensor) and value.is_cpu:
+    if _should_wrap_tensor(value, min_nbytes):
         return ShmPointerMMData(value)
     elif isinstance(value, (list, tuple)):
         wrapped = [
-            (ShmPointerMMData(t) if isinstance(t, torch.Tensor) and t.is_cpu else t)
+            (ShmPointerMMData(t) if _should_wrap_tensor(t, min_nbytes) else t)
             for t in value
         ]
         return type(value)(wrapped) if isinstance(value, tuple) else wrapped
     return value
+
+
+def _wrap_mm_input_tensor_fields(mm_inputs) -> None:
+    for field in _SHM_MM_INPUT_TENSOR_FIELDS:
+        value = getattr(mm_inputs, field, None)
+        if value is not None:
+            setattr(
+                mm_inputs,
+                field,
+                _wrap_tensor_or_list(value, _SHM_TOP_LEVEL_TENSOR_MIN_BYTES),
+            )
 
 
 def wrap_shm_features(obj):
@@ -1778,6 +1804,7 @@ def wrap_shm_features(obj):
                 item.precomputed_embeddings = _wrap_tensor_or_list(
                     item.precomputed_embeddings
                 )
+        _wrap_mm_input_tensor_fields(obj.mm_inputs)
     return obj
 
 
@@ -1801,6 +1828,9 @@ def has_shm_features(recv_reqs):
                 if _feature_has_shm(item.feature):
                     return True
                 if _feature_has_shm(getattr(item, "precomputed_embeddings", None)):
+                    return True
+            for field in _SHM_MM_INPUT_TENSOR_FIELDS:
+                if _feature_has_shm(getattr(req.mm_inputs, field, None)):
                     return True
     return False
 
@@ -1841,4 +1871,8 @@ def unwrap_shm_features(obj):
                 item.precomputed_embeddings = _unwrap_tensor_or_list(
                     item.precomputed_embeddings
                 )
+        for field in _SHM_MM_INPUT_TENSOR_FIELDS:
+            value = getattr(obj.mm_inputs, field, None)
+            if value is not None:
+                setattr(obj.mm_inputs, field, _unwrap_tensor_or_list(value))
     return obj

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -3,7 +3,6 @@ Multi-modality utils
 """
 
 import copy
-import hashlib
 import pickle
 from abc import abstractmethod
 from collections import defaultdict
@@ -12,6 +11,7 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 import numpy as np
 import torch
+import xxhash
 from torch import nn
 
 from sglang.srt.environ import envs
@@ -1317,8 +1317,7 @@ def get_multimodal_data_bounds(
 
 
 def data_hash(data) -> int:
-    hash_bytes = hashlib.sha256(data).digest()[:8]
-    return int.from_bytes(hash_bytes, byteorder="big", signed=False)
+    return xxhash.xxh3_64_intdigest(data)
 
 
 def tensor_hash(tensor_list) -> int:
@@ -1336,21 +1335,17 @@ def tensor_hash(tensor_list) -> int:
             tensor = torch.concat(tensors)
             return gpu_tensor_hash(tensor.cuda())
         # CPU path: hash each tensor incrementally without concat
-        hasher = hashlib.sha256()
+        hasher = xxhash.xxh3_64()
         for t in tensors:
             t = t.detach().contiguous()
             hasher.update(memoryview(t.view(torch.uint8).numpy()))
-        hash_bytes = hasher.digest()[:8]
-        return int.from_bytes(hash_bytes, byteorder="big", signed=False)
+        return hasher.intdigest()
 
     # Single tensor
     if tensor.is_cuda:
         return gpu_tensor_hash(tensor.cuda())
     tensor = tensor.detach().contiguous()
-    hasher = hashlib.sha256()
-    hasher.update(memoryview(tensor.view(torch.uint8).numpy()))
-    hash_bytes = hasher.digest()[:8]
-    return int.from_bytes(hash_bytes, byteorder="big", signed=False)
+    return xxhash.xxh3_64_intdigest(memoryview(tensor.view(torch.uint8).numpy()))
 
 
 def hash_feature(f):
@@ -1360,10 +1355,7 @@ def hash_feature(f):
         return data_hash(tuple(flatten_nested_list(f)))
     elif isinstance(f, np.ndarray):
         arr = np.ascontiguousarray(f)
-        hasher = hashlib.sha256()
-        hasher.update(memoryview(arr))
-        hash_bytes = hasher.digest()[:8]
-        return int.from_bytes(hash_bytes, byteorder="big", signed=False)
+        return xxhash.xxh3_64_intdigest(memoryview(arr))
     elif isinstance(f, torch.Tensor):
         return tensor_hash([f])
     elif isinstance(f, CudaIpcTensorTransportProxy):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -378,12 +378,13 @@ class MultimodalProcessorOutput:
 
     This is the typed replacement for the dict previously returned by
     ``BaseMultimodalProcessor.process_mm_data_async``.  Preprocessed inputs may
-    already carry ``pad_value`` and ``hash`` to avoid hashing the same tensor once
-    per scheduler TP rank.
+    already carry ``pad_value``/``hash`` and ``padded_input_ids`` to avoid
+    repeated scheduler work on each TP rank.
     """
 
     mm_items: List[MultimodalDataItem]
     input_ids: Optional[List[int]] = None
+    padded_input_ids: Optional[List[int]] = None
 
     # image
     im_token_id: Optional[int] = None
@@ -417,6 +418,7 @@ class MultimodalProcessorOutput:
         return MultimodalProcessorOutput(
             mm_items=d["mm_items"],
             input_ids=d.get("input_ids"),
+            padded_input_ids=d.get("padded_input_ids"),
             im_token_id=d.get("im_token_id"),
             im_start_id=d.get("im_start_id"),
             im_end_id=d.get("im_end_id"),
@@ -433,6 +435,27 @@ class MultimodalProcessorOutput:
             visible_frame_counts=d.get("visible_frame_counts"),
         )
 
+    @staticmethod
+    def build_padded_input_ids(input_ids, mm_items: List[MultimodalDataItem]):
+        if input_ids is None or not mm_items:
+            return None
+
+        for item in mm_items:
+            if item.pad_value is None or item.offsets is None:
+                return None
+
+        if isinstance(input_ids, torch.Tensor):
+            padded_input_ids = input_ids.flatten().tolist()
+        else:
+            padded_input_ids = list(input_ids)
+
+        for item in mm_items:
+            for start, end in item.offsets:
+                padded_input_ids[start : end + 1] = [item.pad_value] * (
+                    end - start + 1
+                )
+        return padded_input_ids
+
 
 @dataclasses.dataclass
 class MultimodalInputs:
@@ -440,6 +463,7 @@ class MultimodalInputs:
 
     # items of data
     mm_items: List[MultimodalDataItem]
+    padded_input_ids: Optional[List[int]] = None
     image_pad_len: Optional[list] = None
     num_image_tokens: Optional[int] = None
 
@@ -481,6 +505,7 @@ class MultimodalInputs:
 
         ret = MultimodalInputs(
             mm_items=mm_items,
+            padded_input_ids=obj.padded_input_ids,
         )
 
         assert isinstance(ret.mm_items, list)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -374,11 +374,12 @@ class MultimodalDataItem:
 
 @dataclasses.dataclass
 class MultimodalProcessorOutput:
-    """Raw output from multimodal processors, before pad/hash computation.
+    """Raw output from multimodal processors before scheduler-side preparation.
 
     This is the typed replacement for the dict previously returned by
-    ``BaseMultimodalProcessor.process_mm_data_async``.  Unlike
-    ``MultimodalInputs``, items here do NOT carry pad_value or hash yet.
+    ``BaseMultimodalProcessor.process_mm_data_async``.  Preprocessed inputs may
+    already carry ``pad_value`` and ``hash`` to avoid hashing the same tensor once
+    per scheduler TP rank.
     """
 
     mm_items: List[MultimodalDataItem]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -451,9 +451,7 @@ class MultimodalProcessorOutput:
 
         for item in mm_items:
             for start, end in item.offsets:
-                padded_input_ids[start : end + 1] = [item.pad_value] * (
-                    end - start + 1
-                )
+                padded_input_ids[start : end + 1] = [item.pad_value] * (end - start + 1)
         return padded_input_ids
 
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -342,7 +342,15 @@ class MultimodalDataItem:
         return ret
 
     def reconstruct(self):
-        if not isinstance(self.feature, CudaIpcTensorTransportProxy):
+        has_ipc_proxy = isinstance(
+            self.feature, CudaIpcTensorTransportProxy
+        ) or isinstance(self.precomputed_embeddings, CudaIpcTensorTransportProxy)
+        if not has_ipc_proxy:
+            has_ipc_proxy = any(
+                isinstance(value, CudaIpcTensorTransportProxy)
+                for value in self.model_specific_data.values()
+            )
+        if not has_ipc_proxy:
             return
 
         reconstruct_device = torch.cuda.current_device()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1922,9 +1922,10 @@ class Scheduler(
 
             # Expand a single image token into multiple dummy tokens for receiving image embeddings.
             # The pad function is model-specific and can be None for some backends.
-            if not self._try_apply_padded_mm_input_ids(
-                recv_req, req, image_inputs
-            ) and self.pad_input_ids_func:
+            if (
+                not self._try_apply_padded_mm_input_ids(recv_req, req, image_inputs)
+                and self.pad_input_ids_func
+            ):
                 req.origin_input_ids = self.pad_input_ids_func(
                     req.origin_input_ids, image_inputs
                 )
@@ -2197,9 +2198,10 @@ class Scheduler(
             # The `pad_input_ids_func` is model-specific and may be None for
             # embedding models or models not requiring special padding.
             # If None, `req.origin_input_ids` is expected to be correctly populated already.
-            if not self._try_apply_padded_mm_input_ids(
-                recv_req, req, image_inputs
-            ) and self.pad_input_ids_func:
+            if (
+                not self._try_apply_padded_mm_input_ids(recv_req, req, image_inputs)
+                and self.pad_input_ids_func
+            ):
                 req.origin_input_ids = self.pad_input_ids_func(
                     req.origin_input_ids, image_inputs
                 )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1733,6 +1733,28 @@ class Scheduler(
         else:
             return MultimodalInputs.from_processor_output(mm_inputs_dict)
 
+    @staticmethod
+    def _try_apply_padded_mm_input_ids(recv_req, req, image_inputs) -> bool:
+        padded_input_ids = image_inputs.padded_input_ids
+        if padded_input_ids is None or recv_req.input_ids is None:
+            return False
+
+        recv_input_len = len(recv_req.input_ids)
+        if len(padded_input_ids) != recv_input_len:
+            return False
+
+        prefix_len = len(req.origin_input_ids) - recv_input_len
+        if prefix_len < 0:
+            return False
+
+        if prefix_len == 0:
+            req.origin_input_ids = list(padded_input_ids)
+        else:
+            req.origin_input_ids = req.origin_input_ids[:prefix_len] + list(
+                padded_input_ids
+            )
+        return True
+
     def _maybe_compute_mrope_positions(self, req) -> None:
         """Compute M-RoPE positions when they are missing (e.g. gRPC preprocessed path)."""
         if self._mm_processor is None:
@@ -1898,10 +1920,11 @@ class Scheduler(
 
             SessionController.adjust_mm_offsets(recv_req, req, image_inputs)
 
-            # The following steps are already fast, execute locally on each rank.
             # Expand a single image token into multiple dummy tokens for receiving image embeddings.
             # The pad function is model-specific and can be None for some backends.
-            if self.pad_input_ids_func:
+            if not self._try_apply_padded_mm_input_ids(
+                recv_req, req, image_inputs
+            ) and self.pad_input_ids_func:
                 req.origin_input_ids = self.pad_input_ids_func(
                     req.origin_input_ids, image_inputs
                 )
@@ -2174,7 +2197,9 @@ class Scheduler(
             # The `pad_input_ids_func` is model-specific and may be None for
             # embedding models or models not requiring special padding.
             # If None, `req.origin_input_ids` is expected to be correctly populated already.
-            if self.pad_input_ids_func:
+            if not self._try_apply_padded_mm_input_ids(
+                recv_req, req, image_inputs
+            ) and self.pad_input_ids_func:
                 req.origin_input_ids = self.pad_input_ids_func(
                     req.origin_input_ids, image_inputs
                 )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1748,7 +1748,7 @@ class Scheduler(
             return False
 
         if prefix_len == 0:
-            req.origin_input_ids = list(padded_input_ids)
+            req.origin_input_ids = padded_input_ids
         else:
             req.origin_input_ids = req.origin_input_ids[:prefix_len] + list(
                 padded_input_ids

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1191,11 +1191,16 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
-        # in qwen-vl, last dim is the same
-        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
-            self.visual.dtype
+        pixel_values = (
+            items[0].feature
+            if len(items) == 1
+            else torch.cat([item.feature for item in items], dim=0)
         )
-        image_grid_thw = torch.concat([item.image_grid_thw for item in items], dim=0)
+        image_grid_thw = (
+            items[0].image_grid_thw
+            if len(items) == 1
+            else torch.concat([item.image_grid_thw for item in items], dim=0)
+        )
         assert pixel_values.dim() == 2, pixel_values.dim()
         assert image_grid_thw.dim() == 2, image_grid_thw.dim()
 
@@ -1210,11 +1215,16 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             return self.visual(pixel_values, grid_thw=image_grid_thw)
 
     def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
-        # in qwen-vl, last dim is the same
-        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
-            self.visual.dtype
+        pixel_values = (
+            items[0].feature
+            if len(items) == 1
+            else torch.cat([item.feature for item in items], dim=0)
         )
-        video_grid_thw = torch.concat([item.video_grid_thw for item in items], dim=0)
+        video_grid_thw = (
+            items[0].video_grid_thw
+            if len(items) == 1
+            else torch.concat([item.video_grid_thw for item in items], dim=0)
+        )
         assert pixel_values.dim() == 2, pixel_values.dim()
         assert video_grid_thw.dim() == 2, video_grid_thw.dim()
         if self.use_data_parallel:

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -756,7 +756,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                 return self.forward_with_npu_graph(x, grid_thw)
             return self.forward_with_cuda_graph(x, grid_thw)
 
-        x = x.to(device=self.device, dtype=self.dtype)
+        x = x.to(device=self.device, dtype=self.dtype, non_blocking=True)
         x = self.patch_embed(x)
 
         if isinstance(grid_thw, list):
@@ -938,7 +938,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
         torch.Tensor,
     ]:
         # patchify
-        x = x.to(device=self.device, dtype=self.dtype)
+        x = x.to(device=self.device, dtype=self.dtype, non_blocking=True)
         x = self.patch_embed(x)
 
         if isinstance(grid_thw, list):

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -985,9 +985,12 @@ class BaseMultimodalProcessor(ABC):
                     modality, raw_data, frame_limit = next(task_info_iter)
                     result = next(futures_iter).result()
 
-                    is_precomputed, new_imgs, new_vids, new_auds = (
-                        self._process_loaded_mm_data(modality, raw_data, result)
-                    )
+                    (
+                        is_precomputed,
+                        new_imgs,
+                        new_vids,
+                        new_auds,
+                    ) = self._process_loaded_mm_data(modality, raw_data, result)
 
                     has_precomputed_input |= is_precomputed
                     images.extend(new_imgs)
@@ -1080,7 +1083,7 @@ class BaseMultimodalProcessor(ABC):
 
         items: dict[Modality, MultimodalDataItem] = {}
         for attr_name, value in data_dict.items():
-            if attr_name == "input_ids":
+            if attr_name in ("input_ids", "format", "modality", "hash", "pad_value"):
                 continue
 
             # Get modality for this attribute
@@ -1106,6 +1109,19 @@ class BaseMultimodalProcessor(ABC):
                     attr_name = "feature"
 
                 items[current_modality].set(attr_name, value)
+
+        if len(items) == 1:
+            item = next(iter(items.values()))
+            hash_value = data_dict.get("hash")
+            if hash_value is not None:
+                if isinstance(hash_value, torch.Tensor):
+                    hash_value = hash_value.item()
+                item.hash = int(hash_value)
+                pad_value = data_dict.get("pad_value")
+                if pad_value is not None:
+                    if isinstance(pad_value, torch.Tensor):
+                        pad_value = pad_value.item()
+                    item.pad_value = int(pad_value)
 
         return list(items.values())
 
@@ -1139,9 +1155,11 @@ class BaseMultimodalProcessor(ABC):
         if not tensor.is_cuda:
             return tensor
 
-        sync_flag, available_slice, byte_offset = (
-            self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(tensor)
-        )
+        (
+            sync_flag,
+            available_slice,
+            byte_offset,
+        ) = self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(tensor)
         if isinstance(available_slice, torch.Tensor):
             available_slice.copy_(tensor.view(torch.int8).view(-1), non_blocking=True)
             return CudaIpcTensorTransportProxy(

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1083,7 +1083,14 @@ class BaseMultimodalProcessor(ABC):
 
         items: dict[Modality, MultimodalDataItem] = {}
         for attr_name, value in data_dict.items():
-            if attr_name in ("input_ids", "format", "modality", "hash", "pad_value"):
+            if attr_name in (
+                "input_ids",
+                "format",
+                "modality",
+                "hash",
+                "pad_value",
+                "offsets",
+            ):
                 continue
 
             # Get modality for this attribute
@@ -1112,6 +1119,12 @@ class BaseMultimodalProcessor(ABC):
 
         if len(items) == 1:
             item = next(iter(items.values()))
+            offsets = data_dict.get("offsets")
+            if offsets is not None:
+                if isinstance(offsets, torch.Tensor):
+                    offsets = offsets.detach().cpu().tolist()
+                item.offsets = [(int(start), int(end)) for start, end in offsets]
+
             hash_value = data_dict.get("hash")
             if hash_value is not None:
                 if isinstance(hash_value, torch.Tensor):
@@ -1274,6 +1287,8 @@ class BaseMultimodalProcessor(ABC):
 
         # Add offsets to all items
         for mm_item in all_collected_items:
+            if mm_item.offsets is not None:
+                continue
             mm_token_id = mm_tokens.get_token_id_by_modality(mm_item.modality)
             if mm_token_id is None:
                 raise ValueError(f"No token id found for modality: {mm_item.modality}")

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1195,8 +1195,9 @@ class BaseMultimodalProcessor(ABC):
         self,
         base_output: BaseMultiModalProcessorOutput,
         mm_tokens: MultimodalSpecialTokens,
+        preserve_input_ids_list: bool = False,
         **kwargs,
-    ) -> Tuple[List[MultimodalDataItem], torch.Tensor, dict]:
+    ) -> Tuple[List[MultimodalDataItem], Union[List[int], torch.Tensor], dict]:
         """
         Process multimodal data and return the combined multimodal items and input_ids.
         Supports mixed modalities (images and audio in the same request).
@@ -1269,12 +1270,20 @@ class BaseMultimodalProcessor(ABC):
         if ret is None and dict_ret is not None:
             ret = dict_ret
 
-        if input_ids is None:
+        if input_ids is None and preserve_input_ids_list and isinstance(
+            base_output.input_ids, list
+        ):
+            input_ids = base_output.input_ids
+        elif input_ids is None:
             input_ids = self._as_input_ids_tensor(base_output.input_ids)
 
         if input_ids is None:
             for _, dict_item in dict_items:
-                input_ids = self._as_input_ids_tensor(dict_item.get("input_ids"))
+                dict_input_ids = dict_item.get("input_ids")
+                if preserve_input_ids_list and isinstance(dict_input_ids, list):
+                    input_ids = dict_input_ids
+                else:
+                    input_ids = self._as_input_ids_tensor(dict_input_ids)
                 if input_ids is not None:
                     break
 
@@ -1289,6 +1298,8 @@ class BaseMultimodalProcessor(ABC):
         for mm_item in all_collected_items:
             if mm_item.offsets is not None:
                 continue
+            if not isinstance(input_ids, torch.Tensor):
+                input_ids = self._as_input_ids_tensor(input_ids)
             mm_token_id = mm_tokens.get_token_id_by_modality(mm_item.modality)
             if mm_token_id is None:
                 raise ValueError(f"No token id found for modality: {mm_item.modality}")

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1270,8 +1270,10 @@ class BaseMultimodalProcessor(ABC):
         if ret is None and dict_ret is not None:
             ret = dict_ret
 
-        if input_ids is None and preserve_input_ids_list and isinstance(
-            base_output.input_ids, list
+        if (
+            input_ids is None
+            and preserve_input_ids_list
+            and isinstance(base_output.input_ids, list)
         ):
             input_ids = base_output.input_ids
         elif input_ids is None:

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1135,6 +1135,32 @@ class BaseMultimodalProcessor(ABC):
             return input_ids.flatten().to(dtype=torch.long)
         return torch.tensor(input_ids, dtype=torch.long).flatten()
 
+    def _wrap_tensor_for_cuda_ipc(self, tensor: torch.Tensor):
+        source_tensor = tensor
+        if not tensor.is_cuda:
+            tensor = tensor.to("cuda", non_blocking=True)
+
+        sync_flag, available_slice, byte_offset = (
+            self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(tensor)
+        )
+        if isinstance(available_slice, torch.Tensor):
+            available_slice.copy_(tensor.view(torch.int8).view(-1), non_blocking=True)
+            return CudaIpcTensorTransportProxy(
+                data=available_slice,
+                info_data=tensor,
+                sync_buffer_meta=sync_flag,
+                pool_ipc_handle=(
+                    self.cudaipc_mmfeature_pool._pool_ipc_handle
+                    if _IPC_POOL_HANDLE_CACHE
+                    else None
+                ),
+                pool_byte_offset=byte_offset,
+                pool_device_index=self.cudaipc_mmfeature_pool._pool_device_index,
+            )
+        if self.server_args.keep_mm_feature_on_device:
+            return tensor
+        return source_tensor if not source_tensor.is_cuda else source_tensor.cpu()
+
     def process_and_combine_mm_data(
         self,
         base_output: BaseMultiModalProcessorOutput,
@@ -1255,58 +1281,13 @@ class BaseMultimodalProcessor(ABC):
         if SGL_USE_CUDA_IPC:
             # post-process
             for item in all_collected_items:
-                if isinstance(item.feature, torch.Tensor) and item.feature.is_cuda:
-                    sync_flag, available_slice, byte_offset = (
-                        self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(
-                            item.feature
-                        )
-                    )
-                    if isinstance(available_slice, torch.Tensor):
-                        available_slice.copy_(
-                            item.feature.view(torch.int8).view(-1), non_blocking=True
-                        )
-                        item.feature = CudaIpcTensorTransportProxy(
-                            data=available_slice,
-                            info_data=item.feature,
-                            sync_buffer_meta=sync_flag,
-                            pool_ipc_handle=(
-                                self.cudaipc_mmfeature_pool._pool_ipc_handle
-                                if _IPC_POOL_HANDLE_CACHE
-                                else None
-                            ),
-                            pool_byte_offset=byte_offset,
-                            pool_device_index=self.cudaipc_mmfeature_pool._pool_device_index,
-                        )
-                    elif not self.server_args.keep_mm_feature_on_device:
-                        item.feature = item.feature.cpu()
-                elif (
+                if isinstance(item.feature, torch.Tensor):
+                    item.feature = self._wrap_tensor_for_cuda_ipc(item.feature)
+                if (
                     isinstance(item.precomputed_embeddings, torch.Tensor)
-                    and item.precomputed_embeddings.is_cuda
                 ):
-
-                    sync_flag, available_slice, byte_offset = (
-                        self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(
-                            item.precomputed_embeddings
-                        )
+                    item.precomputed_embeddings = self._wrap_tensor_for_cuda_ipc(
+                        item.precomputed_embeddings
                     )
-                    if isinstance(available_slice, torch.Tensor):
-                        available_slice.copy_(
-                            item.precomputed_embeddings.view(torch.int8).view(-1),
-                            non_blocking=True,
-                        )
-                        item.precomputed_embeddings = CudaIpcTensorTransportProxy(
-                            data=available_slice,
-                            info_data=item.precomputed_embeddings,
-                            sync_buffer_meta=sync_flag,
-                            pool_ipc_handle=(
-                                self.cudaipc_mmfeature_pool._pool_ipc_handle
-                                if _IPC_POOL_HANDLE_CACHE
-                                else None
-                            ),
-                            pool_byte_offset=byte_offset,
-                            pool_device_index=self.cudaipc_mmfeature_pool._pool_device_index,
-                        )
-                    elif not self.server_args.keep_mm_feature_on_device:
-                        item.precomputed_embeddings = item.precomputed_embeddings.cpu()
 
         return all_collected_items, input_ids, ret

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1269,6 +1269,13 @@ class BaseMultimodalProcessor(ABC):
 
         all_collected_items = get_new_expanded_mm_items(all_collected_items)
 
+        for item in all_collected_items:
+            if item.format in (
+                MultimodalInputFormat.PROCESSOR_OUTPUT,
+                MultimodalInputFormat.PRECOMPUTED_EMBEDDING,
+            ):
+                item.set_pad_value()
+
         """
         solution for cuda-ipc memory-leak:
         1. memory-pool:  each time get a slice from memory-pool and use it as transport-data (with async lock guard)

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1136,9 +1136,8 @@ class BaseMultimodalProcessor(ABC):
         return torch.tensor(input_ids, dtype=torch.long).flatten()
 
     def _wrap_tensor_for_cuda_ipc(self, tensor: torch.Tensor):
-        source_tensor = tensor
         if not tensor.is_cuda:
-            tensor = tensor.to("cuda", non_blocking=True)
+            return tensor
 
         sync_flag, available_slice, byte_offset = (
             self.cudaipc_mmfeature_pool.return_a_slice_tensor_with_flag(tensor)
@@ -1159,7 +1158,7 @@ class BaseMultimodalProcessor(ABC):
             )
         if self.server_args.keep_mm_feature_on_device:
             return tensor
-        return source_tensor if not source_tensor.is_cuda else source_tensor.cpu()
+        return tensor.cpu()
 
     def process_and_combine_mm_data(
         self,

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1282,9 +1282,7 @@ class BaseMultimodalProcessor(ABC):
             for item in all_collected_items:
                 if isinstance(item.feature, torch.Tensor):
                     item.feature = self._wrap_tensor_for_cuda_ipc(item.feature)
-                if (
-                    isinstance(item.precomputed_embeddings, torch.Tensor)
-                ):
+                if isinstance(item.precomputed_embeddings, torch.Tensor):
                     item.precomputed_embeddings = self._wrap_tensor_for_cuda_ipc(
                         item.precomputed_embeddings
                     )

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -48,6 +48,9 @@ _IPC_POOL_HANDLE_CACHE = envs.SGLANG_USE_IPC_POOL_HANDLE_CACHE.get()
 class BaseMultiModalProcessorOutput:
     # input_text with all multimodality placeholder token expanded
     input_text: str
+    # original pre-tokenized ids, used when processor_output/precomputed inputs
+    # already carry the expanded prompt
+    input_ids: Optional[Union[List[int], torch.Tensor]] = None
 
     # frames loaded from image, in given order
     images: Optional[list[Union[Image.Image, dict]]] = dataclasses.field(
@@ -516,15 +519,8 @@ class BaseMultimodalProcessor(ABC):
 
         Class method that can be pickled for multiprocessing
         """
-        if isinstance(data, dict):
-            data_format = data.get("format")
-            if data_format in (
-                MultimodalInputFormat.PROCESSOR_OUTPUT.name,
-                MultimodalInputFormat.PRECOMPUTED_EMBEDDING.name,
-                "processor_output",
-                "precomputed_embedding",
-            ):
-                return data
+        if cls._is_preprocessed_input(data):
+            return data
         try:
             if modality == Modality.IMAGE:
                 img, _ = load_image(data, cls.gpu_image_decode)
@@ -543,6 +539,45 @@ class BaseMultimodalProcessor(ABC):
 
         except Exception as e:
             raise RuntimeError(f"Error while loading data {data}: {e}")
+
+    @staticmethod
+    def _get_preprocessed_input_format(data):
+        if not isinstance(data, dict):
+            return None
+        data_format = data.get("format")
+        if isinstance(data_format, MultimodalInputFormat):
+            return data_format
+        if data_format in (
+            MultimodalInputFormat.PROCESSOR_OUTPUT.name,
+            "processor_output",
+        ):
+            return MultimodalInputFormat.PROCESSOR_OUTPUT
+        if data_format in (
+            MultimodalInputFormat.PRECOMPUTED_EMBEDDING.name,
+            "precomputed_embedding",
+        ):
+            return MultimodalInputFormat.PRECOMPUTED_EMBEDDING
+        return None
+
+    @classmethod
+    def _is_preprocessed_input(cls, data):
+        return cls._get_preprocessed_input_format(data) is not None
+
+    @classmethod
+    def _all_mm_data_is_preprocessed(cls, *data_lists):
+        has_mm_data = False
+        for data_list in data_lists:
+            if not data_list:
+                continue
+            if not isinstance(data_list, list):
+                data_list = [data_list]
+            for item in data_list:
+                if item is None:
+                    continue
+                has_mm_data = True
+                if not cls._is_preprocessed_input(item):
+                    return False
+        return has_mm_data
 
     def _submit_mm_data_loading_tasks_simple(
         self,
@@ -668,10 +703,8 @@ class BaseMultimodalProcessor(ABC):
 
         formatted_indices = []
         for idx, item in enumerate(data_list):
-            if isinstance(item, dict):
-                fmt = item.get("format")
-                if fmt in {"processor_output", "precomputed_embedding"}:
-                    formatted_indices.append(idx)
+            if BaseMultimodalProcessor._is_preprocessed_input(item):
+                formatted_indices.append(idx)
 
         if formatted_indices:
             if len(data_list) != 1:
@@ -706,12 +739,7 @@ class BaseMultimodalProcessor(ABC):
     def _process_loaded_mm_data(self, modality, raw_data, result):
         images, videos, audios = [], [], []
 
-        is_precomputed = isinstance(raw_data, dict) and raw_data.get("format") in [
-            MultimodalInputFormat.PROCESSOR_OUTPUT.name,
-            MultimodalInputFormat.PRECOMPUTED_EMBEDDING.name,
-            "processor_output",
-            "precomputed_embedding",
-        ]
+        is_precomputed = self._is_preprocessed_input(raw_data)
 
         if modality == Modality.IMAGE:
             if is_precomputed:
@@ -741,6 +769,18 @@ class BaseMultimodalProcessor(ABC):
     ) -> BaseMultiModalProcessorOutput:
 
         BaseMultimodalProcessor.validate_mm_data(image_data, video_data, audio_data)
+
+        input_ids = prompt if isinstance(prompt, list) else None
+        if input_ids is not None and self._all_mm_data_is_preprocessed(
+            image_data, video_data, audio_data
+        ):
+            return BaseMultiModalProcessorOutput(
+                input_text="",
+                input_ids=input_ids,
+                images=list(image_data or []),
+                videos=list(video_data or []),
+                audios=list(audio_data or []),
+            )
 
         multimodal_tokens_pattern = multimodal_tokens.get_combined_regex()
         if isinstance(prompt, list) and return_text:
@@ -780,6 +820,7 @@ class BaseMultimodalProcessor(ABC):
                 return_text=return_text,
                 discard_alpha_channel=discard_alpha_channel,
                 audio_sample_rate=audio_sample_rate,
+                input_ids=input_ids,
             )
         # For models other than MiniCPMO and MiniCPMV,
         # totally align multimodal_tokens, fast path
@@ -792,6 +833,7 @@ class BaseMultimodalProcessor(ABC):
             return_text=return_text,
             discard_alpha_channel=discard_alpha_channel,
             audio_sample_rate=audio_sample_rate,
+            input_ids=input_ids,
         )
 
     def fast_load_mm_data(
@@ -804,6 +846,7 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        input_ids: Optional[Union[List[int], torch.Tensor]] = None,
     ) -> BaseMultiModalProcessorOutput:
         """
         A fast version of `load_mm_data` that loads multimodal data directly.
@@ -876,6 +919,7 @@ class BaseMultimodalProcessor(ABC):
             audios=audios,
             videos=videos,
             input_text=prompt_str,
+            input_ids=input_ids,
         )
 
     def legacy_load_mm_data(
@@ -888,6 +932,7 @@ class BaseMultimodalProcessor(ABC):
         return_text: Optional[bool] = True,
         discard_alpha_channel: bool = True,
         audio_sample_rate: Optional[int] = None,
+        input_ids: Optional[Union[List[int], torch.Tensor]] = None,
     ) -> BaseMultiModalProcessorOutput:
         """
         Each frame of video/image will be replaced by a single image token
@@ -995,6 +1040,7 @@ class BaseMultimodalProcessor(ABC):
             audios=audios,
             videos=videos,
             input_text="".join(new_text_parts),
+            input_ids=input_ids,
         )
 
     @staticmethod
@@ -1081,6 +1127,14 @@ class BaseMultimodalProcessor(ABC):
 
         return collected_items, input_ids, ret
 
+    @staticmethod
+    def _as_input_ids_tensor(input_ids) -> Optional[torch.Tensor]:
+        if input_ids is None:
+            return None
+        if isinstance(input_ids, torch.Tensor):
+            return input_ids.flatten().to(dtype=torch.long)
+        return torch.tensor(input_ids, dtype=torch.long).flatten()
+
     def process_and_combine_mm_data(
         self,
         base_output: BaseMultiModalProcessorOutput,
@@ -1134,16 +1188,19 @@ class BaseMultimodalProcessor(ABC):
             ret = None
 
         # Handle dict items (processed or precomputed)
+        dict_ret = None
         for modality, dict_item in dict_items:
-            input_format = dict_item.get("format", None)
-            if input_format == "processor_output":
+            input_format = self._get_preprocessed_input_format(dict_item)
+            if input_format is not None and dict_ret is None:
+                dict_ret = dict_item
+            if input_format == MultimodalInputFormat.PROCESSOR_OUTPUT:
                 items = self.collect_mm_items_from_processor_output(dict_item)
                 for item in items:
                     item.format = MultimodalInputFormat.PROCESSOR_OUTPUT
                 all_collected_items.extend(items)
-            elif input_format == "precomputed_embedding":
-                feature = dict_item["feature"]
-                del dict_item["feature"]
+            elif input_format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
+                dict_item = dict(dict_item)
+                feature = dict_item.pop("feature")
                 all_collected_items.append(
                     MultimodalDataItem(
                         modality=modality,
@@ -1153,6 +1210,18 @@ class BaseMultimodalProcessor(ABC):
                     )
                 )
         # Fallback tokenization if no raw items were processed
+        if ret is None and dict_ret is not None:
+            ret = dict_ret
+
+        if input_ids is None:
+            input_ids = self._as_input_ids_tensor(base_output.input_ids)
+
+        if input_ids is None:
+            for _, dict_item in dict_items:
+                input_ids = self._as_input_ids_tensor(dict_item.get("input_ids"))
+                if input_ids is not None:
+                    break
+
         if input_ids is None:
             input_ids = self._tokenizer(
                 base_output.input_text,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -697,22 +697,27 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 self.mm_tokens,
                 video_metadata=video_metadata,
                 do_sample_frames=False,
+                preserve_input_ids_list=True,
             )
         else:
             mm_items, input_ids, ret = self.process_and_combine_mm_data(
-                base_output, self.mm_tokens
+                base_output, self.mm_tokens, preserve_input_ids_list=True
             )
 
         process_time = time.perf_counter()
 
-        input_ids = input_ids.flatten()
-        if (
-            isinstance(base_output.input_ids, list)
-            and len(base_output.input_ids) == input_ids.numel()
-        ):
-            input_ids_list = base_output.input_ids
+        input_ids_tensor = None
+        if isinstance(input_ids, list):
+            input_ids_list = input_ids
         else:
-            input_ids_list = input_ids.tolist()
+            input_ids_tensor = input_ids.flatten()
+            if (
+                isinstance(base_output.input_ids, list)
+                and len(base_output.input_ids) == input_ids_tensor.numel()
+            ):
+                input_ids_list = base_output.input_ids
+            else:
+                input_ids_list = input_ids_tensor.tolist()
         padded_input_ids = self._get_processor_output_value(ret, "padded_input_ids")
         if padded_input_ids is None:
             padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(
@@ -725,6 +730,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         mrope_result = self._get_precomputed_mrope_from_output(ret)
         if mrope_result is None:
+            if input_ids_tensor is None:
+                input_ids_tensor = torch.tensor(input_ids_list, dtype=torch.long)
+
             audio_feature_lengths = None
             if self.model_type == "qwen3_omni_moe":
                 audio_item = next((mm for mm in mm_items if mm.is_audio()), None)
@@ -759,8 +767,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 mrope_result = self._compute_image_only_mrope_positions_from_offsets(
                     input_len=len(input_ids_list),
                     mm_items=mm_items,
-                    dtype=input_ids.dtype,
-                    device=input_ids.device,
+                    dtype=input_ids_tensor.dtype,
+                    device=input_ids_tensor.device,
                 )
         if mrope_result is None:
             mrope_result = MRotaryEmbedding.get_rope_index(
@@ -773,7 +781,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                     self.hf_config.vision_config, "tokens_per_second", None
                 ),
                 # use the expanded token ids
-                input_ids=input_ids.unsqueeze(0),
+                input_ids=input_ids_tensor.unsqueeze(0),
                 image_grid_thw=image_grid_thw,
                 video_grid_thw=video_grid_thw,
                 second_per_grid_ts=second_per_grid_ts,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -606,6 +606,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         process_time = time.perf_counter()
 
         input_ids = input_ids.flatten()
+        padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(
+            input_ids, mm_items
+        )
 
         image_grid_thw = self._get_grid_from_output_or_items(
             ret, mm_items, "image_grid_thw", Modality.IMAGE, image_data
@@ -653,6 +656,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         return MultimodalProcessorOutput(
             input_ids=input_ids.tolist(),
+            padded_input_ids=padded_input_ids,
             mm_items=mm_items,
             im_start_id=self.vision_start_token_id,
             im_end_id=self.vision_end_token_id,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -721,7 +721,13 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         process_time = time.perf_counter()
 
         input_ids = input_ids.flatten()
-        input_ids_list = input_ids.tolist()
+        if (
+            isinstance(base_output.input_ids, list)
+            and len(base_output.input_ids) == input_ids.numel()
+        ):
+            input_ids_list = base_output.input_ids
+        else:
+            input_ids_list = input_ids.tolist()
         padded_input_ids = self._get_processor_output_value(ret, "padded_input_ids")
         if padded_input_ids is None:
             padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -30,7 +30,9 @@ from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
-from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+from sglang.srt.multimodal.processors.base_processor import (
+    MultimodalSpecialTokens,
+)
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -30,9 +30,7 @@ from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
-from sglang.srt.multimodal.processors.base_processor import (
-    MultimodalSpecialTokens,
-)
+from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 
@@ -606,8 +604,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         process_time = time.perf_counter()
 
         input_ids = input_ids.flatten()
+        input_ids_list = input_ids.tolist()
         padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(
-            input_ids, mm_items
+            input_ids_list, mm_items
         )
 
         image_grid_thw = self._get_grid_from_output_or_items(
@@ -655,7 +654,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         )
 
         return MultimodalProcessorOutput(
-            input_ids=input_ids.tolist(),
+            input_ids=input_ids_list,
             padded_input_ids=padded_input_ids,
             mm_items=mm_items,
             im_start_id=self.vision_start_token_id,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -2,7 +2,7 @@ import math
 import os
 import re
 import time
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import torch
@@ -395,6 +395,98 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         )
         return mrope_positions.squeeze(1), mrope_position_delta
 
+    def _compute_image_only_mrope_positions_from_offsets(
+        self,
+        input_len: int,
+        mm_items: List[MultimodalDataItem],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> Optional[tuple[torch.Tensor, torch.Tensor]]:
+        if self.model_type not in (
+            "qwen3_vl",
+            "qwen3_vl_moe",
+            "qwen3_5",
+            "qwen3_5_moe",
+            "intern_s2_preview",
+        ):
+            return None
+
+        image_items = [item for item in mm_items if item.is_image()]
+        if not image_items or len(image_items) != len(mm_items):
+            return None
+
+        spatial_merge_size = self.hf_config.vision_config.spatial_merge_size
+        sorted_items = sorted(image_items, key=lambda item: item.offsets[0][0])
+        position_segments = []
+        st = 0
+        next_pos = 0
+
+        for item in sorted_items:
+            if item.offsets is None or len(item.offsets) != 1:
+                return None
+
+            start, end = item.offsets[0]
+            if start < st or end >= input_len:
+                return None
+
+            text_len = start - st
+            if text_len > 0:
+                position_segments.append(
+                    torch.arange(text_len, dtype=dtype, device=device)
+                    .view(1, -1)
+                    .expand(3, -1)
+                    + next_pos
+                )
+                next_pos += text_len
+
+            grid = self._as_grid_batch(item.model_specific_data.get("image_grid_thw"))
+            if grid is None or grid.shape[0] != 1:
+                return None
+            t, h, w = [int(x) for x in grid[0].tolist()]
+            llm_grid_t = t
+            llm_grid_h = h // spatial_merge_size
+            llm_grid_w = w // spatial_merge_size
+            num_image_tokens = llm_grid_t * llm_grid_h * llm_grid_w
+            if num_image_tokens != end - start + 1:
+                return None
+
+            t_index = (
+                torch.arange(llm_grid_t, dtype=dtype, device=device)
+                .view(-1, 1)
+                .expand(llm_grid_t, llm_grid_h * llm_grid_w)
+                .reshape(-1)
+            )
+            h_index = (
+                torch.arange(llm_grid_h, dtype=dtype, device=device)
+                .view(1, -1, 1)
+                .expand(llm_grid_t, llm_grid_h, llm_grid_w)
+                .reshape(-1)
+            )
+            w_index = (
+                torch.arange(llm_grid_w, dtype=dtype, device=device)
+                .view(1, 1, -1)
+                .expand(llm_grid_t, llm_grid_h, llm_grid_w)
+                .reshape(-1)
+            )
+            position_segments.append(
+                torch.stack([t_index, h_index, w_index]) + next_pos
+            )
+            next_pos += max(llm_grid_t, llm_grid_h, llm_grid_w)
+            st = end + 1
+
+        if st < input_len:
+            text_len = input_len - st
+            position_segments.append(
+                torch.arange(text_len, dtype=dtype, device=device)
+                .view(1, -1)
+                .expand(3, -1)
+                + next_pos
+            )
+
+        mrope_positions = torch.cat(position_segments, dim=1).unsqueeze(1)
+        mrope_position_delta = (mrope_positions.max() + 1 - input_len).reshape(1, 1)
+        return mrope_positions, mrope_position_delta
+
     @staticmethod
     def _get_processor_output_value(ret, key):
         if ret is None:
@@ -620,28 +712,43 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             request_obj.video_data,
         )
 
-        mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index(
-            spatial_merge_size=self.hf_config.vision_config.spatial_merge_size,
-            image_token_id=self.mm_tokens.image_token_id,
-            video_token_id=self.mm_tokens.video_token_id,
-            vision_start_token_id=self.vision_start_token_id,
-            model_type=self.model_type,
-            tokens_per_second=getattr(
-                self.hf_config.vision_config, "tokens_per_second", None
-            ),
-            # use the expanded token ids
-            input_ids=input_ids.unsqueeze(0),
-            image_grid_thw=image_grid_thw,
-            video_grid_thw=video_grid_thw,
-            second_per_grid_ts=second_per_grid_ts,
-            use_audio_in_video=False,
-            audio_seqlens=audio_feature_lengths,
-            audio_token_id=getattr(self.hf_config, "audio_token_id", None),
-            audio_start_token_id=self.audio_start_token_id,
-            position_id_per_seconds=getattr(
-                self.hf_config, "position_id_per_seconds", None
-            ),
-        )
+        mrope_result = None
+        if (
+            video_grid_thw is None
+            and second_per_grid_ts is None
+            and audio_feature_lengths is None
+        ):
+            mrope_result = self._compute_image_only_mrope_positions_from_offsets(
+                input_len=len(input_ids_list),
+                mm_items=mm_items,
+                dtype=input_ids.dtype,
+                device=input_ids.device,
+            )
+        if mrope_result is None:
+            mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index(
+                spatial_merge_size=self.hf_config.vision_config.spatial_merge_size,
+                image_token_id=self.mm_tokens.image_token_id,
+                video_token_id=self.mm_tokens.video_token_id,
+                vision_start_token_id=self.vision_start_token_id,
+                model_type=self.model_type,
+                tokens_per_second=getattr(
+                    self.hf_config.vision_config, "tokens_per_second", None
+                ),
+                # use the expanded token ids
+                input_ids=input_ids.unsqueeze(0),
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                second_per_grid_ts=second_per_grid_ts,
+                use_audio_in_video=False,
+                audio_seqlens=audio_feature_lengths,
+                audio_token_id=getattr(self.hf_config, "audio_token_id", None),
+                audio_start_token_id=self.audio_start_token_id,
+                position_id_per_seconds=getattr(
+                    self.hf_config, "position_id_per_seconds", None
+                ),
+            )
+        else:
+            mrope_positions, mrope_position_delta = mrope_result
         mrope_positions = mrope_positions.squeeze(1)
         get_rope_index_time = time.perf_counter()
         logger.debug(

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -722,23 +722,28 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         input_ids = input_ids.flatten()
         input_ids_list = input_ids.tolist()
-        padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(
-            input_ids_list, mm_items
-        )
-
-        image_grid_thw = self._get_grid_from_output_or_items(
-            ret, mm_items, "image_grid_thw", Modality.IMAGE, image_data
-        )
-        video_grid_thw = self._get_grid_from_output_or_items(
-            ret,
-            mm_items,
-            "video_grid_thw",
-            Modality.VIDEO,
-            request_obj.video_data,
-        )
+        padded_input_ids = self._get_processor_output_value(ret, "padded_input_ids")
+        if padded_input_ids is None:
+            padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(
+                input_ids_list, mm_items
+            )
+        elif isinstance(padded_input_ids, torch.Tensor):
+            padded_input_ids = padded_input_ids.flatten().tolist()
+        else:
+            padded_input_ids = list(padded_input_ids)
 
         mrope_result = self._get_precomputed_mrope_from_output(ret)
         if mrope_result is None:
+            image_grid_thw = self._get_grid_from_output_or_items(
+                ret, mm_items, "image_grid_thw", Modality.IMAGE, image_data
+            )
+            video_grid_thw = self._get_grid_from_output_or_items(
+                ret,
+                mm_items,
+                "video_grid_thw",
+                Modality.VIDEO,
+                request_obj.video_data,
+            )
             if (
                 video_grid_thw is None
                 and second_per_grid_ts is None

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -489,6 +489,29 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         mrope_position_delta = (mrope_positions.max() + 1 - input_len).reshape(1, 1)
         return mrope_positions, mrope_position_delta
 
+    def _get_precomputed_mrope_from_output(self, ret):
+        mrope_positions = self._get_processor_output_value(ret, "mrope_positions")
+        mrope_position_delta = self._get_processor_output_value(
+            ret, "mrope_position_delta"
+        )
+        if mrope_positions is None or mrope_position_delta is None:
+            return None
+
+        mrope_positions = torch.as_tensor(mrope_positions)
+        if mrope_positions.ndim == 3:
+            if mrope_positions.shape[1] != 1:
+                return None
+            mrope_positions = mrope_positions.squeeze(1)
+        if mrope_positions.ndim != 2 or mrope_positions.shape[0] != 3:
+            return None
+
+        mrope_position_delta = torch.as_tensor(mrope_position_delta)
+        if mrope_position_delta.ndim == 0:
+            mrope_position_delta = mrope_position_delta.reshape(1, 1)
+        elif mrope_position_delta.ndim == 1:
+            mrope_position_delta = mrope_position_delta.reshape(-1, 1)
+        return mrope_positions, mrope_position_delta
+
     @staticmethod
     def _get_processor_output_value(ret, key):
         if ret is None:
@@ -714,20 +737,21 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             request_obj.video_data,
         )
 
-        mrope_result = None
-        if (
-            video_grid_thw is None
-            and second_per_grid_ts is None
-            and audio_feature_lengths is None
-        ):
-            mrope_result = self._compute_image_only_mrope_positions_from_offsets(
-                input_len=len(input_ids_list),
-                mm_items=mm_items,
-                dtype=input_ids.dtype,
-                device=input_ids.device,
-            )
+        mrope_result = self._get_precomputed_mrope_from_output(ret)
         if mrope_result is None:
-            mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index(
+            if (
+                video_grid_thw is None
+                and second_per_grid_ts is None
+                and audio_feature_lengths is None
+            ):
+                mrope_result = self._compute_image_only_mrope_positions_from_offsets(
+                    input_len=len(input_ids_list),
+                    mm_items=mm_items,
+                    dtype=input_ids.dtype,
+                    device=input_ids.device,
+                )
+        if mrope_result is None:
+            mrope_result = MRotaryEmbedding.get_rope_index(
                 spatial_merge_size=self.hf_config.vision_config.spatial_merge_size,
                 image_token_id=self.mm_tokens.image_token_id,
                 video_token_id=self.mm_tokens.video_token_id,
@@ -749,9 +773,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                     self.hf_config, "position_id_per_seconds", None
                 ),
             )
-        else:
-            mrope_positions, mrope_position_delta = mrope_result
-        mrope_positions = mrope_positions.squeeze(1)
+        mrope_positions, mrope_position_delta = mrope_result
+        if mrope_positions.ndim == 3:
+            mrope_positions = mrope_positions.squeeze(1)
         get_rope_index_time = time.perf_counter()
         logger.debug(
             f"[QwenVLProcessor Perf] {rid=}, "

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -703,21 +703,6 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 base_output, self.mm_tokens
             )
 
-        audio_feature_lengths = None
-
-        if self.model_type == "qwen3_omni_moe":
-            audio_item = next((mm for mm in mm_items if mm.is_audio()), None)
-            if audio_item:
-                audio_feature_lengths = torch.sum(
-                    audio_item.feature_attention_mask, dim=1
-                )
-
-        second_per_grid_ts = self._get_processor_output_value(ret, "second_per_grid_ts")
-        if second_per_grid_ts is None:
-            second_per_grid_ts = self._get_processor_output_value(
-                ret, "video_second_per_grid"
-            )
-
         process_time = time.perf_counter()
 
         input_ids = input_ids.flatten()
@@ -740,6 +725,22 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         mrope_result = self._get_precomputed_mrope_from_output(ret)
         if mrope_result is None:
+            audio_feature_lengths = None
+            if self.model_type == "qwen3_omni_moe":
+                audio_item = next((mm for mm in mm_items if mm.is_audio()), None)
+                if audio_item:
+                    audio_feature_lengths = torch.sum(
+                        audio_item.feature_attention_mask, dim=1
+                    )
+
+            second_per_grid_ts = self._get_processor_output_value(
+                ret, "second_per_grid_ts"
+            )
+            if second_per_grid_ts is None:
+                second_per_grid_ts = self._get_processor_output_value(
+                    ret, "video_second_per_grid"
+                )
+
             image_grid_thw = self._get_grid_from_output_or_items(
                 ret, mm_items, "image_grid_thw", Modality.IMAGE, image_data
             )

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -374,13 +374,12 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         return input_ids, offsets, modality_list
 
     def compute_mrope_positions(self, input_ids, mm_items):
-        image_grid_thw = None
-        video_grid_thw = None
-        for item in mm_items:
-            if "image_grid_thw" in item.model_specific_data:
-                image_grid_thw = item.model_specific_data["image_grid_thw"]
-            if "video_grid_thw" in item.model_specific_data:
-                video_grid_thw = item.model_specific_data["video_grid_thw"]
+        image_grid_thw = self._concat_mm_item_grid(
+            mm_items, "image_grid_thw", Modality.IMAGE
+        )
+        video_grid_thw = self._concat_mm_item_grid(
+            mm_items, "video_grid_thw", Modality.VIDEO
+        )
 
         input_ids_tensor = torch.tensor(input_ids, dtype=torch.long).unsqueeze(0)
         mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index(
@@ -397,6 +396,51 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             video_grid_thw=video_grid_thw,
         )
         return mrope_positions.squeeze(1), mrope_position_delta
+
+    @staticmethod
+    def _get_processor_output_value(ret, key):
+        if ret is None:
+            return None
+        if hasattr(ret, "get"):
+            value = ret.get(key)
+            if value is not None:
+                return value
+        return getattr(ret, key, None)
+
+    @staticmethod
+    def _as_grid_batch(value):
+        if value is None:
+            return None
+        if isinstance(value, torch.Tensor):
+            return value.unsqueeze(0) if value.ndim == 1 else value
+        tensor = torch.as_tensor(value, dtype=torch.long)
+        return tensor.unsqueeze(0) if tensor.ndim == 1 else tensor
+
+    @classmethod
+    def _concat_mm_item_grid(cls, mm_items, key, modality):
+        grids = []
+        for item in mm_items:
+            if not item.is_modality(modality):
+                continue
+            grid = cls._as_grid_batch(item.model_specific_data.get(key))
+            if grid is not None:
+                grids.append(grid)
+        if not grids:
+            return None
+        if len(grids) == 1:
+            return grids[0]
+        return torch.cat(grids, dim=0)
+
+    @classmethod
+    def _get_grid_from_output_or_items(
+        cls, ret, mm_items, key, modality, input_data=None
+    ):
+        grid = cls._get_processor_output_value(ret, key)
+        if grid is None:
+            grid = cls._concat_mm_item_grid(mm_items, key, modality)
+        if grid is None and input_data and isinstance(input_data[0], dict):
+            grid = input_data[0].get(key)
+        return grid
 
     def get_mm_data(self, prompt, embeddings, **kwargs):
         img_grid_thw = kwargs.get("img_grid_thw", None)
@@ -516,7 +560,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         rid = getattr(request_obj, "rid", "anonymous_rid")
 
         video_metadata = None
-        if base_output.videos:
+        if base_output.videos and not isinstance(base_output.videos[0], dict):
             videos_processed = [
                 await preprocess_video(video, video_config=self.video_config)
                 for video in base_output.videos
@@ -553,29 +597,26 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                     audio_item.feature_attention_mask, dim=1
                 )
 
-        second_per_grid_ts = getattr(ret, "second_per_grid_ts", None)
+        second_per_grid_ts = self._get_processor_output_value(ret, "second_per_grid_ts")
         if second_per_grid_ts is None:
-            second_per_grid_ts = getattr(ret, "video_second_per_grid", None)
+            second_per_grid_ts = self._get_processor_output_value(
+                ret, "video_second_per_grid"
+            )
 
         process_time = time.perf_counter()
 
         input_ids = input_ids.flatten()
 
-        image_grid_thw = None
-        if hasattr(ret, "image_grid_thw"):
-            image_grid_thw = ret.image_grid_thw
-
-        if image_grid_thw is None and image_data and isinstance(image_data[0], dict):
-            image_grid_thw = image_data[0].get("image_grid_thw")
-
-        video_grid_thw = None
-        if hasattr(ret, "video_grid_thw"):
-            video_grid_thw = ret.video_grid_thw
-
-        if video_grid_thw is None and request_obj.video_data:
-            first_video = request_obj.video_data[0]
-            if isinstance(first_video, dict):
-                video_grid_thw = first_video.get("video_grid_thw")
+        image_grid_thw = self._get_grid_from_output_or_items(
+            ret, mm_items, "image_grid_thw", Modality.IMAGE, image_data
+        )
+        video_grid_thw = self._get_grid_from_output_or_items(
+            ret,
+            mm_items,
+            "video_grid_thw",
+            Modality.VIDEO,
+            request_obj.video_data,
+        )
 
         mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index(
             spatial_merge_size=self.hf_config.vision_config.spatial_merge_size,
@@ -588,8 +629,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             ),
             # use the expanded token ids
             input_ids=input_ids.unsqueeze(0),
-            image_grid_thw=getattr(ret, "image_grid_thw", None),
-            video_grid_thw=getattr(ret, "video_grid_thw", None),
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
             second_per_grid_ts=second_per_grid_ts,
             use_audio_in_video=False,
             audio_seqlens=audio_feature_lengths,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -725,7 +725,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             )
         elif isinstance(padded_input_ids, torch.Tensor):
             padded_input_ids = padded_input_ids.flatten().tolist()
-        else:
+        elif not isinstance(padded_input_ids, list):
             padded_input_ids = list(padded_input_ids)
 
         mrope_result = self._get_precomputed_mrope_from_output(ret)

--- a/test/manual/vlm/test_mm_utils.py
+++ b/test/manual/vlm/test_mm_utils.py
@@ -45,6 +45,58 @@ class TestMultimodalInputsFromDict(unittest.TestCase):
         self.assertTrue(torch.equal(mm_inputs.mm_items[0].feature, feature_tensor))
         proxy_feature.reconstruct_on_target_device.assert_called_once_with(0)
 
+    def test_materialize_precomputed_embedding_proxy_without_feature(self):
+        embedding_tensor = torch.tensor([[1.0, 2.0]], dtype=torch.float32)
+        proxy_embedding = _make_proxy_with_reconstruct_result(embedding_tensor)
+        mm_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 1)],
+            precomputed_embeddings=proxy_embedding,
+        )
+
+        with (
+            patch.object(schedule_batch.torch.cuda, "is_available", return_value=True),
+            patch.object(schedule_batch.torch.cuda, "current_device", return_value=0),
+            patch.object(
+                schedule_batch.envs.SGLANG_MM_BUFFER_SIZE_MB, "get", return_value=0
+            ),
+        ):
+            mm_inputs = MultimodalInputs.from_dict({"mm_items": [mm_item]})
+
+        self.assertTrue(
+            torch.equal(
+                mm_inputs.mm_items[0].precomputed_embeddings,
+                embedding_tensor,
+            )
+        )
+        proxy_embedding.reconstruct_on_target_device.assert_called_once_with(0)
+
+    def test_materialize_model_specific_proxy_without_feature(self):
+        grid_tensor = torch.tensor([[1, 2, 3]], dtype=torch.int64)
+        proxy_grid = _make_proxy_with_reconstruct_result(grid_tensor)
+        mm_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 1)],
+            model_specific_data={"image_grid_thw": proxy_grid},
+        )
+
+        with (
+            patch.object(schedule_batch.torch.cuda, "is_available", return_value=True),
+            patch.object(schedule_batch.torch.cuda, "current_device", return_value=0),
+            patch.object(
+                schedule_batch.envs.SGLANG_MM_BUFFER_SIZE_MB, "get", return_value=0
+            ),
+        ):
+            mm_inputs = MultimodalInputs.from_dict({"mm_items": [mm_item]})
+
+        self.assertTrue(
+            torch.equal(
+                mm_inputs.mm_items[0].model_specific_data["image_grid_thw"],
+                grid_tensor,
+            )
+        )
+        proxy_grid.reconstruct_on_target_device.assert_called_once_with(0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -41,6 +41,20 @@ class DummyProcessor(BaseMultimodalProcessor):
         raise NotImplementedError
 
 
+class NoToListInputIds:
+    def __init__(self, values):
+        self.values = values
+
+    def flatten(self):
+        return self
+
+    def numel(self):
+        return len(self.values)
+
+    def tolist(self):
+        raise AssertionError("input_ids.tolist should not run")
+
+
 def make_processor():
     processor = DummyProcessor.__new__(DummyProcessor)
     processor._tokenizer = FailingTokenizer()
@@ -451,6 +465,50 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
             MultimodalProcessorOutput.build_padded_input_ids = original_build
 
         self.assertEqual(output.padded_input_ids, padded_input_ids)
+
+    def test_qwen_reuses_base_output_input_ids_list(self):
+        processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+        processor.hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            vision_config=SimpleNamespace(spatial_merge_size=1, tokens_per_second=None),
+        )
+        processor.model_type = "qwen3_5"
+        processor.mm_tokens = SimpleNamespace(
+            image_token_id=42,
+            video_token_id=43,
+            audio_token_id=None,
+        )
+        processor.vision_start_token_id = 11
+        processor.vision_end_token_id = 12
+        processor.audio_start_token_id = None
+
+        input_ids = [11, 42, 42, 12]
+        padded_input_ids = [11, -1001, -1001, 12]
+        processor_output = {
+            "padded_input_ids": padded_input_ids,
+            "mrope_positions": torch.arange(12, dtype=torch.long).reshape(3, 4),
+            "mrope_position_delta": torch.tensor([[0]], dtype=torch.long),
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+        request_obj = SimpleNamespace(
+            rid="rid",
+            video_data=None,
+            audio_data=None,
+        )
+        processor.load_mm_data = lambda **kwargs: base_output
+        processor.process_and_combine_mm_data = lambda *args, **kwargs: (
+            [],
+            NoToListInputIds(input_ids),
+            processor_output,
+        )
+
+        output = asyncio.run(processor.process_mm_data_async([], "", request_obj))
+
+        self.assertIs(output.input_ids, input_ids)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -5,11 +5,14 @@ import torch
 
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from sglang.srt.multimodal.processors.base_processor import (
-    BaseMultiModalProcessorOutput,
     BaseMultimodalProcessor,
+    BaseMultiModalProcessorOutput,
     MultimodalSpecialTokens,
 )
 from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 
 class FailingTokenizer:

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -284,6 +284,45 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertEqual(tuple(mrope_positions.shape), (3, len(input_ids)))
         self.assertEqual(tuple(mrope_delta.shape), (1, 1))
 
+    def test_qwen_image_only_mrope_offset_fast_path_matches_generic(self):
+        processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+        processor.hf_config = SimpleNamespace(
+            vision_config=SimpleNamespace(spatial_merge_size=2, tokens_per_second=None)
+        )
+        processor.mm_tokens = SimpleNamespace(image_token_id=42, video_token_id=43)
+        processor.vision_start_token_id = 11
+        processor.model_type = "qwen3_5"
+
+        mm_items = []
+        for offset, grid in (
+            ((1, 4), torch.tensor([[1, 4, 4]])),
+            ((7, 15), torch.tensor([[1, 6, 6]])),
+        ):
+            mm_items.append(
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    offsets=[offset],
+                    model_specific_data={"image_grid_thw": grid},
+                )
+            )
+
+        input_ids = [11, 42, 42, 42, 42, 12, 11] + [42] * 9 + [12]
+        generic_positions, generic_delta = processor.compute_mrope_positions(
+            input_ids, mm_items
+        )
+        (
+            fast_positions,
+            fast_delta,
+        ) = processor._compute_image_only_mrope_positions_from_offsets(
+            input_len=len(input_ids),
+            mm_items=mm_items,
+            dtype=torch.long,
+            device=torch.device("cpu"),
+        )
+
+        self.assertTrue(torch.equal(fast_positions.squeeze(1), generic_positions))
+        self.assertTrue(torch.equal(fast_delta, generic_delta))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -7,6 +7,7 @@ import torch
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     ShmPointerMMData,
+    _get_multimodal_indices_from_offsets,
 )
 from sglang.srt.managers.schedule_batch import (
     Modality,
@@ -213,6 +214,18 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
 
         self.assertEqual(output_ids, [1, -1001, -1001, 2, -1002, -1002, 3])
         self.assertEqual(input_ids, [1, 42, 42, 2, 43, 43, 3])
+
+    def test_offset_placement_indices_respect_batch_starts_and_chunks(self):
+        indices = _get_multimodal_indices_from_offsets(
+            items_size=[0, 2, 3],
+            prefix_length=[2, 0],
+            extend_length=[5, 4],
+            items_offset_list=[[(1, 3), (6, 8)], [(0, 1)]],
+            input_token_starts=[0, 5],
+            device=torch.device("cpu"),
+        )
+
+        self.assertEqual(indices.tolist(), [0, 1, 4, 5, 6])
 
     def test_shm_pointer_materialize_keeps_zero_copy_view_alive(self):
         source = torch.arange(8, dtype=torch.float32).reshape(2, 4)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -1,9 +1,13 @@
 import unittest
+from multiprocessing import shared_memory
 from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.managers.mm_utils import MultiModalityDataPaddingPatternMultimodalTokens
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    ShmPointerMMData,
+)
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -209,6 +213,33 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
 
         self.assertEqual(output_ids, [1, -1001, -1001, 2, -1002, -1002, 3])
         self.assertEqual(input_ids, [1, 42, 42, 2, 43, 43, 3])
+
+    def test_shm_pointer_materialize_keeps_zero_copy_view_alive(self):
+        source = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+        pointer = ShmPointerMMData(source)
+        shm_name = pointer.shm_name
+        receiver = ShmPointerMMData.__new__(ShmPointerMMData)
+        output = None
+
+        try:
+            receiver.__setstate__(pointer.__getstate__())
+            output = receiver.materialize()
+
+            self.assertEqual(output.tolist(), source.tolist())
+            self.assertTrue(hasattr(output, "_sglang_shm_handle"))
+            with self.assertRaises(FileNotFoundError):
+                shared_memory.SharedMemory(name=shm_name)
+        finally:
+            if output is not None:
+                shm_handle = getattr(output, "_sglang_shm_handle", None)
+                if shm_handle is not None:
+                    shm_handle.close()
+            try:
+                shm = shared_memory.SharedMemory(name=shm_name)
+                shm.unlink()
+                shm.close()
+            except FileNotFoundError:
+                pass
 
     def test_qwen_mrope_collects_all_split_image_grids(self):
         processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from multiprocessing import shared_memory
 from types import SimpleNamespace
@@ -389,6 +390,69 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
 
         self.assertTrue(torch.equal(output_positions, positions.squeeze(1)))
         self.assertTrue(torch.equal(output_delta, delta))
+
+    def test_qwen_reuses_precomputed_padded_input_ids_from_processor_output(self):
+        processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+        processor.hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            vision_config=SimpleNamespace(spatial_merge_size=1, tokens_per_second=None),
+        )
+        processor.model_type = "qwen3_5"
+        processor.mm_tokens = SimpleNamespace(
+            image_token_id=42,
+            video_token_id=43,
+            audio_token_id=None,
+        )
+        processor.vision_start_token_id = 11
+        processor.vision_end_token_id = 12
+        processor.audio_start_token_id = None
+
+        input_ids = [11, 42, 42, 12]
+        padded_input_ids = [11, -1001, -1001, 12]
+        mm_items = [
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                offsets=[(1, 2)],
+                pad_value=-1001,
+                feature=torch.arange(8).reshape(2, 4),
+            )
+        ]
+        processor_output = {
+            "padded_input_ids": padded_input_ids,
+            "mrope_positions": torch.arange(12, dtype=torch.long).reshape(3, 4),
+            "mrope_position_delta": torch.tensor([[0]], dtype=torch.long),
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+        request_obj = SimpleNamespace(
+            rid="rid",
+            video_data=None,
+            audio_data=None,
+        )
+        processor.load_mm_data = lambda **kwargs: base_output
+        processor.process_and_combine_mm_data = lambda *args, **kwargs: (
+            mm_items,
+            torch.tensor(input_ids),
+            processor_output,
+        )
+
+        original_build = MultimodalProcessorOutput.build_padded_input_ids
+
+        def fail_build(*args, **kwargs):
+            raise AssertionError("padded_input_ids should not be rebuilt")
+
+        try:
+            MultimodalProcessorOutput.build_padded_input_ids = staticmethod(fail_build)
+            output = asyncio.run(
+                processor.process_mm_data_async([], "", request_obj)
+            )
+        finally:
+            MultimodalProcessorOutput.build_padded_input_ids = original_build
+
+        self.assertEqual(output.padded_input_ids, padded_input_ids)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -125,6 +125,33 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertEqual(mm_items[0].hash, 12345)
         self.assertEqual(mm_items[0].pad_value, _compute_pad_value(12345))
 
+    def test_processor_output_preserves_precomputed_offsets(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2]
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.arange(8).reshape(2, 4),
+            "image_grid_thw": torch.tensor([[1, 1, 2]]),
+            "offsets": [(1, 2)],
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+
+        def fail_offset_scan(*args, **kwargs):
+            raise AssertionError("offset scan should not run")
+
+        processor.get_mm_items_offset = fail_offset_scan
+        mm_items, _, _ = processor.process_and_combine_mm_data(
+            base_output,
+            MultimodalSpecialTokens(image_token_id=42),
+        )
+
+        self.assertEqual(mm_items[0].offsets, [(1, 2)])
+
     def test_processor_output_multi_image_split_uses_grid_lengths(self):
         processor = make_processor()
         input_ids = [1, 42, 42, 2, 42, 42, 42, 3]

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputs,
     MultimodalProcessorOutput,
+    _compute_pad_value,
 )
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor,
@@ -99,6 +100,30 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertTrue(
             torch.equal(mm_items[0].feature, processor_output["pixel_values"])
         )
+
+    def test_processor_output_preserves_precomputed_hash(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2]
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.arange(8).reshape(2, 4),
+            "image_grid_thw": torch.tensor([[1, 1, 2]]),
+            "hash": 12345,
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+
+        mm_items, _, _ = processor.process_and_combine_mm_data(
+            base_output,
+            MultimodalSpecialTokens(image_token_id=42),
+        )
+
+        self.assertEqual(mm_items[0].hash, 12345)
+        self.assertEqual(mm_items[0].pad_value, _compute_pad_value(12345))
 
     def test_processor_output_multi_image_split_uses_grid_lengths(self):
         processor = make_processor()

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -3,7 +3,13 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.managers.mm_utils import MultiModalityDataPaddingPatternMultimodalTokens
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    MultimodalProcessorOutput,
+)
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor,
     BaseMultiModalProcessorOutput,
@@ -146,6 +152,63 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertEqual(len(mm_items), 1)
         self.assertIs(mm_items[0].feature, feature)
         self.assertIsNotNone(mm_items[0].pad_value)
+
+    def test_precomputed_padded_input_ids_are_preserved(self):
+        input_ids = [1, 42, 42, 2, 42, 3]
+        mm_items = [
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                offsets=[(1, 2)],
+                pad_value=-1001,
+                feature=torch.arange(8).reshape(2, 4),
+            ),
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                offsets=[(4, 4)],
+                pad_value=-1002,
+                feature=torch.arange(4).reshape(1, 4),
+            ),
+        ]
+
+        padded_input_ids = MultimodalProcessorOutput.build_padded_input_ids(
+            torch.tensor([input_ids]), mm_items
+        )
+        processor_output = MultimodalProcessorOutput(
+            input_ids=input_ids,
+            padded_input_ids=padded_input_ids,
+            mm_items=mm_items,
+            im_token_id=42,
+        )
+        mm_inputs = MultimodalInputs.from_processor_output(processor_output)
+
+        self.assertEqual(padded_input_ids, [1, -1001, -1001, 2, -1002, 3])
+        self.assertEqual(mm_inputs.padded_input_ids, padded_input_ids)
+
+    def test_multimodal_token_padding_uses_offsets(self):
+        input_ids = [1, 42, 42, 2, 43, 43, 3]
+        mm_inputs = MultimodalInputs(
+            mm_items=[
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    offsets=[(1, 2)],
+                    pad_value=-1001,
+                ),
+                MultimodalDataItem(
+                    modality=Modality.VIDEO,
+                    offsets=[(4, 5)],
+                    pad_value=-1002,
+                ),
+            ],
+            im_token_id=42,
+            video_token_id=43,
+        )
+
+        output_ids = MultiModalityDataPaddingPatternMultimodalTokens().pad_input_tokens(
+            input_ids, mm_inputs
+        )
+
+        self.assertEqual(output_ids, [1, -1001, -1001, 2, -1002, -1002, 3])
+        self.assertEqual(input_ids, [1, 42, 42, 2, 43, 43, 3])
 
     def test_qwen_mrope_collects_all_split_image_grids(self):
         processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -55,6 +55,20 @@ class NoToListInputIds:
         raise AssertionError("input_ids.tolist should not run")
 
 
+class GuardedProcessorOutput(dict):
+    blocked_keys = {
+        "second_per_grid_ts",
+        "video_second_per_grid",
+        "image_grid_thw",
+        "video_grid_thw",
+    }
+
+    def get(self, key, default=None):
+        if key in self.blocked_keys:
+            raise AssertionError(f"{key} should not be read")
+        return super().get(key, default)
+
+
 def make_processor():
     processor = DummyProcessor.__new__(DummyProcessor)
     processor._tokenizer = FailingTokenizer()
@@ -431,11 +445,13 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
                 feature=torch.arange(8).reshape(2, 4),
             )
         ]
-        processor_output = {
-            "padded_input_ids": padded_input_ids,
-            "mrope_positions": torch.arange(12, dtype=torch.long).reshape(3, 4),
-            "mrope_position_delta": torch.tensor([[0]], dtype=torch.long),
-        }
+        processor_output = GuardedProcessorOutput(
+            {
+                "padded_input_ids": padded_input_ids,
+                "mrope_positions": torch.arange(12, dtype=torch.long).reshape(3, 4),
+                "mrope_position_delta": torch.tensor([[0]], dtype=torch.long),
+            }
+        )
         base_output = BaseMultiModalProcessorOutput(
             input_text="",
             input_ids=input_ids,

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -41,20 +41,6 @@ class DummyProcessor(BaseMultimodalProcessor):
         raise NotImplementedError
 
 
-class NoToListInputIds:
-    def __init__(self, values):
-        self.values = values
-
-    def flatten(self):
-        return self
-
-    def numel(self):
-        return len(self.values)
-
-    def tolist(self):
-        raise AssertionError("input_ids.tolist should not run")
-
-
 class GuardedProcessorOutput(dict):
     blocked_keys = {
         "second_per_grid_ts",
@@ -180,6 +166,35 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         )
 
         self.assertEqual(mm_items[0].offsets, [(1, 2)])
+
+    def test_processor_output_can_preserve_input_ids_list(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2]
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.arange(8).reshape(2, 4),
+            "image_grid_thw": torch.tensor([[1, 1, 2]]),
+            "offsets": [(1, 2)],
+            "hash": 12345,
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+
+        def fail_input_ids_tensor(*args, **kwargs):
+            raise AssertionError("input_ids tensor should not be built")
+
+        processor._as_input_ids_tensor = fail_input_ids_tensor
+        _, output_ids, _ = processor.process_and_combine_mm_data(
+            base_output,
+            MultimodalSpecialTokens(image_token_id=42),
+            preserve_input_ids_list=True,
+        )
+
+        self.assertIs(output_ids, input_ids)
 
     def test_processor_output_multi_image_split_uses_grid_lengths(self):
         processor = make_processor()
@@ -497,11 +512,20 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         processor.vision_start_token_id = 11
         processor.vision_end_token_id = 12
         processor.audio_start_token_id = None
+        processor.ATTR_NAME_TO_MODALITY = {
+            "pixel_values": Modality.IMAGE,
+            "image_grid_thw": Modality.IMAGE,
+        }
+        processor.FEATURE_NAMES = ["pixel_values"]
 
         input_ids = [11, 42, 42, 12]
         padded_input_ids = [11, -1001, -1001, 12]
         processor_output = {
+            "format": "processor_output",
             "padded_input_ids": padded_input_ids,
+            "pixel_values": torch.arange(8).reshape(2, 4),
+            "offsets": [(1, 2)],
+            "hash": 12345,
             "mrope_positions": torch.arange(12, dtype=torch.long).reshape(3, 4),
             "mrope_position_delta": torch.tensor([[0]], dtype=torch.long),
         }
@@ -516,11 +540,11 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
             audio_data=None,
         )
         processor.load_mm_data = lambda **kwargs: base_output
-        processor.process_and_combine_mm_data = lambda *args, **kwargs: (
-            [],
-            NoToListInputIds(input_ids),
-            processor_output,
-        )
+
+        def fail_input_ids_tensor(*args, **kwargs):
+            raise AssertionError("input_ids tensor should not be built")
+
+        processor._as_input_ids_tensor = fail_input_ids_tensor
 
         output = asyncio.run(processor.process_mm_data_async([], "", request_obj))
 

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -348,6 +348,21 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertTrue(torch.equal(fast_positions.squeeze(1), generic_positions))
         self.assertTrue(torch.equal(fast_delta, generic_delta))
 
+    def test_qwen_uses_precomputed_mrope_from_processor_output(self):
+        processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+        positions = torch.arange(18, dtype=torch.long).reshape(3, 1, 6)
+        delta = torch.tensor([[7]], dtype=torch.long)
+
+        output_positions, output_delta = processor._get_precomputed_mrope_from_output(
+            {
+                "mrope_positions": positions,
+                "mrope_position_delta": delta,
+            }
+        )
+
+        self.assertTrue(torch.equal(output_positions, positions.squeeze(1)))
+        self.assertTrue(torch.equal(output_delta, delta))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -446,9 +446,7 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
 
         try:
             MultimodalProcessorOutput.build_padded_input_ids = staticmethod(fail_build)
-            output = asyncio.run(
-                processor.process_mm_data_async([], "", request_obj)
-            )
+            output = asyncio.run(processor.process_mm_data_async([], "", request_obj))
         finally:
             MultimodalProcessorOutput.build_padded_input_ids = original_build
 

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -84,6 +84,7 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertIs(ret, processor_output)
         self.assertEqual(len(mm_items), 1)
         self.assertEqual(mm_items[0].offsets, [(1, 2)])
+        self.assertIsNotNone(mm_items[0].pad_value)
         self.assertTrue(
             torch.equal(mm_items[0].feature, processor_output["pixel_values"])
         )
@@ -112,6 +113,8 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertEqual(len(mm_items), 2)
         self.assertEqual(mm_items[0].offsets, [(1, 2)])
         self.assertEqual(mm_items[1].offsets, [(4, 6)])
+        self.assertIsNotNone(mm_items[0].pad_value)
+        self.assertIsNotNone(mm_items[1].pad_value)
         self.assertEqual(tuple(mm_items[0].feature.shape), (2, 4))
         self.assertEqual(tuple(mm_items[1].feature.shape), (3, 4))
         self.assertEqual(mm_items[0].image_grid_thw.tolist(), [[1, 1, 2]])
@@ -142,6 +145,7 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         self.assertIs(precomputed_input["feature"], feature)
         self.assertEqual(len(mm_items), 1)
         self.assertIs(mm_items[0].feature, feature)
+        self.assertIsNotNone(mm_items[0].pad_value)
 
     def test_qwen_mrope_collects_all_split_image_grids(self):
         processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -1,14 +1,20 @@
 import asyncio
+import pickle
 import unittest
 from multiprocessing import shared_memory
 from types import SimpleNamespace
 
 import torch
 
+import sglang.srt.managers.mm_utils as mm_utils
+import sglang.srt.server_args as server_args_module
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
     ShmPointerMMData,
     _get_multimodal_indices_from_offsets,
+    has_shm_features,
+    unwrap_shm_features,
+    wrap_shm_features,
 )
 from sglang.srt.managers.schedule_batch import (
     Modality,
@@ -24,6 +30,7 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+from sglang.srt.server_args import set_global_server_args_for_tokenizer
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
@@ -374,6 +381,47 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
                 shm.close()
             except FileNotFoundError:
                 pass
+
+    def test_shm_wraps_large_top_level_mm_tensors(self):
+        source = torch.arange(768, dtype=torch.long).reshape(3, 256)
+        delta = torch.tensor([[7]], dtype=torch.long)
+        tokenized_req = SimpleNamespace(
+            mm_inputs=SimpleNamespace(
+                mm_items=[],
+                mrope_positions=source,
+                mrope_position_delta=delta,
+            )
+        )
+        old_server_args = server_args_module._global_server_args
+        old_transport = mm_utils._is_default_tensor_transport
+        output = None
+
+        try:
+            set_global_server_args_for_tokenizer(
+                SimpleNamespace(skip_tokenizer_init=False, dist_init_addr=None)
+            )
+            mm_utils._is_default_tensor_transport = False
+
+            wrap_shm_features(tokenized_req)
+
+            self.assertIsInstance(
+                tokenized_req.mm_inputs.mrope_positions, ShmPointerMMData
+            )
+            self.assertIs(tokenized_req.mm_inputs.mrope_position_delta, delta)
+            self.assertTrue(has_shm_features([tokenized_req]))
+
+            receiver_req = pickle.loads(pickle.dumps(tokenized_req))
+            unwrap_shm_features(receiver_req)
+            output = receiver_req.mm_inputs.mrope_positions
+
+            self.assertTrue(torch.equal(output, source))
+            self.assertTrue(hasattr(output, "_sglang_shm_handle"))
+        finally:
+            shm_handle = getattr(output, "_sglang_shm_handle", None)
+            if shm_handle is not None:
+                shm_handle.close()
+            server_args_module._global_server_args = old_server_args
+            mm_utils._is_default_tensor_transport = old_transport
 
     def test_qwen_mrope_collects_all_split_image_grids(self):
         processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -495,7 +495,7 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         finally:
             MultimodalProcessorOutput.build_padded_input_ids = original_build
 
-        self.assertEqual(output.padded_input_ids, padded_input_ids)
+        self.assertIs(output.padded_input_ids, padded_input_ids)
 
     def test_qwen_reuses_base_output_input_ids_list(self):
         processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -10,6 +10,7 @@ from sglang.srt.managers.mm_utils import (
     ShmPointerMMData,
     _get_multimodal_indices_from_offsets,
 )
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -284,6 +285,34 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
 
         self.assertEqual(padded_input_ids, [1, -1001, -1001, 2, -1002, 3])
         self.assertEqual(mm_inputs.padded_input_ids, padded_input_ids)
+
+    def test_scheduler_reuses_precomputed_padded_ids_without_prefix(self):
+        padded_input_ids = [1, -1001, -1001, 2]
+        recv_req = SimpleNamespace(input_ids=[1, 42, 42, 2])
+        req = SimpleNamespace(origin_input_ids=list(recv_req.input_ids))
+        image_inputs = SimpleNamespace(padded_input_ids=padded_input_ids)
+
+        applied = Scheduler._try_apply_padded_mm_input_ids(
+            recv_req, req, image_inputs
+        )
+
+        self.assertTrue(applied)
+        self.assertIs(req.origin_input_ids, padded_input_ids)
+
+    def test_scheduler_keeps_prefix_when_applying_precomputed_padded_ids(self):
+        padded_input_ids = [1, -1001, -1001, 2]
+        prefix = [101, 102]
+        recv_req = SimpleNamespace(input_ids=[1, 42, 42, 2])
+        req = SimpleNamespace(origin_input_ids=prefix + list(recv_req.input_ids))
+        image_inputs = SimpleNamespace(padded_input_ids=padded_input_ids)
+
+        applied = Scheduler._try_apply_padded_mm_input_ids(
+            recv_req, req, image_inputs
+        )
+
+        self.assertTrue(applied)
+        self.assertEqual(req.origin_input_ids, prefix + padded_input_ids)
+        self.assertIsNot(req.origin_input_ids, padded_input_ids)
 
     def test_multimodal_token_padding_uses_offsets(self):
         input_ids = [1, 42, 42, 2, 43, 43, 3]

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -10,7 +10,6 @@ from sglang.srt.managers.mm_utils import (
     ShmPointerMMData,
     _get_multimodal_indices_from_offsets,
 )
-from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -18,6 +17,7 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalProcessorOutput,
     _compute_pad_value,
 )
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor,
     BaseMultiModalProcessorOutput,
@@ -292,9 +292,7 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         req = SimpleNamespace(origin_input_ids=list(recv_req.input_ids))
         image_inputs = SimpleNamespace(padded_input_ids=padded_input_ids)
 
-        applied = Scheduler._try_apply_padded_mm_input_ids(
-            recv_req, req, image_inputs
-        )
+        applied = Scheduler._try_apply_padded_mm_input_ids(recv_req, req, image_inputs)
 
         self.assertTrue(applied)
         self.assertIs(req.origin_input_ids, padded_input_ids)
@@ -306,9 +304,7 @@ class TestPreprocessedInputFastPath(unittest.TestCase):
         req = SimpleNamespace(origin_input_ids=prefix + list(recv_req.input_ids))
         image_inputs = SimpleNamespace(padded_input_ids=padded_input_ids)
 
-        applied = Scheduler._try_apply_padded_mm_input_ids(
-            recv_req, req, image_inputs
-        )
+        applied = Scheduler._try_apply_padded_mm_input_ids(recv_req, req, image_inputs)
 
         self.assertTrue(applied)
         self.assertEqual(req.origin_input_ids, prefix + padded_input_ids)

--- a/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
+++ b/test/registered/unit/multimodal/test_preprocessed_input_fast_path.py
@@ -1,0 +1,175 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultiModalProcessorOutput,
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
+from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+
+
+class FailingTokenizer:
+    def __call__(self, *args, **kwargs):
+        raise AssertionError("tokenizer should not run for preprocessed inputs")
+
+    def decode(self, *args, **kwargs):
+        raise AssertionError("decode should not run for preprocessed inputs")
+
+
+class DummyProcessor(BaseMultimodalProcessor):
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def make_processor():
+    processor = DummyProcessor.__new__(DummyProcessor)
+    processor._tokenizer = FailingTokenizer()
+    processor.ATTR_NAME_TO_MODALITY = {
+        "pixel_values": Modality.IMAGE,
+        "image_grid_thw": Modality.IMAGE,
+    }
+    processor.FEATURE_NAMES = ["pixel_values"]
+    return processor
+
+
+class TestPreprocessedInputFastPath(unittest.TestCase):
+    def test_load_mm_data_skips_decode_for_preprocessed_input_ids(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2]
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.arange(8).reshape(2, 4),
+            "image_grid_thw": torch.tensor([[1, 1, 2]]),
+        }
+
+        base_output = processor.load_mm_data(
+            prompt=input_ids,
+            multimodal_tokens=MultimodalSpecialTokens(image_token_id=42),
+            image_data=[processor_output],
+        )
+
+        self.assertEqual(base_output.input_ids, input_ids)
+        self.assertEqual(base_output.input_text, "")
+        self.assertIs(base_output.images[0], processor_output)
+
+    def test_processor_output_uses_original_input_ids_without_tokenizing(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2]
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.arange(8).reshape(2, 4),
+            "image_grid_thw": torch.tensor([[1, 1, 2]]),
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+
+        mm_items, output_ids, ret = processor.process_and_combine_mm_data(
+            base_output,
+            MultimodalSpecialTokens(image_token_id=42),
+        )
+
+        self.assertEqual(output_ids.tolist(), input_ids)
+        self.assertIs(ret, processor_output)
+        self.assertEqual(len(mm_items), 1)
+        self.assertEqual(mm_items[0].offsets, [(1, 2)])
+        self.assertTrue(
+            torch.equal(mm_items[0].feature, processor_output["pixel_values"])
+        )
+
+    def test_processor_output_multi_image_split_uses_grid_lengths(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2, 42, 42, 42, 3]
+        processor_output = {
+            "format": "processor_output",
+            "input_ids": torch.tensor([input_ids]),
+            "pixel_values": torch.arange(20).reshape(5, 4),
+            "image_grid_thw": torch.tensor([[1, 1, 2], [1, 1, 3]]),
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[processor_output],
+        )
+
+        mm_items, output_ids, _ = processor.process_and_combine_mm_data(
+            base_output,
+            MultimodalSpecialTokens(image_token_id=42),
+        )
+
+        self.assertEqual(output_ids.tolist(), input_ids)
+        self.assertEqual(len(mm_items), 2)
+        self.assertEqual(mm_items[0].offsets, [(1, 2)])
+        self.assertEqual(mm_items[1].offsets, [(4, 6)])
+        self.assertEqual(tuple(mm_items[0].feature.shape), (2, 4))
+        self.assertEqual(tuple(mm_items[1].feature.shape), (3, 4))
+        self.assertEqual(mm_items[0].image_grid_thw.tolist(), [[1, 1, 2]])
+        self.assertEqual(mm_items[1].image_grid_thw.tolist(), [[1, 1, 3]])
+
+    def test_precomputed_embedding_input_dict_is_not_mutated(self):
+        processor = make_processor()
+        input_ids = [1, 42, 42, 2]
+        feature = torch.arange(8).reshape(2, 4)
+        precomputed_input = {
+            "format": "precomputed_embedding",
+            "feature": feature,
+            "image_grid_thw": torch.tensor([[1, 1, 2]]),
+        }
+        base_output = BaseMultiModalProcessorOutput(
+            input_text="",
+            input_ids=input_ids,
+            images=[precomputed_input],
+        )
+
+        mm_items, output_ids, _ = processor.process_and_combine_mm_data(
+            base_output,
+            MultimodalSpecialTokens(image_token_id=42),
+        )
+
+        self.assertEqual(output_ids.tolist(), input_ids)
+        self.assertIn("feature", precomputed_input)
+        self.assertIs(precomputed_input["feature"], feature)
+        self.assertEqual(len(mm_items), 1)
+        self.assertIs(mm_items[0].feature, feature)
+
+    def test_qwen_mrope_collects_all_split_image_grids(self):
+        processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+        processor.hf_config = SimpleNamespace(
+            vision_config=SimpleNamespace(spatial_merge_size=1, tokens_per_second=None)
+        )
+        processor.mm_tokens = SimpleNamespace(image_token_id=42, video_token_id=43)
+        processor.vision_start_token_id = 11
+        processor.model_type = "qwen2_vl"
+
+        mm_items = []
+        for offset, grid in (
+            ((1, 4), torch.tensor([[1, 2, 2]])),
+            ((7, 15), torch.tensor([[1, 3, 3]])),
+        ):
+            mm_items.append(
+                MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    offsets=[offset],
+                    model_specific_data={"image_grid_thw": grid},
+                )
+            )
+
+        input_ids = [11, 42, 42, 42, 42, 12, 11] + [42] * 9 + [12]
+        mrope_positions, mrope_delta = processor.compute_mrope_positions(
+            input_ids, mm_items
+        )
+
+        self.assertEqual(tuple(mrope_positions.shape), (3, len(input_ids)))
+        self.assertEqual(tuple(mrope_delta.shape), (1, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Reuse precomputed VLM input ids, hashes, offsets, and padded ids.
- Avoid extra multimodal tensor copies in the gRPC scheduler path.
- Add focused coverage for the preprocessed-input fast path.

## Tests

- `git diff --check`
