### PR TITLE
Preserve unacked DP dispatch load

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -92,6 +92,32 @@ class DPBudget:
         self.total_requests = [0] * dp_size
         self.total_tokens = [0] * dp_size
         self.last_timestamp = [0.0] * dp_size
+        self.sent_dispatch_seqs = [0] * dp_size
+        self.sent_dispatch_cum_tokens = [0] * dp_size
+        self.acked_dispatch_seqs = [0] * dp_size
+        self.acked_dispatch_cum_tokens = [0] * dp_size
+
+    def get_effective_load(self, load):
+        dp_rank = load.dp_rank
+        acked_seq = max(
+            self.acked_dispatch_seqs[dp_rank],
+            load.dp_dispatch_ack_seq,
+        )
+        acked_tokens = max(
+            self.acked_dispatch_cum_tokens[dp_rank],
+            load.dp_dispatch_ack_cum_tokens,
+        )
+        acked_seq = min(acked_seq, self.sent_dispatch_seqs[dp_rank])
+        acked_tokens = min(acked_tokens, self.sent_dispatch_cum_tokens[dp_rank])
+
+        unacked_requests = self.sent_dispatch_seqs[dp_rank] - acked_seq
+        unacked_tokens = self.sent_dispatch_cum_tokens[dp_rank] - acked_tokens
+        reported_requests = load.num_running_reqs + load.num_waiting_reqs
+
+        return (
+            reported_requests + unacked_requests,
+            load.num_total_tokens + unacked_tokens,
+        )
 
     def update_budget(self, loads):
         """Update budget from shm snapshots, skipping stale reads."""
@@ -99,10 +125,24 @@ class DPBudget:
             if load.timestamp == self.last_timestamp[load.dp_rank]:
                 continue
             self.last_timestamp[load.dp_rank] = load.timestamp
-            self.total_requests[load.dp_rank] = (
-                load.num_running_reqs + load.num_waiting_reqs
+            dp_rank = load.dp_rank
+            acked_seq = max(
+                self.acked_dispatch_seqs[dp_rank],
+                load.dp_dispatch_ack_seq,
             )
-            self.total_tokens[load.dp_rank] = load.num_total_tokens
+            acked_tokens = max(
+                self.acked_dispatch_cum_tokens[dp_rank],
+                load.dp_dispatch_ack_cum_tokens,
+            )
+            self.acked_dispatch_seqs[dp_rank] = min(
+                acked_seq, self.sent_dispatch_seqs[dp_rank]
+            )
+            self.acked_dispatch_cum_tokens[dp_rank] = min(
+                acked_tokens, self.sent_dispatch_cum_tokens[dp_rank]
+            )
+            total_requests, total_tokens = self.get_effective_load(load)
+            self.total_requests[dp_rank] = total_requests
+            self.total_tokens[dp_rank] = total_tokens
 
     def dispatch(self, method: LoadBalanceMethod, estimated_tokens: int = 0):
         if method == LoadBalanceMethod.TOTAL_REQUESTS:
@@ -117,9 +157,15 @@ class DPBudget:
             return None
 
         # Increment the load of that worker by one as a heuristic
+        self.sent_dispatch_seqs[target_rank] += 1
+        self.sent_dispatch_cum_tokens[target_rank] += estimated_tokens
         self.total_requests[target_rank] += 1
         self.total_tokens[target_rank] += estimated_tokens
-        return target_rank
+        return (
+            target_rank,
+            self.sent_dispatch_seqs[target_rank],
+            self.sent_dispatch_cum_tokens[target_rank],
+        )
 
 
 class DataParallelController:
@@ -631,16 +677,22 @@ class DataParallelController:
     def total_requests_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
-        target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
+        target_worker, dispatch_seq, dispatch_cum_tokens = self.dp_budget.dispatch(
+            LoadBalanceMethod.TOTAL_REQUESTS
+        )
+        req.dp_dispatch_seq = dispatch_seq
+        req.dp_dispatch_cum_tokens = dispatch_cum_tokens
         self.workers[target_worker].send_pyobj(req)
 
     def total_tokens_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
         estimated_tokens = len(req.input_ids)
-        target_worker = self.dp_budget.dispatch(
+        target_worker, dispatch_seq, dispatch_cum_tokens = self.dp_budget.dispatch(
             LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
         )
+        req.dp_dispatch_seq = dispatch_seq
+        req.dp_dispatch_cum_tokens = dispatch_cum_tokens
         self.workers[target_worker].send_pyobj(req)
 
     def event_loop(self):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -845,6 +845,10 @@ class TokenizedGenerateReqInput(BaseReq):
     # For observability
     time_stats: Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]] = None
 
+    # For DP load-balance pending accounting.
+    dp_dispatch_seq: int = 0
+    dp_dispatch_cum_tokens: int = 0
+
 
 @dataclass
 class BatchTokenizedGenerateReqInput(BaseBatchReq):
@@ -1100,6 +1104,10 @@ class TokenizedEmbeddingReqInput(BaseReq):
     multi_item_delimiter_indices: Optional[List[int]] = None
     # For observability
     time_stats: Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]] = None
+
+    # For DP load-balance pending accounting.
+    dp_dispatch_seq: int = 0
+    dp_dispatch_cum_tokens: int = 0
 
     # Whether to return pooled hidden states (pre-head transformer output)
     return_pooled_hidden_states: bool = False
@@ -2147,6 +2155,19 @@ class GetLoadsReqOutput(BaseReq):
     )
     max_running_requests: int = field(
         metadata={"metric": ("gauge", "Maximum running requests capacity")}
+    )
+    # Latest per-DP controller dispatch counters reflected in this scheduler's
+    # load report. Used by the controller to preserve dispatched-but-not-yet-
+    # reported load.
+    dp_dispatch_ack_seq: int = field(
+        default=0,
+        metadata={"metric": ("gauge", "Latest accounted DP dispatch sequence")},
+    )
+    dp_dispatch_ack_cum_tokens: int = field(
+        default=0,
+        metadata={
+            "metric": ("gauge", "Latest accounted cumulative DP dispatch tokens")
+        },
     )
 
     memory: Optional[MemoryMetrics] = None

--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -153,6 +153,8 @@ CORE_METRIC_FIELDS = (
     "gen_throughput",
     "cache_hit_rate",
     "utilization",
+    "dp_dispatch_ack_seq",
+    "dp_dispatch_ack_cum_tokens",
 )
 SECTION_FIELDS = (
     (
@@ -228,6 +230,8 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
     gen_throughput: float = 0.0
     cache_hit_rate: float = 0.0
     utilization: float = 0.0
+    dp_dispatch_ack_seq: int = 0
+    dp_dispatch_ack_cum_tokens: int = 0
 
     has_memory: int = 0
     memory_weight_gb: float = 0.0
@@ -303,6 +307,8 @@ class LoadSnapshot(msgspec.Struct, omit_defaults=True):
             "gen_throughput": self.gen_throughput,
             "cache_hit_rate": self.cache_hit_rate,
             "utilization": self.utilization,
+            "dp_dispatch_ack_seq": self.dp_dispatch_ack_seq,
+            "dp_dispatch_ack_cum_tokens": self.dp_dispatch_ack_cum_tokens,
         }
 
         if include is None or "all" in include:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -351,6 +351,9 @@ class Scheduler(
         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
         self.enable_hisparse = server_args.enable_hisparse
         self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
+        self.dp_dispatch_ack_seq = 0
+        self.dp_dispatch_ack_cum_tokens = 0
+        self._dp_dispatch_accounted: Dict[int, int] = {}
 
         # Distributed rank info
         attn_tp_rank, attn_tp_size, attn_dp_rank, attn_dp_size = (
@@ -1598,6 +1601,7 @@ class Scheduler(
                 self.return_health_check_ipcs.append(
                     getattr(recv_req, "http_worker_ipc", None)
                 )
+                self.observe_dp_dispatch_accounted(recv_req)
                 continue
 
             output = self._request_dispatcher(recv_req)
@@ -1607,6 +1611,7 @@ class Scheduler(
                 else:
                     if self.ipc_channels.recv_from_rpc is not None:
                         self.ipc_channels.recv_from_rpc.send_pyobj(output)
+            self.observe_dp_dispatch_accounted(recv_req)
 
         self.flush_wrapper.check_pending()
         if self.external_corpus_manager is not None:
@@ -1773,6 +1778,8 @@ class Scheduler(
             get_disagg_decode_transfer_queue=lambda: self.disagg_decode_transfer_queue,
             get_spec_total_num_accept_tokens=lambda: self.metrics_reporter.spec_total_num_accept_tokens,
             get_spec_total_num_forward_ct=lambda: self.metrics_reporter.spec_total_num_forward_ct,
+            get_dp_dispatch_ack_seq=lambda: self.dp_dispatch_ack_seq,
+            get_dp_dispatch_ack_cum_tokens=lambda: self.dp_dispatch_ack_cum_tokens,
         )
 
     def init_output_streamer(self) -> None:
@@ -1811,6 +1818,26 @@ class Scheduler(
             output_streamer=self.output_streamer,
             abort_request=self.abort_request,
         )
+
+    def observe_dp_dispatch_accounted(self, recv_req):
+        if isinstance(
+            recv_req, (BatchTokenizedGenerateReqInput, BatchTokenizedEmbeddingReqInput)
+        ):
+            for req in recv_req:
+                self.observe_dp_dispatch_accounted(req)
+            return
+
+        dispatch_seq = getattr(recv_req, "dp_dispatch_seq", 0) or 0
+        if dispatch_seq <= 0 or dispatch_seq <= self.dp_dispatch_ack_seq:
+            return
+
+        self._dp_dispatch_accounted[dispatch_seq] = (
+            getattr(recv_req, "dp_dispatch_cum_tokens", 0) or 0
+        )
+        while self.dp_dispatch_ack_seq + 1 in self._dp_dispatch_accounted:
+            next_seq = self.dp_dispatch_ack_seq + 1
+            self.dp_dispatch_ack_seq = next_seq
+            self.dp_dispatch_ack_cum_tokens = self._dp_dispatch_accounted.pop(next_seq)
 
     def init_req_max_new_tokens(self, req):
         input_len = len(req.origin_input_ids)

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -51,6 +51,8 @@ class SchedulerLoadInquirer:
     get_disagg_decode_transfer_queue: Callable
     get_spec_total_num_accept_tokens: Callable
     get_spec_total_num_forward_ct: Callable
+    get_dp_dispatch_ack_seq: Callable
+    get_dp_dispatch_ack_cum_tokens: Callable
 
     def _get_num_pending_tokens(self, chunk_deduct: int = 0) -> int:
         """Get the total number of tokens pending prefill.
@@ -226,6 +228,8 @@ class SchedulerLoadInquirer:
             cache_hit_rate=round(self.get_stats().cache_hit_rate, 4),
             utilization=round(self.get_stats().utilization, 4),
             max_running_requests=self.max_running_requests,
+            dp_dispatch_ack_seq=self.get_dp_dispatch_ack_seq(),
+            dp_dispatch_ack_cum_tokens=self.get_dp_dispatch_ack_cum_tokens(),
             memory=memory,
             speculative=speculative,
             lora=lora,

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -22,12 +22,16 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.data_parallel_controller import (
     DataParallelController,
     DPBudget,
     LoadBalanceMethod,
 )
+from sglang.srt.managers.io_struct import GetLoadsReqInput
 from sglang.srt.managers.load_snapshot import LoadSnapshot
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.load_inquirer import SchedulerLoadInquirer
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
@@ -116,6 +120,64 @@ class TestDPBudgetUpdateBudget(CustomTestCase):
         self.assertEqual(budget.total_requests, [10, 2, 30])
         self.assertEqual(budget.total_tokens, [100, 50, 300])
 
+    def test_load_update_preserves_unacked_dispatched_load(self):
+        budget = DPBudget(dp_size=2)
+
+        target_rank, dispatch_seq, dispatch_cum_tokens = budget.dispatch(
+            LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=1536
+        )
+        self.assertEqual(target_rank, 0)
+        self.assertEqual(dispatch_seq, 1)
+        self.assertEqual(dispatch_cum_tokens, 1536)
+
+        budget.update_budget(
+            [
+                _load(
+                    dp_rank=0,
+                    timestamp=1.0,
+                    num_running_reqs=0,
+                    num_waiting_reqs=0,
+                    num_total_tokens=0,
+                    dp_dispatch_ack_seq=0,
+                    dp_dispatch_ack_cum_tokens=0,
+                )
+            ]
+        )
+        self.assertEqual(budget.total_requests, [1, 0])
+        self.assertEqual(budget.total_tokens, [1536, 0])
+
+        budget.update_budget(
+            [
+                _load(
+                    dp_rank=0,
+                    timestamp=2.0,
+                    num_running_reqs=1,
+                    num_waiting_reqs=0,
+                    num_total_tokens=1024,
+                    dp_dispatch_ack_seq=1,
+                    dp_dispatch_ack_cum_tokens=1536,
+                )
+            ]
+        )
+        self.assertEqual(budget.total_requests, [1, 0])
+        self.assertEqual(budget.total_tokens, [1024, 0])
+
+        budget.update_budget(
+            [
+                _load(
+                    dp_rank=0,
+                    timestamp=3.0,
+                    num_running_reqs=0,
+                    num_waiting_reqs=0,
+                    num_total_tokens=0,
+                    dp_dispatch_ack_seq=1,
+                    dp_dispatch_ack_cum_tokens=1536,
+                )
+            ]
+        )
+        self.assertEqual(budget.total_requests, [0, 0])
+        self.assertEqual(budget.total_tokens, [0, 0])
+
 
 class TestDPBudgetDispatch(CustomTestCase):
     """DPBudget.dispatch picks a rank from current state and updates counters."""
@@ -123,8 +185,12 @@ class TestDPBudgetDispatch(CustomTestCase):
     def test_total_requests_dispatch_picks_min_and_increments(self):
         budget = DPBudget(dp_size=3)
         budget.total_requests = [4, 2, 7]
-        rank = budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
+        rank, dispatch_seq, dispatch_cum_tokens = budget.dispatch(
+            LoadBalanceMethod.TOTAL_REQUESTS
+        )
         self.assertEqual(rank, 1)
+        self.assertEqual(dispatch_seq, 1)
+        self.assertEqual(dispatch_cum_tokens, 0)
         self.assertEqual(
             budget.total_requests[1],
             3,
@@ -135,8 +201,12 @@ class TestDPBudgetDispatch(CustomTestCase):
         budget = DPBudget(dp_size=3)
         budget.total_tokens = [100, 50, 200]
         budget.total_requests = [0, 0, 0]
-        rank = budget.dispatch(LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=30)
+        rank, dispatch_seq, dispatch_cum_tokens = budget.dispatch(
+            LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=30
+        )
         self.assertEqual(rank, 1, "should pick worker with min total_tokens")
+        self.assertEqual(dispatch_seq, 1)
+        self.assertEqual(dispatch_cum_tokens, 30)
         self.assertEqual(
             budget.total_tokens[1],
             80,
@@ -152,10 +222,14 @@ class TestDPBudgetDispatch(CustomTestCase):
         budget = DPBudget(dp_size=3)
         budget.total_tokens = [50, 50, 50]
         budget.total_requests = [4, 2, 7]
-        rank = budget.dispatch(LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=10)
+        rank, dispatch_seq, dispatch_cum_tokens = budget.dispatch(
+            LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=10
+        )
         self.assertEqual(
             rank, 1, "tie on total_tokens should fall back to min total_requests"
         )
+        self.assertEqual(dispatch_seq, 1)
+        self.assertEqual(dispatch_cum_tokens, 10)
 
     def test_dispatch_returns_none_for_methods_not_handled(self):
         """Round-robin and follow_bootstrap_room dispatch elsewhere; DPBudget
@@ -259,6 +333,99 @@ class TestTotalRequestsScheduler(CustomTestCase):
             [5, 3, 1, 4],
             "external routing must not mutate DPBudget state",
         )
+
+
+def _scheduler_accounting_state():
+    return SimpleNamespace(
+        dp_dispatch_ack_seq=0,
+        dp_dispatch_ack_cum_tokens=0,
+        _dp_dispatch_accounted={},
+    )
+
+
+class TestSchedulerDPDispatchAccounting(CustomTestCase):
+    def test_ack_advances_only_after_contiguous_accounting(self):
+        scheduler = _scheduler_accounting_state()
+
+        Scheduler.observe_dp_dispatch_accounted(
+            scheduler,
+            SimpleNamespace(dp_dispatch_seq=2, dp_dispatch_cum_tokens=300),
+        )
+        self.assertEqual(scheduler.dp_dispatch_ack_seq, 0)
+        self.assertEqual(scheduler.dp_dispatch_ack_cum_tokens, 0)
+
+        Scheduler.observe_dp_dispatch_accounted(
+            scheduler,
+            SimpleNamespace(dp_dispatch_seq=1, dp_dispatch_cum_tokens=100),
+        )
+        self.assertEqual(scheduler.dp_dispatch_ack_seq, 2)
+        self.assertEqual(scheduler.dp_dispatch_ack_cum_tokens, 300)
+        self.assertEqual(scheduler._dp_dispatch_accounted, {})
+
+    def test_duplicate_or_unstamped_request_does_not_move_ack(self):
+        scheduler = _scheduler_accounting_state()
+
+        Scheduler.observe_dp_dispatch_accounted(
+            scheduler,
+            SimpleNamespace(dp_dispatch_seq=0, dp_dispatch_cum_tokens=0),
+        )
+        Scheduler.observe_dp_dispatch_accounted(
+            scheduler,
+            SimpleNamespace(dp_dispatch_seq=1, dp_dispatch_cum_tokens=100),
+        )
+        Scheduler.observe_dp_dispatch_accounted(
+            scheduler,
+            SimpleNamespace(dp_dispatch_seq=1, dp_dispatch_cum_tokens=200),
+        )
+
+        self.assertEqual(scheduler.dp_dispatch_ack_seq, 1)
+        self.assertEqual(scheduler.dp_dispatch_ack_cum_tokens, 100)
+        self.assertEqual(scheduler._dp_dispatch_accounted, {})
+
+
+class TestSchedulerLoadInquirerDispatchAck(CustomTestCase):
+    def test_load_report_uses_scheduler_dispatch_ack_callables(self):
+        stats = SimpleNamespace(
+            gen_throughput=0.0,
+            cache_hit_rate=0.0,
+            utilization=0.0,
+        )
+        pool_stats_observer = SimpleNamespace(
+            get_pool_stats=lambda: SimpleNamespace(
+                get_kv_token_stats=lambda: (0, 0.0)
+            )
+        )
+
+        load_inquirer = SchedulerLoadInquirer(
+            disaggregation_mode=DisaggregationMode.NULL,
+            ps=SimpleNamespace(dp_rank=3),
+            server_args=SimpleNamespace(enable_lora=False),
+            max_total_num_tokens=4096,
+            max_running_requests=128,
+            pool_stats_observer=pool_stats_observer,
+            tp_worker=SimpleNamespace(),
+            token_to_kv_pool_allocator=SimpleNamespace(),
+            spec_algorithm=SimpleNamespace(is_none=lambda: True),
+            get_running_batch=lambda: SimpleNamespace(reqs=[]),
+            get_waiting_queue=lambda: [],
+            get_stats=lambda: stats,
+            get_chunked_req=lambda: None,
+            get_disagg_prefill_bootstrap_queue=lambda: SimpleNamespace(queue=[]),
+            get_disagg_prefill_inflight_queue=lambda: [],
+            get_disagg_decode_prealloc_queue=lambda: SimpleNamespace(
+                queue=[], retracted_queue=[]
+            ),
+            get_disagg_decode_transfer_queue=lambda: SimpleNamespace(queue=[]),
+            get_spec_total_num_accept_tokens=lambda: 0,
+            get_spec_total_num_forward_ct=lambda: 0,
+            get_dp_dispatch_ack_seq=lambda: 7,
+            get_dp_dispatch_ack_cum_tokens=lambda: 1234,
+        )
+
+        load = load_inquirer.get_loads(GetLoadsReqInput(include=["core"]))
+
+        self.assertEqual(load.dp_dispatch_ack_seq, 7)
+        self.assertEqual(load.dp_dispatch_ack_cum_tokens, 1234)
 
 
 class TestStatusAwarenessInconsistency(CustomTestCase):

--- a/test/registered/unit/managers/test_load_snapshot_backends.py
+++ b/test/registered/unit/managers/test_load_snapshot_backends.py
@@ -75,6 +75,29 @@ class TestShmRoundTrip(CustomTestCase):
             if os.path.exists(path):
                 os.unlink(path)
 
+    def test_dispatch_ack_fields_round_trip(self):
+        path = _temp_path()
+        writer = ShmLoadSnapshotWriter(path, dp_size=1, dp_rank=0)
+        reader = ShmLoadSnapshotReader(path, dp_size=1)
+        try:
+            writer.write(
+                LoadSnapshot(
+                    dp_rank=0,
+                    timestamp=1.0,
+                    dp_dispatch_ack_seq=3,
+                    dp_dispatch_ack_cum_tokens=4096,
+                )
+            )
+            load = reader.read(0)
+            self.assertIsNotNone(load)
+            self.assertEqual(load.dp_dispatch_ack_seq, 3)
+            self.assertEqual(load.dp_dispatch_ack_cum_tokens, 4096)
+        finally:
+            reader.close()
+            writer.close()
+            if os.path.exists(path):
+                os.unlink(path)
+
     def test_multi_rank_write_read_all(self):
         path = _temp_path()
         writers = []


### PR DESCRIPTION
## Summary
- Add per-DP dispatch sequence and cumulative token counters to DP-balanced requests.
- Have schedulers acknowledge only dispatches they have observed, and include those ack counters in load reports.
- Preserve dispatched-but-not-yet-reported request/token load when the DP controller applies asynchronous load updates, preventing stale load reports from under-accounting a rank.
- Add unit coverage for unacked load preservation and contiguous scheduler ack ordering.

This PR intentionally contains only the seq/ack accounting fix. It does not include load-update coalescing, direct scheduler-to-controller updates, pending-output-token accounting, or disaggregated decode token-accounting changes.

## Problem
The current DP controller updates its local load budget from asynchronous scheduler load reports. Those reports can be delayed relative to controller dispatch decisions: after the controller dispatches requests to a rank, the scheduler only reflects them after it receives and accounts those requests in a later load report.

With delayed feedback, a stale load report can overwrite the controller's local dispatch estimate and make a recently selected rank look artificially light again. The controller can then keep sending more requests to that same rank until the delayed feedback catches up. This forms a positive feedback loop and can show up as feedback-induced, self-excited oscillation: per-rank request/token imbalance grows instead of damping out. In practice, the oscillation can make the feedback-based policy extremely imbalanced, even worse than a non-feedback baseline such as round-robin dispatch.

## Why this fixes it
Each DP-balanced dispatch now carries a per-rank monotonic dispatch sequence and cumulative dispatched-token counter. The scheduler only acknowledges dispatches it has actually observed, and load reports include the latest acknowledged sequence/token counters.

When the controller applies a load report, it computes effective load as:

`reported scheduler load + dispatched load not yet acknowledged by that scheduler`

As a result, a delayed load report can no longer erase requests that the controller has already dispatched but the scheduler has not accounted yet. Delayed feedback may still be stale, but it cannot under-account recently dispatched work and repeatedly pull traffic toward the same rank.

## Tests
- `python3 -m py_compile python/sglang/srt/managers/data_parallel_controller.py python/sglang/srt/managers/io_struct.py python/sglang/srt/managers/scheduler.py python/sglang/srt/managers/scheduler_components/load_inquirer.py test/registered/unit/managers/test_dp_budget.py`
- `git diff --check`























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27525262245](https://github.com/sgl-project/sglang/actions/runs/27525262245)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27525262102](https://github.com/sgl-project/sglang/actions/runs/27525262102)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->