### PR TITLE
fix(model-gateway): rustfmt nightly in conversations/handlers.rs

### DIFF
--- a/sgl-model-gateway/src/routers/conversations/handlers.rs
+++ b/sgl-model-gateway/src/routers/conversations/handlers.rs
@@ -83,7 +83,7 @@ fn internal_error(message: impl Into<String>) -> Response {
 }
 
 fn bad_request_structured(error_obj: Value) -> Response {
-    (StatusCode::BAD_REQUEST, Json(json!({"error": error_obj}))).into_response()
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": error_obj }))).into_response()
 }
 
 // ============================================================================


### PR DESCRIPTION
`json!({"error": error_obj})` did not satisfy the nightly rustfmt hook added in #19524; apply the formatter-suggested spacing `json!({ "error": error_obj })` so cargo +nightly fmt --check passes.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26209342339](https://github.com/sgl-project/sglang/actions/runs/26209342339)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26209342265](https://github.com/sgl-project/sglang/actions/runs/26209342265)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->