### PR TITLE
[PD] Clean up stale decode_kv_args_table entries on session failure

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1283,8 +1283,14 @@ class MooncakeKVManager(CommonKVManager):
                                 # Failures should never happen if the session is not dead, if the session fails once, mark it as failed
                                 if self.session_failures[req.mooncake_session_id] >= 1:
                                     self.failed_sessions.add(req.mooncake_session_id)
+                                    # Remove stale entry to prevent memory leak;
+                                    # a new decode instance will re-register on reconnect.
+                                    self.decode_kv_args_table.pop(
+                                        req.mooncake_session_id, None
+                                    )
                                     logger.error(
-                                        f"Session {req.mooncake_session_id} failed."
+                                        f"Session {req.mooncake_session_id} failed, "
+                                        f"removed from decode_kv_args_table."
                                     )
                             self.record_failure(
                                 kv_chunk.room,


### PR DESCRIPTION
## Motivation

In PD disaggregation mode with mooncake backend, when a decode instance dies (e.g. during rolling update), the prefill side adds the session to `failed_sessions` but never removes the corresponding entry from `decode_kv_args_table`. This causes:

1. **Memory leak**: Stale entries accumulate for every dead decode session
2. **Stale state**: `decode_kv_args_table` grows indefinitely until prefill pod restarts

Related to #25287 which added probe-based un-blacklisting for `failed_sessions`, but did not address the `decode_kv_args_table` cleanup.

## Changes

When a session is marked as failed in `transfer_worker`, also remove its entry from `decode_kv_args_table` via `.pop()`. When a new decode instance registers, a fresh entry is created via the existing registration path.

## Testing

- Verified the code path in a production PD disaggregation cluster (10 nodes, 40 engine/decoder pods)
- During rolling updates, stale entries were observed accumulating in `decode_kv_args_table` — this patch prevents that







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26269216720](https://github.com/sgl-project/sglang/actions/runs/26269216720)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26269216602](https://github.com/sgl-project/sglang/actions/runs/26269216602)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->