### PR TITLE
[Feature][Draft] Refactor vit cudagraph

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -530,6 +530,8 @@ class Envs:
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
     SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)
     SGLANG_VIT_ENABLE_CUDA_GRAPH = EnvBool(False)
+    SGLANG_VIT_PACK = EnvBool(False)
+    SGLANG_VIT_INFER_TIMES = EnvInt(1)
     SGLANG_MM_SKIP_COMPUTE_HASH = EnvBool(False)
 
 

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -340,14 +340,9 @@ class VisionTritonAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
-        if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
-            if "output_ws" not in kwargs:
-                raise RuntimeError("output_ws should be prepared for cuda-graph mode")
-
-            if not isinstance(cu_seqlens, list):
-                raise RuntimeError("cuda-graph mode cu_seqlens should be a list")
-
-            output = kwargs["output_ws"]
+        if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get() and isinstance(cu_seqlens, list):
+            # [b * s, head, head_size]
+            output = torch.empty_like(q)
             context_attention_fwd(
                 q,
                 k,

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -587,6 +587,174 @@ def _get_chunked_embedding_by_item(
     return torch.cat(chunk_slices, dim=0)
 
 
+def _get_item_feature_dim0(item: MultimodalDataItem) -> int:
+    shape = getattr(item.feature, "shape", None)
+    if shape is None or len(shape) == 0:
+        return 1
+    return max(int(shape[0]), 1)
+
+
+def _partition_miss_items_by_feature_size(
+    miss_items: List[Tuple[int, int, MultimodalDataItem, int, int]],
+    infer_times: int,
+) -> List[List[Tuple[int, int, MultimodalDataItem, int, int]]]:
+    if not miss_items:
+        return []
+
+    if len(miss_items) <= 1:
+        return [miss_items]
+
+    num_partitions = min(max(infer_times, 1), len(miss_items))
+    if num_partitions == 1:
+        return [miss_items]
+
+    total_size = sum(_get_item_feature_dim0(item) for _, _, item, _, _ in miss_items)
+    target_size = total_size / num_partitions
+
+    partitions = []
+    cur_partition = []
+    cur_size = 0
+
+    for idx, miss_item in enumerate(miss_items):
+        _, _, item, _, _ = miss_item
+        item_size = _get_item_feature_dim0(item)
+
+        remaining_items = len(miss_items) - idx
+        remaining_partitions = num_partitions - len(partitions)
+        if cur_partition and remaining_items == remaining_partitions:
+            partitions.append(cur_partition)
+            cur_partition = []
+            cur_size = 0
+        elif cur_partition and len(partitions) < num_partitions - 1:
+            size_with_item = cur_size + item_size
+            if cur_size >= target_size or abs(target_size - cur_size) <= abs(
+                target_size - size_with_item
+            ):
+                partitions.append(cur_partition)
+                cur_partition = []
+                cur_size = 0
+
+        cur_partition.append(miss_item)
+        cur_size += item_size
+
+    if cur_partition:
+        partitions.append(cur_partition)
+
+    return partitions
+
+
+def _is_vit_cuda_graph_enabled() -> bool:
+    if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
+        return True
+    try:
+        return bool(getattr(get_global_server_args(), "enable_vit_cuda_graph", False))
+    except Exception:
+        return False
+
+
+def _get_chunked_embedding_by_item_packed(
+    data_embedding_func: DataEmbeddingFunc,
+    per_image_reqs: List[
+        Tuple[
+            List[MultimodalDataItem],
+            List[Tuple[int, int]],
+            int,
+            int,
+        ]
+    ],
+    infer_times: int,
+    device: torch.device,
+) -> List[Optional[torch.Tensor]]:
+    req_states = []
+    miss_items = []
+
+    for req_idx, (
+        embedding_items_per_req,
+        items_offset,
+        extend_prefix_len,
+        extend_seq_len,
+    ) in enumerate(per_image_reqs):
+        chunk_start = extend_prefix_len
+        chunk_end = extend_prefix_len + extend_seq_len
+
+        if extend_seq_len <= 0:
+            req_states.append(None)
+            continue
+
+        overlapping = []
+        for item_idx, (item, offset) in enumerate(
+            zip(embedding_items_per_req, items_offset)
+        ):
+            start, end = offset
+            if end >= chunk_start and start < chunk_end:
+                overlapping.append((item_idx, item, start, end))
+
+        if not overlapping:
+            req_states.append(None)
+            continue
+
+        cached_embeddings = {}
+        for item_idx, item, start, end in overlapping:
+            cached = embedding_cache.get_single(item.hash)
+            if cached is not None:
+                cached_embeddings[item_idx] = cached.embedding
+            else:
+                miss_items.append((req_idx, item_idx, item, start, end))
+
+        req_states.append(
+            {
+                "chunk_start": chunk_start,
+                "chunk_end": chunk_end,
+                "overlapping": overlapping,
+                "cached_embeddings": cached_embeddings,
+            }
+        )
+
+    if _is_vit_cuda_graph_enabled():
+        partitions = [miss_items] if miss_items else []
+    else:
+        partitions = _partition_miss_items_by_feature_size(miss_items, infer_times)
+
+    for partition in partitions:
+        miss_item_list = [item for _, _, item, _, _ in partition]
+        _move_items_to_device(miss_item_list, device)
+        all_miss_embedding = data_embedding_func(miss_item_list)
+        all_miss_embedding = all_miss_embedding.reshape(
+            -1, all_miss_embedding.shape[-1]
+        )
+
+        token_counts = [end - start + 1 for _, _, _, start, end in partition]
+        split_embeddings = torch.split(all_miss_embedding, token_counts, dim=0)
+
+        for (req_idx, item_idx, item, _, _), emb in zip(partition, split_embeddings):
+            req_states[req_idx]["cached_embeddings"][item_idx] = emb
+            emb_result = EmbeddingResult(embedding=emb)
+            embedding_cache.set(item.hash, emb_result)
+
+    chunk_embeddings = []
+    for state in req_states:
+        if state is None:
+            chunk_embeddings.append(None)
+            continue
+
+        chunk_start = state["chunk_start"]
+        chunk_end = state["chunk_end"]
+        cached_embeddings = state["cached_embeddings"]
+        chunk_slices = []
+
+        for item_idx, _, start, end in state["overlapping"]:
+            emb = cached_embeddings[item_idx]
+            overlap_start = max(start, chunk_start)
+            overlap_end = min(end, chunk_end - 1)
+            local_start = overlap_start - start
+            local_end = overlap_end - start + 1
+            chunk_slices.append(emb[local_start:local_end])
+
+        chunk_embeddings.append(torch.cat(chunk_slices, dim=0))
+
+    return chunk_embeddings
+
+
 def _get_chunked_prefill_embedding(
     data_embedding_func: DataEmbeddingFunc,
     embedding_items: List[MultimodalDataItem],
@@ -602,6 +770,44 @@ def _get_chunked_prefill_embedding(
     """
     embedding_list = []
     device = input_ids.device
+    vit_pack = envs.SGLANG_VIT_PACK.get()
+    vit_infer_times = max(envs.SGLANG_VIT_INFER_TIMES.get(), 1)
+    packed_per_image_reqs = []
+
+    def flush_packed_per_image_reqs():
+        if not packed_per_image_reqs:
+            return
+        if len(packed_per_image_reqs) == 1:
+            (
+                embedding_items_per_req,
+                items_offset,
+                extend_prefix_len,
+                extend_seq_len,
+            ) = packed_per_image_reqs[0]
+            chunk_embedding = _get_chunked_embedding_by_item(
+                data_embedding_func,
+                embedding_items_per_req,
+                items_offset,
+                extend_prefix_len,
+                extend_seq_len,
+                device,
+            )
+            if chunk_embedding is not None:
+                embedding_list.append(chunk_embedding)
+            packed_per_image_reqs.clear()
+            return
+
+        chunk_embeddings = _get_chunked_embedding_by_item_packed(
+            data_embedding_func,
+            packed_per_image_reqs,
+            vit_infer_times,
+            device,
+        )
+        for chunk_embedding in chunk_embeddings:
+            if chunk_embedding is not None:
+                embedding_list.append(chunk_embedding)
+        packed_per_image_reqs.clear()
+
     # FIXME(Xinyuan): temporary workaround for eagle3
     max_iterations = min(len(items_size) - 1, len(prefix_length))
 
@@ -625,17 +831,28 @@ def _get_chunked_prefill_embedding(
         is_per_image = all(len(item.offsets) == 1 for item in embedding_items_per_req)
 
         if is_per_image:
-            chunk_embedding = _get_chunked_embedding_by_item(
-                data_embedding_func,
-                embedding_items_per_req,
-                items_offset,
-                extend_prefix_len,
-                extend_seq_len,
-                device,
-            )
-            if chunk_embedding is not None:
-                embedding_list.append(chunk_embedding)
+            if vit_pack:
+                packed_per_image_reqs.append(
+                    (
+                        embedding_items_per_req,
+                        items_offset,
+                        extend_prefix_len,
+                        extend_seq_len,
+                    )
+                )
+            else:
+                chunk_embedding = _get_chunked_embedding_by_item(
+                    data_embedding_func,
+                    embedding_items_per_req,
+                    items_offset,
+                    extend_prefix_len,
+                    extend_seq_len,
+                    device,
+                )
+                if chunk_embedding is not None:
+                    embedding_list.append(chunk_embedding)
         else:
+            flush_packed_per_image_reqs()
             chunk_embedding, input_ids = _get_chunked_embedding_full(
                 data_embedding_func,
                 embedding_items_per_req,
@@ -647,6 +864,8 @@ def _get_chunked_prefill_embedding(
             )
             if chunk_embedding is not None:
                 embedding_list.append(chunk_embedding)
+
+    flush_packed_per_image_reqs()
 
     if len(embedding_list) == 0:
         return None, input_ids

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -738,6 +738,10 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # Deduce KV cache dtype
         self.configure_kv_cache_dtype()
 
+        # Capture ViT CUDA graphs before KV cache pool sizing so the graph memory
+        # pool is accounted for in available-memory profiling.
+        self.init_vit_cuda_graphs()
+
         # Init memory pool and attention backends
         self.init_memory_pool(pre_model_load_memory)
 
@@ -2798,6 +2802,55 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         logger.info(
             f"Capture {graph_backend[self.device]} end. Time elapsed: {time.perf_counter() - tic:.2f} s. "
             f"mem usage={self.graph_mem_usage:.2f} GB. avail mem={after_mem:.2f} GB."
+        )
+
+    def init_vit_cuda_graphs(self):
+        """Capture image ViT CUDA graphs."""
+        self.vit_cuda_graph_mem_usage = 0
+
+        if self.device != "cuda":
+            return
+        if not (
+            getattr(self.server_args, "enable_vit_cuda_graph", False)
+            or envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get()
+        ):
+            return
+        if self.server_args.model_impl.lower() == ModelImpl.MINDSPORE:
+            return
+
+        capturers = []
+        seen = set()
+        for module in self.model.modules():
+            capture_fn = getattr(module, "capture_vit_cuda_graphs", None)
+            if not callable(capture_fn):
+                continue
+            module_id = id(module)
+            if module_id in seen:
+                continue
+            seen.add(module_id)
+            capturers.append(capture_fn)
+
+        if not capturers:
+            logger.info("ViT CUDA graph is enabled, but no capturable ViT module was found.")
+            return
+
+        tic = time.perf_counter()
+        before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        logger.info(
+            "Capture ViT CUDA graph begin. capturable modules=%s, avail mem=%.2f GB",
+            len(capturers),
+            before_mem,
+        )
+        for capture_fn in capturers:
+            capture_fn()
+        after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        self.vit_cuda_graph_mem_usage = before_mem - after_mem
+        logger.info(
+            "Capture ViT CUDA graph end. Time elapsed: %.2f s. mem usage=%.2f GB. "
+            "avail mem=%.2f GB.",
+            time.perf_counter() - tic,
+            self.vit_cuda_graph_mem_usage,
+            after_mem,
         )
 
     def init_piecewise_cuda_graphs(self, force_for_draft_worker: bool = False):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2831,7 +2831,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             capturers.append(capture_fn)
 
         if not capturers:
-            logger.info("ViT CUDA graph is enabled, but no capturable ViT module was found.")
+            logger.info(
+                "ViT CUDA graph is enabled, but no capturable ViT module was found."
+            )
             return
 
         tic = time.perf_counter()

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -75,7 +75,11 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2Model
 from sglang.srt.models.utils import RotaryPosMixin, WeightsMapper, permute_inv
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
-from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
+from sglang.srt.multimodal.vit_cuda_graph_runner import (
+    ViTCudaGraphRunner,
+    is_vit_cuda_graph_enabled,
+    make_image_grid_for_vision_tokens,
+)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, is_cuda, is_npu
 
@@ -280,6 +284,8 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
         patch_size: int = vision_config.patch_size
         temporal_patch_size: int = vision_config.temporal_patch_size
         spatial_merge_size: int = vision_config.spatial_merge_size
+        self.in_channels = vision_config.in_channels
+        self.temporal_patch_size = temporal_patch_size
         self.spatial_merge_size = spatial_merge_size
         self.spatial_merge_unit: int = spatial_merge_size * spatial_merge_size
         in_channels: int = vision_config.in_channels
@@ -331,7 +337,7 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
             1 if use_data_parallel else get_tensor_model_parallel_world_size()
         )
         self.max_context_len = max_context_len
-        self.enable_cg = _is_cuda and envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get()
+        self.enable_cg = _is_cuda and is_vit_cuda_graph_enabled()
 
         self.cuda_graph_runner: Optional[ViTCudaGraphRunner] = None
         if self.enable_cg:
@@ -407,9 +413,15 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
         x: torch.Tensor,
         grid_thw: torch.Tensor,
     ) -> torch.Tensor:
-        if self.enable_cg:
+        if self.enable_cg and self._is_image_only_grid(grid_thw):
             return self.forward_with_cuda_graph(x, grid_thw)
+        return self.raw_forward(x, grid_thw)
 
+    def raw_forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
         # patchify
         x = x.to(device=self.device, dtype=self.dtype)
         x = self.patch_embed(x)
@@ -484,11 +496,45 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
 
         return x
 
-    def forward_with_cuda_graph(
+    def _raw_patch_dim(self) -> int:
+        return (
+            self.in_channels
+            * self.temporal_patch_size
+            * self.patch_size
+            * self.patch_size
+        )
+
+    def _grid_to_tensor(self, grid_thw) -> torch.Tensor:
+        if isinstance(grid_thw, torch.Tensor):
+            return grid_thw.cpu().to(dtype=torch.int32)
+        return torch.tensor(grid_thw, dtype=torch.int32)
+
+    def _is_image_only_grid(self, grid_thw) -> bool:
+        if isinstance(grid_thw, list):
+            return all(int(grid[0]) == 1 for grid in grid_thw)
+        return bool(torch.all(grid_thw[:, 0] == 1).item())
+
+    def _vision_token_counts(self, grid_thw) -> List[int]:
+        grid = self._grid_to_tensor(grid_thw).cpu().tolist()
+        return [
+            int(t) * int(h) * int(w) // self.spatial_merge_unit for t, h, w in grid
+        ]
+
+    def _raw_token_counts(self, grid_thw) -> List[int]:
+        grid = self._grid_to_tensor(grid_thw).cpu().tolist()
+        return [int(t) * int(h) * int(w) for t, h, w in grid]
+
+    def _prepare_cuda_graph_inputs(
         self,
         x: torch.Tensor,
         grid_thw: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> Tuple[
+        torch.Tensor,
+        Tuple[torch.Tensor, torch.Tensor],
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
         # patchify
         x = x.to(device=self.device, dtype=self.dtype)
         x = self.patch_embed(x)
@@ -542,12 +588,279 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
         )
         cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
 
-        return self.cuda_graph_runner.run(
-            x=x,
-            position_embeddings=position_embeddings,
-            cu_seqlens=cu_seqlens,
-            cu_window_seqlens=cu_window_seqlens,
+        return x, position_embeddings, cu_seqlens, cu_window_seqlens, reverse_indices
+
+    def _pad_hidden_states(self, x: torch.Tensor, raw_budget: int) -> torch.Tensor:
+        if x.shape[0] == raw_budget:
+            return x
+        padded = x.new_zeros((raw_budget, x.shape[-1]))
+        padded[: x.shape[0]].copy_(x)
+        return padded
+
+    def _pad_position_embeddings(
+        self,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        raw_budget: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        cos, sin = position_embeddings
+        if cos.shape[0] == raw_budget:
+            return position_embeddings
+        padded_cos = cos.new_ones((raw_budget, cos.shape[-1]))
+        padded_sin = sin.new_zeros((raw_budget, sin.shape[-1]))
+        padded_cos[: cos.shape[0]].copy_(cos)
+        padded_sin[: sin.shape[0]].copy_(sin)
+        return padded_cos, padded_sin
+
+    def _pad_full_cu_seqlens(
+        self,
+        cu_seqlens: torch.Tensor,
+        raw_budget: int,
+    ) -> Optional[torch.Tensor]:
+        runner = self.cuda_graph_runner
+        target_len = runner.max_full_cu_len
+        values = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+        total_raw = values[-1]
+        if len(values) > target_len - 1:
+            return None
+        while len(values) < target_len - 1:
+            values.append(total_raw)
+        values.append(raw_budget)
+        return torch.tensor(values, device=self.device, dtype=torch.int32)
+
+    def _vit_window_raw_size(self) -> int:
+        vit_merger_window_size = (
+            self.window_size // self.spatial_merge_size // self.patch_size
+        )
+        return max(
+            1, vit_merger_window_size * vit_merger_window_size * self.spatial_merge_unit
+        )
+
+    def _pad_window_cu_seqlens(
+        self,
+        cu_window_seqlens: torch.Tensor,
+        raw_budget: int,
+    ) -> Optional[torch.Tensor]:
+        runner = self.cuda_graph_runner
+        target_len = runner.max_window_cu_len
+        values = [int(x) for x in cu_window_seqlens.detach().cpu().tolist()]
+        total_raw = values[-1]
+        window_raw_size = self._vit_window_raw_size()
+
+        tail_values = []
+        tail_offset = total_raw
+        if tail_offset == raw_budget:
+            tail_values.append(raw_budget)
+        else:
+            while tail_offset < raw_budget:
+                tail_offset = min(raw_budget, tail_offset + window_raw_size)
+                tail_values.append(tail_offset)
+
+        if len(values) + len(tail_values) > target_len:
+            return None
+        while len(values) + len(tail_values) < target_len:
+            values.append(total_raw)
+        values.extend(tail_values)
+        return torch.tensor(values, device=self.device, dtype=torch.int32)
+
+    def _pad_cuda_graph_inputs(
+        self,
+        x: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        cu_window_seqlens: torch.Tensor,
+        raw_budget: int,
+    ) -> Optional[
+        Tuple[
+            torch.Tensor,
+            Tuple[torch.Tensor, torch.Tensor],
+            torch.Tensor,
+            torch.Tensor,
+        ]
+    ]:
+        padded_cu_seqlens = self._pad_full_cu_seqlens(cu_seqlens, raw_budget)
+        padded_cu_window_seqlens = self._pad_window_cu_seqlens(
+            cu_window_seqlens, raw_budget
+        )
+        if padded_cu_seqlens is None or padded_cu_window_seqlens is None:
+            return None
+        return (
+            self._pad_hidden_states(x, raw_budget),
+            self._pad_position_embeddings(position_embeddings, raw_budget),
+            padded_cu_seqlens,
+            padded_cu_window_seqlens,
+        )
+
+    def _grid_index_select(self, grid_thw: torch.Tensor, indices: List[int]):
+        index_tensor = torch.tensor(indices, dtype=torch.long, device=grid_thw.device)
+        return grid_thw.index_select(0, index_tensor)
+
+    def _run_cuda_graph_batch(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        vision_token_counts: List[int],
+    ) -> torch.Tensor:
+        runner = self.cuda_graph_runner
+        total_vision_tokens = sum(vision_token_counts)
+        budget = runner.select_budget(total_vision_tokens)
+        if budget is None:
+            runner.record_fallback("over_budget")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        _, raw_budget = budget
+        if raw_budget not in runner.block_graphs:
+            runner.record_fallback("graph_not_captured")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        (
+            x,
+            position_embeddings,
+            cu_seqlens,
+            cu_window_seqlens,
+            reverse_indices,
+        ) = self._prepare_cuda_graph_inputs(pixel_values, grid_thw)
+        if x.shape[0] > raw_budget:
+            runner.record_fallback("raw_tokens_over_budget")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        padded = self._pad_cuda_graph_inputs(
+            x, position_embeddings, cu_seqlens, cu_window_seqlens, raw_budget
+        )
+        if padded is None:
+            runner.record_fallback("window_metadata_capacity")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        padded_x, padded_position_embeddings, padded_cu, padded_cu_window = padded
+        out = runner.replay(
+            graph_key=raw_budget,
+            x_3d=padded_x.unsqueeze(1),
+            position_embeddings=padded_position_embeddings,
+            cu_seqlens=padded_cu,
+            cu_window_seqlens=padded_cu_window,
             output_indices=reverse_indices,
+        )
+        return out[:total_vision_tokens]
+
+    def forward_with_cuda_graph(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        runner = self.cuda_graph_runner
+        if runner is None or not runner.capture_completed:
+            if runner is not None:
+                runner.record_fallback("graph_not_captured")
+            return self.raw_forward(x, grid_thw)
+
+        grid_thw = self._grid_to_tensor(grid_thw)
+        vision_counts = self._vision_token_counts(grid_thw)
+        raw_counts = self._raw_token_counts(grid_thw)
+        pixel_chunks = list(torch.split(x, raw_counts, dim=0))
+        outputs: List[Optional[torch.Tensor]] = [None] * len(vision_counts)
+
+        def flush(indices: List[int]) -> None:
+            if not indices:
+                return
+            batch_pixels = torch.cat([pixel_chunks[i] for i in indices], dim=0)
+            batch_grid = self._grid_index_select(grid_thw, indices)
+            batch_counts = [vision_counts[i] for i in indices]
+            batch_out = self._run_cuda_graph_batch(
+                batch_pixels, batch_grid, batch_counts
+            )
+            split_out = torch.split(batch_out, batch_counts, dim=0)
+            for idx, emb in zip(indices, split_out):
+                outputs[idx] = emb
+
+        current: List[int] = []
+        current_tokens = 0
+        for idx in sorted(range(len(vision_counts)), key=lambda i: vision_counts[i]):
+            num_tokens = vision_counts[idx]
+            if num_tokens > runner.max_vision_budget:
+                flush(current)
+                current = []
+                current_tokens = 0
+                runner.record_fallback("single_image_over_budget")
+                outputs[idx] = self.raw_forward(
+                    pixel_chunks[idx], self._grid_index_select(grid_thw, [idx])
+                )
+                continue
+
+            if current and (
+                current_tokens + num_tokens > runner.max_vision_budget
+                or len(current) >= runner.max_batch_size
+            ):
+                flush(current)
+                current = []
+                current_tokens = 0
+
+            current.append(idx)
+            current_tokens += num_tokens
+
+        flush(current)
+        if any(emb is None for emb in outputs):
+            raise RuntimeError("ViT CUDA graph bin-pack did not produce all outputs")
+        return torch.cat(outputs, dim=0)
+
+    @torch.no_grad()
+    def capture_vit_cuda_graphs(self) -> None:
+        runner = self.cuda_graph_runner
+        if not self.enable_cg or runner is None or runner.capture_completed:
+            return
+
+        mm_backend = get_global_server_args().mm_attention_backend
+        if mm_backend not in ("triton_attn", "fa3"):
+            logger.warning(
+                "ViT CUDA graph supports mm_attention_backend triton_attn/fa3, "
+                "but got %s; Qwen2.5-VL vision encoder will use eager fallback.",
+                mm_backend,
+            )
+            return
+
+        runner.log_capture_config()
+        raw_patch_dim = self._raw_patch_dim()
+        for vision_budget, raw_budget in zip(
+            runner.vision_token_budgets, runner.raw_token_budgets
+        ):
+            grid = torch.tensor(
+                [make_image_grid_for_vision_tokens(vision_budget, self.spatial_merge_size)],
+                dtype=torch.int32,
+            )
+            pixel_values = torch.zeros(
+                raw_budget,
+                raw_patch_dim,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            (
+                x,
+                position_embeddings,
+                cu_seqlens,
+                cu_window_seqlens,
+                _,
+            ) = self._prepare_cuda_graph_inputs(pixel_values, grid)
+            padded = self._pad_cuda_graph_inputs(
+                x, position_embeddings, cu_seqlens, cu_window_seqlens, raw_budget
+            )
+            if padded is None:
+                raise RuntimeError(
+                    f"Failed to pad Qwen2.5-VL ViT CUDA graph capture inputs for "
+                    f"vision_budget={vision_budget}, raw_budget={raw_budget}"
+                )
+            padded_x, padded_position_embeddings, padded_cu, padded_cu_window = padded
+            runner.create_graph(
+                x_3d=padded_x.unsqueeze(1),
+                position_embeddings=padded_position_embeddings,
+                cu_seqlens=padded_cu,
+                cu_window_seqlens=padded_cu_window,
+                max_full_len=raw_budget,
+                max_window_len=self._vit_window_raw_size(),
+            )
+
+        runner.capture_completed = True
+        torch.cuda.synchronize()
+        logger.info(
+            "Captured Qwen2.5-VL ViT CUDA graphs for raw budgets=%s",
+            runner.raw_token_budgets,
         )
 
 
@@ -662,7 +975,7 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
                 vision_conf, "embed_dim", getattr(vision_conf, "hidden_size", -1)
             )
 
-        raw_patch_dim = 1176
+        raw_patch_dim = self.visual._raw_patch_dim()
 
         if pixel_values.dim() == 2:
             current_dim = pixel_values.shape[-1]

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -47,7 +47,6 @@ from sglang.srt.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from sglang.srt.distributed.parallel_state import get_pp_group
-from sglang.srt.environ import envs
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.layernorm import RMSNorm
@@ -516,9 +515,7 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
 
     def _vision_token_counts(self, grid_thw) -> List[int]:
         grid = self._grid_to_tensor(grid_thw).cpu().tolist()
-        return [
-            int(t) * int(h) * int(w) // self.spatial_merge_unit for t, h, w in grid
-        ]
+        return [int(t) * int(h) * int(w) // self.spatial_merge_unit for t, h, w in grid]
 
     def _raw_token_counts(self, grid_thw) -> List[int]:
         grid = self._grid_to_tensor(grid_thw).cpu().tolist()
@@ -822,7 +819,11 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
             runner.vision_token_budgets, runner.raw_token_budgets
         ):
             grid = torch.tensor(
-                [make_image_grid_for_vision_tokens(vision_budget, self.spatial_merge_size)],
+                [
+                    make_image_grid_for_vision_tokens(
+                        vision_budget, self.spatial_merge_size
+                    )
+                ],
                 dtype=torch.int32,
             )
             pixel_values = torch.zeros(

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -891,9 +891,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
     def _vision_token_counts(self, grid_thw) -> List[int]:
         grid = self._grid_to_tensor(grid_thw).tolist()
-        return [
-            int(t) * int(h) * int(w) // self.spatial_merge_unit for t, h, w in grid
-        ]
+        return [int(t) * int(h) * int(w) // self.spatial_merge_unit for t, h, w in grid]
 
     def _raw_token_counts(self, grid_thw) -> List[int]:
         grid = self._grid_to_tensor(grid_thw).tolist()

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1222,7 +1222,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             grid_thw = grid_thw.cpu().to(dtype=torch.int32)
             grid_thw_list = grid_thw.tolist()
 
-        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        pos_embeds = self.fast_pos_embed_interpolate_from_list(grid_thw_list)
         x += pos_embeds
 
         # rotary embedding -> (cos, sin)

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -70,7 +70,11 @@ from sglang.srt.models.utils import (
     compute_cu_seqlens_from_grid_numpy,
 )
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
-from sglang.srt.multimodal.vit_cuda_graph_runner import ViTCudaGraphRunner
+from sglang.srt.multimodal.vit_cuda_graph_runner import (
+    ViTCudaGraphRunner,
+    is_vit_cuda_graph_enabled,
+    make_image_grid_for_vision_tokens,
+)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     add_prefix,
@@ -422,6 +426,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             1 if use_data_parallel else get_tensor_model_parallel_world_size()
         )
         self.graph_runners = graph_runners_dict[self.device.type](self)
+        self.inner_rope_compiled = False
 
     @property
     def dtype(self) -> torch.dtype:
@@ -751,11 +756,21 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
         x: torch.Tensor,
         grid_thw: torch.Tensor,
     ) -> torch.Tensor:
-        if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
-            if _is_npu:
-                return self.forward_with_npu_graph(x, grid_thw)
+        if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get() and _is_npu:
+            return self.forward_with_npu_graph(x, grid_thw)
+        if (
+            self.device.type == "cuda"
+            and is_vit_cuda_graph_enabled()
+            and self._is_image_only_grid(grid_thw)
+        ):
             return self.forward_with_cuda_graph(x, grid_thw)
+        return self.raw_forward(x, grid_thw)
 
+    def raw_forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
         x = x.to(device=self.device, dtype=self.dtype)
         x = self.patch_embed(x)
 
@@ -856,6 +871,148 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
         )  # [seq_len, hidden_size * (1 + depth_of_deepstack)]
         return hidden_states
 
+    def _raw_patch_dim(self) -> int:
+        return (
+            self.patch_embed.in_channels
+            * self.patch_embed.temporal_patch_size
+            * self.patch_embed.patch_size
+            * self.patch_embed.patch_size
+        )
+
+    def _grid_to_tensor(self, grid_thw) -> torch.Tensor:
+        if isinstance(grid_thw, torch.Tensor):
+            return grid_thw.cpu().to(dtype=torch.int32)
+        return torch.tensor(grid_thw, dtype=torch.int32)
+
+    def _is_image_only_grid(self, grid_thw) -> bool:
+        if isinstance(grid_thw, list):
+            return all(int(grid[0]) == 1 for grid in grid_thw)
+        return bool(torch.all(grid_thw[:, 0] == 1).item())
+
+    def _vision_token_counts(self, grid_thw) -> List[int]:
+        grid = self._grid_to_tensor(grid_thw).tolist()
+        return [
+            int(t) * int(h) * int(w) // self.spatial_merge_unit for t, h, w in grid
+        ]
+
+    def _raw_token_counts(self, grid_thw) -> List[int]:
+        grid = self._grid_to_tensor(grid_thw).tolist()
+        return [int(t) * int(h) * int(w) for t, h, w in grid]
+
+    def _pad_hidden_states(self, x: torch.Tensor, raw_budget: int) -> torch.Tensor:
+        if x.shape[0] == raw_budget:
+            return x
+        padded = x.new_zeros((raw_budget, x.shape[-1]))
+        padded[: x.shape[0]].copy_(x)
+        return padded
+
+    def _pad_rotary_embeddings(
+        self,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+        raw_budget: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if rotary_pos_emb_cos.shape[0] == raw_budget:
+            return rotary_pos_emb_cos, rotary_pos_emb_sin
+        padded_cos = rotary_pos_emb_cos.new_ones(
+            (raw_budget, rotary_pos_emb_cos.shape[-1])
+        )
+        padded_sin = rotary_pos_emb_sin.new_zeros(
+            (raw_budget, rotary_pos_emb_sin.shape[-1])
+        )
+        padded_cos[: rotary_pos_emb_cos.shape[0]].copy_(rotary_pos_emb_cos)
+        padded_sin[: rotary_pos_emb_sin.shape[0]].copy_(rotary_pos_emb_sin)
+        return padded_cos, padded_sin
+
+    def _pad_full_cu_seqlens(
+        self,
+        cu_seqlens: torch.Tensor,
+        raw_budget: int,
+    ) -> Optional[torch.Tensor]:
+        runner = self.graph_runners
+        target_len = runner.max_full_cu_len
+        values = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+        total_raw = values[-1]
+        if len(values) > target_len - 1:
+            return None
+        while len(values) < target_len - 1:
+            values.append(total_raw)
+        values.append(raw_budget)
+        return torch.tensor(values, device=self.device, dtype=torch.int32)
+
+    def _pad_cuda_graph_inputs(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+        raw_budget: int,
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]:
+        padded_cu = self._pad_full_cu_seqlens(cu_seqlens, raw_budget)
+        if padded_cu is None:
+            return None
+        padded_cos, padded_sin = self._pad_rotary_embeddings(
+            rotary_pos_emb_cos, rotary_pos_emb_sin, raw_budget
+        )
+        return self._pad_hidden_states(x, raw_budget), padded_cu, padded_cos, padded_sin
+
+    def _grid_index_select(self, grid_thw: torch.Tensor, indices: List[int]):
+        index_tensor = torch.tensor(indices, dtype=torch.long)
+        return grid_thw.index_select(0, index_tensor)
+
+    def _run_cuda_graph_batch(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        vision_token_counts: List[int],
+    ) -> torch.Tensor:
+        runner = self.graph_runners
+        total_vision_tokens = sum(vision_token_counts)
+        budget = runner.select_budget(total_vision_tokens)
+        if budget is None:
+            runner.record_fallback("over_budget")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        _, raw_budget = budget
+        if raw_budget not in runner.block_graphs:
+            runner.record_fallback("graph_not_captured")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        (
+            x,
+            cu_seqlens,
+            rotary_pos_emb_cos,
+            rotary_pos_emb_sin,
+        ) = self._prepare_graph_inputs(pixel_values, grid_thw)
+        if not isinstance(cu_seqlens, torch.Tensor):
+            cu_seqlens = torch.tensor(cu_seqlens, device=x.device, dtype=torch.int32)
+        else:
+            cu_seqlens = cu_seqlens.to(device=x.device, dtype=torch.int32)
+        cu_seqlens = cu_seqlens.contiguous()
+        if x.shape[0] > raw_budget:
+            runner.record_fallback("raw_tokens_over_budget")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        padded = self._pad_cuda_graph_inputs(
+            x, cu_seqlens, rotary_pos_emb_cos, rotary_pos_emb_sin, raw_budget
+        )
+        if padded is None:
+            runner.record_fallback("batch_metadata_capacity")
+            return self.raw_forward(pixel_values, grid_thw)
+
+        padded_x, padded_cu, padded_cos, padded_sin = padded
+        out = runner.replay(
+            graph_key=raw_budget,
+            x_3d=padded_x.unsqueeze(1),
+            position_embeddings=None,
+            rotary_pos_emb_cos=padded_cos,
+            rotary_pos_emb_sin=padded_sin,
+            cu_seqlens=padded_cu,
+            cu_window_seqlens=None,
+            output_indices=None,
+        )
+        return out[:total_vision_tokens]
+
     def forward_with_npu_graph(
         self,
         x: torch.Tensor,
@@ -882,26 +1039,143 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
         x: torch.Tensor,
         grid_thw: torch.Tensor,
     ) -> torch.Tensor:
-        (
-            x,
-            cu_seqlens,
-            rotary_pos_emb_cos,
-            rotary_pos_emb_sin,
-        ) = self._prepare_graph_inputs(x, grid_thw)
-        if not isinstance(cu_seqlens, torch.Tensor):
-            cu_seqlens = torch.tensor(cu_seqlens, device=x.device, dtype=torch.int32)
-        else:
-            cu_seqlens = cu_seqlens.to(device=x.device, dtype=torch.int32)
-        cu_seqlens = cu_seqlens.contiguous()
+        runner = self.graph_runners
+        if not isinstance(runner, ViTCudaGraphRunner) or not runner.capture_completed:
+            if isinstance(runner, ViTCudaGraphRunner):
+                runner.record_fallback("graph_not_captured")
+            return self.raw_forward(x, grid_thw)
 
-        return self.graph_runners.run(
-            x=x,
-            position_embeddings=None,
-            rotary_pos_emb_cos=rotary_pos_emb_cos,
-            rotary_pos_emb_sin=rotary_pos_emb_sin,
-            cu_seqlens=cu_seqlens,
-            cu_window_seqlens=None,
-            output_indices=None,
+        grid_thw = self._grid_to_tensor(grid_thw)
+        vision_counts = self._vision_token_counts(grid_thw)
+        raw_counts = self._raw_token_counts(grid_thw)
+        pixel_chunks = list(torch.split(x, raw_counts, dim=0))
+        outputs: List[Optional[torch.Tensor]] = [None] * len(vision_counts)
+
+        def flush(indices: List[int]) -> None:
+            if not indices:
+                return
+            batch_pixels = torch.cat([pixel_chunks[i] for i in indices], dim=0)
+            batch_grid = self._grid_index_select(grid_thw, indices)
+            batch_counts = [vision_counts[i] for i in indices]
+            batch_out = self._run_cuda_graph_batch(
+                batch_pixels, batch_grid, batch_counts
+            )
+            split_out = torch.split(batch_out, batch_counts, dim=0)
+            for idx, emb in zip(indices, split_out):
+                outputs[idx] = emb
+
+        current: List[int] = []
+        current_tokens = 0
+        for idx in sorted(range(len(vision_counts)), key=lambda i: vision_counts[i]):
+            num_tokens = vision_counts[idx]
+            if num_tokens > runner.max_vision_budget:
+                flush(current)
+                current = []
+                current_tokens = 0
+                runner.record_fallback("single_image_over_budget")
+                outputs[idx] = self.raw_forward(
+                    pixel_chunks[idx], self._grid_index_select(grid_thw, [idx])
+                )
+                continue
+
+            if current and (
+                current_tokens + num_tokens > runner.max_vision_budget
+                or len(current) >= runner.max_batch_size
+            ):
+                flush(current)
+                current = []
+                current_tokens = 0
+
+            current.append(idx)
+            current_tokens += num_tokens
+
+        flush(current)
+        if any(emb is None for emb in outputs):
+            raise RuntimeError("ViT CUDA graph bin-pack did not produce all outputs")
+        return torch.cat(outputs, dim=0)
+
+    @torch.no_grad()
+    def capture_vit_cuda_graphs(self) -> None:
+        runner = self.graph_runners
+        if (
+            self.device.type != "cuda"
+            or not is_vit_cuda_graph_enabled()
+            or not isinstance(runner, ViTCudaGraphRunner)
+            or runner.capture_completed
+        ):
+            return
+
+        mm_backend = get_global_server_args().mm_attention_backend
+        if mm_backend not in ("triton_attn", "fa3"):
+            logger.warning(
+                "ViT CUDA graph supports mm_attention_backend triton_attn/fa3, "
+                "but got %s; Qwen3-VL vision encoder will use eager fallback.",
+                mm_backend,
+            )
+            return
+
+        runner.log_capture_config()
+        raw_patch_dim = self._raw_patch_dim()
+        for idx, (vision_budget, raw_budget) in enumerate(
+            zip(runner.vision_token_budgets, runner.raw_token_budgets)
+        ):
+            grid = torch.tensor(
+                [
+                    make_image_grid_for_vision_tokens(
+                        vision_budget, self.spatial_merge_size
+                    )
+                ],
+                dtype=torch.int32,
+            )
+            pixel_values = torch.zeros(
+                raw_budget,
+                raw_patch_dim,
+                dtype=self.dtype,
+                device=self.device,
+            )
+
+            if not self.inner_rope_compiled:
+                self.raw_forward(pixel_values, grid)
+                self.inner_rope_compiled = True
+
+            (
+                x,
+                cu_seqlens,
+                rotary_pos_emb_cos,
+                rotary_pos_emb_sin,
+            ) = self._prepare_graph_inputs(pixel_values, grid)
+            cu_seqlens = cu_seqlens.to(device=x.device, dtype=torch.int32).contiguous()
+            padded = self._pad_cuda_graph_inputs(
+                x, cu_seqlens, rotary_pos_emb_cos, rotary_pos_emb_sin, raw_budget
+            )
+            if padded is None:
+                raise RuntimeError(
+                    f"Failed to pad Qwen3-VL ViT CUDA graph capture inputs for "
+                    f"vision_budget={vision_budget}, raw_budget={raw_budget}"
+                )
+            padded_x, padded_cu, padded_cos, padded_sin = padded
+            runner.create_graph(
+                x_3d=padded_x.unsqueeze(1),
+                position_embeddings=None,
+                rotary_pos_emb_cos=padded_cos,
+                rotary_pos_emb_sin=padded_sin,
+                cu_seqlens=padded_cu,
+                cu_window_seqlens=None,
+                max_full_len=raw_budget,
+            )
+            logger.info(
+                "Captured Qwen3-VL ViT CUDA graph %s/%s: vision_budget=%s, raw_budget=%s",
+                idx + 1,
+                len(runner.vision_token_budgets),
+                vision_budget,
+                raw_budget,
+            )
+
+        runner.capture_completed = True
+        torch.cuda.synchronize()
+        logger.info(
+            "Captured Qwen3-VL ViT CUDA graphs for raw budgets=%s",
+            runner.raw_token_budgets,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -945,6 +1219,7 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             grid_thw_list = grid_thw
             grid_thw = torch.tensor(grid_thw, dtype=torch.int32)
         else:
+            grid_thw = grid_thw.cpu().to(dtype=torch.int32)
             grid_thw_list = grid_thw.tolist()
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
@@ -1198,6 +1473,15 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         image_grid_thw = torch.concat([item.image_grid_thw for item in items], dim=0)
         assert pixel_values.dim() == 2, pixel_values.dim()
         assert image_grid_thw.dim() == 2, image_grid_thw.dim()
+
+        raw_patch_dim = (
+            self.visual.patch_embed.in_channels
+            * self.visual.patch_embed.temporal_patch_size
+            * self.visual.patch_embed.patch_size
+            * self.visual.patch_embed.patch_size
+        )
+        if pixel_values.shape[-1] != raw_patch_dim:
+            return pixel_values
 
         if self.use_data_parallel:
             return run_dp_sharded_mrope_vision_model(

--- a/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
@@ -327,8 +327,7 @@ class ViTCudaGraphRunner:
             ).contiguous()
             self.cu_window_len[graph_key] = cu_window.clone()
             self.cu_window_len_kk[graph_key] = (
-                self.cu_window_len[graph_key][1:]
-                - self.cu_window_len[graph_key][:-1]
+                self.cu_window_len[graph_key][1:] - self.cu_window_len[graph_key][:-1]
             ).contiguous()
             self.max_window_lens[graph_key] = int(
                 max_window_len
@@ -360,9 +359,7 @@ class ViTCudaGraphRunner:
                     f"got {cu_window.numel()}, expected {self.cu_window_len[graph_key].numel()}"
                 )
             self.cu_window_len[graph_key].copy_(cu_window)
-            self.cu_window_len_kk[graph_key].copy_(
-                cu_window[1:] - cu_window[:-1]
-            )
+            self.cu_window_len_kk[graph_key].copy_(cu_window[1:] - cu_window[:-1])
 
     def _create_graph(
         self,

--- a/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
@@ -16,31 +16,122 @@
 
 from __future__ import annotations
 
-import inspect
+import logging
+import math
+from collections import defaultdict
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import Dict, Hashable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 
 from sglang.srt.distributed.parallel_state import get_tp_group
-from sglang.srt.layers.attention.vision import VisionAttention
+from sglang.srt.environ import envs
 from sglang.srt.server_args import get_global_server_args
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ViTCudaGraphConfig:
+    # Budgets are post-merge vision tokens, aligned with LLM placeholders.
+    vision_token_budgets: List[int]
+    raw_token_budgets: List[int]
+    max_batch_size: int
+
+
+def is_vit_cuda_graph_enabled() -> bool:
+    if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
+        return True
+    try:
+        return bool(getattr(get_global_server_args(), "enable_vit_cuda_graph", False))
+    except Exception:
+        return False
+
+
+def _get_server_args():
+    try:
+        return get_global_server_args()
+    except Exception:
+        return None
+
+
+def _auto_vision_token_budgets() -> List[int]:
+    server_args = _get_server_args()
+    max_budget = None
+    if server_args is not None:
+        max_budget = getattr(server_args, "chunked_prefill_size", None)
+        if max_budget is None or max_budget <= 0:
+            max_budget = getattr(server_args, "max_prefill_tokens", None)
+        max_total_tokens = getattr(server_args, "max_total_tokens", None)
+        if max_total_tokens is not None and max_total_tokens > 0:
+            max_budget = (
+                min(max_budget, max_total_tokens)
+                if max_budget is not None and max_budget > 0
+                else max_total_tokens
+            )
+
+    if max_budget is None or max_budget <= 0:
+        max_budget = 8192
+
+    max_budget = max(int(max_budget), 1)
+    if max_budget <= 1024:
+        return [max_budget]
+
+    budgets = []
+    budget = 1024
+    while budget < max_budget:
+        budgets.append(budget)
+        budget *= 2
+    budgets.append(max_budget)
+    return sorted(set(budgets))
+
+
+def resolve_vit_cuda_graph_config(spatial_merge_size: int) -> ViTCudaGraphConfig:
+    server_args = _get_server_args()
+    budgets = None
+    max_batch_size = 0
+    if server_args is not None:
+        budgets = getattr(server_args, "vit_cuda_graph_token_budgets", None)
+        max_batch_size = int(
+            getattr(server_args, "vit_cuda_graph_max_batch_size", 0) or 0
+        )
+
+    vision_token_budgets = sorted(set(int(x) for x in budgets or [] if int(x) > 0))
+    if not vision_token_budgets:
+        vision_token_budgets = _auto_vision_token_budgets()
+
+    merge_unit = int(spatial_merge_size) ** 2
+    raw_token_budgets = [budget * merge_unit for budget in vision_token_budgets]
+
+    if max_batch_size <= 0:
+        max_batch_size = max(1, min(64, vision_token_budgets[-1]))
+
+    return ViTCudaGraphConfig(
+        vision_token_budgets=vision_token_budgets,
+        raw_token_budgets=raw_token_budgets,
+        max_batch_size=max_batch_size,
+    )
+
+
+def make_image_grid_for_vision_tokens(
+    vision_tokens: int, spatial_merge_size: int
+) -> List[int]:
+    """Build a single-image grid whose post-merge token count is vision_tokens."""
+    h_tokens = int(math.sqrt(vision_tokens))
+    while h_tokens > 1 and vision_tokens % h_tokens != 0:
+        h_tokens -= 1
+    w_tokens = vision_tokens // h_tokens
+    return [1, h_tokens * spatial_merge_size, w_tokens * spatial_merge_size]
 
 
 class ViTCudaGraphRunner:
     """Generic ViT CUDA Graph Runner.
 
-    This runner captures the "blocks + merger + deepstack merger (optional)" part
-    of a vision transformer into a CUDA graph and replays it for identical shapes.
-
-    Optional for Qwen2.5 windowed attention:
-      - vit.fullatt_block_indexes: Sequence[int]
-      - run() provides both cu_seqlens and cu_window_seqlens
-
-    Optional for Qwen3 deepstack:
-      - vit.deepstack_vision_indexes: Sequence[int]
-      - vit.deepstack_merger_list: nn.ModuleList (same length as deepstack_vision_indexes)
+    Captures the "blocks + merger + deepstack merger (optional)" part of a
+    vision transformer for fixed post-merge budgets. Runtime batches with fewer
+    tokens are padded into the selected budget before replay.
     """
 
     def __init__(
@@ -48,25 +139,43 @@ class ViTCudaGraphRunner:
         vit: nn.Module,
     ) -> None:
         self.vit = vit
+        self.spatial_merge_size = int(getattr(vit, "spatial_merge_size", 1))
+        self.spatial_merge_unit = self.spatial_merge_size**2
+        self.config = resolve_vit_cuda_graph_config(self.spatial_merge_size)
+        self.vision_token_budgets = self.config.vision_token_budgets
+        self.raw_token_budgets = self.config.raw_token_budgets
+        self.max_batch_size = self.config.max_batch_size
+        self.max_raw_budget = self.raw_token_budgets[-1]
+        self.max_vision_budget = self.vision_token_budgets[-1]
 
-        # graph_key -> buffers / graphs
+        # graph_key -> buffers / graphs. graph_key is the raw ViT token budget.
         self.block_input: Dict[Hashable, torch.Tensor] = {}
-        self.block_ws: Dict[Hashable, torch.Tensor] = {}
         self.block_graphs: Dict[Hashable, torch.cuda.CUDAGraph] = {}
         self.block_output: Dict[Hashable, torch.Tensor] = {}
+        self.input_buffer: Optional[torch.Tensor] = None
 
-        # captured seqlens buffers (addresses must be stable for cuda-graph replay)
+        # Captured seqlens buffers. Addresses are stable; contents are updated
+        # before every replay. The *_kk buffers are Triton seq_lens.
         self.cu_full_len: Dict[Hashable, torch.Tensor] = {}
         self.cu_window_len: Dict[Hashable, torch.Tensor] = {}
         self.cu_full_len_kk: Dict[Hashable, torch.Tensor] = {}
         self.cu_window_len_kk: Dict[Hashable, torch.Tensor] = {}
+        self.max_full_lens: Dict[Hashable, int] = {}
+        self.max_window_lens: Dict[Hashable, int] = {}
 
-        # rotary position buffers shared across graphs
+        # Rotary position buffers shared across graphs. Allocate to the maximum
+        # raw budget on first use so earlier captured graphs never hold stale
+        # pointers after a later, larger budget is captured.
         self.sin_cos_ws: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
-        self.max_context_len = getattr(vit, "max_context_len", None)
+        self.max_context_len = max(
+            int(getattr(vit, "max_context_len", 0) or 0), self.max_raw_budget
+        )
 
-        # Qwen2.5-VL specific viarable.
-        self._fullatt_block_indexes = set(getattr(vit, "fullatt_block_indexes", ()))
+        # Qwen2.5-VL specific variables.
+        fullatt_block_indexes = getattr(vit, "fullatt_block_indexes", ())
+        if isinstance(fullatt_block_indexes, torch.Tensor):
+            fullatt_block_indexes = fullatt_block_indexes.tolist()
+        self._fullatt_block_indexes = set(int(x) for x in fullatt_block_indexes)
 
         # Qwen3-VL specific variables.
         self._deepstack_visual_indexes = list(
@@ -74,13 +183,11 @@ class ViTCudaGraphRunner:
         )
         self._deepstack_merger_list = getattr(vit, "deepstack_merger_list", None)
 
-        first_blk = vit.blocks[0]
-        self._blk_accepts_output_ws = (
-            "output_ws" in inspect.signature(first_blk.forward).parameters
-        )
-
-        self._attn: Optional[VisionAttention] = getattr(first_blk, "attn", None)
-        self._attn_backend = getattr(self._attn, "qkv_backend", None)
+        self.capture_completed = False
+        self.graph_hit_count = 0
+        self.graph_hit_by_budget = defaultdict(int)
+        self.eager_fallback_count = 0
+        self.eager_fallback_reasons = defaultdict(int)
 
     @property
     def device(self) -> torch.device:
@@ -90,31 +197,172 @@ class ViTCudaGraphRunner:
     def dtype(self) -> torch.dtype:
         return self.vit.dtype
 
-    def _ensure_sin_cos_ws(self, seq_len: int, head_dim: int):
-        if self.sin_cos_ws is None:
-            max_shape = self.max_context_len or seq_len
-            max_shape = max(max_shape, seq_len)
+    @property
+    def max_full_cu_len(self) -> int:
+        # Qwen2.5 has an extra leading empty sequence: [0, 0, ...].
+        return self.max_batch_size + (3 if self._fullatt_block_indexes else 2)
+
+    @property
+    def max_window_cu_len(self) -> int:
+        # Window metadata is per post-merge window and is upper-bounded by the
+        # post-merge budget when every window contains one merged token.
+        return self.max_vision_budget + 2
+
+    def log_capture_config(self) -> None:
+        logger.info(
+            "ViT CUDA graph capture config: vision token budgets=%s, raw token budgets=%s, "
+            "max batch size=%s",
+            self.vision_token_budgets,
+            self.raw_token_budgets,
+            self.max_batch_size,
+        )
+
+    def record_fallback(self, reason: str) -> None:
+        self.eager_fallback_count += 1
+        self.eager_fallback_reasons[reason] += 1
+        if self.eager_fallback_count <= 5 or self.eager_fallback_count % 100 == 0:
+            logger.info(
+                "ViT CUDA graph fallback stats: fallbacks=%s, reasons=%s, hits=%s",
+                self.eager_fallback_count,
+                dict(self.eager_fallback_reasons),
+                self.graph_hit_count,
+            )
+
+    def _record_hit(self, graph_key: int) -> None:
+        self.graph_hit_count += 1
+        self.graph_hit_by_budget[graph_key] += 1
+        if self.graph_hit_count <= 5 or self.graph_hit_count % 100 == 0:
+            logger.info(
+                "ViT CUDA graph replay stats: hits=%s, raw_budget_hits=%s, fallbacks=%s",
+                self.graph_hit_count,
+                dict(self.graph_hit_by_budget),
+                self.eager_fallback_count,
+            )
+
+    def select_budget(self, total_vision_tokens: int) -> Optional[Tuple[int, int]]:
+        for vision_budget, raw_budget in zip(
+            self.vision_token_budgets, self.raw_token_budgets
+        ):
+            if total_vision_tokens <= vision_budget:
+                return vision_budget, raw_budget
+        return None
+
+    def _ensure_sin_cos_ws(
+        self, seq_len: int, head_dim: int, sin_cos_dtype: torch.dtype
+    ) -> None:
+        need_new = self.sin_cos_ws is None
+        if not need_new:
+            cos_ws, _ = self.sin_cos_ws
+            need_new = (
+                cos_ws.size(0) < seq_len
+                or cos_ws.size(1) != head_dim
+                or cos_ws.dtype != sin_cos_dtype
+            )
+
+        if need_new:
+            current_size = 0 if self.sin_cos_ws is None else self.sin_cos_ws[0].size(0)
+            max_shape = max(self.max_context_len or 0, current_size * 2, seq_len)
             cos_ws = torch.empty(
-                max_shape, head_dim, dtype=self.dtype, device=self.device
+                max_shape, head_dim, dtype=sin_cos_dtype, device=self.device
             )
             sin_ws = torch.empty(
-                max_shape, head_dim, dtype=self.dtype, device=self.device
+                max_shape, head_dim, dtype=sin_cos_dtype, device=self.device
             )
             self.sin_cos_ws = (cos_ws, sin_ws)
-        else:
-            if self.sin_cos_ws[0].size(0) < seq_len:
-                max_shape = max(self.sin_cos_ws[0].size(0) * 2, seq_len)
-                cos_ws = torch.empty(
-                    max_shape, head_dim, dtype=self.dtype, device=self.device
-                )
-                sin_ws = torch.empty(
-                    max_shape, head_dim, dtype=self.dtype, device=self.device
-                )
-                self.sin_cos_ws = (cos_ws, sin_ws)
 
     def _get_graph_key(self, x_3d: torch.Tensor) -> int:
-        # x_3d: [S, B, H], B=1, S as graph_key
+        # x_3d: [S, B=1, H], S is the raw graph budget.
         return x_3d.shape[0]
+
+    def _prepare_input_buffer(self, graph_key: int, x_3d: torch.Tensor) -> None:
+        if graph_key in self.block_input:
+            return
+
+        if graph_key <= self.max_raw_budget:
+            if (
+                self.input_buffer is None
+                or self.input_buffer.dtype != x_3d.dtype
+                or self.input_buffer.device != x_3d.device
+                or self.input_buffer.shape[1:] != x_3d.shape[1:]
+            ):
+                self.input_buffer = torch.empty(
+                    self.max_raw_budget,
+                    x_3d.shape[1],
+                    x_3d.shape[2],
+                    dtype=x_3d.dtype,
+                    device=x_3d.device,
+                ).contiguous()
+            self.block_input[graph_key] = self.input_buffer[:graph_key, :, :]
+        else:
+            self.block_input[graph_key] = torch.empty_like(
+                x_3d, device=self.device
+            ).contiguous()
+
+    def _store_cu_buffers(
+        self,
+        graph_key: int,
+        cu_seqlens: torch.Tensor,
+        cu_window_seqlens: Optional[torch.Tensor],
+        max_full_len: Optional[int],
+        max_window_len: Optional[int],
+    ) -> None:
+        cu_full = cu_seqlens.to(device=self.device, dtype=torch.int32).contiguous()
+        self.cu_full_len[graph_key] = cu_full.clone()
+        self.cu_full_len_kk[graph_key] = (
+            self.cu_full_len[graph_key][1:] - self.cu_full_len[graph_key][:-1]
+        ).contiguous()
+        self.max_full_lens[graph_key] = int(
+            max_full_len
+            if max_full_len is not None
+            else self.cu_full_len_kk[graph_key].max().item()
+        )
+
+        if self._fullatt_block_indexes:
+            if cu_window_seqlens is None:
+                raise RuntimeError(
+                    "cu_window_seqlens is required for windowed ViT CUDA graph"
+                )
+            cu_window = cu_window_seqlens.to(
+                device=self.device, dtype=torch.int32
+            ).contiguous()
+            self.cu_window_len[graph_key] = cu_window.clone()
+            self.cu_window_len_kk[graph_key] = (
+                self.cu_window_len[graph_key][1:]
+                - self.cu_window_len[graph_key][:-1]
+            ).contiguous()
+            self.max_window_lens[graph_key] = int(
+                max_window_len
+                if max_window_len is not None
+                else self.cu_window_len_kk[graph_key].max().item()
+            )
+
+    def _update_cu_buffers(
+        self,
+        graph_key: int,
+        cu_seqlens: Optional[torch.Tensor],
+        cu_window_seqlens: Optional[torch.Tensor],
+    ) -> None:
+        if cu_seqlens is not None:
+            cu_full = cu_seqlens.to(device=self.device, dtype=torch.int32)
+            if cu_full.numel() != self.cu_full_len[graph_key].numel():
+                raise RuntimeError(
+                    f"cu_seqlens length mismatch for ViT CUDA graph replay: "
+                    f"got {cu_full.numel()}, expected {self.cu_full_len[graph_key].numel()}"
+                )
+            self.cu_full_len[graph_key].copy_(cu_full)
+            self.cu_full_len_kk[graph_key].copy_(cu_full[1:] - cu_full[:-1])
+
+        if self._fullatt_block_indexes and cu_window_seqlens is not None:
+            cu_window = cu_window_seqlens.to(device=self.device, dtype=torch.int32)
+            if cu_window.numel() != self.cu_window_len[graph_key].numel():
+                raise RuntimeError(
+                    f"cu_window_seqlens length mismatch for ViT CUDA graph replay: "
+                    f"got {cu_window.numel()}, expected {self.cu_window_len[graph_key].numel()}"
+                )
+            self.cu_window_len[graph_key].copy_(cu_window)
+            self.cu_window_len_kk[graph_key].copy_(
+                cu_window[1:] - cu_window[:-1]
+            )
 
     def _create_graph(
         self,
@@ -124,20 +372,18 @@ class ViTCudaGraphRunner:
         ] = None,  # (cos, sin), [S, D]
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
-    ):
-
+    ) -> None:
         graph = torch.cuda.CUDAGraph()
         vit = self.vit
 
-        # Qwen2.5-VL
         if self._fullatt_block_indexes:
             cu_window = self.cu_window_len[graph_key]
             cu_window_kk = self.cu_window_len_kk[graph_key]
-            max_window_len = int(cu_window_kk.max().item())
+            max_window_len = self.max_window_lens[graph_key]
 
         cu_full = self.cu_full_len[graph_key]
         cu_full_kk = self.cu_full_len_kk[graph_key]
-        max_full_len = int(cu_full_kk.max().item())
+        max_full_len = self.max_full_lens[graph_key]
 
         override_backend = get_global_server_args().mm_attention_backend
 
@@ -152,7 +398,7 @@ class ViTCudaGraphRunner:
 
             for layer_num, blk in enumerate(vit.blocks):
                 if self._fullatt_block_indexes:
-                    if layer_num in vit.fullatt_block_indexes:
+                    if layer_num in self._fullatt_block_indexes:
                         cu_seqlens_now = cu_full
                         cu_seqlens_kk_now = cu_full_kk
                         max_len = max_full_len
@@ -178,14 +424,12 @@ class ViTCudaGraphRunner:
                             self.block_input[graph_key],
                             cu_seqlens=cu_seq_len_ws,
                             position_embeddings=position_embeddings,
-                            output_ws=self.block_ws[graph_key],
                         )
                     else:
                         y = blk(
                             y,
                             cu_seqlens=cu_seq_len_ws,
                             position_embeddings=position_embeddings,
-                            output_ws=self.block_ws[graph_key],
                         )
                 elif rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
                     if layer_num == 0:
@@ -194,7 +438,6 @@ class ViTCudaGraphRunner:
                             cu_seqlens=cu_seq_len_ws,
                             rotary_pos_emb_cos=rotary_pos_emb_cos,
                             rotary_pos_emb_sin=rotary_pos_emb_sin,
-                            output_ws=self.block_ws[graph_key],
                         )
                     else:
                         y = blk(
@@ -202,10 +445,10 @@ class ViTCudaGraphRunner:
                             cu_seqlens=cu_seq_len_ws,
                             rotary_pos_emb_cos=rotary_pos_emb_cos,
                             rotary_pos_emb_sin=rotary_pos_emb_sin,
-                            output_ws=self.block_ws[graph_key],
                         )
+                else:
+                    raise RuntimeError("ViT CUDA graph requires rotary embeddings")
 
-                # Optional deepstack support (Qwen3-VL)
                 if (
                     self._deepstack_visual_indexes
                     and layer_num in self._deepstack_visual_indexes
@@ -235,81 +478,62 @@ class ViTCudaGraphRunner:
         self,
         x_3d: torch.Tensor,  # [S, 1, H]
         cu_seqlens: torch.Tensor,
-        cu_window_seqlens: torch.Tensor,
+        cu_window_seqlens: Optional[torch.Tensor],
         position_embeddings: Optional[
             Tuple[torch.Tensor, torch.Tensor]
         ],  # (cos, sin), [S, D]
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
+        max_full_len: Optional[int] = None,
+        max_window_len: Optional[int] = None,
     ) -> int:
-        vit = self.vit
         graph_key = self._get_graph_key(x_3d)
 
         if graph_key in self.block_graphs:
             return graph_key
 
-        # pre-allocate workspace
-        attn_module: VisionAttention = vit.blocks[0].attn
-        num_heads = attn_module.num_attention_heads_per_partition
-        attn_head_dim = attn_module.head_size
-
-        if graph_key not in self.block_output:
-            self.block_output[graph_key] = torch.empty_like(
-                x_3d, device=self.device
-            ).contiguous()
-            self.block_input[graph_key] = torch.empty_like(
-                x_3d, device=self.device
-            ).contiguous()
-            self.block_ws[graph_key] = torch.empty(
-                graph_key,
-                num_heads,
-                attn_head_dim,
-                device=self.device,
-                dtype=self.dtype,
-            )
-
-        # Qwen2.5-VL
-        if self._fullatt_block_indexes:
-            if graph_key not in self.cu_window_len:
-                self.cu_window_len[graph_key] = cu_window_seqlens
-                self.cu_full_len[graph_key] = cu_seqlens
-                self.cu_window_len_kk[graph_key] = (
-                    cu_window_seqlens[1:] - cu_window_seqlens[:-1]
-                )
-                self.cu_full_len_kk[graph_key] = cu_seqlens[1:] - cu_seqlens[:-1]
-        else:
-            if graph_key not in self.cu_full_len:
-                self.cu_full_len[graph_key] = cu_seqlens
-                self.cu_full_len_kk[graph_key] = cu_seqlens[1:] - cu_seqlens[:-1]
+        self._prepare_input_buffer(graph_key, x_3d)
+        self.block_input[graph_key].copy_(x_3d)
+        self._store_cu_buffers(
+            graph_key,
+            cu_seqlens,
+            cu_window_seqlens,
+            max_full_len,
+            max_window_len,
+        )
 
         if position_embeddings is not None:
-            # make sure rotary workspace
             head_dim = position_embeddings[0].shape[1]
-            self._ensure_sin_cos_ws(graph_key, head_dim)
+            sin_cos_dtype = position_embeddings[0].dtype
+            self._ensure_sin_cos_ws(graph_key, head_dim, sin_cos_dtype)
 
             used_cos_ws = self.sin_cos_ws[0][:graph_key, :]
             used_sin_ws = self.sin_cos_ws[1][:graph_key, :]
             used_cos_ws.copy_(position_embeddings[0])
             used_sin_ws.copy_(position_embeddings[1])
             persist_position_embeddings = (used_cos_ws, used_sin_ws)
+            torch.cuda.synchronize()
             self._create_graph(
                 graph_key=graph_key, position_embeddings=persist_position_embeddings
             )
         elif rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
-            # make sure rotary workspace
             head_dim = rotary_pos_emb_cos.shape[1]
-            self._ensure_sin_cos_ws(graph_key, head_dim)
+            sin_cos_dtype = rotary_pos_emb_cos.dtype
+            self._ensure_sin_cos_ws(graph_key, head_dim, sin_cos_dtype)
 
             used_cos_ws = self.sin_cos_ws[0][:graph_key, :]
             used_sin_ws = self.sin_cos_ws[1][:graph_key, :]
             used_cos_ws.copy_(rotary_pos_emb_cos)
             used_sin_ws.copy_(rotary_pos_emb_sin)
+            torch.cuda.synchronize()
             self._create_graph(
                 graph_key=graph_key,
                 position_embeddings=None,
                 rotary_pos_emb_cos=used_cos_ws,
                 rotary_pos_emb_sin=used_sin_ws,
             )
+        else:
+            raise RuntimeError("ViT CUDA graph requires rotary embeddings")
 
         return graph_key
 
@@ -320,35 +544,37 @@ class ViTCudaGraphRunner:
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        cu_window_seqlens: Optional[torch.Tensor] = None,
         output_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if graph_key not in self.block_graphs:
+            raise RuntimeError(f"ViT CUDA graph for raw budget {graph_key} is missing")
+
+        self._update_cu_buffers(graph_key, cu_seqlens, cu_window_seqlens)
 
         if position_embeddings is not None:
-            # update rotary workspace content
             head_dim = position_embeddings[0].shape[1]
-            self._ensure_sin_cos_ws(graph_key, head_dim)
+            sin_cos_dtype = position_embeddings[0].dtype
+            self._ensure_sin_cos_ws(graph_key, head_dim, sin_cos_dtype)
             used_cos_ws = self.sin_cos_ws[0][:graph_key, :]
             used_sin_ws = self.sin_cos_ws[1][:graph_key, :]
             used_cos_ws.copy_(position_embeddings[0])
             used_sin_ws.copy_(position_embeddings[1])
         elif rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
-            # update rotary workspace content
             head_dim = rotary_pos_emb_cos.shape[1]
-            self._ensure_sin_cos_ws(graph_key, head_dim)
+            sin_cos_dtype = rotary_pos_emb_cos.dtype
+            self._ensure_sin_cos_ws(graph_key, head_dim, sin_cos_dtype)
             used_cos_ws = self.sin_cos_ws[0][:graph_key, :]
             used_sin_ws = self.sin_cos_ws[1][:graph_key, :]
             used_cos_ws.copy_(rotary_pos_emb_cos)
             used_sin_ws.copy_(rotary_pos_emb_sin)
 
-        # copy input
         self.block_input[graph_key].copy_(x_3d)
-
-        # replay
         self.block_graphs[graph_key].replay()
+        self._record_hit(graph_key)
 
         out = self.block_output[graph_key]
-
-        # Optional output reordering (Qwen2.5-VL window permutation inverse)
         if output_indices is not None:
             out = out.index_select(0, output_indices)
 
@@ -358,13 +584,14 @@ class ViTCudaGraphRunner:
         self,
         x: torch.Tensor,
         cu_seqlens: torch.Tensor,
-        cu_window_seqlens: torch.Tensor,
+        cu_window_seqlens: Optional[torch.Tensor],
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]],
         rotary_pos_emb_cos: Optional[torch.Tensor] = None,
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
         output_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        # x: [seq_len, hidden] -> [S, B=1, H]
+        # Compatibility path for direct callers. The Qwen image path pre-captures
+        # graphs at launch and calls replay() with padded budget tensors.
         x_3d = x.unsqueeze(1)
         graph_key = self._get_graph_key(x_3d)
 
@@ -384,5 +611,7 @@ class ViTCudaGraphRunner:
             position_embeddings=position_embeddings,
             rotary_pos_emb_cos=rotary_pos_emb_cos,
             rotary_pos_emb_sin=rotary_pos_emb_sin,
+            cu_seqlens=cu_seqlens,
+            cu_window_seqlens=cu_window_seqlens,
             output_indices=output_indices,
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -690,6 +690,9 @@ class ServerArgs:
     enable_breakable_cuda_graph: bool = False
     enable_profile_cuda_graph: bool = False
     enable_cudagraph_gc: bool = False
+    enable_vit_cuda_graph: bool = False
+    vit_cuda_graph_token_budgets: Optional[List[int]] = None
+    vit_cuda_graph_max_batch_size: int = 0
     debug_cuda_graph: bool = False
     enable_layerwise_nvtx_marker: bool = False
     enable_nccl_nvls: bool = False
@@ -3900,6 +3903,17 @@ class ServerArgs:
 
     def _handle_environment_variables(self):
         envs.SGLANG_ENABLE_TORCH_COMPILE.set("1" if self.enable_torch_compile else "0")
+        if self.enable_vit_cuda_graph or envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
+            self.enable_vit_cuda_graph = True
+            envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.set("1")
+        if self.vit_cuda_graph_max_batch_size < 0:
+            raise ValueError("--vit-cuda-graph-max-batch-size must be >= 0")
+        if self.vit_cuda_graph_token_budgets is not None:
+            self.vit_cuda_graph_token_budgets = sorted(
+                set(self.vit_cuda_graph_token_budgets)
+            )
+            if any(x <= 0 for x in self.vit_cuda_graph_token_budgets):
+                raise ValueError("--vit-cuda-graph-token-budgets must be positive")
         if self.mamba_ssm_dtype is not None:
             envs.SGLANG_MAMBA_SSM_DTYPE.set(self.mamba_ssm_dtype)
         envs.SGLANG_DISABLE_OUTLINES_DISK_CACHE.set(
@@ -6165,6 +6179,28 @@ class ServerArgs:
             "--enable-cudagraph-gc",
             action="store_true",
             help="Enable garbage collection during CUDA graph capture. If disabled (default), GC is frozen during capture to speed up the process.",
+        )
+        parser.add_argument(
+            "--enable-vit-cuda-graph",
+            action="store_true",
+            default=ServerArgs.enable_vit_cuda_graph,
+            help="Enable ViT CUDA graph pre-capture for image vision encoder batches.",
+        )
+        parser.add_argument(
+            "--vit-cuda-graph-token-budgets",
+            type=int,
+            nargs="*",
+            default=ServerArgs.vit_cuda_graph_token_budgets,
+            help="Post-merge vision token budgets for ViT CUDA graph capture. "
+            "Raw ViT token budgets are derived by multiplying by spatial_merge_size^2. "
+            "When omitted or empty, budgets are generated automatically.",
+        )
+        parser.add_argument(
+            "--vit-cuda-graph-max-batch-size",
+            type=int,
+            default=ServerArgs.vit_cuda_graph_max_batch_size,
+            help="Maximum number of images packed into one ViT CUDA graph replay. "
+            "0 lets SGLang choose a conservative automatic value.",
         )
         parser.add_argument(
             "--debug-cuda-graph",


### PR DESCRIPTION
## Motivation

This PR refactors ViT CUDA Graph support for multimodal encoders and adds ViT pack support for chunked prefill image encoding.

The CUDA Graph refactor makes ViT graph capture reusable across runtime image batches with different per-image shapes, as long as the packed token count fits a captured budget. The previous ViT CUDA Graph path was more tightly coupled to runtime shapes and attention metadata, which limited reuse and made memory/performance behavior harder to control.

The ViT pack path improves multimodal chunked prefill by batching cache-miss per-image items across requests into fewer ViT calls. This can be used independently from ViT CUDA Graph.

## Modifications

- Add configurable ViT CUDA Graph launch options:
  - `--enable-vit-cuda-graph`
  - `--vit-cuda-graph-token-budgets`
  - `--vit-cuda-graph-max-batch-size`
  - keep `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` as an env-compatible enable path.

- Add ViT pack support for per-image chunked prefill.
  - Enable with `SGLANG_VIT_PACK=1`.
  - Can be used independently without enabling ViT CUDA Graph.
  - Packs cache-miss per-image items across requests and runs them through ViT together.
  - `SGLANG_VIT_INFER_TIMES` controls fixed partitioning when ViT CUDA Graph is disabled.
  - When ViT CUDA Graph is enabled, `SGLANG_VIT_INFER_TIMES` no longer forces fixed splitting; packed cache misses are passed to the graph-aware budget/bin-pack path instead.

- Redesign `ViTCudaGraphRunner` to pre-capture graphs by post-merge vision token budgets.
  - Raw ViT token budgets are derived as `vision_budget * spatial_merge_size ** 2`.
  - Runtime image batches select the smallest captured budget that can hold the packed image tokens.
  - Runtime inputs, rotary buffers, `cu_seqlens`, and window metadata are copied into graph-owned stable buffers before replay.
  - Over-budget requests or metadata-capacity misses fall back to eager execution.

- Update Qwen2.5-VL and Qwen3-VL image paths to use the new ViT CUDA Graph runner.
  - Image inputs are packed and bin-packed by post-merge vision token count.
  - Precomputed image embeddings and non-raw patch inputs bypass ViT CUDA Graph.
  - Video inputs keep the existing eager path.

- Fix attention metadata handling for CUDA Graph replay.
  - Triton attention graph path updates padded `seq_lens` from runtime `cu_seqlens`.
  - FA3 graph path is only used when graph-specific metadata is passed.
  - Qwen2.5 window attention uses fixed-capacity padded `cu_window_seqlens`, with eager fallback when metadata exceeds capacity.

- Include stability fixes from previous ViT CUDA Graph work.
  - Qwen3/Qwen3.5 visual warmup before capture.
  - Rotary sin/cos buffer dtype follows actual rotary tensor dtype.
  - Avoid hard-coded ViT max token assumptions by deriving max raw budget from configuration.
  - Align Qwen3 graph input position embedding construction with the eager/reference path.


## Accuracy Tests
MMMU test:
without cudagraph:
```
Result [basic]
: {'results': {'mmmu_val': {'alias': 'mmmu_val', 'mmmu_acc,none': 0.50111, 'mmmu_acc_stderr,none': 'N/A', 'mmmu_acc_stderr_clt,none': 'N/A', 'mmmu_acc_stderr_clustered,none': 'N/A', 'mmmu_acc_pass_at_k,none': [], 'mmmu_acc_pass_at_k_stderr,none': [], 'submission,none': [], 'submission_stderr,none': []}}, 'group_subtasks': {'mmmu_val': []}, 'configs': {'mmmu_val': {'task': 'mmmu_val', 'dataset_path': 'lmms-lab/MMMU', 'test_split': 'validation', 'full_docs': False, 'process_results_use_image': False, 'doc_to_visual': '<function mmmu_doc_to_visual at 0x7fb02c40af20>', 'doc_to_text': '<function mmmu_doc_to_text at 0x7fb02c40bf60>', 'doc_to_target': 'answer', 'doc_to_messages': '<function mmmu_doc_to_messages at 0x7fb02c44d440>', 'process_results': '<function mmmu_process_results at 0x7fb02c44e7a0>', 'description': '', 'target_delimiter': ' ', 'fewshot_delimiter': '\n\n', 'num_fewshot': 0, 'metric_list': [{'metric': 'mmmu_acc', 'aggregation': '<function mmmu_aggregate_results at 0x7fb02c44fc40>', 'higher_is_better': True}], 'output_type': 'generate_until', 'generation_kwargs': {'max_new_tokens': 128, 'until': ['\n\n']}, 'repeats': 1, 'should_decontaminate': False, 'score_key': 'score', 'metadata': {'version': 0.0, 'interleaved_format': False}, 'lmms_eval_specific_kwargs': {'default': {'prompt_type': 'format', 'multiple_choice_prompt': "Answer with the option's letter from the given choices directly.", 'open_ended_prompt': 'Answer the question using a single word or phrase.'}, 'qwen3_vl': {'format': 'qwen3_vl', 'pre_prompt': 'Question: ', 'post_prompt': 'Answer with the option letter only.', 'open_ended_prompt': 'Please select the correct answer from the options above.'}, 'prompt_type': 'format', 'multiple_choice_prompt': "Answer with the option's letter from the given choices directly.", 'open_ended_prompt': 'Answer the question using a single word or phrase.'}}}, 'versions': {'mmmu_val': 0.0}, 'n-shot': {'mmmu_val': 0}, 'higher_is_better': {'mmmu_val': {'mmmu_acc': True}}, 'n-samples': {'mmmu_val': {'original': 900, 'effective': 900}}, 'config': {'model': 'openai_compatible', 'model_args': 'model_version="/data00/models/Qwen3-VL-8B-Instruct/",tp=1', 'batch_size': '64', 'batch_sizes': [], 'device': None, 'use_cache': None, 'limit': None, 'offset': 0, 'bootstrap_iters': 100000, 'gen_kwargs': '', 'random_seed': 0, 'numpy_seed': 1234, 'torch_seed': 1234, 'fewshot_seed': 1234}, 'git_hash': None, 'date': '20260521_172357', 'throughput': {'total_gen_tokens': 25479, 'total_elapsed_time': 2352.725122690201, 'avg_speed': 10.82956940199894}, 'task_hashes': {'mmmu_val': '614600386b06b53646ff0656be64e14e0f33e49b2e8eb7e528d482ff0ba6e7ae'}, 'model_source': 'openai_compatible', 'model_name': '"/data00/models/Qwen3-VL-8B-Instruct/"', 'model_name_sanitized': 'Qwen3-VL-8B-Instruct__', 'system_instruction': None, 'system_instruction_sha': None, 'fewshot_as_multiturn': False, 'chat_template': None, 'chat_template_sha': None, 'start_time': 22540730.842458677, 'end_time': 22540851.726701338, 'total_evaluation_time_seconds': '120.88424266129732'}
Model /data00/models/Qwen3-VL-8B-Instruct/ achieved accuracy [basic]: 0.5011
[METRIC] mmmu_score=0.50111 labels={"model": "/data00/models/Qwen3-VL-8B-Instruct/", "eval": "mmmu", "api": "lmms-eval"}
Cleaning up process 1505630
>>> [2026-05-21 09:26:00] 完成 variant=basic -> PASS, acc=0.5011
```
with cudagraph
```
Result [basic]
: {'results': {'mmmu_val': {'alias': 'mmmu_val', 'mmmu_acc,none': 0.50333, 'mmmu_acc_stderr,none': 'N/A', 'mmmu_acc_stderr_clt,none': 'N/A', 'mmmu_acc_stderr_clustered,none': 'N/A', 'mmmu_acc_pass_at_k,none': [], 'mmmu_acc_pass_at_k_stderr,none': [], 'submission,none': [], 'submission_stderr,none': []}}, 'group_subtasks': {'mmmu_val': []}, 'configs': {'mmmu_val': {'task': 'mmmu_val', 'dataset_path': 'lmms-lab/MMMU', 'test_split': 'validation', 'full_docs': False, 'process_results_use_image': False, 'doc_to_visual': '<function mmmu_doc_to_visual at 0x7fefd37daf20>', 'doc_to_text': '<function mmmu_doc_to_text at 0x7fefd37dbf60>', 'doc_to_target': 'answer', 'doc_to_messages': '<function mmmu_doc_to_messages at 0x7fefd3621440>', 'process_results': '<function mmmu_process_results at 0x7fefd36227a0>', 'description': '', 'target_delimiter': ' ', 'fewshot_delimiter': '\n\n', 'num_fewshot': 0, 'metric_list': [{'metric': 'mmmu_acc', 'aggregation': '<function mmmu_aggregate_results at 0x7fefd3623c40>', 'higher_is_better': True}], 'output_type': 'generate_until', 'generation_kwargs': {'max_new_tokens': 128, 'until': ['\n\n']}, 'repeats': 1, 'should_decontaminate': False, 'score_key': 'score', 'metadata': {'version': 0.0, 'interleaved_format': False}, 'lmms_eval_specific_kwargs': {'default': {'prompt_type': 'format', 'multiple_choice_prompt': "Answer with the option's letter from the given choices directly.", 'open_ended_prompt': 'Answer the question using a single word or phrase.'}, 'qwen3_vl': {'format': 'qwen3_vl', 'pre_prompt': 'Question: ', 'post_prompt': 'Answer with the option letter only.', 'open_ended_prompt': 'Please select the correct answer from the options above.'}, 'prompt_type': 'format', 'multiple_choice_prompt': "Answer with the option's letter from the given choices directly.", 'open_ended_prompt': 'Answer the question using a single word or phrase.'}}}, 'versions': {'mmmu_val': 0.0}, 'n-shot': {'mmmu_val': 0}, 'higher_is_better': {'mmmu_val': {'mmmu_acc': True}}, 'n-samples': {'mmmu_val': {'original': 900, 'effective': 900}}, 'config': {'model': 'openai_compatible', 'model_args': 'model_version="/data00/models/Qwen3-VL-8B-Instruct/",tp=1', 'batch_size': '64', 'batch_sizes': [], 'device': None, 'use_cache': None, 'limit': None, 'offset': 0, 'bootstrap_iters': 100000, 'gen_kwargs': '', 'random_seed': 0, 'numpy_seed': 1234, 'torch_seed': 1234, 'fewshot_seed': 1234}, 'git_hash': None, 'date': '20260521_171641', 'throughput': {'total_gen_tokens': 25380, 'total_elapsed_time': 2277.516343832016, 'avg_speed': 11.143718054421113}, 'task_hashes': {'mmmu_val': '614600386b06b53646ff0656be64e14e0f33e49b2e8eb7e528d482ff0ba6e7ae'}, 'model_source': 'openai_compatible', 'model_name': '"/data00/models/Qwen3-VL-8B-Instruct/"', 'model_name_sanitized': 'Qwen3-VL-8B-Instruct__', 'system_instruction': None, 'system_instruction_sha': None, 'fewshot_as_multiturn': False, 'chat_template': None, 'chat_template_sha': None, 'start_time': 22540294.803105276, 'end_time': 22540415.20750536, 'total_evaluation_time_seconds': '120.40440008416772'}
Model /data00/models/Qwen3-VL-8B-Instruct/ achieved accuracy [basic]: 0.5033
[METRIC] mmmu_score=0.50333 labels={"model": "/data00/models/Qwen3-VL-8B-Instruct/", "eval": "mmmu", "api": "lmms-eval"}
Cleaning up process 1501530
>>> [2026-05-21 09:18:43] 完成 variant=basic -> PASS, acc=0.5033
```
with cudagraph
Known local validation:
- Qwen3-VL exact-shape graph/eager debug comparison showed bitwise-matched ViT outputs after aligning position embedding construction:
  - `max_abs=0`
  - `mean_abs=0`
  - `allclose=True`

## Speed Tests and Profiling
on single H20 test Qwen3-VL-8B-Instruct
run: 
```
for i in {1..3}; do     python3 -m sglang.bench_serving --backend sglang-oai-chat --dataset-name image --num-prompts 96 --apply-chat-template --random-output-len 64 --random-input-len 32 --image-resolution 448x448 --image-format jpeg --image-count 1 --image-content blank --random-range-ratio 1 --max-concurrency 16 --host=127.0.0.1 --port=8070; done
```
without cudagraph:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     96
Benchmark duration (s):                  7.57
Total input tokens:                      23280
Total input text tokens:                 4308
Total input vision tokens:               18972
Total generated tokens:                  6144
Total generated tokens (retokenized):    6144
Request throughput (req/s):              12.68
Input token throughput (tok/s):          3075.04
Output token throughput (tok/s):         811.56
Peak output token throughput (tok/s):    1023.00
Peak concurrent requests:                32
Total token throughput (tok/s):          3886.60
Concurrency:                             15.96
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1258.46
Median E2E Latency (ms):                 1281.48
P90 E2E Latency (ms):                    1290.79
P99 E2E Latency (ms):                    1292.00
---------------Time to First Token----------------
Mean TTFT (ms):                          697.92
Median TTFT (ms):                        753.87
P99 TTFT (ms):                           837.65
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          8.90
Median TPOT (ms):                        7.20
P99 TPOT (ms):                           16.87
---------------Inter-Token Latency----------------
Mean ITL (ms):                           8.90
Median ITL (ms):                         7.19
P95 ITL (ms):                            7.24
P99 ITL (ms):                            9.63
Max ITL (ms):                            619.51
==================================================

```

with cudagraph(shape not hit, with padding):
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     96
Benchmark duration (s):                  7.05
Total input tokens:                      23279
Total input text tokens:                 4311
Total input vision tokens:               18968
Total generated tokens:                  6144
Total generated tokens (retokenized):    6144
Request throughput (req/s):              13.61
Input token throughput (tok/s):          3300.07
Output token throughput (tok/s):         870.98
Peak output token throughput (tok/s):    1024.00
Peak concurrent requests:                32
Total token throughput (tok/s):          4171.06
Concurrency:                             15.96
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1172.42
Median E2E Latency (ms):                 1135.35
P90 E2E Latency (ms):                    1284.41
P99 E2E Latency (ms):                    1285.72
---------------Time to First Token----------------
Mean TTFT (ms):                          618.30
Median TTFT (ms):                        679.17
P99 TTFT (ms):                           831.27
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          8.80
Median TPOT (ms):                        7.21
P99 TPOT (ms):                           16.40
---------------Inter-Token Latency----------------
Mean ITL (ms):                           8.80
Median ITL (ms):                         7.20
P95 ITL (ms):                            7.30
P99 ITL (ms):                            9.67
Max ITL (ms):                            585.83
==================================================

```

with cudagraph (hit pre_capture  shape, without padding):
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     96
Benchmark duration (s):                  6.90
Total input tokens:                      23204
Total input text tokens:                 4242
Total input vision tokens:               18962
Total generated tokens:                  6144
Total generated tokens (retokenized):    6144
Request throughput (req/s):              13.91
Input token throughput (tok/s):          3362.72
Output token throughput (tok/s):         890.39
Peak output token throughput (tok/s):    1024.00
Peak concurrent requests:                32
Total token throughput (tok/s):          4253.10
Concurrency:                             15.95
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1146.66
Median E2E Latency (ms):                 1145.02
P90 E2E Latency (ms):                    1192.39
P99 E2E Latency (ms):                    1193.98
---------------Time to First Token----------------
Mean TTFT (ms):                          596.31
Median TTFT (ms):                        652.78
P99 TTFT (ms):                           736.92
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          8.74
Median TPOT (ms):                        7.23
P99 TPOT (ms):                           15.02
---------------Inter-Token Latency----------------
Mean ITL (ms):                           8.74
Median ITL (ms):                         7.20
P95 ITL (ms):                            7.27
P99 ITL (ms):                            9.60
Max ITL (ms):                            571.35
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26221263564](https://github.com/sgl-project/sglang/actions/runs/26221263564)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26221263435](https://github.com/sgl-project/sglang/actions/runs/26221263435)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->