### PR TITLE
Fix DeepSeek-V2 MoE/MLA correctness + perf with padded forward batches

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2253,7 +2253,10 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
             output_dtype = torch.bfloat16
 
-            if DispatchOutputChecker.format_is_flashinfer(dispatch_output):
+            if (
+                DispatchOutputChecker.format_is_flashinfer(dispatch_output)
+                and dispatch_output.moe_output is not None
+            ):
                 symm_output = dispatch_output.moe_output
             else:
                 # If x_sf is not None, x is FP4 packed (half size), so we need * 2

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2115,6 +2115,9 @@ class DeepseekV2DecoderLayer(nn.Module):
             getattr(self, "_gfx95_quant_format", ""),
         )
 
+        # Zero the padded attention-input rows so they can't contaminate valid tokens.
+        hidden_states = _zero_padded_token_tail(hidden_states, forward_batch)
+
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
@@ -2478,8 +2481,6 @@ class DeepseekV2Model(nn.Module):
                     llama_4_scaling,
                     prev_topk_indices=topk_indices,
                 )
-                hidden_states = _zero_padded_token_tail(hidden_states, forward_batch)
-                residual = _zero_padded_token_tail(residual, forward_batch)
 
         if normal_end_layer != self.end_layer:
             hidden_states, residual = model_forward_maybe_tbo(
@@ -2494,8 +2495,6 @@ class DeepseekV2Model(nn.Module):
                 ].layer_scatter_modes.layer_output_mode,
                 zero_allocator=zero_allocator,
             )
-            hidden_states = _zero_padded_token_tail(hidden_states, forward_batch)
-            residual = _zero_padded_token_tail(residual, forward_batch)
 
         if not self.pp_group.is_last_rank:
             return PPProxyTensors(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -208,6 +208,43 @@ else:
 logger = logging.getLogger(__name__)
 
 
+def _zero_padded_token_tail(
+    hidden_states: Optional[torch.Tensor],
+    forward_batch: ForwardBatch,
+) -> Optional[torch.Tensor]:
+    num_token_non_padded = forward_batch.num_token_non_padded
+    if hidden_states is None or num_token_non_padded is None:
+        return hidden_states
+    if not isinstance(hidden_states, torch.Tensor):
+        return hidden_states
+    # Decode/spec-decode CGs capture num_token_non_padded as 0; only EP>1
+    # ever writes it. Plain prefill still needs the zeroing.
+    if (
+        get_moe_expert_parallel_world_size() == 1
+        and not forward_batch.forward_mode.is_extend_without_speculative()
+    ):
+        return hidden_states
+
+    real = num_token_non_padded.view(())
+    token_idx = torch.arange(
+        hidden_states.shape[0],
+        dtype=real.dtype,
+        device=hidden_states.device,
+    )
+    view_shape = (hidden_states.shape[0],) + (1,) * (hidden_states.ndim - 1)
+    # In-place so any side-channel state on the tensor remains
+    hidden_states.masked_fill_(token_idx.reshape(view_shape) >= real, 0)
+    return hidden_states
+
+
+def _topk_num_token_non_padded(
+    forward_batch: Optional[ForwardBatch],
+) -> Optional[torch.Tensor]:
+    if forward_batch is None:
+        return None
+    return forward_batch.num_token_non_padded
+
+
 class DeepseekV2MLP(nn.Module):
     def __init__(
         self,
@@ -845,6 +882,7 @@ class DeepseekV2MoE(nn.Module):
                     gemm_output_zero_allocator,
                     input_ids,
                     input_ids_global=input_ids_global,
+                    forward_batch=forward_batch,
                 )
             else:
                 return self.forward_normal(
@@ -854,6 +892,7 @@ class DeepseekV2MoE(nn.Module):
                     gemm_output_zero_allocator,
                     input_ids,
                     input_ids_global=input_ids_global,
+                    forward_batch=forward_batch,
                 )
         else:
             return self.forward_deepep(
@@ -868,6 +907,7 @@ class DeepseekV2MoE(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
         current_stream = torch.cuda.current_stream()
         self.alt_stream.wait_stream(current_stream)
@@ -891,6 +931,7 @@ class DeepseekV2MoE(nn.Module):
             topk_output = self.topk(
                 hidden_states,
                 router_logits,
+                num_token_non_padded=_topk_num_token_non_padded(forward_batch),
                 expert_location_dispatch_info=dispatch_info,
                 **topk_kwargs,
             )
@@ -932,6 +973,7 @@ class DeepseekV2MoE(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
+        forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
         if hasattr(self, "shared_experts") and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
@@ -959,6 +1001,7 @@ class DeepseekV2MoE(nn.Module):
             topk_output = self.topk(
                 hidden_states,
                 router_logits,
+                num_token_non_padded=_topk_num_token_non_padded(forward_batch),
                 expert_location_dispatch_info=dispatch_info,
                 **topk_kwargs,
             )
@@ -1129,7 +1172,7 @@ class DeepseekV2MoE(nn.Module):
             topk_output = self.topk(
                 hidden_states,
                 router_logits,
-                num_token_non_padded=forward_batch.num_token_non_padded,
+                num_token_non_padded=_topk_num_token_non_padded(forward_batch),
                 expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
                     layer_id=self.layer_id,
                 ),
@@ -1355,7 +1398,9 @@ class DeepseekV2MoE(nn.Module):
                 state.topk_output = self.topk(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
-                    num_token_non_padded=state.forward_batch.num_token_non_padded,
+                    num_token_non_padded=_topk_num_token_non_padded(
+                        state.forward_batch
+                    ),
                     expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
                         layer_id=self.layer_id,
                     ),
@@ -2433,6 +2478,8 @@ class DeepseekV2Model(nn.Module):
                     llama_4_scaling,
                     prev_topk_indices=topk_indices,
                 )
+                hidden_states = _zero_padded_token_tail(hidden_states, forward_batch)
+                residual = _zero_padded_token_tail(residual, forward_batch)
 
         if normal_end_layer != self.end_layer:
             hidden_states, residual = model_forward_maybe_tbo(
@@ -2447,6 +2494,8 @@ class DeepseekV2Model(nn.Module):
                 ].layer_scatter_modes.layer_output_mode,
                 zero_allocator=zero_allocator,
             )
+            hidden_states = _zero_padded_token_tail(hidden_states, forward_batch)
+            residual = _zero_padded_token_tail(residual, forward_batch)
 
         if not self.pp_group.is_last_rank:
             return PPProxyTensors(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Three latent bugs in DeepSeek-V2's MoE and MLA prefill paths can surface whenever the forward batch has padded positions beyond `num_token_non_padded` — e.g. CUDA-graph replay at a captured bucket size larger than the real batch, dual-stream batching, or padded chunked prefill. The fixes are defensive against these padded-batch scenarios and are correctness-preserving on the non-padded path.

## Modifications

1. `models/deepseek_v2.py` — zero `hidden_states[num_token_non_padded:]` before MoE topk and the shared-expert residual add; thread `num_token_non_padded` into the four MoE topk call sites. Without this, padded positions retain stale hidden states that topk routes to real experts, polluting expert dispatch / scaling for the valid tokens.
2. model_executor/forward_batch_deepseek_mha_mixin.py — add `get_prefix_chunk_batch_size()`; round chunked-prefix-cache chunks to `prefill_max_requests` when involved in graph capture, or fall back to `chunk_capacity // batch_size`.
3. `layers/quantization/modelopt_quant.py` — guard symmetric-memory MoE buffer reuse on `dispatch_output.moe_output is not None` so dispatch formats producing flashinfer-format metadata without a preallocated buffer fall through to allocation instead of passing `None` to `flashinfer_cutlass_fused_moe`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26929843669](https://github.com/sgl-project/sglang/actions/runs/26929843669)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26929843545](https://github.com/sgl-project/sglang/actions/runs/26929843545)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->