### PR TITLE
[diffusion] Use Diffusers stage names in profiles

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -719,7 +719,7 @@ class DiffusersPipeline(ComposedPipelineBase):
             raise ValueError(f"Duplicate stage name detected: {stage_name}")
 
         stage.set_registered_stage_name(stage_name)
-        stage.set_profile_stage_name(self._profile_stage_name(stage, stage_name))
+        stage.set_profile_stage_name(stage_name)
         self._stages.append(stage)
         self._stage_name_mapping[stage_name] = stage
         return self


### PR DESCRIPTION
## Summary

keep Diffusers pipeline profiling keyed by explicit stage names

## Tests
- pre-commit run --files python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26304878889](https://github.com/sgl-project/sglang/actions/runs/26304878889)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26304878733](https://github.com/sgl-project/sglang/actions/runs/26304878733)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->