### PR TITLE
[VLM] optimize gRPC multimodal dispatch for preprocessed input

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import time
+from smg_grpc_servicer.sglang import servicer as grpc_servicer
 
 import grpc
 from aiohttp import web
@@ -165,8 +166,7 @@ def _hash_grpc_mm_proto(mm_proto) -> int | None:
 
 
 def _patch_grpc_multimodal_hashes() -> None:
-    from smg_grpc_servicer.sglang import servicer as grpc_servicer
-
+    """for processed-vlm input, hash on raw proto bytes is faster than hashing before scheduler dispatch (on python objects)"""
     cls = grpc_servicer.SGLangSchedulerServicer
     original_parse = cls._parse_mm_inputs
     if getattr(original_parse, "_sglang_sets_mm_hash", False):

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -57,7 +57,7 @@ def _grpc_max_message_bytes() -> int:
 
 def _with_grpc_message_size_options(options, max_message_bytes: int):
     keys = {"grpc.max_send_message_length", "grpc.max_receive_message_length"}
-    merged = [(k, v) for k, v in (options or []) if k not in keys]
+    merged = [(k, v) for k, v in options if k not in keys]
     merged.extend(
         [
             ("grpc.max_send_message_length", max_message_bytes),
@@ -77,17 +77,20 @@ def _patch_grpc_message_size_options() -> None:
 
     def aio_server_with_message_size(*args, **kwargs):
         if "options" in kwargs:
+            kwargs["options"] = [] if kwargs["options"] is None else kwargs["options"]
             kwargs["options"] = _with_grpc_message_size_options(
                 kwargs["options"], max_message_bytes
             )
         elif len(args) >= 3:
             args = list(args)
+            args[2] = [] if args[2] is None else args[2]
             args[2] = _with_grpc_message_size_options(args[2], max_message_bytes)
         else:
-            kwargs["options"] = _with_grpc_message_size_options(None, max_message_bytes)
+            kwargs["options"] = _with_grpc_message_size_options([], max_message_bytes)
         return original_aio_server(*args, **kwargs)
 
     def insecure_channel_with_message_size(target, options=None, *args, **kwargs):
+        options = [] if options is None else options
         options = _with_grpc_message_size_options(options, max_message_bytes)
         return original_insecure_channel(target, options, *args, **kwargs)
 

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -11,6 +11,7 @@ is set.
 """
 
 import copy
+import hashlib
 import inspect
 import json
 import logging
@@ -122,6 +123,64 @@ def _patch_grpc_request_manager_shm_transport() -> None:
 
     send_to_scheduler_with_shm._sglang_wraps_shm_features = True
     cls._send_to_scheduler = send_to_scheduler_with_shm
+
+
+def _hash_grpc_bytes(chunks) -> int:
+    hasher = hashlib.sha256()
+    for chunk in chunks:
+        hasher.update(len(chunk).to_bytes(8, byteorder="big", signed=False))
+        hasher.update(chunk)
+    return int.from_bytes(hasher.digest()[:8], byteorder="big", signed=False)
+
+
+def _encode_grpc_shape(shape) -> bytes:
+    return b"".join(
+        int(dim).to_bytes(8, byteorder="big", signed=False) for dim in shape
+    )
+
+
+def _hash_grpc_mm_proto(mm_proto):
+    if mm_proto.image_data:
+        return _hash_grpc_bytes(mm_proto.image_data)
+
+    if not mm_proto.HasField("pixel_values"):
+        return None
+
+    chunks = [
+        mm_proto.pixel_values.dtype.encode(),
+        _encode_grpc_shape(mm_proto.pixel_values.shape),
+        mm_proto.pixel_values.data,
+    ]
+    for key in sorted(mm_proto.model_specific_tensors):
+        tensor_data = mm_proto.model_specific_tensors[key]
+        chunks.extend(
+            [
+                key.encode(),
+                tensor_data.dtype.encode(),
+                _encode_grpc_shape(tensor_data.shape),
+                tensor_data.data,
+            ]
+        )
+    return _hash_grpc_bytes(chunks)
+
+
+def _patch_grpc_multimodal_hashes() -> None:
+    from smg_grpc_servicer.sglang import servicer as grpc_servicer
+
+    cls = grpc_servicer.SGLangSchedulerServicer
+    original_parse = cls._parse_mm_inputs
+    if getattr(original_parse, "_sglang_sets_mm_hash", False):
+        return
+
+    def parse_mm_inputs_with_hash(self, mm_proto):
+        mm_inputs = original_parse(self, mm_proto)
+        mm_hash = _hash_grpc_mm_proto(mm_proto)
+        if mm_hash is not None and len(mm_inputs.mm_items) == 1:
+            mm_inputs.mm_items[0].hash = mm_hash
+        return mm_inputs
+
+    parse_mm_inputs_with_hash._sglang_sets_mm_hash = True
+    cls._parse_mm_inputs = parse_mm_inputs_with_hash
 
 
 async def _start_sidecar_server(host: str, port: int, app):
@@ -268,6 +327,7 @@ async def serve_grpc(server_args, model_info=None):
 
     set_global_server_args_for_tokenizer(server_args)
     _patch_grpc_message_size_options()
+    _patch_grpc_multimodal_hashes()
     _patch_grpc_request_manager_shm_transport()
 
     sidecar_app = web.Application()

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -18,11 +18,11 @@ import json
 import logging
 import os
 import time
-from smg_grpc_servicer.sglang import servicer as grpc_servicer
 
 import grpc
 from aiohttp import web
 from smg_grpc_servicer.sglang import request_manager as grpc_request_manager
+from smg_grpc_servicer.sglang import servicer as grpc_servicer
 
 from sglang.srt.managers.io_struct import (
     ProfileReq,

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -18,18 +18,22 @@ import logging
 import os
 import time
 
+import grpc
 from aiohttp import web
+from smg_grpc_servicer.sglang import request_manager as grpc_request_manager
 
 from sglang.srt.managers.io_struct import (
     ProfileReq,
     ProfileReqType,
     TokenizedGenerateReqInput,
 )
+from sglang.srt.managers.mm_utils import wrap_shm_features
 from sglang.srt.server_args import set_global_server_args_for_tokenizer
 from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
+# 512 MB
 _DEFAULT_GRPC_MAX_MESSAGE_MB = 512
 
 
@@ -62,8 +66,6 @@ def _with_grpc_message_size_options(options, max_message_bytes: int):
 
 
 def _patch_grpc_message_size_options() -> None:
-    import grpc
-
     if getattr(grpc, "_sglang_message_size_options_patched", False):
         return
 
@@ -93,14 +95,11 @@ def _patch_grpc_message_size_options() -> None:
 
 
 def _patch_grpc_request_manager_shm_transport() -> None:
-    from smg_grpc_servicer.sglang import request_manager as grpc_request_manager
-
+    """wrap shm/cuda-ipc features before sending to scheduler"""
     cls = grpc_request_manager.GrpcRequestManager
     original_send = cls._send_to_scheduler
     if getattr(original_send, "_sglang_wraps_shm_features", False):
         return
-
-    from sglang.srt.managers.mm_utils import wrap_shm_features
 
     def copy_multimodal_request(obj):
         if not isinstance(obj, TokenizedGenerateReqInput) or obj.mm_inputs is None:
@@ -139,7 +138,8 @@ def _encode_grpc_shape(shape) -> bytes:
     )
 
 
-def _hash_grpc_mm_proto(mm_proto):
+def _hash_grpc_mm_proto(mm_proto) -> int | None:
+    """hash for multimodal data"""
     if mm_proto.image_data:
         return _hash_grpc_bytes(mm_proto.image_data)
 

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -11,6 +11,7 @@ is set.
 """
 
 import copy
+import dataclasses
 import hashlib
 import inspect
 import json
@@ -33,24 +34,24 @@ from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
-# 512 MB
+# gRPC defaults to a small 4MB message cap. SMG sends already-preprocessed
+# pixel tensors, so use a larger bounded default and keep an env override.
 _DEFAULT_GRPC_MAX_MESSAGE_MB = 512
 
 
 def _grpc_max_message_bytes() -> int:
     raw = os.environ.get("SGLANG_GRPC_MAX_MESSAGE_MB")
-    if raw is None:
-        return _DEFAULT_GRPC_MAX_MESSAGE_MB * 1024 * 1024
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.warning(
-            "Invalid SGLANG_GRPC_MAX_MESSAGE_MB=%r; falling back to %dMB",
-            raw,
-            _DEFAULT_GRPC_MAX_MESSAGE_MB,
-        )
-        value = _DEFAULT_GRPC_MAX_MESSAGE_MB
-    return max(value, 1) * 1024 * 1024
+    mb = _DEFAULT_GRPC_MAX_MESSAGE_MB
+    if raw is not None:
+        try:
+            mb = int(raw)
+        except ValueError:
+            logger.warning(
+                "Invalid SGLANG_GRPC_MAX_MESSAGE_MB=%r; falling back to %dMB",
+                raw,
+                _DEFAULT_GRPC_MAX_MESSAGE_MB,
+            )
+    return max(mb, 1) * 1024 * 1024
 
 
 def _with_grpc_message_size_options(options, max_message_bytes: int):
@@ -78,9 +79,9 @@ def _patch_grpc_message_size_options() -> None:
             kwargs["options"] = _with_grpc_message_size_options(
                 kwargs["options"], max_message_bytes
             )
-        elif len(args) >= 4:
+        elif len(args) >= 3:
             args = list(args)
-            args[3] = _with_grpc_message_size_options(args[3], max_message_bytes)
+            args[2] = _with_grpc_message_size_options(args[2], max_message_bytes)
         else:
             kwargs["options"] = _with_grpc_message_size_options(None, max_message_bytes)
         return original_aio_server(*args, **kwargs)
@@ -105,14 +106,11 @@ def _patch_grpc_request_manager_shm_transport() -> None:
         if not isinstance(obj, TokenizedGenerateReqInput) or obj.mm_inputs is None:
             return obj
 
-        copied = copy.copy(obj)
-        copied.mm_inputs = copy.copy(obj.mm_inputs)
-        copied.mm_inputs.mm_items = [
-            copy.copy(item) for item in copied.mm_inputs.mm_items
-        ]
-        for item in copied.mm_inputs.mm_items:
+        mm_items = [copy.copy(item) for item in obj.mm_inputs.mm_items]
+        for item in mm_items:
             item.set_pad_value()
-        return copied
+        mm_inputs = dataclasses.replace(obj.mm_inputs, mm_items=mm_items)
+        return dataclasses.replace(obj, mm_inputs=mm_inputs)
 
     async def send_to_scheduler_with_shm(self, obj):
         if obj is not None:

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -10,17 +10,118 @@ once the gRPC request manager is ready, regardless of whether --enable-metrics
 is set.
 """
 
+import copy
 import inspect
 import json
 import logging
+import os
 import time
 
 from aiohttp import web
 
-from sglang.srt.managers.io_struct import ProfileReq, ProfileReqType
+from sglang.srt.managers.io_struct import (
+    ProfileReq,
+    ProfileReqType,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.server_args import set_global_server_args_for_tokenizer
 from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_GRPC_MAX_MESSAGE_MB = 512
+
+
+def _grpc_max_message_bytes() -> int:
+    raw = os.environ.get("SGLANG_GRPC_MAX_MESSAGE_MB")
+    if raw is None:
+        return _DEFAULT_GRPC_MAX_MESSAGE_MB * 1024 * 1024
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid SGLANG_GRPC_MAX_MESSAGE_MB=%r; falling back to %dMB",
+            raw,
+            _DEFAULT_GRPC_MAX_MESSAGE_MB,
+        )
+        value = _DEFAULT_GRPC_MAX_MESSAGE_MB
+    return max(value, 1) * 1024 * 1024
+
+
+def _with_grpc_message_size_options(options, max_message_bytes: int):
+    keys = {"grpc.max_send_message_length", "grpc.max_receive_message_length"}
+    merged = [(k, v) for k, v in (options or []) if k not in keys]
+    merged.extend(
+        [
+            ("grpc.max_send_message_length", max_message_bytes),
+            ("grpc.max_receive_message_length", max_message_bytes),
+        ]
+    )
+    return merged
+
+
+def _patch_grpc_message_size_options() -> None:
+    import grpc
+
+    if getattr(grpc, "_sglang_message_size_options_patched", False):
+        return
+
+    max_message_bytes = _grpc_max_message_bytes()
+    original_aio_server = grpc.aio.server
+    original_insecure_channel = grpc.insecure_channel
+
+    def aio_server_with_message_size(*args, **kwargs):
+        if "options" in kwargs:
+            kwargs["options"] = _with_grpc_message_size_options(
+                kwargs["options"], max_message_bytes
+            )
+        elif len(args) >= 4:
+            args = list(args)
+            args[3] = _with_grpc_message_size_options(args[3], max_message_bytes)
+        else:
+            kwargs["options"] = _with_grpc_message_size_options(None, max_message_bytes)
+        return original_aio_server(*args, **kwargs)
+
+    def insecure_channel_with_message_size(target, options=None, *args, **kwargs):
+        options = _with_grpc_message_size_options(options, max_message_bytes)
+        return original_insecure_channel(target, options, *args, **kwargs)
+
+    grpc.aio.server = aio_server_with_message_size
+    grpc.insecure_channel = insecure_channel_with_message_size
+    grpc._sglang_message_size_options_patched = True
+
+
+def _patch_grpc_request_manager_shm_transport() -> None:
+    from smg_grpc_servicer.sglang import request_manager as grpc_request_manager
+
+    cls = grpc_request_manager.GrpcRequestManager
+    original_send = cls._send_to_scheduler
+    if getattr(original_send, "_sglang_wraps_shm_features", False):
+        return
+
+    from sglang.srt.managers.mm_utils import wrap_shm_features
+
+    def copy_multimodal_request(obj):
+        if not isinstance(obj, TokenizedGenerateReqInput) or obj.mm_inputs is None:
+            return obj
+
+        copied = copy.copy(obj)
+        copied.mm_inputs = copy.copy(obj.mm_inputs)
+        copied.mm_inputs.mm_items = [
+            copy.copy(item) for item in copied.mm_inputs.mm_items
+        ]
+        for item in copied.mm_inputs.mm_items:
+            item.set_pad_value()
+        return copied
+
+    async def send_to_scheduler_with_shm(self, obj):
+        if obj is not None:
+            obj = copy_multimodal_request(obj)
+            obj = wrap_shm_features(obj)
+        return await original_send(self, obj)
+
+    send_to_scheduler_with_shm._sglang_wraps_shm_features = True
+    cls._send_to_scheduler = send_to_scheduler_with_shm
 
 
 async def _start_sidecar_server(host: str, port: int, app):
@@ -164,6 +265,10 @@ async def serve_grpc(server_args, model_info=None):
             "If already installed, there may be a broken import due to a "
             "version mismatch — see the chained exception above for details."
         ) from e
+
+    set_global_server_args_for_tokenizer(server_args)
+    _patch_grpc_message_size_options()
+    _patch_grpc_request_manager_shm_transport()
 
     sidecar_app = web.Application()
     sidecar_runner = None


### PR DESCRIPTION
## Summary

- Dispatch gRPC multimodal scheduler updates without per-item repeated awaits.
- Reuse preprocessed multimodal gRPC payload hashes before scheduler dispatch.

## Analysis

SMG sends already-preprocessed VLM inputs through gRPC, including pixel payloads. On the SGLang side, the remaining redundant work in this path was CPU/control-plane work around scheduler dispatch: repeated awaits for multimodal scheduler updates and re-hashing preprocessed payloads before dispatch.

The default gRPC max message size is raised to 512MB because the SMG path can carry preprocessed pixel tensors instead of small image URLs/bytes. This is a bounded default to avoid gRPC's small message cap on the target VLM path; deployments can override it with `SGLANG_GRPC_MAX_MESSAGE_MB`.

This PR keeps the change scoped to `grpc_server.py`. It does not touch `multimodal_gen` or model-level VLM preprocessing. After this change, the remaining OCRBench gap vs vLLM is mostly first-serving-batch/cold runtime, not the preprocessed-pixel gRPC path: SGLang first 100 OCRBench requests average about 6.41s TTFT and later requests average about 1.82s, while the same-env vLLM split is about 3.91s / 3.55s.

## Benchmark Results

Qwen3.5 397B FP8, TP8, B200, SMG gRPC, cuda-ipc enabled, `limit=200`, `concurrency=100`, `max_tokens=5`.

| Scenario | No-hash control TTFT mean | This PR TTFT mean | Change |
| --- | ---: | ---: | ---: |
| ocrbench | 5.458s | 4.111s | -24.7% |
| ocrbench-text | 1.157s | 1.037s | -10.4% |
| synthetic-text | 0.829s | 0.807s | -2.7% |

Follow-up #26197 improves the same setup further to 4.010s OCRBench TTFT and 0.690s ocrbench-text TTFT. Same-env vLLM OCRBench TTFT is 3.730s.

## Follow-up

- Move preprocessed-payload hash construction into `smg_grpc_servicer`'s `_parse_mm_inputs` / tensor decode path, so parsing and hashing share the same tensor traversal. If the hash is meant to cover full multimodal request semantics, include parsed `mm_placeholders` and `im_token_id` there as well.

## Tests

- `uvx ruff@0.15.1 check --select=F401,F821 --fix python/sglang/srt/entrypoints/grpc_server.py`
- `uvx black==26.1.0 --check python/sglang/srt/entrypoints/grpc_server.py`
- `pre-commit run --files python/sglang/srt/entrypoints/grpc_server.py`













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26445425639](https://github.com/sgl-project/sglang/actions/runs/26445425639)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26445425463](https://github.com/sgl-project/sglang/actions/runs/26445425463)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
