### PR TITLE
Fix SMG service discovery Clippy lint

### DIFF
--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -113,13 +113,12 @@ impl PodInfo {
 
     pub fn should_include(pod: &Pod, config: &ServiceDiscoveryConfig) -> bool {
         if config.pd_mode {
-            if config.prefill_selector.is_empty() && config.decode_selector.is_empty() {
-                if !(config.igw_mode && !config.selector.is_empty()) {
-                    warn!(
-                        "PD mode enabled but both prefill_selector and decode_selector are empty"
-                    );
-                    return false;
-                }
+            if config.prefill_selector.is_empty()
+                && config.decode_selector.is_empty()
+                && (!config.igw_mode || config.selector.is_empty())
+            {
+                warn!("PD mode enabled but both prefill_selector and decode_selector are empty");
+                return false;
             }
             let matches_pd = Self::matches_selector(pod, &config.prefill_selector)
                 || Self::matches_selector(pod, &config.decode_selector);


### PR DESCRIPTION
## Summary

Fix the SMG service discovery Clippy failure caused by the IGW-mode selector condition added in #25294: https://github.com/sgl-project/sglang/actions/runs/26263711751/job/77302497886

cc @Kangyan-Zhou

## Test

`cargo clippy --all-targets --all-features -- -D warnings`

Passed: `Finished dev profile in 0.29s`

`cargo +nightly fmt -- --check`

Passed: no formatting diffs







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26264769444](https://github.com/sgl-project/sglang/actions/runs/26264769444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26264769377](https://github.com/sgl-project/sglang/actions/runs/26264769377)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->