### PR TITLE
fix(swa): eliminate spurious translate_loc_from_full_to_swa warning in BCG and CG paths

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -329,7 +329,7 @@ class TritonAttnBackend(AttentionBackend):
                 seq_lens,
                 req_pool_indices,
                 bs,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                token_to_kv_pool=self.token_to_kv_pool,
                 window_kv_indices=self.cuda_graph_window_kv_indices,
             )
         return kv_indptr, window_kv_indptr, window_kv_lens
@@ -374,7 +374,7 @@ class TritonAttnBackend(AttentionBackend):
                     seq_lens[:bs],
                     req_pool_indices,
                     bs,
-                    token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                    token_to_kv_pool=self.token_to_kv_pool,
                     window_kv_indices=window_kv_indices,
                 )
             )
@@ -461,7 +461,7 @@ class TritonAttnBackend(AttentionBackend):
                             forward_batch.req_pool_indices,
                             bs,
                             self.device,
-                            self.token_to_kv_pool_allocator,
+                            self.token_to_kv_pool,
                         )
                     )
                     window_num_kv_splits = torch.empty(
@@ -532,7 +532,7 @@ class TritonAttnBackend(AttentionBackend):
                     forward_batch.req_pool_indices,
                     bs,
                     self.device,
-                    self.token_to_kv_pool_allocator,
+                    self.token_to_kv_pool,
                 )
 
             custom_mask = spec_info.custom_mask
@@ -592,7 +592,7 @@ class TritonAttnBackend(AttentionBackend):
                     forward_batch.req_pool_indices,
                     bs,
                     self.device,
-                    self.token_to_kv_pool_allocator,
+                    self.token_to_kv_pool,
                 )
 
             qo_indptr = self.qo_indptr
@@ -1445,7 +1445,7 @@ def update_sliding_window_buffer(
     req_pool_indices,
     bs,
     device=None,
-    token_to_kv_pool_allocator=None,
+    token_to_kv_pool=None,
     window_kv_indices=None,
 ):
     """Fill window KV buffers for sliding-window attention.
@@ -1474,11 +1474,14 @@ def update_sliding_window_buffer(
         window_kv_indices,
         req_to_token.stride(0),
     )
-    if hasattr(token_to_kv_pool_allocator, "translate_loc_from_full_to_swa"):
+    if hasattr(token_to_kv_pool, "translate_loc_from_full_to_swa"):
         kv_last_index = window_kv_indptr[-1]
+        # Flush before+after: window_kv_indices is a different tensor than out_cache_loc.
+        token_to_kv_pool.invalidate_loc_cache()
         window_kv_indices[:kv_last_index] = (
-            token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+            token_to_kv_pool.translate_loc_from_full_to_swa(
                 window_kv_indices[:kv_last_index]
             )
         )
+        token_to_kv_pool.invalidate_loc_cache()
     return window_kv_indptr, window_kv_indices, window_kv_lens, window_kv_start_idx

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3266,6 +3266,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 self.hisparse_coordinator.wait_for_pending_backup()
                 self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
 
+            if self.is_hybrid_swa:
+                self.token_to_kv_pool.invalidate_loc_cache()
+
             # Replay cuda graph if applicable
             if can_run_graph:
                 ret = self.graph_runner.replay(
@@ -3291,9 +3294,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 forward_batch.adjust_num_token_non_padded_for_attn_tp(
                     server_args=self.server_args,
                 )
-
-            if self.is_hybrid_swa:
-                self.token_to_kv_pool.invalidate_loc_cache()
 
             # Hisparse coordinator — backends now read it from self.model_runner.
             if self.hisparse_coordinator is not None:


### PR DESCRIPTION
## Motivation

PR #25824 introduced `SWAKVPool.translate_loc_from_full_to_swa` with a per-batch memoisation cache keyed on `(data_ptr, numel)`. The cache fires a warning whenever the loc tensor changes without a prior `invalidate_loc_cache()` call. This warning was appearing on every BCG and CG forward.

Two root causes:

**1. `model_runner._forward_raw()` only invalidated on the eager path.**
`invalidate_loc_cache()` sat after the `can_run_graph` early return, so BCG replay and regular CG replay never cleared the cache before `init_forward_metadata` ran on the new batch.

**2. `update_sliding_window_buffer` uses a different tensor than `out_cache_loc`.**
The function translates `window_kv_indices[:kv_last]` (indices into the sliding window), which is always a freshly-computed tensor — different from the `out_cache_loc` that `set_kv_buffer` later translates. The cache always missed, and the stale key from the previous call triggered the warning.

## Modifications

**`model_runner.py`** — move `invalidate_loc_cache()` to before the `can_run_graph` check so it covers all forward paths (eager, regular CG replay, PCG replay, BCG replay).

**`triton_backend.py`** — in `update_sliding_window_buffer`:
- Rename param `token_to_kv_pool_allocator` → `token_to_kv_pool` (cache lives on the pool, not the allocator; this also removes the need for an extra delegation method)
- Call `invalidate_loc_cache()` before the window-KV translation (prevents the mid-forward warning) and after it (leaves the cache clean for subsequent `set_kv_buffer` calls with `out_cache_loc`)

## Accuracy

No change to computed values — `invalidate_loc_cache()` is a pure Python state reset; the actual gather kernel output is identical.

## Speed

`invalidate_loc_cache()` sets two Python attributes to `None`. Negligible overhead.

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/sgl-project/sglang/blob/main/CONTRIBUTING.md)
- [x] I have run `pre-commit run --all-files` and fixed issues
- [x] Verified: `gpt-oss-20b` (`GptOssForCausalLM`, hybrid SWA, 24 alternating layers) with `--enable-breakable-cuda-graph` — zero `translate_loc_from_full_to_swa` warnings during CG capture, BCG capture (74 sizes), and live request serving

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26325601887](https://github.com/sgl-project/sglang/actions/runs/26325601887)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26325601808](https://github.com/sgl-project/sglang/actions/runs/26325601808)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->