### PR TITLE
[CI] Fix bot-cherry-pick: use state == "MERGED" instead of invalid `merged` field

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -89,13 +89,12 @@ jobs:
           PR_URL=""
 
           if [[ -n "$PR_NUMBER" ]]; then
-            if ! PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,merged,mergeCommit,title,number,url); then
+            if ! PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,mergeCommit,title,number,url); then
               echo "::error::Failed to fetch PR #$PR_NUMBER from $GITHUB_REPOSITORY (see gh output above)."
               exit 1
             fi
-            MERGED=$(jq -r '.merged' <<<"$PR_JSON")
             STATE=$(jq -r '.state' <<<"$PR_JSON")
-            if [[ "$MERGED" != "true" ]]; then
+            if [[ "$STATE" != "MERGED" ]]; then
               echo "::error::PR #$PR_NUMBER is not merged (state=$STATE). Only merged PRs can be cherry-picked."
               exit 1
             fi


### PR DESCRIPTION
## Summary

Follow-up to #25981. The first invocation of the updated workflow failed with:

```
Unknown JSON field: "merged"
```

`merged` is not a valid `gh pr view --json` field. Switch the merge check to use `state == "MERGED"` (the canonical way `gh` exposes it).

Failing run: https://github.com/sgl-project/sglang/actions/runs/26220693680

## Test plan

- [ ] Re-trigger the workflow with `pr_number=25733` and a target release branch — expect `Resolve PR / commit` to pass and proceed to cherry-pick.
- [ ] Trigger with an open PR — expect failure with `state=OPEN` in the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26224810552](https://github.com/sgl-project/sglang/actions/runs/26224810552)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26224810480](https://github.com/sgl-project/sglang/actions/runs/26224810480)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->