### PR TITLE
[CI] Drop unused 'environment: prod' from bot-cherry-pick job

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -28,7 +28,6 @@ jobs:
   cherry-pick:
     if: github.repository == 'sgl-project/sglang'
     runs-on: ubuntu-latest
-    environment: 'prod'
     steps:
       - name: Validate inputs
         env:


### PR DESCRIPTION
## Summary

The `cherry-pick` job in `.github/workflows/bot-cherry-pick.yml` declares `environment: 'prod'`, but the `prod` environment on this repo has:

- `protection_rules: []` (no required reviewers, no wait timers)
- `deployment_branch_policy: null` (no branch restriction)
- `0` environment-scoped secrets

The PAT used by the workflow (`GH_PAT_FOR_CHERRY_PICK`) is a **repo-level** Actions secret, so it remains available without the environment binding.

## Why this matters

Every cherry-pick workflow run creates a GitHub Deployment record under the `prod` environment, which then surfaces on the **source PR's timeline** as a misleading "deployed to prod" event — even though the run only opens a cherry-pick PR against a release branch and ships nothing.

Example: PR #25945 shows ``Kangyan-Zhou deployed to prod`` from triggering a cherry-pick, which is confusing because no production deployment happened.

## Change

Remove the no-op `environment: 'prod'` line from the job. Behavior is otherwise unchanged.

If gating becomes desirable later, prefer a distinctly named environment (e.g. `release-automation`) with required reviewers — reusing `prod` for non-deploy jobs is what created the original confusion.

## Test plan

- [ ] Trigger the `Bot Cherry Pick to Release Branch` workflow from the Actions tab on a recent merged PR.
- [ ] Confirm the run still completes successfully (PAT auth, cherry-pick, push, `gh pr create` all work).
- [ ] Confirm no new `Deployment` record is created under the `prod` environment for that run.
- [ ] Confirm the source PR's timeline no longer shows a "deployed to prod" event for cherry-picks.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26276353599](https://github.com/sgl-project/sglang/actions/runs/26276353599)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26276353557](https://github.com/sgl-project/sglang/actions/runs/26276353557)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->