### PR TITLE
refactor(attn): init hisparse_coordinator before attn_backend; replace lazy property with init-time capture

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -358,10 +358,9 @@ class DeepseekV4AttnBackend(
         # corresponding ForwardBatch fields.
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
-        # Keep a runner ref to read live state set after backend construction
-        # (e.g. hisparse_coordinator is built in model_runner *after*
-        # init_attention_backend()).
+        # Keep a runner ref for other live state that needs runtime reads.
         self.model_runner = model_runner
+        self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
 
@@ -384,12 +383,6 @@ class DeepseekV4AttnBackend(
             DSV4RawDecodeMetadata,
         ] = None
         self._replay_forward_batch: Optional[ForwardBatch] = None  # FIXME: out-of-band
-
-    @property
-    def hisparse_coordinator(self):
-        # Live read: model_runner builds the coordinator *after*
-        # init_attention_backend(), so we cannot capture at __init__ time.
-        return self.model_runner.hisparse_coordinator
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -356,7 +356,6 @@ class DeepseekV4AttnBackend(
 
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
-        self.model_runner = model_runner
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
@@ -1186,7 +1185,6 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
     ):
         super().__init__(model_runner)
-        self.model_runner = model_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.attn_backends: List[DeepseekV4AttnBackend] = []

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -354,11 +354,8 @@ class DeepseekV4AttnBackend(
         self.page_size = model_runner.page_size
         assert self.page_size == 256, "the system hardcodes page_size=256"
 
-        # Pool refs — captured at construction so they survive deletion of the
-        # corresponding ForwardBatch fields.
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
-        # Keep a runner ref for other live state that needs runtime reads.
         self.model_runner = model_runner
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -350,7 +350,6 @@ class DeepseekV4HipRadixBackend(
 
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
-        self.model_runner = model_runner
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
@@ -1186,7 +1185,6 @@ class DeepseekV4MultiStepBackend(DeepseekV4HipRadixBackend):
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
     ):
         super().__init__(model_runner)
-        self.model_runner = model_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.attn_backends: List[DeepseekV4HipRadixBackend] = []

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -352,10 +352,9 @@ class DeepseekV4HipRadixBackend(
         # corresponding ForwardBatch fields.
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
-        # Keep a runner ref to read live state set after backend construction
-        # (e.g. hisparse_coordinator is built in model_runner *after*
-        # init_attention_backend()).
+        # Keep a runner ref for other live state that needs runtime reads.
         self.model_runner = model_runner
+        self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.MAX_SEQ_LEN_FOR_CAPTURE = self.req_to_token.shape[1]
 
@@ -378,12 +377,6 @@ class DeepseekV4HipRadixBackend(
             DSV4RawDecodeMetadata,
         ] = None
         self._replay_forward_batch: Optional[ForwardBatch] = None  # FIXME: out-of-band
-
-    @property
-    def hisparse_coordinator(self):
-        # Live read: model_runner builds the coordinator *after*
-        # init_attention_backend(), so we cannot capture at __init__ time.
-        return self.model_runner.hisparse_coordinator
 
     def _move_to_device(self, x: List[int]) -> torch.Tensor:
         pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -348,11 +348,8 @@ class DeepseekV4HipRadixBackend(
         self.page_size = model_runner.page_size
         assert self.page_size == 256, "the system hardcodes page_size=256"
 
-        # Pool refs — captured at construction so they survive deletion of the
-        # corresponding ForwardBatch fields.
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool: DeepSeekV4TokenToKVPool = model_runner.token_to_kv_pool
-        # Keep a runner ref for other live state that needs runtime reads.
         self.model_runner = model_runner
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -330,11 +330,8 @@ class DeepseekSparseAttnBackend(
         self.qk_rope_head_dim = model_runner.model_config.qk_rope_head_dim
 
         assert model_runner.req_to_token_pool is not None
-        # Pool refs — captured at construction so they survive deletion of the
-        # corresponding ForwardBatch fields.
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
-        # Keep a runner ref for other live state that needs runtime reads.
         self.model_runner = model_runner
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -334,10 +334,9 @@ class DeepseekSparseAttnBackend(
         # corresponding ForwardBatch fields.
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
-        # Keep a runner ref to read live state set after backend construction
-        # (e.g. hisparse_coordinator is built in model_runner *after*
-        # init_attention_backend()).
+        # Keep a runner ref for other live state that needs runtime reads.
         self.model_runner = model_runner
+        self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
 
         self.use_mha: bool = False
@@ -399,12 +398,6 @@ class DeepseekSparseAttnBackend(
             self.workspace_buffer = global_workspace_buffer
         else:
             self.workspace_buffer = None
-
-    @property
-    def hisparse_coordinator(self):
-        # Live read: model_runner builds the coordinator *after*
-        # init_attention_backend(), so we cannot capture at __init__ time.
-        return self.model_runner.hisparse_coordinator
 
     def get_device_int32_arange(self, l: int) -> torch.Tensor:
         if l > len(self._arange_buf):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -332,7 +332,6 @@ class DeepseekSparseAttnBackend(
         assert model_runner.req_to_token_pool is not None
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
-        self.model_runner = model_runner
         self.hisparse_coordinator = model_runner.hisparse_coordinator
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
 
@@ -2308,7 +2307,6 @@ class DeepseekSparseAttnMultiStepBackend:
     def __init__(
         self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
     ):
-        self.model_runner = model_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.attn_backends = []

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -761,9 +761,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
-            self.init_attention_backend()
-            self.kernel_warmup()
-            # Init hisparse coordinator (must happen before CUDA graph capture)
+            # Init hisparse coordinator (must happen before init_attention_backend()
+            # so backends can capture it at construction time)
             if self.enable_hisparse:
                 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
                 from sglang.srt.mem_cache.sparsity import parse_hisparse_config
@@ -785,6 +784,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     ),
                     host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
                 )
+            self.init_attention_backend()
+            self.kernel_warmup()
             self._pre_initialize_flashinfer_allreduce_workspace()
             self.init_device_graphs()
         elif self.device == "cpu":

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -761,8 +761,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
-            # Init hisparse coordinator (must happen before init_attention_backend()
-            # so backends can capture it at construction time)
             if self.enable_hisparse:
                 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
                 from sglang.srt.mem_cache.sparsity import parse_hisparse_config

--- a/test/manual/attention/test_flashattn_backend.py
+++ b/test/manual/attention/test_flashattn_backend.py
@@ -91,6 +91,7 @@ class MockModelRunner:
             device=self.device,
             enable_memory_saver=False,
         )
+        self.hisparse_coordinator = None
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")

--- a/test/manual/attention/test_flashattn_mla_backend.py
+++ b/test/manual/attention/test_flashattn_mla_backend.py
@@ -76,6 +76,7 @@ class MockModelRunner:
             device=self.device,
             enable_memory_saver=False,
         )
+        self.hisparse_coordinator = None
 
 
 class MockReqToTokenPool:

--- a/test/manual/attention/test_trtllm_mla_backend.py
+++ b/test/manual/attention/test_trtllm_mla_backend.py
@@ -268,6 +268,7 @@ class MockModelRunner:
             device=self.device,
             enable_memory_saver=False,
         )
+        self.hisparse_coordinator = None
 
 
 def compare_outputs(trtllm_out, reference_out, tolerance=1e-2):

--- a/test/registered/kernels/test_dsa_indexer.py
+++ b/test/registered/kernels/test_dsa_indexer.py
@@ -252,6 +252,7 @@ class MockModelRunner:
                 "dsa_decode_backend": "fa3",
             },
         )()
+        self.hisparse_coordinator = None
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")


### PR DESCRIPTION
## Motivation

`HiSparseCoordinator` was built in `ModelRunner` *after* `init_attention_backend()`, so the three DSV4 attention backends (`DeepseekV4AttnBackend`, `DeepseekSparseAttnBackend`, `DeepseekV4HipRadixBackend`) could not capture it at `__init__` time. Each backend worked around this with a `@property` that reads `self.model_runner.hisparse_coordinator` on every call.

Now that pool refs are no longer threaded through `ForwardBatch` (landed in #25983), the same principle applies to `hisparse_coordinator`: it should be captured at construction time, not read lazily through `model_runner`.

## Modifications

- **`model_runner.py`**: Move the `if self.enable_hisparse:` initialization block to before `init_attention_backend()` in the cuda/musa init path. The only ordering constraint on `hisparse_coordinator` is that it precedes CUDA graph capture; there is no dependency on `kernel_warmup`.

- **`deepseek_v4_backend.py`, `dsa_backend.py`, `deepseek_v4_backend_hip_radix.py`**: Replace the 5-line `@property hisparse_coordinator` (lazy forwarder to `model_runner`) with a plain `self.hisparse_coordinator = model_runner.hisparse_coordinator` assignment in `__init__`.

## Accuracy Tests

No model-output changes. Pure initialization-order and attribute-access refactor.

## Speed Tests and Profiling

No runtime overhead change. Replaces a dict-lookup property call with a direct attribute read.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26257998255](https://github.com/sgl-project/sglang/actions/runs/26257998255)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26257998110](https://github.com/sgl-project/sglang/actions/runs/26257998110)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->