### PR TITLE
[core] Add --debug-graph-tensor-dump-output-folder for CUDA graph tensor dump

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -1122,6 +1122,10 @@ class CudaGraphRunner:
 
             self.deepep_adapter.capture(is_extend_in_batch=False)
 
+            from sglang.srt.utils.graph_debug_utils import gdebug
+
+            gdebug.set_phase("capture", batch_size=bs)
+
             for _ in range(2):
                 self.device_module.synchronize()
                 self.model_runner.tp_group.barrier()
@@ -1133,9 +1137,13 @@ class CudaGraphRunner:
             # Set graph pool id globally to be able to use symmetric memory
             set_graph_pool_id(get_global_graph_memory_pool())
 
+            gdebug.set_capturing_graph(True)
             out = self._capture_graph(
                 graph, get_global_graph_memory_pool(), stream, run_once
             )
+            gdebug.set_capturing_graph(False)
+
+            gdebug.set_phase("idle")
 
         return graph, out
 
@@ -1285,6 +1293,11 @@ class CudaGraphRunner:
             graph_key = f"{get_current_stream_idx()}_{self.bs}"
         else:
             graph_key = self.bs
+
+        from sglang.srt.utils.graph_debug_utils import gdebug
+
+        gdebug.set_phase("replay", batch_size=self.bs)
+
         ctx = (
             self.model_runner.device_timer.wrap(
                 metadata={
@@ -1296,6 +1309,8 @@ class CudaGraphRunner:
         )
         with ctx:
             self.graphs[graph_key].replay()
+
+        gdebug.flush()
 
         output = self.output_buffers[graph_key]
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1403,6 +1403,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.pp_rank,
             )
 
+        if self.server_args.debug_graph_tensor_dump_output_folder is not None:
+            from sglang.srt.utils.graph_debug_utils import gdebug
+
+            gdebug.configure(
+                self.server_args.debug_graph_tensor_dump_output_folder,
+                self.tp_size,
+                self.tp_rank,
+                self.pp_rank,
+            )
+            gdebug.register_hooks(self.model)
+
         if dumper.may_enable:
             dumper.apply_source_patches()
             dumper.register_non_intrusive_dumper(self.model)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -795,6 +795,8 @@ class ServerArgs:
     # TODO(guoyuhong): clean the old dumper code.
     debug_tensor_dump_input_file: Optional[str] = None
     debug_tensor_dump_inject: bool = False
+    # Graph-compatible tensor dump (works WITH cuda graph enabled).
+    debug_graph_tensor_dump_output_folder: Optional[str] = None
 
     # PD disaggregation: can be "null" (not disaggregated), "prefill" (prefill-only), or "decode" (decode-only)
     disaggregation_mode: Literal["null", "prefill", "decode"] = "null"
@@ -6705,6 +6707,13 @@ class ServerArgs:
             type=str,
             default=ServerArgs.debug_tensor_dump_inject,
             help="Inject the outputs from jax as the input of every layer.",
+        )
+        parser.add_argument(
+            "--debug-graph-tensor-dump-output-folder",
+            type=str,
+            default=ServerArgs.debug_graph_tensor_dump_output_folder,
+            help="Output folder for dumping tensors during CUDA graph replay. "
+            "Unlike --debug-tensor-dump-output-folder, this works with CUDA graphs enabled.",
         )
 
         # PD disaggregation

--- a/python/sglang/srt/utils/graph_debug_utils.py
+++ b/python/sglang/srt/utils/graph_debug_utils.py
@@ -1,0 +1,163 @@
+"""
+CUDA Graph compatible tensor dump tool.
+
+Unlike --debug-tensor-dump-output-folder which disables CUDA graphs,
+this tool works WITH graphs by pre-allocating GPU buffers whose
+copy ops are recorded into the graph during capture.
+
+Activated via --debug-graph-tensor-dump-output-folder CLI flag.
+Hooks are registered automatically on the model (same as the non-graph
+tensor dumper). During graph capture the hooks record buffer.copy_(tensor)
+into the graph; on replay the copies execute inside the graph; flush()
+persists to disk as Pass{N}.pt files.
+
+Phase flow:
+  1. "capture" (warmup, outside graph ctx): hooks allocate buffers + copy
+  2. "capture" (inside graph ctx): hooks only copy into existing buffers
+     (recorded into graph)
+  3. "idle": hooks are no-ops
+  4. "replay": graph executes recorded copies, flush() saves to disk
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class GraphDebugger:
+    _instance: Optional["GraphDebugger"] = None
+
+    def __init__(self):
+        self.enabled = False
+        self._dump_dir: Optional[Path] = None
+        self._max_buffers = 200
+        self._capturing_graph = False
+
+        self._phase = "idle"
+        self._batch_size = 0
+        self._flush_count = 0
+
+        # {batch_size: {name: (buffer, shape, dtype)}}
+        self._buffers: Dict[
+            int, Dict[str, Tuple[torch.Tensor, List[int], torch.dtype]]
+        ] = {}
+        self._buffer_order: Dict[int, List[str]] = {}
+
+    @classmethod
+    def get_instance(cls) -> "GraphDebugger":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def configure(
+        self,
+        dump_dir: str,
+        tp_size: int,
+        tp_rank: int,
+        pp_rank: int,
+        max_buffers: int = 200,
+    ):
+        self.enabled = True
+        rank = tp_size * pp_rank + tp_rank
+        self._dump_dir = (
+            Path(dump_dir) / f"TP{tp_rank}_PP{pp_rank}_Rank{rank}_pid{os.getpid()}"
+        )
+        self._dump_dir.mkdir(parents=True, exist_ok=True)
+        self._max_buffers = max_buffers
+        logger.info("GraphDebugger enabled, dump_dir=%s", self._dump_dir)
+
+    def register_hooks(self, model: torch.nn.Module):
+        top_level_name = os.getenv("TENSOR_DUMP_TOP_LEVEL_MODULE_NAME", "model")
+        self._add_hooks_recursive(model, "", top_level_name)
+        logger.info("GraphDebugger hooks registered on model")
+
+    def _add_hooks_recursive(self, module, prefix, top_level_name):
+        for name, child in module._modules.items():
+            if child is None:
+                continue
+            cur_name = name if not prefix else f"{prefix}.{name}"
+            sub_count = self._add_hooks_recursive(child, cur_name, top_level_name)
+            is_top_level = (not prefix) and (name == top_level_name)
+            if sub_count == 0 or is_top_level:
+                child.register_forward_hook(self._make_hook(cur_name))
+        return len(module._modules)
+
+    def _make_hook(self, name: str):
+        def hook(module, input, output):
+            if not self.enabled or self._phase != "capture":
+                return
+            if isinstance(output, torch.Tensor):
+                self.capture_tensor(name, output)
+            elif isinstance(output, (tuple, list)):
+                for i, t in enumerate(output):
+                    if isinstance(t, torch.Tensor):
+                        self.capture_tensor(f"{name}.{i}", t)
+
+        return hook
+
+    def set_phase(self, phase: str, batch_size: int = 0):
+        if not self.enabled:
+            return
+        self._phase = phase
+        self._batch_size = batch_size
+
+    def set_capturing_graph(self, capturing: bool):
+        self._capturing_graph = capturing
+
+    def capture_tensor(self, name: str, tensor: torch.Tensor):
+        if not self.enabled or self._phase != "capture":
+            return
+
+        bs = self._batch_size
+        buf_dict = self._buffers.setdefault(bs, {})
+        if name not in buf_dict:
+            if self._capturing_graph:
+                # Inside graph capture context: allocation is forbidden.
+                # Skip tensors not seen during warmup.
+                return
+            if len(buf_dict) >= self._max_buffers:
+                return
+            buf_dict[name] = (
+                torch.empty_like(tensor),
+                list(tensor.shape),
+                tensor.dtype,
+            )
+            self._buffer_order.setdefault(bs, []).append(name)
+        buf_dict[name][0].copy_(tensor)
+
+    def flush(self):
+        if not self.enabled or self._phase != "replay":
+            return
+
+        bs = self._batch_size
+        buf_dict = self._buffers.get(bs)
+        if not buf_dict:
+            return
+
+        tensors = {}
+        for name in self._buffer_order.get(bs, []):
+            entry = buf_dict.get(name)
+            if entry is None:
+                continue
+            buffer, shape, dtype = entry
+            try:
+                tensors[name] = buffer.detach().cpu()
+            except RuntimeError as e:
+                logger.warning("GraphDebugger: failed to copy tensor %s: %s", name, e)
+                continue
+
+        if tensors:
+            out_file = self._dump_dir / f"Pass{self._flush_count:05d}.pt"
+            torch.save(tensors, out_file)
+            logger.info(
+                "GraphDebugger flushed %d tensors to %s", len(tensors), out_file
+            )
+            self._flush_count += 1
+
+
+gdebug = GraphDebugger.get_instance()


### PR DESCRIPTION
  ## Summary
  - Adds `--debug-graph-tensor-dump-output-folder` CLI flag that dumps intermediate tensors during CUDA graph replay, complementing
  the existing `--debug-tensor-dump-output-folder` which is incompatible with CUDA graphs.
  - Registers forward hooks automatically on the model (same pattern as the existing tensor dumper). During graph capture, hooks
  record `buffer.copy_(tensor)` ops into the graph; on replay these copies execute inside the graph; `flush()` persists buffers to
  disk.
  - Output format matches `--debug-tensor-dump-output-folder`: per-rank subdirectory (`TP{}_PP{}_Rank{}_pid{}`) with `Pass{N}.pt`
  files containing `{module_name: tensor}` dicts.

  ## Changes
  | File | Change |
  |------|--------|
  | `python/sglang/srt/utils/graph_debug_utils.py` | New file — `GraphDebugger` class with hook registration, buffer management, and
  flush logic |
  | `python/sglang/srt/server_args.py` | Add `--debug-graph-tensor-dump-output-folder` argument |
  | `python/sglang/srt/model_executor/model_runner.py` | Call `gdebug.configure()` + `register_hooks()` after model load |
  | `python/sglang/srt/model_executor/cuda_graph_runner.py` | Phase management: set "capture" before warmup, "idle" after, "replay" before replay, flush after |

  ## Test plan
  - [x] Tested with Qwen3 model: confirmed `Pass{N}.pt` files generated with correct tensor data
  - [ ] Verify no performance regression when flag is not set (hooks are no-ops)
  - [ ] Test with TP>1 to confirm per-rank directories













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26623172026](https://github.com/sgl-project/sglang/actions/runs/26623172026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26623171760](https://github.com/sgl-project/sglang/actions/runs/26623171760)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->