### PR TITLE
[diffusion] add debug_tensor_dump_output_folder support

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -163,6 +163,71 @@ class GPUWorker:
 
         self.pipeline = build_pipeline(self.server_args)
 
+        # Register tensor dump hooks if enabled
+        if self.server_args.debug_tensor_dump_output_folder:
+            from dataclasses import fields as dc_fields
+            from dataclasses import is_dataclass
+
+            from sglang.srt.debug_utils.tensor_dump_forward_hook import TensorDumper
+
+            class DiffusionTensorDumper(TensorDumper):
+                """Extends TensorDumper to handle diffusion-specific output types."""
+
+                def add_tensor(self, name, tensor_item):
+                    if is_dataclass(tensor_item) and not isinstance(tensor_item, type):
+                        for f in dc_fields(tensor_item):
+                            val = getattr(tensor_item, f.name)
+                            if isinstance(val, torch.Tensor):
+                                self._current_tensors[f"{name}.{f.name}"] = val.cpu()
+                            elif isinstance(val, (tuple, list)):
+                                tensors = [
+                                    t.cpu() for t in val if isinstance(t, torch.Tensor)
+                                ]
+                                if len(tensors) == 1:
+                                    self._current_tensors[f"{name}.{f.name}"] = tensors[
+                                        0
+                                    ]
+                                elif tensors:
+                                    self._current_tensors[f"{name}.{f.name}"] = tensors
+                    else:
+                        super().add_tensor(name, tensor_item)
+
+            tp_rank = get_tp_rank() if model_parallel_is_initialized() else 0
+            tp_size = get_tp_world_size() if model_parallel_is_initialized() else 1
+
+            self._tensor_dumper = DiffusionTensorDumper(
+                dump_dir=self.server_args.debug_tensor_dump_output_folder,
+                dump_layers=None,
+                tp_size=tp_size,
+                tp_rank=tp_rank,
+                pp_rank=0,
+            )
+            for module_name, module in self.pipeline.modules.items():
+                if isinstance(module, torch.nn.Module):
+                    self._tensor_dumper._add_hook_recursive(
+                        module, module_name, module_name, "layers"
+                    )
+                    module.register_forward_hook(
+                        self._tensor_dumper._dump_hook(module_name, True)
+                    )
+
+            # VAE uses .decode() instead of forward(), so forward hooks won't
+            # fire. Wrap .decode() to capture its input/output.
+            vae = self.pipeline.get_module("vae", None)
+            if vae is not None and hasattr(vae, "decode"):
+                dumper = self._tensor_dumper
+                _orig_decode = vae.decode
+
+                def _wrapped_decode(*args, **kwargs):
+                    result = _orig_decode(*args, **kwargs)
+                    if args:
+                        dumper.add_tensor("vae.decode.input", args[0])
+                    dumper.add_tensor("vae.decode.output", result)
+                    dumper.dump_current_tensors()
+                    return result
+
+                vae.decode = _wrapped_decode
+
         # apply layerwise offload after lora is applied while building LoRAPipeline
         # otherwise empty offloaded weights could fail lora converting
         if self.server_args.layerwise_offload_components:

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -313,6 +313,9 @@ class ServerArgs(DisaggArgsMixin):
     enable_trace: bool = False
     otlp_traces_endpoint: str = "localhost:4317"
 
+    # Debug tensor dump
+    debug_tensor_dump_output_folder: Optional[str] = None
+
     # get_role_parallelism, derive_pool_*_endpoint — from DisaggArgsMixin
 
     @property
@@ -663,6 +666,11 @@ class ServerArgs(DisaggArgsMixin):
         return None, None
 
     def _adjust_warmup(self):
+        if self.debug_tensor_dump_output_folder is not None:
+            logger.warning("Warmup is disabled because tensor dump mode is enabled.")
+            self.warmup = False
+            return
+
         if self.warmup_resolutions is not None:
             self.warmup = True
             self.server_warmup = False
@@ -1515,6 +1523,13 @@ class ServerArgs(DisaggArgsMixin):
             help="Exclude uvicorn access logs whose request path starts with any of these prefixes. "
             "Defaults to empty (disabled). "
             "Example: --uvicorn-access-log-exclude-prefixes /metrics /health",
+        )
+        parser.add_argument(
+            "--debug-tensor-dump-output-folder",
+            type=str,
+            default=ServerArgs.debug_tensor_dump_output_folder,
+            help="Output folder for dumping intermediate tensors from forward passes. "
+            "Each GPU rank creates a subdirectory. Disables warmup when set.",
         )
         parser.add_argument(
             "--backend",


### PR DESCRIPTION
  ## Summary
  - Add `--debug-tensor-dump-output-folder` CLI flag to the diffusion module, mirroring SRT's existing tensor dump capability.
  - Register forward hooks on all pipeline modules (transformer, text_encoder, etc.) to capture intermediate tensors per forward pass
  as `.pt` files.
  `BaseEncoderOutput`).
  - Wrap `VAE.decode()` to capture input/output since VAE uses `.decode()` instead of `forward()`.
  - Automatically disable warmup when tensor dump mode is enabled.

  ## Test plan
  - [x] Run `sglang generate --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers --debug-tensor-dump-output-folder dump
  --num-inference-steps 1 --prompt "test"`
  - [x] Verify dump folder contains `.pt` files with transformer layer tensors
  - [x] Verify text encoder output (BaseEncoderOutput) is dumped without errors
  - [x] Verify VAE decode input/output is captured in the final Pass file







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26622949742](https://github.com/sgl-project/sglang/actions/runs/26622949742)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26622949680](https://github.com/sgl-project/sglang/actions/runs/26622949680)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->