### PR TITLE
include staged chunked_req when counting running LoRAs (#25865)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2517,6 +2517,7 @@ class Scheduler(
 
         if self.enable_lora:
             running_loras = {req.lora_id for req in self.running_batch.reqs}
+            running_loras.update(req.lora_id for req in adder.can_run_list)
 
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:


### PR DESCRIPTION
## Summary
LoRA admission built \`running_loras\` from \`running_batch.reqs\` only, missing the chunked-prefill request already staged into \`adder.can_run_list\`. This over-admitted by one and tripped \`max_loras_per_batch\` in \`LoRAManager.fetch_new_loras\`. Union in LoRA IDs from \`adder.can_run_list\` so admission accounting matches the actual forward batch.

Closes #25865.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26261921780](https://github.com/sgl-project/sglang/actions/runs/26261921780)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26261921735](https://github.com/sgl-project/sglang/actions/runs/26261921735)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->