### PR TITLE
[CPU] Fix TP padding issue for DeepSeek OCR/OCR2 models

### DIFF
--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -187,12 +187,14 @@ def adjust_config_with_unaligned_cpu_tp(
 ) -> ModelConfig:
     # Support the case where the num_attention_heads is not divisible by the TP size.
     weight_block_size = may_get_weight_block_size(model_config, load_config)
-
-    for config in [
+    config_list = [
+        model_config,
         model_config.hf_config,
         model_config.hf_text_config,
-        model_config.hf_config.text_config,
-    ]:
+    ]
+    if hasattr(model_config.hf_config, "text_config"):
+        config_list.append(model_config.hf_config.text_config)
+    for config in config_list:
         update_config(
             config,
             "original_num_attention_heads",
@@ -233,12 +235,7 @@ def adjust_config_with_unaligned_cpu_tp(
         num_key_value_heads = pad_vocab_size(total_kv_heads, pad_size)
 
         num_attention_heads = num_key_value_heads * query_heads_per_kv
-        for config in [
-            model_config,
-            model_config.hf_config,
-            model_config.hf_text_config,
-            model_config.hf_config.text_config,
-        ]:
+        for config in config_list:
             update_config(config, "num_key_value_heads", num_key_value_heads)
             update_config(config, "num_attention_heads", num_attention_heads)
 

--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -188,7 +188,11 @@ def adjust_config_with_unaligned_cpu_tp(
     # Support the case where the num_attention_heads is not divisible by the TP size.
     weight_block_size = may_get_weight_block_size(model_config, load_config)
 
-    for config in [model_config.hf_config, model_config.hf_text_config]:
+    for config in [
+        model_config.hf_config,
+        model_config.hf_text_config,
+        model_config.hf_config.text_config,
+    ]:
         update_config(
             config,
             "original_num_attention_heads",
@@ -233,6 +237,7 @@ def adjust_config_with_unaligned_cpu_tp(
             model_config,
             model_config.hf_config,
             model_config.hf_text_config,
+            model_config.hf_config.text_config,
         ]:
             update_config(config, "num_key_value_heads", num_key_value_heads)
             update_config(config, "num_attention_heads", num_attention_heads)

--- a/python/sglang/srt/models/deepseek.py
+++ b/python/sglang/srt/models/deepseek.py
@@ -223,6 +223,7 @@ class DeepseekAttention(nn.Module):
         hidden_size: int,
         num_heads: int,
         num_kv_heads: int,
+        head_dim: int,
         layer_id: int = 0,
         rope_theta: float = 10000,
         rope_scaling: Optional[Dict[str, Any]] = None,
@@ -246,7 +247,7 @@ class DeepseekAttention(nn.Module):
             # the KV heads across multiple tensor parallel GPUs.
             assert tp_size % self.total_num_kv_heads == 0
         self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
-        self.head_dim = hidden_size // self.total_num_heads
+        self.head_dim = head_dim
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
@@ -315,10 +316,16 @@ class DeepseekDecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         rope_theta, rope_scaling = get_rope_config(config)
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+        head_dim = (
+            self.hidden_size // config.num_attention_heads
+            if not _is_cpu
+            else self.hidden_size // config.original_num_attention_heads
+        )
         self.self_attn = DeepseekAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
+            head_dim=head_dim,
             layer_id=layer_id,
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,

--- a/python/sglang/srt/models/deepseek.py
+++ b/python/sglang/srt/models/deepseek.py
@@ -316,10 +316,9 @@ class DeepseekDecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         rope_theta, rope_scaling = get_rope_config(config)
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
-        head_dim = (
-            self.hidden_size // config.num_attention_heads
-            if not _is_cpu
-            else self.hidden_size // config.original_num_attention_heads
+        # CPU uses attr of original_num_attention_heads for padding needs, others stay unchanged.
+        head_dim = self.hidden_size // getattr(
+            config, "original_num_attention_heads", config.num_attention_heads
         )
         self.self_attn = DeepseekAttention(
             hidden_size=self.hidden_size,


### PR DESCRIPTION
This PR fix following issue met by TP=3/6 case on CPU (3/6 numa node)，which is specific for DeepSeek OCR/OCR2 models
, as they are unlike other model usually using `model_config.hf_config` or `model_config.hf_text_config`, they are using `model_config.hf_config.text_config`
```
  File "sglang/python/sglang/srt/models/deepseek.py", line 397, in __init__
    DeepseekDecoderLayer(
  File "sglang/python/sglang/srt/models/deepseek.py", line 318, in __init__
    self.self_attn = DeepseekAttention(
                     ^^^^^^^^^^^^^^^^^^
  File "sglang/python/sglang/srt/models/deepseek.py", line 237, in __init__
    assert self.total_num_heads % tp_size == 0
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```
All changes are CPU specific, by updating the existing padding logic for num_head / head_dim.

Before this PR:
num_head: 10 # is original model config
After this PR:
num_head: 12 # pad to work with TP=6



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26213309646](https://github.com/sgl-project/sglang/actions/runs/26213309646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26484186039](https://github.com/sgl-project/sglang/actions/runs/26484186039)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->