### PR TITLE
[CI] bot-cherry-pick: remove concurrency group to enable batch dispatch

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -20,10 +20,6 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: cherry-pick-${{ github.event.inputs.target_branch }}
-  cancel-in-progress: false
-
 jobs:
   cherry-pick:
     if: github.repository == 'sgl-project/sglang'


### PR DESCRIPTION
## Summary

Removes the per-target-branch `concurrency` block from `bot-cherry-pick.yml`. The intent was to serialize multiple cherry-pick dispatches to the same release branch, but **`cancel-in-progress: false` does not actually queue multiple pending runs** — GitHub Actions keeps only one pending entry per concurrency group and **cancels** any earlier-queued one when a new dispatch arrives. The observed result of batch-dispatching 8 PRs to the same release branch:

| PR | Outcome |
|---|---|
| #25585 (first) | success |
| #25646 .. #25889 (middle 6) | **cancelled** — `created_at == cancelled_at`, no job ever started |
| #25810 (last) | success |

Run IDs of the cancelled ones (e.g. [26276759535](https://github.com/sgl-project/sglang/actions/runs/26276759535)) confirm they were cancelled by the concurrency group before any step executed.

## Why removing it is safe

Cherry-pick runs are independent:

- Each run creates a randomly-suffixed branch `cherry-pick/<short_sha>-to-<branch>-<rand>` from `origin/<target_branch>` at the moment its checkout step runs — no branch-name collisions.
- Each run pushes its own branch (no push contention).
- Each run opens its own PR (the merge into the release branch is a separate, human-reviewed step).

There is no shared mutable state that the concurrency group was actually protecting.

## Effect

Release managers using `/sglang-cherrypick` (or just `gh workflow run` in a loop) can now batch-dispatch N PRs and get N parallel runs instead of 2 successes + N-2 cancellations.

## Test plan

- [x] Pre-commit clean
- [ ] After merge: re-dispatch the 6 cancelled PRs in parallel and confirm all complete
- [ ] Optional follow-up: refresh the `sglang-cherrypick` skill's notes that reference the (now-removed) concurrency group

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26277075021](https://github.com/sgl-project/sglang/actions/runs/26277075021)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26277074881](https://github.com/sgl-project/sglang/actions/runs/26277074881)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->