### PR TITLE
[CI] pr-test-extra: add run_all_tests to workflow_dispatch inputs

### DIFF
--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_all_tests:
+        description: "Run all tests — bypasses paths-filter (needed when dispatching against long-lived branches whose diff against main can't resolve a merge-base in a shallow clone)"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       git_ref:


### PR DESCRIPTION
## Summary

Adds a `run_all_tests` boolean input to `pr-test-extra.yml`'s `workflow_dispatch` block, matching the input that's already on `pr-test.yml` and on `pr-test-extra.yml`'s `workflow_call` interface. Five lines of YAML, no logic changes.

The downstream plumbing is already in place:

- `pr-test-extra.yml:83` reads `inputs.run_all_tests` when calling `_pr-test-check-changes.yml`
- `_pr-test-check-changes.yml:77` gates the dorny/paths-filter step behind `if: steps.run-mode.outputs.run_all_tests != 'true'`

Without the input on the workflow_dispatch interface, `inputs.run_all_tests` was always undefined / false for manual dispatches, so the paths-filter step always ran.

## Concrete failure mode this unlocks

Dispatching `pr-test-extra.yml` against a long-lived release branch (e.g. `release/v0.5.12`, which diverged from `main` many commits ago) fails reproducibly:

```
[command]/usr/bin/git fetch --deepen=200 origin main release/v0.5.12
fatal: shallow file has changed since we read it
##[error]The process '/usr/bin/git' failed with exit code 128
```

Three back-to-back manual dispatches all hit this:
- [run 26277795792](https://github.com/sgl-project/sglang/actions/runs/26277795792)
- [run 26277841759](https://github.com/sgl-project/sglang/actions/runs/26277841759)
- [run 26279866825](https://github.com/sgl-project/sglang/actions/runs/26279866825)

paths-filter v3 can't find a merge-base in the shallow clone, so it falls back to `git fetch --deepen=200` to extend history, and that races with concurrent index updates. With `run_all_tests=true`, the paths-filter step is skipped entirely (intentional design — `run_all_tests` mode runs everything regardless of path filter), and every downstream `extra-*` job runs against the dispatched ref.

`pr-test.yml`'s workflow_dispatch already has this input for exactly this reason — this PR just brings `pr-test-extra.yml` to parity.

## Followup

I'll cherry-pick this onto `release/v0.5.12` after merge so the release branch can immediately use it for manual dispatches.

## Test plan

- [x] Pre-commit clean (including duplicate workflow job name check)
- [ ] After merge + cherry-pick to `release/v0.5.12`, dispatch `pr-test-extra.yml` with `run_all_tests: true` against the release branch and confirm `check-changes / Detect file changes` is skipped and downstream `extra-*` jobs all run

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26280912772](https://github.com/sgl-project/sglang/actions/runs/26280912772)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26280912725](https://github.com/sgl-project/sglang/actions/runs/26280912725)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->