### PR TITLE
[CI] bot-cherry-pick: surface created PR number/URL in job summary

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -207,6 +207,7 @@ jobs:
           git push origin "$NEW_BRANCH"
 
       - name: Create Pull Request
+        id: create_pr
         if: steps.cherry_pick.outputs.cherry_pick_success == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_CHERRY_PICK }}
@@ -233,12 +234,16 @@ jobs:
           BODY+="---"$'\n'
           BODY+="*This PR was automatically created by the cherry-pick workflow.*"
 
-          printf '%s' "$BODY" | gh pr create \
+          CREATED_PR_URL=$(printf '%s' "$BODY" | gh pr create \
             --title "$CHERRY_PICK_TITLE" \
             --base "$TARGET_BRANCH" \
             --head "$NEW_BRANCH" \
             --label "cherry-pick" \
-            --body-file -
+            --body-file -)
+          CREATED_PR_NUMBER="${CREATED_PR_URL##*/}"
+          echo "created_pr_url=$CREATED_PR_URL" >> $GITHUB_OUTPUT
+          echo "created_pr_number=$CREATED_PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Created cherry-pick PR #${CREATED_PR_NUMBER}: ${CREATED_PR_URL}"
 
       - name: Summary
         if: always()
@@ -249,6 +254,8 @@ jobs:
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
           CHERRY_PICK_SUCCESS: ${{ steps.cherry_pick.outputs.cherry_pick_success }}
           NEW_BRANCH: ${{ steps.cherry_pick.outputs.new_branch }}
+          CREATED_PR_NUMBER: ${{ steps.create_pr.outputs.created_pr_number }}
+          CREATED_PR_URL: ${{ steps.create_pr.outputs.created_pr_url }}
           ACTOR: ${{ github.actor }}
         run: |
           echo "## Cherry-Pick Summary" >> $GITHUB_STEP_SUMMARY
@@ -263,6 +270,9 @@ jobs:
           if [[ "$CHERRY_PICK_SUCCESS" == "true" ]]; then
             echo "- **Status:** Success" >> $GITHUB_STEP_SUMMARY
             echo "- **PR Branch:** ${NEW_BRANCH}" >> $GITHUB_STEP_SUMMARY
+            if [[ -n "$CREATED_PR_NUMBER" ]]; then
+              echo "- **Cherry-pick PR:** [#${CREATED_PR_NUMBER}](${CREATED_PR_URL})" >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "- **Status:** Failed" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Summary
- Capture the URL returned by `gh pr create` in the **Create Pull Request** step and expose it as `created_pr_url` / `created_pr_number` step outputs.
- Render the new cherry-pick PR as `- **Cherry-pick PR:** [#N](URL)` in `GITHUB_STEP_SUMMARY` so operators can click straight into the generated PR from the workflow run page.

## Test plan
- [ ] Trigger the workflow with a known merged PR and confirm the run summary contains the **Cherry-pick PR** line linking to the new PR.
- [ ] Trigger with a cherry-pick that conflicts (cherry_pick_success != true) and confirm the summary still renders (without the new PR line) and the job fails as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26233296459](https://github.com/sgl-project/sglang/actions/runs/26233296459)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26233296252](https://github.com/sgl-project/sglang/actions/runs/26233296252)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->