### PR TITLE
Fix DeepSeek V4 expert distribution recording

### DIFF
--- a/python/sglang/srt/layers/moe/hash_topk.py
+++ b/python/sglang/srt/layers/moe/hash_topk.py
@@ -7,6 +7,9 @@ import torch
 from torch import nn
 
 from sglang.srt.environ import envs
+from sglang.srt.eplb.expert_distribution import (
+    get_global_expert_distribution_recorder,
+)
 from sglang.srt.eplb.expert_location_dispatch import (
     ExpertLocationDispatchInfo,
     topk_ids_logical_to_physical,
@@ -145,6 +148,7 @@ class HashTopK(nn.Module):
 
         topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
         _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+        get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
         topk_output = StandardTopKOutput(
             topk_weights=topk_weights, topk_ids=topk_ids, router_logits=router_logits
         )

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import time
+from contextlib import nullcontext
 from typing import (
     TYPE_CHECKING,
     Iterable,
@@ -33,6 +34,9 @@ from sglang.srt.distributed import (
     get_tp_group,
 )
 from sglang.srt.environ import envs
+from sglang.srt.eplb.expert_distribution import (
+    get_global_expert_distribution_recorder,
+)
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_cp_split,
@@ -1134,13 +1138,19 @@ class DeepseekV4Model(nn.Module):
 
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
-            hidden_states = layer(
-                positions=positions,
-                hidden_states=hidden_states,
-                forward_batch=forward_batch,
-                input_ids=input_ids,
-                input_ids_global=input_ids_global,
+            ctx = (
+                nullcontext()
+                if not get_global_server_args().disable_piecewise_cuda_graph
+                else get_global_expert_distribution_recorder().with_current_layer(i)
             )
+            with ctx:
+                hidden_states = layer(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                    input_ids=input_ids,
+                    input_ids_global=input_ids_global,
+                )
 
         # CP all-gather only on the last PP rank; PP IPC carries CP-split tensors.
         if self.pp_group.is_last_rank and dsa_use_prefill_cp(forward_batch):


### PR DESCRIPTION
## Summary
- Add DeepSeek V4 decoder-layer context for the expert distribution recorder so recorded expert counts are attributed to the correct layer.
- Keep the same piecewise CUDA graph behavior as DeepSeek V2/V3 by only entering the recorder layer context when piecewise CUDA graph is disabled.
- This enables DeepSeek V4 record dumps to be used for static EPLB expert location initialization.

## Verification
- `PYTHONPATH=$PWD/python python -m py_compile python/sglang/srt/models/deepseek_v4.py`
- Pre-commit hooks from `git commit --amend` passed.
- DeepSeek-V4-Flash-FP8 TP4 DeepEP record smoke:
  - start record -> generate -> stop record -> dump record all returned successfully.
  - Dumped `logical_count` shape: `(16, 43, 256)`, total count: `2400`.
  - Nonzero recorded layers: `40 / 43`, matching V4's early dense/non-MoE layers followed by MoE layers.
- DeepSeek-V4-Flash-FP8 TP4 DeepEP record workload smoke:
  - `bench_serving` random workload completed while recording: 16 requests, random input len 512, random output len 16, max concurrency 4.
  - Dumped `logical_count` shape: `(32, 43, 256)`, total count: `189600`.
  - Nonzero recorded layers: `40 / 43`.
- DeepSeek-V4-Flash-FP8 TP4 DeepEP static EPLB smoke:
  - Launched with `--ep-dispatch-algorithm static --init-expert-location <record_dump>`.
  - Server logged `init_expert_location from init_by_eplb using ServerArgs.init_expert_location` on all TP ranks.
  - `/generate` returned HTTP 200 after static EPLB initialization.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26263830117](https://github.com/sgl-project/sglang/actions/runs/26263830117)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26263830039](https://github.com/sgl-project/sglang/actions/runs/26263830039)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->