### PR TITLE
[diffusion] Batch standard CFG text encoding

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -306,6 +306,65 @@ class TextEncodingStage(PipelineStage):
                 )
             )
 
+    def _split_cfg_text_outputs(
+        self,
+        *,
+        prompt_count: int,
+        prompt_embeds_list,
+        prompt_masks_list,
+        pooler_embeds_list,
+        prompt_embeds_masks_list,
+        prompt_seq_lens_list,
+    ):
+        return (
+            [tensor[:prompt_count] for tensor in prompt_embeds_list],
+            [tensor[:prompt_count] for tensor in prompt_masks_list],
+            [tensor[:prompt_count] for tensor in pooler_embeds_list],
+            [tensor[:prompt_count] for tensor in prompt_embeds_masks_list],
+            [seq_lens[:prompt_count] for seq_lens in prompt_seq_lens_list],
+            [tensor[prompt_count:] for tensor in prompt_embeds_list],
+            [tensor[prompt_count:] for tensor in prompt_masks_list],
+            [tensor[prompt_count:] for tensor in pooler_embeds_list],
+            [tensor[prompt_count:] for tensor in prompt_embeds_masks_list],
+            [seq_lens[prompt_count:] for seq_lens in prompt_seq_lens_list],
+        )
+
+    def _encode_cfg_text_batch(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+        prompt_text: str | list[str],
+        all_indices: list[int],
+        max_seq_length: int | None,
+    ):
+        assert isinstance(batch.negative_prompt, str)
+        prompts = [prompt_text] if isinstance(prompt_text, str) else list(prompt_text)
+        outputs = self.encode_text(
+            prompts + [batch.negative_prompt],
+            server_args,
+            encoder_index=all_indices,
+            return_attention_mask=True,
+            max_length=max_seq_length,
+        )
+        return self._split_cfg_text_outputs(
+            prompt_count=len(prompts),
+            prompt_embeds_list=outputs[0],
+            prompt_masks_list=outputs[1],
+            pooler_embeds_list=outputs[2],
+            prompt_embeds_masks_list=outputs[3],
+            prompt_seq_lens_list=outputs[4],
+        )
+
+    def _should_encode_cfg_text_batch(
+        self, batch: Req, server_args: ServerArgs
+    ) -> bool:
+        if not batch.do_classifier_free_guidance:
+            return False
+        if not isinstance(batch.negative_prompt, str):
+            return False
+        # TurboWan/DMD validation output changes when the two prompts share a batch
+        return not hasattr(server_args.pipeline_config, "dmd_denoising_steps")
+
     @torch.no_grad()
     def forward(
         self,
@@ -329,31 +388,86 @@ class TextEncodingStage(PipelineStage):
         # Get max_sequence_length from batch if available
         max_seq_length = getattr(batch, "max_sequence_length", None)
 
-        (
-            prompt_embeds_list,
-            prompt_masks_list,
-            pooler_embeds_list,
-            prompt_embeds_masks_list,
-            prompt_seq_lens_list,
-        ) = self.encode_text(
-            prompt_text,
-            server_args,
-            encoder_index=all_indices,
-            return_attention_mask=True,
-            max_length=max_seq_length,
-        )
-
+        negative_cache_key = None
+        cached_negative = None
         if batch.do_classifier_free_guidance:
-            assert isinstance(batch.negative_prompt, str)
+            negative_cache_key = self._build_negative_text_cache_key(
+                batch, server_args, all_indices
+            )
+            cached_negative = self._get_cached_negative_text_embedding(
+                negative_cache_key
+            )
+
+        if cached_negative is not None:
+            (
+                prompt_embeds_list,
+                prompt_masks_list,
+                pooler_embeds_list,
+                prompt_embeds_masks_list,
+                prompt_seq_lens_list,
+            ) = self.encode_text(
+                prompt_text,
+                server_args,
+                encoder_index=all_indices,
+                return_attention_mask=True,
+                max_length=max_seq_length,
+            )
             (
                 neg_embeds_list,
                 neg_masks_list,
                 neg_pooler_embeds_list,
                 neg_embeds_masks_list,
                 neg_seq_lens_list,
-            ) = self.get_or_compute_negative_text_embedding(
-                batch, server_args, all_indices
+            ) = cached_negative
+        elif self._should_encode_cfg_text_batch(batch, server_args):
+            (
+                prompt_embeds_list,
+                prompt_masks_list,
+                pooler_embeds_list,
+                prompt_embeds_masks_list,
+                prompt_seq_lens_list,
+                neg_embeds_list,
+                neg_masks_list,
+                neg_pooler_embeds_list,
+                neg_embeds_masks_list,
+                neg_seq_lens_list,
+            ) = self._encode_cfg_text_batch(
+                batch, server_args, prompt_text, all_indices, max_seq_length
             )
+            self._maybe_cache_negative_text_embedding(
+                negative_cache_key,
+                (
+                    neg_embeds_list,
+                    neg_masks_list,
+                    neg_pooler_embeds_list,
+                    neg_embeds_masks_list,
+                    neg_seq_lens_list,
+                ),
+            )
+        else:
+            (
+                prompt_embeds_list,
+                prompt_masks_list,
+                pooler_embeds_list,
+                prompt_embeds_masks_list,
+                prompt_seq_lens_list,
+            ) = self.encode_text(
+                prompt_text,
+                server_args,
+                encoder_index=all_indices,
+                return_attention_mask=True,
+                max_length=max_seq_length,
+            )
+            if batch.do_classifier_free_guidance:
+                (
+                    neg_embeds_list,
+                    neg_masks_list,
+                    neg_pooler_embeds_list,
+                    neg_embeds_masks_list,
+                    neg_seq_lens_list,
+                ) = self.get_or_compute_negative_text_embedding(
+                    batch, server_args, all_indices
+                )
 
         self._append_positive_text_outputs(
             batch,

--- a/python/sglang/multimodal_gen/test/unit/test_text_encoding_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_text_encoding_cache.py
@@ -41,6 +41,23 @@ def make_req(**kwargs):
     return SimpleNamespace(**defaults)
 
 
+def make_forward_req(**kwargs):
+    defaults = {
+        "prompt_embeds": [],
+        "pooled_embeds": [],
+        "prompt_attention_mask": None,
+        "prompt_embeds_mask": None,
+        "prompt_seq_lens": None,
+        "negative_prompt_embeds": [],
+        "neg_pooled_embeds": [],
+        "negative_attention_mask": None,
+        "negative_prompt_embeds_mask": None,
+        "negative_prompt_seq_lens": None,
+    }
+    defaults.update(make_req(**kwargs).__dict__)
+    return SimpleNamespace(**defaults)
+
+
 def make_server_args(**kwargs):
     defaults = {
         "pipeline_class_name": "LTX2TwoStagePipeline",
@@ -100,3 +117,29 @@ def test_negative_text_cache_keeps_default_warmup():
         get_negative_embedding_twice(stage, server_args, make_req(is_warmup=True))
 
     assert stage.calls == 1
+
+
+def test_cfg_text_batch_encodes_positive_and_negative_once():
+    stage = DummyTextEncodingStage()
+    server_args = make_server_args()
+    batch = make_forward_req()
+
+    stage.forward(batch, server_args)
+
+    assert stage.calls == 1
+    assert batch.prompt_embeds[0].shape[0] == 1
+    assert batch.negative_prompt_embeds[0].shape[0] == 1
+
+
+def test_cfg_text_batch_skips_dmd_pipeline():
+    stage = DummyTextEncodingStage()
+    server_args = make_server_args(
+        pipeline_config=SimpleNamespace(
+            text_encoder_configs=[],
+            dmd_denoising_steps=1,
+        )
+    )
+
+    stage.forward(make_forward_req(), server_args)
+
+    assert stage.calls == 2


### PR DESCRIPTION
## Summary
- Batch standard CFG positive and negative prompts into one text encoder call.
- Keep DMD-style pipelines on the existing separate encoding path.

## Tests
- `pre-commit run --files python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py python/sglang/multimodal_gen/test/unit/test_text_encoding_cache.py`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26323178284](https://github.com/sgl-project/sglang/actions/runs/26323178284)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26323178303](https://github.com/sgl-project/sglang/actions/runs/26323178303)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->