### PR TITLE
Default MegaMoE to W4A8 for Max-Throughput recipe

### DIFF
--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -615,7 +615,8 @@ export const DeepSeekV4Deployment = () => {
       }
       // allinone H200 gates DEEPEP_LARGE_SMS_FLAG on !multinode — only H200 big
       // is multi-node; all Blackwell cells get the flag unconditionally.
-      if (!multinode) flags.push(DEEPEP_LARGE_SMS_FLAG);
+      // Skip when MegaMoE is enabled (uses its own backend, not DeepEP).
+      if (!multinode && megamoe === "disabled") flags.push(DEEPEP_LARGE_SMS_FLAG);
     } else if (recipe === "max-throughput") {
       // allinone max-throughput: TP + DP + DP-attn + DeepEP (NO MTP).
       //   H200 small: cg=128 max-run=256  |  H200 big: cg=128 max-run=256 (same)
@@ -652,7 +653,7 @@ export const DeepSeekV4Deployment = () => {
         flags.push("  --cuda-graph-max-bs 64");
         flags.push("  --max-running-requests 256");
       }
-      if (!multinode) flags.push(DEEPEP_LARGE_SMS_FLAG);
+      if (!multinode && megamoe === "disabled") flags.push(DEEPEP_LARGE_SMS_FLAG);
     } else if (recipe === "cp") {
       // allinone cp: TP (NO --dp) + DeepEP + _CP_FLAGS (mem-frac 0.78, max-run 1024).
       //   Blackwell big additionally: mem-frac 0.70 (overrides), cg=256, max-run=256.

--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -177,6 +177,16 @@ export const DeepSeekV4Deployment = () => {
       ) {
         next.megamoe = "disabled";
       }
+      // Switching to max-throughput on supported hardware: default MegaMoE to
+      // W4A8 if it's currently disabled (best throughput config).
+      if (
+        (optionName === "recipe" || optionName === "hardware") &&
+        next.recipe === "max-throughput" &&
+        next.megamoe === "disabled" &&
+        !isMegamoeUnsupported(next)
+      ) {
+        next.megamoe = "w4a8";
+      }
       return next;
     });
   };


### PR DESCRIPTION
## Summary
- Auto-select MegaMoE W4A8 when switching to Max-Throughput recipe on supported hardware (Blackwell)
- Skip `--deepep-config` flag when MegaMoE is enabled (MegaMoE uses its own backend, not DeepEP)
- MegaMoE stays disabled on unsupported hardware (Hopper) or recipes (low-latency, cp)
- Users can still manually switch to W4A4 or Disabled after the auto-selection