### PR TITLE
[Dsv4] Fix non-determenistic K-cache write in fused_k_norm_rope_flashmla

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/main_norm_rope.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/main_norm_rope.cuh
@@ -294,8 +294,6 @@ K_KERNEL void fused_k_norm_rope_flashmla(const __grid_constant__ FusedKNormRopeF
   const auto page_ptr = params.kvcache + page * kPageBytes;
   const auto value_ptr = page_ptr + offset * 576;
 
-  PDLTriggerSecondary<kUsePDL>();
-
   // part 2: rope on warp 7 (BF16 store), per-warp UE8M0 quant + store on warps 0..6.
   if (warp_id == kRopeWarp) {
     const auto x_real = data[0];
@@ -319,6 +317,8 @@ K_KERNEL void fused_k_norm_rope_flashmla(const __grid_constant__ FusedKNormRopeF
     reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[tx] = result;
     if (lane_id == 0) static_cast<uint8_t*>(scale_ptr)[warp_id] = scale_ue8m0;
   }
+
+  PDLTriggerSecondary<kUsePDL>();
 }
 
 template <typename DType, int64_t kHeadDim, int64_t kRopeDim, uint32_t kPageSize, bool kUsePDL>

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -444,15 +444,19 @@ class MQALayer(nn.Module):
         assert len(self.alt_streams) >= 3
 
         current_stream = torch.cuda.current_stream()
+        stream_kv = self.alt_streams[0]
         stream_compressor = self.alt_streams[1]
         stream_indexer = self.alt_streams[2]
 
+        stream_kv.wait_stream(current_stream)
         stream_compressor.wait_stream(current_stream)
         stream_indexer.wait_stream(current_stream)
 
         qkv_a: Optional[torch.Tensor] = None
+        qkv_a_ready: Optional[torch.cuda.Event] = None
         if self.fuse_wqa_wkv:
             qkv_a, _ = self.wqkv_a(x)
+            qkv_a_ready = current_stream.record_event()
 
         q_lora = self._compute_q_a(x, qkv_a=qkv_a)
         q_lora_ready = current_stream.record_event()
@@ -467,7 +471,11 @@ class MQALayer(nn.Module):
                     q_lora_ready=q_lora_ready,
                 )
 
-        self._compute_kv_to_cache(x, positions, forward_batch, qkv_a=qkv_a)
+        with torch.cuda.stream(stream_kv):
+            if qkv_a_ready is not None:
+                stream_kv.wait_event(qkv_a_ready)
+            # Fused norm + rope + cache write -- no bf16 KV intermediate.
+            self._compute_kv_to_cache(x, positions, forward_batch, qkv_a=qkv_a)
 
         del qkv_a
 
@@ -478,6 +486,7 @@ class MQALayer(nn.Module):
                 )
 
         q = self._compute_q_b(q_lora, positions, q_out)
+        current_stream.wait_stream(stream_kv)
         current_stream.wait_stream(stream_compressor)
         current_stream.wait_stream(stream_indexer)
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -444,19 +444,15 @@ class MQALayer(nn.Module):
         assert len(self.alt_streams) >= 3
 
         current_stream = torch.cuda.current_stream()
-        stream_kv = self.alt_streams[0]
         stream_compressor = self.alt_streams[1]
         stream_indexer = self.alt_streams[2]
 
-        stream_kv.wait_stream(current_stream)
         stream_compressor.wait_stream(current_stream)
         stream_indexer.wait_stream(current_stream)
 
         qkv_a: Optional[torch.Tensor] = None
-        qkv_a_ready: Optional[torch.cuda.Event] = None
         if self.fuse_wqa_wkv:
             qkv_a, _ = self.wqkv_a(x)
-            qkv_a_ready = current_stream.record_event()
 
         q_lora = self._compute_q_a(x, qkv_a=qkv_a)
         q_lora_ready = current_stream.record_event()
@@ -471,11 +467,7 @@ class MQALayer(nn.Module):
                     q_lora_ready=q_lora_ready,
                 )
 
-        with torch.cuda.stream(stream_kv):
-            if qkv_a_ready is not None:
-                stream_kv.wait_event(qkv_a_ready)
-            # Fused norm + rope + cache write -- no bf16 KV intermediate.
-            self._compute_kv_to_cache(x, positions, forward_batch, qkv_a=qkv_a)
+        self._compute_kv_to_cache(x, positions, forward_batch, qkv_a=qkv_a)
 
         del qkv_a
 
@@ -486,7 +478,6 @@ class MQALayer(nn.Module):
                 )
 
         q = self._compute_q_b(q_lora, positions, q_out)
-        current_stream.wait_stream(stream_kv)
         current_stream.wait_stream(stream_compressor)
         current_stream.wait_stream(stream_indexer)
 

--- a/test/registered/dsv4/test_dsv4_flash_decode_vs_prefill_kl.py
+++ b/test/registered/dsv4/test_dsv4_flash_decode_vs_prefill_kl.py
@@ -1,0 +1,188 @@
+"""Decode-vs-prefill KL match across parallelism configs (DSv4-Flash-FP8).
+
+For each config, generate ``Q`` tokens by greedy-decode after a 512-token
+prefix ``P``, then re-prefill the full ``P + Q`` and compare logprobs at the
+same Q positions. Cache-write and decode-vs-prefill attention kernels should
+agree modulo small FP noise (KL ≈ 0.005-0.006).
+
+Three configs exercise the same model under different attention parallelism
+schemes (TP, DP, CP). The DP and CP paths skip post-attention allreduce, so
+any per-rank non-determinism in K-cache writes that TP-allreduce would mask
+becomes visible here.
+"""
+
+import unittest
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kl_multiturn_utils import (
+    get_input_ids,
+    test_input_output_logprobs_match_helper,
+)
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=900, stage="stage-c", runner_config="dsv4-8-gpu-h200")
+
+MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
+LAUNCH_TIMEOUT = 3600
+DEEPEP_CONFIG = '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+PREFIX_LEN = 512
+DECODE_LEN = 512
+NUM_SAMPLES = 4
+
+
+class _DecodeVsPrefillKLMixin:
+    model = MODEL
+    kl_threshold: float = 0.015
+
+    def test_decode_vs_prefill_logprobs_match(self):
+        raw_ids = get_input_ids(self.model, num_samples=NUM_SAMPLES * 4)
+        prompts = [ids[:PREFIX_LEN] for ids in raw_ids if len(ids) >= PREFIX_LEN][
+            :NUM_SAMPLES
+        ]
+        assert len(prompts) == NUM_SAMPLES
+        test_input_output_logprobs_match_helper(
+            self.base_url,
+            self.model,
+            self.kl_threshold,
+            prompts,
+            label=f"{self.__class__.__name__}.decode_vs_prefill",
+            max_new_tokens=DECODE_LEN,
+            sampling_temperature=0,
+        )
+
+
+class TestDSV4FlashDecodeVsPrefillKL_TP4(_DecodeVsPrefillKLMixin, CustomTestCase):
+    """TP=4, no DP-attention, no CP. Baseline: TP allreduce after attention
+    smooths per-rank FP noise across ranks."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--chunked-prefill-size",
+                "16384",
+                "--mem-fraction-static",
+                "0.85",
+                "--max-running-requests",
+                "4",
+            ],
+            env={
+                "SGLANG_DSV4_FP4_EXPERTS": "0",
+                "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestDSV4FlashDecodeVsPrefillKL_DP4EP4(_DecodeVsPrefillKLMixin, CustomTestCase):
+    """TP=4 + DP=4 + EP=4 + DeepEP, no CP. DP-attention path: each rank owns
+    a request slice, no post-attention allreduce, so per-rank K-write noise is
+    not averaged out."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--dp",
+                "4",
+                "--enable-dp-attention",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-config",
+                DEEPEP_CONFIG,
+                "--chunked-prefill-size",
+                "8192",
+                "--mem-fraction-static",
+                "0.6",
+                "--max-running-requests",
+                "4",
+                "--cuda-graph-max-bs",
+                "8",
+            ],
+            env={
+                "SGLANG_DSV4_FP4_EXPERTS": "0",
+                "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "1024",
+                "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+class TestDSV4FlashDecodeVsPrefillKL_CP4(_DecodeVsPrefillKLMixin, CustomTestCase):
+    """TP=4 + NSA prefill context-parallel (round-robin). validate_deepseek_v4_cp
+    forces enable_dp_attention=True and attn_cp_size=4. Prefill takes the CP
+    path (gather raw bf16 across CP ranks + fused JIT write); decode takes the
+    normal multi-stream path. Both must produce K-cache bit-equivalent to the
+    eager / re-prefill reference."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--moe-a2a-backend",
+                "deepep",
+                "--deepep-config",
+                DEEPEP_CONFIG,
+                "--enable-nsa-prefill-context-parallel",
+                "--nsa-prefill-cp-mode",
+                "round-robin-split",
+                "--chunked-prefill-size",
+                "16384",
+                "--mem-fraction-static",
+                "0.78",
+                "--swa-full-tokens-ratio",
+                "0.25",
+                "--max-total-tokens",
+                "20000",
+                "--max-running-requests",
+                "4",
+            ],
+            env={
+                "SGLANG_DSV4_FP4_EXPERTS": "0",
+                "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "1",
+                "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "1024",
+                "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1",
+                "SGLANG_OPT_USE_FUSED_STORE_CACHE": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

RadixCache tests use a test with the following idea in several places:
* An input is taken and an output is generated
* The merged input+output re-prefilled
* Logprobs are compared using KL

https://github.com/sgl-project/sglang/blob/a24c374f844455ba1a6994a94b491a36ccb8afea/python/sglang/test/kl_multiturn_utils.py#L100-L123

The fail of these tests may be interpreted as a cache write/read issues. However, there is currently no test that verifies the correctness of this check regardless of caches logic.

Adding this test for three Dsv4-Flash setups (TP4, DP4 EP4, CP4) highlights the real problem:

| Setup   | avg KL  |
|---------|---------|
| TP4     | 0.004 |
| DP4 EP4 | 0.127   |
| CP4     | 0.591   |

As a result, adding tests that use CP/DP in the hicache area will result in a falling CI (for example, here https://github.com/sgl-project/sglang/pull/25395)

## Modifications

The fix was found empirically, because moving the `_compute_kv_to_cache` launch to the main stream also provided an improvement in tests, which hints at problems with overlap.
However, it is not entirely clear (for me) what kind of race took place here, because the secondary kernel here is the kernel of the N+1 layer, which was not supposed to compete in memory.

After fix:

| Setup   | avg KL  |
|---------|---------|
| TP4     | 0.005 |
| DP4 EP4 | 0.006 |
| CP4     | 0.006  |

## Accuracy Tests


## Speed Tests and Profiling
























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26241733066](https://github.com/sgl-project/sglang/actions/runs/26241733066)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26241732904](https://github.com/sgl-project/sglang/actions/runs/26241732904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->