### PR TITLE
[CI] Run pr-test + pr-test-extra on PRs targeting release/v0.5.12

### DIFF
--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -11,7 +11,7 @@ name: PR Test Extra
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release/v0.5.12]
   workflow_dispatch:
     inputs:
       force_continue_on_error:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 1,9,17 * * *'  # Run 3x daily: 2am / 10am / 6pm Pacific (PDT)
   pull_request:
-    branches: [main]
+    branches: [main, release/v0.5.12]
   workflow_dispatch:
     inputs:
       force_continue_on_error:


### PR DESCRIPTION
## Summary

Adds `release/v0.5.12` to the `pull_request.branches:` filter on both `pr-test.yml` and `pr-test-extra.yml` so PRs targeting the release branch (including the auto-opened cherry-pick PRs) get the same per-commit CI coverage that `main`-targeted PRs get.

Two-line diff, one branch added in each file. `pr-test-extra`'s `run-ci-extra` label gate on `pull_request` events is unchanged.

## Why not snapshot the workflows from main

A previous attempt (#26081, closed) tried to snapshot the full set of pr-test workflow files from `main` to also pick up the scheduling and labelling fixes. Code review caught that the `stage-* → base-*` rename in #25420 has a wide blast radius across `scripts/ci/utils/compute_partitions.py`, `scripts/ci/utils/slash_command_handler.py`, `test/run_suite.py`, ~200 `register_*_ci(suite=...)` call sites, and three sibling reusable workflows — landing the snapshot without the rest would break every per-commit job on the release branch.

This PR is therefore scoped to the only thing actually needed for release-branch CI to fire: the trigger filter.

## Test plan

- [x] Pre-commit clean (including the duplicate-workflow-job-name check)
- [ ] After merge, open a no-op PR against `release/v0.5.12` and confirm both `PR Test` and `PR Test Extra` (when `run-ci-extra` label applied) workflows fire
- [ ] Confirm existing cherry-pick PRs (#26070, #26071, #26072, #26075–#26079) get a fresh CI run after this lands (may need a no-op push or manual re-trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26279648646](https://github.com/sgl-project/sglang/actions/runs/26279648646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->