### PR TITLE
[Perf] Skip prompt-list concat in scheduler cache-aware prefix match when output_ids is empty

### DIFF
--- a/benchmark/bench_schedule_policy/bench_schedule_policy_calc_priority.py
+++ b/benchmark/bench_schedule_policy/bench_schedule_policy_calc_priority.py
@@ -1,0 +1,121 @@
+"""Microbenchmark for `SchedulePolicy.calc_priority` host-side cost.
+
+Measures the full scheduler-tick cost of cache-aware (LPM) priority
+computation as the waiting queue depth and prompt length vary. The
+optimization in `_compute_prefix_matches` removes an unconditional
+`origin_input_ids + output_ids` list copy when `output_ids` is empty.
+
+This bench drives the public `SchedulePolicy.calc_priority` API end to end
+so it captures every Python overhead a real scheduler tick pays:
+
+- per-req `_prefix_match_token_ids` (the optimization site);
+- per-req `tree_cache.match_prefix(...)`;
+- per-req in-batch radix tree match + insert;
+- final `_sort_by_longest_prefix`.
+
+GPU is not needed: `RadixCache.create_simulated()` provides a CPU-only
+prefix tree and the priority computation never touches a model.
+
+Run:
+
+    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=python \\
+        python3 benchmark/bench_schedule_policy/bench_schedule_policy_calc_priority.py
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import List
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_policy import SchedulePolicy
+from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+
+def make_waiting_queue(
+    queue_size: int, prompt_len: int, retracted_fraction: float = 0.0
+) -> List[Req]:
+    """Build a synthetic waiting queue with the requested shape.
+
+    `retracted_fraction` of the requests carry a non-empty `output_ids`,
+    simulating retracted re-admissions (which still pay the concat cost).
+    """
+    reqs = []
+    n_retracted = int(round(queue_size * retracted_fraction))
+    for i in range(queue_size):
+        # Use distinct token ranges per req so radix tree inserts diverge.
+        prompt = list(range(i * prompt_len, (i + 1) * prompt_len))
+        req = Req(i, "x", prompt, SamplingParams())
+        if i < n_retracted:
+            # Pretend this req has generated 4 tokens before being retracted.
+            req.output_ids = [99000 + k for k in range(4)]
+        reqs.append(req)
+    return reqs
+
+
+def run_one_cycle(policy: SchedulePolicy, queue: List[Req]) -> None:
+    """One scheduler-tick worth of cache-aware priority computation."""
+    policy.calc_priority(queue)
+
+
+def time_cycles(
+    queue_size: int,
+    prompt_len: int,
+    retracted_fraction: float,
+    repeats: int = 50,
+) -> List[float]:
+    """Time `repeats` independent scheduling cycles. Returns elapsed ms."""
+    samples: List[float] = []
+    for _ in range(repeats):
+        # Fresh tree + queue each iteration: real schedulers see new work
+        # every tick and the in-batch tree is reset at the top of
+        # `_compute_prefix_matches` anyway.
+        tree_cache = RadixCache.create_simulated()
+        policy = SchedulePolicy(
+            policy="lpm",
+            tree_cache=tree_cache,
+            enable_hierarchical_cache=False,
+            enable_priority_scheduling=False,
+            schedule_low_priority_values_first=False,
+        )
+        queue = make_waiting_queue(queue_size, prompt_len, retracted_fraction)
+        t0 = time.perf_counter()
+        run_one_cycle(policy, queue)
+        samples.append((time.perf_counter() - t0) * 1000.0)
+    return samples
+
+
+def fmt_row(label: str, samples: List[float]) -> str:
+    median = statistics.median(samples)
+    p90 = sorted(samples)[int(0.9 * (len(samples) - 1))]
+    return f"  {label:<32} median={median:7.3f} ms   p90={p90:7.3f} ms"
+
+
+def bench_grid() -> None:
+    grids = [
+        (50, 1024, 0.0),
+        (50, 4096, 0.0),
+        (50, 16384, 0.0),
+        (50, 32768, 0.0),
+        (100, 8192, 0.0),
+        (100, 32768, 0.0),
+        # Retracted-mix: half the queue carries output_ids, so the helper
+        # falls back to the original concat for those reqs. Expected to be
+        # at parity with the old code.
+        (50, 16384, 0.5),
+    ]
+    print("`SchedulePolicy.calc_priority` (LPM) host-side cost")
+    print("=" * 70)
+    for queue_size, prompt_len, retract_frac in grids:
+        label = (
+            f"queue={queue_size}, prompt={prompt_len:>5}, "
+            f"retracted={int(retract_frac * 100):>3}%"
+        )
+        samples = time_cycles(queue_size, prompt_len, retract_frac)
+        print(fmt_row(label, samples))
+
+
+if __name__ == "__main__":
+    bench_grid()

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -81,6 +81,25 @@ IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD = int(
 IGNORE_EOS_RESERVE_TOKENS = 1
 
 
+def _prefix_match_token_ids(req: Req) -> List[int]:
+    """Token sequence used as the prefix-match key for ``req``.
+
+    Skips concatenation when ``output_ids`` is empty -- the common case for
+    fresh waiting-queue requests, where ``origin_input_ids + []`` would
+    otherwise allocate and copy the entire prompt list every scheduling cycle.
+    Retracted requests carry generated tokens and still take the concat path.
+
+    The returned list may alias ``req.origin_input_ids``, and downstream
+    ``RadixKey`` consumers can retain the alias inside tree nodes. Callers
+    must not mutate the returned list in-place; ``req.origin_input_ids`` is
+    only ever reassigned (e.g. truncation in ``managers/utils.py``) and never
+    mutated, so the alias is safe under existing call sites.
+    """
+    if req.output_ids:
+        return req.origin_input_ids + req.output_ids
+    return req.origin_input_ids
+
+
 def match_prefix_for_req(
     tree_cache: BasePrefixCache,
     req: Req,
@@ -90,7 +109,7 @@ def match_prefix_for_req(
     include_req: bool = False,
 ):
     if token_ids is None:
-        token_ids = req.origin_input_ids + req.output_ids
+        token_ids = _prefix_match_token_ids(req)
 
     match_result = tree_cache.match_prefix(
         MatchPrefixParams(
@@ -234,7 +253,7 @@ class SchedulePolicy:
         self.waiting_queue_radix_tree.reset()
 
         for r in waiting_queue:
-            prefix_ids = r.origin_input_ids + r.output_ids
+            prefix_ids = _prefix_match_token_ids(r)
             extra_key = r.extra_key
             match_result = match_prefix_for_req(self.tree_cache, r, prefix_ids)
 

--- a/test/registered/unit/managers/test_schedule_policy_prefix_token_ids.py
+++ b/test/registered/unit/managers/test_schedule_policy_prefix_token_ids.py
@@ -1,12 +1,15 @@
 import unittest
 
+import torch
+
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import (
     CacheAwarePolicy,
     SchedulePolicy,
     _prefix_match_token_ids,
 )
-from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -65,14 +68,25 @@ class TestPrefixMatchTokenIds(CustomTestCase):
 
 class TestComputePrefixMatchesParity(CustomTestCase):
     """Confirm `_compute_prefix_matches` (LPM cache-aware policy) produces the
-    same priority order as the previous implementation, even when the waiting
-    queue mixes fresh requests (`output_ids == []`) and retracted requests
-    (`output_ids != []`). The helper-driven optimization must not change which
-    request lands first.
+    expected priority order across the helper's two branches:
+
+    - fresh requests (``output_ids == []``) take the no-copy branch and the
+      cache lookup uses ``origin_input_ids`` directly;
+    - retracted requests (``output_ids != []``) take the concat branch and
+      the cache lookup must include the generated tokens.
     """
 
     def setUp(self):
+        # Pre-populate the radix cache with [100, 200, 300, 400] so the three
+        # requests below land at distinct match lengths and the LPM order is
+        # determined by `len(prefix_indices)` rather than stable-sort fallback.
         self.tree_cache = RadixCache.create_simulated()
+        self.tree_cache.insert(
+            InsertParams(
+                key=RadixKey(token_ids=[100, 200, 300, 400]),
+                value=torch.arange(4, dtype=torch.int64),
+            )
+        )
 
     def _build_policy(self):
         return SchedulePolicy(
@@ -84,25 +98,33 @@ class TestComputePrefixMatchesParity(CustomTestCase):
         )
 
     def test_lpm_order_with_mixed_output_state(self):
-        # Three reqs with the same prompt prefix; one is "retracted" with
-        # generated tokens so its prefix-match key includes output_ids.
-        req_fresh = Req(1, "p", [10, 20, 30], SamplingParams())
-        req_retracted = Req(2, "p", [10, 20], SamplingParams())
-        req_retracted.output_ids = [30, 40]
-        req_short = Req(3, "p", [10], SamplingParams())
+        # rid=1 (req_long): no-copy branch; origin alone yields a 2-token match.
+        req_long = Req(1, "p", [100, 200, 999], SamplingParams())
+        # rid=2 (req_retracted): concat branch; the 4-token match only exists
+        # because output_ids contributes the trailing 400, proving output_ids
+        # really is included in the prefix-match key.
+        req_retracted = Req(2, "p", [100, 200, 300], SamplingParams())
+        req_retracted.output_ids = [400, 999]
+        # rid=3 (req_short): no-copy branch; matches a 1-token prefix only.
+        req_short = Req(3, "p", [100], SamplingParams())
 
-        waiting_queue = [req_fresh, req_retracted, req_short]
+        waiting_queue = [req_long, req_retracted, req_short]
         policy = self._build_policy()
         self.assertEqual(policy.policy, CacheAwarePolicy.LPM)
 
         policy.calc_priority(waiting_queue)
 
-        # The order must be deterministic under LPM regardless of the helper
-        # taking the no-copy branch for req_fresh / req_short and the copy
-        # branch for req_retracted.
-        rids_after = [r.rid for r in waiting_queue]
-        self.assertEqual(len(rids_after), 3)
-        self.assertEqual(set(rids_after), {1, 2, 3})
+        # Match lengths witnessed during _compute_prefix_matches.
+        self.assertEqual(req_retracted.prefix_indices.numel(), 4)
+        self.assertEqual(req_long.prefix_indices.numel(), 2)
+        self.assertEqual(req_short.prefix_indices.numel(), 1)
+
+        # LPM sorts by descending match length, so the queue order is the
+        # exact list below -- not just a set membership check.
+        self.assertEqual(
+            [r.rid for r in waiting_queue],
+            [req_retracted.rid, req_long.rid, req_short.rid],
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_schedule_policy_prefix_token_ids.py
+++ b/test/registered/unit/managers/test_schedule_policy_prefix_token_ids.py
@@ -1,0 +1,109 @@
+import unittest
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_policy import (
+    CacheAwarePolicy,
+    SchedulePolicy,
+    _prefix_match_token_ids,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPrefixMatchTokenIds(CustomTestCase):
+    """Unit tests for the `_prefix_match_token_ids` helper used by the
+    cache-aware scheduler to build prefix-match keys without an unconditional
+    list copy of `origin_input_ids`.
+    """
+
+    def _make_req(self, rid: int, prompt_ids, output_ids):
+        req = Req(rid, "x", list(prompt_ids), SamplingParams())
+        req.output_ids = list(output_ids)
+        return req
+
+    def test_empty_output_returns_origin_reference(self):
+        req = self._make_req(1, [10, 20, 30], [])
+        result = _prefix_match_token_ids(req)
+        # No copy when output_ids is empty: caller can mutate origin_input_ids
+        # only by going through the Req itself. Sharing identity is safe because
+        # downstream RadixKey consumers slice rather than mutate.
+        self.assertIs(result, req.origin_input_ids)
+        self.assertEqual(result, [10, 20, 30])
+
+    def test_non_empty_output_concats_to_new_list(self):
+        req = self._make_req(2, [10, 20], [99, 100])
+        result = _prefix_match_token_ids(req)
+        self.assertIsNot(result, req.origin_input_ids)
+        self.assertEqual(result, [10, 20, 99, 100])
+
+    def test_origin_unchanged_after_call(self):
+        req = self._make_req(3, [10, 20, 30], [])
+        before = list(req.origin_input_ids)
+        _prefix_match_token_ids(req)
+        self.assertEqual(req.origin_input_ids, before)
+
+    def test_equivalent_to_old_concat_form(self):
+        # Behaviour parity with the previous `origin_input_ids + output_ids`
+        # expression, across both branches of the helper.
+        for prompt, out in (
+            ([], []),
+            ([1], []),
+            ([1, 2, 3], []),
+            ([1, 2], [3]),
+            ([1], [2, 3]),
+        ):
+            req = self._make_req(0, prompt, out)
+            self.assertEqual(
+                _prefix_match_token_ids(req),
+                req.origin_input_ids + req.output_ids,
+            )
+
+
+class TestComputePrefixMatchesParity(CustomTestCase):
+    """Confirm `_compute_prefix_matches` (LPM cache-aware policy) produces the
+    same priority order as the previous implementation, even when the waiting
+    queue mixes fresh requests (`output_ids == []`) and retracted requests
+    (`output_ids != []`). The helper-driven optimization must not change which
+    request lands first.
+    """
+
+    def setUp(self):
+        self.tree_cache = RadixCache.create_simulated()
+
+    def _build_policy(self):
+        return SchedulePolicy(
+            policy="lpm",
+            tree_cache=self.tree_cache,
+            enable_hierarchical_cache=False,
+            enable_priority_scheduling=False,
+            schedule_low_priority_values_first=False,
+        )
+
+    def test_lpm_order_with_mixed_output_state(self):
+        # Three reqs with the same prompt prefix; one is "retracted" with
+        # generated tokens so its prefix-match key includes output_ids.
+        req_fresh = Req(1, "p", [10, 20, 30], SamplingParams())
+        req_retracted = Req(2, "p", [10, 20], SamplingParams())
+        req_retracted.output_ids = [30, 40]
+        req_short = Req(3, "p", [10], SamplingParams())
+
+        waiting_queue = [req_fresh, req_retracted, req_short]
+        policy = self._build_policy()
+        self.assertEqual(policy.policy, CacheAwarePolicy.LPM)
+
+        policy.calc_priority(waiting_queue)
+
+        # The order must be deterministic under LPM regardless of the helper
+        # taking the no-copy branch for req_fresh / req_short and the copy
+        # branch for req_retracted.
+        rids_after = [r.rid for r in waiting_queue]
+        self.assertEqual(len(rids_after), 3)
+        self.assertEqual(set(rids_after), {1, 2, 3})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`SchedulePolicy._compute_prefix_matches` and `match_prefix_for_req` build a
prefix-match key as `req.origin_input_ids + req.output_ids` for every waiting
request on every cache-aware scheduling cycle.

For a fresh waiting-queue request `output_ids` is `[]`, so this is a full
prompt-length list copy that the cache lookup never uses. Long-context
production workloads pay this disproportionately — a 100-deep waiting queue
with 32K-token prompts copies ~3.2M list elements per scheduling cycle just
to drop them.

## Modifications

- New helper `_prefix_match_token_ids(req)` in
  `python/sglang/srt/managers/schedule_policy.py`: returns
  `req.origin_input_ids` directly when `output_ids` is empty, otherwise
  falls back to the original concat for retracted requests.
- Two call sites updated to use it: `match_prefix_for_req` default branch
  and `SchedulePolicy._compute_prefix_matches` waiting-queue loop.
- Helper docstring captures the read-only contract: the returned list may
  alias `req.origin_input_ids`, and downstream `RadixKey` consumers can
  retain that alias inside radix tree nodes. The alias is safe because
  `req.origin_input_ids` is only ever reassigned, never mutated in place
  — `git grep -E 'origin_input_ids\.(append|extend|insert|pop|remove|clear|sort|reverse|__setitem__)|origin_input_ids\[[^]]*\] *='`
  against `python/sglang/srt/` returns zero hits.
- New CPU unit test
  `test/registered/unit/managers/test_schedule_policy_prefix_token_ids.py`
  (`register_cpu_ci(est_time=2, suite="base-a-test-cpu")`):
  - identity / non-identity assertions on the two helper branches;
  - behaviour parity against the old `+` expression for five
    prompt × output_ids combinations;
  - LPM `_compute_prefix_matches` integration test mixing fresh and
    retracted-style requests.
- New microbenchmark
  `benchmark/bench_schedule_policy/bench_schedule_policy_calc_priority.py`
  driving `SchedulePolicy.calc_priority` end to end with `RadixCache`
  (CPU-only — no GPU needed).

Existing `test/manual/test_schedule_policy.py` (14 tests) reruns clean.

## Accuracy Tests

This change touches only the host-side construction of the prefix-match key
list passed to `RadixKey`. It does not change which tokens are looked up,
matched, or inserted, and the unit test `test_equivalent_to_old_concat_form`
asserts list-level parity against the previous `origin_input_ids + output_ids`
expression for five input combinations (empty / output-empty / both
non-empty / asymmetric lengths). End-to-end accuracy benchmarks were not run
because no model output path is reached.

## Speed Tests and Profiling

`benchmark/bench_schedule_policy/bench_schedule_policy_calc_priority.py`
drives `SchedulePolicy.calc_priority` with the LPM cache-aware policy and
varies waiting-queue depth, prompt length, and the fraction of retracted
(non-empty `output_ids`) requests. Median of 50 cycles, on Apple Silicon:

| queue | prompt | retracted | main (median) | this PR (median) | speedup |
|-------|--------|-----------|--------------:|-----------------:|--------:|
|    50 |  1,024 |        0% |      0.644 ms |         0.590 ms |   1.09x |
|    50 |  4,096 |        0% |      1.037 ms |         0.643 ms |   1.61x |
|    50 | 16,384 |        0% |      2.472 ms |         0.683 ms |   3.62x |
|    50 | 32,768 |        0% |      4.279 ms |         0.799 ms |   5.36x |
|   100 |  8,192 |        0% |      3.083 ms |         1.277 ms |   2.41x |
|   100 | 32,768 |        0% |      8.566 ms |         1.507 ms |   5.68x |
|    50 | 16,384 |       50% |      2.368 ms |         1.452 ms |   1.63x |

The retracted=50% row is the worst-case mixed workload: half the queue still
goes through the original concat path, so half the savings carry over (1.6x
vs 5.4x for the all-fresh row at the same prompt length). Retracted-only
behaviour is at parity by design.

End-to-end serving benchmark (`bench_serving.py` against a real model) was
not run — happy to add numbers if reviewers want them; the host-side cost
above is what the scheduler tick actually pays per cycle in cache-aware
mode.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).  *(no `docs/` change — host-side perf change with helper docstring only; happy to add a docs note if reviewers want one)*
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).  *(host-side scheduler-tick benchmark provided; e2e bench on a real model not run, see Speed Tests above)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). *(pre-commit clean: ruff / isort / black / codespell)*















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26216785243](https://github.com/sgl-project/sglang/actions/runs/26216785243)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26216785176](https://github.com/sgl-project/sglang/actions/runs/26216785176)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->