### PR TITLE
[NPU] adapt LFM models

### DIFF
--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -24,6 +24,28 @@ from sglang.srt.layers.attention.mamba.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from sglang.srt.utils import is_npu
+
+if is_npu():
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_fn_npu,
+        causal_conv1d_update_v2,
+    )
+
+    # prefill: _npu expects standard layout (..., dim, state_len),
+    #          but NPU native is (..., state_len, dim) → transpose conv_states.
+    def causal_conv1d_fn(x, weight, bias=None, conv_states=None, **kwargs):
+        if conv_states is not None:
+            conv_states = conv_states.transpose(-1, -2)
+        return causal_conv1d_fn_npu(
+            x, weight, bias=bias, conv_states=conv_states, **kwargs
+        )
+
+    # decode: v2 expects NPU-native conv_state (..., state_len, dim) — no transpose.
+    #         v2 expects weight (width, dim); model stores (dim, width) → weight.T.
+    def causal_conv1d_update(x, conv_state, weight, bias=None, **kwargs):
+        return causal_conv1d_update_v2(x, conv_state, weight.T, bias=bias, **kwargs)
+
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,

--- a/python/sglang/srt/models/lfm2.py
+++ b/python/sglang/srt/models/lfm2.py
@@ -46,6 +46,7 @@ if is_npu():
     def causal_conv1d_update(x, conv_state, weight, bias=None, **kwargs):
         return causal_conv1d_update_v2(x, conv_state, weight.T, bias=bias, **kwargs)
 
+
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -46,6 +46,7 @@ if is_npu():
     def causal_conv1d_update(x, conv_state, weight, bias=None, **kwargs):
         return causal_conv1d_update_v2(x, conv_state, weight.T, bias=bias, **kwargs)
 
+
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     MergedColumnParallelLinear,

--- a/python/sglang/srt/models/lfm2_moe.py
+++ b/python/sglang/srt/models/lfm2_moe.py
@@ -24,6 +24,28 @@ from sglang.srt.layers.attention.mamba.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from sglang.srt.utils import is_npu
+
+if is_npu():
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_fn_npu,
+        causal_conv1d_update_v2,
+    )
+
+    # prefill: _npu expects standard layout (..., dim, state_len),
+    #          but NPU native is (..., state_len, dim) → transpose conv_states.
+    def causal_conv1d_fn(x, weight, bias=None, conv_states=None, **kwargs):
+        if conv_states is not None:
+            conv_states = conv_states.transpose(-1, -2)
+        return causal_conv1d_fn_npu(
+            x, weight, bias=bias, conv_states=conv_states, **kwargs
+        )
+
+    # decode: v2 expects NPU-native conv_state (..., state_len, dim) — no transpose.
+    #         v2 expects weight (width, dim); model stores (dim, width) → weight.T.
+    def causal_conv1d_update(x, conv_state, weight, bias=None, **kwargs):
+        return causal_conv1d_update_v2(x, conv_state, weight.T, bias=bias, **kwargs)
+
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     MergedColumnParallelLinear,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Adapt LFM models on npu，and fix a issue about torch_npu update.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
### Problem 1: 
We want to replace Triton ops with sgl-kernel-npu ops, NPU's AscendC ops require dim as the last dimension, so _init_npu_conv_state stores conv_state as (..., state_len, dim). But the two NPU kernels expect different layouts:
NPU native storage:  conv_state (..., state_len,  dim)
                      weight      (dim,   width)
v2 kernel expects:   conv_state (..., state_len,  dim)   ✓ match
                      weight      (width, dim)            ✗ mismatch — model has (dim, width)
_npu kernel expects: conv_state (..., dim,   state_len)  ✗ mismatch
                      weight      (dim,   width)          ✓ match
<img width="1254" height="462" alt="image" src="https://github.com/user-attachments/assets/e9ab8be2-363c-4b91-87bf-f296b2b1a573" />
Fix: Two wrapper functions that each handle the mismatched axis:
##### prefill:
transpose conv_states only, weight passed through causal_conv1d_fn_wrapper:
    conv_states.T  →  _npu  # (..., state_len, dim) → (..., dim, state_len)
##### decode:
transpose weight only, conv_state passed through  causal_conv1d_update_wrapper:
    weight.T  →  v2  # (dim, width) → (width, dim)
Both .T / .transpose() return views, so in-place state writes by the kernels propagate to the original NPU-native storage. The forward() method needs zero layout awareness.

### Problem 2: 
When upgrading torch_npu from version 2.8 to 2.10, torchair introduces the AOT Autograd compilation pipeline, and the compiled NPU graphs are stored in device memory. Every time a new batch size is encountered, a new graph is recompiled. In concurrent scenarios where the batch size changes continuously, the accumulated graphs exhaust the NPU video memory.
<img width="1259" height="864" alt="image" src="https://github.com/user-attachments/assets/babb8650-6a00-4d00-986a-a495d8d84a1a" />
Fix: apply_scaling_penalties is a pure element-wise operation. The speedup brought by compilation is minimal, but the memory consumption and latency overhead caused by compilation are significant,  So skip @torch.compile()
https://github.com/sgl-project/sglang/pull/26573/files solved this.
## Accuracy Tests

<img width="686" height="157" alt="image" src="https://github.com/user-attachments/assets/334d3055-6af4-4aad-bcb7-86ff3c79d97f" />
<img width="772" height="164" alt="image" src="https://github.com/user-attachments/assets/f6beeb4b-860a-43ef-b788-b9ae58d4e414" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29384190834](https://github.com/sgl-project/sglang/actions/runs/29384190834)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29384190712](https://github.com/sgl-project/sglang/actions/runs/29384190712)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->