### PR TITLE
[CI] release/v0.5.12: fix base-* suite names dragged in by cherry-picks

### DIFF
--- a/test/manual/core/test_dsv4_stale_loc_crash.py
+++ b/test/manual/core/test_dsv4_stale_loc_crash.py
@@ -31,7 +31,7 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+register_cpu_ci(est_time=3, suite="stage-a-test-cpu")
 
 _NUM_HEADS = 2
 _HEAD_DIM = 8

--- a/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
+++ b/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
@@ -24,7 +24,7 @@ MAMBA_TRACK_INTERVAL = 128
 DSV4_FLASH_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
 DSV4_FLASH_LAUNCH_TIMEOUT = 3600
 
-register_cuda_ci(est_time=768, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=768, stage="stage-c", runner_config="8-gpu-h200")
 
 
 class TestUnifiedMambaHiCache(UnifiedRadixTreeTestMixin, CustomTestCase):


### PR DESCRIPTION
## Summary

Two cherry-picked test files on `release/v0.5.12` register against the new `base-*` suite vocabulary (introduced by #25420 on `main` as part of the `stage-{a,b,c}` → `base-{a,b,c}` rename), but this branch hasn't done the rename, so `test/run_suite.py`'s `PER_COMMIT_SUITES` doesn't know those names.

Every per-commit job (e.g. [run 26279864881 / job 77353155071](https://github.com/sgl-project/sglang/actions/runs/26279864881/job/77353155071)) aborts at suite validation:

```
ValueError: Tests registered to invalid suites:
  test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py:
    backend=CUDA, suite='base-c-test-8-gpu-h200'
```

## Fix

Repoint both registrations at the existing `stage-*` names that ARE present in this branch's `PER_COMMIT_SUITES`:

| File | Before | After |
|---|---|---|
| `test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py:27` | `register_cuda_ci(stage="base-c", ...)` | `register_cuda_ci(stage="stage-c", ...)` |
| `test/manual/core/test_dsv4_stale_loc_crash.py:34` | `register_cpu_ci(suite="base-a-test-cpu")` | `register_cpu_ci(suite="stage-a-test-cpu")` |

Both `stage-c-test-8-gpu-h200` and `stage-a-test-cpu` are valid suites on `release/v0.5.12`.

## Why not the proper rename

The full `stage-*` → `base-*` rename has a wide blast radius — `scripts/ci/utils/compute_partitions.py` (`_STAGE_A_OVERRIDES`), `scripts/ci/utils/slash_command_handler.py` (`CUDA_SUITE_TO_RUNNER`, `DEEPEP_SUITES`), `test/run_suite.py` (`PER_COMMIT_SUITES`), ~200 `register_*_ci(suite=...)` call sites, and 4 workflow files. Doing it coherently on `release/v0.5.12` is significant scope and intentionally deferred. This PR is the surgical 2-line patch to make pr-test dispatches on `release/v0.5.12` actually run.

## Test plan

- [x] Pre-commit clean, including the `check registered tests have CI registry` hook (which is the same validation that fails in CI — so the fix is verified locally)
- [ ] After merge, re-dispatch `pr-test.yml` against `release/v0.5.12` with `run_all_tests=true` and confirm `check-changes` passes + `stage-a-test-1-gpu-small` reaches the actual test phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->