### PR TITLE
Add non-MTP DSV4 test coverage

### DIFF
--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
@@ -100,14 +100,41 @@ class TestDSV4FlashFP4B200Balanced(
                 "--enable-dp-attention",
                 "--moe-a2a-backend",
                 "deepep",
-                "--speculative-algorithm",
-                "EAGLE",
-                "--speculative-num-steps",
-                "1",
-                "--speculative-eagle-topk",
-                "1",
-                "--speculative-num-draft-tokens",
-                "2",
+                "--deepep-config",
+                DEEPEP_CONFIG,
+            ],
+            env=_DEEPEP_ENV,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        _gsm8k_check(self)
+
+
+class TestDSV4FlashFP4NonMTPB200(ServerSanityMixin, CustomTestCase):
+    """Non-MTP recipe: TP=4, DP=4, DeepEP, no speculative decoding."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--dp",
+                "4",
+                "--enable-dp-attention",
+                "--moe-a2a-backend",
+                "deepep",
                 "--deepep-config",
                 DEEPEP_CONFIG,
             ],

--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_h200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_h200.py
@@ -131,5 +131,47 @@ class TestDSV4FlashFP4H200FlashInferCutlass(
             kill_process_tree(cls.process.pid)
 
 
+class TestDSV4FlashFP4NonMTPH200(ServerSanityMixin, CustomTestCase):
+    """LowLatency recipe without MTP: TP=4, Marlin FP4, no speculative decoding."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(MODEL)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--moe-runner-backend",
+                "marlin",
+                "--watchdog-timeout",
+                "900",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"[DSV4 Flash FP4 NonMTP H200] GSM8K {metrics=}")
+        self.assertGreater(metrics["score"], 0.93)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Cherry-picked from #25801 (commit 8e8feb6c) by @yhyang201 — adds non-MTP DSV4 test coverage to `test_deepseek_v4_flash_fp4_b200.py` and `test_deepseek_v4_flash_fp4_h200.py`.

## Test plan

- [ ] CI runs `test_deepseek_v4_flash_fp4_b200.py` and `test_deepseek_v4_flash_fp4_h200.py` on B200/H200 runners
- [ ] Non-MTP DSV4 cases pass alongside existing MTP cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26314827119](https://github.com/sgl-project/sglang/actions/runs/26314827119)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26314827083](https://github.com/sgl-project/sglang/actions/runs/26314827083)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->