### PR TITLE
Add DP cache affinity by routing key

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -19,6 +19,7 @@ import multiprocessing as mp
 import signal
 import threading
 import time
+from collections import OrderedDict
 from enum import Enum, auto
 from typing import Callable, List, Optional
 
@@ -86,6 +87,21 @@ class LoadBalanceMethod(Enum):
             raise ValueError(f"Invalid load balance method: {method}") from exc
 
 
+class DPCacheAffinityMethod(Enum):
+    """DP cache affinity method."""
+
+    NONE = auto()
+    ROUTING_KEY = auto()
+
+    @classmethod
+    def from_str(cls, method: str):
+        method = method.upper()
+        try:
+            return cls[method]
+        except KeyError as exc:
+            raise ValueError(f"Invalid DP cache affinity method: {method}") from exc
+
+
 class DPBudget:
     def __init__(self, dp_size: int):
         self.dp_size = dp_size
@@ -100,22 +116,39 @@ class DPBudget:
             )
             self.total_tokens[load.dp_rank] = load.num_total_tokens
 
-    def dispatch(self, method: LoadBalanceMethod, estimated_tokens: int = 0):
+    def dispatch(
+        self,
+        method: LoadBalanceMethod,
+        estimated_tokens: int = 0,
+        available_ranks: Optional[List[int]] = None,
+    ):
+        candidate_ranks = (
+            available_ranks if available_ranks is not None else range(self.dp_size)
+        )
+        candidate_ranks = [
+            rank for rank in candidate_ranks if 0 <= rank < self.dp_size
+        ]
+        if not candidate_ranks:
+            raise RuntimeError("No available DP ranks for dispatch")
+
         if method == LoadBalanceMethod.TOTAL_REQUESTS:
-            target_rank = self.total_requests.index(min(self.total_requests))
+            target_rank = min(candidate_ranks, key=lambda i: self.total_requests[i])
         elif method == LoadBalanceMethod.TOTAL_TOKENS:
             # Use total_requests as a tie-breaker when total_tokens are equal
             target_rank = min(
-                range(self.dp_size),
+                candidate_ranks,
                 key=lambda i: (self.total_tokens[i], self.total_requests[i]),
             )
         else:
             return None
 
-        # Increment the load of that worker by one as a heuristic
+        self.record_dispatch(target_rank, estimated_tokens=estimated_tokens)
+        return target_rank
+
+    def record_dispatch(self, target_rank: int, estimated_tokens: int = 0):
+        # Increment the load of that worker by one as a heuristic.
         self.total_requests[target_rank] += 1
         self.total_tokens[target_rank] += estimated_tokens
-        return target_rank
 
 
 class DataParallelController:
@@ -133,6 +166,10 @@ class DataParallelController:
         self.load_balance_method = LoadBalanceMethod.from_str(
             server_args.load_balance_method
         )
+        self.dp_cache_affinity_method = DPCacheAffinityMethod.from_str(
+            server_args.dp_cache_affinity
+        )
+        self.dp_cache_affinity_max_keys = server_args.dp_cache_affinity_max_keys
         self.run_scheduler_process_func = run_scheduler_process_func
 
         # Init inter-process communication
@@ -144,6 +181,7 @@ class DataParallelController:
 
         # Dispatch method
         self.round_robin_counter = 0
+        self.routing_key_to_dp_rank: OrderedDict[str, int] = OrderedDict()
         dispatch_lookup = {
             LoadBalanceMethod.ROUND_ROBIN: self.round_robin_scheduler,
             LoadBalanceMethod.FOLLOW_BOOTSTRAP_ROOM: self.follow_bootstrap_room_scheduler,
@@ -558,54 +596,126 @@ class DataParallelController:
         self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
 
+    def _send_to_worker(self, target_rank: int, req: Req):
+        logger.debug(f"Choose worker {target_rank}")
+        self.workers[target_rank].send_pyobj(req)
+
     def maybe_external_dp_rank_routing(self, req: Req):
         if req.routed_dp_rank is not None:
             logger.debug(f"Direct routing to DP rank {req.routed_dp_rank}")
-            self.workers[req.routed_dp_rank].send_pyobj(req)
+            self._send_to_worker(req.routed_dp_rank, req)
             return True
         return False
 
-    def round_robin_scheduler(self, req: Req):
-        if self.maybe_external_dp_rank_routing(req):
-            return
+    def _is_rank_available(self, target_rank: int):
+        return 0 <= target_rank < len(self.workers) and self.status[target_rank]
 
+    def _available_worker_indices(self):
+        available_ranks = [
+            rank for rank in range(len(self.workers)) if self.status[rank]
+        ]
+        if not available_ranks:
+            raise RuntimeError("No available DP ranks for dispatch")
+        return available_ranks
+
+    def _select_round_robin_worker(self):
+        self._available_worker_indices()
         while True:
-            if self.status[self.round_robin_counter]:
-                logger.debug(f"Choose worker {self.round_robin_counter}")
-                self.workers[self.round_robin_counter].send_pyobj(req)
-                self.round_robin_counter = (self.round_robin_counter + 1) % len(
-                    self.workers
-                )
-                break
+            target_rank = self.round_robin_counter
             self.round_robin_counter = (self.round_robin_counter + 1) % len(
                 self.workers
             )
+            if self.status[target_rank]:
+                return target_rank
 
-    def follow_bootstrap_room_scheduler(self, req: Req):
-        if self.maybe_external_dp_rank_routing(req):
-            return
-
+    def _select_follow_bootstrap_room_worker(self, req: Req):
         assert req.bootstrap_room is not None, (
             "req.bootstrap_room should not be None. Do not send requests directly to "
             "prefill or decode instances; send to the router instead."
         )
-        target_rank = req.bootstrap_room % len(self.workers)
-        self.workers[target_rank].send_pyobj(req)
+        return req.bootstrap_room % len(self.workers)
+
+    def _select_total_requests_worker(self):
+        return self.dp_budget.dispatch(
+            LoadBalanceMethod.TOTAL_REQUESTS,
+            available_ranks=self._available_worker_indices(),
+        )
+
+    def _select_total_tokens_worker(self, req: Req):
+        estimated_tokens = len(req.input_ids)
+        return self.dp_budget.dispatch(
+            LoadBalanceMethod.TOTAL_TOKENS,
+            estimated_tokens=estimated_tokens,
+            available_ranks=self._available_worker_indices(),
+        )
+
+    def _record_cache_affinity_hit(self, target_rank: int, req: Req):
+        if self.load_balance_method == LoadBalanceMethod.TOTAL_REQUESTS:
+            self.dp_budget.record_dispatch(target_rank)
+        elif self.load_balance_method == LoadBalanceMethod.TOTAL_TOKENS:
+            self.dp_budget.record_dispatch(
+                target_rank, estimated_tokens=len(req.input_ids)
+            )
+
+    def _record_cache_affinity_mapping(self, routing_key: str, target_rank: int):
+        self.routing_key_to_dp_rank[routing_key] = target_rank
+        self.routing_key_to_dp_rank.move_to_end(routing_key)
+
+        while len(self.routing_key_to_dp_rank) > self.dp_cache_affinity_max_keys:
+            self.routing_key_to_dp_rank.popitem(last=False)
+
+    def _select_worker_with_cache_affinity(
+        self,
+        req: Req,
+        select_worker: Callable[[], int],
+    ):
+        if self.dp_cache_affinity_method != DPCacheAffinityMethod.ROUTING_KEY:
+            return select_worker()
+
+        routing_key = getattr(req, "routing_key", None)
+        if not routing_key:
+            return select_worker()
+
+        mapped_rank = self.routing_key_to_dp_rank.get(routing_key)
+        if mapped_rank is not None and self._is_rank_available(mapped_rank):
+            self.routing_key_to_dp_rank.move_to_end(routing_key)
+            self._record_cache_affinity_hit(mapped_rank, req)
+            return mapped_rank
+
+        if mapped_rank is not None:
+            logger.debug(
+                f"Remap routing_key={routing_key} from unavailable DP rank "
+                f"{mapped_rank}"
+            )
+
+        target_rank = select_worker()
+        self._record_cache_affinity_mapping(routing_key, target_rank)
+        return target_rank
+
+    def _dispatch_with_cache_affinity(
+        self, req: Req, select_worker: Callable[[], int]
+    ):
+        if self.maybe_external_dp_rank_routing(req):
+            return
+
+        target_rank = self._select_worker_with_cache_affinity(req, select_worker)
+        self._send_to_worker(target_rank, req)
+
+    def round_robin_scheduler(self, req: Req):
+        self._dispatch_with_cache_affinity(req, self._select_round_robin_worker)
+
+    def follow_bootstrap_room_scheduler(self, req: Req):
+        self._dispatch_with_cache_affinity(
+            req, lambda: self._select_follow_bootstrap_room_worker(req)
+        )
 
     def total_requests_scheduler(self, req: Req):
-        if self.maybe_external_dp_rank_routing(req):
-            return
-        target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
-        self.workers[target_worker].send_pyobj(req)
+        self._dispatch_with_cache_affinity(req, self._select_total_requests_worker)
 
     def total_tokens_scheduler(self, req: Req):
-        if self.maybe_external_dp_rank_routing(req):
-            return
-        estimated_tokens = len(req.input_ids)
-        target_worker = self.dp_budget.dispatch(
-            LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
+        self._dispatch_with_cache_affinity(
+            req, lambda: self._select_total_tokens_worker(req)
         )
-        self.workers[target_worker].send_pyobj(req)
 
     def event_loop(self):
         while True:

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -690,6 +690,7 @@ class GenerateReqInput(BaseReq):
             conversation_id=self.conversation_id,
             priority=self.priority,
             extra_key=self.extra_key,
+            routing_key=self.routing_key,
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -499,6 +499,8 @@ class ServerArgs:
     # Data parallelism
     dp_size: int = 1
     load_balance_method: str = "auto"
+    dp_cache_affinity: str = "none"
+    dp_cache_affinity_max_keys: int = 100_000
 
     attn_cp_size: int = 1
     moe_dp_size: int = 1
@@ -997,17 +999,45 @@ class ServerArgs:
                 f"Invalid disaggregation_mode={self.disaggregation_mode!r}"
             )
 
+        valid_dp_cache_affinity = ("none", "routing_key")
+        if self.dp_cache_affinity not in valid_dp_cache_affinity:
+            raise ValueError(
+                f"Invalid dp_cache_affinity={self.dp_cache_affinity!r}; "
+                f"must be one of {valid_dp_cache_affinity}"
+            )
+        if self.dp_cache_affinity_max_keys <= 0:
+            raise ValueError(
+                f"Invalid dp_cache_affinity_max_keys="
+                f"{self.dp_cache_affinity_max_keys!r}; must be positive"
+            )
+
         if self.load_balance_method == "auto":
             # Default behavior:
             # - non-PD: round_robin
             # - PD prefill: follow_bootstrap_room
+            # - PD prefill with cache affinity: total_tokens
             # - PD decode: round_robin
-            self.load_balance_method = (
-                "follow_bootstrap_room"
-                if self.disaggregation_mode == "prefill"
-                else "round_robin"
-            )
+            if self.disaggregation_mode == "prefill":
+                self.load_balance_method = (
+                    "total_tokens"
+                    if self.dp_cache_affinity != "none"
+                    else "follow_bootstrap_room"
+                )
+            else:
+                self.load_balance_method = "round_robin"
             return
+
+        if (
+            self.disaggregation_mode == "prefill"
+            and self.dp_cache_affinity != "none"
+            and self.load_balance_method == "follow_bootstrap_room"
+        ):
+            raise ValueError(
+                "--dp-cache-affinity cannot be used with "
+                "--load-balance-method=follow_bootstrap_room in PD prefill mode. "
+                "Use auto, round_robin, total_requests, or total_tokens so decode "
+                "can query the actual prefill DP rank."
+            )
 
     def _handle_ssl_validation(self):
         """Ensure SSL arguments are consistent and referenced files exist."""
@@ -5211,6 +5241,26 @@ class ServerArgs:
                 "total_requests",
                 "total_tokens",
             ],
+        )
+        parser.add_argument(
+            "--dp-cache-affinity",
+            type=str,
+            default=ServerArgs.dp_cache_affinity,
+            help=(
+                "The DP cache affinity strategy. 'routing_key' keeps requests with "
+                "the same X-SMG-Routing-Key on the same DP rank after the first "
+                "assignment."
+            ),
+            choices=["none", "routing_key"],
+        )
+        parser.add_argument(
+            "--dp-cache-affinity-max-keys",
+            type=int,
+            default=ServerArgs.dp_cache_affinity_max_keys,
+            help=(
+                "Maximum number of routing keys remembered by DP cache affinity. "
+                "When the limit is exceeded, least-recently used keys are evicted."
+            ),
         )
         parser.add_argument(
             "--prefill-round-robin-balance",

--- a/test/registered/unit/managers/test_dp_cache_affinity.py
+++ b/test/registered/unit/managers/test_dp_cache_affinity.py
@@ -1,0 +1,157 @@
+import unittest
+from collections import OrderedDict
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.data_parallel_controller import (  # noqa: E402
+    DPCacheAffinityMethod,
+    DataParallelController,
+    DPBudget,
+    LoadBalanceMethod,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.sent = []
+
+    def send_pyobj(self, req):
+        self.sent.append(req)
+
+
+def _req(
+    rid: str,
+    routing_key=None,
+    num_tokens: int = 1,
+    routed_dp_rank=None,
+    bootstrap_room: int = 0,
+):
+    return SimpleNamespace(
+        rid=rid,
+        routing_key=routing_key,
+        input_ids=list(range(num_tokens)),
+        routed_dp_rank=routed_dp_rank,
+        bootstrap_room=bootstrap_room,
+    )
+
+
+def _controller(
+    load_balance_method=LoadBalanceMethod.TOTAL_TOKENS,
+    dp_cache_affinity_method=DPCacheAffinityMethod.ROUTING_KEY,
+    dp_size: int = 3,
+    dp_cache_affinity_max_keys: int = 100_000,
+):
+    controller = DataParallelController.__new__(DataParallelController)
+    controller.workers = [_FakeWorker() for _ in range(dp_size)]
+    controller.status = [True] * dp_size
+    controller.round_robin_counter = 0
+    controller.dp_budget = DPBudget(dp_size)
+    controller.load_balance_method = load_balance_method
+    controller.dp_cache_affinity_method = dp_cache_affinity_method
+    controller.dp_cache_affinity_max_keys = dp_cache_affinity_max_keys
+    controller.routing_key_to_dp_rank = OrderedDict()
+    return controller
+
+
+class TestDPCacheAffinity(CustomTestCase):
+    def test_routing_key_sticks_to_first_total_token_assignment(self):
+        controller = _controller()
+        controller.dp_budget.total_tokens = [50, 5, 20]
+
+        first_req = _req("first", routing_key="session-a", num_tokens=7)
+        controller.total_tokens_scheduler(first_req)
+
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 1)
+        self.assertEqual(controller.workers[1].sent, [first_req])
+        self.assertEqual(controller.dp_budget.total_tokens, [50, 12, 20])
+
+        controller.dp_budget.total_tokens = [0, 100, 0]
+        second_req = _req("second", routing_key="session-a", num_tokens=3)
+        controller.total_tokens_scheduler(second_req)
+
+        self.assertEqual(controller.workers[1].sent, [first_req, second_req])
+        self.assertEqual(controller.dp_budget.total_tokens, [0, 103, 0])
+
+    def test_missing_routing_key_falls_back_to_load_balance_method(self):
+        controller = _controller()
+        controller.dp_budget.total_tokens = [10, 1, 2]
+
+        req = _req("no-key", routing_key=None, num_tokens=4)
+        controller.total_tokens_scheduler(req)
+
+        self.assertEqual(controller.routing_key_to_dp_rank, {})
+        self.assertEqual(controller.workers[1].sent, [req])
+        self.assertEqual(controller.dp_budget.total_tokens, [10, 5, 2])
+
+    def test_unavailable_mapped_rank_is_remapped(self):
+        controller = _controller()
+        controller.routing_key_to_dp_rank["session-a"] = 1
+        controller.status[1] = False
+        controller.dp_budget.total_tokens = [30, 0, 5]
+
+        req = _req("remap", routing_key="session-a", num_tokens=2)
+        controller.total_tokens_scheduler(req)
+
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 2)
+        self.assertEqual(controller.workers[2].sent, [req])
+        self.assertEqual(controller.workers[1].sent, [])
+        self.assertEqual(controller.dp_budget.total_tokens, [30, 0, 7])
+
+    def test_explicit_routed_dp_rank_overrides_cache_affinity(self):
+        controller = _controller()
+        controller.routing_key_to_dp_rank["session-a"] = 1
+
+        req = _req("direct", routing_key="session-a", routed_dp_rank=2)
+        controller.total_tokens_scheduler(req)
+
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 1)
+        self.assertEqual(controller.workers[2].sent, [req])
+        self.assertEqual(controller.workers[1].sent, [])
+
+    def test_routing_key_affinity_can_use_round_robin_for_first_assignment(self):
+        controller = _controller(load_balance_method=LoadBalanceMethod.ROUND_ROBIN)
+
+        first_req = _req("first", routing_key="session-a")
+        second_req = _req("second", routing_key="session-b")
+        third_req = _req("third", routing_key="session-a")
+
+        controller.round_robin_scheduler(first_req)
+        controller.round_robin_scheduler(second_req)
+        controller.round_robin_scheduler(third_req)
+
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 0)
+        self.assertEqual(controller.routing_key_to_dp_rank["session-b"], 1)
+        self.assertEqual(controller.workers[0].sent, [first_req, third_req])
+        self.assertEqual(controller.workers[1].sent, [second_req])
+
+    def test_routing_key_affinity_evicts_least_recent_key(self):
+        controller = _controller(
+            load_balance_method=LoadBalanceMethod.ROUND_ROBIN,
+            dp_cache_affinity_max_keys=2,
+        )
+
+        first_req = _req("first", routing_key="session-a")
+        second_req = _req("second", routing_key="session-b")
+        refresh_req = _req("refresh", routing_key="session-a")
+        third_req = _req("third", routing_key="session-c")
+
+        controller.round_robin_scheduler(first_req)
+        controller.round_robin_scheduler(second_req)
+        controller.round_robin_scheduler(refresh_req)
+        controller.round_robin_scheduler(third_req)
+
+        self.assertEqual(
+            list(controller.routing_key_to_dp_rank.keys()),
+            ["session-a", "session-c"],
+        )
+        self.assertNotIn("session-b", controller.routing_key_to_dp_rank)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -258,6 +258,31 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         # Modalities should be set for all 3 examples
         self.assertEqual(req.modalities, ["image", "image", "image"])
 
+    def test_routing_key_preserved_in_batch_sub_requests(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            rid=["id1", "id2"],
+            routing_key="session-a",
+        )
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].routing_key, "session-a")
+        self.assertEqual(req[1].routing_key, "session-a")
+
+    def test_routing_key_preserved_in_parallel_sample_sub_requests(self):
+        req = GenerateReqInput(
+            text="Hello",
+            sampling_params={"n": 2},
+            routing_key="session-a",
+        )
+
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].routing_key, "session-a")
+        self.assertEqual(req[1].routing_key, "session-a")
+
     def test_audio_data_handling(self):
         """Test handling of audio_data."""
         req = copy.deepcopy(self.base_req)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -39,6 +39,7 @@ class TestLoadBalanceMethod(unittest.TestCase):
     def test_non_pd_defaults_to_round_robin(self):
         server_args = ServerArgs(model_path="dummy", disaggregation_mode="null")
         self.assertEqual(server_args.load_balance_method, "round_robin")
+        self.assertEqual(server_args.dp_cache_affinity, "none")
 
     def test_pd_prefill_defaults_to_follow_bootstrap_room(self):
         server_args = ServerArgs(model_path="dummy", disaggregation_mode="prefill")
@@ -47,6 +48,53 @@ class TestLoadBalanceMethod(unittest.TestCase):
     def test_pd_decode_defaults_to_round_robin(self):
         server_args = ServerArgs(model_path="dummy", disaggregation_mode="decode")
         self.assertEqual(server_args.load_balance_method, "round_robin")
+
+    def test_pd_prefill_cache_affinity_auto_uses_total_tokens(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            disaggregation_mode="prefill",
+            dp_cache_affinity="routing_key",
+        )
+        self.assertEqual(server_args.load_balance_method, "total_tokens")
+        self.assertEqual(server_args.dp_cache_affinity, "routing_key")
+
+    def test_pd_prefill_cache_affinity_rejects_follow_bootstrap_room(self):
+        with self.assertRaises(ValueError) as context:
+            ServerArgs(
+                model_path="dummy",
+                disaggregation_mode="prefill",
+                dp_cache_affinity="routing_key",
+                load_balance_method="follow_bootstrap_room",
+            )
+
+        self.assertIn("--dp-cache-affinity", str(context.exception))
+        self.assertIn("follow_bootstrap_room", str(context.exception))
+
+    def test_dp_cache_affinity_cli_arg(self):
+        server_args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--dp-cache-affinity",
+                "routing_key",
+                "--dp-cache-affinity-max-keys",
+                "128",
+            ]
+        )
+        self.assertEqual(server_args.dp_cache_affinity, "routing_key")
+        self.assertEqual(server_args.dp_cache_affinity_max_keys, 128)
+
+    def test_invalid_dp_cache_affinity_rejected(self):
+        with self.assertRaises(ValueError) as context:
+            ServerArgs(model_path="dummy", dp_cache_affinity="prefix")
+
+        self.assertIn("dp_cache_affinity='prefix'", str(context.exception))
+
+    def test_invalid_dp_cache_affinity_max_keys_rejected(self):
+        with self.assertRaises(ValueError) as context:
+            ServerArgs(model_path="dummy", dp_cache_affinity_max_keys=0)
+
+        self.assertIn("dp_cache_affinity_max_keys=0", str(context.exception))
 
     def test_pd_decode_radix_cache_rejects_hisparse(self):
         with self.assertRaises(ValueError) as context:


### PR DESCRIPTION
Implement https://github.com/sgl-project/sglang/issues/26066
## Summary
- add `--dp-cache-affinity routing_key` for data-parallel controller routing
- keep requests with the same routing key on the same active DP rank after the first assignment
- make PD prefill `auto` load balancing use `total_tokens` when cache affinity is enabled, and reject the incompatible `follow_bootstrap_room` combination
- add unit coverage for sticky routing, remapping unavailable ranks, direct DP-rank overrides, and server args validation

This can increase cache hit rate on Artificial Analysis Agent workload from about 70% to 96%
 
## Test
- `PYTHONPATH=python python3 -m pytest test/registered/unit/managers/test_dp_cache_affinity.py test/registered/unit/server_args/test_server_args.py -q` (60 passed, Lyris GB300 container)















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26281458181](https://github.com/sgl-project/sglang/actions/runs/26281458181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26281458050](https://github.com/sgl-project/sglang/actions/runs/26281458050)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->