### PR TITLE
Update pyproject_xpu.toml- add apache-tvm-ffi

### DIFF
--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -24,6 +24,7 @@ dependencies = [
   "IPython",
   "aiohttp",
   "anthropic>=0.20.0",
+  "apache-tvm-ffi>=0.0.1",
   "blobfile==3.0.0",
   "build",
   "compressed-tensors",
@@ -68,7 +69,6 @@ dependencies = [
   "uvloop",
   # "xgrammar==0.2.0", xgrammar depends on CUDA PyTorch and Triton only
   "smg-grpc-servicer>=0.5.0",
-  "apache-tvm-ffi",
 ]
 
 [project.optional-dependencies]

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -68,6 +68,7 @@ dependencies = [
   "uvloop",
   # "xgrammar==0.2.0", xgrammar depends on CUDA PyTorch and Triton only
   "smg-grpc-servicer>=0.5.0",
+  "apache-tvm-ffi",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR introduced a new library, causing the XPU CI to fail: https://github.com/sgl-project/sglang/pull/25884/changes#diff-4d166ac5ad73e0c648b1e3ee8f0f6d763110b40db4855b3874820e04fef80235



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26274779607](https://github.com/sgl-project/sglang/actions/runs/26274779607)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26274779401](https://github.com/sgl-project/sglang/actions/runs/26274779401)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->