### PR TITLE
pass lora_ids to ForwardBatch in piecewise CUDA graph capture (#25307)

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -564,7 +564,7 @@ class PiecewiseCudaGraphRunner:
                 num_token_non_padded=None,
                 num_token_non_padded_cpu=num_tokens,
                 global_forward_mode=ForwardMode.EXTEND,
-                lora_ids=None,
+                lora_ids=lora_ids,
                 return_pooled_hidden_states=self.capture_return_pooled_hidden_states,
             )
             self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)


### PR DESCRIPTION
## Summary
\`capture_one_batch_size\` constructed dummy \`lora_ids\` but passed \`lora_ids=None\` to \`ForwardBatch\`, causing \`len(None)\` to crash in \`prepare_lora_batch\`. Wire the constructed IDs through, matching the pattern in non-piecewise \`CudaGraphRunner.capture_one_batch\`.

Closes #25307.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26261920153](https://github.com/sgl-project/sglang/actions/runs/26261920153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26261920049](https://github.com/sgl-project/sglang/actions/runs/26261920049)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->