### PR TITLE
[Cherry-pick to release/v0.5.12] [CI] pr-test-extra: add run_all_tests to workflow_dispatch inputs (#26110)

### DIFF
--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_all_tests:
+        description: "Run all tests — bypasses paths-filter (needed when dispatching against long-lived branches whose diff against main can't resolve a merge-base in a shallow clone)"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       git_ref:


### PR DESCRIPTION
## Summary

Manual cherry-pick of #26110 (already landed on `main` as `d4082eab4`). The bot-cherry-pick workflow failed at the push step because its `GITHUB_TOKEN` lacks the `workflows` write permission — that's the kind of token-scope restriction GitHub enforces specifically for workflow-file modifications. So this PR was assembled manually:

```
git worktree add -b manual-cherrypick-... upstream/release/v0.5.12
git cherry-pick d4082eab4d1c78b645c16c50ad4d8038a0040593
git push upstream ...
```

Cherry-pick was clean: 5 insertions, no conflicts.

## What this enables

`pr-test-extra.yml`'s `workflow_dispatch` gains a `run_all_tests` input, matching `pr-test.yml`. This lets `gh workflow run pr-test-extra.yml --ref release/v0.5.12 -f run_all_tests=true ...` succeed by skipping the dorny/paths-filter step (which fails on long-lived branches via the shallow-fetch race described in #26110).

## Followup

Separately, the bot-cherry-pick workflow itself should learn to use a PAT (or be granted `workflows: write`) for the push step so future workflow-file cherry-picks don't hit this. That's a different scope from this PR.

## Test plan

- [x] Pre-commit verified pre-push (auto-applied by upstream main's CI on #26110)
- [ ] After merge, re-dispatch `pr-test-extra.yml --ref release/v0.5.12 -f run_all_tests=true -f test_parallel_dispatch=true` and confirm `check-changes` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->