### PR TITLE
Add --disable-attn-tp-gather opt-out for model-managed SP

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -747,6 +747,7 @@ class ServerArgs:
     enable_deterministic_inference: bool = False
     rl_on_policy_target: Optional[str] = None
     enable_attn_tp_input_scattered: bool = False
+    disable_attn_tp_gather: bool = False
     gc_threshold: Optional[List[int]] = None
     # Context parallelism used in the long sequence prefill phase of DeepSeek v3.2
     enable_dsa_prefill_context_parallel: bool = False
@@ -6473,6 +6474,18 @@ class ServerArgs:
             "--enable-attn-tp-input-scattered",
             action="store_true",
             help="Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent.",
+        )
+        parser.add_argument(
+            "--disable-attn-tp-gather",
+            action="store_true",
+            help="Disable scheduler-side attn_tp_gather (the upstream SP path "
+            "that pads num_tokens to attn_tp_size and pre-allocates a gathered "
+            "buffer). Use for models that manage SP scatter/gather at the "
+            "model level (e.g., perform their own all_gather/reduce_scatter "
+            "inside attention) and do not consume the upstream gathered_buffer. "
+            "Without this, the cuda graph runner pads num_tokens to attn_tp_size, "
+            "which can cause kernel autotuners to select wrong-sized variants "
+            "at small batches.",
         )
         parser.add_argument(
             "--enable-dsa-prefill-context-parallel",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3046,6 +3046,13 @@ def require_attn_tp_gather(server_args: ServerArgs):
     """
     Check if the input of attention is scattered.
     """
+    # Opt-out for models that manage SP scatter/gather at the model level
+    # and do not consume the upstream gathered_buffer. Without this, the
+    # cuda graph runner pads num_tokens to attn_tp_size, which can cause
+    # autotuners to pick suboptimal kernel variants at small batches.
+    if server_args.disable_attn_tp_gather:
+        return False
+
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 
     assert server_args.moe_dense_tp_size in [1, None]


### PR DESCRIPTION
## Motivation

Some models manage sequence-parallel (SP) scatter/gather entirely at the model level — they issue their own `all_gather`/`reduce_scatter` inside attention and do not consume the upstream `gathered_buffer`. For those models the scheduler-side `attn_tp_gather` machinery is dead weight: it pads `num_tokens` up to `attn_tp_size` before CUDA graph capture, which causes kernel autotuners (e.g. FlashInfer) to select wrong-sized variants at small batches and visibly regress decode TPOT.

Today the only way to disable this path is to drop `--moe-a2a-backend` entirely, which also disables the model's intended MoE A2A path.

## Modifications

Add a new generic `ServerArgs` field `disable_attn_tp_gather` (CLI flag `--disable-attn-tp-gather`, default `False`, no behavior change unless set). When set, `require_attn_tp_gather` short-circuits to `False`, which cascades through `require_gathered_buffer` and `require_mlp_sync`:

- `cuda_graph_runner` does not allocate `gathered_buffer`.
- `adjust_num_token_non_padded_for_attn_tp` does not run in forward.
- Scheduler-side `gloo:all_gather` in `prepare_mlp_sync_batch` is skipped.

Help text is generic — no model-specific wording.

## Verification

- BS=1 TPOT regression of +29% is fully eliminated.
- Sweep across BS=1..64 matches baseline on decode

Kernel-variant check at BS=1 (post-flag matches baseline tactic):

| | baseline | sp + flag |
|---|---|---|
| `bmm_E2m1` MoE gemm1 | `t128x8x512u2`, 11.1 µs | `t128x8x512u2`, 10.9 µs |
| router gemm | `cublasLt::gemvx::kernel`, 17.2 µs | `cublasLt::gemvx::kernel`, 17.2 µs |
| `gloo:all_gather` | 0 | 0 |

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/contributing/development_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/contributing/development_guide.html#running-unit-tests-adding-to-ci) — N/A, opt-in flag with no behavior change at default.
- [x] Update documentation / docstrings — done in CLI help text.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26268222947](https://github.com/sgl-project/sglang/actions/runs/26268222947)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26268222915](https://github.com/sgl-project/sglang/actions/runs/26268222915)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->