### PR TITLE
amd/deepseek_v4 30/N Fuse Q per-head RMSNorm + Q RoPE into single Triton kernel on HIP

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1623,17 +1623,28 @@ class MQALayer(nn.Module):
         # [bs, n_local_heads, head_dim]
         q, _ = self.wq_b(q)
         q = q.view(-1, self.n_local_heads, self.head_dim)
-        q = rms_normalize_triton(q, self.eps)
 
-        if positions is not None:
-            fused_rope(
-                q[..., -self.qk_rope_head_dim :],
-                None,
-                self.freqs_cis,
-                positions=positions,
+        if _is_hip and positions is not None:
+            q_2d = q.view(-1, self.head_dim)
+            positions_expanded = positions.unsqueeze(1).expand(
+                -1, self.n_local_heads
+            ).reshape(-1)
+            fused_norm_rope_inplace_triton(
+                q_2d, None, self.eps, self.freqs_cis, positions=positions_expanded,
             )
         else:
-            apply_rotary_emb_triton(q[..., -self.qk_rope_head_dim :], self.freqs_cis)
+            q = rms_normalize_triton(q, self.eps)
+            if positions is not None:
+                fused_rope(
+                    q[..., -self.qk_rope_head_dim :],
+                    None,
+                    self.freqs_cis,
+                    positions=positions,
+                )
+            else:
+                apply_rotary_emb_triton(
+                    q[..., -self.qk_rope_head_dim :], self.freqs_cis
+                )
         return q
 
     def _compute_kv(
@@ -1756,18 +1767,32 @@ class MQALayer(nn.Module):
         # [bs, n_local_heads, head_dim]
         q, _ = self.wq_b(q_for_wqb)
         q = q.view(-1, self.n_local_heads, self.head_dim)
-        # [bs, n_local_heads, head_dim]
-        q = rms_normalize_triton(q, self.eps)
 
         # fp8 tuple: same as wq_a
         kv = self.kv_norm(kv)
 
-        fused_rope(
-            q[..., -self.qk_rope_head_dim :],
-            kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
-            self.freqs_cis,
-            positions=positions,
-        )
+        if _is_hip:
+            # Fused Q per-head RMSNorm + Q RoPE (single Triton kernel)
+            q_2d = q.view(-1, self.head_dim)
+            positions_expanded = positions.unsqueeze(1).expand(
+                -1, self.n_local_heads
+            ).reshape(-1)
+            fused_norm_rope_inplace_triton(
+                q_2d, None, self.eps, self.freqs_cis, positions=positions_expanded,
+            )
+            apply_rotary_emb_triton(
+                kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
+                self.freqs_cis,
+                positions=positions,
+            )
+        else:
+            q = rms_normalize_triton(q, self.eps)
+            fused_rope(
+                q[..., -self.qk_rope_head_dim :],
+                kv[..., -self.qk_rope_head_dim :].unsqueeze(1),
+                self.freqs_cis,
+                positions=positions,
+            )
 
         _use_cp = self.nsa_enable_prefill_cp and nsa_use_prefill_cp(forward_batch)
         if _use_cp:


### PR DESCRIPTION
## Motivation

On MI355, the Q per-head RMSNorm and Q RoPE in `MQALayer._forward_prepare` and `_compute_q_b` run as 3 separate Triton kernel launches (`_rms_normalize_kernel` + 2x `apply_rotary_emb_triton_kernel`), totaling ~125 us per layer on extend. An existing fused Triton kernel `_fused_norm_rope_kernel` (in `deepseek_v4_rope.py`) already combines RMSNorm + RoPE in a single pass with `HAS_WEIGHT=False` support, but was not wired up in the MQALayer attention prep path.

This PR reuses `fused_norm_rope_inplace_triton` to fuse Q norm + Q RoPE into a single kernel launch on HIP, reducing the kernel count from 3 to 2 per layer. The CUDA path is unchanged.

## Modifications

- **`python/sglang/srt/models/deepseek_v4.py`**
  - `MQALayer._forward_prepare`: On HIP, replace separate `rms_normalize_triton(q)` + `fused_rope(q, kv)` with `fused_norm_rope_inplace_triton(q_2d)` for Q norm+rope and `apply_rotary_emb_triton(kv)` for K rope. Positions are expanded from `[bs]` to `[bs*n_local_heads]` to match the 2D `[M, head_dim]` layout required by the fused kernel.
  - `MQALayer._compute_q_b`: Same fusion on HIP when `positions is not None`. The `positions is None` path (pre-indexed `freqs_cis`) is kept unchanged since it requires a different `freqs_cis` shape.
  - Both changes gated behind `_is_hip` (pure Triton, no aiter dependency). CUDA path is byte-identical.

## Accuracy Tests

| Benchmark | Score | Threshold |
|---|---|---|
| GSM8K 5-shot (2000 questions, parallel=1000) | 0.898 | 0.88 |

## Benchmarking and Profiling

**Setup:** DeepSeek-V4-Pro, MI355 x8 TP8, compressed attention backend

### Kernel replacement (extend, per layer in MQALayer)

| Phase | Kernel | Before (us) | After (us) |
|---|---|---|---|
| Q Norm | `_rms_normalize_kernel` | 66.2 | -- (fused) |
| Q RoPE | `apply_rotary_emb_triton_kernel` | 53.6 | -- (fused) |
| Q Norm+RoPE | `_fused_norm_rope_kernel` | -- | 115.6 |
| K RoPE | `apply_rotary_emb_triton_kernel` | 5.0 | 5.8 |
| **Total** | | **124.8** | **121.4** |
| **Kernel count** | | **3** | **2** |

### End-to-end benchmark (random, il8k_ol1k, concurrency=4, 32 prompts)

| Metric | Value |
|---|---|
| Total token throughput | 1575.73 tok/s |
| Output throughput | 175.08 tok/s |
| Median ITL | 20.67 ms |
| P99 ITL | 20.79 ms |
| Median TTFT | 1541.05 ms |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->