### PR TITLE
[CI] Sync pr-test workflows from main to release/v0.5.12

### DIFF
--- a/.github/actions/check-pr-test-health/action.yml
+++ b/.github/actions/check-pr-test-health/action.yml
@@ -1,4 +1,4 @@
-name: Check Stage Health
+name: Check PR Test Health
 description: Fail fast if any job in the current workflow run has already failed, or if the lint check (from lint.yml) has failed. Auto-skips for scheduled runs. The jobs-failed check (but not the lint check) is bypassed when the PR carries the `bypass-fastfail` label.
 
 inputs:
@@ -10,16 +10,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check stage health
+    - name: Check PR test health
       uses: actions/github-script@v7
       env:
-        SKIP_STAGE_HEALTH_CHECK: ${{ env.SKIP_STAGE_HEALTH_CHECK }}
+        SKIP_PR_TEST_HEALTH_CHECK: ${{ env.SKIP_PR_TEST_HEALTH_CHECK }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           // Skip when explicitly requested via env var (e.g. release branch cut)
-          if (process.env.SKIP_STAGE_HEALTH_CHECK === 'true') {
-            core.info('Skipping health check (SKIP_STAGE_HEALTH_CHECK=true)');
+          if (process.env.SKIP_PR_TEST_HEALTH_CHECK === 'true') {
+            core.info('Skipping health check (SKIP_PR_TEST_HEALTH_CHECK=true)');
             return;
           }
 
@@ -83,12 +83,12 @@ runs:
             // match so we cover both inline + reusable forms without confusing
             // 'h20' with the 'h200' prefix.
             const baseName = j.name.split(/[ /]/)[0];
-            if (baseName === 'stage-c-test-8-gpu-h20') {
+            if (baseName === 'base-c-test-8-gpu-h20') {
               return false;
             }
             // If the failing step is the health check, it's a cascade — skip it
             const failedStep = (j.steps || []).find(s => s.conclusion === 'failure');
-            if (failedStep && (failedStep.name.includes('check-stage-health') || failedStep.name.includes('Check stage health'))) {
+            if (failedStep && (failedStep.name.includes('check-pr-test-health') || failedStep.name.includes('Check PR test health'))) {
               return false;
             }
             return true;

--- a/.github/workflows/_pr-test-sgl-kernel-build.yml
+++ b/.github/workflows/_pr-test-sgl-kernel-build.yml
@@ -24,7 +24,7 @@ on:
       git_ref:
         type: string
         default: ''
-      skip_stage_health_check:
+      skip_pr_test_health_check:
         description: 'Forwarded from the caller workflow input of the same name. Not consumed inside this reusable workflow today, but mirrored so the resulting env context matches the inline-job baseline.'
         type: boolean
         default: false
@@ -39,7 +39,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_STAGE_HEALTH_CHECK: ${{ inputs.skip_stage_health_check && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ inputs.skip_pr_test_health_check && 'true' || 'false' }}
   FORCE_REBUILD_DEEPEP: '1'
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -4,7 +4,7 @@ name: PR Test Stage
 # `caller_inputs` = toJson(inputs) as bundles. `partitions` is forwarded
 # separately to keep matrix expressions single-fromJson — its value is itself
 # a JSON string, so reading it via `check_changes` would need double fromJson,
-# and matrix can't use step-resolved values. stage-a-test-cpu stays inline in
+# and matrix can't use step-resolved values. base-a-test-cpu stays inline in
 # pr-test.yml (bespoke uv pip / protoc / rust-cache install).
 
 on:
@@ -23,7 +23,7 @@ on:
         type: string
         required: true
       caller_inputs:
-        description: 'toJson(inputs) from pr-test.yml. Read via fromJson(...).git_ref / skip_stage_health_check / test_parallel_dispatch.'
+        description: 'toJson(inputs) from pr-test.yml. Read via fromJson(...).git_ref / skip_pr_test_health_check / test_parallel_dispatch.'
         type: string
         required: true
       partitions:
@@ -62,7 +62,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_STAGE_HEALTH_CHECK: ${{ fromJson(inputs.caller_inputs).skip_stage_health_check && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ fromJson(inputs.caller_inputs).skip_pr_test_health_check && 'true' || 'false' }}
   FORCE_REBUILD_DEEPEP: '1'
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
@@ -97,7 +97,7 @@ jobs:
       - name: Export rdma_devices to job env
         run: echo "SGLANG_CI_RDMA_ALL_DEVICES=${{ steps.rc.outputs.rdma_devices || '' }}" >> "$GITHUB_ENV"
 
-      - uses: ./.github/actions/check-stage-health
+      - uses: ./.github/actions/check-pr-test-health
 
       - uses: ./.github/actions/check-maintenance
 

--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -1,9 +1,13 @@
 name: PR Test Extra
-# Label-gated CI for nightly-class tests opted into a per-PR run.
+# Label-gated extra CI workflow opted into per-PR via labels.
 #
-# Adds runtime to a PR only when the author asks for it: pull_request
-# events bail unless the PR carries the `run-ci-extra` label. The same job
-# graph runs unconditionally on workflow_dispatch / workflow_call so it
+# Adds runtime to a PR only when the author asks for it: the PR must carry
+# BOTH `run-ci` (basic-CI prerequisite) and `run-ci-extra` (explicit opt-in
+# to this workflow). The label check happens at runtime in pr-gate.yml via
+# live `gh pr view --json labels`, so reruns after adding the labels via
+# slash command pick up the new label set (workflow-level `if` checks would
+# read the frozen event payload, which never updates on rerun). The same
+# job graph runs unconditionally on workflow_dispatch / workflow_call so it
 # can be triggered manually or chained from another workflow.
 #
 # Stages: extra-a (1-/2-gpu) and extra-b (4-/8-gpu) caller stubs reuse
@@ -12,6 +16,11 @@ name: PR Test Extra
 on:
   pull_request:
     branches: [main]
+    # `labeled` lets the workflow re-fire when `run-ci-extra` (or `run-ci`)
+    # is added after the latest push — otherwise GHA leaves the stale
+    # skipped run in place and there's no way to enable extra without
+    # another push. See check-changes.if below for the matching guard.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       force_continue_on_error:
@@ -36,8 +45,8 @@ on:
         required: false
         type: boolean
         default: false
-      skip_stage_health_check:
-        description: "Skip stage health check fast-fail (e.g. for release branch cuts)"
+      skip_pr_test_health_check:
+        description: "Skip PR test health check fast-fail (e.g. for release branch cuts)"
         required: false
         type: boolean
         default: false
@@ -50,7 +59,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_STAGE_HEALTH_CHECK: ${{ (inputs.skip_stage_health_check == true || inputs.run_all_tests == true) && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ (inputs.skip_pr_test_health_check == true || inputs.run_all_tests == true) && 'true' || 'false' }}
   FORCE_REBUILD_DEEPEP: '1'
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
@@ -63,20 +72,24 @@ permissions:
 
 jobs:
   # =============================================== check changes ====================================================
-  # Label gate: pull_request events only proceed when the PR carries BOTH
-  # `run-ci` and `run-ci-extra` labels — `run-ci` is the basic-CI prerequisite
-  # (matching pr-test.yml's pr-gate `require-run-ci`) and `run-ci-extra` is the
-  # explicit opt-in to this workflow. Other event types
-  # (workflow_dispatch / workflow_call) always run. When this job is
-  # skipped by the gate, every downstream caller stub naturally skips
-  # because its needs do not resolve.
+  # The actual `run-ci` + `run-ci-extra` label gate now lives in the
+  # `call-gate` job below, which calls pr-gate.yml. pr-gate.yml live-fetches
+  # the PR's current labels at runtime, so a rerun (e.g. via
+  # /tag-and-rerun-ci extra, which adds labels via GITHUB_TOKEN — these
+  # don't cascade-trigger labeled events) picks up the new label set and
+  # passes. The previous workflow-level `if` checked the frozen event
+  # payload, which never updates on rerun and made the slash-add-label flow
+  # impossible to recover.
+  #
+  # We only keep one filter here: for `labeled` events, only proceed if the
+  # just-added label is one of the gating labels. This prevents every
+  # unrelated label addition from dispatching a full CI run.
   check-changes:
     if: |
       github.event_name != 'pull_request' ||
-      (
-        contains(github.event.pull_request.labels.*.name, 'run-ci') &&
-        contains(github.event.pull_request.labels.*.name, 'run-ci-extra')
-      )
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'run-ci' ||
+      github.event.label.name == 'run-ci-extra'
     uses: ./.github/workflows/_pr-test-check-changes.yml
     with:
       git_ref: ${{ inputs.git_ref || '' }}
@@ -85,24 +98,39 @@ jobs:
       pr_test_yml: '.github/workflows/pr-test-extra.yml'
     secrets: inherit
 
+  # =============================================== PR Gate ====================================================
+  # Runtime live-fetch gate. Mirrors pr-test.yml's call-gate, but additionally
+  # requires `run-ci-extra`. Failure here cascades down to every test job
+  # via `needs`, so the workflow ends with one red gate job (~30s) plus a
+  # row of skipped test jobs instead of consuming a runner.
+  call-gate:
+    needs: check-changes
+    if: github.event_name != 'schedule' && needs.check-changes.result == 'success'
+    uses: ./.github/workflows/pr-gate.yml
+    with:
+      require-run-ci: true
+      require-run-ci-extra: true
+    secrets: inherit
+
   # =============================================== sgl-kernel ====================================================
   sgl-kernel-build-wheels:
-    needs: check-changes
+    needs: [check-changes, call-gate]
     if: |
       needs.check-changes.result == 'success' &&
+      (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') &&
       needs.check-changes.outputs.sgl_kernel == 'true'
     uses: ./.github/workflows/_pr-test-sgl-kernel-build.yml
     with:
       runs_on: x64-kernel-build-node
       job_display_name: Build Wheel
       git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
+      skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}
     secrets: inherit
 
   # =============================================== extra-a (1-/2-gpu) ===============================================
   extra-a-test-1-gpu-small:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-a-test-1-gpu-small
@@ -114,8 +142,8 @@ jobs:
     secrets: inherit
 
   extra-a-test-1-gpu-large:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-a-test-1-gpu-large
@@ -128,8 +156,8 @@ jobs:
     secrets: inherit
 
   extra-a-test-2-gpu-large:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-a-test-2-gpu-large
@@ -142,8 +170,8 @@ jobs:
 
   # =============================================== extra-b (4-/8-gpu) ===============================================
   extra-b-test-4-gpu-h100:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-4-gpu-h100
@@ -155,8 +183,8 @@ jobs:
     secrets: inherit
 
   extra-b-test-4-gpu-b200:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-4-gpu-b200
@@ -169,8 +197,8 @@ jobs:
     secrets: inherit
 
   extra-b-test-8-gpu-h200:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-8-gpu-h200
@@ -182,8 +210,8 @@ jobs:
     secrets: inherit
 
   extra-b-test-deepep-8-gpu-h200:
-    needs: [check-changes, sgl-kernel-build-wheels]
-    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' }}
+    needs: [check-changes, call-gate, sgl-kernel-build-wheels]
+    if: ${{ !failure() && !cancelled() && needs.check-changes.result == 'success' && (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped') }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
       self_name: extra-b-test-deepep-8-gpu-h200
@@ -193,3 +221,67 @@ jobs:
       partitions: ${{ needs.check-changes.outputs.partitions }}
       run_timeout_minutes: '60'
     secrets: inherit
+
+  # =============================================== aggregator ====================================================
+  # Mirrors pr-test.yml's `pr-test-finish` so notify-pr-states below only
+  # depends on one job rather than re-listing every stage. Fails if any
+  # dependent failed/cancelled.
+  pr-test-extra-finish:
+    needs:
+      [
+        check-changes,
+        call-gate,
+        sgl-kernel-build-wheels,
+        extra-a-test-1-gpu-small,
+        extra-a-test-1-gpu-large,
+        extra-a-test-2-gpu-large,
+        extra-b-test-4-gpu-h100,
+        extra-b-test-4-gpu-b200,
+        extra-b-test-8-gpu-h200,
+        extra-b-test-deepep-8-gpu-h200,
+      ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all dependent job statuses
+        run: |
+          json_needs='${{ toJson(needs) }}'
+          job_names=$(echo "$json_needs" | jq -r 'keys_unsorted[]')
+          for job in $job_names; do
+            result=$(echo "$json_needs" | jq -r --arg j "$job" '.[$j].result')
+            echo "$job: $result"
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "The above jobs failed."
+              exit 1
+            fi
+          done
+          echo "All jobs completed successfully"
+          exit 0
+
+  # =============================================== notify pr-states ====================================================
+  # Dispatches pr-states.yml after every attempt (initial + every rerun).
+  # workflow_run.completed only fires on the initial completion (one
+  # workflow_run record across attempts), so we explicitly dispatch —
+  # workflow_dispatch is the only event GITHUB_TOKEN can cascade-create.
+  #
+  # Fork PRs are excluded: their pull_request GITHUB_TOKEN is forced
+  # read-only regardless of declared `actions: write`, so dispatch 403s.
+  # Fork PRs get pr-states updates via the workflow_run subscription
+  # there (initial completion) and pull_request_target (push / label).
+  notify-pr-states:
+    needs: [pr-test-extra-finish]
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch pr-states refresh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run pr-states.yml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            -f pr_number="$PR_NUMBER"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,8 +1,15 @@
-name: PR Test
+name: PR Test Base
+run-name: >-
+  ${{
+    github.event_name == 'schedule' && 'Scheduled Full Run'
+    || github.event_name == 'workflow_dispatch' && format('Manual run by {0}', github.actor)
+    || github.event_name == 'pull_request' && format('PR #{0} - {1}', github.event.pull_request.number, github.event.pull_request.title)
+    || 'PR Test Base'
+  }}
 
 on:
   schedule:
-    - cron: '0 1,9,17 * * *'  # Run 3x daily: 2am / 10am / 6pm Pacific (PDT)
+    - cron: '0 11,23 * * *'  # Run 2x daily, 12h apart, off PR-push peaks
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -34,8 +41,8 @@ on:
         required: false
         type: boolean
         default: false
-      skip_stage_health_check:
-        description: "Skip stage health check fast-fail (e.g. for release branch cuts)"
+      skip_pr_test_health_check:
+        description: "Skip PR test health check fast-fail (e.g. for release branch cuts)"
         required: false
         type: boolean
         default: false
@@ -52,7 +59,7 @@ env:
   SGLANG_IS_IN_CI: true
   SGLANG_CUDA_COREDUMP: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
-  SKIP_STAGE_HEALTH_CHECK: ${{ (inputs.skip_stage_health_check == true || inputs.test_parallel_dispatch == true || inputs.run_all_tests == true) && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ (inputs.skip_pr_test_health_check == true || inputs.test_parallel_dispatch == true || inputs.run_all_tests == true) && 'true' || 'false' }}
   # TEMP: rebuild deepep against the new torch for torch-211-merge PR only — revert before merging to main.
   FORCE_REBUILD_DEEPEP: '1'
   # Schedule / main-branch dispatch / workflow_call from main use refs/heads/main; PR events use refs/pull/*/merge
@@ -89,7 +96,7 @@ jobs:
   # For PRs with the `bypass-fastfail` label: wait jobs run but return success immediately
   # (handled inside the wait-for-jobs action), so downstream stages dispatch in parallel.
 
-  wait-for-stage-a:
+  wait-for-base-a:
     needs: [check-changes, call-gate]
     if: |
       always() &&
@@ -100,7 +107,7 @@ jobs:
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
-      stage_a_result: ${{ steps.wait.outputs.result }}
+      base_a_result: ${{ steps.wait.outputs.result }}
     steps:
       - uses: actions/checkout@v4
 
@@ -109,27 +116,27 @@ jobs:
       - uses: ./.github/actions/wait-for-jobs
         id: wait
         with:
-          stage-name: stage-a
+          stage-name: base-a
           jobs: |
             [
-              {"prefix": "stage-a-test-1-gpu-small", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-1-gpu-small'].size }}},
-              {"prefix": "stage-a-test-cpu", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }}}
+              {"prefix": "base-a-test-1-gpu-small", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-1-gpu-small'].size }}},
+              {"prefix": "base-a-test-cpu", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].size }}}
             ]
           max-wait-minutes: '240'
 
-  wait-for-stage-b:
-    needs: [check-changes, call-gate, wait-for-stage-a]
+  wait-for-base-b:
+    needs: [check-changes, call-gate, wait-for-base-a]
     if: |
       always() &&
       !cancelled() &&
       github.event_name == 'pull_request' &&
       inputs.test_parallel_dispatch != true &&
       (needs.check-changes.outputs.main_package == 'true' || needs.check-changes.outputs.sgl_kernel == 'true') &&
-      (needs.wait-for-stage-a.result == 'success' || needs.wait-for-stage-a.result == 'skipped') &&
+      (needs.wait-for-base-a.result == 'success' || needs.wait-for-base-a.result == 'skipped') &&
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
-      stage_b_result: ${{ steps.wait.outputs.result }}
+      base_b_result: ${{ steps.wait.outputs.result }}
     steps:
       - uses: actions/checkout@v4
 
@@ -138,13 +145,13 @@ jobs:
       - uses: ./.github/actions/wait-for-jobs
         id: wait
         with:
-          stage-name: stage-b
+          stage-name: base-b
           jobs: |
             [
-              {"prefix": "stage-b-test-1-gpu-small", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['stage-b-test-1-gpu-small'].size }}},
-              {"prefix": "stage-b-test-1-gpu-large", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['stage-b-test-1-gpu-large'].size }}},
-              {"prefix": "stage-b-test-2-gpu-large", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['stage-b-test-2-gpu-large'].size }}},
-              {"prefix": "stage-b-test-4-gpu-b200", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['stage-b-test-4-gpu-b200'].size }}}
+              {"prefix": "base-b-test-1-gpu-small", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['base-b-test-1-gpu-small'].size }}},
+              {"prefix": "base-b-test-1-gpu-large", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['base-b-test-1-gpu-large'].size }}},
+              {"prefix": "base-b-test-2-gpu-large", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['base-b-test-2-gpu-large'].size }}},
+              {"prefix": "base-b-test-4-gpu-b200", "expected_count": ${{ fromJson(needs.check-changes.outputs.partitions)['base-b-test-4-gpu-b200'].size }}}
             ]
           max-wait-minutes: '480'
 
@@ -180,7 +187,7 @@ jobs:
       runs_on: x64-kernel-build-node
       job_display_name: Build Wheel
       git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
+      skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}
     secrets: inherit
 
   sgl-kernel-build-wheels-arm:
@@ -198,7 +205,7 @@ jobs:
       job_display_name: Build Wheel Arm
       arch_suffix: '-aarch64'
       git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
+      skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}
     secrets: inherit
 
   call-sgl-kernel-tests:
@@ -213,7 +220,7 @@ jobs:
       runs_on_map: ${{ needs.check-changes.outputs.runs_on_map }}
       sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
       git_ref: ${{ inputs.git_ref || '' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
+      skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}
     secrets: inherit
 
   # =============================================== jit-kernel ====================================================
@@ -234,18 +241,18 @@ jobs:
       sgl_kernel: ${{ needs.check-changes.outputs.sgl_kernel }}
       git_ref: ${{ inputs.git_ref || '' }}
       test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true }}
+      skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}
     secrets: inherit
 
   # =============================================== primary ====================================================
 
   # Runs on 5090 (32GB, SM120)
-  stage-a-test-1-gpu-small:
+  base-a-test-1-gpu-small:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-a-test-1-gpu-small
+      self_name: base-a-test-1-gpu-small
       runner_config: 1-gpu-small
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -253,7 +260,7 @@ jobs:
       run_timeout_minutes: '10'
     secrets: inherit
 
-  stage-a-test-cpu:
+  base-a-test-cpu:
     needs: [check-changes, call-gate]
     if: |
       always() &&
@@ -263,9 +270,9 @@ jobs:
     timeout-minutes: 240
     strategy:
       fail-fast: false
-      max-parallel: ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].max_parallel }}
+      max-parallel: ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].max_parallel }}
       matrix:
-        partition: ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].arr }}
+        partition: ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].arr }}
     steps:
       - name: Free disk space
         run: |
@@ -277,7 +284,7 @@ jobs:
         with:
           ref: ${{ inputs.git_ref || github.sha }}
 
-      - uses: ./.github/actions/check-stage-health
+      - uses: ./.github/actions/check-pr-test-health
 
       - uses: ./.github/actions/check-maintenance
 
@@ -316,15 +323,15 @@ jobs:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          python3 run_suite.py --hw cpu --suite stage-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['stage-a-test-cpu'].size }} $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cpu --suite base-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].size }} $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)
-  stage-b-test-1-gpu-small:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+  base-b-test-1-gpu-small:
+    needs: [check-changes, call-gate, wait-for-base-a, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-b-test-1-gpu-small
+      self_name: base-b-test-1-gpu-small
       runner_config: 1-gpu-small
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -333,12 +340,12 @@ jobs:
     secrets: inherit
 
   # Runs on H100 (80GB, SM90) - tests that don't pass on 5090 (FA3, FP8, high VRAM, etc.)
-  stage-b-test-1-gpu-large:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+  base-b-test-1-gpu-large:
+    needs: [check-changes, call-gate, wait-for-base-a, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-b-test-1-gpu-large
+      self_name: base-b-test-1-gpu-large
       runner_config: 1-gpu-large
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -347,12 +354,12 @@ jobs:
       timeout_per_file: '1800'
     secrets: inherit
 
-  stage-b-test-2-gpu-large:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+  base-b-test-2-gpu-large:
+    needs: [check-changes, call-gate, wait-for-base-a, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-b-test-2-gpu-large
+      self_name: base-b-test-2-gpu-large
       runner_config: 2-gpu-large
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -360,12 +367,12 @@ jobs:
       run_timeout_minutes: '30'
     secrets: inherit
 
-  stage-b-test-4-gpu-b200:
-    needs: [check-changes, call-gate, wait-for-stage-a, sgl-kernel-build-wheels]
+  base-b-test-4-gpu-b200:
+    needs: [check-changes, call-gate, wait-for-base-a, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-b-test-4-gpu-b200
+      self_name: base-b-test-4-gpu-b200
       runner_config: 4-gpu-b200
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -391,15 +398,15 @@ jobs:
       git_ref: ${{ inputs.git_ref || '' }}
       test_parallel_dispatch: ${{ inputs.test_parallel_dispatch == true && 'true' || 'false' }}
       caller_needs_failure: ${{ (needs.call-gate.result == 'failure' || needs.sgl-kernel-build-wheels.result == 'failure' || needs.check-changes.result == 'failure') && 'true' || 'false' }}
-      skip_stage_health_check: ${{ inputs.skip_stage_health_check == true && 'true' || 'false' }}
+      skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true && 'true' || 'false' }}
     secrets: inherit
 
-  stage-c-test-4-gpu-h100:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-4-gpu-h100:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-4-gpu-h100
+      self_name: base-c-test-4-gpu-h100
       runner_config: 4-gpu-h100
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -407,12 +414,12 @@ jobs:
       run_timeout_minutes: '30'
     secrets: inherit
 
-  stage-c-test-8-gpu-h200:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-8-gpu-h200:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-8-gpu-h200
+      self_name: base-c-test-8-gpu-h200
       runner_config: 8-gpu-h200
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -427,12 +434,12 @@ jobs:
       warmup_timeout_minutes: '60'
     secrets: inherit
 
-  stage-c-test-8-gpu-h20:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-8-gpu-h20:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-8-gpu-h20
+      self_name: base-c-test-8-gpu-h20
       runner_config: 8-gpu-h20
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -440,12 +447,12 @@ jobs:
       run_timeout_minutes: '30'
     secrets: inherit
 
-  stage-c-test-deepep-4-gpu-h100:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-deepep-4-gpu-h100:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-deepep-4-gpu-h100
+      self_name: base-c-test-deepep-4-gpu-h100
       runner_config: deepep-4-gpu-h100
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -455,12 +462,12 @@ jobs:
       warmup_server_models: 'lmsys/sglang-ci-dsv3-test:4'
     secrets: inherit
 
-  stage-c-test-4-gpu-b200:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-4-gpu-b200:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-4-gpu-b200
+      self_name: base-c-test-4-gpu-b200
       runner_config: 4-gpu-b200
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -469,12 +476,12 @@ jobs:
       timeout_per_file: '1800'
     secrets: inherit
 
-  stage-c-test-dsv4-4-gpu-b200:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-dsv4-4-gpu-b200:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-dsv4-4-gpu-b200
+      self_name: base-c-test-dsv4-4-gpu-b200
       runner_config: dsv4-4-gpu-b200
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -483,12 +490,12 @@ jobs:
       timeout_per_file: '1800'
     secrets: inherit
 
-  stage-c-test-dsv4-8-gpu-h200:
-    needs: [check-changes, call-gate, wait-for-stage-b, sgl-kernel-build-wheels]
+  base-c-test-dsv4-8-gpu-h200:
+    needs: [check-changes, call-gate, wait-for-base-b, sgl-kernel-build-wheels]
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/_pr-test-stage.yml
     with:
-      self_name: stage-c-test-dsv4-8-gpu-h200
+      self_name: base-c-test-dsv4-8-gpu-h200
       runner_config: dsv4-8-gpu-h200
       check_changes: ${{ toJson(needs.check-changes.outputs) }}
       caller_inputs: ${{ toJson(inputs) }}
@@ -507,27 +514,27 @@ jobs:
         sgl-kernel-build-wheels-arm,
         call-sgl-kernel-tests,
 
-        wait-for-stage-a,
-        wait-for-stage-b,
+        wait-for-base-a,
+        wait-for-base-b,
 
         call-jit-kernel-tests,
 
         call-multimodal-gen-tests,
 
-        stage-a-test-1-gpu-small,
-        stage-a-test-cpu,
-        stage-b-test-1-gpu-small,
-        stage-b-test-1-gpu-large,
-        stage-b-test-2-gpu-large,
-        stage-b-test-4-gpu-b200,
-        stage-c-test-4-gpu-h100,
-        stage-c-test-8-gpu-h20,
-        stage-c-test-8-gpu-h200,
-        stage-c-test-deepep-4-gpu-h100,
-        stage-c-test-4-gpu-b200,
-        stage-c-test-dsv4-4-gpu-b200,
-        stage-c-test-dsv4-8-gpu-h200,
-        # stage-c-test-4-gpu-gb200,  # Temporarily disabled — no GB200 runner
+        base-a-test-1-gpu-small,
+        base-a-test-cpu,
+        base-b-test-1-gpu-small,
+        base-b-test-1-gpu-large,
+        base-b-test-2-gpu-large,
+        base-b-test-4-gpu-b200,
+        base-c-test-4-gpu-h100,
+        base-c-test-8-gpu-h20,
+        base-c-test-8-gpu-h200,
+        base-c-test-deepep-4-gpu-h100,
+        base-c-test-4-gpu-b200,
+        base-c-test-dsv4-4-gpu-b200,
+        base-c-test-dsv4-8-gpu-h200,
+        # base-c-test-4-gpu-gb200,  # Temporarily disabled — no GB200 runner
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -556,3 +563,31 @@ jobs:
           # If the loop completes, all jobs were successful
           echo "All jobs completed successfully"
           exit 0
+
+  # =============================================== notify pr-states ====================================================
+  # Dispatches pr-states.yml after every attempt (initial + every rerun).
+  # workflow_run.completed only fires on the initial completion (one
+  # workflow_run record across attempts), so we explicitly dispatch —
+  # workflow_dispatch is the only event GITHUB_TOKEN can cascade-create.
+  #
+  # Fork PRs are excluded: their pull_request GITHUB_TOKEN is forced
+  # read-only regardless of declared `actions: write`, so dispatch 403s.
+  # Fork PRs get pr-states updates via the workflow_run subscription
+  # there (initial completion) and pull_request_target (push / label).
+  notify-pr-states:
+    needs: [pr-test-finish]
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch pr-states refresh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh workflow run pr-states.yml \
+            --repo ${{ github.repository }} \
+            --ref main \
+            -f pr_number="$PR_NUMBER"


### PR DESCRIPTION
## Summary

Snapshots the current `main` versions of the PR Test workflows onto `release/v0.5.12` as a single coherent change. A naive per-PR cherry-pick of the 6 contributing commits (#25420, #25452, #25465, #25732, #25812, #25872) would hit conflicts because the stage-a/b/c → base-a/b/c rename in #25420 lands in the middle of the series; a snapshot is cleaner.

### Files updated to match `main`

- `.github/workflows/pr-test.yml`
- `.github/workflows/pr-test-extra.yml`
- `.github/workflows/_pr-test-stage.yml` (reusable workflow)
- `.github/workflows/_pr-test-sgl-kernel-build.yml` (reusable workflow)

### Renamed action

- `.github/actions/check-stage-health/` → removed
- `.github/actions/check-pr-test-health/` → added (copy of the `main` version)

The rename carries two identifiers used across the four workflows:
- input `skip_stage_health_check` → `skip_pr_test_health_check`
- env var `SKIP_STAGE_HEALTH_CHECK` → `SKIP_PR_TEST_HEALTH_CHECK`

### Pre-merge verification

- ✅ Every `uses:` / `./.github/actions/` / `./.github/workflows/` / `scripts/` path referenced by the new workflows exists on `release/v0.5.12` (checked `check-maintenance`, `upload-cuda-coredumps`, `wait-for-jobs`, `_pr-test-check-changes.yml`, `pr-gate.yml`, `pr-test-jit-kernel.yml`, `pr-test-multimodal-gen.yml`, `pr-test-sgl-kernel.yml`, `scripts/ci/runner_configs.{py,yml}`, etc. — all present).
- ✅ No other tracked file on this branch still references the old `skip_stage_health_check` / `SKIP_STAGE_HEALTH_CHECK` / `check-stage-health` identifiers, with the one exception of `.claude/skills/ci-workflow-guide/SKILL.md` (docs skill — stale on both branches, out of scope for this PR).
- ✅ Pre-commit passes, including the duplicate-workflow-job-name check (so the rename doesn't collide with any retained `stage-*` job).

### What this enables

CI on the release branch picks up the same scheduling and gating fixes that landed on `main`:
- #25420 — rename basic CI stages `a/b/c` → `base-a/b/c` (symmetry with extra)
- #25452 — distinct `run-name` per event
- #25465 — `verify_done`: wait, not synchronize
- #25732 — `pr-test-extra`: re-trigger on labeled event
- #25812 — `pr-states` dispatch from notify job (fix rerun status)
- #25872 — schedule 3× → 2×; fix extra gate skipped on schedule

## Test plan

- [x] Pre-commit clean (incl. duplicate workflow job name check)
- [ ] After merge, observe the next PR-Test run on `release/v0.5.12` and confirm jobs render under the new `base-a/b/c` names
- [ ] Confirm the extra-CI label re-trigger fires correctly on a PR labelled with `run-ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->