### PR TITLE
[log] Support structured JSON output for inference stats logging

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1329,20 +1329,35 @@ class Req(ReqDllmMixin):
         if self.has_log_time_stats:
             return
 
-        bootstrap_info = (
-            f", bootstrap_room={self.bootstrap_room}"
-            if self.bootstrap_room is not None
-            else ""
-        )
-        prefix = (
-            f"ReqTimeStats("
-            f"rid={self.rid}{bootstrap_info}, "
-            f"input_len={len(self.origin_input_ids)}, "
-            f"cached_input_len={self.cached_tokens}, "
-            f"output_len={len(self.output_ids)}, "
-            f"type={self.time_stats.disagg_mode_str()})"
-        )
-        logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
+        log_stats_format = get_global_server_args().log_stats_format
+        if log_stats_format == "json":
+            log_data = self.time_stats.convert_to_duration_dict()
+            log_data["event"] = "request.time_stats"
+            log_data["rid"] = self.rid
+            log_data["input_len"] = len(self.origin_input_ids)
+            log_data["cached_input_len"] = self.cached_tokens
+            log_data["output_len"] = len(self.output_ids)
+            log_data["type"] = self.time_stats.disagg_mode_str()
+            if self.bootstrap_room is not None:
+                log_data["bootstrap_room"] = self.bootstrap_room
+            import json
+
+            logger.info(json.dumps(log_data, ensure_ascii=False))
+        else:
+            bootstrap_info = (
+                f", bootstrap_room={self.bootstrap_room}"
+                if self.bootstrap_room is not None
+                else ""
+            )
+            prefix = (
+                f"ReqTimeStats("
+                f"rid={self.rid}{bootstrap_info}, "
+                f"input_len={len(self.origin_input_ids)}, "
+                f"cached_input_len={self.cached_tokens}, "
+                f"output_len={len(self.output_ids)}, "
+                f"type={self.time_stats.disagg_mode_str()})"
+            )
+            logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
 
     def set_extend_input_len(self, extend_input_len: int):

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import logging
 import tempfile
 import time
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     List,
@@ -485,23 +487,31 @@ class SchedulerMetricsReporter:
             if batch is not None and batch.forward_iter is not None
             else self.scheduler.forward_ct
         )
-        iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
 
-        msg = (
-            f"Prefill batch{iter_msg}, "
-            f"#new-seq: {prefill_stats.num_new_seqs}, "
-            f"#new-token: {prefill_stats.log_input_tokens}, "
-            f"#cached-token: {prefill_stats.log_hit_tokens}, "
-            f"{token_usage_msg}"
-            f"#running-req: {prefill_stats.num_running_reqs.total}, "
-            f"#queue-req: {len(self.scheduler.waiting_queue)}, "
-            f"#pending-token: {prefill_stats.num_pending_tokens}, "
-        )
+        # Build log data as a dict first (shared by both text and json formats)
+        prefill_log_data = {
+            "event": "prefill.batch",
+            "timestamp": datetime.now().isoformat(),
+            "new_seqs": prefill_stats.num_new_seqs,
+            "new_tokens": prefill_stats.log_input_tokens,
+            "cached_tokens": prefill_stats.log_hit_tokens,
+            "token_usage": pool_stats.get_prefill_usage_msg_parts(),
+            "running_reqs": prefill_stats.num_running_reqs.total,
+            "queue_reqs": len(self.scheduler.waiting_queue),
+            "pending_tokens": prefill_stats.num_pending_tokens,
+            "graph_backend": self._graph_backend_label,
+            "can_run_cuda_graph": can_run_cuda_graph,
+            "input_throughput_token_per_s": round(self.last_input_throughput, 2),
+        }
+        if LOG_FORWARD_ITERS:
+            prefill_log_data["iter"] = batch_iter
 
         if self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL:
-            msg += f"#bootstrap-req: {len(self.scheduler.disagg_prefill_bootstrap_queue.queue)}, "
-            msg += (
-                f"#inflight-req: {len(self.scheduler.disagg_prefill_inflight_queue)}, "
+            prefill_log_data["bootstrap_reqs"] = len(
+                self.scheduler.disagg_prefill_bootstrap_queue.queue
+            )
+            prefill_log_data["inflight_reqs"] = len(
+                self.scheduler.disagg_prefill_inflight_queue
             )
 
         if (
@@ -509,23 +519,52 @@ class SchedulerMetricsReporter:
             and self.scheduler.server_args.encoder_transfer_backend
             == "zmq_to_scheduler"
         ):
-            msg += (
-                f"waiting-image-req: {len(self.scheduler.mm_receiver.waiting_list)}, "
+            prefill_log_data["waiting_image_reqs"] = len(
+                self.scheduler.mm_receiver.waiting_list
             )
-
-        msg += f"{self._graph_backend_label}: {can_run_cuda_graph}, "
-        msg += f"input throughput (token/s): {self.last_input_throughput:.2f}"
 
         if self.enable_mfu_metrics and gap_latency > 0:
             flops, _, _ = self._estimate_prefill_perf(prefill_stats.log_input_tokens)
             tflops_per_s = flops / gap_latency / 1e12
-            msg += f", est. prefill TFLOPS/s (per GPU): {tflops_per_s:.2f}"
+            prefill_log_data["est_prefill_tflops_per_s_per_gpu"] = round(
+                tflops_per_s, 2
+            )
 
         if ENABLE_METRICS_DEVICE_TIMER:
-            msg += f", fwd occupancy: {self.fwd_occupancy:.2f}%"
+            prefill_log_data["fwd_occupancy_pct"] = round(self.fwd_occupancy, 2)
 
         if self.is_stats_logging_rank:
-            logger.info(msg)
+            if self.scheduler.server_args.log_stats_format == "json":
+                logger.info(json.dumps(prefill_log_data, ensure_ascii=False))
+            else:
+                iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
+                token_usage_msg = ", ".join(prefill_log_data["token_usage"]) + ", "
+                msg = (
+                    f"Prefill batch{iter_msg}, "
+                    f"#new-seq: {prefill_log_data['new_seqs']}, "
+                    f"#new-token: {prefill_log_data['new_tokens']}, "
+                    f"#cached-token: {prefill_log_data['cached_tokens']}, "
+                    f"{token_usage_msg}"
+                    f"#running-req: {prefill_log_data['running_reqs']}, "
+                    f"#queue-req: {prefill_log_data['queue_reqs']}, "
+                    f"#pending-token: {prefill_log_data['pending_tokens']}, "
+                )
+                if "bootstrap_reqs" in prefill_log_data:
+                    msg += f"#bootstrap-req: {prefill_log_data['bootstrap_reqs']}, "
+                    msg += f"#inflight-req: {prefill_log_data['inflight_reqs']}, "
+                if "waiting_image_reqs" in prefill_log_data:
+                    msg += (
+                        f"waiting-image-req: {prefill_log_data['waiting_image_reqs']}, "
+                    )
+                msg += f"{prefill_log_data['graph_backend']}: {prefill_log_data['can_run_cuda_graph']}, "
+                msg += f"input throughput (token/s): {prefill_log_data['input_throughput_token_per_s']:.2f}"
+                if "est_prefill_tflops_per_s_per_gpu" in prefill_log_data:
+                    msg += f", est. prefill TFLOPS/s (per GPU): {prefill_log_data['est_prefill_tflops_per_s_per_gpu']:.2f}"
+                if "fwd_occupancy_pct" in prefill_log_data:
+                    msg += (
+                        f", fwd occupancy: {prefill_log_data['fwd_occupancy_pct']:.2f}%"
+                    )
+                logger.info(msg)
         if self.current_scheduler_metrics_enabled:
             self.metrics_collector.increment_prefill_cuda_graph_pass(
                 value=can_run_cuda_graph
@@ -656,8 +695,20 @@ class SchedulerMetricsReporter:
             if batch is not None and batch.forward_iter is not None
             else self.scheduler.forward_ct
         )
-        iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
-        msg = f"Decode batch{iter_msg}, #running-req: {num_running_reqs}, {token_usage_msg}"
+
+        # Build log data as a dict first (shared by both text and json formats)
+        decode_log_data = {
+            "event": "decode.batch",
+            "timestamp": datetime.now().isoformat(),
+            "running_reqs": num_running_reqs,
+            "token_usage": pool_stats.get_decode_usage_msg_parts(),
+            "graph_backend": self._graph_backend_label,
+            "can_run_cuda_graph": can_run_cuda_graph,
+            "gen_throughput_token_per_s": round(self.last_gen_throughput, 2),
+            "queue_reqs": len(self.scheduler.waiting_queue),
+        }
+        if LOG_FORWARD_ITERS:
+            decode_log_data["iter"] = batch_iter
 
         if self.scheduler.spec_algorithm.is_none():
             spec_accept_length = 0
@@ -678,29 +729,34 @@ class SchedulerMetricsReporter:
             self.spec_total_num_accept_tokens += self.spec_num_accept_tokens
             self.spec_total_num_forward_ct += self.spec_num_forward_ct
             self.spec_num_accept_tokens = self.spec_num_forward_ct = 0
-            msg += f"accept len: {spec_accept_length:.2f}, accept rate: {spec_accept_rate:.2f}, "
+            decode_log_data["spec_accept_length"] = round(spec_accept_length, 2)
+            decode_log_data["spec_accept_rate"] = round(spec_accept_rate, 2)
         cache_hit_rate = 0.0
 
         if self.scheduler.disaggregation_mode == DisaggregationMode.DECODE:
-            msg += f"pre-allocated usage: {self.scheduler.disagg_decode_prealloc_queue.num_tokens_pre_allocated / self.scheduler.max_total_num_tokens:.2f}, "
-            msg += f"#prealloc-req: {len(self.scheduler.disagg_decode_prealloc_queue.queue)}, "
-            msg += f"#transfer-req: {len(self.scheduler.disagg_decode_transfer_queue.queue)}, "
-            msg += f"#retracted-req: {len(self.scheduler.disagg_decode_prealloc_queue.retracted_queue)}, "
+            decode_log_data["preallocated_usage"] = round(
+                self.scheduler.disagg_decode_prealloc_queue.num_tokens_pre_allocated
+                / self.scheduler.max_total_num_tokens,
+                2,
+            )
+            decode_log_data["prealloc_reqs"] = len(
+                self.scheduler.disagg_decode_prealloc_queue.queue
+            )
+            decode_log_data["transfer_reqs"] = len(
+                self.scheduler.disagg_decode_transfer_queue.queue
+            )
+            decode_log_data["retracted_reqs"] = len(
+                self.scheduler.disagg_decode_prealloc_queue.retracted_queue
+            )
 
         if (
             self.scheduler.server_args.language_only
             and self.scheduler.server_args.encoder_transfer_backend
             == "zmq_to_scheduler"
         ):
-            msg += (
-                f"waiting-image-req: {len(self.scheduler.mm_receiver.waiting_list)}, "
+            decode_log_data["waiting_image_reqs"] = len(
+                self.scheduler.mm_receiver.waiting_list
             )
-
-        msg += (
-            f"{self._graph_backend_label}: {can_run_cuda_graph}, "
-            f"gen throughput (token/s): {self.last_gen_throughput:.2f}, "
-            f"#queue-req: {len(self.scheduler.waiting_queue)}"
-        )
 
         if self.enable_mfu_metrics and gap_latency > 0:
             flops_per_s = self._mfu_log_flops / gap_latency
@@ -709,20 +765,50 @@ class SchedulerMetricsReporter:
             tflops_per_s = flops_per_s / 1e12
             read_gb_per_s = read_bytes_per_s / 1e9
             write_gb_per_s = write_bytes_per_s / 1e9
-            msg += (
-                f", est. decode TFLOPS/s (per GPU): {tflops_per_s:.2f}, "
-                f"est. read BW (GB/s per GPU): {read_gb_per_s:.2f}, "
-                f"est. write BW (GB/s per GPU): {write_gb_per_s:.2f}"
-            )
+            decode_log_data["est_decode_tflops_per_s_per_gpu"] = round(tflops_per_s, 2)
+            decode_log_data["est_read_bw_gb_per_s_per_gpu"] = round(read_gb_per_s, 2)
+            decode_log_data["est_write_bw_gb_per_s_per_gpu"] = round(write_gb_per_s, 2)
             self._mfu_log_flops = 0.0
             self._mfu_log_read_bytes = 0.0
             self._mfu_log_write_bytes = 0.0
 
         if ENABLE_METRICS_DEVICE_TIMER:
-            msg += f", fwd occupancy: {self.fwd_occupancy:.2f}%"
+            decode_log_data["fwd_occupancy_pct"] = round(self.fwd_occupancy, 2)
 
         if self.is_stats_logging_rank:
-            logger.info(msg)
+            if self.scheduler.server_args.log_stats_format == "json":
+                logger.info(json.dumps(decode_log_data, ensure_ascii=False))
+            else:
+                iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
+                token_usage_msg = ", ".join(decode_log_data["token_usage"]) + ", "
+                msg = f"Decode batch{iter_msg}, #running-req: {num_running_reqs}, {token_usage_msg}"
+                if "spec_accept_length" in decode_log_data:
+                    msg += f"accept len: {decode_log_data['spec_accept_length']:.2f}, accept rate: {decode_log_data['spec_accept_rate']:.2f}, "
+                if "preallocated_usage" in decode_log_data:
+                    msg += f"pre-allocated usage: {decode_log_data['preallocated_usage']:.2f}, "
+                    msg += f"#prealloc-req: {decode_log_data['prealloc_reqs']}, "
+                    msg += f"#transfer-req: {decode_log_data['transfer_reqs']}, "
+                    msg += f"#retracted-req: {decode_log_data['retracted_reqs']}, "
+                if "waiting_image_reqs" in decode_log_data:
+                    msg += (
+                        f"waiting-image-req: {decode_log_data['waiting_image_reqs']}, "
+                    )
+                msg += (
+                    f"{decode_log_data['graph_backend']}: {decode_log_data['can_run_cuda_graph']}, "
+                    f"gen throughput (token/s): {decode_log_data['gen_throughput_token_per_s']:.2f}, "
+                    f"#queue-req: {decode_log_data['queue_reqs']}"
+                )
+                if "est_decode_tflops_per_s_per_gpu" in decode_log_data:
+                    msg += (
+                        f", est. decode TFLOPS/s (per GPU): {decode_log_data['est_decode_tflops_per_s_per_gpu']:.2f}, "
+                        f"est. read BW (GB/s per GPU): {decode_log_data['est_read_bw_gb_per_s_per_gpu']:.2f}, "
+                        f"est. write BW (GB/s per GPU): {decode_log_data['est_write_bw_gb_per_s_per_gpu']:.2f}"
+                    )
+                if "fwd_occupancy_pct" in decode_log_data:
+                    msg += (
+                        f", fwd occupancy: {decode_log_data['fwd_occupancy_pct']:.2f}%"
+                    )
+                logger.info(msg)
         if self.current_scheduler_metrics_enabled:
             priority_enabled = self.scheduler.enable_priority_scheduling
 

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -1092,6 +1092,105 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
         else:
             return "Unknown Time Stats"
 
+    def convert_to_duration_dict(self) -> dict:
+        """Return time stats as a structured dict for JSON logging."""
+        if self.disagg_mode == DisaggregationMode.NULL:
+            queue_duration = self.duration_between(
+                self.wait_queue_entry_time, self.forward_entry_time
+            )
+            forward_duration = self.duration_between(
+                self.forward_entry_time, self.completion_time
+            )
+            return {
+                "queue_duration_ms": round(queue_duration * 1e3, 2),
+                "forward_duration_ms": round(forward_duration * 1e3, 2),
+                "entry_time": self.format_wallclock(self.wait_queue_entry_time),
+            }
+        elif self.disagg_mode == DisaggregationMode.PREFILL:
+            result = {}
+            bootstrap_queue_duration = self.duration_between(
+                self.prefill_bootstrap_queue_entry_time, self.wait_queue_entry_time
+            )
+            queue_duration = self.duration_between(
+                self.wait_queue_entry_time, self.forward_entry_time
+            )
+            forward_duration = self.duration_between(
+                self.forward_entry_time, self.completion_time
+            )
+            if self.bootstrap_done_time > 0:
+                result["bootstrap_duration_ms"] = round(
+                    self.duration_between(
+                        self.prefill_bootstrap_queue_entry_time,
+                        self.bootstrap_done_time,
+                    )
+                    * 1e3,
+                    2,
+                )
+                result["alloc_wait_duration_ms"] = round(
+                    self.duration_between(
+                        self.bootstrap_done_time, self.wait_queue_entry_time
+                    )
+                    * 1e3,
+                    2,
+                )
+            else:
+                result["bootstrap_queue_duration_ms"] = round(
+                    bootstrap_queue_duration * 1e3, 2
+                )
+            result["queue_duration_ms"] = round(queue_duration * 1e3, 2)
+            result["forward_duration_ms"] = round(forward_duration * 1e3, 2)
+            result["entry_time"] = self.format_wallclock(
+                self.prefill_bootstrap_queue_entry_time
+            )
+            result["transfer_speed_gb_s"] = round(self.transfer_speed_gb_s, 2)
+            result["transfer_total_mb"] = round(self.transfer_total_mb, 2)
+            result["retries"] = self.prefill_retry_count
+            return result
+        elif self.disagg_mode == DisaggregationMode.DECODE:
+            result = {}
+            prealloc_duration = self.duration_between(
+                self.decode_prealloc_queue_entry_time,
+                self.decode_transfer_queue_entry_time,
+            )
+            transfer_duration = self.duration_between(
+                self.decode_transfer_queue_entry_time,
+                self.wait_queue_entry_time,
+            )
+            queue_duration = self.duration_between(
+                self.wait_queue_entry_time,
+                self.forward_entry_time,
+            )
+            forward_duration = self.duration_between(
+                self.forward_entry_time,
+                self.completion_time,
+            )
+            if self.bootstrap_done_time > 0:
+                result["bootstrap_duration_ms"] = round(
+                    self.duration_between(
+                        self.decode_prealloc_queue_entry_time, self.bootstrap_done_time
+                    )
+                    * 1e3,
+                    2,
+                )
+                result["alloc_wait_duration_ms"] = round(
+                    self.duration_between(
+                        self.bootstrap_done_time, self.decode_transfer_queue_entry_time
+                    )
+                    * 1e3,
+                    2,
+                )
+            else:
+                result["prealloc_queue_duration_ms"] = round(prealloc_duration * 1e3, 2)
+            result["transfer_duration_ms"] = round(transfer_duration * 1e3, 2)
+            result["queue_duration_ms"] = round(queue_duration * 1e3, 2)
+            result["forward_duration_ms"] = round(forward_duration * 1e3, 2)
+            result["entry_time"] = self.format_wallclock(
+                self.decode_prealloc_queue_entry_time
+            )
+            return result
+        else:
+            return {}
+
     def convert_to_output_meta_info(self):
         meta_data = {}
         if self.forward_entry_time > 0.0:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -443,6 +443,7 @@ class ServerArgs:
     log_requests: bool = False
     log_requests_level: int = 2
     log_requests_format: str = "text"
+    log_stats_format: str = "text"
     log_requests_target: Optional[List[str]] = None
     uvicorn_access_log_exclude_prefixes: List[str] = dataclasses.field(
         default_factory=lambda: list(DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES)
@@ -4841,6 +4842,13 @@ class ServerArgs:
             default=ServerArgs.log_requests_format,
             choices=["text", "json"],
             help="Format for request logging: 'text' (human-readable) or 'json' (structured)",
+        )
+        parser.add_argument(
+            "--log-stats-format",
+            type=str,
+            default=ServerArgs.log_stats_format,
+            choices=["text", "json"],
+            help="Format for prefill/decode stats logging: 'text' (human-readable) or 'json' (structured)",
         )
         parser.add_argument(
             "--log-requests-target",


### PR DESCRIPTION

## Motivation

The inference stats logging (`report_prefill_stats`, `report_decode_stats`, `log_time_stats`) only supports human-readable text output, which makes it difficult to programmatically parse and aggregate metrics in production environments. Adding structured JSON output enables better integration with log collectors, monitoring systems, and automated analysis pipelines.

## Modifications
* ServerArgs: Add log_stats_format field with `--log-stats-format` CLI argument (choices: `text`, `json`, default: `text`)
* metrics_reporter.py: Refactor `report_prefill_stats()` and `report_decode_stats()` to build a structured dict first, then output either JSON or text based on log_stats_format
* schedule_batch.py: Refactor `log_time_stats()` to read `log_stats_format` from `get_global_server_args()` and support JSON output
* req_time_stats.py: Add `convert_to_duration_dict()` method to `TimeStats`, returning a structured dict with millisecond-precision durations (mirrors `convert_to_duration()` for all disaggregation modes)

Text mode output remains identical to the original format. JSON mode adds an event field for log type identification (prefill.batch, decode.batch, request.time_stats).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26213855277](https://github.com/sgl-project/sglang/actions/runs/26213855277)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26213854848](https://github.com/sgl-project/sglang/actions/runs/26213854848)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->