### PR TITLE
ci: self-heal $GITHUB_PATH/$GITHUB_ENV writes

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -56,13 +56,16 @@ configure_environment() {
         [ "$(command -v python3)" = "$UV_VENV/bin/python3" ] || { echo "FATAL: python3 still resolves outside venv (got $(command -v python3))"; exit 1; }
 
         if [ -n "${GITHUB_ENV:-}" ]; then
-            echo "VIRTUAL_ENV=$UV_VENV" >> "$GITHUB_ENV"
-            echo "SGLANG_CI_VENV_PATH=$UV_VENV" >> "$GITHUB_ENV"
-            echo "BASH_ENV=$UV_VENV/env.sh" >> "$GITHUB_ENV"
+            # Self-heal: see install_rustup.sh for context on missing _runner_file_commands/.
+            mkdir -p "$(dirname "$GITHUB_ENV")" 2>/dev/null || true
+            echo "VIRTUAL_ENV=$UV_VENV" >> "$GITHUB_ENV" || true
+            echo "SGLANG_CI_VENV_PATH=$UV_VENV" >> "$GITHUB_ENV" || true
+            echo "BASH_ENV=$UV_VENV/env.sh" >> "$GITHUB_ENV" || true
             touch "$UV_VENV/env.sh"
         fi
         if [ -n "${GITHUB_PATH:-}" ]; then
-            echo "$UV_VENV/bin" >> "$GITHUB_PATH"
+            mkdir -p "$(dirname "$GITHUB_PATH")" 2>/dev/null || true
+            echo "$UV_VENV/bin" >> "$GITHUB_PATH" || true
         fi
     else
         echo "USE_VENV=0: skipping uv venv creation, installing into system Python"

--- a/scripts/ci/utils/install_rustup.sh
+++ b/scripts/ci/utils/install_rustup.sh
@@ -8,7 +8,11 @@ set -euxo pipefail
 # GitHub Actions steps in the same job.
 export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
 if [ -n "${GITHUB_PATH:-}" ]; then
-    echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "${GITHUB_PATH}"
+    # Self-heal if _runner_file_commands/ disappears mid-job on some self-hosted
+    # runners; the runner reads this file by its registered UUID at step end, so
+    # recreating the path keeps PATH propagation working for subsequent steps.
+    mkdir -p "$(dirname "${GITHUB_PATH}")" 2>/dev/null || true
+    echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "${GITHUB_PATH}" || true
 fi
 
 if command -v cargo >/dev/null 2>&1 && command -v rustc >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes intermittent B200 CI failure: https://github.com/sgl-project/sglang/actions/runs/26259146223/job/77288688364 — `install_rustup.sh` crashed when the runner's `_runner_file_commands/add_path_<uuid>` file went missing mid-job. Recreate the parent dir and tolerate write failures so PATH propagation still works; same for `$GITHUB_ENV` writes in `ci_install_dependency.sh`.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26265945140](https://github.com/sgl-project/sglang/actions/runs/26265945140)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26265945110](https://github.com/sgl-project/sglang/actions/runs/26265945110)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->