### PR TITLE
[core] step 1: route non-spec `seq_lens` via `FutureMap` with per-mode bootstrap fixes

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -173,14 +173,13 @@ class ScheduleBatchDisaggregationDecodeMixin:
                 topk_index=topk_index,
                 hidden_states=hidden_states,
                 bonus_tokens=last_tokens_tensor,
-                new_seq_lens=self.seq_lens,
             )
             spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
             if self.enable_overlap:
                 from sglang.srt.managers.overlap_utils import FutureIndices
 
                 spec_info.future_indices = FutureIndices(indices=self.req_pool_indices)
-                future_map.publish(spec_info.future_indices, spec_info.new_seq_lens)
+                future_map.publish(spec_info.future_indices, self.seq_lens)
                 future_map.stash(spec_info.future_indices, spec_info)
             self.spec_info = spec_info
         else:

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -185,3 +185,13 @@ class ScheduleBatchDisaggregationDecodeMixin:
         else:
             # Non-spec: input_ids feeds the next decode forward directly.
             self.input_ids = last_tokens_tensor
+            if self.enable_overlap:
+                from sglang.srt.managers.overlap_utils import FutureIndices
+
+                future_indices = FutureIndices(indices=self.req_pool_indices)
+                # Bootstrap FutureMap so the first DECODE after PREBUILT can
+                # resolve_future from buf. Non-spec convention: batch.seq_lens
+                # at decode forward INCLUDES this iter's new token, so publish
+                # current + 1.
+                future_map.publish(future_indices, self.seq_lens + 1)
+                future_map.stash(future_indices, last_tokens_tensor)

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -48,28 +48,22 @@ class FutureMap:
         spec_algo: SpeculativeAlgorithm,
         req_to_token_pool: ReqToTokenPool,
     ):
-        # All buffers are indexed by req_pool_idx. Slot 0 mirrors the KV cache
-        # pool's padding row, so CUDA-graph padded batches (req_pool_idx == 0)
-        # read/write here harmlessly.
+        # Bufs indexed by req_pool_idx; slot 0 mirrors KV padding row so
+        # CUDA-graph padded batches (req_pool_idx == 0) are harmless.
         self.device = device
         self.spec_algo = spec_algo
         self.req_pool_size = req_to_token_pool.req_to_token.shape[0]
 
-        # Forward-only token slot, eager (int64 fixed). Both modes use it:
-        # non-spec stashes next_token_ids; spec stashes bonus_tokens.
         self.output_tokens_buf = torch.empty(
             (self.req_pool_size,), dtype=torch.int64, device=self.device
         )
-        if not self.spec_algo.is_none():
-            # Schedule-consumed buf, eager fixed dtype.
-            self.new_seq_lens_buf = torch.empty(
-                (self.req_pool_size,), dtype=torch.int64, device=self.device
-            )
-            # Remaining forward-only bufs are lazy (worker-dependent shape).
+        self.new_seq_lens_buf = torch.empty(
+            (self.req_pool_size,), dtype=torch.int64, device=self.device
+        )
+        if self.spec_algo.is_some():
             self._forward_buf_initialized = False
 
-        # Fences schedule-consumed buf fields; lazy device.Event() (cuda/hip-agnostic).
-        self.publish_ready = None
+        self.publish_ready = None  # lazy device.Event(); only spec_v2 needs it
 
     def _lazy_init_forward_buf(self, draft_input: EagleDraftInput):
         self._forward_buf_initialized = True
@@ -95,29 +89,34 @@ class FutureMap:
             )
 
     def resolve_future(self, batch: ScheduleBatch):
+        if batch.forward_mode.is_decode():
+            batch.seq_lens = self.new_seq_lens_buf[batch.req_pool_indices]
+            torch._assert_async((batch.seq_lens > 0).all())
+
         if self.spec_algo.is_none():
             _resolve_future_token_ids(batch.input_ids, self.output_tokens_buf)
         else:
-            draft_input: EagleDraftInput = batch.spec_info
-            if draft_input is None:
-                # FIXME(lsyin): No future exists, only for prefill batch, not compatible with mixed mode
-                return
-            indices = draft_input.future_indices.indices
-            # FIXME: redundant. `indices` = batch.req_pool_indices, pinned via
-            # record_batch_in_overlap's attr_snapshot for 2 iters; refcount > 0
-            # across forward's read, allocator can't reclaim. Safe to remove.
-            indices.record_stream(torch.get_device_module(self.device).current_stream())
-            draft_input.topk_p = self.topk_p_buf[indices]
-            draft_input.topk_index = self.topk_index_buf[indices]
-            draft_input.bonus_tokens = self.output_tokens_buf[indices]
-            draft_input.new_seq_lens = self.new_seq_lens_buf[indices]
-            # Resolve seq_lens placeholder (-indices) to the post-verify view.
-            batch.seq_lens = draft_input.new_seq_lens
-            # Async guard: catches a (-indices) sentinel slipping through if
-            # publish_ready fencing or buf indexing is wrong.
-            torch._assert_async((batch.seq_lens > 0).all())
-            if spec_need_hidden_states():
-                draft_input.hidden_states = self.hidden_states_buf[indices]
+            self._resolve_spec_extras(batch)
+
+    def _resolve_spec_extras(self, batch: ScheduleBatch) -> None:
+        draft_input: EagleDraftInput = batch.spec_info
+        if draft_input is None:
+            # FIXME(lsyin): only prefill; not compatible with mixed mode
+            return
+        indices = draft_input.future_indices.indices
+        # FIXME: indices = batch.req_pool_indices, pinned 2 iters via
+        # record_batch_in_overlap; record_stream here is redundant.
+        indices.record_stream(torch.get_device_module(self.device).current_stream())
+        draft_input.topk_p = self.topk_p_buf[indices]
+        draft_input.topk_index = self.topk_index_buf[indices]
+        draft_input.bonus_tokens = self.output_tokens_buf[indices]
+        if spec_need_hidden_states():
+            draft_input.hidden_states = self.hidden_states_buf[indices]
+
+    def invalidate(self, batch: ScheduleBatch, future_indices: FutureIndices) -> None:
+        sentinel = -future_indices.indices
+        batch.input_ids = sentinel
+        batch.seq_lens = sentinel
 
     def resolve_seq_lens_cpu(self, batch: ScheduleBatch) -> None:
         fi = batch.spec_info.future_indices if batch.spec_info is not None else None
@@ -131,30 +130,26 @@ class FutureMap:
     def publish(
         self, future_indices: FutureIndices, new_seq_lens: torch.Tensor
     ) -> None:
-        """Store schedule-consumed fields and signal publish_ready."""
-        if self.spec_algo.is_none():
-            return
         indices = future_indices.indices
         if indices.shape[0] == 0:
             return  # DP idle
         self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
-        if self.publish_ready is None:
-            self.publish_ready = torch.get_device_module(self.device).Event()
-        self.publish_ready.record()
+        # Fast path: only spec_v2 needs the event (schedule-stream D2H sync).
+        if self.spec_algo.is_some():
+            if self.publish_ready is None:
+                self.publish_ready = torch.get_device_module(self.device).Event()
+            self.publish_ready.record()
 
     def stash(
         self,
         future_indices: FutureIndices,
         payload: Union[torch.Tensor, EagleDraftInput],
     ) -> None:
-        """Store forward-only fields for the next forward batch to pick up."""
         indices = future_indices.indices
         if indices.shape[0] == 0:
             # DP idle: payload is empty stub; lazy-init shape peek would IndexError.
             return
         if self.spec_algo.is_none():
-            # next_token_ids is int32; buf is int64. Advanced indexing requires
-            # an explicit cast.
             self.output_tokens_buf[indices] = payload.to(torch.int64)
             return
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2159,6 +2159,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req.fill_ids = req.origin_input_ids + req.output_ids
             req.set_extend_input_len(1)
 
+        if running_batch.enable_overlap:
+            # running_batch.seq_lens (GPU) is the FutureMap sentinel between iters;
+            # restore from CPU shadow before merge so MIXED's seq_lens has real values.
+            # (resolve_future only restores for is_decode(), not is_mixed().)
+            running_batch.seq_lens = running_batch.seq_lens_cpu.to(
+                running_batch.device, non_blocking=True
+            )
+
         input_ids = torch.cat([self.input_ids, running_batch.input_ids])
         out_cache_loc = torch.cat([self.out_cache_loc, running_batch.out_cache_loc])
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2411,8 +2411,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         # Update seq_lens after allocation
         if self.enable_overlap:
-            # Do not use in-place operations in the overlap mode
-            self.seq_lens = self.seq_lens + 1
+            # Overlap: GPU seq_lens restored by resolve_future from FutureMap buf.
             self.seq_lens_cpu = self.seq_lens_cpu + 1
             self.orig_seq_lens = self.orig_seq_lens + 1
         else:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2849,11 +2849,14 @@ class Scheduler(
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
 
-                    # Both modes publish next-iter seq_lens via FutureMap;
-                    # spec_v2 fires post-verify (overlaps draft_extend), non-spec post-sample.
-                    fwd_kwargs = {
-                        "on_publish": partial(self.future_map.publish, future_indices)
-                    }
+                    # Spec_v2 fires on_publish mid-worker (between verify and
+                    # draft_extend) so schedule prep can overlap with draft_extend.
+                    # Non-spec has no later work — scheduler publishes after return.
+                    fwd_kwargs = (
+                        {"on_publish": partial(self.future_map.publish, future_indices)}
+                        if batch.is_spec_v2
+                        else {}
+                    )
 
                     with self.forward_stream_ctx:
                         self.forward_stream.wait_stream(self.schedule_stream)
@@ -2862,6 +2865,8 @@ class Scheduler(
                         batch_result = self.model_worker.forward_batch_generation(
                             batch, **fwd_kwargs
                         )
+                        if not batch.is_spec_v2:
+                            self.future_map.publish(future_indices, batch.seq_lens + 1)
                         # Park any refs the worker wants kept alive 2 iters
                         # (cross-stream tensor lifetime; pinned in the same
                         # ring slot as the SB attr snapshot).

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2849,14 +2849,11 @@ class Scheduler(
                 with self._overlap_forward_isolation(batch):
                     future_indices = FutureIndices(indices=batch.req_pool_indices)
 
-                    # Spec_v2 worker fires this between sample-end and
-                    # draft_extend; publish moves the fence to verify-end so
-                    # schedule prep can overlap with draft_extend.
-                    fwd_kwargs = (
-                        {"on_publish": partial(self.future_map.publish, future_indices)}
-                        if batch.is_spec_v2
-                        else {}
-                    )
+                    # Both modes publish next-iter seq_lens via FutureMap;
+                    # spec_v2 fires post-verify (overlaps draft_extend), non-spec post-sample.
+                    fwd_kwargs = {
+                        "on_publish": partial(self.future_map.publish, future_indices)
+                    }
 
                     with self.forward_stream_ctx:
                         self.forward_stream.wait_stream(self.schedule_stream)
@@ -2888,16 +2885,11 @@ class Scheduler(
                         else:
                             batch_result.future_indices = future_indices
 
-                # Placeholder for next iter's resolve_future to look up the
-                # real token from output_tokens_buf via the negated indices.
-                batch.input_ids = -future_indices.indices
+                self.future_map.invalidate(batch, future_indices)
 
                 if batch.is_spec_v2:
                     batch.spec_info = batch_result.next_draft_input
                     batch.spec_info.future_indices = future_indices
-                    # Schedule-stream sentinel between iters; next iter's
-                    # resolve_future reassigns batch.seq_lens from new_seq_lens_buf.
-                    batch.seq_lens = -future_indices.indices
             elif self.enable_pdmux and batch.forward_mode.is_split_prefill():
                 batch_result = self.tp_worker.forward_batch_split_prefill(batch)
                 if isinstance(batch_result.next_token_ids, torch.Tensor):

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -451,7 +451,6 @@ class TpModelWorker(BaseTpWorker):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         is_verify: bool = False,
         skip_attn_backend_init=False,
-        on_publish=None,
     ) -> GenerationBatchResult:
         # FIXME(lsyin): maybe remove skip_attn_backend_init in forward_batch_generation,
         #               which requires preparing replay to always be in this function
@@ -487,13 +486,6 @@ class TpModelWorker(BaseTpWorker):
             if is_verify:
                 # Skip sampling; spec_v2 worker fires its own publish post-verify.
                 return batch_result
-
-            if batch is not None:
-                # Non-spec convention: batch.seq_lens INCLUDES this iter's token,
-                # so next iter expects current + 1.
-                batch_result.new_seq_lens = batch.seq_lens + 1
-                if on_publish is not None:
-                    on_publish(batch_result.new_seq_lens)
 
             if (
                 self.enable_overlap

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -451,6 +451,7 @@ class TpModelWorker(BaseTpWorker):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         is_verify: bool = False,
         skip_attn_backend_init=False,
+        on_publish=None,
     ) -> GenerationBatchResult:
         # FIXME(lsyin): maybe remove skip_attn_backend_init in forward_batch_generation,
         #               which requires preparing replay to always be in this function
@@ -484,8 +485,15 @@ class TpModelWorker(BaseTpWorker):
             )
 
             if is_verify:
-                # Skip sampling and return logits for target forward
+                # Skip sampling; spec_v2 worker fires its own publish post-verify.
                 return batch_result
+
+            if batch is not None:
+                # Non-spec convention: batch.seq_lens INCLUDES this iter's token,
+                # so next iter expects current + 1.
+                batch_result.new_seq_lens = batch.seq_lens + 1
+                if on_publish is not None:
+                    on_publish(batch_result.new_seq_lens)
 
             if (
                 self.enable_overlap

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -47,6 +47,9 @@ class GenerationBatchResult:
     # sync path: forward stream -> output processor
     accept_lens: Optional[torch.Tensor] = None
 
+    # Next-iter seq_lens; published via on_publish.
+    new_seq_lens: Optional[torch.Tensor] = None
+
     # relay path: forward stream -> next step forward
     next_draft_input: Optional[EagleDraftInput] = None
 

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -531,7 +531,13 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
 
     batch.maybe_evict_swa()
 
-    bs = batch.seq_lens.shape[0]
+    if batch.enable_overlap:
+        # batch.seq_lens (GPU) is a sentinel between iters (FutureMap.invalidate);
+        # materialize from CPU shadow for the allocator. Tensor stays local.
+        seq_lens_gpu = batch.seq_lens_cpu.to(batch.device, non_blocking=True)
+    else:
+        seq_lens_gpu = batch.seq_lens
+    bs = seq_lens_gpu.shape[0]
 
     if batch.tree_cache.page_size == 1:
         # Non-paged allocation
@@ -539,9 +545,9 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     else:
         # Paged allocation
         last_loc = batch.req_to_token_pool.req_to_token[
-            batch.req_pool_indices, batch.seq_lens - 1
+            batch.req_pool_indices, seq_lens_gpu - 1
         ]
-        seq_lens_next = batch.seq_lens + token_per_req
+        seq_lens_next = seq_lens_gpu + token_per_req
         out_cache_loc = alloc_paged_token_slots_decode(
             tree_cache=batch.tree_cache,
             seq_lens=seq_lens_next,
@@ -552,9 +558,9 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
 
     # Write to req_to_token_pool
     if batch.model_config.is_encoder_decoder:
-        locs = batch.encoder_lens + batch.seq_lens
+        locs = batch.encoder_lens + seq_lens_gpu
     else:
-        locs = batch.seq_lens.clone()
+        locs = seq_lens_gpu.clone()
 
     batch.req_to_token_pool.write(
         (batch.req_pool_indices, locs), out_cache_loc.to(torch.int32)

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -695,7 +695,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
 
     # V2 overlap worker only
     future_indices: Optional[FutureIndices] = None
-    new_seq_lens: Optional[torch.Tensor] = None
     # V2 reuses `EagleDraftInput` across phases (V1 has a separate
     # `EagleDraftExtendInput` for these). Set during V2's draft-extend.
     num_correct_drafts: Optional[torch.Tensor] = None
@@ -742,7 +741,6 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             topk_p=torch.empty((0, topk), device=device, dtype=torch.float32),
             topk_index=torch.empty((0, topk), device=device, dtype=torch.int64),
             capture_hidden_mode=capture_hidden_mode,
-            new_seq_lens=torch.empty((0,), device=device, dtype=torch.int32),
         )
 
     def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -552,7 +552,6 @@ class EagleDraftWorker(BaseDraftWorker):
         next_draft_input = EagleDraftInput(
             hidden_states=target_hidden_states,
             bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
             # draft mode is same with decode mode, only 1 token per req
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
@@ -772,9 +771,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
+            # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
+            # Extend processed L prompt tokens; next verify iter expects same L.
+            batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft_extend so the fence is at target-end.
             if on_publish is not None:
-                on_publish(batch.seq_lens)
+                on_publish(batch_output.new_seq_lens)
 
             # Draft prefill
             with (
@@ -820,7 +822,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             batch_output = self.verify(batch)
             # Publish before draft_extend so the fence is at verify-end.
             if on_publish is not None:
-                on_publish(batch_output.next_draft_input.new_seq_lens)
+                on_publish(batch_output.new_seq_lens)
             with (
                 self.draft_worker.draft_tp_context(
                     self.draft_worker.draft_runner.tp_group
@@ -1097,9 +1099,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 batch, logits_output, predict, accept_index, self.speculative_num_steps
             )
 
-        next_draft_input = EagleDraftInput(
-            bonus_tokens=bonus_tokens, new_seq_lens=new_seq_lens
-        )
+        next_draft_input = EagleDraftInput(bonus_tokens=bonus_tokens)
 
         # verify_forward_batch transitively holds verify-time GPU tensors
         # (draft_token / out_cache_loc / ...) that must outlive the imminent
@@ -1112,6 +1112,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             next_draft_input=next_draft_input,
             accept_lens=accept_lens,
+            new_seq_lens=new_seq_lens,
             routed_experts_output=forward_batch_output.routed_experts_output,
             indexer_topk_output=forward_batch_output.indexer_topk_output,
             extra_keep_alive_refs=[verify_forward_batch],

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -384,7 +384,6 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         next_draft_input = EagleDraftInput(
             hidden_states=target_hidden_states,
             bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
             # draft mode is same with decode mode, only 1 token per req
             num_tokens_per_req=1,
             num_tokens_for_logprob_per_req=1,
@@ -674,9 +673,12 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             batch.capture_hidden_mode = target_capture_mode
             batch_output = self.target_worker.forward_batch_generation(batch)
 
+            # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
+            # Extend processed L prompt tokens; next verify iter expects same L.
+            batch_output.new_seq_lens = batch.seq_lens
             # Publish before draft_extend so the fence is at target-end.
             if on_publish is not None:
-                on_publish(batch.seq_lens)
+                on_publish(batch_output.new_seq_lens)
 
             # Chain-style MTP needs FULL to get all-token hidden states;
             # non-chain only needs LAST (the target model's hidden states).
@@ -706,7 +708,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             batch_output = self.verify(batch)
             # Publish before draft_extend so the fence is at verify-end.
             if on_publish is not None:
-                on_publish(batch_output.next_draft_input.new_seq_lens)
+                on_publish(batch_output.new_seq_lens)
             self.draft_worker._draft_extend_for_decode(batch, batch_output)
             return batch_output
 
@@ -786,10 +788,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                 batch, logits_output, predict, accept_index, self.speculative_num_steps
             )
 
-        next_draft_input = EagleDraftInput(
-            bonus_tokens=bonus_tokens,
-            new_seq_lens=new_seq_lens,
-        )
+        next_draft_input = EagleDraftInput(bonus_tokens=bonus_tokens)
         # verify_forward_batch transitively holds verify-time GPU tensors that
         # must outlive the imminent batch.input_ids rebind; scheduler pins it
         # in batch_record_buf via extra_keep_alive_refs. See EAGLEWorkerV2.verify.
@@ -800,6 +799,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             speculative_num_draft_tokens=self.speculative_num_draft_tokens,
             next_draft_input=next_draft_input,
             accept_lens=accept_lens,
+            new_seq_lens=new_seq_lens,
             routed_experts_output=forward_batch_output.routed_experts_output,
             indexer_topk_output=forward_batch_output.indexer_topk_output,
             extra_keep_alive_refs=[verify_forward_batch],

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -82,6 +82,9 @@ class SpeculativeAlgorithm(Enum):
             spec_class=spec_class,
         )
 
+    def is_some(self) -> bool:
+        return self != SpeculativeAlgorithm.NONE
+
     def is_none(self) -> bool:
         return self == SpeculativeAlgorithm.NONE
 


### PR DESCRIPTION
Follows up on #25922. Step 1 of a two-PR series to unify `seq_lens` handling across spec/non-spec overlap modes (step 2: #26020).

## drop `EagleDraftInput.new_seq_lens` — route via `GenerationBatchResult.new_seq_lens`

`new_seq_lens` lived on `EagleDraftInput` as a transient courier — pulled off `batch_output.next_draft_input.new_seq_lens` only to feed `on_publish`, then re-aliased onto `batch.seq_lens` inside `resolve_future`. Route through `GenerationBatchResult.new_seq_lens` (peer of `accept_lens`) instead; drops the redundant field on `EagleDraftInput` and the corresponding `create_idle_input` / disagg-bootstrap constructor args.

## non-spec: relay `seq_lens` via `FutureMap`

Non-spec `prepare_for_decode` did `batch.seq_lens = batch.seq_lens + 1` on `schedule_stream`, leaving the new GPU tensor visible to `forward_stream` — same L1 cross-stream race surface that spec_v2 already moved off via FutureMap relay.

Route non-spec `seq_lens` through `new_seq_lens_buf`:
- `prepare_for_decode` drops GPU `+= 1` in overlap mode (CPU mirror still maintained locally — `+= 1` is deterministic)
- `resolve_future` non-spec branch restores `batch.seq_lens` from `new_seq_lens_buf` for `is_decode()` batches; extend keeps `prepare_for_extend`'s value
- Sentinel `batch.seq_lens = -future_indices.indices` between iters now applies to both modes
- Scheduler publishes non-spec `seq_lens + 1` directly after the worker returns (no `on_publish` kwarg needed for non-spec; spec_v2 still fires mid-worker)

Fast path: non-spec `publish` skips the `publish_ready` event — change is deterministic, schedule maintains `seq_lens_cpu` locally, no cross-stream read of the buf, so same-stream FIFO ordering on `forward_stream` covers visibility.

## Per-mode bootstrap fixes

The relay introduces a between-iter sentinel on `batch.seq_lens` GPU. Three schedule-stream sites previously read it directly; each now materializes from `seq_lens_cpu` shadow:

- **`alloc_for_decode` (overlap)**: materialize `seq_lens_gpu = batch.seq_lens_cpu.to(device, non_blocking=True)` locally; tensor stays in function scope. Without this, allocator indexed `req_to_token` with sentinel `-indices` and silently corrupted KV slot allocation (caught by `test_color_completion` degenerate output in CI).
- **`mix_with_running` (chunked prefill)**: restore `running_batch.seq_lens` from CPU shadow before `merge_batch` cats it. Otherwise the MIXED batch's running portion carries sentinel into the forward.
- **`process_prebuilt` (disagg non-spec)**: bootstrap `FutureMap.publish(future_indices, self.seq_lens + 1)` + `stash(future_indices, last_tokens_tensor)` for the first DECODE iter, mirroring the spec_v2 PREBUILT branch. Without this, first DECODE's `resolve_future` reads uninitialized buf entries and `_assert_async((batch.seq_lens > 0).all())` fires (caught by `test_disaggregation_basic` in CI).

## Commits

1. `5547d899ed` — non-spec seq_lens via FutureMap; drop `EagleDraftInput.new_seq_lens`
2. `793acb011c` — `alloc_for_decode`: use `seq_lens_cpu` in overlap mode
3. `d955eafbbb` — `mix_with_running`: restore running's `seq_lens` from CPU shadow before merge
4. `8fb806a1cd` — drop `on_publish` from `tp_worker`; scheduler publishes non-spec directly
5. `1b2955cce6` — non-spec disagg PREBUILT: bootstrap `FutureMap` for first DECODE iter

## Follow-up

#26020 (step 2): drop the sentinel mechanism entirely. SB maintains `seq_lens` GPU as a faithful `seq_lens_cpu` mirror; commits 2/3/5 above become unnecessary and are removed.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26259146223](https://github.com/sgl-project/sglang/actions/runs/26259146223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26259146101](https://github.com/sgl-project/sglang/actions/runs/26259146101)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
