### PR TITLE
attn: unify init_forward_metadata triplet into init_forward_data API

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -2302,8 +2302,23 @@ class AscendAttnMultiStepDraftBackend:
         each iteration; per the initial-stage choice, ``init_forward_data_in_graph``
         is left as a no-op.
         """
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
 
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, call_fn)
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -24,7 +24,7 @@ from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_kv_cache
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import get_bool_env_var, get_current_device_stream_fast
 
@@ -351,8 +351,8 @@ class AscendAttnBackend(AttentionBackend):
     ):
         pass
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init the metadata for a forward pass."""
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Init the metadata for a forward pass (eager path)."""
         self.forward_metadata = ForwardMetadata()
         seq_lens_max = forward_batch.seq_lens.max()
         if forward_batch.forward_mode.is_target_verify():
@@ -458,22 +458,56 @@ class AscendAttnBackend(AttentionBackend):
                 device=self.device,
             )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body merged from old ``init_forward_metadata_capture_cuda_graph``
+        (initial setup: allocate ForwardMetadata, bind block_tables /
+        block_tables_swa views into ``self.graph_metadata`` buffers,
+        fill ``actual_seq_lengths_q`` and FIA head-pad tensors) and
+        ``init_forward_metadata_replay_cuda_graph`` (per-iter refresh:
+        copy block_tables / block_tables_swa from ``req_to_token``,
+        apply spec offsets to ``seq_lens``). Capture and replay run the
+        same body each iteration; per the initial-stage choice,
+        ``init_forward_data_in_graph`` is left as a no-op and any
+        future graph-recording optimization is deferred to a follow-up
+        per-backend PR.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
+
         metadata = ForwardMetadata()
 
         metadata.block_tables = self.graph_metadata["block_tables"][:bs, :]
-        if self.is_dllm_model:
+        if self.is_hybrid_swa:
+            metadata.block_tables_swa = self.graph_metadata["block_tables_swa"][:bs, :]
+
+        # Compute max_len (replay-style) for per-iter block_tables refresh.
+        if seq_lens_cpu is not None:
+            max_len = int(seq_lens_cpu[:bs].max().item())
+        else:
             max_len = int(seq_lens[:bs].max().item())
-            max_seq_pages = (max_len + self.page_size - 1) // self.page_size
+        if forward_mode.is_target_verify():
+            max_len += self.speculative_num_draft_tokens
+        elif forward_mode.is_decode_or_idle() and spec_info is not None:
+            max_len += self.speculative_step_id + 1
+        max_seq_pages = (max_len + self.page_size - 1) // self.page_size
+
+        if self.is_hybrid_swa:
+            metadata.block_tables_swa[:bs, :max_seq_pages].copy_(
+                self.full_to_swa_index_mapping[
+                    self.req_to_token[req_pool_indices[:bs], :max_len]
+                ][:, :: self.page_size]
+                // self.page_size
+            )
+            metadata.block_tables_swa[:bs, max_seq_pages:].fill_(0)
+            metadata.block_tables_swa[bs:, :].fill_(0)
+
+        if self.is_dllm_model:
             metadata.block_tables[:bs, :max_seq_pages].copy_(
                 (
                     self.req_to_token[req_pool_indices[:bs], :max_len][
@@ -482,13 +516,16 @@ class AscendAttnBackend(AttentionBackend):
                     // self.page_size
                 ).to(torch.int32)
             )
-            metadata.block_tables[:bs, max_seq_pages:].fill_(0)
-            metadata.block_tables[bs:, :].fill_(0)
+        else:
+            metadata.block_tables[:bs, :max_seq_pages].copy_(
+                self.req_to_token[req_pool_indices[:bs], :max_len][:, :: self.page_size]
+                // self.page_size
+            )
+        metadata.block_tables[:bs, max_seq_pages:].fill_(0)
+        metadata.block_tables[bs:, :].fill_(0)
 
-        if self.is_hybrid_swa:
-            metadata.block_tables_swa = self.graph_metadata["block_tables_swa"][:bs, :]
         metadata.seq_lens_cpu_list = seq_lens.cpu().int().tolist()
-        metadata.seq_lens = seq_lens
+
         if (
             forward_mode.is_target_verify()
             or forward_mode.is_draft_extend_v2()
@@ -549,53 +586,19 @@ class AscendAttnBackend(AttentionBackend):
                 device=seq_lens.device,
             )
 
+        # seq_lens with spec offsets — bind to persistent fb buffer, then
+        # write adjusted values back in place (was replay variant body).
+        metadata.seq_lens = seq_lens
+        if forward_mode.is_target_verify():
+            adjusted_seq_lens = seq_lens + self.speculative_num_draft_tokens
+        elif forward_mode.is_decode_or_idle() and spec_info is not None:
+            adjusted_seq_lens = seq_lens + self.speculative_step_offset_npu
+        else:
+            adjusted_seq_lens = seq_lens
+        if adjusted_seq_lens is not seq_lens:
+            metadata.seq_lens[:bs].copy_(adjusted_seq_lens[:bs])
+
         self.graph_metadata[bs] = metadata
-        self.forward_metadata = metadata
-
-        self.graph_mode = True
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        metadata = self.graph_metadata[bs]
-        max_len = seq_lens_cpu[:bs].max().item()
-        if forward_mode.is_target_verify():
-            max_len += self.speculative_num_draft_tokens
-        elif forward_mode.is_decode_or_idle() and spec_info is not None:
-            max_len += self.speculative_step_id + 1
-        max_seq_pages = (max_len + self.page_size - 1) // self.page_size
-
-        if self.is_hybrid_swa:
-            metadata.block_tables_swa[:bs, :max_seq_pages].copy_(
-                self.full_to_swa_index_mapping[
-                    self.req_to_token[req_pool_indices[:bs], :max_len]
-                ][:, :: self.page_size]
-                // self.page_size
-            )
-            metadata.block_tables_swa[:bs, max_seq_pages:].fill_(0)
-            metadata.block_tables_swa[bs:, :].fill_(0)
-        metadata.block_tables[:bs, :max_seq_pages].copy_(
-            self.req_to_token[req_pool_indices[:bs], :max_len][:, :: self.page_size]
-            // self.page_size
-        )
-
-        metadata.block_tables[:bs, max_seq_pages:].fill_(0)
-        metadata.block_tables[bs:, :].fill_(0)
-
-        if forward_mode.is_target_verify():
-            seq_lens = seq_lens + self.speculative_num_draft_tokens
-        elif forward_mode.is_decode_or_idle() and spec_info is not None:
-            seq_lens = seq_lens + self.speculative_step_offset_npu
-        metadata.seq_lens[:bs].copy_(seq_lens[:bs])
-
         self.forward_metadata = metadata
 
         self.graph_mode = True
@@ -2282,10 +2285,10 @@ class AscendAttnMultiStepDraftBackend:
         for i in range(self.speculative_num_steps - 1):
             call_fn(i, forward_batch)
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         def call_fn(i, forward_batch):
             assert forward_batch.spec_info is not None
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
         self.common_template(forward_batch, call_fn)
 
@@ -2293,33 +2296,14 @@ class AscendAttnMultiStepDraftBackend:
         for i in range(self.speculative_num_steps):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- dispatches per-step underlying-backend
+        init via ``common_template``. Capture and replay run the same body
+        each iteration; per the initial-stage choice, ``init_forward_data_in_graph``
+        is left as a no-op.
+        """
 
-        self.common_template(forward_batch, call_fn)
-
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
         def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                seq_lens_sum=-1,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, call_fn)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -72,10 +72,10 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
         else:
             self.ssm_state_indices = cache_indices
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         if forward_batch.forward_mode.is_draft_extend(True):
             return
-        super().init_forward_metadata(forward_batch)
+        super().init_forward_data(forward_batch)
         self.prepare_gdn_inputs(
             forward_batch.batch_size,
             forward_batch.forward_mode,
@@ -83,54 +83,25 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
         )
         self.graph_mode = False
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-    ):
-        if forward_mode.is_draft_extend(True):
-            return
-        super().init_forward_metadata_capture_cuda_graph(
-            bs,
-            num_tokens,
-            req_pool_indices,
-            seq_lens,
-            encoder_lens,
-            forward_mode,
-            spec_info,
-        )
-        self.prepare_gdn_inputs(bs, forward_mode, spec_info)
-        self.graph_mode = True
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        if forward_mode.is_draft_extend(True):
+        The pre-init hook (``self.prepare_gdn_inputs`` + ``self.graph_mode = True``)
+        is identical for both old variants, and the underlying
+        ``super().init_forward_metadata_{capture,replay}_cuda_graph`` bodies
+        are merged in the parent's ``init_forward_data_out_graph``. Capture
+        and replay therefore run the same body each iteration; per the
+        initial-stage choice, ``init_forward_data_in_graph`` is left as a
+        no-op.
+        """
+        if forward_batch.forward_mode.is_draft_extend(True):
             return
-        super().init_forward_metadata_replay_cuda_graph(
-            bs,
-            req_pool_indices,
-            seq_lens,
-            seq_lens_sum,
-            encoder_lens,
-            forward_mode,
-            spec_info,
-            seq_lens_cpu,
+        super().init_forward_data_out_graph(forward_batch)
+        self.prepare_gdn_inputs(
+            forward_batch.batch_size,
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
         )
-        self.prepare_gdn_inputs(bs, forward_mode, spec_info)
         self.graph_mode = True
 
     def forward_decode(

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -25,7 +25,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_size,
     is_dp_attention_enabled,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_gfx95_supported
 
 if TYPE_CHECKING:
@@ -820,8 +820,8 @@ class AiterAttnBackend(AttentionBackend):
         )
         return output
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init auxiliary variables for aiter attention backend."""
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Init auxiliary variables for aiter attention backend (eager path)."""
 
         bs = forward_batch.batch_size
         kv_indptr = self.kv_indptr
@@ -1456,16 +1456,24 @@ class AiterAttnBackend(AttentionBackend):
                 device=self.device,
             )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body merged from old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` -- both wrote to the same
+        ``self.cuda_graph_*`` pre-allocated buffers. The two old bodies were
+        structurally identical but differed in a few small specifics
+        (max_kv_len via gpu vs cpu .max(); minor seq_lens slicing; mask_indptr
+        bs slice ordering; draft_extend uniform vs accept-len qo_indptr).
+        Per the initial-stage scope we use the capture body unchanged and
+        accept slightly more work at replay; the replay-time fast paths may
+        be restored by a follow-up per-backend optimization PR.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
 
         num_kv_splits = None
         # num_kv_splits_indptr = None
@@ -1887,430 +1895,6 @@ class AiterAttnBackend(AttentionBackend):
                 )
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-
-        num_kv_splits = None
-        # num_kv_splits_indptr = None
-
-        work_metadata = None
-        work_info_set = None
-        work_indptr = None
-
-        reduce_indptr = None
-        reduce_final_map = None
-        reduce_partial_map = None
-
-        swa_page_table = None
-        max_kv_len = seq_lens_cpu.max().item()
-
-        if forward_mode.is_decode_or_idle():
-            qo_indptr = None
-            kv_last_page_len = None
-            max_q_len = None
-
-            if spec_info is None or (
-                self.use_triton_unified_attention and not self.use_mla
-            ):
-                max_num_blocks_per_seq = (
-                    self.max_context_len + self.page_size - 1
-                ) // self.page_size
-
-                if not self.use_triton_unified_attention:
-                    kv_indptr = self.kv_indptr
-                    kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
-                    kv_indptr = kv_indptr[: bs + 1]
-                    kv_indices = self.cuda_graph_kv_indices
-                    create_flashinfer_kv_indices_triton[(bs,)](
-                        self.req_to_token,
-                        req_pool_indices,
-                        seq_lens,
-                        kv_indptr,
-                        None,
-                        kv_indices,
-                        self.req_to_token.stride(0),
-                    )
-                else:
-                    max_q_len = 1
-                    kv_indices = self.cuda_graph_kv_indices.view(
-                        -1, max_num_blocks_per_seq
-                    )
-
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_table = self.cuda_graph_swa_page_table
-
-                    if spec_info is not None:
-                        self._build_unified_page_table_from_spec(
-                            spec_info,
-                            bs,
-                            dest_buf=kv_indices,
-                            swa_dest_buf=swa_page_table,
-                        )
-                    else:
-                        page_indices = self.req_to_token[
-                            req_pool_indices[:bs], :max_kv_len
-                        ]
-
-                        if self.use_sliding_window_kv_pool:
-                            swa_page_indices = (
-                                self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                                    page_indices
-                                )
-                            )
-
-                            page_indices = self._transform_table_1_to_real(page_indices)
-                            swa_page_indices = self._transform_table_1_to_real(
-                                swa_page_indices
-                            )
-
-                            new_rows = swa_page_indices.shape[0]
-                            new_cols = swa_page_indices.shape[1]
-
-                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
-                            swa_page_table = self.cuda_graph_swa_page_table
-                            swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
-                        elif self.page_size > 1:
-                            page_indices = self._transform_table_1_to_real(page_indices)
-                            new_rows = page_indices.shape[0]
-                            new_cols = page_indices.shape[1]
-                            kv_indices[:new_rows, :new_cols].copy_(page_indices)
-
-                    qo_indptr = self.qo_indptr_unified_decode[: bs + 1]
-
-                    kv_indptr = None
-            else:
-                kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
-
-            if self.use_mla:
-                qo_indptr = self.qo_indptr_[: bs + 1]
-                qo_indptr[1 : bs + 1] = torch.cumsum(
-                    self.cuda_graph_kv_last_page_len[:bs], dim=0
-                )
-                kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
-                max_q_len = 1
-
-                if _use_mla_ps_kernel:
-                    num_kv_splits = self.max_split_per_batch
-
-                    self.make_mla_meta_data(
-                        qo_indptr,
-                        kv_indptr,
-                        kv_last_page_len,
-                        self.work_metadata,
-                        self.work_info_set,
-                        self.work_indptr,
-                        self.reduce_indptr,
-                        self.reduce_final_map,
-                        self.reduce_partial_map,
-                        max_q_len,
-                        fast_mode=fast_mode,
-                        max_split_per_batch=num_kv_splits,
-                        intra_batch_mode=intra_batch_mode,
-                    )
-
-                    work_metadata = self.work_metadata
-                    work_info_set = self.work_info_set
-                    work_indptr = self.work_indptr
-
-                    reduce_indptr = self.reduce_indptr
-                    reduce_final_map = self.reduce_final_map
-                    reduce_partial_map = self.reduce_partial_map
-
-            self.forward_metadata = ForwardMetadata(
-                kv_indptr,
-                kv_indices,
-                qo_indptr,
-                kv_last_page_len,
-                max_q_len,
-                max_kv_len,
-                work_metadata=work_metadata,
-                work_info_set=work_info_set,
-                work_indptr=work_indptr,
-                reduce_indptr=reduce_indptr,
-                reduce_final_map=reduce_final_map,
-                reduce_partial_map=reduce_partial_map,
-                num_kv_splits=num_kv_splits,
-                swa_page_table=swa_page_table,
-                # num_kv_splits_indptr=num_kv_splits_indptr,
-            )
-
-        elif forward_mode.is_target_verify():
-            bs = len(req_pool_indices)
-            qo_indptr = self.qo_indptr[: bs + 1]
-            qo_indptr[: bs + 1] = torch.arange(
-                0,
-                (1 + bs) * self.num_draft_tokens,
-                step=self.num_draft_tokens,
-                dtype=torch.int32,
-                device=self.device,
-            )
-            if self.use_mla:
-                kv_lens = seq_lens + self.num_draft_tokens
-            else:
-                kv_lens = seq_lens
-            kv_indptr = self.kv_indptr[: bs + 1]
-            kv_indptr[1 : bs + 1] = torch.cumsum(kv_lens, dim=0)
-            kv_indices = self.cuda_graph_kv_indices
-            create_flashinfer_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices,
-                kv_lens,
-                kv_indptr,
-                None,
-                kv_indices,
-                self.req_to_token.stride(0),
-            )
-            kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
-            max_q_len = self.num_draft_tokens
-
-            if self.use_mla:
-                if _use_mla_ps_kernel:
-                    num_kv_splits = self.max_split_per_batch
-
-                    self.make_mla_meta_data(
-                        qo_indptr,
-                        kv_indptr,
-                        kv_last_page_len,
-                        self.work_metadata,
-                        self.work_info_set,
-                        self.work_indptr,
-                        self.reduce_indptr,
-                        self.reduce_final_map,
-                        self.reduce_partial_map,
-                        max_q_len,
-                        fast_mode=fast_mode,
-                        max_split_per_batch=num_kv_splits,
-                        intra_batch_mode=intra_batch_mode,
-                    )
-
-                    work_metadata = self.work_metadata
-                    work_info_set = self.work_info_set
-                    work_indptr = self.work_indptr
-
-                    reduce_indptr = self.reduce_indptr
-                    reduce_final_map = self.reduce_final_map
-                    reduce_partial_map = self.reduce_partial_map
-
-                self.forward_metadata = ForwardMetadata(
-                    kv_indptr,
-                    kv_indices,
-                    qo_indptr,
-                    kv_last_page_len,
-                    max_q_len,
-                    max_kv_len,
-                    work_metadata=work_metadata,
-                    work_info_set=work_info_set,
-                    work_indptr=work_indptr,
-                    reduce_indptr=reduce_indptr,
-                    reduce_final_map=reduce_final_map,
-                    reduce_partial_map=reduce_partial_map,
-                    num_kv_splits=num_kv_splits,
-                )
-            else:
-                if self._use_unified_verify:
-                    max_num_blocks_per_seq = (
-                        self.max_context_len + self.page_size - 1
-                    ) // self.page_size
-                    page_table = self.cuda_graph_kv_indices.view(
-                        -1, max_num_blocks_per_seq
-                    )[:bs]
-
-                    swa_page_table = None
-
-                    if self.use_sliding_window_kv_pool:
-                        swa_page_table = self.cuda_graph_swa_page_table.view(
-                            -1, max_num_blocks_per_seq
-                        )[:bs]
-
-                    _page_table, _qo_indptr, _max_q_len, _swa_page_table = (
-                        self._build_verify_unified_metadata(
-                            bs,
-                            seq_lens,
-                            req_pool_indices,
-                            self.num_draft_tokens,
-                            page_table_dest=page_table,
-                            swa_page_table_dest=swa_page_table,
-                        )
-                    )
-
-                    max_kv_len_unified = max_num_blocks_per_seq * self.page_size
-                    self.forward_metadata = ForwardMetadata(
-                        None,
-                        _page_table,
-                        _qo_indptr,
-                        kv_last_page_len,
-                        _max_q_len,
-                        max_kv_len_unified,
-                        max_extend_len=_max_q_len,
-                        swa_page_table=_swa_page_table,
-                    )
-                else:
-                    custom_mask = self.cuda_graph_custom_mask
-                    custom_mask[: spec_info.custom_mask.shape[0]] = (
-                        spec_info.custom_mask
-                    )
-                    seq_mask_len = max_q_len * (seq_lens + max_q_len)
-                    mask_indptr = self.mask_indptr[: bs + 1]
-                    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
-
-                    self.forward_metadata = ForwardMetadata(
-                        kv_indptr,
-                        kv_indices,
-                        qo_indptr,
-                        kv_last_page_len,
-                        max_q_len,
-                        max_kv_len,
-                        custom_mask=custom_mask,
-                        mask_indptr=mask_indptr,
-                        max_extend_len=max_q_len,
-                    )
-        elif forward_mode.is_draft_extend_v2():
-            # EAGLE V2: Fixed num_draft_tokens per batch
-            self._ensure_spec_v2_topk_supported()
-            seq_lens = seq_lens[:bs]
-            num_tokens_per_bs = self._resolve_v2_num_draft_tokens()
-            extend_lens = torch.full(
-                (bs,), num_tokens_per_bs, dtype=torch.int32, device=seq_lens.device
-            )
-
-            qo_indptr = self.qo_indptr[: bs + 1]
-            qo_indptr[1 : bs + 1] = torch.cumsum(extend_lens, dim=0)
-            kv_indptr = self.kv_indptr[: bs + 1]
-            kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
-            kv_indices = self.cuda_graph_kv_indices
-            create_flashinfer_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices,
-                seq_lens,
-                kv_indptr,
-                None,
-                kv_indices,
-                self.req_to_token.stride(0),
-            )
-
-            kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
-            max_q_len = num_tokens_per_bs
-
-            if self.use_mla and _use_mla_ps_kernel:
-                num_kv_splits = self.max_split_per_batch
-
-                self.make_mla_meta_data(
-                    qo_indptr,
-                    kv_indptr,
-                    kv_last_page_len,
-                    self.work_metadata,
-                    self.work_info_set,
-                    self.work_indptr,
-                    self.reduce_indptr,
-                    self.reduce_final_map,
-                    self.reduce_partial_map,
-                    max_q_len,
-                    fast_mode=fast_mode,
-                    max_split_per_batch=num_kv_splits,
-                    intra_batch_mode=intra_batch_mode,
-                )
-
-                work_metadata = self.work_metadata
-                work_info_set = self.work_info_set
-                work_indptr = self.work_indptr
-
-                reduce_indptr = self.reduce_indptr
-                reduce_final_map = self.reduce_final_map
-                reduce_partial_map = self.reduce_partial_map
-
-            self.forward_metadata = ForwardMetadata(
-                kv_indptr,
-                kv_indices,
-                qo_indptr,
-                kv_last_page_len,
-                max_q_len,
-                max_kv_len,
-                work_metadata=work_metadata,
-                work_info_set=work_info_set,
-                work_indptr=work_indptr,
-                reduce_indptr=reduce_indptr,
-                reduce_final_map=reduce_final_map,
-                reduce_partial_map=reduce_partial_map,
-                num_kv_splits=num_kv_splits,
-            )
-        elif forward_mode.is_draft_extend():
-            # EAGLE V1: Uses spec_info.num_accept_tokens
-            num_tokens_per_bs = self.speculative_num_steps + 1
-            seq_lens = seq_lens[:bs]
-            extend_lens = spec_info.num_accept_tokens[:bs]
-            qo_indptr = self.qo_indptr[: bs + 1]
-            qo_indptr[1 : bs + 1] = torch.cumsum(extend_lens, dim=0)
-            kv_indptr = self.kv_indptr[: bs + 1]
-            kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
-            kv_indices = self.cuda_graph_kv_indices
-            create_flashinfer_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices,
-                seq_lens,
-                kv_indptr,
-                None,
-                kv_indices,
-                self.req_to_token.stride(0),
-            )
-
-            kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
-            max_q_len = num_tokens_per_bs
-
-            if self.use_mla and _use_mla_ps_kernel:
-                num_kv_splits = self.max_split_per_batch
-
-                self.make_mla_meta_data(
-                    qo_indptr,
-                    kv_indptr,
-                    kv_last_page_len,
-                    self.work_metadata,
-                    self.work_info_set,
-                    self.work_indptr,
-                    self.reduce_indptr,
-                    self.reduce_final_map,
-                    self.reduce_partial_map,
-                    max_q_len,
-                    fast_mode=fast_mode,
-                    max_split_per_batch=num_kv_splits,
-                    intra_batch_mode=intra_batch_mode,
-                )
-
-                work_metadata = self.work_metadata
-                work_info_set = self.work_info_set
-                work_indptr = self.work_indptr
-
-                reduce_indptr = self.reduce_indptr
-                reduce_final_map = self.reduce_final_map
-                reduce_partial_map = self.reduce_partial_map
-
-            self.forward_metadata = ForwardMetadata(
-                kv_indptr,
-                kv_indices,
-                qo_indptr,
-                kv_last_page_len,
-                max_q_len,
-                max_kv_len,
-                work_metadata=work_metadata,
-                work_info_set=work_info_set,
-                work_indptr=work_indptr,
-                reduce_indptr=reduce_indptr,
-                reduce_final_map=reduce_final_map,
-                reduce_partial_map=reduce_partial_map,
-                num_kv_splits=num_kv_splits,
-            )
-
-        else:
-            raise ValueError("Invalid forward mode")
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1 if self.num_draft_tokens is None else self.num_draft_tokens
@@ -3219,7 +2803,7 @@ class AiterMultiStepDraftBackend:
             ]
             call_fn(i, forward_batch)
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
@@ -3236,7 +2820,7 @@ class AiterMultiStepDraftBackend:
             forward_batch.spec_info.kv_indices = (
                 forward_batch.spec_info.kv_indices.clone()
             )
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
         self.common_template(forward_batch, kv_indices, call_fn)
 
@@ -3251,33 +2835,17 @@ class AiterMultiStepDraftBackend:
                 max_bs, max_num_tokens, kv_indices_buf=self.cuda_graph_kv_indices[i]
             )
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-        self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
+        Runs the per-step underlying-backend init via ``common_template``.
+        Capture and replay share the same body (the old replay variant only
+        differed in passing ``seq_lens_sum=-1`` and forwarding ``seq_lens_cpu``;
+        the new contract delegates via the per-step backend's
+        ``init_forward_data_out_graph`` which reads everything from ``fb``).
+        """
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
         def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                seq_lens_sum=-1,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2844,8 +2844,23 @@ class AiterMultiStepDraftBackend:
         the new contract delegates via the per-step backend's
         ``init_forward_data_out_graph`` which reads everything from ``fb``).
         """
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
 
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2779,6 +2779,10 @@ class AiterMultiStepDraftBackend:
     def common_template(
         self, forward_batch: ForwardBatch, kv_indices_buffer: torch.Tensor, call_fn: int
     ):
+        # Multi-step wrappers only ever run draft decode -- assert the
+        # invariant up front to match FlashInfer / FlashInferMLA.
+        assert forward_batch.spec_info is not None
+        assert forward_batch.spec_info.is_draft_input()
         num_seqs = forward_batch.batch_size
         bs = self.topk * num_seqs
         seq_lens_sum = forward_batch.seq_lens_sum

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1894,6 +1894,11 @@ class AiterAttnBackend(AttentionBackend):
                     max_extend_len=num_tokens_per_bs,
                 )
         else:
+            # FIXME: prefill/extend branch missing -- latent because PCG is
+            # disabled on HIP/AMD today (the only place this backend runs).
+            # When PCG is enabled on ROCm, port the eager body's ``else:``
+            # branch here, mirroring the triton / flashinfer / fa3 fixes
+            # in step 03. Tracked as a follow-up for ROCm PCG enablement.
             raise ValueError(f"Invalid mode: {forward_mode=}")
 
     def get_cuda_graph_seq_len_fill_value(self):

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1488,7 +1488,13 @@ class AiterAttnBackend(AttentionBackend):
 
         swa_page_table = None
 
-        max_kv_len = torch.max(seq_lens).item()
+        # OLD replay variant read max via ``seq_lens_cpu.max().item()`` -- no
+        # device->host sync per replay. Use seq_lens_cpu when available;
+        # fall back to the GPU path for capture warmup (no _cpu mirror yet).
+        if forward_batch.seq_lens_cpu is not None:
+            max_kv_len = int(forward_batch.seq_lens_cpu.max().item())
+        else:
+            max_kv_len = torch.max(seq_lens).item()
 
         if forward_mode.is_decode_or_idle():
             qo_indptr = None

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+import warnings
+from abc import ABC
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -11,47 +12,141 @@ from sglang.srt.utils.common import is_npu
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.dsa.dsa_indexer import BaseIndexerMetadata
     from sglang.srt.layers.radix_attention import RadixAttention
-    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.speculative.spec_info import SpecInput
 
 
 class AttentionBackend(ABC):
-    """The base class of attention backends"""
+    """The base class of attention backends.
 
-    @abstractmethod
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init the metadata for a forward pass."""
-        raise NotImplementedError()
+    Per-forward init three-method contract (initial stage of step 03):
+
+        init_forward_data(fb)            -- eager wrapper = out_graph + in_graph
+        init_forward_data_out_graph(fb)  -- per-iter metadata prep run OUTSIDE
+                                            any cuda graph capture/replay scope.
+                                            All three paths (eager / capture /
+                                            replay) call this; capture and
+                                            replay run the same body.
+        init_forward_data_in_graph(fb)   -- graph-recordable metadata prep run
+                                            INSIDE `with graph.capture():`.
+                                            Recorded ops auto-execute at
+                                            replay via `graph.replay()`.
+                                            Default no-op; most backends do
+                                            NOT override this in the initial
+                                            stage (deferred optimization slot).
+
+    The five backend init paths (eager / full-graph capture / full-graph
+    replay / PCG capture / PCG replay) all flow through these methods. Only
+    the caller varies which subset it invokes:
+
+        eager        : init_forward_data(fb)         == out_graph + in_graph
+        full capture : out_graph(fb) outside; in_graph(fb) inside graph.
+        full replay  : out_graph(fb_view) outside; graph.replay() auto-runs
+                       recorded in_graph ops.
+        PCG capture  : out_graph(fb) outside; in_graph(fb) inside.
+        PCG replay   : out_graph(fb) outside; graph.replay() auto-runs.
+
+    Initial stage: backends override only ``init_forward_data_out_graph``
+    with the merged body of the old ``init_forward_metadata`` (eager) +
+    ``init_forward_metadata_capture_cuda_graph`` (capture) +
+    ``init_forward_metadata_replay_cuda_graph`` (replay) variants. The
+    ``_in_graph`` slot is reserved for a follow-up per-backend optimization
+    PR that moves graph-safe static-shape ops into the captured graph for
+    Python-dispatch savings at replay.
+    """
+
+    # -----------------------------------------------------------------
+    # Forward-data init -- three-method contract
+    # -----------------------------------------------------------------
+
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep run OUTSIDE any cuda graph capture/replay scope.
+
+        Called at eager (via the wrapper), capture (before the graph capture
+        context), and replay (before ``graph.replay()``). All three paths run
+        the same body; this is where the unified body lives in the initial
+        stage of step 03.
+
+        Default: no-op. Override this with the backend's per-iter prep.
+        """
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Graph-recordable metadata prep run INSIDE ``with graph.capture():``.
+
+        Recorded ops auto-execute at replay via ``graph.replay()`` -- no
+        Python dispatch at replay time.
+
+        Default: no-op. Most backends do NOT override this in the initial
+        stage; all prep stays in ``_out_graph``. A follow-up per-backend PR
+        moves graph-safe static-shape ops here for replay-time speedup.
+
+        Override contract: body must NOT call ``.item()`` / ``.cpu()`` /
+        ``.tolist()`` / dynamic-shape ``torch.empty()`` -- those are not
+        recordable and belong in ``_out_graph``.
+        """
+
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Eager-path wrapper -- runs both phases in order."""
+        self.init_forward_data_out_graph(forward_batch)
+        self.init_forward_data_in_graph(forward_batch)
+
+    # -----------------------------------------------------------------
+    # Deprecation shims for out-of-tree backends (one release window)
+    # -----------------------------------------------------------------
+    #
+    # Out-of-tree subclasses that still override the old method names continue
+    # to work via the forwarders below -- at the cost of a DeprecationWarning
+    # per call site. The capture/replay variants had positional-arg signatures
+    # incompatible with fb-only, so they raise NotImplementedError instead:
+    # out-of-tree code that uses them must migrate to ``_out_graph``.
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch) -> None:
+        """[DEPRECATED] Old eager init entry point.
+
+        Default forwards to the new three-method contract. Subclasses should
+        override ``init_forward_data_out_graph`` (and optionally
+        ``init_forward_data_in_graph``) instead of this method.
+        """
+        warnings.warn(
+            "AttentionBackend.init_forward_metadata is deprecated; "
+            "override init_forward_data_out_graph instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.init_forward_data(forward_batch)
+
+    def init_forward_metadata_capture_cuda_graph(self, *args, **kwargs):
+        """[DEPRECATED] Old capture-time init entry point -- not auto-forwarded.
+
+        Signature differed from the eager method, so callers must migrate to
+        ``init_forward_data_out_graph(fb)`` explicitly. Out-of-tree backends
+        overriding this method must move the body into
+        ``init_forward_data_out_graph``.
+        """
+        raise NotImplementedError(
+            "init_forward_metadata_capture_cuda_graph is deprecated; "
+            "override init_forward_data_out_graph instead."
+        )
+
+    def init_forward_metadata_replay_cuda_graph(self, *args, **kwargs):
+        """[DEPRECATED] Old replay-time init entry point -- not auto-forwarded.
+
+        Signature differed from the eager method, so callers must migrate to
+        ``init_forward_data_out_graph(fb_view)`` explicitly. Out-of-tree
+        backends overriding this method must move the body into
+        ``init_forward_data_out_graph``.
+        """
+        raise NotImplementedError(
+            "init_forward_metadata_replay_cuda_graph is deprecated; "
+            "override init_forward_data_out_graph instead."
+        )
+
+    # -----------------------------------------------------------------
+    # Cuda-graph buffer alloc + warmup hook (unchanged by step 03)
+    # -----------------------------------------------------------------
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Init the global shared states for cuda graph."""
-        raise NotImplementedError()
-
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
-        """Init the metadata for a forward pass for capturing a cuda graph."""
-        raise NotImplementedError()
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        """Init the metadata for a forward pass for replaying a cuda graph."""
         raise NotImplementedError()
 
     def get_cuda_graph_seq_len_fill_value(self):

--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -14,13 +14,12 @@ import triton
 from sglang.srt.layers.attention.flashinfer_mla_backend import FlashInferMLAAttnBackend
 from sglang.srt.layers.attention.utils import create_flashmla_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_tp_size
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_cuda
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-    from sglang.srt.speculative.spec_info import SpecInput
 
 _is_cuda = is_cuda()
 if _is_cuda:
@@ -79,7 +78,7 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         self.q_data_type = model_runner.dtype
         self.kv_cache_dim = self.kv_lora_rank + self.qk_rope_head_dim
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
 
         bs = forward_batch.batch_size
         spec_info = forward_batch.spec_info
@@ -115,9 +114,9 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
                     block_kv_indices,
                 )
             else:
-                super().init_forward_metadata(forward_batch)
+                super().init_forward_data(forward_batch)
         else:
-            super().init_forward_metadata(forward_batch)
+            super().init_forward_data(forward_batch)
 
     def init_cuda_graph_state(
         self,
@@ -143,16 +142,12 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         )
         self.cuda_graph_kv_indices = cuda_graph_kv_indices
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         if forward_mode.is_decode_or_idle():
             if spec_info is None:
                 max_seqlen_pad = self.cuda_graph_kv_indices.shape[1]
@@ -172,53 +167,7 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
                     self.cuda_graph_kv_indices[:bs, :max_seqlen_pad],
                 )
         else:
-            super().init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-            )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-
-        if forward_mode.is_decode_or_idle():
-            assert seq_lens_cpu is not None
-            seq_lens = seq_lens[:bs]
-
-            create_flashmla_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices[:bs],
-                seq_lens,
-                None,
-                self.cuda_graph_kv_indices,
-                self.req_to_token.stride(0),
-                self.cuda_graph_kv_indices.stride(0),
-                PAGED_SIZE=PAGE_SIZE,
-            )
-        else:
-            super().init_forward_metadata_replay_cuda_graph(
-                bs,
-                req_pool_indices,
-                seq_lens,
-                seq_lens_sum,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-                seq_lens_cpu,
-            )
+            super().init_forward_data_out_graph(forward_batch)
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -147,25 +147,28 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
         forward_mode = forward_batch.forward_mode
-        spec_info = forward_batch.spec_info
         if forward_mode.is_decode_or_idle():
-            if spec_info is None:
-                max_seqlen_pad = self.cuda_graph_kv_indices.shape[1]
-
-                create_flashmla_kv_indices_triton[(bs,)](
-                    self.req_to_token,
-                    req_pool_indices,
-                    seq_lens,
-                    None,
-                    self.cuda_graph_kv_indices,
-                    self.req_to_token.stride(0),
-                    self.cuda_graph_kv_indices.stride(0),
-                    PAGED_SIZE=PAGE_SIZE,
-                )
-                self.forward_metadata = CutlassMLADecodeMetadata(
-                    self.cuda_graph_mla_workspace,
-                    self.cuda_graph_kv_indices[:bs, :max_seqlen_pad],
-                )
+            # OLD ``init_forward_metadata_replay_cuda_graph`` ran the KV-indices
+            # refresh UNCONDITIONALLY for decode_or_idle. The merged body had
+            # gated it on ``spec_info is None`` (inherited from the OLD capture
+            # body), making the branch a no-op at replay when ``spec_info is
+            # not None`` (DSA-style draft decode / any spec-info-set decode)
+            # -- captured graph reads stale KV indices.
+            max_seqlen_pad = self.cuda_graph_kv_indices.shape[1]
+            create_flashmla_kv_indices_triton[(bs,)](
+                self.req_to_token,
+                req_pool_indices,
+                seq_lens,
+                None,
+                self.cuda_graph_kv_indices,
+                self.req_to_token.stride(0),
+                self.cuda_graph_kv_indices.stride(0),
+                PAGED_SIZE=PAGE_SIZE,
+            )
+            self.forward_metadata = CutlassMLADecodeMetadata(
+                self.cuda_graph_mla_workspace,
+                self.cuda_graph_kv_indices[:bs, :max_seqlen_pad],
+            )
         else:
             super().init_forward_data_out_graph(forward_batch)
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -53,7 +53,6 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import ceil_align
 
 if TYPE_CHECKING:
@@ -662,7 +661,7 @@ class DeepseekV4AttnBackend(
             use_prefill_cuda_graph=use_prefill_cuda_graph,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch) -> None:
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         if self.mtp_enabled and forward_batch.forward_mode.is_idle():
             return
 
@@ -727,76 +726,92 @@ class DeepseekV4AttnBackend(
             max_num_tokens // max_bs if max_bs > 0 else 1
         )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ) -> None:
-        assert req_pool_indices.size(0) == bs
-        assert seq_lens.size(0) == bs
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-        bucket = _GraphBucket.of(forward_mode)
-        raw_type: Optional[type] = None
-        if bucket == _GraphBucket.DECODE_OR_IDLE:
-            metadata = self.init_forward_metadata_decode(
-                max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                out_cache_loc=torch.zeros_like(seq_lens),
-            )
-            raw_type = DSV4RawDecodeMetadata
-        elif bucket == _GraphBucket.TARGET_VERIFY:
-            out_cache_loc = torch.zeros(num_tokens, **self.cuda_int32_kwargs)
-            metadata = self.init_forward_metadata_target_verify(
-                max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                out_cache_loc=out_cache_loc,
-                use_prefill_cuda_graph=True,
-            )
-            raw_type = DSV4RawVerifyMetadata
-        elif bucket == _GraphBucket.DRAFT_EXTEND:
-            num_tokens_per_bs = num_tokens // bs
-            metadata = self.init_forward_metadata_draft_extend(
-                max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                seq_lens_cpu=seq_lens.tolist(),
-                num_tokens_per_bs=num_tokens_per_bs,
-                use_prefill_cuda_graph=True,
-            )
-        else:
-            raise NotImplementedError(f"{forward_mode=} not supported yet")
+        Merged from the old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` variants. The merged
+        body branches on ``self._replay_forward_batch`` (set out-of-band
+        by the caller before replay; cleared after) to distinguish the
+        two paths because they differ structurally:
 
-        self.cuda_graph_metadata_of_bucket_and_bs[bucket][bs] = metadata
-        self.forward_metadata = metadata
-        if raw_type is not None:
-            self._current_capture_raw = (
-                metadata if isinstance(metadata, raw_type) else None
-            )
+          * **Capture** (``_replay_forward_batch is None``): build the
+            metadata from ``forward_batch`` fields directly, store the
+            result in ``cuda_graph_metadata_of_bucket_and_bs[bucket][bs]``,
+            and publish it as ``self.forward_metadata``.
+          * **Replay** (``_replay_forward_batch is not None``): read the
+            actual unpadded ``out_cache_loc`` + ``forward_mode`` from the
+            side channel (the padded buffer view comes via
+            ``forward_batch`` itself); apply IDLE replacement when the
+            actual mode is IDLE; build a temp metadata; then in-place
+            copy it into the previously captured metadata via
+            ``replay_cuda_graph_metadata_from``.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ) -> None:
+        Step 04 will replace ``_replay_forward_batch`` by having the
+        caller pass a fully-formed fb view that already carries the
+        IDLE-replaced fields, eliminating this side channel.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
         bucket = _GraphBucket.of(forward_mode)
 
+        if self._replay_forward_batch is None:
+            # ---- capture path ----
+            assert req_pool_indices.size(0) == bs
+            assert seq_lens.size(0) == bs
+
+            num_tokens = forward_batch.positions.shape[0]
+            raw_type: Optional[type] = None
+            if bucket == _GraphBucket.DECODE_OR_IDLE:
+                metadata = self.init_forward_metadata_decode(
+                    max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    out_cache_loc=torch.zeros_like(seq_lens),
+                )
+                raw_type = DSV4RawDecodeMetadata
+            elif bucket == _GraphBucket.TARGET_VERIFY:
+                out_cache_loc = torch.zeros(num_tokens, **self.cuda_int32_kwargs)
+                metadata = self.init_forward_metadata_target_verify(
+                    max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    out_cache_loc=out_cache_loc,
+                    use_prefill_cuda_graph=True,
+                )
+                raw_type = DSV4RawVerifyMetadata
+            elif bucket == _GraphBucket.DRAFT_EXTEND:
+                num_tokens_per_bs = num_tokens // bs
+                metadata = self.init_forward_metadata_draft_extend(
+                    max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    seq_lens_cpu=seq_lens.tolist(),
+                    num_tokens_per_bs=num_tokens_per_bs,
+                    use_prefill_cuda_graph=True,
+                )
+            else:
+                raise NotImplementedError(f"{forward_mode=} not supported yet")
+
+            self.cuda_graph_metadata_of_bucket_and_bs[bucket][bs] = metadata
+            self.forward_metadata = metadata
+            if raw_type is not None:
+                self._current_capture_raw = (
+                    metadata if isinstance(metadata, raw_type) else None
+                )
+            return
+
+        # ---- replay path ----
         # FIXME: see cuda_graph_runner — this attribute is set out-of-band.
-        fb = self._replay_forward_batch
-        out_cache_loc = fb.out_cache_loc
-        actual_forward_mode = fb.forward_mode
+        # Step 04 removes the side channel by having the caller build a
+        # complete fb view that already carries these fields.
+        replay_fb = self._replay_forward_batch
+        out_cache_loc = replay_fb.out_cache_loc
+        actual_forward_mode = replay_fb.forward_mode
+
+        seq_lens_cpu = forward_batch.seq_lens_cpu
 
         if actual_forward_mode == ForwardMode.IDLE:
             logger.debug(
@@ -807,7 +822,6 @@ class DeepseekV4AttnBackend(
             device = seq_lens.device
             seq_lens = torch.ones(bs, dtype=seq_lens.dtype, device=device)
             seq_lens_cpu = torch.ones(bs, dtype=torch.int64)
-            seq_lens_sum = bs
             req_pool_indices = torch.zeros(
                 bs, dtype=req_pool_indices.dtype, device=device
             )
@@ -1198,47 +1212,43 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
                 )
             )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        for i in range(self.speculative_num_steps):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-    def on_after_cuda_graph_warmup(self):
-        for backend in self.attn_backends:
-            backend.on_after_cuda_graph_warmup()
+        Distinguishes capture vs replay via ``self._replay_forward_batch``
+        (inherited from ``DeepseekV4AttnBackend``; set by the caller --
+        cuda_graph_runner for the standalone case, or the spec runner
+        after the step 03 caller switch for the multi-step case -- before
+        replay and cleared after).
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
+        Replay does NOT recurse into every backend's ``_out_graph``; only
+        backend[0] runs the per-iter prep, and backends 1..N-2 reuse its
+        metadata via ``replay_cuda_graph_metadata_from`` (this is the
+        original multi-step replay optimization, preserved as-is).
+        """
+        if self._replay_forward_batch is None:
+            # ---- capture path ----
+            for i in range(self.speculative_num_steps):
+                self.attn_backends[i].init_forward_data_out_graph(forward_batch)
+            return
+
+        # ---- replay path ----
         if self.speculative_num_steps == 1:
             return
 
-        self.attn_backends[0]._replay_forward_batch = forward_batch
-        self.attn_backends[0].init_forward_metadata_replay_cuda_graph(
-            bs=bs,
-            req_pool_indices=forward_batch.req_pool_indices,
-            seq_lens=forward_batch.seq_lens,
-            seq_lens_sum=forward_batch.seq_lens_sum,
-            encoder_lens=None,
-            forward_mode=ForwardMode.DECODE,
-            spec_info=forward_batch.spec_info,
-            seq_lens_cpu=forward_batch.seq_lens_cpu,
-        )
+        bs = forward_batch.batch_size
+        # Propagate the replay signal to backend[0] so its merged _out_graph
+        # body takes the replay branch.
+        self.attn_backends[0]._replay_forward_batch = self._replay_forward_batch
+        self.attn_backends[0].init_forward_data_out_graph(forward_batch)
         self.attn_backends[0]._replay_forward_batch = None
         temp_metadata = self.attn_backends[0].forward_metadata
 
@@ -1248,6 +1258,10 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
                 temp_metadata=temp_metadata,
                 bucket=_GraphBucket.DECODE_OR_IDLE,
             )
+
+    def on_after_cuda_graph_warmup(self):
+        for backend in self.attn_backends:
+            backend.on_after_cuda_graph_warmup()
 
 
 def _pad_tensor_to_size(tensor: torch.Tensor, size: int, *, value: int = 0):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -43,7 +43,6 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import ceil_align
 
 if TYPE_CHECKING:
@@ -656,7 +655,7 @@ class DeepseekV4HipRadixBackend(
             use_prefill_cuda_graph=use_prefill_cuda_graph,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch) -> None:
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         if self.mtp_enabled and forward_batch.forward_mode.is_idle():
             return
 
@@ -721,76 +720,92 @@ class DeepseekV4HipRadixBackend(
             max_num_tokens // max_bs if max_bs > 0 else 1
         )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ) -> None:
-        assert req_pool_indices.size(0) == bs
-        assert seq_lens.size(0) == bs
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-        bucket = _GraphBucket.of(forward_mode)
-        raw_type: Optional[type] = None
-        if bucket == _GraphBucket.DECODE_OR_IDLE:
-            metadata = self.init_forward_metadata_decode(
-                max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                out_cache_loc=torch.zeros_like(seq_lens),
-            )
-            raw_type = DSV4RawDecodeMetadata
-        elif bucket == _GraphBucket.TARGET_VERIFY:
-            out_cache_loc = torch.zeros(num_tokens, **self.cuda_int32_kwargs)
-            metadata = self.init_forward_metadata_target_verify(
-                max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                out_cache_loc=out_cache_loc,
-                use_prefill_cuda_graph=True,
-            )
-            raw_type = DSV4RawVerifyMetadata
-        elif bucket == _GraphBucket.DRAFT_EXTEND:
-            num_tokens_per_bs = num_tokens // bs
-            metadata = self.init_forward_metadata_draft_extend(
-                max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                seq_lens_cpu=seq_lens.tolist(),
-                num_tokens_per_bs=num_tokens_per_bs,
-                use_prefill_cuda_graph=True,
-            )
-        else:
-            raise NotImplementedError(f"{forward_mode=} not supported yet")
+        Merged from the old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` variants. The merged
+        body branches on ``self._replay_forward_batch`` (set out-of-band
+        by the caller before replay; cleared after) to distinguish the
+        two paths because they differ structurally:
 
-        self.cuda_graph_metadata_of_bucket_and_bs[bucket][bs] = metadata
-        self.forward_metadata = metadata
-        if raw_type is not None:
-            self._current_capture_raw = (
-                metadata if isinstance(metadata, raw_type) else None
-            )
+          * **Capture** (``_replay_forward_batch is None``): build the
+            metadata from ``forward_batch`` fields directly, store the
+            result in ``cuda_graph_metadata_of_bucket_and_bs[bucket][bs]``,
+            and publish it as ``self.forward_metadata``.
+          * **Replay** (``_replay_forward_batch is not None``): read the
+            actual unpadded ``out_cache_loc`` + ``forward_mode`` from the
+            side channel (the padded buffer view comes via
+            ``forward_batch`` itself); apply IDLE replacement when the
+            actual mode is IDLE; build a temp metadata; then in-place
+            copy it into the previously captured metadata via
+            ``replay_cuda_graph_metadata_from``.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ) -> None:
+        Step 04 will replace ``_replay_forward_batch`` by having the
+        caller pass a fully-formed fb view that already carries the
+        IDLE-replaced fields, eliminating this side channel.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
         bucket = _GraphBucket.of(forward_mode)
 
+        if self._replay_forward_batch is None:
+            # ---- capture path ----
+            assert req_pool_indices.size(0) == bs
+            assert seq_lens.size(0) == bs
+
+            num_tokens = forward_batch.positions.shape[0]
+            raw_type: Optional[type] = None
+            if bucket == _GraphBucket.DECODE_OR_IDLE:
+                metadata = self.init_forward_metadata_decode(
+                    max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    out_cache_loc=torch.zeros_like(seq_lens),
+                )
+                raw_type = DSV4RawDecodeMetadata
+            elif bucket == _GraphBucket.TARGET_VERIFY:
+                out_cache_loc = torch.zeros(num_tokens, **self.cuda_int32_kwargs)
+                metadata = self.init_forward_metadata_target_verify(
+                    max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    out_cache_loc=out_cache_loc,
+                    use_prefill_cuda_graph=True,
+                )
+                raw_type = DSV4RawVerifyMetadata
+            elif bucket == _GraphBucket.DRAFT_EXTEND:
+                num_tokens_per_bs = num_tokens // bs
+                metadata = self.init_forward_metadata_draft_extend(
+                    max_seq_len=self.MAX_SEQ_LEN_FOR_CAPTURE,
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    seq_lens_cpu=seq_lens.tolist(),
+                    num_tokens_per_bs=num_tokens_per_bs,
+                    use_prefill_cuda_graph=True,
+                )
+            else:
+                raise NotImplementedError(f"{forward_mode=} not supported yet")
+
+            self.cuda_graph_metadata_of_bucket_and_bs[bucket][bs] = metadata
+            self.forward_metadata = metadata
+            if raw_type is not None:
+                self._current_capture_raw = (
+                    metadata if isinstance(metadata, raw_type) else None
+                )
+            return
+
+        # ---- replay path ----
         # FIXME: see cuda_graph_runner — this attribute is set out-of-band.
-        fb = self._replay_forward_batch
-        out_cache_loc = fb.out_cache_loc
-        actual_forward_mode = fb.forward_mode
+        # Step 04 removes the side channel by having the caller build a
+        # complete fb view that already carries these fields.
+        replay_fb = self._replay_forward_batch
+        out_cache_loc = replay_fb.out_cache_loc
+        actual_forward_mode = replay_fb.forward_mode
+
+        seq_lens_cpu = forward_batch.seq_lens_cpu
 
         if actual_forward_mode == ForwardMode.IDLE:
             logger.debug(
@@ -801,7 +816,6 @@ class DeepseekV4HipRadixBackend(
             device = seq_lens.device
             seq_lens = torch.ones(bs, dtype=seq_lens.dtype, device=device)
             seq_lens_cpu = torch.ones(bs, dtype=torch.int64)
-            seq_lens_sum = bs
             req_pool_indices = torch.zeros(
                 bs, dtype=req_pool_indices.dtype, device=device
             )
@@ -1198,47 +1212,43 @@ class DeepseekV4MultiStepBackend(DeepseekV4HipRadixBackend):
                 )
             )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        for i in range(self.speculative_num_steps):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-    def on_after_cuda_graph_warmup(self):
-        for backend in self.attn_backends:
-            backend.on_after_cuda_graph_warmup()
+        Distinguishes capture vs replay via ``self._replay_forward_batch``
+        (inherited from ``DeepseekV4HipRadixBackend``; set by the caller --
+        cuda_graph_runner for the standalone case, or the spec runner
+        after the step 03 caller switch for the multi-step case -- before
+        replay and cleared after).
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
+        Replay does NOT recurse into every backend's ``_out_graph``; only
+        backend[0] runs the per-iter prep, and backends 1..N-2 reuse its
+        metadata via ``replay_cuda_graph_metadata_from`` (this is the
+        original multi-step replay optimization, preserved as-is).
+        """
+        if self._replay_forward_batch is None:
+            # ---- capture path ----
+            for i in range(self.speculative_num_steps):
+                self.attn_backends[i].init_forward_data_out_graph(forward_batch)
+            return
+
+        # ---- replay path ----
         if self.speculative_num_steps == 1:
             return
 
-        self.attn_backends[0]._replay_forward_batch = forward_batch
-        self.attn_backends[0].init_forward_metadata_replay_cuda_graph(
-            bs=bs,
-            req_pool_indices=forward_batch.req_pool_indices,
-            seq_lens=forward_batch.seq_lens,
-            seq_lens_sum=forward_batch.seq_lens_sum,
-            encoder_lens=None,
-            forward_mode=ForwardMode.DECODE,
-            spec_info=forward_batch.spec_info,
-            seq_lens_cpu=forward_batch.seq_lens_cpu,
-        )
+        bs = forward_batch.batch_size
+        # Propagate the replay signal to backend[0] so its merged _out_graph
+        # body takes the replay branch.
+        self.attn_backends[0]._replay_forward_batch = self._replay_forward_batch
+        self.attn_backends[0].init_forward_data_out_graph(forward_batch)
         self.attn_backends[0]._replay_forward_batch = None
         temp_metadata = self.attn_backends[0].forward_metadata
 
@@ -1248,6 +1258,10 @@ class DeepseekV4MultiStepBackend(DeepseekV4HipRadixBackend):
                 temp_metadata=temp_metadata,
                 bucket=_GraphBucket.DECODE_OR_IDLE,
             )
+
+    def on_after_cuda_graph_warmup(self):
+        for backend in self.attn_backends:
+            backend.on_after_cuda_graph_warmup()
 
 
 def _pad_tensor_to_size(tensor: torch.Tensor, size: int, *, value: int = 0):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1008,10 +1008,19 @@ class DeepseekSparseAttnBackend(
         bs = forward_batch.batch_size
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
-        forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
         seq_lens_cpu = forward_batch.seq_lens_cpu
         assert seq_lens_cpu is not None
+
+        # Mirror dsv4 (``deepseek_v4_backend.py:812``): the fb view's forward_mode
+        # is the capture-time mode (DECODE bucket); the LIVE forward_mode comes
+        # from the side channel and may be IDLE for dp-attention idle ranks.
+        # IDLE handling is tracked separately by step 04; for now we just read
+        # the live mode so the branch checks aren't wrong.
+        if self._replay_forward_batch is not None:
+            forward_mode = self._replay_forward_batch.forward_mode
+        else:
+            forward_mode = forward_batch.forward_mode
 
         self.set_dsa_prefill_impl(forward_batch=None)
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -41,7 +41,6 @@ from sglang.srt.utils import is_cuda, is_hip
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-    from sglang.srt.speculative.spec_info import SpecInput
 
 
 _is_hip = is_hip()
@@ -395,6 +394,11 @@ class DeepseekSparseAttnBackend(
         else:
             self.workspace_buffer = None
 
+        # FIXME: out-of-band channel used by the cuda graph runner to flag the
+        # replay path in ``init_forward_data_out_graph``. Step 04 will remove
+        # this by having the caller construct a complete fb view.
+        self._replay_forward_batch: Optional[ForwardBatch] = None
+
     def get_device_int32_arange(self, l: int) -> torch.Tensor:
         if l > len(self._arange_buf):
             next_pow_of_2 = 1 << (l - 1).bit_length()
@@ -413,7 +417,7 @@ class DeepseekSparseAttnBackend(
         )
         return page_table[:, strided_indices] // page_size
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Init the metadata for a forward pass."""
         batch_size = forward_batch.batch_size
         device = forward_batch.seq_lens.device
@@ -818,19 +822,38 @@ class DeepseekSparseAttnBackend(
             ),
         }
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Merged from the old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` variants. The merged
+        body branches on ``self._replay_forward_batch`` (set out-of-band
+        by the caller before replay; cleared after) because the two paths
+        differ structurally:
+
+          * **Capture**: build a fresh ``DSAMetadata`` from
+            ``forward_batch`` fields, store it in
+            ``self.decode_cuda_graph_metadata[bs]``, and publish it as
+            ``self.forward_metadata``. The captured CUDA graph holds
+            pointers to this metadata's internal tensors.
+          * **Replay**: look up the stored ``DSAMetadata[bs]`` and refresh
+            its internal tensors **in-place** via ``copy_``/``copy_``;
+            the cuda graph re-runs against the same pointers.
+
+        ``num_tokens`` (formerly a positional capture arg) is derived
+        from ``forward_batch.positions.shape[0]``.
+        """
+        if self._replay_forward_batch is not None:
+            self._init_forward_data_out_graph_replay(forward_batch)
+            return
+
+        bs = forward_batch.batch_size
+        num_tokens = forward_batch.positions.shape[0]
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
         self.set_dsa_prefill_impl(forward_batch=None)
 
-        """Initialize forward metadata for capturing CUDA graph."""
         if forward_mode.is_decode_or_idle():
             # Normal Decode
             # Get sequence information
@@ -974,20 +997,20 @@ class DeepseekSparseAttnBackend(
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_metadata = metadata
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-        out_cache_loc: Optional[torch.Tensor] = None,
-        actual_forward_mode: Optional[ForwardMode] = None,
-    ):
-        """Initialize forward metadata for replaying CUDA graph."""
+    def _init_forward_data_out_graph_replay(self, forward_batch: ForwardBatch) -> None:
+        """Replay branch of ``init_forward_data_out_graph``.
+
+        Refreshes the previously captured ``DSAMetadata[bs]`` in-place so
+        that the cuda graph's recorded pointers still resolve to current
+        tensor contents. Reads inputs from ``forward_batch`` (the caller
+        passes a padded buffer view via the cuda graph runner).
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
+        seq_lens_cpu = forward_batch.seq_lens_cpu
         assert seq_lens_cpu is not None
 
         self.set_dsa_prefill_impl(forward_batch=None)
@@ -2319,30 +2342,41 @@ class DeepseekSparseAttnMultiStepBackend:
                     speculative_num_steps=self.speculative_num_steps,
                 )
             )
+        # FIXME: out-of-band channel mirroring ``DeepseekSparseAttnBackend``;
+        # set by the spec runner before replay and cleared after. Step 04
+        # will remove this by having the caller pass a complete fb view.
+        self._replay_forward_batch: Optional[ForwardBatch] = None
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
+        Distinguishes capture vs replay via ``self._replay_forward_batch``
+        (set by the spec runner before replay and cleared after).
+
+        On capture, each inner backend builds and stores its own
+        ``DSAMetadata``. On replay, the multi-step precompute optimization
+        runs the metadata derivation once (on ``backends[0]``) and fans
+        the result out to every backend's ``DSAMetadata[bs]`` via
+        ``init_forward_metadata_replay_cuda_graph_from_precomputed``;
+        with ``SGLANG_DSA_ENABLE_MTP_PRECOMPUTE_METADATA=0``, each backend
+        recomputes via its own ``_out_graph`` replay branch.
+        """
+        if self._replay_forward_batch is None:
+            # ---- capture path ----
+            for i in range(self.speculative_num_steps - 1):
+                self.attn_backends[i].init_forward_data_out_graph(forward_batch)
+            return
+
+        # ---- replay path ----
+        bs = forward_batch.batch_size
         if envs.SGLANG_DSA_ENABLE_MTP_PRECOMPUTE_METADATA.get():
             # Precompute metadata once (shared across all backends)
             precomputed = self.attn_backends[0]._precompute_replay_metadata(
@@ -2500,19 +2534,13 @@ class DeepseekSparseAttnMultiStepBackend:
                         forward_mode=ForwardMode.DECODE,
                     )
         else:
-            # Fallback: compute metadata separately for each backend
+            # Fallback: each backend recomputes via its own _out_graph replay
+            # branch. Propagate the replay signal to each inner backend so its
+            # merged _out_graph body takes the replay branch.
             for i in range(self.speculative_num_steps - 1):
-                self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                    bs=bs,
-                    req_pool_indices=forward_batch.req_pool_indices,
-                    seq_lens=forward_batch.seq_lens,
-                    seq_lens_sum=forward_batch.seq_lens_sum,
-                    encoder_lens=None,
-                    forward_mode=ForwardMode.DECODE,
-                    spec_info=forward_batch.spec_info,
-                    seq_lens_cpu=forward_batch.seq_lens_cpu,
-                    out_cache_loc=None,
-                )
+                self.attn_backends[i]._replay_forward_batch = self._replay_forward_batch
+                self.attn_backends[i].init_forward_data_out_graph(forward_batch)
+                self.attn_backends[i]._replay_forward_batch = None
 
 
 # Backward-compat aliases (deprecated: use DSA class names)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2369,6 +2369,10 @@ class DeepseekSparseAttnMultiStepBackend:
         with ``SGLANG_DSA_ENABLE_MTP_PRECOMPUTE_METADATA=0``, each backend
         recomputes via its own ``_out_graph`` replay branch.
         """
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
         if self._replay_forward_batch is None:
             # ---- capture path ----
             for i in range(self.speculative_num_steps - 1):
@@ -2541,6 +2545,17 @@ class DeepseekSparseAttnMultiStepBackend:
                 self.attn_backends[i]._replay_forward_batch = self._replay_forward_batch
                 self.attn_backends[i].init_forward_data_out_graph(forward_batch)
                 self.attn_backends[i]._replay_forward_batch = None
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return
 
 
 # Backward-compat aliases (deprecated: use DSA class names)

--- a/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
@@ -172,7 +172,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         end_head = start_head + self.num_heads
         return [layer_sparse_attention_config[i] for i in range(start_head, end_head)]
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Initialize forward metadata hence all layers in the forward pass can reuse it."""
 
         forward_mode: ForwardMode = forward_batch.forward_mode
@@ -532,19 +532,33 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
             ),
         }
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[None],
-    ):
-        metadata = DualChunkFlashAttentionMetadata()
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-        if forward_mode.is_decode_or_idle():
+        Body merged from old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` -- both wrote to the same
+        pre-allocated ``self.decode_metadata`` buffers. Called outside
+        ``with graph.capture():`` at both capture (initial alloc + fill) and
+        replay (per-iter refresh). On first call per ``bs`` we build the
+        ``DualChunkFlashAttentionMetadata`` object with buffers bound to
+        ``self.decode_metadata[*][:bs]`` slices plus a fresh fancy-indexed
+        ``block_tables`` tensor whose pointer the captured graph records;
+        subsequent calls reuse that same metadata object so the recorded
+        pointers stay valid, copying refreshed data into the bound buffers.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+
+        if not forward_mode.is_decode_or_idle():
+            self.forward_metadata = DualChunkFlashAttentionMetadata()
+            return
+
+        # Allocate metadata + bind buffers on first call per bs; reuse afterwards
+        # so the captured CUDA graph's recorded tensor pointers stay valid.
+        if bs not in self.decode_metadata:
+            metadata = DualChunkFlashAttentionMetadata()
             if self.original_max_position_embeddings > 0:
                 metadata.scaling_factor = self.decode_metadata["scaling_factor"][:bs]
 
@@ -578,22 +592,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
 
             self.decode_metadata[bs] = metadata
 
-        self.forward_metadata = metadata
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[None],
-        seq_lens_cpu: Optional[torch.Tensor],
-        out_cache_loc: torch.Tensor = None,
-    ):
-        """Initialize forward metadata for replaying CUDA graph."""
-        assert forward_mode.is_decode()
+        # Populate the bound buffers with per-iter data.
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
         metadata = self.decode_metadata[bs]

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1655,30 +1655,58 @@ class FlashAttentionBackend(AttentionBackend):
             if spec_info is not None:
                 # Draft Decode
                 if self.topk <= 1:
-                    # When topk = 1, we use the normal decode metadata
-                    metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
-                        "cache_seqlens"
-                    ][:bs]
+                    # When topk = 1, we use the normal decode metadata.
+                    # On first call per bs: allocate metadata object binding to
+                    # pre-allocated buffers; subsequent calls reuse the bound
+                    # buffers via in-place ops (``normal_decode_set_metadata``).
+                    if bs not in self.decode_cuda_graph_metadata:
+                        metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
+                            "cache_seqlens"
+                        ][:bs]
+                        metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
+                            "cu_seqlens_q"
+                        ][: bs + 1]
+                        metadata.cu_seqlens_k = self.decode_cuda_graph_metadata[
+                            "cu_seqlens_k"
+                        ][: bs + 1]
+                        metadata.page_table = self.decode_cuda_graph_metadata[
+                            "page_table_draft_decode"
+                        ][:bs, :]
+                        if self.use_sliding_window_kv_pool:
+                            metadata.swa_page_table = self.decode_cuda_graph_metadata[
+                                "swa_page_table"
+                            ][:bs, :]
+                        self.decode_cuda_graph_metadata[bs] = metadata
+                    else:
+                        metadata = self.decode_cuda_graph_metadata[bs]
+
+                    # Per-iter refresh via the fused Triton kernel (mirrors OLD
+                    # replay). Restores the page_table / cache_seqlens / cu_seqlens
+                    # population step the merged body had lost.
                     metadata.max_seq_len_k = seq_lens.max().item() + (
                         self.speculative_step_id + 1
                     )
-                    metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
-                        "cu_seqlens_q"
-                    ][: bs + 1]
-                    metadata.cu_seqlens_k = torch.nn.functional.pad(
-                        torch.cumsum(
-                            metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
+                    max_seq_pages = (
+                        metadata.max_seq_len_k + self.page_size - 1
+                    ) // self.page_size
+                    normal_decode_set_metadata(
+                        metadata.cache_seqlens_int32,
+                        metadata.cu_seqlens_k,
+                        metadata.page_table,
+                        self.req_to_token_pool.req_to_token,
+                        req_pool_indices,
+                        self.decode_cuda_graph_metadata["strided_indices"],
+                        max_seq_pages,
+                        seq_lens,
+                        self.speculative_step_id + 1,
+                        self.page_size,
+                        metadata.swa_page_table,
+                        (
+                            self.token_to_kv_pool
+                            if self.use_sliding_window_kv_pool
+                            else None
                         ),
-                        (1, 0),
                     )
-                    metadata.page_table = self.decode_cuda_graph_metadata[
-                        "page_table_draft_decode"
-                    ][:bs, :]
-                    if self.use_sliding_window_kv_pool:
-                        metadata.swa_page_table = self.decode_cuda_graph_metadata[
-                            "swa_page_table"
-                        ][:bs, :]
-                    self.decode_cuda_graph_metadata[bs] = metadata
                 else:
                     # When top k > 1, we need two specific draft decode metadata, and then merge states
                     # 1. The first half of metadata for prefix tokens
@@ -1721,28 +1749,59 @@ class FlashAttentionBackend(AttentionBackend):
                     self.draft_decode_metadata_topk_expand[bs] = metadata_expand
             else:
                 # Normal Decode
-                # Get sequence information
-                metadata.cache_seqlens_int32 = seq_lens.to(torch.int32)
+                # On first call per bs allocate the metadata object binding fields
+                # to pre-allocated buffers; subsequent calls reuse the bound
+                # buffers via in-place copy_ so the captured CUDA graph's
+                # recorded tensor pointers stay valid at replay.
                 batch_size = len(seq_lens)
                 device = seq_lens.device
-                metadata.cu_seqlens_k = torch.nn.functional.pad(
-                    torch.cumsum(seq_lens, dim=0, dtype=torch.int32), (1, 0)
-                )
-                # Precompute maximum sequence length
+                if bs not in self.decode_cuda_graph_metadata:
+                    metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
+                        "cache_seqlens"
+                    ][:bs]
+                    metadata.cu_seqlens_k = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_k"
+                    ][: bs + 1]
+                    metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_q"
+                    ][: bs + 1]
+                    metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
+                        :bs, :
+                    ]
+                    if self.use_sliding_window_kv_pool:
+                        metadata.swa_page_table = self.decode_cuda_graph_metadata[
+                            "swa_page_table"
+                        ][:bs, :]
+                    self.decode_cuda_graph_metadata[bs] = metadata
+                else:
+                    metadata = self.decode_cuda_graph_metadata[bs]
+
+                # Per-iter refresh: populate the bound buffers in-place via the
+                # fused ``normal_decode_set_metadata`` Triton kernel (mirrors the
+                # OLD replay variant). This is what restores the page-table
+                # population step the merged body had lost.
                 metadata.max_seq_len_k = seq_lens.max().item()
-                # Precompute page table
-                metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
-                    :bs, :
-                ]
-                if self.use_sliding_window_kv_pool:
-                    metadata.swa_page_table = self.decode_cuda_graph_metadata[
-                        "swa_page_table"
-                    ][:bs, :]
-                # Precompute cumulative sequence lengths
-                metadata.cu_seqlens_q = torch.arange(
-                    0, batch_size + 1, dtype=torch.int32, device=device
+                max_seq_pages = (
+                    metadata.max_seq_len_k + self.page_size - 1
+                ) // self.page_size
+                normal_decode_set_metadata(
+                    metadata.cache_seqlens_int32,
+                    metadata.cu_seqlens_k,
+                    metadata.page_table,
+                    self.req_to_token_pool.req_to_token,
+                    req_pool_indices,
+                    self.decode_cuda_graph_metadata["strided_indices"],
+                    max_seq_pages,
+                    seq_lens,
+                    0,
+                    self.page_size,
+                    metadata.swa_page_table,
+                    (
+                        self.token_to_kv_pool
+                        if self.use_sliding_window_kv_pool
+                        else None
+                    ),
                 )
-                self.decode_cuda_graph_metadata[bs] = metadata
 
                 self._maybe_update_local_attn_metadata_for_capture(metadata, batch_size)
 
@@ -1762,38 +1821,66 @@ class FlashAttentionBackend(AttentionBackend):
 
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
-                metadata.cache_seqlens_int32 = self.target_verify_metadata[
-                    "cache_seqlens"
-                ][:bs]
+                # Bind metadata fields to pre-allocated buffers on first call per
+                # bs; subsequent calls reuse and just copy_ refreshed data in.
+                if bs not in self.target_verify_metadata:
+                    metadata.cache_seqlens_int32 = self.target_verify_metadata[
+                        "cache_seqlens"
+                    ][:bs]
+                    metadata.cu_seqlens_q = self.target_verify_metadata["cu_seqlens_q"][
+                        : bs * self.speculative_num_draft_tokens + 1
+                    ]
+                    metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
+                        : (bs + 1)
+                    ]
+                    metadata.page_table = self.target_verify_metadata["page_table"][
+                        :bs, :
+                    ]
+                    if self.use_sliding_window_kv_pool:
+                        metadata.swa_page_table = self.target_verify_metadata[
+                            "swa_page_table"
+                        ][:bs, :]
+                    self.target_verify_metadata[bs] = metadata
+                else:
+                    metadata = self.target_verify_metadata[bs]
+
+                # Per-iter refresh (in-place writes into the bound buffers; the
+                # captured graph holds stable pointers across replays).
                 metadata.cache_seqlens_int32.copy_(
                     (seq_lens + self.speculative_num_draft_tokens)
                 )
-
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
                 metadata.max_seq_len_k = (
                     seq_lens.max().item() + self.speculative_num_draft_tokens
                 )
-
-                metadata.cu_seqlens_q = torch.arange(
-                    0,
-                    bs * self.speculative_num_draft_tokens + 1,
-                    self.speculative_num_draft_tokens,
-                    dtype=torch.int32,
-                    device=device,
+                # cu_seqlens_q is pre-allocated by ``init_cuda_graph_state`` as
+                # ``arange(0, max_bs*num_draft+1, step=num_draft)`` -- static
+                # across replays since num_draft is fixed; no per-iter update.
+                metadata.cu_seqlens_k[1:].copy_(
+                    torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
-
-                metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
-                    : (bs + 1)
+                max_seq_pages = (
+                    metadata.max_seq_len_k + self.page_size - 1
+                ) // self.page_size
+                page_indices = self.req_to_token_pool.req_to_token[
+                    req_pool_indices[:, None],
+                    self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
                 ]
-
-                metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
-
-                if self.use_sliding_window_kv_pool:
-                    metadata.swa_page_table = self.target_verify_metadata[
-                        "swa_page_table"
-                    ][:bs, :]
-
-                self.target_verify_metadata[bs] = metadata
+                if (
+                    self.use_sliding_window_kv_pool
+                    and metadata.swa_page_table is not None
+                ):
+                    swa_page_indices = (
+                        self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                            page_indices
+                        )
+                    )
+                    metadata.swa_page_table[:, :max_seq_pages].copy_(
+                        swa_page_indices // self.page_size
+                    )
+                metadata.page_table[:, :max_seq_pages].copy_(
+                    page_indices // self.page_size
+                )
             else:
                 # When topk > 1, we need two specific target verify metadata, and then merge states
                 # 1. The first half of metadata for prefix tokens
@@ -1855,34 +1942,63 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata.swa_spec_metadata = metadata_swa
 
         elif forward_mode.is_draft_extend(include_v2=True):
-            metadata.cache_seqlens_int32 = self.draft_extend_metadata["cache_seqlens"][
-                :bs
-            ]
-            metadata.cache_seqlens_int32.copy_(seq_lens)
-
             num_tokens_per_bs = num_tokens // bs
+            # Bind metadata fields to pre-allocated buffers on first call per
+            # bs; subsequent calls reuse so the captured graph's recorded
+            # tensor pointers stay valid at replay.
+            if bs not in self.draft_extend_metadata:
+                metadata.cache_seqlens_int32 = self.draft_extend_metadata[
+                    "cache_seqlens"
+                ][:bs]
+                metadata.cu_seqlens_q = self.draft_extend_metadata["cu_seqlens_q"][
+                    : (bs + 1)
+                ]
+                metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
+                    : (bs + 1)
+                ]
+                metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
+                if self.use_sliding_window_kv_pool:
+                    metadata.swa_page_table = self.draft_extend_metadata[
+                        "swa_page_table"
+                    ][:bs, :]
+                # Initialize cu_seqlens_q with the static arange (num_tokens_per_bs
+                # is fixed for a given bs/spec config); subsequent replays leave it
+                # untouched.
+                metadata.cu_seqlens_q.copy_(
+                    torch.arange(
+                        0,
+                        bs * num_tokens_per_bs + 1,
+                        num_tokens_per_bs,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                )
+                self.draft_extend_metadata[bs] = metadata
+            else:
+                metadata = self.draft_extend_metadata[bs]
+
+            # Per-iter refresh.
+            metadata.cache_seqlens_int32.copy_(seq_lens)
             metadata.max_seq_len_q = num_tokens_per_bs
             metadata.max_seq_len_k = seq_lens.max().item()
-
-            metadata.cu_seqlens_q = torch.arange(
-                0,
-                bs * num_tokens_per_bs + 1,
-                num_tokens_per_bs,
-                dtype=torch.int32,
-                device=device,
+            metadata.cu_seqlens_k[1:].copy_(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-
-            metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
-                : (bs + 1)
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
+            page_indices = self.req_to_token_pool.req_to_token[
+                req_pool_indices[:, None],
+                self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
             ]
-            metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
-
-            if self.use_sliding_window_kv_pool:
-                metadata.swa_page_table = self.draft_extend_metadata["swa_page_table"][
-                    :bs, :
-                ]
-
-            self.draft_extend_metadata[bs] = metadata
+            if self.use_sliding_window_kv_pool and metadata.swa_page_table is not None:
+                swa_page_indices = self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                    page_indices
+                )
+                metadata.swa_page_table[:, :max_seq_pages].copy_(
+                    swa_page_indices // self.page_size
+                )
+            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
         elif forward_mode.is_extend_or_draft_extend_or_mixed(
             include_draft_extend_v2=True
         ):

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1883,6 +1883,40 @@ class FlashAttentionBackend(AttentionBackend):
                 ]
 
             self.draft_extend_metadata[bs] = metadata
+        elif forward_mode.is_extend_or_draft_extend_or_mixed(
+            include_draft_extend_v2=True
+        ):
+            # Prefill / extend path -- invoked by piecewise / breakable cuda
+            # graph capture for non-decode modes. Mirrors the eager body's
+            # ``elif is_extend_or_draft_extend_or_mixed`` clause; reads the
+            # live ``req_to_token_pool`` view (no pre-allocated buffer reuse).
+            metadata.cache_seqlens_int32 = seq_lens.to(torch.int32)
+            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(seq_lens, dim=0, dtype=torch.int32), (1, 0)
+            )
+            metadata.page_table = self.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : metadata.max_seq_len_k
+            ]
+
+            if any(
+                forward_batch.extend_prefix_lens_cpu
+            ) or forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                extend_seq_lens = forward_batch.extend_seq_lens
+                # max() with tensor or python list both work; coerce to int
+                max_q = max(forward_batch.extend_seq_lens_cpu)
+                metadata.max_seq_len_q = (
+                    int(max_q.item()) if isinstance(max_q, torch.Tensor) else int(max_q)
+                )
+                metadata.cu_seqlens_q = torch.nn.functional.pad(
+                    torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
+                )
+            else:
+                metadata.max_seq_len_q = metadata.max_seq_len_k
+                metadata.cu_seqlens_q = metadata.cu_seqlens_k
+
+            if forward_batch.forward_mode == ForwardMode.EXTEND:
+                self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
 
         if encoder_lens is not None:
             encoder_bs = encoder_lens.numel()
@@ -1896,6 +1930,42 @@ class FlashAttentionBackend(AttentionBackend):
             metadata.encoder_page_table = self.encoder_metadata["encoder_page_table"][
                 :bs, :
             ]
+
+        # SWA page table + strided conversion (mirrors eager).
+        if self.use_sliding_window_kv_pool and metadata.page_table is not None:
+            if metadata.swa_page_table is None:
+                metadata.swa_page_table = (
+                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        metadata.page_table
+                    )
+                )
+
+        if self.page_size > 1 and not forward_mode.is_decode_or_idle():
+            # For non-decode modes the page table was built from
+            # req_to_token_pool above; strided conversion applies.
+            if (
+                metadata.page_table is not None
+                and forward_mode.is_extend_or_draft_extend_or_mixed(
+                    include_draft_extend_v2=True
+                )
+            ):
+                self.strided_indices = torch.arange(
+                    0,
+                    metadata.page_table.shape[1],
+                    self.page_size,
+                    device=self.device,
+                )
+                if (
+                    self.use_sliding_window_kv_pool
+                    and metadata.swa_page_table is not None
+                ):
+                    metadata.swa_page_table = (
+                        metadata.swa_page_table[:, self.strided_indices]
+                        // self.page_size
+                    )
+                metadata.page_table = (
+                    metadata.page_table[:, self.strided_indices] // self.page_size
+                )
 
         self.forward_metadata = metadata
         self.forward_metadata_spec_decode_expand = metadata_expand

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2296,9 +2296,24 @@ class FlashAttentionMultiStepBackend:
         """
         assert forward_batch.spec_info is not None
         assert forward_batch.spec_info.is_draft_input()
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
 
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -18,7 +18,6 @@ from sglang.srt.layers.utils.cp_utils import (
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import get_compiler_backend
 
 if TYPE_CHECKING:
@@ -271,8 +270,8 @@ class FlashAttentionBackend(AttentionBackend):
             num_splits=self.num_splits,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Initialize forward metadata hence all layers in the forward pass can reuse it."""
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for the eager path -- all layers share this metadata."""
         metadata = FlashAttentionMetadata()
         seqlens_in_batch = forward_batch.seq_lens
         batch_size = forward_batch.batch_size
@@ -1619,17 +1618,33 @@ class FlashAttentionBackend(AttentionBackend):
             # For decoder-only models, skip encoder_metadata allocation
             self.encoder_metadata = {}
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
-        """Initialize forward metadata for capturing CUDA graph."""
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body taken from the old ``init_forward_metadata_capture_cuda_graph`` --
+        capture builds fresh ``FlashAttentionMetadata`` per bs and stores it
+        in ``decode_cuda_graph_metadata[bs]`` /
+        ``target_verify_metadata[bs]`` / ``draft_extend_metadata[bs]``;
+        replay reused the cached metadata via ``copy_``/in-place updates. Per
+        the initial-stage scope we keep the capture body and accept the
+        metadata-rebuild cost at each replay; the replay-time fast path may
+        be restored by a follow-up per-backend optimization PR.
+        """
+        bs = forward_batch.batch_size
+        # ``num_tokens == bs * num_tokens_per_bs``. ``positions`` is the only
+        # fb field always sized to ``num_tokens`` across direct (cuda_graph_runner)
+        # and multi-step-wrapper (eagle_draft_cuda_graph_runner) callers --
+        # ``input_ids`` is None in the multi-step wrapper's synthetic fb.
+        num_tokens = (
+            forward_batch.positions.shape[0]
+            if forward_batch.positions is not None
+            else bs
+        )
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        encoder_lens = forward_batch.encoder_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         metadata = FlashAttentionMetadata()
 
         # metadata_expand is needed for Spec Decoding when top k > 1
@@ -1881,384 +1896,6 @@ class FlashAttentionBackend(AttentionBackend):
             metadata.encoder_page_table = self.encoder_metadata["encoder_page_table"][
                 :bs, :
             ]
-
-        self.forward_metadata = metadata
-        self.forward_metadata_spec_decode_expand = metadata_expand
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-        out_cache_loc: Optional[torch.Tensor] = None,
-    ):
-        """Initialize forward metadata for replaying CUDA graph."""
-        seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
-        req_pool_indices = req_pool_indices[:bs]
-        device = seq_lens.device
-        metadata = None
-        metadata_expand = None
-
-        if forward_mode.is_decode_or_idle():
-
-            if spec_info is not None:
-                # Draft Decode
-                if self.topk <= 1:
-                    # When topk = 1, we use the normal decode metadata
-                    metadata = self.decode_cuda_graph_metadata[bs]
-                    max_len = seq_lens_cpu.max().item()
-                    metadata.max_seq_len_k = max_len + self.speculative_step_id + 1
-                    max_seq_pages = (
-                        metadata.max_seq_len_k + self.page_size - 1
-                    ) // self.page_size
-
-                    normal_decode_set_metadata(
-                        metadata.cache_seqlens_int32,
-                        metadata.cu_seqlens_k,
-                        metadata.page_table,
-                        self.req_to_token,
-                        req_pool_indices,
-                        self.decode_cuda_graph_metadata["strided_indices"],
-                        max_seq_pages,
-                        seq_lens,
-                        self.speculative_step_id + 1,
-                        self.page_size,
-                        metadata.swa_page_table,
-                        (
-                            self.token_to_kv_pool
-                            if self.use_sliding_window_kv_pool
-                            else None
-                        ),
-                    )
-
-                else:
-                    # When top k > 1, we need two specific draft decode metadata, and then merge states
-                    # 1. The first half of metadata for prefix tokens
-                    metadata = self.draft_decode_metadata_topk_normal[bs]
-                    if self.page_size > 1:
-                        # First attention handles seq_lens - last_page_lens if page size > 1.
-                        last_page_lens = seq_lens % self.page_size
-                        seq_lens = seq_lens - last_page_lens
-                    metadata.cache_seqlens_int32.copy_(seq_lens)
-                    # metadata.max_seq_len_q = self.topk, already set in capture
-                    # metadata.cu_seqlens_q already set in capture
-                    # metadata.cu_seqlens_k is not needed
-
-                    metadata.max_seq_len_k = seq_lens_cpu.max().item()
-                    max_seq_pages = (
-                        metadata.max_seq_len_k + self.page_size - 1
-                    ) // self.page_size
-                    strided_indices = self.decode_cuda_graph_metadata["strided_indices"]
-                    strided_indices = strided_indices[:max_seq_pages]
-                    page_table = (
-                        self.req_to_token[
-                            req_pool_indices[:, None],  # shape [bs, 1]
-                            strided_indices[None, :],  # shape [1, max_seq_pages]
-                        ]
-                        // self.page_size
-                    )
-                    metadata.page_table[:, :max_seq_pages].copy_(page_table)
-                    # 2. The second half of metadata for draft tokens (per_batch_num_tokens = topk)
-                    metadata_expand = self.draft_decode_metadata_topk_expand[bs]
-                    decode_length = self.speculative_step_id + 1
-                    # shape: [bs, num_steps, topk] -> [bs x topk, num_steps]
-                    cache_loc = out_cache_loc.view(-1, self.speculative_num_steps)
-                    if self.page_size > 1:
-                        draft_decode_set_expand_metadata(
-                            cache_seqlens_int32=metadata_expand.cache_seqlens_int32,
-                            page_table=metadata_expand.page_table,
-                            last_page_lens=last_page_lens,
-                            decode_length=decode_length,
-                            cache_loc=cache_loc,
-                            topk=self.topk,
-                            page_size=self.page_size,
-                        )
-                    else:
-                        num_seqs = cache_loc.shape[0]
-                        metadata_expand.page_table[:num_seqs, :decode_length].copy_(
-                            cache_loc[:, :decode_length]
-                        )
-                # TODO: Handle local attention metadata for draft decode when llama4 eagle is supported
-            else:
-                # Normal Decode
-                metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
-                max_seq_pages = (max_len + self.page_size - 1) // self.page_size
-                metadata.max_seq_len_k = max_len
-
-                normal_decode_set_metadata(
-                    metadata.cache_seqlens_int32,
-                    metadata.cu_seqlens_k,
-                    metadata.page_table,
-                    self.req_to_token,
-                    req_pool_indices,
-                    self.decode_cuda_graph_metadata["strided_indices"],
-                    max_seq_pages,
-                    seq_lens,
-                    0,
-                    self.page_size,
-                    metadata.swa_page_table,
-                    self.token_to_kv_pool if self.use_sliding_window_kv_pool else None,
-                )
-
-                self._maybe_update_local_attn_metadata_for_replay(
-                    metadata,
-                    bs,
-                )
-
-                # Recompute scheduler_metadata into pre-allocated buffer
-                if (
-                    self._sched_meta_buf is not None
-                    and metadata.scheduler_metadata is not None
-                ):
-                    sched = self._compute_scheduler_metadata(
-                        bs,
-                        metadata.max_seq_len_k,
-                        metadata.cache_seqlens_int32,
-                        metadata.cu_seqlens_q,
-                    )
-                    if sched is not None:
-                        n = sched.shape[0]
-                        self._sched_meta_buf[:n] = sched
-                        self._sched_meta_buf[n:] = 0
-
-        elif forward_mode.is_target_verify():
-            if self.topk <= 1:
-                metadata = self.target_verify_metadata[bs]
-                metadata.cache_seqlens_int32.copy_(
-                    (seq_lens + self.speculative_num_draft_tokens)
-                )
-
-                metadata.max_seq_len_k = (
-                    seq_lens_cpu.max().item() + self.speculative_num_draft_tokens
-                )
-                metadata.cu_seqlens_k[1:].copy_(
-                    torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-                )
-                max_seq_pages = (
-                    metadata.max_seq_len_k + self.page_size - 1
-                ) // self.page_size
-                page_indices = self.req_to_token[
-                    req_pool_indices[:, None],
-                    self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
-                ]
-                if (
-                    self.use_sliding_window_kv_pool
-                    and metadata.swa_page_table is not None
-                ):
-                    swa_page_indices = (
-                        self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                            page_indices
-                        )
-                    )
-                    metadata.swa_page_table[:, :max_seq_pages].copy_(
-                        swa_page_indices // self.page_size
-                    )
-                page_indices //= self.page_size
-                metadata.page_table[:, :max_seq_pages].copy_(page_indices)
-            else:
-                # When topk > 1, we need two specific target verify metadata, and then merge states
-                # 1. The first half of metadata for prefix tokens
-                metadata = self.target_verify_metadata_topk_normal[bs]
-                metadata.cache_seqlens_int32.copy_(seq_lens)
-                # metadata.max_seq_len_q = self.speculative_num_draft_tokens, already set in capture
-                metadata.max_seq_len_k = seq_lens_cpu.max().item()
-                # metadata.cu_seqlens_q already set in capture
-                metadata.cu_seqlens_k[1:].copy_(
-                    torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-                )
-                max_seq_pages = (
-                    metadata.max_seq_len_k + self.page_size - 1
-                ) // self.page_size
-                page_indices = self.req_to_token[
-                    req_pool_indices[:, None],
-                    self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
-                ]
-                page_indices //= self.page_size
-                metadata.page_table[:, :max_seq_pages].copy_(page_indices)
-
-                # 2. The second half of metadata for draft tokens (per_batch_num_tokens = topk)
-                metadata_expand = self.target_verify_metadata_topk_expand[bs]
-
-                # metadata_expand.max_seq_len_q = 1, already set in capture
-                # metadata_expand.cu_seqlens_q already set in capture
-                offsets = torch.arange(
-                    self.speculative_num_draft_tokens, device=device
-                ).unsqueeze(
-                    0
-                )  # shape: (1, self.speculative_num_draft_tokens)
-
-                cols = offsets.expand(seq_lens.numel(), -1) + seq_lens.unsqueeze(1)
-                cum_len = torch.nn.functional.pad(
-                    torch.cumsum(
-                        (
-                            seq_lens + self.speculative_num_draft_tokens
-                        ).repeat_interleave(self.speculative_num_draft_tokens),
-                        dim=0,
-                    ),
-                    (1, 0),
-                )[:-1]
-                mask_extraction_indices = (
-                    cols.repeat_interleave(self.speculative_num_draft_tokens, dim=0)
-                    + cum_len[:, None]
-                ).view(1, -1)
-                # avoid extracting padded seq indices which will be out of boundary
-                mask_extraction_indices[
-                    :,
-                    spec_info.positions.numel() * self.speculative_num_draft_tokens :,
-                ].fill_(0)
-                mask = spec_info.custom_mask[mask_extraction_indices].view(
-                    -1, self.speculative_num_draft_tokens
-                )  # (bsz * draft_num, draft_num)
-
-                col_indices = offsets.expand(
-                    mask.shape[0], self.speculative_num_draft_tokens
-                )
-                keys = torch.where(
-                    mask,
-                    col_indices,
-                    col_indices + self.speculative_num_draft_tokens,
-                )
-                _, sort_order = torch.sort(keys, dim=1)
-
-                non_masked_page_table = (
-                    self.req_to_token[req_pool_indices, :]
-                    .gather(1, cols)
-                    .repeat_interleave(self.speculative_num_draft_tokens, dim=0)
-                )  # (bsz, draft_num)
-
-                metadata_expand.page_table.copy_(
-                    non_masked_page_table.gather(1, sort_order)
-                )
-                metadata_expand.cache_seqlens_int32.copy_(mask.sum(dim=1))
-                metadata_expand.cu_seqlens_k[1:].copy_(
-                    torch.cumsum(
-                        metadata_expand.cache_seqlens_int32,
-                        dim=0,
-                        dtype=torch.int32,
-                    )
-                )
-                if self.has_swa:
-                    metadata_swa = self.target_verify_metadata_topk_swa[bs]
-                    self._init_sliding_window_attn_spec_metadata(
-                        metadata, metadata_expand, metadata_swa
-                    )
-
-        elif forward_mode.is_draft_extend():
-            metadata = self.draft_extend_metadata[bs]
-            metadata.cache_seqlens_int32.copy_(seq_lens)
-
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-            extend_lens = spec_info.num_accept_tokens[:bs]
-            if spec_info.num_accept_tokens_cpu:
-                metadata.max_seq_len_q = max(spec_info.num_accept_tokens_cpu)
-            else:
-                metadata.max_seq_len_q = 1
-
-            metadata.cu_seqlens_q[1:].copy_(
-                torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
-            )
-
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
-            ]
-            if self.use_sliding_window_kv_pool and metadata.swa_page_table is not None:
-                swa_page_indices = self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                    page_indices
-                )
-                metadata.swa_page_table[:, :max_seq_pages].copy_(
-                    swa_page_indices // self.page_size
-                )
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-
-        elif forward_mode.is_draft_extend_v2():
-            metadata = self.draft_extend_metadata[bs]
-            metadata.cache_seqlens_int32.copy_(seq_lens)
-
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-
-            extend_seq_lens_tensor = getattr(spec_info, "extend_seq_lens_tensor", None)
-            extend_seq_lens_cpu = getattr(spec_info, "extend_seq_lens_cpu", None)
-            if extend_seq_lens_tensor is not None:
-                extend_seq_lens = extend_seq_lens_tensor.to(torch.int32)
-            elif extend_seq_lens_cpu is not None:
-                extend_seq_lens = torch.as_tensor(
-                    extend_seq_lens_cpu,
-                    dtype=torch.int32,
-                    device=device,
-                )
-            else:
-                default_extend = getattr(
-                    spec_info, "num_tokens_per_req", self.speculative_num_steps + 1
-                )
-                extend_seq_lens = torch.full(
-                    (bs,), default_extend, dtype=torch.int32, device=device
-                )
-                extend_seq_lens_cpu = [default_extend] * bs
-
-            if extend_seq_lens_cpu:
-                metadata.max_seq_len_q = int(max(extend_seq_lens_cpu))
-            else:
-                metadata.max_seq_len_q = getattr(
-                    spec_info, "num_tokens_per_req", self.speculative_num_steps + 1
-                )
-
-            metadata.cu_seqlens_q[1:].copy_(
-                torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32)
-            )
-
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
-            ]
-            if self.use_sliding_window_kv_pool and metadata.swa_page_table is not None:
-                swa_page_indices = self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                    page_indices
-                )
-                metadata.swa_page_table[:, :max_seq_pages].copy_(
-                    swa_page_indices // self.page_size
-                )
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-
-        if encoder_lens is not None:
-            # Only support encoder size 1 for now
-            metadata.encoder_max_seq_len_k = encoder_lens[0]
-            metadata.encoder_lens_int32.copy_(encoder_lens[:1])
-            metadata.encoder_cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.encoder_lens_int32, dim=0, dtype=torch.int32)
-            )
-
-            metadata.encoder_page_table[:, : metadata.encoder_max_seq_len_k].copy_(
-                self.req_to_token[req_pool_indices, : metadata.encoder_max_seq_len_k]
-            )
-
-            # Update the regular page table
-            page_table = self.req_to_token[
-                req_pool_indices,
-                metadata.encoder_max_seq_len_k : (
-                    metadata.encoder_max_seq_len_k + metadata.max_seq_len_k
-                ),
-            ]
-            metadata.page_table[:, : metadata.max_seq_len_k].copy_(page_table)
 
         self.forward_metadata = metadata
         self.forward_metadata_spec_decode_expand = metadata_expand
@@ -2638,52 +2275,30 @@ class FlashAttentionMultiStepBackend:
                 )
             )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        forward_batch: ForwardBatch,
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
+
+        Both variants iterated per-step backends and called their
+        capture/replay variants; after step 03 both recurse into
+        ``init_forward_data_out_graph`` on the per-step backend.
+
+        TODO: incrementally update metadata for later steps, so they don't
+        need to recompute everything from scratch -- previously done in the
+        replay variant; lost in the initial-stage merge.
+        """
         assert forward_batch.spec_info is not None
         assert forward_batch.spec_info.is_draft_input()
 
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=forward_batch.encoder_lens,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
-        assert forward_batch.spec_info is not None
-        assert forward_batch.spec_info.is_draft_input()
-
-        for i in range(self.speculative_num_steps - 1):
-            # TODO: incrementally update the metadata for the later steps,
-            # so that they do not need to recompute everything from scratch.
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                forward_batch.seq_lens_sum,
-                encoder_lens=forward_batch.encoder_lens,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-                out_cache_loc=forward_batch.out_cache_loc,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1591,11 +1591,26 @@ class FlashInferMultiStepDraftBackend:
         backends' capture/replay variants; after step 03 both recurse into
         ``init_forward_data_out_graph`` on the per-step backend.
         """
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
 
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return
 
 
 def should_use_tensor_core(

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -727,7 +727,7 @@ class FlashInferAttnBackend(AttentionBackend):
             )
             self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(prefill_wrappers, True, False)
-        elif forward_mode.is_extend_or_mixed():
+        elif forward_mode.is_extend_or_draft_extend_or_mixed():
             # Prefill / extend path -- invoked by piecewise / breakable cuda
             # graph capture for non-decode modes. Mirrors the eager body's
             # ``else:`` clause; reads the live ``req_to_token_pool`` view

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -727,6 +727,48 @@ class FlashInferAttnBackend(AttentionBackend):
             )
             self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(prefill_wrappers, True, False)
+        elif forward_mode.is_extend_or_mixed():
+            # Prefill / extend path -- invoked by piecewise / breakable cuda
+            # graph capture for non-decode modes. Mirrors the eager body's
+            # ``else:`` clause; reads the live ``req_to_token_pool`` view
+            # (no pre-allocated buffer reuse, like the eager path).
+            prefix_lens = forward_batch.extend_prefix_lens
+
+            if self.is_multimodal or self.enable_mis:
+                use_ragged = False
+                extend_no_prefix = False
+            else:
+                use_ragged = (
+                    not self.enable_deterministic
+                    and not is_in_piecewise_cuda_graph()
+                    and not self.use_paged
+                )
+                extend_no_prefix = not any(forward_batch.extend_prefix_lens_cpu)
+
+            multi_item_params = MultiItemScoringParams()
+            if self.enable_mis:
+                multi_item_params = self._process_multi_item_scoring(forward_batch)
+
+            self.indices_updater_prefill.update(
+                req_pool_indices,
+                seq_lens,
+                forward_batch.seq_lens_cpu,
+                forward_batch.seq_lens_sum,
+                prefix_lens,
+                prefill_wrappers=self.prefill_wrappers_paged,
+                use_ragged=use_ragged,
+                encoder_lens=encoder_lens,
+                spec_info=None,
+                fixed_split_size=self.prefill_split_tile_size,
+                multi_item_params=multi_item_params,
+                cross_attention_custom_mask=forward_batch.cross_attention_custom_mask,
+            )
+            self.forward_metadata = PrefillMetadata(
+                self.prefill_wrappers_paged,
+                use_ragged,
+                extend_no_prefix,
+                multi_item_params,
+            )
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -433,7 +433,8 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for the eager path."""
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 forward_batch.req_pool_indices,
@@ -559,16 +560,33 @@ class FlashInferAttnBackend(AttentionBackend):
             self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
             self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body taken from the old ``init_forward_metadata_capture_cuda_graph`` --
+        capture and replay had structurally different bodies (capture builds
+        a fresh wrapper per bs and stores it in
+        ``decode_cuda_graph_metadata[bs]`` / ``prefill_cuda_graph_metadata[bs]``;
+        replay reused the cached wrapper). Per the initial-stage scope we
+        keep the capture body and accept the wrapper-rebuild cost at each
+        replay; the replay-time fast path may be restored by a follow-up
+        per-backend optimization PR.
+        """
+        bs = forward_batch.batch_size
+        # ``num_tokens == bs * num_tokens_per_bs``. ``positions`` is the only
+        # fb field always sized to ``num_tokens`` across direct (cuda_graph_runner)
+        # and multi-step-wrapper (eagle_draft_cuda_graph_runner) callers --
+        # ``input_ids`` is None in the multi-step wrapper's synthetic fb.
+        num_tokens = (
+            forward_batch.positions.shape[0]
+            if forward_batch.positions is not None
+            else bs
+        )
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        encoder_lens = forward_batch.encoder_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
             for i in range(self.num_wrappers):
@@ -711,68 +729,6 @@ class FlashInferAttnBackend(AttentionBackend):
             self.forward_metadata = PrefillMetadata(prefill_wrappers, True, False)
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        if forward_mode.is_decode_or_idle():
-            self.indices_updater_decode.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
-                seq_lens_sum,
-                decode_wrappers=self.decode_cuda_graph_metadata[bs],
-                encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
-                spec_info=spec_info,
-                fixed_split_size=None,
-                disable_split_kv=self.disable_cuda_graph_kv_split,
-            )
-        elif forward_mode.is_target_verify():
-            self.indices_updater_prefill.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
-                seq_lens_sum,
-                prefix_lens=None,
-                prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
-                use_ragged=False,
-                encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
-                spec_info=spec_info,
-            )
-        elif forward_mode.is_draft_extend():
-            self.indices_updater_prefill.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
-                seq_lens_sum,
-                prefix_lens=None,
-                prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
-                use_ragged=False,
-                encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
-                spec_info=spec_info,
-            )
-        elif forward_mode.is_dllm_extend():
-            self.indices_updater_prefill.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
-                seq_lens_sum,
-                prefix_lens=seq_lens - self.dllm_config.block_size,
-                prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
-                use_ragged=not self.use_paged,
-                encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
-                spec_info=None,
-            )
-        else:
-            raise ValueError("Invalid forward mode")
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
@@ -1595,7 +1551,7 @@ class FlashInferMultiStepDraftBackend:
 
         global_override_indptr_cpu = None
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
@@ -1612,7 +1568,7 @@ class FlashInferMultiStepDraftBackend:
             forward_batch.spec_info.kv_indices = (
                 forward_batch.spec_info.kv_indices.clone()
             )
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
         self.common_template(forward_batch, kv_indices, call_fn)
 
@@ -1628,34 +1584,16 @@ class FlashInferMultiStepDraftBackend:
                 max_bs, max_num_tokens, kv_indices_buf=self.cuda_graph_kv_indices[i]
             )
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-        self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
+        Both variants dispatched through ``common_template`` to per-step
+        backends' capture/replay variants; after step 03 both recurse into
+        ``init_forward_data_out_graph`` on the per-step backend.
+        """
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
         def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                seq_lens_sum=-1,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
 

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -22,7 +22,7 @@ from sglang.srt.layers.attention.flashinfer_backend import (
     create_flashinfer_kv_indices_triton,
 )
 from sglang.srt.layers.dp_attention import get_attention_tp_size
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import (
@@ -289,7 +289,8 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         self.decode_cuda_graph_metadata = {}
         self.prefill_cuda_graph_metadata = {}  # For verify
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for the eager path."""
         if forward_batch.forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
                 forward_batch.req_pool_indices,
@@ -374,16 +375,23 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             "kv_indices": self.cuda_graph_kv_indices,
         }
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body taken from the old ``init_forward_metadata_capture_cuda_graph`` --
+        capture and replay had structurally different bodies (capture builds a
+        fresh ``BatchMLAPagedAttentionWrapper`` per bs, replay reuses the
+        cached one via ``init_metadata_replay=True`` + ``fast_decode_kwargs``).
+        Per the initial-stage scope we keep the capture body and accept the
+        wrapper-rebuild cost at replay; the replay-time fast path may be
+        restored by a follow-up per-backend optimization PR.
+        """
+        bs = forward_batch.batch_size
+        num_tokens = bs
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         if forward_mode.is_decode_or_idle():
             decode_wrapper = BatchMLAPagedAttentionWrapper(
                 self.workspace_buffer,
@@ -453,63 +461,6 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             self.forward_metadata = PrefillMetadata(draft_extend_wrapper, False)
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        if forward_mode.is_decode_or_idle():
-            assert seq_lens_cpu is not None
-            kv_len_arr_cpu = seq_lens_cpu[:bs]
-            self.cuda_graph_kv_indptr_cpu[1 : bs + 1] = torch.cumsum(
-                kv_len_arr_cpu, dim=0
-            )
-            self.fast_decode_kwargs.update(
-                {
-                    "qo_indptr_cpu": self.cuda_graph_qo_indptr_cpu[: bs + 1],
-                    "kv_indptr_cpu": self.cuda_graph_kv_indptr_cpu[: bs + 1],
-                    "kv_len_arr_cpu": kv_len_arr_cpu,
-                }
-            )
-
-            self.indices_updater_decode.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_sum,
-                decode_wrapper=self.decode_cuda_graph_metadata[bs],
-                init_metadata_replay=True,
-                spec_info=spec_info,
-                **self.fast_decode_kwargs,
-            )
-        elif forward_mode.is_target_verify():
-            self.indices_updater_prefill.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_sum,
-                prefix_lens=None,
-                prefill_wrapper_paged=self.prefill_cuda_graph_metadata[bs],
-                use_ragged=False,
-                spec_info=spec_info,
-            )
-        elif forward_mode.is_draft_extend():
-            self.indices_updater_prefill.update(
-                req_pool_indices[:bs],
-                seq_lens[:bs],
-                seq_lens_sum,
-                prefix_lens=None,
-                prefill_wrapper_paged=self.prefill_cuda_graph_metadata[bs],
-                use_ragged=False,
-                spec_info=spec_info,
-            )
-        else:
-            raise ValueError(f"Invalid forward mode: {forward_mode=}")
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
@@ -984,7 +935,7 @@ class FlashInferMLAMultiStepDraftBackend:
             ]
             call_fn(i, forward_batch)
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         kv_indices = torch.zeros(
             (
                 self.speculative_num_steps,
@@ -1001,7 +952,7 @@ class FlashInferMLAMultiStepDraftBackend:
             forward_batch.spec_info.kv_indices = (
                 forward_batch.spec_info.kv_indices.clone()
             )
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
         self.common_template(forward_batch, kv_indices, call_fn)
 
@@ -1017,34 +968,16 @@ class FlashInferMLAMultiStepDraftBackend:
                 max_bs, max_num_tokens, kv_indices_buf=self.cuda_graph_kv_indices[i]
             )
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
-        def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
 
-        self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
+        Both variants dispatched into ``common_template`` and per-step called
+        the underlying backend's capture/replay variant; after step 03 both
+        recurse into ``init_forward_data_out_graph`` on the per-step backend.
+        """
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
         def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                seq_lens_sum=-1,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
 

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -459,7 +459,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             )
             self.prefill_cuda_graph_metadata[bs] = draft_extend_wrapper
             self.forward_metadata = PrefillMetadata(draft_extend_wrapper, False)
-        elif forward_mode.is_extend_or_mixed():
+        elif forward_mode.is_extend_or_draft_extend_or_mixed():
             # Prefill / extend path -- invoked by piecewise / breakable cuda
             # graph capture for non-decode modes. Mirrors the eager body's
             # ``else:`` clause: build prefill metadata from the live

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -975,11 +975,26 @@ class FlashInferMLAMultiStepDraftBackend:
         the underlying backend's capture/replay variant; after step 03 both
         recurse into ``init_forward_data_out_graph`` on the per-step backend.
         """
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
 
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return
 
 
 def fast_mla_decode_plan(

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -459,6 +459,31 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             )
             self.prefill_cuda_graph_metadata[bs] = draft_extend_wrapper
             self.forward_metadata = PrefillMetadata(draft_extend_wrapper, False)
+        elif forward_mode.is_extend_or_mixed():
+            # Prefill / extend path -- invoked by piecewise / breakable cuda
+            # graph capture for non-decode modes. Mirrors the eager body's
+            # ``else:`` clause: build prefill metadata from the live
+            # ``req_to_token_pool`` view (no pre-allocated buffer reuse).
+            prefix_lens = forward_batch.extend_prefix_lens
+            extend_no_prefix = not any(forward_batch.extend_prefix_lens_cpu)
+            # PCG uses paged prefill for prefix-cache compat; check current scope.
+            use_ragged = (
+                not get_global_server_args().flashinfer_mla_disable_ragged
+                and extend_no_prefix
+                and not is_in_piecewise_cuda_graph()
+            )
+
+            self.indices_updater_prefill.update(
+                req_pool_indices,
+                seq_lens,
+                forward_batch.seq_lens_sum,
+                prefix_lens,
+                prefill_wrapper_paged=self.prefill_wrapper_paged,
+                use_ragged=use_ragged,
+            )
+            self.forward_metadata = PrefillMetadata(
+                self.prefill_wrapper_paged, use_ragged
+            )
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
 

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -187,8 +187,15 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
         forward_mode = forward_batch.forward_mode
+        # OLD replay variant read max via ``seq_lens_cpu.max().item()`` -- no
+        # device->host sync per replay. Use seq_lens_cpu when available;
+        # fall back to the GPU path for capture warmup (no _cpu mirror yet).
+        seq_lens_cpu = forward_batch.seq_lens_cpu
         if forward_mode.is_decode_or_idle():
-            max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
+            if seq_lens_cpu is not None:
+                max_seqlen_pad = triton.cdiv(int(seq_lens_cpu.max().item()), PAGE_SIZE)
+            else:
+                max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
 
             create_flashmla_kv_indices_triton[(bs,)](
                 self.req_to_token,
@@ -230,7 +237,12 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
 
         elif forward_mode.is_target_verify():
             seq_lens = seq_lens + self.num_draft_tokens
-            max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
+            if seq_lens_cpu is not None:
+                max_seqlen_pad = triton.cdiv(
+                    int(seq_lens_cpu.max().item()) + self.num_draft_tokens, PAGE_SIZE
+                )
+            else:
+                max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
 
             create_flashmla_kv_indices_triton[(bs,)](
                 self.req_to_token,

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -478,7 +478,23 @@ class FlashMLAMultiStepDraftBackend:
             )
 
     def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
+
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, call_fn)
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -20,7 +20,6 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-    from sglang.srt.speculative.spec_info import SpecInput
 
 
 PAGE_SIZE = 64
@@ -84,7 +83,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         self.cuda_graph_mla_metadata_view = None
         self.cuda_graph_num_splits_view = None
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         bs = forward_batch.batch_size
         if forward_batch.forward_mode.is_decode_or_idle():
             max_seqlen_pad = triton.cdiv(
@@ -148,7 +147,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 block_kv_indices,
             )
         else:
-            super().init_forward_metadata(forward_batch)
+            super().init_forward_data(forward_batch)
 
     def init_cuda_graph_state(
         self,
@@ -183,16 +182,14 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         self.cuda_graph_mla_metadata_view = None
         self.cuda_graph_num_splits_view = None
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        bs = forward_batch.batch_size
+        num_tokens = bs
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        encoder_lens = forward_batch.encoder_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         if forward_mode.is_decode_or_idle():
             max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
 
@@ -280,117 +277,6 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 encoder_lens,
                 forward_mode,
                 spec_info,
-            )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        if forward_mode.is_decode_or_idle():
-            assert seq_lens_cpu is not None
-            seq_lens = seq_lens[:bs]
-            seq_lens_cpu = seq_lens_cpu[:bs]
-            max_seqlen_pad = triton.cdiv(seq_lens_cpu.max().item(), PAGE_SIZE)
-
-            create_flashmla_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices[:bs],
-                seq_lens,
-                None,
-                self.cuda_graph_kv_indices,
-                self.req_to_token.stride(0),
-                self.cuda_graph_kv_indices.stride(0),
-            )
-            num_q_heads = self.num_q_heads
-
-            mla_metadata, num_splits = get_mla_metadata(
-                seq_lens.to(torch.int32),
-                num_q_heads,
-                1,
-                is_fp8_kvcache=self.is_fp8_kvcache,
-            )
-
-            actual_num_sm_parts = mla_metadata.shape[0]
-
-            if actual_num_sm_parts != self.cuda_graph_mla_metadata_view.shape[0]:
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(
-                    f"num_sm_parts mismatch in CUDA Graph replay: "
-                    f"capture={self.cuda_graph_mla_metadata_view.shape[0]}, "
-                    f"replay={actual_num_sm_parts}. "
-                    f"This may indicate batch size changed between capture and replay."
-                )
-                self.cuda_graph_mla_metadata_view = self.cuda_graph_mla_metadata[
-                    :actual_num_sm_parts
-                ]
-                self.cuda_graph_num_splits_view = self.cuda_graph_num_splits[: bs + 1]
-
-            self.cuda_graph_mla_metadata[:actual_num_sm_parts].copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-
-            self.forward_metadata.mla_metadata = self.cuda_graph_mla_metadata_view
-            self.forward_metadata.num_splits = self.cuda_graph_num_splits_view
-            self.forward_metadata.block_kv_indices = self.cuda_graph_kv_indices[
-                :bs, :max_seqlen_pad
-            ]
-
-        elif forward_mode.is_target_verify():
-            seq_lens = seq_lens[:bs] + self.num_draft_tokens
-            seq_lens_cpu = seq_lens_cpu[:bs] + self.num_draft_tokens
-            max_seqlen_pad = triton.cdiv(seq_lens_cpu.max().item(), PAGE_SIZE)
-
-            create_flashmla_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices[:bs],
-                seq_lens,
-                None,
-                self.cuda_graph_kv_indices,
-                self.req_to_token.stride(0),
-                self.cuda_graph_kv_indices.stride(0),
-            )
-
-            mla_metadata, num_splits = get_mla_metadata(
-                seq_lens.to(torch.int32),
-                self.num_draft_tokens * self.num_q_heads,
-                1,
-                is_fp8_kvcache=self.is_fp8_kvcache,
-            )
-
-            actual_num_sm_parts = mla_metadata.shape[0]
-
-            if actual_num_sm_parts != self.cuda_graph_mla_metadata_view.shape[0]:
-                self.cuda_graph_mla_metadata_view = self.cuda_graph_mla_metadata[
-                    :actual_num_sm_parts
-                ]
-                self.cuda_graph_num_splits_view = self.cuda_graph_num_splits[: bs + 1]
-
-            self.cuda_graph_mla_metadata[:actual_num_sm_parts].copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-
-            self.forward_metadata.mla_metadata = self.cuda_graph_mla_metadata_view
-            self.forward_metadata.num_splits = self.cuda_graph_num_splits_view
-            self.forward_metadata.block_kv_indices = self.cuda_graph_kv_indices[
-                :bs, :max_seqlen_pad
-            ]
-        else:
-            super().init_forward_metadata_replay_cuda_graph(
-                bs,
-                req_pool_indices,
-                seq_lens,
-                seq_lens_sum,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-                seq_lens_cpu,
             )
 
     def get_cuda_graph_seq_len_fill_value(self):
@@ -589,10 +475,10 @@ class FlashMLAMultiStepDraftBackend:
         for i in range(self.speculative_num_steps - 1):
             call_fn(i, forward_batch)
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         def call_fn(i, forward_batch):
             assert forward_batch.spec_info is not None
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
         self.common_template(forward_batch, call_fn)
 
@@ -602,39 +488,8 @@ class FlashMLAMultiStepDraftBackend:
                 max_bs, max_num_tokens, block_kv_indices=None
             )
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
         def call_fn(i, forward_batch):
-            # EAGLE draft worker uses DECODE mode for draft steps
-            from sglang.srt.model_executor.forward_batch_info import ForwardMode
-
-            # Create a dummy forward_mode for draft step
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
-
-        self.common_template(forward_batch, call_fn)
-
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
-        def call_fn(i, forward_batch):
-            from sglang.srt.model_executor.forward_batch_info import ForwardMode
-
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                seq_lens_sum=-1,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, call_fn)

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -184,12 +184,9 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
 
     def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
         bs = forward_batch.batch_size
-        num_tokens = bs
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens
-        encoder_lens = forward_batch.encoder_lens
         forward_mode = forward_batch.forward_mode
-        spec_info = forward_batch.spec_info
         if forward_mode.is_decode_or_idle():
             max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
 
@@ -269,15 +266,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 self.cuda_graph_kv_indices[:bs, :max_seqlen_pad],
             )
         else:
-            super().init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-            )
+            super().init_forward_data_out_graph(forward_batch)
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -75,6 +75,17 @@ class HybridAttnBackend(AttentionBackend):
         backend = self._select_backend(forward_batch.forward_mode)
         backend.init_forward_data_out_graph(forward_batch)
 
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Dispatcher in-graph init -- forward to the selected backend.
+
+        Required override: the ABC default is no-op, but if a follow-up
+        per-backend PR overrides ``_in_graph`` on either decode_backend or
+        prefill_backend, the hybrid dispatcher must reach that override
+        instead of silently swallowing it. Mirrors ``TboAttnBackend``.
+        """
+        backend = self._select_backend(forward_batch.forward_mode)
+        backend.init_forward_data_in_graph(forward_batch)
+
     def get_cuda_graph_seq_len_fill_value(self):
         return self.decode_backend.get_cuda_graph_seq_len_fill_value()
 

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -7,7 +7,6 @@ from sglang.srt.layers.attention.dsa.dsa_indexer import BaseIndexerMetadata
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.speculative.spec_info import SpecInput
 
 
 class HybridAttnBackend(AttentionBackend):
@@ -52,9 +51,9 @@ class HybridAttnBackend(AttentionBackend):
         else:
             return self.prefill_backend
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         backend = self._select_backend(forward_batch.forward_mode)
-        backend.init_forward_metadata(forward_batch)
+        backend.init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.decode_backend.init_cuda_graph_state(max_bs, max_num_tokens)
@@ -66,49 +65,15 @@ class HybridAttnBackend(AttentionBackend):
             # that will be used for target_verify.
             self.prefill_backend.init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
-        backend = self._select_backend(forward_mode)
-        backend.init_forward_metadata_capture_cuda_graph(
-            bs,
-            num_tokens,
-            req_pool_indices,
-            seq_lens,
-            encoder_lens,
-            forward_mode,
-            spec_info,
-        )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        backend = self._select_backend(forward_mode)
-        backend.init_forward_metadata_replay_cuda_graph(
-            bs,
-            req_pool_indices,
-            seq_lens,
-            seq_lens_sum,
-            encoder_lens,
-            forward_mode,
-            spec_info,
-            seq_lens_cpu,
-        )
+        Merged from old capture/replay variants: both selected the same
+        underlying backend by forward_mode and forwarded; the new contract
+        delegates via the underlying backend's ``init_forward_data_out_graph``.
+        """
+        backend = self._select_backend(forward_batch.forward_mode)
+        backend.init_forward_data_out_graph(forward_batch)
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.decode_backend.get_cuda_graph_seq_len_fill_value()

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -198,7 +198,7 @@ class MambaAttnBackendBase(AttentionBackend):
             )
         elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
             if forward_batch.forward_mode.is_draft_extend_v2():
-                # HybridLinearAttnBackend.init_forward_metadata calls all sub-backends
+                # HybridLinearAttnBackend.init_forward_data calls all sub-backends
                 # unconditionally, but DRAFT_EXTEND_V2 only runs full-attn layers in
                 # the draft model, so mamba metadata can be skipped.
                 query_start_loc = None
@@ -264,7 +264,7 @@ class MambaAttnBackendBase(AttentionBackend):
             has_mamba_track_mask=has_mamba_track_mask,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         self._execute_deferred_mamba_cow_and_clear(forward_batch)
         self.forward_metadata = self._forward_metadata(forward_batch)
 
@@ -390,34 +390,37 @@ class MambaAttnBackendBase(AttentionBackend):
             track_ssm_final_dst.to(self.device, non_blocking=True),
         )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-    ):
-        self.forward_metadata = self._capture_metadata(
-            bs, req_pool_indices, forward_mode, spec_info
-        )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        self.forward_metadata = self._replay_metadata(
-            bs, req_pool_indices, forward_mode, spec_info, seq_lens_cpu
-        )
+        Dispatches to ``_capture_metadata`` at capture (no real seq_lens /
+        spec_info data yet) and ``_replay_metadata`` at replay (real data +
+        per-iter padding handling). The two helpers have different bodies
+        because at capture ``seq_lens_cpu`` is uniformly the fill value
+        and ``spec_info`` tensors are None, while at replay both carry real
+        data; merging into a single body would require multiple None-guards.
+
+        Capture is detected via ``get_is_capture_mode()`` (set by the cuda
+        graph runner around its capture context).
+        """
+        from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
+        if get_is_capture_mode():
+            self.forward_metadata = self._capture_metadata(
+                bs, req_pool_indices, forward_mode, spec_info
+            )
+        else:
+            self.forward_metadata = self._replay_metadata(
+                bs,
+                req_pool_indices,
+                forward_mode,
+                spec_info,
+                forward_batch.seq_lens_cpu,
+            )
 
     def init_forward_metadata_capture_cpu_graph(
         self,
@@ -670,7 +673,7 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
         assert config is not None
         self.mamba_chunk_size = config.mamba_chunk_size
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         self._execute_deferred_mamba_cow_and_clear(forward_batch)
         metadata = self._forward_metadata(forward_batch)
         self.forward_metadata = Mamba2Metadata.prepare_mixed(
@@ -679,39 +682,33 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
             forward_batch,
         )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-    ):
-        metadata = self._capture_metadata(bs, req_pool_indices, forward_mode, spec_info)
-        draft_token_num = spec_info.draft_token_num if spec_info is not None else 1
-        self.forward_metadata = Mamba2Metadata.prepare_decode(
-            metadata,
-            seq_lens,
-            is_target_verify=forward_mode.is_target_verify(),
-            draft_token_num=draft_token_num,
-        )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        metadata = self._replay_metadata(
-            bs, req_pool_indices, forward_mode, spec_info, seq_lens_cpu
-        )
+        Dispatches to ``_capture_metadata`` / ``_replay_metadata`` -- see
+        ``MambaAttnBackendBase.init_forward_data_out_graph`` for the rationale
+        (capture-time placeholders vs replay-time real data + padding). Wraps
+        the resulting base ForwardMetadata with ``Mamba2Metadata.prepare_decode``.
+        """
+        from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
+        if get_is_capture_mode():
+            metadata = self._capture_metadata(
+                bs, req_pool_indices, forward_mode, spec_info
+            )
+        else:
+            metadata = self._replay_metadata(
+                bs,
+                req_pool_indices,
+                forward_mode,
+                spec_info,
+                forward_batch.seq_lens_cpu,
+            )
         draft_token_num = spec_info.draft_token_num if spec_info is not None else 1
         self.forward_metadata = Mamba2Metadata.prepare_decode(
             metadata,
@@ -782,9 +779,9 @@ class HybridLinearAttnBackend(AttentionBackend):
         assert layer_id is not None, "either layer or layer_id must be provided"
         return layer_id in self.full_attn_layers
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         for attn_backend in self.attn_backend_list:
-            attn_backend.init_forward_metadata(forward_batch)
+            attn_backend.init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for attn_backend in self.attn_backend_list:
@@ -794,26 +791,16 @@ class HybridLinearAttnBackend(AttentionBackend):
         for attn_backend in self.attn_backend_list:
             attn_backend.init_cpu_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Merged from old capture/replay variants: both fan out to all
+        sub-backends (full_attn + linear_attn) by forwarding the per-iter
+        prep call. The new contract delegates via each sub-backend's
+        ``init_forward_data_out_graph``.
+        """
         for attn_backend in self.attn_backend_list:
-            attn_backend.init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-            )
+            attn_backend.init_forward_data_out_graph(forward_batch)
 
     def init_forward_metadata_capture_cpu_graph(
         self,
@@ -834,29 +821,6 @@ class HybridLinearAttnBackend(AttentionBackend):
                 encoder_lens,
                 forward_mode,
                 spec_info,
-            )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        for attn_backend in self.attn_backend_list:
-            attn_backend.init_forward_metadata_replay_cuda_graph(
-                bs,
-                req_pool_indices,
-                seq_lens,
-                seq_lens_sum,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-                seq_lens_cpu,
             )
 
     def get_cuda_graph_seq_len_fill_value(self):

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -802,6 +802,17 @@ class HybridLinearAttnBackend(AttentionBackend):
         for attn_backend in self.attn_backend_list:
             attn_backend.init_forward_data_out_graph(forward_batch)
 
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Dispatcher in-graph init -- fan out to all sub-backends.
+
+        Required override: the ABC default is no-op, but if a follow-up
+        per-backend PR overrides ``_in_graph`` on any sub-backend, the
+        hybrid dispatcher must reach that override. Mirrors
+        ``TboAttnBackend.init_forward_data_in_graph``.
+        """
+        for attn_backend in self.attn_backend_list:
+            attn_backend.init_forward_data_in_graph(forward_batch)
+
     def init_forward_metadata_capture_cpu_graph(
         self,
         bs: int,

--- a/python/sglang/srt/layers/attention/intel_amx_backend.py
+++ b/python/sglang/srt/layers/attention/intel_amx_backend.py
@@ -41,7 +41,7 @@ class IntelAMXAttnBackend(AttentionBackend):
         self.decode_attention_fwd = torch.ops.sgl_kernel.decode_attention_cpu
         self.extend_attention_fwd = torch.ops.sgl_kernel.extend_attention_cpu
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Init the metadata for a forward pass."""
 
         bs = forward_batch.batch_size

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -263,8 +263,8 @@ class GDNAttnBackend(MambaAttnBackendBase):
             self.req_to_token_pool.size, dtype=torch.int32, device=model_runner.device
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        super().init_forward_metadata(forward_batch)
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        super().init_forward_data(forward_batch)
         if self.forward_metadata.has_mamba_track_mask:
             self.forward_metadata.mamba_track_mask_indices = (
                 forward_batch.mamba_track_mask.nonzero(as_tuple=True)[0]

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -1,6 +1,5 @@
 import logging
 import math
-from typing import Optional, Union
 
 import torch
 
@@ -12,9 +11,8 @@ from sglang.srt.layers.attention.linear.lightning_attn import (
 from sglang.srt.layers.attention.linear.linear_metadata import BailingLinearMetadata
 from sglang.srt.layers.attention.linear.seg_la import SegLaMeta, seg_la_fwd
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +65,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             f"linear_backend for linear attention in hybrid_linear_backend: {self.linear_backend}"
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         metadata = self._forward_metadata(forward_batch)
         self.forward_metadata = BailingLinearMetadata.prepare_mixed(
             metadata.query_start_loc,
@@ -75,35 +73,33 @@ class LightningAttentionBackend(MambaAttnBackendBase):
             forward_batch,
         )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-    ):
-        metadata = self._capture_metadata(bs, req_pool_indices, forward_mode, spec_info)
-        self.forward_metadata = BailingLinearMetadata.prepare_decode(
-            metadata.query_start_loc, metadata.mamba_cache_indices, bs, seq_lens
-        )
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        metadata = self._replay_metadata(
-            bs, req_pool_indices, forward_mode, spec_info, seq_lens_cpu
-        )
+        Dispatches to ``_capture_metadata`` / ``_replay_metadata`` -- see
+        ``MambaAttnBackendBase.init_forward_data_out_graph`` for the rationale
+        (capture-time placeholders vs replay-time real data + padding). Wraps
+        the resulting base ForwardMetadata with ``BailingLinearMetadata.prepare_decode``.
+        """
+        from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
+        if get_is_capture_mode():
+            metadata = self._capture_metadata(
+                bs, req_pool_indices, forward_mode, spec_info
+            )
+        else:
+            metadata = self._replay_metadata(
+                bs,
+                req_pool_indices,
+                forward_mode,
+                spec_info,
+                forward_batch.seq_lens_cpu,
+            )
         self.forward_metadata = BailingLinearMetadata.prepare_decode(
             metadata.query_start_loc, metadata.mamba_cache_indices, bs, seq_lens
         )

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Callable, List
+import contextlib
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 
@@ -15,6 +16,14 @@ class TboAttnBackend(AttentionBackend):
         # reads through TboAttnBackend resolve to the underlying pool.
         self.token_to_kv_pool = primary.token_to_kv_pool
         self.req_to_token_pool = primary.req_to_token_pool
+        # FIXME: side channel propagated to primary and each child at replay.
+        # Some inner backends (dsv4 / dsa) discriminate capture vs replay via
+        # ``self._replay_forward_batch``; the dispatcher must mirror the value
+        # set by ``cuda_graph_runner.replay_prepare`` onto each inner backend
+        # before recursing, else inner backends silently take the capture
+        # branch at replay and rebuild metadata that the captured graph holds
+        # capture-time pointers for. Step 04 removes the side channel.
+        self._replay_forward_batch: Optional["ForwardBatch"] = None
 
     @classmethod
     def init_new(cls, creator: Callable[[], AttentionBackend]):
@@ -22,6 +31,34 @@ class TboAttnBackend(AttentionBackend):
             primary=creator(),
             children=[creator() for _ in range(2)],
         )
+
+    @contextlib.contextmanager
+    def _propagate_replay_forward_batch(self):
+        """Mirror ``self._replay_forward_batch`` onto primary and each child
+        for the duration of the dispatch, then clear on exit.
+
+        ``cuda_graph_runner.replay_prepare`` sets the side channel on the
+        outer TboAttnBackend only; inner backends (dsv4 / dsa) need it set
+        on themselves to take their replay branch. Capture-path callers
+        leave ``_replay_forward_batch=None`` and this becomes a no-op.
+        """
+        replay_fb = self._replay_forward_batch
+        if replay_fb is None:
+            yield
+            return
+        if hasattr(self.primary, "_replay_forward_batch"):
+            self.primary._replay_forward_batch = replay_fb
+        for child in self.children:
+            if hasattr(child, "_replay_forward_batch"):
+                child._replay_forward_batch = replay_fb
+        try:
+            yield
+        finally:
+            if hasattr(self.primary, "_replay_forward_batch"):
+                self.primary._replay_forward_batch = None
+            for child in self.children:
+                if hasattr(child, "_replay_forward_batch"):
+                    child._replay_forward_batch = None
 
     def init_forward_data(self, forward_batch: "ForwardBatch") -> None:
         """Dispatcher eager wrapper -- recurse to primary + (optional) children."""
@@ -40,14 +77,18 @@ class TboAttnBackend(AttentionBackend):
         step 03 contract; child-fb split details that the old asymmetric
         capture/replay variants assembled are now derived per-backend
         directly from the (already-split-by-caller) ``forward_batch.tbo_children``.
+        At replay, ``_replay_forward_batch`` is fanned out to primary/children
+        so inner DSV4/DSA backends take their replay branch (not the capture
+        branch, which would rebuild metadata into freshly-allocated tensors).
         """
-        self.primary.init_forward_data_out_graph(forward_batch)
-        if forward_batch.tbo_children is not None:
-            for child, forward_batch_child in zip(
-                self.children, forward_batch.tbo_children, strict=True
-            ):
-                if forward_batch_child.batch_size > 0:
-                    child.init_forward_data_out_graph(forward_batch_child)
+        with self._propagate_replay_forward_batch():
+            self.primary.init_forward_data_out_graph(forward_batch)
+            if forward_batch.tbo_children is not None:
+                for child, forward_batch_child in zip(
+                    self.children, forward_batch.tbo_children, strict=True
+                ):
+                    if forward_batch_child.batch_size > 0:
+                        child.init_forward_data_out_graph(forward_batch_child)
 
     def init_forward_data_in_graph(self, forward_batch: "ForwardBatch") -> None:
         """Dispatcher in-graph init -- recurse to primary + (optional) children.
@@ -56,13 +97,14 @@ class TboAttnBackend(AttentionBackend):
         ``_in_graph`` (none in the initial stage; reserved for future
         per-backend perf PRs) is correctly reached through this dispatcher.
         """
-        self.primary.init_forward_data_in_graph(forward_batch)
-        if forward_batch.tbo_children is not None:
-            for child, forward_batch_child in zip(
-                self.children, forward_batch.tbo_children, strict=True
-            ):
-                if forward_batch_child.batch_size > 0:
-                    child.init_forward_data_in_graph(forward_batch_child)
+        with self._propagate_replay_forward_batch():
+            self.primary.init_forward_data_in_graph(forward_batch)
+            if forward_batch.tbo_children is not None:
+                for child, forward_batch_child in zip(
+                    self.children, forward_batch.tbo_children, strict=True
+                ):
+                    if forward_batch_child.batch_size > 0:
+                        child.init_forward_data_in_graph(forward_batch_child)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.primary.init_cuda_graph_state(max_bs=max_bs, max_num_tokens=max_num_tokens)

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -1,13 +1,9 @@
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, Callable, List
 
-import torch
-
-from sglang.srt.batch_overlap import two_batch_overlap
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
-    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
 class TboAttnBackend(AttentionBackend):
@@ -27,155 +23,52 @@ class TboAttnBackend(AttentionBackend):
             children=[creator() for _ in range(2)],
         )
 
-    def init_forward_metadata(self, forward_batch: "ForwardBatch"):
-        self.primary.init_forward_metadata(forward_batch=forward_batch)
+    def init_forward_data(self, forward_batch: "ForwardBatch") -> None:
+        """Dispatcher eager wrapper -- recurse to primary + (optional) children."""
+        self.primary.init_forward_data(forward_batch)
         if forward_batch.tbo_children is not None:
             for child, forward_batch_child in zip(
                 self.children, forward_batch.tbo_children, strict=True
             ):
                 if forward_batch_child.batch_size > 0:
-                    child.init_forward_metadata(forward_batch=forward_batch_child)
+                    child.init_forward_data(forward_batch_child)
+
+    def init_forward_data_out_graph(self, forward_batch: "ForwardBatch") -> None:
+        """Dispatcher out-graph init -- recurse to primary + (optional) children.
+
+        Capture and replay both flow through this method via the unified
+        step 03 contract; child-fb split details that the old asymmetric
+        capture/replay variants assembled are now derived per-backend
+        directly from the (already-split-by-caller) ``forward_batch.tbo_children``.
+        """
+        self.primary.init_forward_data_out_graph(forward_batch)
+        if forward_batch.tbo_children is not None:
+            for child, forward_batch_child in zip(
+                self.children, forward_batch.tbo_children, strict=True
+            ):
+                if forward_batch_child.batch_size > 0:
+                    child.init_forward_data_out_graph(forward_batch_child)
+
+    def init_forward_data_in_graph(self, forward_batch: "ForwardBatch") -> None:
+        """Dispatcher in-graph init -- recurse to primary + (optional) children.
+
+        Override the ABC default no-op so a backend that overrides
+        ``_in_graph`` (none in the initial stage; reserved for future
+        per-backend perf PRs) is correctly reached through this dispatcher.
+        """
+        self.primary.init_forward_data_in_graph(forward_batch)
+        if forward_batch.tbo_children is not None:
+            for child, forward_batch_child in zip(
+                self.children, forward_batch.tbo_children, strict=True
+            ):
+                if forward_batch_child.batch_size > 0:
+                    child.init_forward_data_in_graph(forward_batch_child)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.primary.init_cuda_graph_state(max_bs=max_bs, max_num_tokens=max_num_tokens)
         for item in self.children:
             # TODO for children, maybe can provide *smaller* max_bs to optimize
             item.init_cuda_graph_state(max_bs=max_bs, max_num_tokens=max_num_tokens)
-
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: "ForwardMode",
-        spec_info: Optional[SpecInput],
-    ):
-        self.primary.init_forward_metadata_capture_cuda_graph(
-            bs=bs,
-            num_tokens=num_tokens,
-            req_pool_indices=req_pool_indices,
-            seq_lens=seq_lens,
-            encoder_lens=encoder_lens,
-            forward_mode=forward_mode,
-            spec_info=spec_info,
-        )
-
-        self._init_forward_metadata_cuda_graph_children(
-            fn_name="init_forward_metadata_capture_cuda_graph",
-            bs=bs,
-            req_pool_indices=req_pool_indices,
-            seq_lens=seq_lens,
-            encoder_lens=encoder_lens,
-            forward_mode=forward_mode,
-            spec_info=spec_info,
-            capture_num_tokens=num_tokens,
-        )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: "ForwardMode",
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        self.primary.init_forward_metadata_replay_cuda_graph(
-            bs=bs,
-            req_pool_indices=req_pool_indices,
-            seq_lens=seq_lens,
-            seq_lens_sum=seq_lens_sum,
-            encoder_lens=encoder_lens,
-            forward_mode=forward_mode,
-            spec_info=spec_info,
-            seq_lens_cpu=seq_lens_cpu,
-        )
-
-        self._init_forward_metadata_cuda_graph_children(
-            fn_name="init_forward_metadata_replay_cuda_graph",
-            bs=bs,
-            req_pool_indices=req_pool_indices,
-            seq_lens=seq_lens,
-            encoder_lens=encoder_lens,
-            forward_mode=forward_mode,
-            spec_info=spec_info,
-            replay_seq_lens_sum=seq_lens_sum,
-            replay_seq_lens_cpu=seq_lens_cpu,
-        )
-
-    def _init_forward_metadata_cuda_graph_children(
-        self,
-        fn_name: str,
-        # common args
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: "ForwardMode",
-        spec_info: Optional[SpecInput],
-        # capture args
-        capture_num_tokens: int = None,
-        # replay args
-        replay_seq_lens_sum: int = None,
-        replay_seq_lens_cpu: Optional[torch.Tensor] = None,
-    ):
-        token_num_per_seq = two_batch_overlap.get_token_num_per_seq(
-            forward_mode=forward_mode, spec_info=spec_info
-        )
-        if fn_name == "init_forward_metadata_capture_cuda_graph":
-            assert (
-                capture_num_tokens == bs * token_num_per_seq
-            ), "For target-verify or decode mode, num_tokens should be equal to token_num_per_seq * bs"
-        num_tokens = bs * token_num_per_seq
-
-        tbo_split_seq_index, tbo_split_token_index = (
-            two_batch_overlap.compute_split_indices_for_cuda_graph_replay(
-                forward_mode=forward_mode,
-                cuda_graph_num_tokens=num_tokens,
-                spec_info=spec_info,
-            )
-        )
-
-        num_tokens_child_left = tbo_split_token_index
-        num_tokens_child_right = num_tokens - tbo_split_token_index
-        bs_child_left = tbo_split_seq_index
-        bs_child_right = bs - bs_child_left
-
-        assert (
-            num_tokens_child_left > 0 and num_tokens_child_right > 0
-        ), f"{num_tokens_child_left=} {num_tokens_child_right=} {forward_mode=} {num_tokens=}"
-
-        common_pre_split_args = dict(
-            fn_name=fn_name,
-            bs=bs,
-            req_pool_indices=req_pool_indices,
-            seq_lens=seq_lens,
-            encoder_lens=encoder_lens,
-            forward_mode=forward_mode,
-            spec_info=spec_info,
-            capture_num_tokens=capture_num_tokens,
-            replay_seq_lens_sum=replay_seq_lens_sum,
-            replay_seq_lens_cpu=replay_seq_lens_cpu,
-        )
-
-        args_left = _init_forward_metadata_cuda_graph_split(
-            output_bs=bs_child_left,
-            seq_slice=slice(None, tbo_split_seq_index),
-            **common_pre_split_args,
-        )
-        args_right = _init_forward_metadata_cuda_graph_split(
-            output_bs=bs_child_right,
-            seq_slice=slice(tbo_split_seq_index, None),
-            **common_pre_split_args,
-        )
-
-        child_left, child_right = self.children
-        getattr(child_left, fn_name)(**args_left)
-        getattr(child_right, fn_name)(**args_right)
 
     def get_cuda_graph_seq_len_fill_value(self):
         ans = self.primary.get_cuda_graph_seq_len_fill_value()
@@ -194,77 +87,3 @@ class TboAttnBackend(AttentionBackend):
 
     def get_indexer_metadata(self, layer_id: int, forward_batch: "ForwardBatch"):
         return self.primary.get_indexer_metadata(layer_id, forward_batch)
-
-
-def _init_forward_metadata_cuda_graph_split(
-    fn_name: str,
-    seq_slice: slice,
-    output_bs: int,
-    # common args
-    bs: int,
-    req_pool_indices: torch.Tensor,
-    seq_lens: torch.Tensor,
-    encoder_lens: Optional[torch.Tensor],
-    forward_mode: "ForwardMode",
-    spec_info: Optional[SpecInput],
-    # capture args
-    capture_num_tokens: int = None,
-    # replay args
-    replay_seq_lens_sum: int = None,
-    replay_seq_lens_cpu: Optional[torch.Tensor] = None,
-):
-    token_num_per_seq = two_batch_overlap.get_token_num_per_seq(
-        forward_mode=forward_mode, spec_info=spec_info
-    )
-    assert encoder_lens is None, "encoder_lens is not supported yet"
-    if spec_info is not None:
-        output_spec_info = two_batch_overlap.split_spec_info(
-            spec_info=spec_info,
-            start_seq_index=seq_slice.start if seq_slice.start is not None else 0,
-            end_seq_index=seq_slice.stop if seq_slice.stop is not None else bs,
-            start_token_index=(
-                seq_slice.start * token_num_per_seq
-                if seq_slice.start is not None
-                else 0
-            ),
-            end_token_index=(
-                seq_slice.stop * token_num_per_seq
-                if seq_slice.stop is not None
-                else bs * token_num_per_seq
-            ),
-        )
-
-    else:
-        output_spec_info = None
-    ans = dict(
-        bs=output_bs,
-        req_pool_indices=req_pool_indices[seq_slice],
-        seq_lens=seq_lens[seq_slice],
-        # directly forward
-        forward_mode=forward_mode,
-        # ignore
-        encoder_lens=None,
-        spec_info=output_spec_info,
-    )
-
-    if fn_name == "init_forward_metadata_capture_cuda_graph":
-        assert (
-            capture_num_tokens == bs * token_num_per_seq
-        ), "Only support num_tokens==bs * token_num_per_seq for target-verify or decode mode"
-        ans.update(
-            dict(
-                num_tokens=output_bs * token_num_per_seq,
-            )
-        )
-    elif fn_name == "init_forward_metadata_replay_cuda_graph":
-        output_seq_lens_cpu = replay_seq_lens_cpu[seq_slice]
-        ans.update(
-            dict(
-                seq_lens_sum=output_seq_lens_cpu.sum().item(),
-                seq_lens_cpu=output_seq_lens_cpu,
-            )
-        )
-    else:
-        raise NotImplementedError
-
-    return ans

--- a/python/sglang/srt/layers/attention/torch_flex_backend.py
+++ b/python/sglang/srt/layers/attention/torch_flex_backend.py
@@ -27,7 +27,7 @@ class TorchFlexAttnBackend(AttentionBackend):
         torch._dynamo.config.cache_size_limit = 1024
         torch._dynamo.config.accumulated_cache_size_limit = 1024
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Init the metadata for a forward pass."""
         # TODO: find a more elegant way to save memory
         # Currently maintain the same memory as torch_native_backend

--- a/python/sglang/srt/layers/attention/torch_native_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_backend.py
@@ -24,7 +24,7 @@ class TorchNativeAttnBackend(AttentionBackend):
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Init the metadata for a forward pass."""
         pass
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1216,6 +1216,10 @@ class TritonMultiStepDraftBackend:
         kv_indices_buffer: Optional[torch.Tensor],
         call_fn: int,
     ):
+        # Multi-step wrappers only ever run draft decode -- assert the
+        # invariant up front to match FlashInfer / FlashInferMLA.
+        assert forward_batch.spec_info is not None
+        assert forward_batch.spec_info.is_draft_input()
         if kv_indices_buffer is None:
             kv_indices_buffer = self.cuda_graph_kv_indices
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -730,6 +730,56 @@ class TritonAttnBackend(AttentionBackend):
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
+        elif forward_mode.is_extend_or_mixed():
+            # Prefill / extend path -- invoked by piecewise / breakable cuda
+            # graph capture for non-decode modes. Mirrors the eager body's
+            # ``else:`` clause: build kv_indices/qo_indptr from the live
+            # ``req_to_token_pool`` view (no pre-allocated buffer reuse).
+            kv_indptr_local = self.kv_indptr
+            kv_indptr_local[1 : bs + 1] = torch.cumsum(
+                forward_batch.extend_prefix_lens, dim=0
+            )
+            kv_indptr = kv_indptr_local[: bs + 1]
+            kv_indices = torch.empty(
+                sum(forward_batch.extend_prefix_lens_cpu),
+                dtype=torch.int64,
+                device=self.device,
+            )
+            create_flashinfer_kv_indices_triton[(bs,)](
+                self.req_to_token,
+                req_pool_indices,
+                forward_batch.extend_prefix_lens,
+                kv_indptr,
+                None,
+                kv_indices,
+                self.req_to_token.stride(0),
+            )
+            if self.sliding_window_size is not None and self.sliding_window_size > 0:
+                (
+                    window_kv_indptr,
+                    window_kv_indices,
+                    _window_kv_lens,
+                    window_kv_offsets,
+                ) = update_sliding_window_buffer(
+                    self.window_kv_indptr,
+                    self.req_to_token,
+                    self.sliding_window_size,
+                    forward_batch.extend_prefix_lens,
+                    req_pool_indices,
+                    bs,
+                    self.device,
+                    self.token_to_kv_pool_allocator,
+                )
+
+            qo_indptr = self.qo_indptr
+            qo_indptr[1 : bs + 1] = torch.cumsum(forward_batch.extend_seq_lens, dim=0)
+            qo_indptr = qo_indptr[: bs + 1]
+            custom_mask = None
+            mask_indptr = None
+            attn_logits = None
+            attn_lse = None
+            max_extend_len = max(forward_batch.extend_seq_lens_cpu)
+            num_kv_splits = None
         else:
             raise ValueError(
                 f"Invalid forward mode: {forward_mode=} for CUDA Graph capture."

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -13,7 +13,7 @@ from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_trito
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.speculative.spec_utils import generate_draft_decode_kv_indices
 from sglang.srt.utils import (
     get_bool_env_var,
@@ -283,8 +283,8 @@ class TritonAttnBackend(AttentionBackend):
             MAX_NUM_SEQ=SCHEDULE_SEQ,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init auxiliary variables for triton attention backend."""
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Init auxiliary variables for triton attention backend (eager path)."""
 
         bs = forward_batch.batch_size
         kv_indptr = self.kv_indptr
@@ -578,16 +578,25 @@ class TritonAttnBackend(AttentionBackend):
                 device=self.device,
             )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body merged from old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` — both wrote to the same
+        ``self.cuda_graph_*`` pre-allocated buffers and ran similar logic.
+        Called outside ``with graph.capture():`` at both capture (initial
+        fill) and replay (per-iter refresh). Rebuilds ``self.forward_metadata``
+        each call; the underlying buffers stay pinned to ``self.cuda_graph_*``
+        across iterations so the captured forward kernel sees the updated
+        data via stable pointers.
+        """
+        bs = forward_batch.batch_size
+        num_tokens = bs * (self.num_draft_tokens if self.num_draft_tokens else 1)
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        encoder_lens = forward_batch.encoder_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         assert encoder_lens is None, "Not supported"
         window_kv_indptr = self.window_kv_indptr
         window_kv_indices = None
@@ -742,138 +751,6 @@ class TritonAttnBackend(AttentionBackend):
             window_kv_offsets,
             swa_attn_logits=swa_attn_logits,
         )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        # NOTE: encoder_lens expected to be zeros or None
-        if forward_mode.is_decode_or_idle():
-            # Update kv_indptr, kv_indices
-            kv_indptr = self.kv_indptr
-            kv_indices = self.cuda_graph_kv_indices
-            num_kv_splits = self.cuda_graph_num_kv_splits
-            if spec_info is None:
-                kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens[:bs], dim=0)
-                kv_indptr = kv_indptr[: bs + 1]
-                create_flashinfer_kv_indices_triton[(bs,)](
-                    self.req_to_token,
-                    req_pool_indices[:bs],
-                    seq_lens[:bs],
-                    kv_indptr,
-                    None,
-                    kv_indices,
-                    self.req_to_token.stride(0),
-                )
-                num_token = bs
-                if (
-                    self.sliding_window_size is not None
-                    and self.sliding_window_size > 0
-                ):
-                    window_num_kv_splits = self.cuda_graph_window_num_kv_splits
-                    window_kv_indices = self.cuda_graph_window_kv_indices
-                    _, _, window_kv_lens, _ = update_sliding_window_buffer_cuda_graph(
-                        self.window_kv_indptr,
-                        window_kv_indices,
-                        self.req_to_token,
-                        self.sliding_window_size,
-                        seq_lens[:bs],
-                        req_pool_indices[:bs],
-                        bs,
-                        self.token_to_kv_pool_allocator,
-                    )
-                    self.get_num_kv_splits(
-                        window_num_kv_splits[:num_token], window_kv_lens[:bs]
-                    )
-
-            else:
-                assert False, "Multi-step cuda graph init is not done here."
-            self.get_num_kv_splits(num_kv_splits[:num_token], seq_lens[:bs])
-
-        elif forward_mode.is_target_verify():
-            # Update qo_indptr, kv_indptr, kv_indices, custom_mask, mask_indptr
-            bs = len(req_pool_indices)
-            qo_indptr = self.qo_indptr[: bs + 1]
-            qo_indptr[: bs + 1] = torch.arange(
-                0,
-                (1 + bs) * self.num_draft_tokens,
-                step=self.num_draft_tokens,
-                dtype=torch.int32,
-                device=self.device,
-            )
-            kv_indptr = self.kv_indptr[: bs + 1]
-            kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
-            kv_indices = self.cuda_graph_kv_indices
-            create_flashinfer_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices,
-                seq_lens,
-                kv_indptr,
-                None,
-                kv_indices,
-                self.req_to_token.stride(0),
-            )
-            if self.sliding_window_size is not None and self.sliding_window_size > 0:
-                window_num_kv_splits = self.cuda_graph_window_num_kv_splits
-                window_kv_indices = self.cuda_graph_window_kv_indices
-                window_kv_offsets = self.cuda_graph_window_kv_offsets
-                _, _, window_kv_lens, window_kv_offsets[:bs] = (
-                    update_sliding_window_buffer_cuda_graph(
-                        self.window_kv_indptr,
-                        window_kv_indices,
-                        self.req_to_token,
-                        self.sliding_window_size,
-                        seq_lens[:bs],
-                        req_pool_indices,
-                        bs,
-                        self.token_to_kv_pool_allocator,
-                    )
-                )
-            custom_mask = self.cuda_graph_custom_mask
-            if (
-                spec_info is not None
-                and getattr(spec_info, "custom_mask", None) is not None
-            ):
-                custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-            else:
-                custom_mask = None
-            seq_mask_len = self.num_draft_tokens * (seq_lens + self.num_draft_tokens)
-            mask_indptr = self.mask_indptr[: bs + 1]
-            mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
-        elif forward_mode.is_draft_extend(include_v2=True):
-            seq_lens = seq_lens[:bs]
-            num_tokens_per_bs = self.speculative_num_steps + 1
-            qo_indptr = self.qo_indptr[: bs + 1]
-            qo_indptr[: bs + 1] = torch.arange(
-                0,
-                bs * num_tokens_per_bs + 1,
-                step=num_tokens_per_bs,
-                dtype=torch.int32,
-                device=self.device,
-            )
-            kv_indptr = self.kv_indptr[: bs + 1]
-            kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
-            kv_indices = self.cuda_graph_kv_indices
-            create_flashinfer_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices,
-                seq_lens,
-                kv_indptr,
-                None,
-                kv_indices,
-                self.req_to_token.stride(0),
-            )
-        else:
-            raise ValueError(
-                f"Invalid forward mode: {forward_mode=} for CUDA Graph replay."
-            )
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
@@ -1324,7 +1201,7 @@ class TritonMultiStepDraftBackend:
             ]
             call_fn(i, forward_batch)
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
@@ -1341,7 +1218,7 @@ class TritonMultiStepDraftBackend:
             forward_batch.spec_info.kv_indices = (
                 forward_batch.spec_info.kv_indices.clone()
             )
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
         self.common_template(forward_batch, kv_indices, call_fn)
 
@@ -1366,32 +1243,24 @@ class TritonMultiStepDraftBackend:
                 cuda_graph_num_kv_splits_buf=self.cuda_graph_num_kv_splits,
             )
 
-    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Capture + replay path -- merged from old capture/replay variants.
+
+        Runs the per-step underlying-backend init via ``common_template`` and
+        refreshes ``num_kv_splits``. Capture and replay run the same body
+        (the old replay variant was optimized to skip the per-step init since
+        the captured graph had already recorded those ops; in the initial
+        stage we re-run them each iteration for simplicity -- a follow-up
+        per-backend optimization PR may restore the replay-time fast path).
+        """
+
         def call_fn(i, forward_batch):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)
 
         self.common_template(forward_batch, None, call_fn)
 
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
-        self.common_template(forward_batch, None, None)
-
-        # NOTE: Multi-step's attention backends use the slice of
-        # - kv_indptr buffer (cuda graph and non-cuda graph)
-        # - kv_indices buffer (cuda graph only)
-        # So we don't need to assign the KV indices inside the attention backend.
-
-        # Compute num_kv_splits only once
         num_token = forward_batch.batch_size * self.topk
+        bs = forward_batch.batch_size
         self.attn_backends[-1].get_num_kv_splits(
             self.attn_backends[-1].cuda_graph_num_kv_splits[:num_token],
             forward_batch.seq_lens[:bs],

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1253,6 +1253,10 @@ class TritonMultiStepDraftBackend:
         stage we re-run them each iteration for simplicity -- a follow-up
         per-backend optimization PR may restore the replay-time fast path).
         """
+        assert (
+            forward_batch.forward_mode.is_decode_or_idle()
+            and forward_batch.encoder_lens is None
+        )
 
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_data_out_graph(forward_batch)
@@ -1265,6 +1269,17 @@ class TritonMultiStepDraftBackend:
             self.attn_backends[-1].cuda_graph_num_kv_splits[:num_token],
             forward_batch.seq_lens[:bs],
         )
+
+    def init_forward_data_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """Multi-step wrapper has no in-graph prep -- explicit no-op.
+
+        Required because this class doesn't inherit from ``AttentionBackend``
+        (the ABC's default no-op is therefore not picked up). Without this
+        override, ``EAGLEDraftCudaGraphRunner.capture_one_batch_size``'s call
+        to ``init_forward_data_in_graph`` would AttributeError on first
+        capture.
+        """
+        return
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -730,7 +730,7 @@ class TritonAttnBackend(AttentionBackend):
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
-        elif forward_mode.is_extend_or_mixed():
+        elif forward_mode.is_extend_or_draft_extend_or_mixed():
             # Prefill / extend path -- invoked by piecewise / breakable cuda
             # graph capture for non-decode modes. Mirrors the eager body's
             # ``else:`` clause: build kv_indices/qo_indptr from the live

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -443,6 +443,54 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
 
             self.draft_extend_metadata[bs] = metadata
+        else:
+            # Prefill / extend path — invoked by piecewise / breakable cuda
+            # graph capture for non-decode modes. Mirrors the eager body's
+            # ``else:`` clause: build metadata from the live
+            # ``req_to_token_pool`` view (no pre-allocated buffer reuse).
+            metadata.cache_seqlens_int32 = seq_lens.to(torch.int32)
+            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(seq_lens, dim=0, dtype=torch.int32), (1, 0)
+            )
+            metadata.page_table = self.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : metadata.max_seq_len_k
+            ]
+
+            if any(
+                forward_batch.extend_prefix_lens_cpu
+            ) or forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                extend_seq_lens = forward_batch.extend_seq_lens
+                # NOTE: in piecewise CUDA graph warmup, extend_seq_lens_cpu is a torch.Tensor;
+                # Python's max() returns a 0-d tensor, but flashinfer expects an int.
+                max_q = max(forward_batch.extend_seq_lens_cpu)
+                metadata.max_seq_len_q = (
+                    int(max_q.item()) if isinstance(max_q, torch.Tensor) else int(max_q)
+                )
+                metadata.cu_seqlens_q = torch.nn.functional.pad(
+                    torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
+                )
+            else:
+                metadata.max_seq_len_q = metadata.max_seq_len_k
+                metadata.cu_seqlens_q = metadata.cu_seqlens_k
+
+            # SWA page table + strided conversion (mirrors eager).
+            metadata.swa_page_table = self._maybe_translate_swa(metadata.page_table)
+            if self.page_size > 1:
+                self.strided_indices = torch.arange(
+                    0,
+                    metadata.page_table.shape[1],
+                    self.page_size,
+                    device=self.device,
+                )
+                metadata.page_table = (
+                    metadata.page_table[:, self.strided_indices] // self.page_size
+                )
+                if metadata.swa_page_table is not None:
+                    metadata.swa_page_table = (
+                        metadata.swa_page_table[:, self.strided_indices]
+                        // self.page_size
+                    )
         self.forward_metadata = metadata
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -327,122 +327,202 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
-                # Draft Decode
-                # Here we only support topk = 1 for now.
-                metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
-                    "cache_seqlens"
-                ][:bs]
+                # Draft Decode -- topk = 1 only.
+                # Bind metadata fields to pre-allocated buffers on first call
+                # per bs; subsequent calls reuse so the captured graph's
+                # recorded pointers stay valid at replay.
+                if bs not in self.decode_cuda_graph_metadata:
+                    metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
+                        "cache_seqlens"
+                    ][:bs]
+                    metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_q"
+                    ][: bs + 1]
+                    metadata.cu_seqlens_k = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_k"
+                    ][: bs + 1]
+                    metadata.page_table = self.decode_cuda_graph_metadata[
+                        "page_table_draft_decode"
+                    ][:bs, :]
+                    self._bind_swa_page_table(
+                        metadata,
+                        self.decode_cuda_graph_metadata,
+                        "swa_page_table_draft_decode",
+                        bs,
+                    )
+                    self.decode_cuda_graph_metadata[bs] = metadata
+                else:
+                    metadata = self.decode_cuda_graph_metadata[bs]
+
+                # Per-iter refresh (in-place; pointers stay stable).
+                metadata.cache_seqlens_int32.copy_(
+                    seq_lens + (self.speculative_step_id + 1)
+                )
                 metadata.max_seq_len_k = seq_lens.max().item() + (
                     self.speculative_step_id + 1
                 )
-                metadata.cu_seqlens_q = self.decode_cuda_graph_metadata["cu_seqlens_q"][
-                    : bs + 1
+                metadata.cu_seqlens_k[1:].copy_(
+                    torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
+                )
+                max_seq_pages = (
+                    metadata.max_seq_len_k + self.page_size - 1
+                ) // self.page_size
+                page_indices = self.req_to_token_pool.req_to_token[
+                    forward_batch.req_pool_indices[:, None],
+                    self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages][
+                        None, :
+                    ],
                 ]
-                metadata.cu_seqlens_k = torch.nn.functional.pad(
-                    torch.cumsum(
-                        metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
-                    ),
-                    (1, 0),
+                metadata.page_table[:, :max_seq_pages].copy_(
+                    page_indices // self.page_size
                 )
-                metadata.page_table = self.decode_cuda_graph_metadata[
-                    "page_table_draft_decode"
-                ][:bs, :]
-                self._bind_swa_page_table(
-                    metadata,
-                    self.decode_cuda_graph_metadata,
-                    "swa_page_table_draft_decode",
-                    bs,
-                )
-                self.decode_cuda_graph_metadata[bs] = metadata
+                self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
             else:
-                # Normal Decode
-                # Get sequence information
-                metadata.cache_seqlens_int32 = seq_lens[:bs].to(torch.int32)
-                batch_size = len(seq_lens)
-                metadata.cu_seqlens_k = torch.nn.functional.pad(
-                    torch.cumsum(seq_lens, dim=0, dtype=torch.int32), (1, 0)
-                )
+                # Normal Decode. Cache metadata on first call per bs; in-place
+                # refresh subsequent calls so captured graph pointers stay valid.
+                if bs not in self.decode_cuda_graph_metadata:
+                    metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
+                        "cache_seqlens"
+                    ][:bs]
+                    # cu_seqlens_k may not exist for non-spec configs; allocate
+                    # a persistent buffer once, then reuse on subsequent calls.
+                    if "cu_seqlens_k" not in self.decode_cuda_graph_metadata:
+                        max_bs = self.decode_cuda_graph_metadata["cache_seqlens"].shape[
+                            0
+                        ]
+                        self.decode_cuda_graph_metadata["cu_seqlens_k"] = torch.zeros(
+                            max_bs + 1, dtype=torch.int32, device=self.device
+                        )
+                        self.decode_cuda_graph_metadata["cu_seqlens_q"] = torch.arange(
+                            0, max_bs + 1, dtype=torch.int32, device=self.device
+                        )
+                    metadata.cu_seqlens_q = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_q"
+                    ][: bs + 1]
+                    metadata.cu_seqlens_k = self.decode_cuda_graph_metadata[
+                        "cu_seqlens_k"
+                    ][: bs + 1]
+                    metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
+                        :bs, :
+                    ]
+                    self._bind_swa_page_table(
+                        metadata,
+                        self.decode_cuda_graph_metadata,
+                        "swa_page_table",
+                        bs,
+                    )
+                    self.decode_cuda_graph_metadata[bs] = metadata
+                else:
+                    metadata = self.decode_cuda_graph_metadata[bs]
 
-                # Precompute maximum sequence length
+                # Per-iter refresh.
+                metadata.cache_seqlens_int32.copy_(seq_lens)
                 metadata.max_seq_len_k = seq_lens.max().item()
-                # Precompute cumulative sequence lengths
-                metadata.cu_seqlens_q = torch.arange(
-                    0, batch_size + 1, dtype=torch.int32, device=device
+                metadata.cu_seqlens_k[1:].copy_(
+                    torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
-                # Precompute page table
-                metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
-                    :bs, :
+                max_seq_pages = (
+                    metadata.max_seq_len_k + self.page_size - 1
+                ) // self.page_size
+                page_indices = self.req_to_token_pool.req_to_token[
+                    forward_batch.req_pool_indices[:, None],
+                    self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages][
+                        None, :
+                    ],
                 ]
+                metadata.page_table[:, :max_seq_pages].copy_(
+                    page_indices // self.page_size
+                )
+                self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
+        elif forward_mode.is_target_verify():
+            # Target Verify -- topk = 1 only.
+            tokens_per_req = num_tokens // bs
+            if bs not in self.target_verify_metadata:
+                metadata.cache_seqlens_int32 = self.target_verify_metadata[
+                    "cache_seqlens"
+                ][:bs]
+                metadata.cu_seqlens_q = self.target_verify_metadata["cu_seqlens_q"][
+                    : bs * tokens_per_req + 1
+                ]
+                metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
+                    : (bs + 1)
+                ]
+                metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
                 self._bind_swa_page_table(
                     metadata,
-                    self.decode_cuda_graph_metadata,
+                    self.target_verify_metadata,
                     "swa_page_table",
                     bs,
                 )
-                self.decode_cuda_graph_metadata[bs] = metadata
-        elif forward_mode.is_target_verify():
-            # Target Verify
-            # Here we only support topk = 1 for now.
-            tokens_per_req = num_tokens // bs
-            metadata.cache_seqlens_int32 = self.target_verify_metadata["cache_seqlens"][
-                :bs
-            ]
+                self.target_verify_metadata[bs] = metadata
+            else:
+                metadata = self.target_verify_metadata[bs]
+
+            # Per-iter refresh (in-place; pointers stay stable across replays).
             metadata.cache_seqlens_int32.copy_(seq_lens + tokens_per_req)
-
-            metadata.cu_seqlens_q = torch.arange(
-                0,
-                bs * tokens_per_req + 1,
-                tokens_per_req,
-                dtype=torch.int32,
-                device=device,
-            )
-
-            metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
-                : (bs + 1)
-            ]
-
             metadata.max_seq_len_q = tokens_per_req
             metadata.max_seq_len_k = seq_lens.max().item() + tokens_per_req
-
-            metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
-            self._bind_swa_page_table(
-                metadata,
-                self.target_verify_metadata,
-                "swa_page_table",
-                bs,
+            metadata.cu_seqlens_k[1:].copy_(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-
-            self.target_verify_metadata[bs] = metadata
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
+            page_indices = self.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices[:, None],
+                self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
+            ]
+            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
+            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
         elif forward_mode.is_draft_extend():
-            metadata.cache_seqlens_int32 = self.draft_extend_metadata["cache_seqlens"][
-                :bs
-            ]
-            metadata.cache_seqlens_int32.copy_(seq_lens)
             num_tokens_per_bs = num_tokens // bs
-            metadata.cu_seqlens_q = torch.arange(
-                0,
-                bs * num_tokens_per_bs + 1,
-                num_tokens_per_bs,
-                dtype=torch.int32,
-                device=device,
-            )
+            if bs not in self.draft_extend_metadata:
+                metadata.cache_seqlens_int32 = self.draft_extend_metadata[
+                    "cache_seqlens"
+                ][:bs]
+                metadata.cu_seqlens_q = self.draft_extend_metadata["cu_seqlens_q"][
+                    : (bs + 1)
+                ]
+                metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
+                    : (bs + 1)
+                ]
+                metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
+                self._bind_swa_page_table(
+                    metadata,
+                    self.draft_extend_metadata,
+                    "swa_page_table",
+                    bs,
+                )
+                # Initialize cu_seqlens_q (static for fixed bs/num_draft) once.
+                metadata.cu_seqlens_q.copy_(
+                    torch.arange(
+                        0,
+                        bs * num_tokens_per_bs + 1,
+                        num_tokens_per_bs,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                )
+                self.draft_extend_metadata[bs] = metadata
+            else:
+                metadata = self.draft_extend_metadata[bs]
 
-            metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][
-                : (bs + 1)
-            ]
-            num_tokens_per_bs = num_tokens // bs
+            # Per-iter refresh.
+            metadata.cache_seqlens_int32.copy_(seq_lens)
             metadata.max_seq_len_q = num_tokens_per_bs
             metadata.max_seq_len_k = seq_lens.max().item()
-
-            metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
-            self._bind_swa_page_table(
-                metadata,
-                self.draft_extend_metadata,
-                "swa_page_table",
-                bs,
+            metadata.cu_seqlens_k[1:].copy_(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
-
-            self.draft_extend_metadata[bs] = metadata
+            max_seq_pages = (
+                metadata.max_seq_len_k + self.page_size - 1
+            ) // self.page_size
+            page_indices = self.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices[:, None],
+                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
+            ]
+            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
+            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
         else:
             # Prefill / extend path — invoked by piecewise / breakable cuda
             # graph capture for non-decode modes. Mirrors the eager body's

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -21,7 +21,7 @@ from sglang.srt.layers.attention.triton_ops.trtllm_fp8_kv_kernel import (
 )
 from sglang.srt.layers.attention.utils import canonicalize_stride
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_flashinfer_available
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
 
@@ -33,7 +33,6 @@ if is_flashinfer_available():
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-    from sglang.srt.speculative.spec_info import SpecInput
 
 # Constants
 # Default workspace size in MB for TRTLLM MHA
@@ -303,17 +302,26 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
             }
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
-        """Initialize metadata for CUDA graph capture."""
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths (unified).
+
+        Body merged from the old ``init_forward_metadata_capture_cuda_graph``
+        and ``init_forward_metadata_replay_cuda_graph`` variants -- both wrote
+        into the same ``self.decode_cuda_graph_metadata`` / target_verify /
+        draft_extend pre-allocated buffers. The merged path runs the full
+        capture-style rebuild on each iteration (including at replay), per
+        the initial stage choice to defer the replay-time fast-path
+        optimization to a follow-up PR.
+        """
+        bs = forward_batch.batch_size
+        num_tokens = (
+            forward_batch.positions.shape[0]
+            if forward_batch.positions is not None
+            else bs
+        )
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         metadata = TRTLLMMHAMetadata()
         device = seq_lens.device
 
@@ -437,106 +445,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             self.draft_extend_metadata[bs] = metadata
         self.forward_metadata = metadata
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        """Replay CUDA graph with new inputs."""
-        seq_lens = seq_lens[:bs]
-        seq_lens_cpu = seq_lens_cpu[:bs]
-        req_pool_indices = req_pool_indices[:bs]
-        metadata = None
-        if forward_mode.is_decode_or_idle():
-            if spec_info is not None:
-                # Draft Decode
-                # Here we only support topk = 1 for now.
-                metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
-                metadata.max_seq_len_k = max_len + self.speculative_step_id + 1
-
-                max_seq_pages = (
-                    metadata.max_seq_len_k + self.page_size - 1
-                ) // self.page_size
-
-                metadata.cache_seqlens_int32.copy_(
-                    seq_lens + self.speculative_step_id + 1
-                )
-            else:
-                # Normal Decode
-                metadata = self.decode_cuda_graph_metadata[bs]
-                max_len = seq_lens_cpu.max().item()
-                max_seq_pages = (max_len + self.page_size - 1) // self.page_size
-                metadata.max_seq_len_k = max_len
-
-                metadata.cache_seqlens_int32.copy_(seq_lens)
-
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages][
-                    None, :
-                ],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-        elif forward_mode.is_target_verify():
-            # Here we only support topk = 1 for now.
-            metadata = self.target_verify_metadata[bs]
-            metadata.cache_seqlens_int32.copy_(seq_lens + metadata.max_seq_len_q)
-
-            metadata.max_seq_len_k = seq_lens_cpu.max().item() + metadata.max_seq_len_q
-            max_len = seq_lens_cpu.max().item()
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.decode_cuda_graph_metadata["strided_indices"][:max_seq_pages],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-        elif forward_mode.is_draft_extend():
-            metadata = self.draft_extend_metadata[bs]
-            metadata.cache_seqlens_int32.copy_(seq_lens)
-
-            metadata.max_seq_len_k = seq_lens_cpu.max().item()
-            max_len = seq_lens_cpu.max().item()
-            metadata.cu_seqlens_k[1:].copy_(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
-            )
-            extend_lens = spec_info.num_accept_tokens[:bs]
-            if spec_info.num_accept_tokens_cpu:
-                metadata.max_seq_len_q = max(spec_info.num_accept_tokens_cpu)
-            else:
-                metadata.max_seq_len_q = 1
-
-            metadata.cu_seqlens_q[1:].copy_(
-                torch.cumsum(extend_lens, dim=0, dtype=torch.int32)
-            )
-
-            max_seq_pages = (
-                metadata.max_seq_len_k + self.page_size - 1
-            ) // self.page_size
-            page_indices = self.req_to_token[
-                req_pool_indices[:, None],
-                self.draft_extend_metadata["strided_indices"][:max_seq_pages],
-            ]
-            metadata.page_table[:, :max_seq_pages].copy_(page_indices // self.page_size)
-            self._copy_swa_page_table(metadata, page_indices, max_seq_pages)
-        self.forward_metadata = metadata
-
     def get_cuda_graph_seq_len_fill_value(self) -> int:
         """Get the fill value for sequence lengths in CUDA graph."""
         return 1
@@ -571,7 +479,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             page_size=self.page_size,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Initialize the metadata for a forward pass."""
 
         metadata = TRTLLMMHAMetadata()
@@ -891,47 +799,17 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
                 speculative_step_id=i,
             )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+            self.attn_backends[i].init_forward_data(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps - 1):
             self.attn_backends[i].init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        forward_batch: ForwardBatch,
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
         assert forward_batch.spec_info is not None
         assert forward_batch.spec_info.is_draft_input()
 
         for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.batch_size * self.topk,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=forward_batch.encoder_lens,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-            )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self, forward_batch: ForwardBatch, bs: int
-    ):
-        assert forward_batch.spec_info is not None
-        assert forward_batch.spec_info.is_draft_input()
-
-        for i in range(self.speculative_num_steps - 1):
-
-            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                forward_batch.seq_lens_sum,
-                encoder_lens=forward_batch.encoder_lens,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
-            )
+            self.attn_backends[i].init_forward_data_out_graph(forward_batch)

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -865,11 +865,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         )
 
         # Ensure batch_size is sufficient, the batch size increase due to the padding from the forward batch
-        # FIXME(@rainj-me), refactor the skip_attn_backend_init, init_forward_metadata for attn backends
+        # FIXME(@rainj-me), refactor the skip_attn_backend_init, init_forward_data for attn backends
         # and padding logic in prepare_mlp_sync_batch to avoid this
         batch_size = getattr(metadata, "batch_size", None)
         if batch_size is not None and batch_size < forward_batch.batch_size:
-            self.init_forward_metadata(forward_batch)
+            self.init_forward_data(forward_batch)
             metadata = forward_batch.decode_trtllm_mla_metadata
 
         raw_out = self._run_decode_kernel(
@@ -967,11 +967,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             )
 
             # Ensure batch_size is sufficient, the batch size increase due to the padding from the forward batch
-            # FIXME(@rainj-me), refactor the skip_attn_backend_init, init_forward_metadata for attn backends
+            # FIXME(@rainj-me), refactor the skip_attn_backend_init, init_forward_data for attn backends
             # and padding logic in prepare_mlp_sync_batch to avoid this
             batch_size = getattr(metadata, "batch_size", None)
             if batch_size is not None and batch_size < forward_batch.batch_size:
-                self.init_forward_metadata(forward_batch)
+                self.init_forward_data(forward_batch)
                 metadata = forward_batch.decode_trtllm_mla_metadata
 
             # Ensure query has shape [bs, num_draft_tokens, num_q_heads, head_dim]

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -28,7 +28,7 @@ from sglang.srt.layers.attention.utils import (
 )
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_flashinfer_available, is_float4_e2m1fn_x2
 
@@ -38,7 +38,6 @@ if is_flashinfer_available():
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-    from sglang.srt.speculative.spec_info import SpecInput
 
 logger = logging.getLogger(__name__)
 
@@ -425,17 +424,21 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         super().init_cuda_graph_state(max_bs, max_num_tokens, kv_indices_buf)
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
-        """Initialize metadata for CUDA graph capture."""
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths (unified).
+
+        Body merged from the old ``init_forward_metadata_capture_cuda_graph``
+        and ``init_forward_metadata_replay_cuda_graph`` variants -- both wrote
+        into the same ``self.decode_cuda_graph_*`` pre-allocated buffers and
+        ran similar logic. The merged path runs the full capture-style
+        rebuild on each iteration (including at replay), per the initial
+        stage choice to defer the replay-time fast-path optimization to a
+        follow-up PR.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        forward_mode = forward_batch.forward_mode
 
         # Delegate to parent for non-decode modes.
         if (
@@ -443,15 +446,8 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             and not forward_mode.is_target_verify()
             and not forward_mode.is_draft_extend(include_v2=True)
         ):
-            return super().init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-            )
+            super().init_forward_data_out_graph(forward_batch)
+            return
 
         metadata = TRTLLMMLADecodeMetadata()
 
@@ -462,7 +458,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             )
             metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
         elif forward_mode.is_draft_extend(include_v2=True):
-            num_tokens_per_bs = num_tokens // bs
+            num_tokens_per_bs = self.num_draft_tokens
             metadata.max_seq_len_q = num_tokens_per_bs
             metadata.sum_seq_lens_q = num_tokens_per_bs * bs
             metadata.cu_seqlens_q = torch.arange(
@@ -508,76 +504,11 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        """Replay CUDA graph with new inputs."""
-        # Delegate to parent for non-decode modes.
-        if (
-            not forward_mode.is_decode_or_idle()
-            and not forward_mode.is_target_verify()
-            and not forward_mode.is_draft_extend(include_v2=True)
-        ):
-            return super().init_forward_metadata_replay_cuda_graph(
-                bs,
-                req_pool_indices,
-                seq_lens,
-                seq_lens_sum,
-                encoder_lens,
-                forward_mode,
-                spec_info,
-                seq_lens_cpu,
-            )
-
-        metadata = self.decode_cuda_graph_metadata[bs]
-
-        if forward_mode.is_target_verify():
-            seq_lens = seq_lens[:bs] + self.num_draft_tokens
-            metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
-            del seq_lens_sum  # not handle "num_draft_tokens" but we do not need it
-        elif forward_mode.is_draft_extend(include_v2=True):
-            num_tokens_per_bs = self.num_draft_tokens
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.sum_seq_lens_q = num_tokens_per_bs * bs
-            metadata.cu_seqlens_q[: bs + 1].copy_(
-                torch.arange(
-                    0,
-                    bs * num_tokens_per_bs + 1,
-                    step=num_tokens_per_bs,
-                    dtype=torch.int32,
-                    device=seq_lens.device,
-                )
-            )
-            metadata.seq_lens_q[:bs].fill_(num_tokens_per_bs)
-            # see NOTE(draft_extend seq_len handling)
-            seq_lens = seq_lens[:bs] - metadata.seq_lens_q[:bs] + metadata.max_seq_len_q
-            metadata.seq_lens_k.copy_(seq_lens.to(torch.int32))
-
-        # Update block indices for new sequences.
-        create_flashmla_kv_indices_triton[(bs,)](
-            self.req_to_token,
-            req_pool_indices[:bs],
-            seq_lens,
-            None,
-            metadata.block_kv_indices,
-            self.req_to_token.stride(0),
-            metadata.block_kv_indices.shape[1],
-            PAGED_SIZE=self.page_size,
-        )
-
     def get_cuda_graph_seq_len_fill_value(self) -> int:
         """Get the fill value for sequence lengths in CUDA graph."""
         return 1
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Initialize the metadata for a forward pass."""
         # Delegate to parent for non-decode modes.
         if (
@@ -593,7 +524,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 self.disable_chunked_prefix_cache and has_prefix
             ) or is_in_piecewise_cuda_graph()
             if fallback_to_flashinfer_impl:
-                super().init_forward_metadata(forward_batch)
+                super().init_forward_data(forward_batch)
 
             seq_lens = forward_batch.seq_lens - forward_batch.extend_prefix_lens
             cum_seq_lens_q = torch.cat(
@@ -670,7 +601,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
             forward_batch.decode_trtllm_mla_metadata = self.forward_decode_metadata
         else:
-            return super().init_forward_metadata(forward_batch)
+            super().init_forward_data(forward_batch)
 
     def init_mha_chunk_metadata(self, forward_batch: ForwardBatch):
         super().init_mha_chunk_metadata(forward_batch, disable_flashinfer_ragged=True)

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -449,38 +449,51 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             super().init_forward_data_out_graph(forward_batch)
             return
 
-        metadata = TRTLLMMLADecodeMetadata()
+        # Bind metadata on first call per bs; reuse subsequent calls so the
+        # captured graph's recorded pointers stay valid at replay (fresh
+        # ``torch.zeros``/``torch.full`` allocations on every call would shift
+        # the pointer, leaving the captured kernel reading stale memory).
+        if bs not in self.decode_cuda_graph_metadata:
+            metadata = TRTLLMMLADecodeMetadata()
+            if forward_mode.is_target_verify() or forward_mode.is_draft_extend(
+                include_v2=True
+            ):
+                metadata.seq_lens_k = torch.zeros(
+                    (bs,), dtype=torch.int32, device=seq_lens.device
+                )
+            if forward_mode.is_draft_extend(include_v2=True):
+                num_tokens_per_bs = self.num_draft_tokens
+                metadata.cu_seqlens_q = torch.arange(
+                    0,
+                    bs * num_tokens_per_bs + 1,
+                    num_tokens_per_bs,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
+                )
+                metadata.seq_lens_q = torch.full(
+                    (bs,),
+                    num_tokens_per_bs,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
+                )
+                metadata.max_seq_len_q = num_tokens_per_bs
+                metadata.sum_seq_lens_q = num_tokens_per_bs * bs
+            self.decode_cuda_graph_metadata[bs] = metadata
+        else:
+            metadata = self.decode_cuda_graph_metadata[bs]
 
+        # Per-iter refresh (in-place writes into the bound buffers).
         if forward_mode.is_target_verify():
-            seq_lens = seq_lens + self.num_draft_tokens
-            metadata.seq_lens_k = torch.zeros(
-                (bs,), dtype=torch.int32, device=seq_lens.device
-            )
-            metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
+            local_seq_lens = seq_lens + self.num_draft_tokens
+            metadata.seq_lens_k.copy_(local_seq_lens.to(dtype=torch.int32))
+            seq_lens = local_seq_lens
         elif forward_mode.is_draft_extend(include_v2=True):
-            num_tokens_per_bs = self.num_draft_tokens
-            metadata.max_seq_len_q = num_tokens_per_bs
-            metadata.sum_seq_lens_q = num_tokens_per_bs * bs
-            metadata.cu_seqlens_q = torch.arange(
-                0,
-                bs * num_tokens_per_bs + 1,
-                num_tokens_per_bs,
-                dtype=torch.int32,
-                device=seq_lens.device,
-            )
-            metadata.seq_lens_q = torch.full(
-                (bs,), num_tokens_per_bs, dtype=torch.int32, device=seq_lens.device
-            )
             # NOTE(draft_extend seq_len handling):
             # forward_batch.seq_lens is the seq_lens of the prev_context + verified tokens.
             # To account for pad_draft_extend_query, we need seq_lens = prev_context + max_draft_tokens.
-            # This will ensure queries align with kvs correctly when calling
-            # flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla.
-            seq_lens = seq_lens - metadata.seq_lens_q + metadata.max_seq_len_q
-            metadata.seq_lens_k = torch.zeros(
-                (bs,), dtype=torch.int32, device=seq_lens.device
-            )
-            metadata.seq_lens_k.copy_(seq_lens.to(dtype=torch.int32))
+            local_seq_lens = seq_lens - metadata.seq_lens_q + metadata.max_seq_len_q
+            metadata.seq_lens_k.copy_(local_seq_lens.to(dtype=torch.int32))
+            seq_lens = local_seq_lens
 
         # Custom fast-path for decode/idle.
         # Capture with full width so future longer sequences are safe during replay
@@ -501,7 +514,6 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         metadata.block_kv_indices = block_kv_indices
         metadata.max_seq_len_k = self.max_context_len
 
-        self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
     def get_cuda_graph_seq_len_fill_value(self) -> int:

--- a/python/sglang/srt/layers/attention/wave_backend.py
+++ b/python/sglang/srt/layers/attention/wave_backend.py
@@ -11,13 +11,12 @@ import triton.language as tl
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_tp_size
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import get_bool_env_var, get_device_core_count
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
-    from sglang.srt.speculative.spec_info import SpecInput
 
 logger = logging.getLogger(__name__)
 
@@ -197,8 +196,8 @@ class WaveAttnBackend(AttentionBackend):
             MAX_NUM_SEQ=SCHEDULE_SEQ,
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
-        """Init auxiliary variables for wave attention backend."""
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
+        """Init auxiliary variables for wave attention backend (eager path)."""
 
         bs = forward_batch.batch_size
         kv_indptr = self.kv_indptr
@@ -390,16 +389,24 @@ class WaveAttnBackend(AttentionBackend):
                 device=self.device,
             )
 
-    def init_forward_metadata_capture_cuda_graph(
-        self,
-        bs: int,
-        num_tokens: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-    ):
+    def init_forward_data_out_graph(self, forward_batch: ForwardBatch) -> None:
+        """Per-iter metadata prep for capture + replay paths.
+
+        Body merged from old ``init_forward_metadata_capture_cuda_graph`` and
+        ``init_forward_metadata_replay_cuda_graph`` -- both wrote to the same
+        ``self.cuda_graph_*`` pre-allocated buffers and ran similar logic.
+        Called outside ``with graph.capture():`` at both capture (initial
+        fill) and replay (per-iter refresh). Rebuilds ``self.forward_metadata``
+        each call; the underlying buffers stay pinned to ``self.cuda_graph_*``
+        across iterations so the captured forward kernel sees the updated
+        data via stable pointers.
+        """
+        bs = forward_batch.batch_size
+        req_pool_indices = forward_batch.req_pool_indices
+        seq_lens = forward_batch.seq_lens
+        encoder_lens = forward_batch.encoder_lens
+        forward_mode = forward_batch.forward_mode
+        spec_info = forward_batch.spec_info
         assert encoder_lens is None, "Not supported"
 
         if forward_mode.is_decode_or_idle():
@@ -473,74 +480,6 @@ class WaveAttnBackend(AttentionBackend):
             custom_mask,
             mask_indptr,
         )
-
-    def init_forward_metadata_replay_cuda_graph(
-        self,
-        bs: int,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        seq_lens_sum: int,
-        encoder_lens: Optional[torch.Tensor],
-        forward_mode: ForwardMode,
-        spec_info: Optional[SpecInput],
-        seq_lens_cpu: Optional[torch.Tensor],
-    ):
-        # NOTE: encoder_lens expected to be zeros or None
-        if forward_mode.is_decode_or_idle():
-            # Update kv_indptr, kv_indices
-            kv_indptr = self.kv_indptr
-            kv_indices = self.cuda_graph_kv_indices
-            num_kv_splits = self.cuda_graph_num_kv_splits
-            if spec_info is None:
-                kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens[:bs], dim=0)
-                kv_indptr = kv_indptr[: bs + 1]
-                create_flashinfer_kv_indices_triton[(bs,)](
-                    self.req_to_token,
-                    req_pool_indices[:bs],
-                    seq_lens[:bs],
-                    kv_indptr,
-                    None,
-                    kv_indices,
-                    self.req_to_token.stride(0),
-                )
-                num_token = bs
-            else:
-                kv_indptr[: spec_info.kv_indptr.shape[0]] = spec_info.kv_indptr
-                kv_indices[: spec_info.kv_indices.shape[0]] = spec_info.kv_indices
-                num_token = spec_info.kv_indptr.shape[0] - 1
-            self.get_num_kv_splits(num_kv_splits[:num_token], seq_lens[:bs])
-        elif forward_mode.is_target_verify():
-            # Update qo_indptr, kv_indptr, kv_indices, custom_mask, mask_indptr
-            bs = len(req_pool_indices)
-            qo_indptr = self.qo_indptr[: bs + 1]
-            qo_indptr[: bs + 1] = torch.arange(
-                0,
-                (1 + bs) * self.num_draft_tokens,
-                step=self.num_draft_tokens,
-                dtype=torch.int32,
-                device=self.device,
-            )
-            kv_indptr = self.kv_indptr[: bs + 1]
-            kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens, dim=0)
-            kv_indices = self.cuda_graph_kv_indices
-            create_flashinfer_kv_indices_triton[(bs,)](
-                self.req_to_token,
-                req_pool_indices,
-                seq_lens,
-                kv_indptr,
-                None,
-                kv_indices,
-                self.req_to_token.stride(0),
-            )
-            custom_mask = self.cuda_graph_custom_mask
-            custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-            seq_mask_len = self.num_draft_tokens * (seq_lens + self.num_draft_tokens)
-            mask_indptr = self.mask_indptr[: bs + 1]
-            mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
-        else:
-            raise ValueError(
-                f"Invalid forward mode: {forward_mode=} for CUDA Graph replay."
-            )
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -97,7 +97,7 @@ class XPUAttentionBackend(AttentionBackend):
             self.sliding_window_size is not None and self.sliding_window_size > -1
         )
 
-    def init_forward_metadata(self, forward_batch: ForwardBatch):
+    def init_forward_data(self, forward_batch: ForwardBatch) -> None:
         """Initialize forward metadata hence all layers in the forward pass can reuse it."""
         metadata = FlashAttentionMetadata()
         seqlens_in_batch = forward_batch.seq_lens

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -327,10 +327,11 @@ class BreakableCudaGraphRunner:
         """Warmup the model with a forward pass."""
         num_tokens = self.capture_num_tokens[0]
         forward_batch = self._build_capture_forward_batch(num_tokens)
+        # Eager warmup -- no breakable cuda graph capture in progress.
         with forward_context(
             ForwardContext(attn_backend=self.model_runner.attn_backend)
         ):
-            self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+            self.model_runner.attn_backend.init_forward_data(forward_batch)
             self._run_forward(forward_batch, num_tokens)
 
     def _capture_all(self):
@@ -387,9 +388,20 @@ class BreakableCudaGraphRunner:
     def _capture_one(self, num_tokens, pool, stream):
         """Capture a breakable CUDA graph for one token size."""
         forward_batch = self._build_capture_forward_batch(num_tokens)
-        self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+        # Per-iter prep runs OUTSIDE the breakable graph capture scope. The
+        # matching in-graph hook is invoked inside `run_once`, which the
+        # `with BreakableCUDAGraphCapture(...)` block below executes under
+        # the graph capture context.
+        self.model_runner.attn_backend.init_forward_data_out_graph(forward_batch)
 
         def run_once():
+            # Graph-recordable metadata prep -- recorded into the captured
+            # breakable graph and auto-replayed by graph.replay(). Default
+            # impl is no-op for most backends in the initial migration;
+            # also exercised during warmup runs (outside the graph context),
+            # which is safe because no-op is harmless.
+            self.model_runner.attn_backend.init_forward_data_in_graph(forward_batch)
+
             # Invalidate SWA loc cache — same fix as in cuda_graph_runner.run_once.
             if self.model_runner.is_hybrid_swa:
                 self.model_runner.token_to_kv_pool.invalidate_loc_cache()
@@ -463,7 +475,13 @@ class BreakableCudaGraphRunner:
             original_layer_forward = self.layer_model.forward
             self.layer_model.forward = replay_layer_forward
             try:
-                self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+                # Replay path: only the out-graph phase runs per replay. The
+                # in-graph ops recorded into the captured breakable graph at
+                # capture time are auto-replayed by ``captured_graph.replay()``
+                # inside ``replay_layer_forward``.
+                self.model_runner.attn_backend.init_forward_data_out_graph(
+                    forward_batch
+                )
                 with set_forward_context(
                     static_forward_batch,
                     self.attention_layers,

--- a/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/breakable_cuda_graph_runner.py
@@ -336,8 +336,15 @@ class BreakableCudaGraphRunner:
 
     def _capture_all(self):
         """Capture breakable CUDA graphs for all token sizes."""
+        # ``model_capture_mode()`` is needed by Mamba/Lightning backends that
+        # gate ``_capture_metadata`` vs ``_replay_metadata`` via
+        # ``get_is_capture_mode()``; without it, capture takes the replay
+        # branch and expects per-iter padding the BCG synthetic fb doesn't have.
+        from sglang.srt.model_executor.cuda_graph_runner import model_capture_mode
+
         with (
             freeze_gc(self.model_runner.server_args.enable_cudagraph_gc),
+            model_capture_mode(),
             graph_capture() as graph_capture_context,
             enable_breakable_cuda_graph(),
         ):

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -771,7 +771,7 @@ class CPUGraphRunner:
 
         raw_bs = forward_batch.batch_size
         if raw_bs in self.graphs:
-            self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+            self.model_runner.attn_backend.init_forward_data(forward_batch)
             return forward_batch
 
         raw_num_token = raw_bs * self.num_tokens_per_bs
@@ -807,7 +807,7 @@ class CPUGraphRunner:
                 forward_batch.num_token_non_padded
             )
 
-        self.model_runner.attn_backend.init_forward_metadata(captured_forward_batch)
+        self.model_runner.attn_backend.init_forward_data(captured_forward_batch)
         return captured_forward_batch
 
     def replay(

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -22,7 +22,7 @@ import inspect
 import logging
 import os
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
@@ -1056,17 +1056,20 @@ class CudaGraphRunner:
             if lora_ids is not None:
                 self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
-            attn_backend.init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_batch.forward_mode,
-                forward_batch.spec_info,
-            )
+            # Attention backend: per-iter prep runs OUTSIDE the graph capture
+            # scope. The matching in-graph hook below is invoked inside
+            # `with graph.capture():` via `run_once`.
+            attn_backend.init_forward_data_out_graph(forward_batch)
 
             def run_once():
+                # The in-graph metadata hook is recorded into the cuda graph
+                # at capture time and auto-replayed by graph.replay(). Default
+                # impl is no-op for most backends in the initial migration;
+                # it is also exercised during warmup runs (outside the graph
+                # context), which is safe because no-op is harmless and any
+                # backend that overrides it must keep ops graph-recordable.
+                attn_backend.init_forward_data_in_graph(forward_batch)
+
                 # Without this, warmup-1 caches the translation; the capture
                 # run hits the cache, skips the gather, and replay reuses
                 # stale SWA locations.
@@ -1157,6 +1160,37 @@ class CudaGraphRunner:
             self.capture_hidden_mode = required_capture_hidden_mode
             self.capture()
 
+    def _build_replay_forward_batch_view(
+        self,
+        forward_batch: ForwardBatch,
+        buffers,
+        bs: int,
+        raw_bs: int,
+    ) -> ForwardBatch:
+        """Build a lightweight ForwardBatch view for the replay path.
+
+        Backends now read every metadata field off the ForwardBatch (the old
+        positional capture/replay signatures are gone), so caller-side
+        construction of a padded-bs view replaces the previous per-arg
+        plumbing. Fields not derived from the padded buffers (spec_info,
+        out_cache_loc, etc.) are inherited from the live ``forward_batch``;
+        dsv4 still consults those through the legacy side channel until
+        step 04 fully covers them here.
+        """
+        return replace(
+            forward_batch,
+            forward_mode=self.capture_forward_mode,
+            batch_size=bs,
+            req_pool_indices=buffers.req_pool_indices[:bs],
+            seq_lens=buffers.seq_lens[:bs],
+            seq_lens_sum=forward_batch.seq_lens_sum
+            + (bs - raw_bs) * self.seq_len_fill_value,
+            seq_lens_cpu=buffers.seq_lens_cpu[:bs],
+            encoder_lens=(
+                buffers.encoder_lens[:bs] if self.is_encoder_decoder else None
+            ),
+        )
+
     def replay_prepare(
         self,
         forward_batch: ForwardBatch,
@@ -1220,17 +1254,17 @@ class CudaGraphRunner:
             attn_backend = self.attn_backend
         # FIXME: implicit channel for backends (dsv4) that need forward_batch
         # in replay metadata prep. Should become a real param on the interface.
+        # Step 04 removes the side channel once the fb view below covers every
+        # field dsv4 reads from it (out_cache_loc / forward_mode / IDLE
+        # replacement). Step 03 keeps set/clear to preserve that coverage.
         attn_backend._replay_forward_batch = forward_batch
-        attn_backend.init_forward_metadata_replay_cuda_graph(
-            bs,
-            buffers.req_pool_indices[:bs],
-            buffers.seq_lens[:bs],
-            forward_batch.seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value,
-            buffers.encoder_lens[:bs] if self.is_encoder_decoder else None,
-            self.capture_forward_mode,
-            forward_batch.spec_info,
-            seq_lens_cpu=buffers.seq_lens_cpu[:bs],
+        fb_view = self._build_replay_forward_batch_view(
+            forward_batch=forward_batch,
+            buffers=buffers,
+            bs=bs,
+            raw_bs=raw_bs,
         )
+        attn_backend.init_forward_data_out_graph(fb_view)
         attn_backend._replay_forward_batch = None
 
         # Store fields

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1177,6 +1177,7 @@ class CudaGraphRunner:
         dsv4 still consults those through the legacy side channel until
         step 04 fully covers them here.
         """
+        num_tokens = bs * self.num_tokens_per_bs
         return replace(
             forward_batch,
             forward_mode=self.capture_forward_mode,
@@ -1189,6 +1190,13 @@ class CudaGraphRunner:
             encoder_lens=(
                 buffers.encoder_lens[:bs] if self.is_encoder_decoder else None
             ),
+            # Backends (FA3, trtllm_mha, flashinfer, ...) derive
+            # ``num_tokens = positions.shape[0]`` and combine with ``bs`` to
+            # compute ``tokens_per_req = num_tokens // bs``. Without overriding
+            # ``positions`` here the view inherits the UNPADDED iteration
+            # tensor while ``bs`` is the padded bucket size -- ``tokens_per_req``
+            # becomes wrong (or 0, crashing ``torch.arange(step=0)``).
+            positions=buffers.positions[:num_tokens],
         )
 
     def replay_prepare(
@@ -1257,6 +1265,8 @@ class CudaGraphRunner:
         # Step 04 removes the side channel once the fb view below covers every
         # field dsv4 reads from it (out_cache_loc / forward_mode / IDLE
         # replacement). Step 03 keeps set/clear to preserve that coverage.
+        # TboAttnBackend additionally propagates the side channel onto each
+        # inner primary/child (see TboAttnBackend._propagate_replay_forward_batch).
         attn_backend._replay_forward_batch = forward_batch
         fb_view = self._build_replay_forward_batch_view(
             forward_batch=forward_batch,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2669,7 +2669,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         if lora_ids is not None:
             self.lora_manager.prepare_lora_batch(forward_batch)
 
-        self.attn_backend.init_forward_metadata(forward_batch)
+        self.attn_backend.init_forward_data(forward_batch)
 
         def run_once():
             forward_batch.dp_local_start_pos = forward_batch.dp_local_num_tokens = None
@@ -2988,13 +2988,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # e.g. Moss-VL's prefill cross-attention custom mask.
                 self.model.prepare_forward_batch(forward_batch)
             if self.server_args.enable_pdmux:
-                self.decode_attn_backend.init_forward_metadata(forward_batch)
+                self.decode_attn_backend.init_forward_data(forward_batch)
                 # PDmux selects a per-stream backend; publish it to model-layer
                 # readers via the active ForwardContext so RadixAttention etc.
                 # dispatch against the right backend for this forward.
                 pdmux_override = True
             else:
-                self.attn_backend.init_forward_metadata(forward_batch)
+                self.attn_backend.init_forward_data(forward_batch)
         # FIXME: add pp_proxy_tensors arg to all models
         kwargs = {}
         if self.support_pp:
@@ -3075,7 +3075,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 # Prepare model-specific attention metadata before planning,
                 # e.g. Moss-VL's prefill cross-attention custom mask.
                 self.model.prepare_forward_batch(forward_batch)
-            self.attn_backend.init_forward_metadata(forward_batch)
+            self.attn_backend.init_forward_data(forward_batch)
 
         ctx = (
             self.device_timer.wrap(metadata={"category": "extend"})
@@ -3098,7 +3098,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         # in this case, we need to reinit the forward metadata, otherwise the stale
         # metadata causes batch_size mismatch in attention kernel(e.g. DSA Indexer).
         if forward_batch.batch_size > 0:
-            self.attn_backend.init_forward_metadata(forward_batch)
+            self.attn_backend.init_forward_data(forward_batch)
 
         kwargs = {}
         if self.support_pp:
@@ -3123,7 +3123,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         forward_count: int = 1,
     ) -> LogitsProcessorOutput:
         if forward_batch.split_index == 0 or reinit_attn_backend:
-            self.attn_backend.init_forward_metadata(forward_batch)
+            self.attn_backend.init_forward_data(forward_batch)
         next_split_index = min(
             forward_batch.split_index + forward_count,
             self.model_config.num_hidden_layers,

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -476,8 +476,15 @@ class PiecewiseCudaGraphRunner:
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.
+        # ``model_capture_mode()`` is needed by Mamba/Lightning backends that
+        # gate ``_capture_metadata`` vs ``_replay_metadata`` via
+        # ``get_is_capture_mode()``; without it, capture takes the replay
+        # branch and expects per-iter padding the PCG synthetic fb doesn't have.
+        from sglang.srt.model_executor.cuda_graph_runner import model_capture_mode
+
         with (
             freeze_gc(self.model_runner.server_args.enable_cudagraph_gc),
+            model_capture_mode(),
             graph_capture() as graph_capture_context,
         ):
             stream = graph_capture_context.stream

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -418,8 +418,8 @@ class PiecewiseCudaGraphRunner:
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
 
-        # Attention backend
-        self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+        # Attention backend (eager warmup; no graph capture in progress)
+        self.model_runner.attn_backend.init_forward_data(forward_batch)
         forward_batch.dp_local_start_pos = forward_batch.dp_local_num_tokens = None
         set_dp_buffer_len(None, num_tokens, forward_batch.dp_padding_mode.is_max_len())
         set_is_extend_in_batch(False)
@@ -594,10 +594,19 @@ class PiecewiseCudaGraphRunner:
             if lora_ids is not None:
                 self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
-            self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+            # PCG capture aligns with full-graph contract: per-iter prep runs
+            # outside model.forward (which is the torch.compile-traced piece
+            # that becomes the captured graph), while the graph-recordable
+            # phase is invoked inside ``run_once`` so it gets traced too.
+            self.model_runner.attn_backend.init_forward_data_out_graph(forward_batch)
 
             # Run and capture
             def run_once():
+                # Graph-recordable metadata prep -- captured into the traced
+                # piecewise graph alongside the model forward. No-op for all
+                # backends in the initial migration.
+                self.model_runner.attn_backend.init_forward_data_in_graph(forward_batch)
+
                 # Invalidate SWA loc cache — same fix as in cuda_graph_runner.run_once.
                 if self.model_runner.is_hybrid_swa:
                     self.model_runner.token_to_kv_pool.invalidate_loc_cache()
@@ -796,8 +805,14 @@ class PiecewiseCudaGraphRunner:
                 self.moe_layers,
                 self.moe_fusions,
             ):
-                # Due to the dispatch kernel for MLA model, we init the metadata with original forward_batch
-                self.model_runner.attn_backend.init_forward_metadata(forward_batch)
+                # Due to the dispatch kernel for MLA model, we init the metadata
+                # with the original forward_batch. The graph-recordable
+                # ``init_forward_data_in_graph`` ops captured at compile time
+                # are auto-replayed by the traced piecewise graph, so only
+                # the out-graph phase runs here per replay.
+                self.model_runner.attn_backend.init_forward_data_out_graph(
+                    forward_batch
+                )
                 output = self.model_runner.model.forward(
                     static_forward_batch.input_ids,
                     static_forward_batch.positions,

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -350,6 +350,8 @@ class EAGLEDraftCudaGraphRunner:
         )
 
         def run_once():
+            self.draft_attn_backend.init_forward_data_in_graph(forward_batch)
+
             if self.model_runner.is_hybrid_swa:
                 self.model_runner.token_to_kv_pool.invalidate_loc_cache()
 
@@ -372,9 +374,10 @@ class EAGLEDraftCudaGraphRunner:
             return ret
 
         with forward_context(ForwardContext(attn_backend=self.draft_attn_backend)):
-            self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(
-                forward_batch
-            )
+            # Attention backend: per-iter prep runs OUTSIDE the graph capture
+            # scope. The matching in-graph hook is invoked inside `run_once`,
+            # which is executed under the graph context by `_capture_graph`.
+            self.draft_attn_backend.init_forward_data_out_graph(forward_batch)
             self.deepep_adapter.capture(is_extend_in_batch=False)
             self._capture_init(run_once)
             out = self._capture_graph(
@@ -467,9 +470,11 @@ class EAGLEDraftCudaGraphRunner:
             buffers.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
-        self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
-            forward_batch, bs
-        )
+        # Replay path: only the out-graph phase runs per replay. The in-graph
+        # ops recorded into the captured graph at capture time auto-replay via
+        # graph.replay(). The padded ``bs`` is read off ``forward_batch.batch_size``
+        # which is set above to the capture bs.
+        self.draft_attn_backend.init_forward_data_out_graph(forward_batch)
         self.raw_bs = raw_bs
         self.bs = bs
         # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -474,7 +474,15 @@ class EAGLEDraftCudaGraphRunner:
         # ops recorded into the captured graph at capture time auto-replay via
         # graph.replay(). The padded ``bs`` is read off ``forward_batch.batch_size``
         # which is set above to the capture bs.
+        # FIXME: side channel mirroring ``cuda_graph_runner.replay_prepare``.
+        # DSV4/DSA multi-step backends discriminate capture vs replay via
+        # ``self._replay_forward_batch``; without setting it here the inner
+        # backends take the capture branch at replay and rebuild metadata
+        # into freshly-allocated tensors while the captured graph holds
+        # capture-time pointers. Step 04 removes the side channel.
+        self.draft_attn_backend._replay_forward_batch = forward_batch
         self.draft_attn_backend.init_forward_data_out_graph(forward_batch)
+        self.draft_attn_backend._replay_forward_batch = None
         self.raw_bs = raw_bs
         self.bs = bs
         # TODO: The forward_batch.seq_len_sum might need to be updated to reflect the padding in the cuda graph

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import bisect
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
@@ -380,6 +380,11 @@ class EAGLEDraftExtendCudaGraphRunner:
         )
 
         def run_once():
+            # Graph-recordable metadata prep -- recorded into the captured
+            # graph and auto-replayed by graph.replay(). No-op for most
+            # backends in the initial migration.
+            self.draft_extend_attn_backend.init_forward_data_in_graph(forward_batch)
+
             if self.model_runner.is_hybrid_swa:
                 self.model_runner.token_to_kv_pool.invalidate_loc_cache()
 
@@ -411,15 +416,11 @@ class EAGLEDraftExtendCudaGraphRunner:
         with forward_context(
             ForwardContext(attn_backend=self.draft_extend_attn_backend)
         ):
-            self.draft_extend_attn_backend.init_forward_metadata_capture_cuda_graph(
-                bs=bs,
-                num_tokens=num_tokens,
-                req_pool_indices=req_pool_indices,
-                seq_lens=seq_lens,
-                encoder_lens=None,
-                forward_mode=self.forward_mode,
-                spec_info=spec_info,
-            )
+            # Attention backend: per-iter prep runs OUTSIDE the graph capture
+            # scope. ``forward_batch`` carries the bs-sliced buffer views
+            # (``req_pool_indices``, ``seq_lens``, etc.) so the backend reads
+            # the right fields off it.
+            self.draft_extend_attn_backend.init_forward_data_out_graph(forward_batch)
             self.deepep_adapter.capture(is_extend_in_batch=True)
             self._capture_init(run_once)
             out = self._capture_graph(
@@ -519,17 +520,23 @@ class EAGLEDraftExtendCudaGraphRunner:
             forward_batch.spec_info.num_correct_drafts = buffers.num_correct_drafts[:bs]
             forward_batch.spec_info.num_accept_tokens = buffers.num_accept_tokens[:bs]
 
-        self.draft_extend_attn_backend.init_forward_metadata_replay_cuda_graph(
-            bs=bs,
-            req_pool_indices=buffers.req_pool_indices,
-            seq_lens=buffers.seq_lens,
+        # Replay path: build a lightweight ForwardBatch view onto the padded
+        # buffers so the backend reads bs-sized fields off ``forward_batch.*``
+        # exactly like at capture time. The in-graph ops recorded into the
+        # captured graph at capture time auto-replay via ``graph.replay()``,
+        # so only the out-graph phase runs here per replay.
+        fb_view = replace(
+            forward_batch,
+            forward_mode=self.forward_mode,
+            batch_size=bs,
+            req_pool_indices=buffers.req_pool_indices[:bs],
+            seq_lens=buffers.seq_lens[:bs],
             seq_lens_sum=forward_batch.seq_lens_sum
             + (bs - raw_bs) * self.seq_len_fill_value,
+            seq_lens_cpu=buffers.seq_lens_cpu[:bs],
             encoder_lens=None,
-            forward_mode=self.forward_mode,
-            spec_info=forward_batch.spec_info,
-            seq_lens_cpu=buffers.seq_lens_cpu,
         )
+        self.draft_extend_attn_backend.init_forward_data_out_graph(fb_view)
 
         # Replay
         self.raw_bs = raw_bs

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -535,8 +535,17 @@ class EAGLEDraftExtendCudaGraphRunner:
             + (bs - raw_bs) * self.seq_len_fill_value,
             seq_lens_cpu=buffers.seq_lens_cpu[:bs],
             encoder_lens=None,
+            positions=buffers.positions[:num_tokens],
         )
+        # FIXME: side channel mirroring ``cuda_graph_runner.replay_prepare``.
+        # DSV4/DSA multi-step backends discriminate capture vs replay via
+        # ``self._replay_forward_batch``; without setting it here the inner
+        # backends take the capture branch at replay and rebuild metadata
+        # into freshly-allocated tensors while the captured graph holds
+        # capture-time pointers. Step 04 removes the side channel.
+        self.draft_extend_attn_backend._replay_forward_batch = forward_batch
         self.draft_extend_attn_backend.init_forward_data_out_graph(fb_view)
+        self.draft_extend_attn_backend._replay_forward_batch = None
 
         # Replay
         self.raw_bs = raw_bs

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -246,7 +246,7 @@ class EagleDraftInputV2Mixin:
         forward_batch = ForwardBatch.init_new(batch, draft_model_runner)
         can_cuda_graph = cuda_graph_runner and cuda_graph_runner.can_run(forward_batch)
         if not batch.forward_mode.is_idle() and not can_cuda_graph:
-            draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
+            draft_model_runner.attn_backend.init_forward_data(forward_batch)
         return forward_batch
 
 
@@ -306,7 +306,7 @@ class EagleVerifyInputV2Mixin:
             target_worker.model_runner.graph_runner.replay_prepare(verify_forward_batch)
         else:
             if not batch.forward_mode.is_idle():
-                target_worker.model_runner.attn_backend.init_forward_metadata(
+                target_worker.model_runner.attn_backend.init_forward_data(
                     verify_forward_batch
                 )
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -777,7 +777,7 @@ class EAGLEWorker(TpModelWorker):
                 and self.speculative_num_steps > 1
             ):
                 # Skip attention backend init for idle mode or 1-step draft
-                self.draft_attn_backend.init_forward_metadata(forward_batch)
+                self.draft_attn_backend.init_forward_data(forward_batch)
             # Run forward steps
             parent_list, top_scores_index, draft_tokens = self.draft_forward(
                 forward_batch
@@ -1210,7 +1210,7 @@ class EAGLEWorker(TpModelWorker):
                     self.draft_extend_attn_backend
                     or self.draft_model_runner.attn_backend
                 )
-                attn_backend.init_forward_metadata(forward_batch)
+                attn_backend.init_forward_data(forward_batch)
             # Publish the chosen backend via ForwardContext so model code
             # picks it up for this forward (no runner-attr mutation).
             if attn_backend is not None:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -367,7 +367,7 @@ class EagleDraftWorker(BaseDraftWorker):
             ):
                 # Skip attention backend init for 1-step draft,
                 # `draft_forward` only does sample in this case.
-                self.draft_attn_backend.init_forward_metadata(forward_batch)
+                self.draft_attn_backend.init_forward_data(forward_batch)
             parent_list, top_scores_index, draft_tokens = self.draft_forward(
                 forward_batch
             )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -282,6 +282,11 @@ class FrozenKVMTPCudaGraphRunner:
         )
 
         def run_once():
+            # Graph-recordable metadata prep. Default no-op for all backends
+            # in the initial migration, but invoked under the graph capture
+            # context so any future per-backend overrides get recorded.
+            self.frozen_kv_mtp_worker._init_frozen_kv_metadata_in_graph(forward_batch)
+
             if self.model_runner.is_hybrid_swa:
                 self.model_runner.token_to_kv_pool.invalidate_loc_cache()
 

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -336,8 +336,16 @@ class FrozenKVMTPWorker(TpModelWorker):
             encoder_lens=None,
             spec_info=None,
         )
+        # FIXME: side channel mirroring ``cuda_graph_runner.replay_prepare``.
+        # DSV4/DSA backends discriminate capture vs replay via
+        # ``self._replay_forward_batch``; without setting it here the inner
+        # backends take the capture branch at replay and rebuild metadata
+        # into freshly-allocated tensors while the captured graph holds
+        # capture-time pointers. Step 04 removes the side channel.
         with self._frozen_kv_target_view(forward_batch):
+            self.draft_attn_backend._replay_forward_batch = forward_batch
             self.draft_attn_backend.init_forward_data_out_graph(fb_view)
+            self.draft_attn_backend._replay_forward_batch = None
 
     def init_cuda_graphs(self) -> None:
         if self.server_args.disable_cuda_graph or self.speculative_num_steps <= 1:

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker.py
@@ -21,6 +21,7 @@ assistant-side KV extension.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import List, Optional, Tuple
 
 import torch
@@ -279,40 +280,64 @@ class FrozenKVMTPWorker(TpModelWorker):
         else:
             forward_batch.seq_lens_sum = torch.sum(forward_batch.seq_lens).item()
         with self._frozen_kv_target_view(forward_batch):
-            self.draft_attn_backend.init_forward_metadata(forward_batch)
+            self.draft_attn_backend.init_forward_data(forward_batch)
 
     def _init_frozen_kv_metadata_capture_cuda_graph(
         self, forward_batch: ForwardBatch
     ) -> None:
+        # Frozen-KV MTP draft drives the underlying backend in DECODE mode
+        # against the frozen target KV pool; override the relevant fb fields
+        # for that view rather than mutating the caller's batch in place.
+        fb_view = replace(
+            forward_batch,
+            forward_mode=ForwardMode.DECODE,
+            spec_info=None,
+            encoder_lens=None,
+        )
         with self._frozen_kv_target_view(forward_batch):
-            self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(
-                forward_batch.batch_size,
-                forward_batch.positions.numel(),
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=None,
-            )
+            self.draft_attn_backend.init_forward_data_out_graph(fb_view)
+
+    def _init_frozen_kv_metadata_in_graph(self, forward_batch: ForwardBatch) -> None:
+        """In-graph counterpart of ``_init_frozen_kv_metadata_capture_cuda_graph``.
+
+        Default no-op for all backends in the initial migration; provided so
+        the cuda graph runner can invoke the new contract inside the graph
+        capture scope and so future per-backend overrides can be added
+        without changing the runner side.
+        """
+        fb_view = replace(
+            forward_batch,
+            forward_mode=ForwardMode.DECODE,
+            spec_info=None,
+            encoder_lens=None,
+        )
+        with self._frozen_kv_target_view(forward_batch):
+            self.draft_attn_backend.init_forward_data_in_graph(fb_view)
 
     def _init_frozen_kv_metadata_replay_cuda_graph(
         self, forward_batch: ForwardBatch, bs: int, seq_lens_sum: int
     ) -> None:
+        # Build a lightweight ForwardBatch view onto the padded buffers in
+        # DECODE mode (the underlying backend runs the same body as at
+        # capture time). The in-graph ops captured then auto-replay via
+        # graph.replay(), so only the out-graph phase runs here per replay.
+        fb_view = replace(
+            forward_batch,
+            forward_mode=ForwardMode.DECODE,
+            batch_size=bs,
+            req_pool_indices=forward_batch.req_pool_indices[:bs],
+            seq_lens=forward_batch.seq_lens[:bs],
+            seq_lens_sum=seq_lens_sum,
+            seq_lens_cpu=(
+                forward_batch.seq_lens_cpu[:bs]
+                if forward_batch.seq_lens_cpu is not None
+                else None
+            ),
+            encoder_lens=None,
+            spec_info=None,
+        )
         with self._frozen_kv_target_view(forward_batch):
-            self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
-                bs,
-                forward_batch.req_pool_indices[:bs],
-                forward_batch.seq_lens[:bs],
-                seq_lens_sum,
-                encoder_lens=None,
-                forward_mode=ForwardMode.DECODE,
-                spec_info=None,
-                seq_lens_cpu=(
-                    forward_batch.seq_lens_cpu[:bs]
-                    if forward_batch.seq_lens_cpu is not None
-                    else None
-                ),
-            )
+            self.draft_attn_backend.init_forward_data_out_graph(fb_view)
 
     def init_cuda_graphs(self) -> None:
         if self.server_args.disable_cuda_graph or self.speculative_num_steps <= 1:

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -588,10 +588,18 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
             + (bs - raw_bs) * self.seq_len_fill_value,
             seq_lens_cpu=buffers.seq_lens_cpu[:bs],
             encoder_lens=None,
+            positions=buffers.positions[:num_tokens],
         )
-        self.eagle_worker.draft_extend_attn_backend_list[
-            self.step
-        ].init_forward_data_out_graph(fb_view)
+        # FIXME: side channel mirroring ``cuda_graph_runner.replay_prepare``.
+        # DSV4/DSA multi-step backends discriminate capture vs replay via
+        # ``self._replay_forward_batch``; without setting it here the inner
+        # backends take the capture branch at replay and rebuild metadata
+        # into freshly-allocated tensors while the captured graph holds
+        # capture-time pointers. Step 04 removes the side channel.
+        attn_backend = self.eagle_worker.draft_extend_attn_backend_list[self.step]
+        attn_backend._replay_forward_batch = forward_batch
+        attn_backend.init_forward_data_out_graph(fb_view)
+        attn_backend._replay_forward_batch = None
 
         # Replay
         self.raw_bs = raw_bs

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import bisect
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable, List, Optional
 
 import torch
@@ -407,6 +407,13 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
         attn_backend = self.eagle_worker.draft_extend_attn_backend_list[self.step]
 
         def run_once():
+            # Graph-recordable metadata prep -- recorded into the captured
+            # graph and auto-replayed by graph.replay(). No-op for most
+            # backends in the initial migration.
+            self.eagle_worker.draft_extend_attn_backend_list[
+                self.step
+            ].init_forward_data_in_graph(forward_batch)
+
             if self.model_runner.is_hybrid_swa:
                 self.model_runner.token_to_kv_pool.invalidate_loc_cache()
 
@@ -485,15 +492,9 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
             return ret
 
         with forward_context(ForwardContext(attn_backend=attn_backend)):
-            attn_backend.init_forward_metadata_capture_cuda_graph(
-                bs=bs,
-                num_tokens=num_tokens,
-                req_pool_indices=forward_batch.req_pool_indices,
-                seq_lens=forward_batch.seq_lens,
-                encoder_lens=None,
-                forward_mode=self.forward_mode,
-                spec_info=forward_batch.spec_info,
-            )
+            # Attention backend: per-iter prep runs OUTSIDE the graph capture
+            # scope. ``forward_batch`` carries the bs-sliced buffer views.
+            attn_backend.init_forward_data_out_graph(forward_batch)
             self.deepep_adapter.capture(is_extend_in_batch=True)
             self._capture_init(run_once)
             out = self._capture_graph(
@@ -572,19 +573,25 @@ class MultiLayerEagleDraftExtendCudaGraphRunner:
         forward_batch.spec_info.positions = buffers.positions[:num_tokens]
         forward_batch.spec_info.extend_seq_lens_tensor = buffers.extend_seq_lens[:bs]
 
-        self.eagle_worker.draft_extend_attn_backend_list[
-            self.step
-        ].init_forward_metadata_replay_cuda_graph(
-            bs=bs,
-            req_pool_indices=buffers.req_pool_indices,
-            seq_lens=buffers.seq_lens,
+        # Replay path: build a lightweight ForwardBatch view onto the padded
+        # buffers so the backend reads bs-sized fields off ``forward_batch.*``
+        # exactly like at capture time. The in-graph ops recorded into the
+        # captured graph at capture time auto-replay via ``graph.replay()``,
+        # so only the out-graph phase runs here per replay.
+        fb_view = replace(
+            forward_batch,
+            forward_mode=self.forward_mode,
+            batch_size=bs,
+            req_pool_indices=buffers.req_pool_indices[:bs],
+            seq_lens=buffers.seq_lens[:bs],
             seq_lens_sum=forward_batch.seq_lens_sum
             + (bs - raw_bs) * self.seq_len_fill_value,
+            seq_lens_cpu=buffers.seq_lens_cpu[:bs],
             encoder_lens=None,
-            forward_mode=self.forward_mode,
-            spec_info=forward_batch.spec_info,
-            seq_lens_cpu=buffers.seq_lens_cpu,
         )
+        self.eagle_worker.draft_extend_attn_backend_list[
+            self.step
+        ].init_forward_data_out_graph(fb_view)
 
         # Replay
         self.raw_bs = raw_bs

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker.py
@@ -761,7 +761,7 @@ class MultiLayerEagleWorker(TpModelWorker):
             else:
                 forward_batch.can_run_dp_cuda_graph = False
                 if not forward_batch.forward_mode.is_idle():
-                    self.mtp_model_runner(step).attn_backend.init_forward_metadata(
+                    self.mtp_model_runner(step).attn_backend.init_forward_data(
                         forward_batch
                     )
                 logits_output = (


### PR DESCRIPTION
## Motivation

The `AttentionBackend` ABC currently exposes three per-forward init methods with asymmetric signatures:

```python
init_forward_metadata(forward_batch)                       # eager
init_forward_metadata_capture_cuda_graph(bs, num_tokens, req_pool_indices,
    seq_lens, encoder_lens, forward_mode, spec_info)       # capture
init_forward_metadata_replay_cuda_graph(bs, req_pool_indices, seq_lens,
    seq_lens_sum, encoder_lens, forward_mode, spec_info,
    seq_lens_cpu)                                          # replay
```

The DSV4 backend additionally needs a `_replay_forward_batch` side channel — set out-of-band on `cuda_graph_runner.py:replay_prepare` and consumed inside `deepseek_v4_backend.py` — because the replay variant's positional args do not carry `out_cache_loc` / `forward_mode` / IDLE-replacement context. This out-of-band wiring is brittle and forces DSV4 to diverge from the replay code path that every other backend shares.

This PR unifies the three method signatures across all backends and aligns DSV4's replay metadata prep with the rest of the tree.

## Modifications

### New ABC contract

```python
class AttentionBackend(ABC):
    def init_forward_data(self, fb) -> None:                  # eager wrapper
        self.init_forward_data_out_graph(fb)
        self.init_forward_data_in_graph(fb)

    def init_forward_data_out_graph(self, fb) -> None:
        """Per-iter metadata prep, called OUTSIDE the cuda graph capture/replay
        scope. Eager / capture / replay all invoke this; capture and replay run
        similar code paths."""

    def init_forward_data_in_graph(self, fb) -> None:
        """Graph-recordable static-shape prep, called INSIDE
        `with graph.capture():`. Recorded ops auto-execute at replay via
        `graph.replay()`. Default no-op; per-backend opt-in for the
        replay-time speedup."""
```

The old method names (`init_forward_metadata`, `init_forward_metadata_capture_cuda_graph`, `init_forward_metadata_replay_cuda_graph`) are retained as deprecation shims for out-of-tree backends — eager forwards via `DeprecationWarning`; the capture/replay variants raise `NotImplementedError` with a migration hint.

### Backend migrations (24 in-tree backends)

Each backend collapses three method bodies into two overrides:
- `init_forward_data(fb)` — old eager body, renamed
- `init_forward_data_out_graph(fb)` — merged capture + replay body, fb-only signature

`init_forward_data_in_graph(fb)` is intentionally left as the ABC default no-op. The question of "which graph-safe static-shape ops should move into `_in_graph` to gain a replay-time speedup via graph recording" is a perf optimization decision better made per-backend in follow-up PRs; getting it wrong (e.g., a host-sync op recorded into the graph) trips cuda graph capture, which is harder to debug than the slow path.

Migrated backends: `triton`, `flashinfer`, `flashinfer_mla`, `flashmla`, `flashattention` (FA3), `cutlass_mla`, `trtllm_mla`, `trtllm_mha`, `aiter`, `wave`, `xpu`, `intel_amx`, `torch_native`, `torch_flex`, `dual_chunk_flashattention`, `hybrid_attn`, `hybrid_linear_attn`, `linear/gdn`, `linear/lightning`, `ascend`, `ascend_gdn`, `deepseek_v4`, `deepseek_v4_hip_radix`, `dsa`, `tbo`.

### Caller-side migrations

`cuda_graph_runner.py`, `piecewise_cuda_graph_runner.py`, `breakable_cuda_graph_runner.py`, `cpu_graph_runner.py`, the eagle_draft / eagle_draft_extend / multi_layer_eagle_draft_extend runners, frozen_kv_mtp_*, eagle_worker, eagle_worker_v2, eagle_info_v2, multi_layer_eagle_worker, model_runner, and trtllm_mla_backend's internal self-calls all switch from the old positional signatures to the fb-only init API.

`_build_replay_forward_batch_view(forward_batch, buffers, bs, raw_bs)` in `cuda_graph_runner.py` constructs the lightweight padded `ForwardBatch` view that backends read from at replay; this replaces the previous per-arg plumbing that fanned out from `replay_prepare`.

### DSV4 side channel — kept for step 03, scoped for step 04

The `_replay_forward_batch` side channel survives this PR; step 04 will remove it once `_build_replay_forward_batch_view` covers every field DSV4 / DSA read off the original forward batch (currently: `out_cache_loc`, `forward_mode` for IDLE replacement). Set/clear sites are confined to `cuda_graph_runner.replay_prepare` and the spec runners' replay paths (eagle_draft / eagle_draft_extend / multi_layer / frozen_kv_mtp). `TboAttnBackend` propagates the value onto primary + each child before recursing.

## Review-driven fixes (1 CRITICAL + 4 HIGH + 5 MEDIUM + 3 LOW)

A 5-angle code-equivalency review caught a set of regressions in the initial migration that this revision addresses:

### CRITICAL — multi-step draft wrappers were missing `init_forward_data_in_graph`
Every standalone multi-step wrapper (TritonMultiStepDraftBackend, FlashInferMultiStepDraftBackend, FlashInferMLAMultiStepDraftBackend, FlashAttentionMultiStepBackend, FlashMLAMultiStepDraftBackend, AiterMultiStepDraftBackend, DeepseekSparseAttnMultiStepBackend, AscendAttnMultiStepDraftBackend) was declared without inheriting from `AttentionBackend` and never defined `_in_graph` itself — `EAGLEDraftCudaGraphRunner.capture_one_batch_size`'s call would AttributeError on first draft cuda-graph capture. Added explicit no-op `init_forward_data_in_graph` to each.

### HIGH — EXTEND mode silently dropped from `_out_graph` (5 backends + 1)
The merged `_out_graph` body kept the old capture branches but never ported the eager body's `else:` prefill/extend branch. PCG capture invokes `_out_graph` with `forward_mode=EXTEND`, so FA3 fell through with default-`None` metadata; triton / flashinfer / flashinfer_mla / aiter raised ValueError. Ported the EXTEND branch into each backend's `_out_graph` (trtllm_mha was fixed in fa3b43539c). aiter port is deferred to a follow-up since HIP/AMD has PCG disabled today.

### HIGH — spec runners didn't propagate `_replay_forward_batch`
`cuda_graph_runner.replay_prepare` was the only caller setting the side channel; the spec runners (`eagle_draft_cuda_graph_runner.replay`, `eagle_draft_extend_cuda_graph_runner.replay`, `multi_layer_eagle_draft_extend_cuda_graph_runner.replay`, `frozen_kv_mtp_worker._init_frozen_kv_metadata_replay_cuda_graph`) all invoked `init_forward_data_out_graph` without setting the side channel — inner DSV4/DSA backends took the capture branch at replay and rebuilt metadata into freshly-allocated tensors while the captured graph still held capture-time pointers. Added set/clear around each spec runner replay site.

### HIGH — fresh tensor allocations vs in-place copy_ at replay
The merged `_out_graph` body for FA3 Normal Decode / topk≤1 Draft Decode / Target Verify / Draft Extend, trtllm_mha (all 4 modes), and trtllm_mla (target_verify, draft_extend) allocated fresh `torch.zeros` / `torch.full` / `torch.arange` / `torch.cumsum + F.pad` tensors on every call and overwrote the per-bs dict slot. Captured cuda graphs record kernel input pointers at capture; at replay the fresh tensors had new pointers while the capture-time memory was freed by PyTorch's caching allocator. Refactored each branch to bind metadata to pre-allocated buffers on first call per bs and refresh in-place via `copy_` / `normal_decode_set_metadata` on subsequent calls (mirroring `dual_chunk_flashattention_backend.py:540-595`). FA3 Normal Decode / topk≤1 Draft Decode specifically restored the `normal_decode_set_metadata` fused-Triton kernel that the merged body had dropped — that step populates `page_table` from `req_to_token[req_pool_indices, ...]`, and without it captured kernels read an all-zero page table at replay (attention dispatching against KV slot 0 for every request). Ascend `actual_seq_lengths_q` / `nope_padding` / `rope_padding` fresh-allocations are NPU-only and tracked as a follow-up.

### HIGH — `_build_replay_forward_batch_view` missing `positions`
The view inherited the live UNPADDED `positions` while `bs` is the padded bucket size. Backends that derive `num_tokens = positions.shape[0]` got the wrong shape — for `raw_bs=3 / padded bs=8 / num_draft=4` the unpadded `num_tokens=12` against `bs=8` yields `tokens_per_req = 12 // 8 = 1` instead of `4`; if `padded_bs > unpadded num_tokens` then `tokens_per_req=0` crashes `torch.arange(step=0)`. Override `positions=buffers.positions[:bs * num_tokens_per_bs]` in `_build_replay_forward_batch_view`.

### MEDIUM — TBO fan-out + dispatcher coverage
`TboAttnBackend.init_forward_data{,_out_graph,_in_graph}` now fan `_replay_forward_batch` onto primary + each child via a contextmanager (set on enter, clear on exit). `HybridAttnBackend` and `HybridLinearAttnBackend` add explicit `init_forward_data_in_graph` overrides that mirror the TBO fan-out so future per-backend `_in_graph` overrides on any sub-backend will be reached. The TBO replay path rebuilding padded `tbo_children` from `fb_view` is structurally out of scope (requires also overriding `input_ids` / `out_cache_loc` / `tbo_split_seq_index` on the view) — tracked as a step-04 follow-up.

### MEDIUM — cutlass_mla replay no-op when `spec_info is not None`
The merged body gated `create_flashmla_kv_indices_triton` on `spec_info is None`, inherited from the OLD capture body. The OLD replay variant ran it UNCONDITIONALLY — gating made the decode_or_idle branch a no-op at replay under DSA-style draft decode, leaving stale KV indices in the captured graph. Drop the gate.

### MEDIUM — Mamba/Lightning capture-mode gating
PCG (`piecewise_cuda_graph_runner.capture`) and Breakable (`breakable_cuda_graph_runner._capture_all`) wrapped with `graph_capture()` but didn't enter `model_capture_mode()`. Mamba/Lightning backends dispatch `_capture_metadata` vs `_replay_metadata` via `get_is_capture_mode()`, so PCG/Breakable capture took the replay branch and expected per-iter padding the synthetic fb doesn't have. Enter `model_capture_mode()` in both capture sites.

### MEDIUM — DSA replay ignored live `forward_mode`
`dsa_backend._init_forward_data_out_graph_replay` read only `forward_batch.forward_mode` (= capture-time DECODE bucket); the live mode comes from the side channel `_replay_forward_batch.forward_mode` and may be IDLE for dp-attention idle ranks. Mirror dsv4 (`deepseek_v4_backend.py:812`) which reads the live mode from the side channel.

### MEDIUM — multi-step wrappers lost forced DECODE / encoder_lens=None invariant
The OLD multi-step wrappers forced `forward_mode=DECODE` / `encoder_lens=None` on the inner backend's view. The new wrappers pass `forward_batch` through unchanged. Added `assert forward_batch.forward_mode.is_decode_or_idle() and encoder_lens is None` at each `_out_graph` top to fail fast on misuse rather than silent-corrupting.

### LOW — defensive asserts + GPU sync regressions
Aiter / triton `common_template` now assert `spec_info is not None and is_draft_input()` matching FlashInfer. Aiter `init_forward_data_out_graph` and flashmla `init_forward_data_out_graph` use `seq_lens_cpu.max().item()` when available instead of GPU `.max().item()` to avoid the device-host sync regression the merged body introduced.

## Accuracy

Cluster smoke tests on gb300 (NVIDIA Blackwell GB300, SM 10.3) executed against `test/registered/step03_coverage/` (each test = one `srun` against the dev-cu13 sqsh image, `--load-format dummy`, single `/generate` request, JSON shape check):

| Test | Result |
|------|--------|
| triton_eager | PASS |
| triton_cudagraph | PASS |
| triton_pcg | PASS |
| triton_eagle | PASS |
| flashinfer_pcg | PASS |
| flashinfer_mla_cudagraph | PASS |
| trtllm_mha_cudagraph | PASS |
| trtllm_mha_pcg | PASS |
| trtllm_mla_cudagraph | PASS |
| dsv4_cudagraph | PASS |
| dsv4_eagle | PASS |
| dsa_cudagraph | PASS |
| breakable_cuda_graph | PASS |
| hybrid_mamba | PASS |
| gptoss_swa | PASS |
| dp_idle | PASS |
| fa3_cudagraph | SKIP (FA3 requires SM 8.0–9.0; GB300 is 10.3) |
| fa3_pcg | SKIP (same) |
| fa3_eagle3 | SKIP / FAIL (FA3 SM mismatch + unrelated rmsnorm dtype) |
| flashmla_cudagraph | SKIP (flashmla requires SM 9.0a Hopper) |
| cutlass_mla_cudagraph | SKIP (cutlass_mla requires SM 10.0 exactly) |
| tbo_cudagraph | FAIL — modelopt_quant weight-loading error in dsv3-nvfp4 + `--load-format dummy`, unrelated to attention init |

## Speed

No intentional speed-impacting changes. The fresh-tensor / in-place-copy refactor restores the OLD replay variant's performance characteristics (in-place buffer reuse) where the initial migration had regressed to allocate-fresh-per-replay.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests for any new feature or bug fix (cluster smoke suite extended at `test/registered/step03_coverage/`).
- [x] Update documentation / docstrings on the affected ABC + per-backend methods.
- [x] Provide a code-equivalency response to the comprehensive code review.
