### PR TITLE
[diffusion] CI: disable torch compile in nightly comparison

### DIFF
--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -13,7 +13,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --dit-layerwise-offload false",
+                    "serve_args": "--warmup --dit-layerwise-offload false",
                     "extra_env": {}
                 }
             }
@@ -29,7 +29,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --dit-layerwise-offload false",
+                    "serve_args": "--warmup --dit-layerwise-offload false",
                     "extra_env": {}
                 }
             }
@@ -45,7 +45,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup",
+                    "serve_args": "--warmup",
                     "extra_env": {}
                 }
             }
@@ -62,7 +62,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup",
+                    "serve_args": "--warmup",
                     "extra_env": {}
                 }
             }
@@ -78,7 +78,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup",
+                    "serve_args": "--warmup",
                     "extra_env": {}
                 }
             }
@@ -95,7 +95,7 @@
             "num_gpus": 4,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
+                    "serve_args": "--warmup --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
                     "extra_env": {}
                 }
             }
@@ -113,7 +113,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup",
+                    "serve_args": "--warmup",
                     "extra_env": {}
                 }
             }
@@ -130,7 +130,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --enable-cfg-parallel --pipeline-class-name LTX2TwoStagePipeline",
+                    "serve_args": "--warmup --enable-cfg-parallel --pipeline-class-name LTX2TwoStagePipeline",
                     "extra_env": {}
                 }
             }
@@ -148,7 +148,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
+                    "serve_args": "--warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
                     "extra_env": {}
                 }
             }
@@ -166,7 +166,7 @@
             "num_gpus": 4,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--enable-torch-compile --warmup --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
+                    "serve_args": "--warmup --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
                     "extra_env": {}
                 }
             }

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -43,9 +43,7 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 30000
 SGLANG_MASTER_PORT_OFFSET = 5
 SGLANG_SCHEDULER_PORT_OFFSET = 55
-HEALTH_TIMEOUT = (
-    2400  # seconds (40 min — FLUX.2-dev needs ~10 min download + torch.compile)
-)
+HEALTH_TIMEOUT = 2400  # seconds (40 min — keep large model download/warmup headroom)
 REQUEST_TIMEOUT = 1200  # seconds
 GPU_CLEAR_WAIT = 15  # seconds between framework runs
 SERVER_FATAL_ERROR_PATTERNS = (


### PR DESCRIPTION
## Summary
- remove default `--enable-torch-compile` from SGLang cases in diffusion nightly comparison
- keep `--warmup` and existing parallel/offload settings unchanged
- update the comparison timeout comment now that torch compile is no longer part of the default path

## Context
The failing nightly comparison job showed Wan A14B warmup timing out after 1200s while the server was launched with `--enable-torch-compile --warmup`. The logs also contained repeated `torch/_inductor/select_algorithm.py` Triton resource errors before the timeout.

Run: https://github.com/sgl-project/sglang/actions/runs/26262258716/job/77353566110















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26291843115](https://github.com/sgl-project/sglang/actions/runs/26291843115)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26291889997](https://github.com/sgl-project/sglang/actions/runs/26291889997)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->