### PR TITLE
FutureMap: debug-assert that gather sees a stashed value

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -18,9 +18,9 @@ _is_cuda = is_cuda()
 _is_hip = is_hip()
 
 # Token-buf consume tracking: init to -1, assert non-negative on gather,
-# write -1 back. Catches "gather without intermediate stash" bugs. Off by
-# default; CI enables via SGLANG_FUTURE_MAP_DEBUG_ASSERT=1.
-_DEBUG_ASSERT = os.getenv("SGLANG_FUTURE_MAP_DEBUG_ASSERT", "0") == "1"
+# write -1 back. Catches "gather without intermediate stash" bugs. CI enables
+# via the existing SGLANG_IS_IN_CI; off in production.
+_DEBUG_ASSERT = os.getenv("SGLANG_IS_IN_CI", "").lower() == "true"
 
 
 def _resolve_future_token_ids_native(input_ids, future_token_ids_map):

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Union
 
 import torch
@@ -15,6 +16,11 @@ if TYPE_CHECKING:
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+
+# Token-buf consume tracking: init to -1, assert non-negative on gather,
+# write -1 back. Catches "gather without intermediate stash" bugs. Off by
+# default; CI enables via SGLANG_FUTURE_MAP_DEBUG_ASSERT=1.
+_DEBUG_ASSERT = os.getenv("SGLANG_FUTURE_MAP_DEBUG_ASSERT", "0") == "1"
 
 
 def _resolve_future_token_ids_native(input_ids, future_token_ids_map):
@@ -59,8 +65,12 @@ class FutureMap:
         self.spec_algo = spec_algo
         self.req_pool_size = req_to_token_pool.req_to_token.shape[0]
 
-        self.output_tokens_buf = torch.empty(
-            (self.req_pool_size,), dtype=torch.int64, device=self.device
+        self.output_tokens_buf = (
+            torch.full((self.req_pool_size,), -1, dtype=torch.int64, device=self.device)
+            if _DEBUG_ASSERT
+            else torch.empty(
+                (self.req_pool_size,), dtype=torch.int64, device=self.device
+            )
         )
         self.new_seq_lens_buf = torch.empty(
             (self.req_pool_size,), dtype=torch.int64, device=self.device
@@ -99,6 +109,10 @@ class FutureMap:
         # input_ids tokens / spec extras here.
         if self.spec_algo.is_none():
             _resolve_future_token_ids(batch.input_ids, self.output_tokens_buf)
+            if _DEBUG_ASSERT:
+                # Any remaining negative means the sentinel slot was empty (-1).
+                torch._assert_async((batch.input_ids >= 0).all())
+                self.output_tokens_buf[batch.req_pool_indices] = -1
         else:
             self._resolve_spec_extras(batch)
 
@@ -114,6 +128,9 @@ class FutureMap:
         draft_input.topk_p = self.topk_p_buf[indices]
         draft_input.topk_index = self.topk_index_buf[indices]
         draft_input.bonus_tokens = self.output_tokens_buf[indices]
+        if _DEBUG_ASSERT:
+            torch._assert_async((draft_input.bonus_tokens >= 0).all())
+            self.output_tokens_buf[indices] = -1
         if spec_need_hidden_states():
             draft_input.hidden_states = self.hidden_states_buf[indices]
 

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -23,6 +23,16 @@ _is_hip = is_hip()
 _DEBUG_ASSERT = os.getenv("SGLANG_IS_IN_CI", "").lower() == "true"
 
 
+@torch.compile(dynamic=True)
+def _assert_nonneg_and_invalidate(
+    values: torch.Tensor, buf: torch.Tensor, indices: torch.Tensor
+) -> None:
+    """Fused: assert all `values >= 0` and scatter -1 into `buf[indices]`.
+    Compiled so the reduction + assert + scatter run as one kernel launch."""
+    torch._assert_async((values >= 0).all())
+    buf[indices] = -1
+
+
 def _resolve_future_token_ids_native(input_ids, future_token_ids_map):
     input_ids[:] = torch.where(
         input_ids < 0,
@@ -110,9 +120,9 @@ class FutureMap:
         if self.spec_algo.is_none():
             _resolve_future_token_ids(batch.input_ids, self.output_tokens_buf)
             if _DEBUG_ASSERT:
-                # Any remaining negative means the sentinel slot was empty (-1).
-                torch._assert_async((batch.input_ids >= 0).all())
-                self.output_tokens_buf[batch.req_pool_indices] = -1
+                _assert_nonneg_and_invalidate(
+                    batch.input_ids, self.output_tokens_buf, batch.req_pool_indices
+                )
         else:
             self._resolve_spec_extras(batch)
 
@@ -129,8 +139,9 @@ class FutureMap:
         draft_input.topk_index = self.topk_index_buf[indices]
         draft_input.bonus_tokens = self.output_tokens_buf[indices]
         if _DEBUG_ASSERT:
-            torch._assert_async((draft_input.bonus_tokens >= 0).all())
-            self.output_tokens_buf[indices] = -1
+            _assert_nonneg_and_invalidate(
+                draft_input.bonus_tokens, self.output_tokens_buf, indices
+            )
         if spec_need_hidden_states():
             draft_input.hidden_states = self.hidden_states_buf[indices]
 


### PR DESCRIPTION
## Invariant

Per slot in `FutureMap.output_tokens_buf`, the only valid trace is `WRWRWR...` — every write has exactly one consuming read before the next write. `WWRR` (two writes without an intermediate read, then two reads) silently drops the first write's value and was tolerated by previous code.

## Check

- Init buf to `-1`
- After `_resolve_future_token_ids` / `_resolve_spec_extras` gather, async-assert gathered values `>= 0` and mark slots `-1`

A `WW` pattern leaves the second `W` value live; first `R` consumes it and marks `-1`; second `R` reads `-1` → assertion fires.

## Gating

`SGLANG_IS_IN_CI` (already `true` in `pr-test.yml`). On for every PR's CI; off in prod (zero overhead).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26281514941](https://github.com/sgl-project/sglang/actions/runs/26281514941)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26281515042](https://github.com/sgl-project/sglang/actions/runs/26281515042)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
