### PR TITLE
fix: has_hf_quant_config raises HFValidationError on local draft model path

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2757,9 +2757,11 @@ def has_hf_quant_config(model_path: str) -> bool:
     Returns:
         True if hf_quant_config.json exists, False otherwise.
     """
-    # Check if the model_path is a local path
-    if os.path.exists(os.path.join(model_path, "hf_quant_config.json")):
-        return True
+    # Local directory: return file existence directly without touching HF hub.
+    # Otherwise try_to_load_from_cache below raises HFValidationError on absolute
+    # paths (e.g. unquantized local --speculative-draft-model-path).
+    if os.path.isdir(model_path):
+        return os.path.exists(os.path.join(model_path, "hf_quant_config.json"))
 
     from huggingface_hub import try_to_load_from_cache
 


### PR DESCRIPTION
## Motivation

When `--speculative-draft-model-path` points to a **local directory** that has no `hf_quant_config.json` (e.g. an unquantized BF16 EAGLE3 draft alongside an NVFP4 target), `has_hf_quant_config()` falls through to `try_to_load_from_cache()`, which calls `validate_repo_id()` and rejects absolute paths:

```
File "sglang/srt/utils/common.py", in has_hf_quant_config
  result = try_to_load_from_cache(model_path, "hf_quant_config.json")
File "huggingface_hub/utils/_validators.py", line 139, in validate_repo_id
HFValidationError: Repo id must use alphanumeric chars... '/weights-draft'
```

The target path doesn't hit this because its `hf_quant_config.json` exists and the first branch returns early.

## Modification

Short-circuit on `os.path.isdir(model_path)` before touching HF hub — a local directory's quant status is fully determined by whether the file exists on disk.

## Reproduction

`lukealonso/MiniMax-M2.7-NVFP4` target + local `thoughtworks/MiniMax-M2.5-Eagle3` draft, `--speculative-algorithm EAGLE3`, 2× RTX Pro 6000. Draft worker init crashes at `EagleDraftWorker → TpModelWorker → ModelRunner.load_model → loader._is_already_quantized`.

Related: #18772 #19988 (offline mode for HF repo IDs — different code path).

## Checklist

- [x] Format with `pre-commit run --all-files`
- [x] Minimal, surgical change







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26207237676](https://github.com/sgl-project/sglang/actions/runs/26207237676)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26207237628](https://github.com/sgl-project/sglang/actions/runs/26207237628)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->