### PR TITLE
Use flashinfer_mxfp4 MoE runner for DeepSeek V4 with MXFP4

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -45,6 +45,12 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
             envs.SGLANG_ENABLE_SPEC_V2.set(True)
             logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
 
+    if server_args.moe_runner_backend == "auto" and server_args.quantization == "mxfp4":
+        server_args.moe_runner_backend = "flashinfer_mxfp4"
+        logger.info(
+            f"Use flashinfer_mxfp4 as MoE runner backend for {model_arch} with MXFP4 quantization"
+        )
+
     if server_args.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
         server_args.swa_full_tokens_ratio = 0.1
         logger.info(


### PR DESCRIPTION
## Summary
- Default `moe_runner_backend` to `flashinfer_mxfp4` for DeepSeekV4 when quantization is `mxfp4`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26321522605](https://github.com/sgl-project/sglang/actions/runs/26321522605)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26321522525](https://github.com/sgl-project/sglang/actions/runs/26321522525)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->