### PR TITLE
[VLM] Reuse Qwen pretokenized ids

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -560,6 +560,11 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         process_time = time.perf_counter()
 
         input_ids = input_ids.flatten()
+        base_input_ids = getattr(base_output, "input_ids", None)
+        if isinstance(base_input_ids, list) and len(base_input_ids) == input_ids.numel():
+            input_ids_list = base_input_ids
+        else:
+            input_ids_list = input_ids.tolist()
 
         image_grid_thw = None
         if hasattr(ret, "image_grid_thw"):
@@ -611,7 +616,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         )
 
         return MultimodalProcessorOutput(
-            input_ids=input_ids.tolist(),
+            input_ids=input_ids_list,
             mm_items=mm_items,
             im_start_id=self.vision_start_token_id,
             im_end_id=self.vision_end_token_id,


### PR DESCRIPTION
## Summary

- Reuse Qwen pre-tokenized input id lists when available.

## Tests

- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->