### PR TITLE
[RL] [Spec v2] Use stop-aware seqlen for returned topk metadata

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -117,25 +117,27 @@ class SchedulerBatchResultProcessor:
         if capturer is None:
             return
         start_len = req.routed_experts_start_len
+        seqlen = len(req.origin_input_ids) + len(req.output_ids_through_stop)
         req.routed_experts = capturer.get_topk(
             req_pool_idx=req.req_pool_idx,
-            seqlen=req.seqlen,
+            seqlen=seqlen,
             req_to_token_pool=self.req_to_token_pool,
             start_len=start_len,
         )
 
-        expected_rows = max(0, req.seqlen - 1 - start_len)
+        expected_rows = max(0, seqlen - 1 - start_len)
         if (
             req.routed_experts is not None
             and req.routed_experts.shape[0] != expected_rows
         ):
             logger.warning(
-                "routed_experts row-count mismatch for req %s: got %d, "
-                "expected %d (seqlen=%d, cached_tokens=%d, start_len=%s). "
+                "routed_experts row-count mismatch for req %s: got %d, expected %d "
+                "(seqlen=%d, raw_seqlen=%d, cached_tokens=%d, start_len=%s). "
                 "This indicates a silent bug.",
                 req.rid,
                 req.routed_experts.shape[0],
                 expected_rows,
+                seqlen,
                 req.seqlen,
                 req.cached_tokens,
                 req.routed_experts_start_len,
@@ -145,9 +147,10 @@ class SchedulerBatchResultProcessor:
         capturer = get_global_indexer_capturer()
         if capturer is None:
             return
+        seqlen = len(req.origin_input_ids) + len(req.output_ids_through_stop)
         req.indexer_topk = capturer.get_topk(
             req_pool_idx=req.req_pool_idx,
-            seqlen=req.seqlen,
+            seqlen=seqlen,
             req_to_token_pool=self.req_to_token_pool,
         )
 


### PR DESCRIPTION
## Summary
- Use `output_ids_through_stop` when collecting returned routed experts and indexer top-k metadata.
- Keep the warning expected-row calculation aligned with the logical stop boundary while still logging the raw sequence length.

## Root Cause
Speculative decoding can leave internal `req.output_ids` longer than the public output boundary tracked by `finished_len`. Regular text/token output already uses `output_ids_through_stop`, but returned top-k metadata was collected with `req.seqlen`, so it could include rows for trailing tokens past the stop boundary.

This upstreams the corresponding sglang-miles fix from https://github.com/sgl-project/sglang/commit/71bda1af3b01f2821b077cd91d25da2a15573e4d.

## Validation
- `python -m py_compile python/sglang/srt/managers/scheduler_components/batch_result_processor.py`
- `git diff --check -- python/sglang/srt/managers/scheduler_components/batch_result_processor.py`

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26311531870](https://github.com/sgl-project/sglang/actions/runs/26311531870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26311550158](https://github.com/sgl-project/sglang/actions/runs/26311550158)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->