### PR TITLE
amd/deepseek_v4 30/N Enable fused nosplitk attention dispatch for extend, from separate gather+attention to 1 fused kernel

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_optimized.py
+++ b/python/sglang/srt/layers/attention/nsa/triton_decode/triton_mla_kernels_decode_optimized.py
@@ -96,7 +96,16 @@ def _should_use_fused_nosplitk(total_tokens: int, h_q: int, total_topk: int) -> 
 
     For total_tokens < 256, the separate path is faster because the
     fused kernel has insufficient parallelism.
+
+    For extend (total_tokens >= 1024), the fused kernel always wins
+    regardless of h_q or total_topk because:
+    - The grid already has thousands of blocks (good GPU utilization)
+    - It eliminates 1.5-5 GB gathered_kv buffer allocation
+    - It eliminates 2x gather_dequant kernel launches (~414 us)
+    - It avoids chunking that TP>1 configs require with the separate path
     """
+    if total_tokens >= 1024:
+        return True
     if h_q <= 64:
         return False  # Not benchmarked for h_q <= 64
     if total_topk < 200:


### PR DESCRIPTION
Update amd/deepseek_v4 integration branch

Following PRs have large set of conflict, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608

## Motivation

On MI355, the Triton MLA attention dispatch for DeepSeek V4 extend/prefill has two issues:

1. **c128 layers (L31-type, non-MoE)**: Fall through to the slow separate `gather_dequant + unified_sparse_decode` fallback path because `_should_use_fused_nosplitk()` rejects `total_topk < 200`. The fused dual-scope kernel already exists and works for c4 layers with larger topk. c128 layers with `total_topk=192` are blocked solely by this threshold, which was calibrated for decode workloads.

2. **TP>1 configurations (h_q <= 64)**: Both c128 and c4 layers are blocked by a `h_q <= 64: return False` guard, causing c4 layers to fall into a 3-chunk fallback (5 GB intermediate buffer exceeds 2 GB limit). The fused kernel avoids buffer allocation entirely, so this limit is irrelevant.

For extend with `total_tokens >= 1024`, the GPU grid already has thousands of blocks, so the fused kernel is strictly better: it eliminates the intermediate `gathered_kv` buffer (1.5-5 GB), removes 2x `_gather_dequant_dsv4_kernel` launches (~414 us), and avoids chunking overhead.

## Modifications

- **`triton_mla_kernels_decode_optimized.py`**: Add an early `return True` in `_should_use_fused_nosplitk()` when `total_tokens >= 1024`. This routes all extend workloads to the fused dual-scope kernel regardless of `h_q` or `total_topk`. Decode paths (`total_tokens < 1024`) are unchanged.

## Accuracy Tests

| Benchmark | Score | Threshold | Status |
|---|---|---|---|
| GSM8K 5-shot (2000 questions) | 0.911 | 0.88 | PASS |

## Benchmarking and Profiling

### Kernel Change (L31 c128, extend il8k, TP=8)

| | Before | After |
|---|---|---|
| Kernel(s) | `_gather_dequant_dsv4` x2 + `_unified_sparse_decode` | `_fused_gather_attn_dsv4_dual_scope` |
| Kernel count | 3 | 1 |
| Attention time | ~2005 us | 1882 us |
| Intermediate buffer | 1.5 GB `gathered_kv` | None |

### Kernel Change (L32 c4, extend il8k, TP=8)

| | Before (TP=8) | After |
|---|---|---|
| Path | 3-chunk fallback (5 GB > 2 GB limit) | fused nosplitk |
| Kernel(s) | 3x chunked gather+attention | `_fused_gather_attn_dsv4_dual_scope` |
| Attention time | chunked (multiple launches) | 4459 us (single kernel) |

### E2E Benchmark (il8k_ol1k, concurrency=4, TP=8, 8xMI355)

| Metric | Value |
|---|---|
| Total token throughput | 1584 tok/s |
| Output throughput | 176 tok/s |
| Median TTFT | 1532 ms |
| Median ITL | 20.56 ms |
| Median E2E | 23065 ms |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->