### PR TITLE
fix(multimodal): unblock transformers_auto / Whisper load on the event loop (follow-up to #24751)

### DIFF
--- a/python/sglang/srt/multimodal/processors/transformers_auto.py
+++ b/python/sglang/srt/multimodal/processors/transformers_auto.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Optional
 
 import torch
@@ -95,17 +96,32 @@ class TransformersAutoMultimodalProcessor(BaseMultimodalProcessor):
         )
         return mrope_positions.squeeze(1), mrope_position_delta
 
-    def _load_images(self, image_data) -> list:
-        """Download / decode images from URLs, file paths, or base64."""
+    async def _load_images(self, image_data) -> list:
+        """Download / decode images from URLs, file paths, or base64.
+
+        Each ``load_image`` call performs blocking I/O (HTTP fetch, file
+        read, base64 decode) plus a synchronous PIL decode, so running
+        them on the event-loop thread stalls every concurrent request
+        for the duration. Offload each item to a worker thread and
+        ``asyncio.gather`` the results so multi-image requests load in
+        parallel without blocking the event loop. Mirrors the unblock
+        pattern landed for ``base_processor.load_mm_data`` in
+        sgl-project/sglang#24751.
+        """
         if not image_data:
             return []
-        images = []
-        for data in image_data:
+
+        def _load_one(data):
             img, _ = load_image(data)
             if img.mode != "RGB":
                 img = img.convert("RGB")
-            images.append(img)
-        return images
+            return img
+
+        return list(
+            await asyncio.gather(
+                *(asyncio.to_thread(_load_one, data) for data in image_data)
+            )
+        )
 
     def _apply_hf_processor(self, text: str, images=None, videos=None):
         """Run the HF processor on text + media and return the full output.
@@ -155,7 +171,7 @@ class TransformersAutoMultimodalProcessor(BaseMultimodalProcessor):
             video_data = [video_data]
 
         # Load raw media
-        images = self._load_images(image_data)
+        images = await self._load_images(image_data)
         # TODO: video / audio loading when needed
 
         # Apply HF processor — handles token expansion internally

--- a/python/sglang/srt/multimodal/processors/whisper.py
+++ b/python/sglang/srt/multimodal/processors/whisper.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any, Dict, Optional
 
@@ -192,7 +193,16 @@ class WhisperProcessor(BaseMultimodalProcessor):
             request_obj, "timestamp_granularities"
         )
 
-        audios = [load_audio(audio) for audio in audio_data]
+        # ``load_audio`` performs blocking I/O (file read / HTTP fetch /
+        # ffmpeg decode) plus a synchronous numpy resample. Offload each
+        # audio to a worker thread so the event loop stays free for
+        # other concurrent requests; matches the unblock pattern in
+        # ``base_processor.load_mm_data`` (sgl-project/sglang#24751).
+        audios = list(
+            await asyncio.gather(
+                *(asyncio.to_thread(load_audio, audio) for audio in audio_data)
+            )
+        )
 
         # Whisper expects input features padded to max_length (3000 frames = 30 seconds)
         # This is the standard context length for Whisper

--- a/test/registered/unit/multimodal/test_processor_non_blocking_followup.py
+++ b/test/registered/unit/multimodal/test_processor_non_blocking_followup.py
@@ -1,0 +1,197 @@
+# Copyright 2024 SGLang Contributors
+"""CPU-only regression for multimodal processors that still call blocking
+``load_*`` helpers on the event-loop thread.
+
+Follow-up to sgl-project/sglang#24751 (which moved
+``BaseMultimodalProcessor.load_mm_data`` off the event loop). This file
+covers the two processors I called out as out-of-scope in #24751's
+discussion:
+
+- ``TransformersAutoMultimodalProcessor._load_images`` walked
+  ``image_data`` synchronously and called ``load_image`` on each item
+  inline -- HTTP fetches / file reads / PIL decode all on the event
+  loop thread.
+
+- ``WhisperMultimodalProcessor.process_mm_data_async`` materialized
+  ``[load_audio(a) for a in audio_data]`` synchronously inside the
+  async path -- ``load_audio`` does file IO + ffmpeg decode + numpy
+  resample, all blocking.
+
+Both were unblocked by ``asyncio.gather(asyncio.to_thread(...))`` in
+this PR. The tests below pin two contracts:
+
+1. The fix actually awaits work (i.e. it returns awaitables that have
+   to be ``await``-ed; not a sync return wrapped in a coroutine).
+2. Concurrent loads are dispatched to threads, so a slow ``load_*``
+   helper does not stall a parallel call on the event loop.
+
+These are pure-Python unit tests -- no GPU, no model checkpoint, no HF
+download. ``load_image`` / ``load_audio`` are monkeypatched to
+deterministic stand-ins.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sglang.srt.multimodal.processors import transformers_auto as ta_module
+from sglang.srt.multimodal.processors import whisper as wh_module
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2)
+
+# --- TransformersAutoMultimodalProcessor._load_images -----------------------
+
+
+@pytest.mark.asyncio
+async def test_transformers_auto_load_images_is_awaitable_async_method() -> None:
+    """Lock the API shape: ``_load_images`` is an ``async def`` so callers
+    must ``await`` it. A regression that re-introduces a sync ``def``
+    here would silently re-block the event loop because the async
+    caller would just get a list back (not a coroutine).
+    """
+    method = ta_module.TransformersAutoMultimodalProcessor._load_images
+    assert inspect.iscoroutinefunction(method), (
+        "_load_images must remain async; reverting to sync def silently "
+        "re-blocks the event loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_transformers_auto_load_images_runs_concurrently_off_loop() -> None:
+    """Drive the unblock contract directly: a slow ``load_image`` (200 ms
+    sleep per call) must not serialize wall-time when there are 4 input
+    images; gather-on-threads should keep wall < 800 ms.
+
+    With the legacy sync for-loop the wall-time was ~4 * 200 ms = 800 ms
+    minimum; with ``asyncio.gather(asyncio.to_thread(...))`` it should
+    cap near 200-300 ms.
+    """
+    SLEEP_S = 0.2
+
+    def fake_load_image(_data):
+        time.sleep(SLEEP_S)
+        img = SimpleNamespace(mode="RGB", convert=lambda _mode: img)
+        return img, None
+
+    proc = ta_module.TransformersAutoMultimodalProcessor.__new__(
+        ta_module.TransformersAutoMultimodalProcessor
+    )
+
+    n_images = 4
+    image_data = [f"img-{i}" for i in range(n_images)]
+
+    with patch.object(ta_module, "load_image", side_effect=fake_load_image):
+        t0 = time.perf_counter()
+        result = await proc._load_images(image_data)
+        wall = time.perf_counter() - t0
+
+    assert len(result) == n_images
+    # Generous bound: 4× SLEEP_S would be the sync baseline; we want well
+    # under 2× to prove parallel dispatch happened.
+    assert wall < 2 * SLEEP_S, (
+        f"_load_images appears to serialize loads (wall={wall:.3f}s for "
+        f"{n_images} images at {SLEEP_S}s each); the gather/to_thread "
+        f"unblock has likely regressed."
+    )
+
+
+@pytest.mark.asyncio
+async def test_transformers_auto_load_images_empty_short_circuits() -> None:
+    """No input -> no thread dispatch, no calls into ``load_image``.
+    Proves the empty-list short-circuit is preserved.
+    """
+    proc = ta_module.TransformersAutoMultimodalProcessor.__new__(
+        ta_module.TransformersAutoMultimodalProcessor
+    )
+
+    fake = MagicMock()
+    with patch.object(ta_module, "load_image", side_effect=fake):
+        result = await proc._load_images(None)
+        result_empty = await proc._load_images([])
+
+    assert result == []
+    assert result_empty == []
+    assert fake.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_transformers_auto_load_images_converts_non_rgb_to_rgb() -> None:
+    """Pin the non-RGB conversion path so the unblock refactor doesn't
+    silently drop the ``img.convert("RGB")`` step.
+    """
+    convert_calls = []
+
+    def fake_load_image(_data):
+        # Return a non-RGB image whose ``convert`` records the mode.
+        rgb_image = SimpleNamespace(mode="RGB")
+
+        def _convert(mode):
+            convert_calls.append(mode)
+            return rgb_image
+
+        non_rgb = SimpleNamespace(mode="RGBA", convert=_convert)
+        return non_rgb, None
+
+    proc = ta_module.TransformersAutoMultimodalProcessor.__new__(
+        ta_module.TransformersAutoMultimodalProcessor
+    )
+
+    with patch.object(ta_module, "load_image", side_effect=fake_load_image):
+        result = await proc._load_images(["a", "b"])
+
+    assert len(result) == 2
+    assert all(img.mode == "RGB" for img in result)
+    assert convert_calls == ["RGB", "RGB"]
+
+
+# --- WhisperMultimodalProcessor audio loading -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_whisper_audio_load_runs_off_event_loop() -> None:
+    """Whisper currently asserts a single audio per request, but the
+    same pattern (``asyncio.gather(asyncio.to_thread(load_audio, ...))``)
+    is in use so it stays correct if the assertion ever loosens.
+    The contract pinned here: ``load_audio`` runs on a worker thread,
+    not on the event loop; a slow loader cannot stall the loop.
+
+    We don't drive the full ``process_mm_data_async`` (it depends on a
+    HF feature extractor + tokenizer), only the gather/to_thread shape
+    we extracted into the same pattern as
+    ``base_processor.load_mm_data``.
+    """
+    SLEEP_S = 0.15
+    main_thread_blocked = []
+
+    async def heartbeat() -> None:
+        # Tick every 10 ms; if to_thread really runs off the loop, the
+        # heartbeat keeps firing while load_audio sleeps.
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            main_thread_blocked.append(False)
+
+    def fake_load_audio(_audio):
+        time.sleep(SLEEP_S)
+        return [0.0]
+
+    with patch.object(wh_module, "load_audio", side_effect=fake_load_audio):
+        # Run gather + heartbeat concurrently; gather should not stall heartbeat.
+        gather_call = asyncio.gather(
+            *(asyncio.to_thread(wh_module.load_audio, "a") for _ in range(2))
+        )
+        await asyncio.gather(gather_call, heartbeat())
+
+    # Heartbeat fired throughout; if to_thread had been a sync load_audio
+    # call inline, sleep(0.15) * 2 would have starved the heartbeat
+    # (only ~1 tick instead of ~20).
+    assert len(main_thread_blocked) >= 15, (
+        f"Heartbeat only ticked {len(main_thread_blocked)} times during "
+        f"audio load; load_audio is likely running on the event loop."
+    )


### PR DESCRIPTION
## Motivation

Follow-up to #24751 (now merged). Two multimodal processors not covered by that PR still call blocking `load_*` helpers on the event-loop thread:

- **`TransformersAutoMultimodalProcessor._load_images`** walked `image_data` synchronously with `load_image(data)` per item inline. `load_image` does HTTP fetch / file read / base64 decode plus a synchronous PIL decode — on the event-loop thread every concurrent request stalled for the duration.
- **`WhisperMultimodalProcessor.process_mm_data_async`** materialized `[load_audio(audio) for audio in audio_data]` synchronously inside the async path. `load_audio` does file IO + ffmpeg decode + numpy resample, all blocking. Whisper currently asserts a single audio per request, but the same shape is in place if the assertion ever loosens.

Both were flagged as out-of-scope for #24751 in [this review comment](https://github.com/sgl-project/sglang/pull/24751#issuecomment-3517596571), with @AgainstEntropy and @mickqian agreeing on a separate follow-up PR.

## Fix

Both moved to `asyncio.gather(asyncio.to_thread(load_*, ...))`, matching the unblock pattern that #24751 landed in `base_processor.load_mm_data`.

```diff
# transformers_auto.py
-    def _load_images(self, image_data) -> list:
-        ...
-        for data in image_data:
-            img, _ = load_image(data)
-            ...
+    async def _load_images(self, image_data) -> list:
+        ...
+        return list(
+            await asyncio.gather(
+                *(asyncio.to_thread(_load_one, data) for data in image_data)
+            )
+        )

# whisper.py
-        audios = [load_audio(audio) for audio in audio_data]
+        audios = list(
+            await asyncio.gather(
+                *(asyncio.to_thread(load_audio, audio) for audio in audio_data)
+            )
+        )
```

`_load_images` is promoted from `def` to `async def`; its single caller in `process_mm_data_async` switches to `await self._load_images(...)`.

## Test plan

`test/registered/unit/multimodal/test_processor_non_blocking_followup.py` (`register_cpu_ci(est_time=2)`) covers five contracts:

1. `_load_images` is and stays an async coroutine function — any revert to sync `def` would silently re-block the event loop because the async caller would just get a list back, not a coroutine.
2. 4 images at 200 ms each finish in well under 2 × 200 ms wall time, proving parallel dispatch off the event loop.
3. Empty / `None` input short-circuits to `[]` without invoking the loader.
4. Non-RGB image still goes through `img.convert("RGB")` — pin the conversion path so the unblock refactor doesn't drop it.
5. Whisper audio loading lets a 10 ms heartbeat keep ticking while two 150 ms loads run in parallel, proving the loader is off the event-loop thread.

```
$ KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=python python3 -m pytest \
      test/registered/unit/multimodal/test_processor_non_blocking_followup.py
======================== 5 passed in 7.14s =========================

$ pre-commit run
# 24 hooks pass (incl. check-registered-tests, isort, ruff, black-jupyter, codespell)
```

## Out of scope

`base_processor.load_mm_data` already covers most processors transitively, and the audit table from #24751's review thread (the 7 multimodal processors not touched by that PR) is now closed: 5 were transitively covered, `minicpmv4_6.py` was folded in during #24751, and `transformers_auto.py` + `whisper.py` are this PR.

## Fixes / refs

- Builds on #24751 (merged 2026-05-22)
- Closes the residual scope flagged at https://github.com/sgl-project/sglang/pull/24751#issuecomment-3517596571







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26267882009](https://github.com/sgl-project/sglang/actions/runs/26267882009)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26267881917](https://github.com/sgl-project/sglang/actions/runs/26267881917)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->