### PR TITLE
Fix routed-experts device buffer overflow under DP attention

### DIFF
--- a/python/sglang/srt/state_capturer/routed_experts.py
+++ b/python/sglang/srt/state_capturer/routed_experts.py
@@ -59,12 +59,14 @@ class RoutedExpertsCapturer(BaseTopkCapturer):
         num_layers = model_config.hf_text_config.num_hidden_layers
 
         server_args = get_global_server_args()
-        # FIXME: spec decoding is not accounted for here. The device buffer can
-        # overflow when max_running_requests * num_verify_tokens exceeds
-        # chunked_prefill_size * dp_size.
+        # Scale by dp_size so the buffer covers the full DP-concatenated batch.
+        # _get_local_slice indexes into [attention_dp_rank * cuda_graph_batch, ...)
+        # and otherwise overflows on dp_rank > 0 when max_running_requests >
+        # chunked_prefill_size.
+        # FIXME: spec decoding's num_verify_tokens is still not accounted for.
         max_batch_size = max(
             server_args.chunked_prefill_size * server_args.dp_size,
-            max_running_requests,
+            max_running_requests * server_args.dp_size,
         )
 
         super().__init__(


### PR DESCRIPTION
The routed experts device buffer in RoutedExpertsCapturer can overflow when DP attention is enabled and max_running_requests is larger than chunked_prefill_size * dp_size. The buffer's first dim is currently max(chunked_prefill_size * dp_size, max_running_requests). On non-DeepEP DP-attention paths _get_local_slice goes through get_dp_local_slice_cpu, which returns local_start_pos = dp_rank * cuda_graph_batch under a cuda graph. On ranks with dp_rank > 0 the slice can walk past the end of the buffer when the second branch of the max wins.

The fix multiplies the second branch by dp_size so the buffer can hold the full concatenated batch across DP ranks. No-op when dp_size == 1 or when chunked_prefill_size * dp_size already dominates.

Originally part of #23999. Splitting it out as a standalone fix since the larger PR needs to be reworked on top of the recent state_capturer refactor (#24403, #24450).

Verified on an MoE model with DP attention where max_running_requests > chunked_prefill_size, which previously hit the overflow.



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26649038783](https://github.com/sgl-project/sglang/actions/runs/26649038783)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26649038428](https://github.com/sgl-project/sglang/actions/runs/26649038428)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->