### PR TITLE
fix(moe): route FP4-packed experts to DeepGEMM instead of Triton

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1743,11 +1743,28 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
+        from sglang.srt.layers import deep_gemm_wrapper
+
         self.moe_runner_config = moe_runner_config
         moe_runner_backend = get_moe_runner_backend()
 
         if moe_runner_backend.is_auto():
             if self.is_deepgemm_moe_runner_backend_enabled():
+                moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
+            elif (
+                self.is_fp4_expert
+                and _is_cuda
+                and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            ):
+                # FP4-packed expert weights (``w1.shape[2] = hidden_size // 2``)
+                # are incompatible with the Triton fused-MoE path -- the bf16
+                # activations entering MoE would be twice as wide as the
+                # kernel-expected K, tripping the hidden-size assertion in
+                # ``fused_experts_impl``. DeepGEMM has native fp4-expert support
+                # via the ``recipe=(1,128)/(1,32)`` path, so route there even
+                # when no a2a backend is active (e.g., the DSV4 attention
+                # backend without DeepEP, which is exercised by cuda-graph
+                # capture for bs=256).
                 moe_runner_backend = MoeRunnerBackend.DEEP_GEMM
             elif (
                 _is_hip


### PR DESCRIPTION
## Motivation

DSV4 with `is_fp4_experts=True` (default for the V4 architecture; also
auto-detected for mxfp4-packed checkpoints) stores expert weights with
`w1.shape[2] = hidden_size // 2` (FP4 packed). The Triton fused-MoE path
cannot consume this layout -- the bf16 activation entering MoE is twice as
wide as the kernel-expected K, tripping the hidden-size assertion in
`fused_experts_impl`:

```
File ".../layers/moe/moe_runner/triton_utils/fused_moe.py", line 828, in fused_experts_impl
    hidden_states.shape[1] == w1.shape[2] - padded_size
AssertionError: Hidden size mismatch
```

This breaks cuda-graph capture for DSV4-architecture models routed through
the Triton path, surfaced during cuda-graph capture validation in
[#26019](https://github.com/sgl-project/sglang/pull/26019) (step-03 attention
refactor) at `bs=256` with `--attention-backend dsv4` and `--moe-a2a-backend
none`. Pre-fix repro on the gb300 cluster (real DSV4 weights, TP=4 EP=4,
`--load-format dummy`):

```
hidden_states.shape=(256, 7168), w1.shape=(384, 1536, 3584), padded_size=0,
use_fp8_w8a8=True, block_shape=[128, 128]
```

i.e. `w1`'s K dim (3584) is exactly `hidden_size // 2 = 7168 // 2`, the
FP4-packed layout.

## Modifications

In `Fp8MoEMethod.create_moe_runner` auto-mode, add `is_fp4_expert` as a
deciding factor alongside the existing DeepEP/Mooncake/NIXL guard:
route to `DEEP_GEMM` whenever the JIT DeepGEMM is available (CUDA, SM>=90)
instead of falling through to `TRITON`. DeepGEMM has native fp4-expert
support via the `recipe=(1,128)/(1,32)` path in `DeepGemmRunnerCore`, and
its standard-dispatcher pre-permute path runs without an a2a backend.

Existing paths that override the backend earlier (Marlin / FlashInfer-MXFP4
via `Fp8Config.get_quant_method`, DeepEP via the original
`is_deepgemm_moe_runner_backend_enabled` branch) are unaffected; this
change only redirects the previously-broken fall-through.

## Accuracy Tests

Validation on gb300 cluster, real DSV4 weights, TP=4 EP=4 with
`--load-format dummy --attention-backend dsv4 --max-running-requests 256
--cuda-graph-bs 256`:

```
[TP0 EP0] Capture cuda graph end. Time elapsed: 28.04 s.
[TP1 EP1] Capture cuda graph end. Time elapsed: 28.06 s.
[TP2 EP2] Capture cuda graph end. Time elapsed: 28.02 s.
[TP3 EP3] Capture cuda graph end. Time elapsed: 28.03 s.
The server is fired up and ready to roll!
```

End-to-end `/generate` returned 200 OK after the bs=256 cuda graph captured
cleanly. The same launch on `origin/main` fails with `Hidden size mismatch`
during capture (verified on the same cluster image).

## Speed Tests and Profiling

No-op in the steady state for the existing paths -- the new branch only
fires when the previous code path would have crashed (auto mode +
is_fp4_expert + no a2a backend + DeepGEMM JIT available). Production
DSV4 deployments that use DeepEP / Mooncake / NIXL already select
DEEP_GEMM at the first auto-mode check, so they hit the same code path
as before.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26261153181](https://github.com/sgl-project/sglang/actions/runs/26261153181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26261153057](https://github.com/sgl-project/sglang/actions/runs/26261153057)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->