### PR TITLE
[diffusion] add NVTX layerwise profiling support

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -67,6 +67,7 @@ from sglang.multimodal_gen.runtime.utils.perf_logger import (
 from sglang.multimodal_gen.runtime.utils.trace_wrapper import DiffStage, trace_slice
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
 from sglang.srt.utils.network import NetworkAddress
+from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 
 logger = init_logger(__name__)
 
@@ -162,6 +163,19 @@ class GPUWorker:
             setproctitle(f"sgl_diffusion::scheduler_{self.local_rank}")
 
         self.pipeline = build_pipeline(self.server_args)
+
+        # Register layerwise NVTX profiling hooks if enabled.
+        # Retain the hooks manager on `self` so the worker can avoid
+        # duplicate registration across repeated initializations and
+        # optionally manage the hooks later.
+        if self.server_args.enable_layerwise_nvtx_marker:
+            if getattr(self, "_nvtx_hooks", None) is None:
+                self._nvtx_hooks = PytHooks()
+                for module_name, module in self.pipeline.modules.items():
+                    if isinstance(module, torch.nn.Module):
+                        self._nvtx_hooks.register_hooks(
+                            module, module_prefix=module_name
+                        )
 
         # apply layerwise offload after lora is applied while building LoRAPipeline
         # otherwise empty offloaded weights could fail lora converting

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -313,6 +313,9 @@ class ServerArgs(DisaggArgsMixin):
     enable_trace: bool = False
     otlp_traces_endpoint: str = "localhost:4317"
 
+    # NVTX profiling
+    enable_layerwise_nvtx_marker: bool = False
+
     # get_role_parallelism, derive_pool_*_endpoint — from DisaggArgsMixin
 
     @property
@@ -1506,6 +1509,12 @@ class ServerArgs(DisaggArgsMixin):
             type=str,
             default=ServerArgs.otlp_traces_endpoint,
             help="OTLP collector endpoint when --enable-trace is set. Format: <host>:<port>",
+        )
+        parser.add_argument(
+            "--enable-layerwise-nvtx-marker",
+            action="store_true",
+            default=ServerArgs.enable_layerwise_nvtx_marker,
+            help="Enable layerwise NVTX profiling annotations for the model.",
         )
         parser.add_argument(
             "--uvicorn-access-log-exclude-prefixes",


### PR DESCRIPTION
  ## Summary
  
  Add `--enable-layerwise-nvtx-marker` CLI flag to the diffusion (multimodal_gen) 
  subsystem, mirroring the existing SRT feature. When enabled, PyTorch forward pre/post 
  hooks emit NVTX range markers for every sub-module in the pipeline (transformer/DiT, 
  text encoder, VAE), making all FFN, attention, and normalization layers visible in 
  nsys/ncu traces.

  ## Motivation

  SRT already supports layerwise NVTX profiling via `--enable-layerwise-nvtx-marker`. The
   diffusion subsystem had no equivalent, making it harder to profile model forward 
  passes with Nsight tools.
  
  ## Changes
  
  - `server_args.py`: add `enable_layerwise_nvtx_marker` dataclass field and 
  `--enable-layerwise-nvtx-marker` CLI argument
  - `gpu_worker.py`: import `PytHooks` from `sglang.srt.utils.nvtx_pytorch_hooks` and
  register hooks on each pipeline component module in `init_device_and_model()`
  
  ## How it works
  
  `PytHooks.register_hooks()` calls `torch.nn.Module.named_modules()` to recursively walk
   all sub-modules (attention, FFN, norms, etc.) and register `register_forward_pre_hook`
   / `register_forward_hook` pairs. Each pair emits `nvtx.range_push` / `nvtx.range_pop`
  with the module name and parameter metadata. No dependency changes required —
  `torch.cuda.nvtx` is bundled with PyTorch.

  ```
  # Usage
  sglang serve --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
      --enable-layerwise-nvtx-marker

  # Then profile with nsys/ncu to see per-layer NVTX markers
  ```

  ## Test plan

  - [x] Launch a diffusion server with `--enable-layerwise-nvtx-marker` and verify no
  errors during model loading
  - [x] Run a generation request and capture an nsys profile — confirm per-layer NVTX
  ranges appear for transformer, text encoder, and VAE sub-modules
  - [x] Verify the flag defaults to `False` and has zero overhead when disabled















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26623069006](https://github.com/sgl-project/sglang/actions/runs/26623069006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26623068834](https://github.com/sgl-project/sglang/actions/runs/26623068834)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->