### PR TITLE
[VLM] feat: accept grid_thws from preprocessed metadata for kimi

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -680,9 +680,13 @@ class KimiK25ForConditionalGeneration(nn.Module):
         pixel_values = torch.cat([item.feature for item in items], dim=0).to(
             device=device, dtype=target_dtype
         )
-        grid_thws = torch.concat([item.image_grid_thw for item in items], dim=0).to(
-            device
-        )
+        image_grid_thws = []
+        for item in items:
+            grid_thw = item.model_specific_data.get("image_grid_thw")
+            if grid_thw is None:
+                grid_thw = item.model_specific_data["grid_thws"]
+            image_grid_thws.append(grid_thw)
+        grid_thws = torch.concat(image_grid_thws, dim=0).to(device)
 
         if self.use_data_parallel:
             image_embeds = run_dp_sharded_mrope_vision_model(


### PR DESCRIPTION
Summary:
- Allow Kimi-K2.5 image embedding to read `grid_thws` from preprocessed multimodal metadata.
- Preserve existing `image_grid_thw` handling.

Tests:
- `pre-commit run --files python/sglang/srt/models/kimi_k25.py`



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26322784812](https://github.com/sgl-project/sglang/actions/runs/26322784812)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26322784911](https://github.com/sgl-project/sglang/actions/runs/26322784911)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->