### PR TITLE
[Bugfix] Support CUDA UUIDs in custom all-reduce NVLink detection

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from functools import wraps
 from itertools import product
-from typing import Callable, Dict, List, Optional, Sequence, TypeVar
+from typing import Callable, Dict, List, Optional, Sequence, TypeVar, Union
 
 import torch
 import torch.distributed as dist
@@ -56,6 +56,7 @@ if _is_hip:
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+NvmlDeviceIdentifier = Union[int, str]
 
 
 def update_environment_variables(envs: Dict[str, str]):
@@ -349,13 +350,43 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
     return wrapper
 
 
+def _get_cuda_nvml_device_identifier(
+    device: torch.device,
+) -> NvmlDeviceIdentifier:
+    props = torch.cuda.get_device_properties(device)
+    uuid = getattr(props, "uuid", None)
+    if uuid:
+        uuid = str(uuid)
+        return uuid if uuid.startswith(("GPU-", "MIG-")) else f"GPU-{uuid}"
+
+    device_index = (
+        device.index if device.index is not None else torch.cuda.current_device()
+    )
+    get_nvml_device_index = getattr(torch.cuda, "_get_nvml_device_index", None)
+    if get_nvml_device_index is not None:
+        return int(get_nvml_device_index(device_index))
+
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+    if cuda_visible_devices:
+        return int(cuda_visible_devices.split(",")[device_index])
+    return device_index
+
+
+def _get_nvml_handle(identifier: NvmlDeviceIdentifier):
+    if isinstance(identifier, str):
+        return pynvml.nvmlDeviceGetHandleByUUID(identifier)
+    return pynvml.nvmlDeviceGetHandleByIndex(identifier)
+
+
 @with_nvml_context
-def is_full_nvlink(physical_device_ids: List[int], world_size: int) -> bool:
+def is_full_nvlink(
+    device_identifiers: List[NvmlDeviceIdentifier], world_size: int
+) -> bool:
     if _is_hip:
         """
         query if the set of gpus are fully connected by xgmi (1 hop)
         """
-        handles = [amdsmi_get_processor_handles()[i] for i in physical_device_ids]
+        handles = [amdsmi_get_processor_handles()[i] for i in device_identifiers]
         for i, handle in enumerate(handles):
             for j, peer_handle in enumerate(handles):
                 if i < j:
@@ -372,7 +403,7 @@ def is_full_nvlink(physical_device_ids: List[int], world_size: int) -> bool:
         """
         query if the set of gpus are fully connected by nvlink (1 hop)
         """
-        handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids]
+        handles = [_get_nvml_handle(identifier) for identifier in device_identifiers]
         for i, handle in enumerate(handles):
             for j, peer_handle in enumerate(handles):
                 if i < j:
@@ -445,19 +476,24 @@ def can_use_custom_all_reduce_with_nvlink(
         )
         return
 
-    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
-    if cuda_visible_devices:
-        device_ids = list(map(int, cuda_visible_devices.split(",")))
+    if _is_cuda:
+        device_identifier = _get_cuda_nvml_device_identifier(device)
+        device_identifiers = [device_identifier for _ in range(world_size)]
+        dist.all_gather_object(device_identifiers, device_identifier, group=group)
     else:
-        device_ids = list(range(torch.cuda.device_count()))
-    physical_device_id = device_ids[device.index]
-    tensor = torch.tensor([physical_device_id], dtype=torch.int, device="cpu")
-    gather_list = [
-        torch.tensor([0], dtype=torch.int, device="cpu") for _ in range(world_size)
-    ]
-    dist.all_gather(gather_list, tensor, group=group)
-    physical_device_ids = [int(t) for t in gather_list]
-    full_nvlink = is_full_nvlink(physical_device_ids, world_size)
+        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+        if cuda_visible_devices:
+            device_ids = list(map(int, cuda_visible_devices.split(",")))
+        else:
+            device_ids = list(range(torch.cuda.device_count()))
+        physical_device_id = device_ids[device.index]
+        tensor = torch.tensor([physical_device_id], dtype=torch.int, device="cpu")
+        gather_list = [
+            torch.tensor([0], dtype=torch.int, device="cpu") for _ in range(world_size)
+        ]
+        dist.all_gather(gather_list, tensor, group=group)
+        device_identifiers = [int(t) for t in gather_list]
+    full_nvlink = is_full_nvlink(device_identifiers, world_size)
 
     # test nvlink first, this will filter out most of the cases
     # where custom allreduce is not supported

--- a/test/registered/unit/distributed/test_custom_all_reduce_utils.py
+++ b/test/registered/unit/distributed/test_custom_all_reduce_utils.py
@@ -1,0 +1,46 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.distributed.device_communicators import custom_all_reduce_utils as caru
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def test_custom_all_reduce_gathers_cuda_uuid_identifiers():
+    def fake_all_gather_object(output, value, group=None):
+        output[:] = [value, "GPU-peer"]
+
+    with (
+        patch.object(caru, "_is_cuda", True),
+        patch.object(caru, "_is_hip", False),
+        patch.object(caru.dist, "get_backend", return_value="gloo"),
+        patch.object(caru.dist, "get_rank", return_value=0),
+        patch.object(caru.dist, "get_world_size", return_value=2),
+        patch.object(
+            caru.dist, "all_gather_object", side_effect=fake_all_gather_object
+        ) as mock_all_gather_object,
+        patch.object(caru.dist, "all_gather") as mock_all_gather,
+        patch.object(caru, "in_the_same_node_as", return_value=[True, True]),
+        patch.object(
+            caru.torch.cuda,
+            "get_device_properties",
+            return_value=SimpleNamespace(uuid="local"),
+        ),
+        patch.object(caru, "is_full_nvlink", return_value=True) as mock_nvlink,
+        patch.object(caru, "can_p2p", return_value=True),
+        patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "GPU-local,GPU-peer"}),
+    ):
+        assert caru.can_use_custom_all_reduce_with_nvlink(
+            group=MagicMock(),
+            device=torch.device("cuda:0"),
+            supported_world_size=[2],
+            cls_name="CustomAllreduce",
+        )
+
+    mock_all_gather_object.assert_called_once()
+    mock_all_gather.assert_not_called()
+    mock_nvlink.assert_called_once_with(["GPU-local", "GPU-peer"], 2)


### PR DESCRIPTION
## Summary
- Avoid parsing `CUDA_VISIBLE_DEVICES` as integer-only for CUDA custom all-reduce NVLink detection.
- Prefer CUDA device UUIDs and resolve NVML handles by UUID when available.
- Fall back to PyTorch's NVML index helper, then the existing integer-index behavior.
- Keep the existing non-CUDA integer-index path unchanged.
- Add a focused unit test for UUID-style `CUDA_VISIBLE_DEVICES` in custom all-reduce startup.

## Testing
- `PYTHONPATH=/workspace/sglang/python /workspace/sglang/.venv/bin/python -m pytest test/registered/unit/distributed/test_custom_all_reduce_utils.py -q`
- `/workspace/sglang/.venv/bin/python -m black --check python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py test/registered/unit/distributed/test_custom_all_reduce_utils.py`
- `/workspace/sglang/.venv/bin/python -m isort --check-only python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py test/registered/unit/distributed/test_custom_all_reduce_utils.py`
- `/workspace/sglang/.venv/bin/python -m ruff check --select=F401,F821 python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py test/registered/unit/distributed/test_custom_all_reduce_utils.py`
- `/workspace/sglang/.venv/bin/python -m py_compile python/sglang/srt/distributed/device_communicators/custom_all_reduce_utils.py test/registered/unit/distributed/test_custom_all_reduce_utils.py`
- `/workspace/sglang/.venv/bin/python scripts/ci/check_registered_tests.py test/registered/unit/distributed/test_custom_all_reduce_utils.py`
- `git diff --check`

I also ran a local 2-process Gloo smoke test that exercises the new `all_gather_object` path. The machine available for this PR exposes one CUDA GPU, so I could not run a real multi-GPU NVLink hardware test.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26229985083](https://github.com/sgl-project/sglang/actions/runs/26229985083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26229984491](https://github.com/sgl-project/sglang/actions/runs/26229984491)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->