### PR TITLE
[AMD] Add rocm7.2.3 support

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -1,8 +1,10 @@
 # Usage (to build SGLang ROCm docker image):
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942 -t v0.5.10.post1-rocm700-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm723 -t v0.5.10.post1-rocm723-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm723 -t v0.5.10.post1-rocm723-mi35x -f rocm.Dockerfile .
 
 # Usage (to build SGLang ROCm + Mori docker image):
 # remove --build-arg NIC_BACKEND=ainic since new MoRI JIT will do NIC auto detection on target
@@ -11,14 +13,18 @@
 # RDMA NICs installed (rare), overwrite w. runtime env MORI_DEVICE_NIC = "bnxt"|"ionic"|"mlx5"
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm700-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm723 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm723-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm723 --build-arg ENABLE_MORI=1 -t v0.5.10.post1-rocm723-mi35x -f rocm.Dockerfile .
 
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+ARG BASE_IMAGE_942_ROCM723="rocm/pytorch:rocm7.2.3_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+ARG BASE_IMAGE_950_ROCM723="rocm/pytorch:rocm7.2.3_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950
@@ -36,6 +42,16 @@ ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 # ===============================
 # Base image 942 with rocm720 and args
 FROM $BASE_IMAGE_942_ROCM720 AS gfx942-rocm720
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="1"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="1"
+ENV BUILD_MOONCAKE="1"
+ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
+
+# ===============================
+# Base image 942 with rocm723 and args
+FROM $BASE_IMAGE_942_ROCM723 AS gfx942-rocm723
 ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
@@ -64,6 +80,16 @@ ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
 
 # ===============================
+# Base image 950 with rocm723 and args
+FROM $BASE_IMAGE_950_ROCM723 AS gfx950-rocm723
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="1"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="1"
+ENV BUILD_MOONCAKE="1"
+ENV AITER_COMMIT_DEFAULT="32e1e6d76988e4fbc67cabd9eb72a45a3c6a1bab"
+
+# ===============================
 # Chosen arch and args
 FROM ${GPU_ARCH}
 
@@ -81,6 +107,18 @@ ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
+
+# Triton variant for ROCm 7.2.3 (selected by GPU_ARCH=*rocm723* in the Triton
+# hot patch RUN block below). Builds from the ROCm/triton fork with two
+# upstream cherry-picks from triton-lang/triton:
+#   555d04f -> https://github.com/triton-lang/triton/pull/8991
+#   dd998b6 -> https://github.com/triton-lang/triton/pull/9541
+# Pattern adapted from
+#   https://github.com/vllm-project/vllm/blob/main/docker/Dockerfile.rocm_base
+ARG TRITON_ROCM_REPO="https://github.com/ROCm/triton.git"
+ARG TRITON_ROCM_COMMIT="ba5c1517"
+ARG TRITON_ROCM_CHERRY_PICK_1="555d04f"
+ARG TRITON_ROCM_CHERRY_PICK_2="dd998b6"
 
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT=""
@@ -137,12 +175,12 @@ RUN if [ -n "$UBUNTU_MIRROR" ]; then \
 # Fix hipDeviceGetName returning empty string in ROCm 7.0 docker images.
 # The ROCm 7.0 base image is missing libdrm-amdgpu-common which provides the
 # amdgpu.ids device-ID-to-marketing-name mapping file.
-# ROCm 7.2 base images already ship these packages, so this step is skipped.
+# ROCm 7.2.x base images already ship these packages, so this step is skipped.
 # See https://github.com/ROCm/ROCm/issues/5992
 RUN set -eux; \
     case "${GPU_ARCH}" in \
-      *rocm720*) \
-        echo "ROCm 7.2 (GPU_ARCH=${GPU_ARCH}): libdrm-amdgpu packages already present, skipping"; \
+      *rocm72*) \
+        echo "ROCm 7.2.x (GPU_ARCH=${GPU_ARCH}): libdrm-amdgpu packages already present, skipping"; \
         ;; \
       *) \
         echo "ROCm 7.0 (GPU_ARCH=${GPU_ARCH}): installing libdrm-amdgpu packages"; \
@@ -166,16 +204,18 @@ RUN python -m pip install --upgrade pip && pip install setuptools_scm
 RUN apt-get purge -y sccache; python -m pip uninstall -y sccache; rm -f "$(which sccache)"
 
 # Install AMD SMI Python package from ROCm distribution.
-# The ROCm 7.2 base image (rocm/pytorch) does not pre-install this package.
+# rocm/pytorch base images for ROCm 7.2.0 / 7.2.3 do not pre-install amd-smi,
+# so this step installs it for those variants. Other base images either ship
+# it already or do not need it.
 RUN set -eux; \
     case "${GPU_ARCH}" in \
-      *rocm720*) \
-        echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
+      *rocm720*|*rocm723*) \
+        echo "ROCm (GPU_ARCH=${GPU_ARCH}): installing amd-smi"; \
         cd /opt/rocm/share/amd_smi \
         && python3 -m pip install --no-cache-dir . \
         ;; \
       *) \
-        echo "Not rocm720 (GPU_ARCH=${GPU_ARCH}), skip amdsmi installation"; \
+        echo "GPU_ARCH=${GPU_ARCH}: skip amd-smi installation (base image already ships it or not applicable)"; \
         ;; \
     esac
 
@@ -487,68 +527,70 @@ RUN /bin/bash -lc 'set -euo pipefail; \
 
 # -----------------------
 # Hot patch: torch-ROCm
-# The artifact hardcoded the supported triton version to be 3.5.1.
-# Rewrite the restriction directly.
-ARG TORCH_ROCM_FILE="torch-2.9.1+rocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl"
-RUN mkdir /tmp/whl && cd /tmp/whl \
-     && export TORCH_ROCM_FILE="${TORCH_ROCM_FILE}" \
-     && cat > hack.py <<"PY"
-import zipfile, csv, os, re
+# Both rocm7.2.0 and rocm7.2.3 base images install a torch wheel that hardcodes
+# a specific triton version (e.g. triton==3.5.1+rocm7.2.x.git...). Since this
+# Dockerfile builds a custom triton later (BUILD_TRITON=1), that pin would
+# cause `pip check` / future `pip install` to fail with a version conflict.
+# We relax the constraint to `triton>=3.5.1` by editing the installed torch
+# dist-info METADATA in place.
+#
+# (Both rocm720 and rocm723 base images ship a pre-installed torch. rocm720
+# additionally keeps the source wheel at /, which we drop to shrink the image.)
+RUN cat > /tmp/hack_inplace.py <<"PY"
+"""Relax torch's pinned triton requirement in-place.
+
+The rocm/pytorch ROCm 7.2.x base images install torch with a hardcoded
+`Requires-Dist: triton==3.5.1+rocm7.2.x.git...` pin. Since this Dockerfile
+replaces triton with a custom build later, the pin would cause `pip install`
+/ `pip check` to fail with a version conflict. This script edits the
+installed torch dist-info METADATA to relax the pin to `triton>=3.5.1` and
+blanks the corresponding RECORD hash so pip stays happy.
+"""
+import csv, re, sys
 from pathlib import Path
 
-fname = os.environ["TORCH_ROCM_FILE"]
-in_whl  = Path("/")   / fname
-out_whl = Path("/tmp")/ fname
-work = Path("/tmp/whl")
+site = Path("/opt/venv/lib/python3.10/site-packages")
+dist_info = next(site.glob("torch-*.dist-info"), None)
+if dist_info is None:
+    sys.exit("torch dist-info not found under /opt/venv")
 
-# 1) Extract
-with zipfile.ZipFile(in_whl, "r") as z:
-    z.extractall(work)
-
-# 2) Locate dist-info and patch METADATA (edit this logic to match your exact line)
-dist_info = next(work.glob("*.dist-info"))
 meta = dist_info / "METADATA"
 txt = meta.read_text(encoding="utf-8")
-
-# Example: replace one exact requirement form.
-# Adjust the string to match what you actually see.
-pat = r"^Requires-Dist:\s*triton==3.5.1[^\s]*;"
-txt2, n = re.subn(pat, r"triton>=3.5.1;", txt, flags=re.MULTILINE)
-if txt2 == txt:
-    raise SystemExit("Did not find expected Requires-Dist line to replace in METADATA")
+# Match the version string up to (but not including) the env marker ";" so that
+# substituting in "triton>=3.5.1" keeps the trailing "; platform_system ..." part.
+pat = r"^Requires-Dist:\s*triton==3\.5\.1[^;\s]*"
+txt2, n = re.subn(pat, "Requires-Dist: triton>=3.5.1", txt, flags=re.MULTILINE)
+if n == 0:
+    sys.exit("Did not find expected Requires-Dist line to replace in METADATA")
 meta.write_text(txt2, encoding="utf-8")
+print(f"Patched {meta}: triton pin -> triton>=3.5.1 ({n} line)")
 
-# 3) Hacky step: blank hash/size columns in RECORD
+# Blank METADATA hash/size in RECORD so pip is happy on subsequent operations.
 record = dist_info / "RECORD"
-rows = []
-with record.open(newline="", encoding="utf-8") as f:
-    for r in csv.reader(f):
-        if not r:
-            continue
-        # keep filename, blank out hash and size
-        rows.append([r[0], "", ""])
-with record.open("w", newline="", encoding="utf-8") as f:
-    csv.writer(f).writerows(rows)
-
-# 4) Re-zip as a wheel
-with zipfile.ZipFile(out_whl, "w", compression=zipfile.ZIP_DEFLATED) as z:
-    for p in work.rglob("*"):
-        if p.is_file():
-            z.write(p, p.relative_to(work).as_posix())
-
-print("Wrote", out_whl)
+if record.exists():
+    rows = []
+    rel_meta = f"{dist_info.name}/METADATA"
+    with record.open(newline="", encoding="utf-8") as f:
+        for r in csv.reader(f):
+            if not r:
+                continue
+            if r[0] == rel_meta:
+                rows.append([r[0], "", ""])
+            else:
+                rows.append(r)
+    with record.open("w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerows(rows)
+    print(f"Blanked METADATA hash/size in {record}")
 PY
 
-RUN cd /tmp/whl \
-    && case "${GPU_ARCH}" in \
-      *rocm720*) \
-        echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
-        python hack.py \
-        && python3 -m pip install --force --no-deps /tmp/${TORCH_ROCM_FILE} \
-        && rm -fr /tmp/whl /tmp/${TORCH_ROCM_FILE} \
+RUN case "${GPU_ARCH}" in \
+      *rocm720*|*rocm723*) \
+        echo "ROCm 7.2.x (GPU_ARCH=${GPU_ARCH}): relaxing torch METADATA in-place"; \
+        python3 /tmp/hack_inplace.py \
+        && rm -f /tmp/hack_inplace.py /torch-*.whl \
         ;; \
       *) \
-        echo "Not rocm720 (GPU_ARCH=${GPU_ARCH}), skip patch"; \
+        echo "GPU_ARCH=${GPU_ARCH}: skip torch hot patch (only rocm720/rocm723 need it)"; \
         ;; \
     esac
 
@@ -559,14 +601,41 @@ RUN cd /tmp/whl \
 # so future `pip install` will break the ROCm stack.
 # A workaround for this is to reinstall the default triton
 # wheel with the `rocm/pytorch` image in the root directory.
+#
+# Two build variants are selected by GPU_ARCH (same pattern as the libdrm and
+# amd-smi cases above):
+#   - *rocm723*: ROCm/triton fork + upstream cherry-picks (PR#8991, PR#9541),
+#     build pattern adapted from vLLM Dockerfile.rocm_base.
+#   - default (e.g. rocm720): unchanged legacy build from triton-lang/triton.
 RUN if [ "$BUILD_TRITON" = "1" ]; then \
-        pip uninstall -y triton \
-     && apt install -y cmake \
-     && git clone ${TRITON_REPO} triton-custom \
-     && cd triton-custom \
-     && git checkout ${TRITON_COMMIT} \
-     && pip install -r python/requirements.txt \
-     && pip install -e .; \
+        case "${GPU_ARCH}" in \
+          *rocm723*) \
+            set -eux \
+         && pip uninstall -y triton \
+         && apt-get update && apt-get install -y --no-install-recommends cmake \
+         && rm -rf /var/lib/apt/lists/* \
+         && git clone ${TRITON_ROCM_REPO} triton-custom \
+         && cd triton-custom \
+         && git checkout ${TRITON_ROCM_COMMIT} \
+         && git config user.email "build@sglang.local" \
+         && git config user.name "SGLang Build" \
+         && echo "[Triton] Cherry-picking ${TRITON_ROCM_CHERRY_PICK_1} (PR#8991)" \
+         && git cherry-pick ${TRITON_ROCM_CHERRY_PICK_1} \
+         && echo "[Triton] Cherry-picking ${TRITON_ROCM_CHERRY_PICK_2} (PR#9541)" \
+         && git cherry-pick ${TRITON_ROCM_CHERRY_PICK_2} \
+         && if [ ! -f setup.py ]; then cd python; fi \
+         && pip install . \
+            ;; \
+          *) \
+            pip uninstall -y triton \
+         && apt install -y cmake \
+         && git clone ${TRITON_REPO} triton-custom \
+         && cd triton-custom \
+         && git checkout ${TRITON_COMMIT} \
+         && pip install -r python/requirements.txt \
+         && pip install -e . \
+            ;; \
+        esac; \
     fi
 
 # -----------------------


### PR DESCRIPTION

## Motivation
Extend the AMD ROCm docker matrix to include the **`rocm/pytorch:rocm7.2.3_ubuntu22.04_py3.10_pytorch_release_2.9.1`** base image so MI300X / MI355X users can build sglang against the newer ROCm 7.2.3 toolchain. ROCm 7.2.3 ships a different bundled torch + triton (`triton==3.5.1+rocm7.2.3.gita272dfa8`) compared to ROCm 7.2.0, and AITER kernels need a compatible Triton with two upstream cherry-picks to run correctly on top of it. We also take the opportunity to clean up the existing rocm7.2.0 torch hot patch.
## Modifications
### 1. New rocm7.2.3 stages
- New ARGs: `BASE_IMAGE_942_ROCM723`, `BASE_IMAGE_950_ROCM723`
- New FROM stages: `gfx942-rocm723`, `gfx950-rocm723`
  - `BUILD_TRITON=1`
  - `AITER_COMMIT_DEFAULT` synced with the upstream upgrade (`32e1e6d76988...` from #25896)
- Usage examples added to the header comment block
### 2. Custom Triton build for rocm723 (gated by `case "${GPU_ARCH}" in *rocm723*`)
- Repo: `https://github.com/ROCm/triton.git`
- Commit: `ba5c1517`
- Cherry-picks (from triton-lang/triton, reachable in the ROCm fork):
  - `555d04f` → [triton-lang/triton#8991](https://github.com/triton-lang/triton/pull/8991)
  - `dd998b6` → [triton-lang/triton#9541](https://github.com/triton-lang/triton/pull/9541)
rocm720 / rocm700 stages keep the **unchanged legacy** Triton build (`triton-lang/triton @ 42270451…`).
### 3. Unified torch METADATA hot patch (refactor)
Both `rocm/pytorch:rocm7.2.0` and `rocm/pytorch:rocm7.2.3` ship a pre-installed torch wheel whose `METADATA` hard-pins triton:
Requires-Dist: triton==3.5.1+rocm7.2.x.git...; platform_system == "Linux" ...

Since this Dockerfile replaces triton with a custom build (`BUILD_TRITON=1`), the pin causes `pip check` / future `pip install` to fail with a version conflict.
The previous solution (`hack.py`) read a `.whl` from `/`, extracted it, edited `METADATA`, re-zipped, and `pip install --force --no-deps`. That added ~3 minutes per build and kept the 1.6GB source wheel at `/`. **It also doesn't work for rocm7.2.3**, where the base image does not ship a wheel at `/` (only the installed torch).
This PR replaces the wheel-roundtrip with a small `hack_inplace.py` that edits the **installed** `torch-*.dist-info/METADATA` to relax the pin to `triton>=3.5.1` and blanks the matching `RECORD` row. Used by both rocm720 and rocm723 via `case "${GPU_ARCH}" in *rocm720*|*rocm723*)`.
Diff summary:
- Removed: `ARG TORCH_ROCM_FILE`, the wheel-based `hack.py` heredoc, the wheel-based RUN flow
- Added: a single `hack_inplace.py` heredoc + a unified case branch
- rocm720 build now finishes the patch in <1s instead of ~3 min, and the source wheel is cleaned up (`rm -f /torch-*.whl`)
### 4. amd-smi case extended
`rocm/pytorch:rocm7.2.3` does not pre-install amd-smi either (verified inside the base image). Case extended:
```diff
-      *rocm720*) \
+      *rocm720*|*rocm723*) \
         echo "ROCm (GPU_ARCH=${GPU_ARCH}): installing amd-smi"; \
         cd /opt/rocm/share/amd_smi && python3 -m pip install --no-cache-dir . ;;
```
### 5. libdrm-amdgpu case generalized
*rocm720* → *rocm72* so the entire ROCm 7.2.x family bypasses the libdrm-amdgpu install (all 7.2.x bases ship the packages already). Behavior unchanged for rocm720.


## Accuracy Tests
SGLANG_AITER_MLA_PERSIST=1 AITER_MXFP4_MOE_SF=1 SGLANG_USE_AITER=1 SGLANG_INT4_WEIGHT=0 SGLANG_MOE_PADDING=1 SGLANG_SET_CPU_AFFINITY=1 SGLANG_ROCM_FUSED_DECODE_MLA=1 SGLANG_USE_ROCM700A=1 python3 -m sglang.launch_server --model-path /dockerx/data/DeepSeek-R1-MXFP4-Preview/ --tensor-parallel-size 8 --trust-remote-code --host 0.0.0.0 --port 8000 --log-requests --mem-fraction-static 0.95 --chunked-prefill-size 131072 --attention-backend aiter --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --speculative-draft-model-path /dockerx/data/DeepSeek-R1-NextN --max-running-requests 64 --disable-radix-cache --kv-cache-dtype fp8_e4m3
GSM8K: 0.942

 python3 -m sglang.launch_server   --model-path /data/amd/Kimi-K2.5-MXFP4/   --tensor-parallel-size 4   --trust-remote-code   --mem-fraction-static 0.765   --disable-radix-cache   --decode-attention-backend aiter   --prefill-attention-backend aiter   --kv-cache-dtype fp8_e4m3   --chunked-prefill-size 16384   --max-prefill-tokens 16384   --max-running-requests 1024   --cuda-graph-max-bs 1024   --tool-call-parser kimi_k2   --reasoning-parser kimi_k2   --enable-aiter-allreduce-fusion   --host 127.0.0.1 --port 8888
GSM8K: 0.93

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26244096516](https://github.com/sgl-project/sglang/actions/runs/26244096516)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26244096405](https://github.com/sgl-project/sglang/actions/runs/26244096405)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->