### PR TITLE
[VLM] Preserve Qwen preprocessed input ids

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -1083,12 +1083,21 @@ class BaseMultimodalProcessor(ABC):
 
         return collected_items, input_ids, ret
 
+    @staticmethod
+    def _as_input_ids_tensor(input_ids) -> Optional[torch.Tensor]:
+        if input_ids is None:
+            return None
+        if isinstance(input_ids, torch.Tensor):
+            return input_ids.flatten().to(dtype=torch.long)
+        return torch.tensor(input_ids, dtype=torch.long).flatten()
+
     def process_and_combine_mm_data(
         self,
         base_output: BaseMultiModalProcessorOutput,
         mm_tokens: MultimodalSpecialTokens,
+        preserve_input_ids_list: bool = False,
         **kwargs,
-    ) -> Tuple[List[MultimodalDataItem], torch.Tensor, dict]:
+    ) -> Tuple[List[MultimodalDataItem], Union[List[int], torch.Tensor], dict]:
         """
         Process multimodal data and return the combined multimodal items and input_ids.
         Supports mixed modalities (images and audio in the same request).
@@ -1155,6 +1164,23 @@ class BaseMultimodalProcessor(ABC):
                     )
                 )
         # Fallback tokenization if no raw items were processed
+        if (
+            input_ids is None
+            and preserve_input_ids_list
+            and isinstance(getattr(base_output, "input_ids", None), list)
+        ):
+            input_ids = base_output.input_ids
+
+        if input_ids is None:
+            for _, dict_item in dict_items:
+                dict_input_ids = dict_item.get("input_ids")
+                if preserve_input_ids_list and isinstance(dict_input_ids, list):
+                    input_ids = dict_input_ids
+                else:
+                    input_ids = self._as_input_ids_tensor(dict_input_ids)
+                if input_ids is not None:
+                    break
+
         if input_ids is None:
             input_ids = self._tokenizer(
                 base_output.input_text,
@@ -1164,6 +1190,8 @@ class BaseMultimodalProcessor(ABC):
 
         # Add offsets to all items
         for mm_item in all_collected_items:
+            if not isinstance(input_ids, torch.Tensor):
+                input_ids = self._as_input_ids_tensor(input_ids)
             mm_token_id = mm_tokens.get_token_id_by_modality(mm_item.modality)
             if mm_token_id is None:
                 raise ValueError(f"No token id found for modality: {mm_item.modality}")

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -538,10 +538,11 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 self.mm_tokens,
                 video_metadata=video_metadata,
                 do_sample_frames=False,
+                preserve_input_ids_list=True,
             )
         else:
             mm_items, input_ids, ret = self.process_and_combine_mm_data(
-                base_output, self.mm_tokens
+                base_output, self.mm_tokens, preserve_input_ids_list=True
             )
 
         audio_feature_lengths = None
@@ -559,7 +560,12 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         process_time = time.perf_counter()
 
-        input_ids = input_ids.flatten()
+        if isinstance(input_ids, list):
+            input_ids_list = input_ids
+            input_ids = torch.tensor(input_ids, dtype=torch.long)
+        else:
+            input_ids = input_ids.flatten()
+            input_ids_list = input_ids.tolist()
 
         image_grid_thw = None
         if hasattr(ret, "image_grid_thw"):
@@ -611,7 +617,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         )
 
         return MultimodalProcessorOutput(
-            input_ids=input_ids.tolist(),
+            input_ids=input_ids_list,
             mm_items=mm_items,
             im_start_id=self.vision_start_token_id,
             im_end_id=self.vision_end_token_id,


### PR DESCRIPTION
## Summary

- Preserve Qwen preprocessed input ids through the input-list path.

## Tests

- `pre-commit run --files <changed files>`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26287421978](https://github.com/sgl-project/sglang/actions/runs/26287421978)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26287421754](https://github.com/sgl-project/sglang/actions/runs/26287421754)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->