### PR TITLE
[docs] DeepSeek-V4 cookbook: balanced MegaMoE cap, H200 Pro FP4 mem-frac, nsa-* compat, PD-disagg fixes

### DIFF
--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -119,14 +119,22 @@ export const DeepSeekV4Deployment = () => {
   const MARLIN_EFFHW = new Set(["h200-fp4", "h100"]);
   const MARLIN_LABEL = { "h200-fp4": "H200 (FP4)", h100: "H100 (FP4)" };
 
-  // MegaMoE is only supported on Blackwell with DeepEP-based recipes
-  // (balanced / max-throughput / pd-disagg). It's disabled on Hopper
-  // (H100 / H200, both FP4 and FP8) and on low-latency / cp recipes.
-  const MEGAMOE_UNSUPPORTED_RECIPES = new Set(["low-latency", "cp"]);
+  // MegaMoE is only wired into the deepep-replacing recipes on Blackwell
+  // (balanced / max-throughput). Disabled on Hopper (H100 / H200, both FP4
+  // and FP8), on low-latency / cp recipes, and on PD-Disagg (the cookbook's
+  // PD command builder doesn't emit the megamoe backend / env vars yet).
+  const MEGAMOE_UNSUPPORTED_RECIPES = new Set(["low-latency", "cp", "pd-disagg"]);
   const MEGAMOE_UNSUPPORTED_HARDWARE = new Set(["h100", "h200"]);
   const isMegamoeUnsupported = (vals) =>
     MEGAMOE_UNSUPPORTED_HARDWARE.has(vals.hardware) ||
     MEGAMOE_UNSUPPORTED_RECIPES.has(vals.recipe);
+
+  // HiCache works on PD-Disagg in SGLang itself (prefill worker only, per
+  // mooncake_store/README.md), but the cookbook generator doesn't yet emit
+  // the hicache flags into buildPDDisaggCommand. Grey it out for now.
+  const HICACHE_UNSUPPORTED_RECIPES = new Set(["pd-disagg"]);
+  const isHicacheUnsupported = (vals) =>
+    HICACHE_UNSUPPORTED_RECIPES.has(vals.recipe);
 
   // H100 + SGLang FP8 only ships a Flash variant — Pro FP8 on H100 isn't
   // covered by the generator yet, so the Pro radio is greyed out there.
@@ -155,9 +163,18 @@ export const DeepSeekV4Deployment = () => {
     if (option.name === "megamoe" && vals && isMegamoeUnsupported(vals)) {
       const reason = MEGAMOE_UNSUPPORTED_HARDWARE.has(vals.hardware)
         ? "MegaMoE is only supported on Blackwell"
+        : vals.recipe === "pd-disagg"
+        ? "MegaMoE is not yet wired into the PD-Disagg cookbook command"
         : "MegaMoE is not supported on this recipe";
       return option.items.map((it) =>
         it.id === "disabled" ? it : { ...it, disabled: true, disabledReason: reason }
+      );
+    }
+    if (option.name === "hicache" && vals && isHicacheUnsupported(vals)) {
+      return option.items.map((it) =>
+        it.id === "disabled"
+          ? it
+          : { ...it, disabled: true, disabledReason: "HiCache is not yet wired into the PD-Disagg cookbook command" }
       );
     }
     if (option.name === "quantization" && vals && !FP8_SUPPORTED_HARDWARE.has(vals.hardware)) {
@@ -248,6 +265,15 @@ export const DeepSeekV4Deployment = () => {
         isMegamoeUnsupported(next)
       ) {
         next.megamoe = "disabled";
+      }
+      // Switching to a recipe that doesn't support HiCache (pd-disagg) while
+      // L2 is selected: fall back to disabled.
+      if (
+        optionName === "recipe" &&
+        next.hicache !== "disabled" &&
+        isHicacheUnsupported(next)
+      ) {
+        next.hicache = "disabled";
       }
       // Switching to max-throughput on supported hardware: default MegaMoE to
       // W4A8 if it's currently disabled (best throughput config).
@@ -488,7 +514,14 @@ export const DeepSeekV4Deployment = () => {
         fp4Flags.push("  --speculative-eagle-topk 1");
         fp4Flags.push("  --speculative-num-draft-tokens 2");
       }
-      if (isBig) fp4Flags.push("  --mem-fraction-static 0.88");
+      // H200 Pro (FP4) low-latency runs MTP 3/1/4 with flashinfer_mxfp4, which
+      // needs more headroom for the draft model + MTP buffers than the
+      // balanced / max-throughput recipes — drop mem-frac to 0.83.
+      if (isBig) {
+        fp4Flags.push(recipe === "low-latency"
+          ? "  --mem-fraction-static 0.83"
+          : "  --mem-fraction-static 0.88");
+      }
       if (toolcall === "enabled") fp4Flags.push("  --tool-call-parser deepseekv4");
       if (reasoningParser === "enabled") fp4Flags.push("  --reasoning-parser deepseek-v4");
       if (hicache === "l2") {
@@ -762,8 +795,12 @@ export const DeepSeekV4Deployment = () => {
       flags.push(`  --tp ${tp}`);
       if (multinode) flags.push(...multiNodeFlags(nnodes));
       flags.push("  --moe-a2a-backend deepep");
-      flags.push("  --enable-dsa-prefill-context-parallel");
-      flags.push("  --dsa-prefill-cp-mode round-robin-split");
+      // PR #25821 (merged 2026-05-20) renamed these flags from --enable-nsa-* /
+      // --nsa-prefill-cp-mode to --enable-dsa-* / --dsa-prefill-cp-mode. The
+      // :latest release image predates that PR, so we emit the old nsa-* names
+      // here and surface a note above the command for main-branch users.
+      flags.push("  --enable-nsa-prefill-context-parallel");
+      flags.push("  --nsa-prefill-cp-mode round-robin-split");
       flags.push("  --chunked-prefill-size 16384");
       // GB300 big CP needs higher mem-fraction-static: Pro 1.6T weights at
       // tp=4 are ~224 GB/card on a 273 GB GB300, so 0.78 leaves a negative
@@ -827,6 +864,12 @@ export const DeepSeekV4Deployment = () => {
     if (megamoe !== "disabled" && recipe === "max-throughput") {
       megamoeEnv.push("SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320");
     }
+    // Blackwell balanced always runs with MTP (1/1/2) — when MegaMoE is layered on
+    // top, cap the per-rank dispatch buffer at 4096 to keep MoE memory in budget.
+    // (megamoe is gated to Blackwell by MEGAMOE_UNSUPPORTED_HARDWARE.)
+    if (megamoe !== "disabled" && recipe === "balanced") {
+      megamoeEnv.push("SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=4096");
+    }
     if (megamoe === "w4a4") {
       megamoeEnv.push("SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1");
       megamoeEnv.push("SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1");
@@ -849,6 +892,15 @@ export const DeepSeekV4Deployment = () => {
     // GB200 multinode may need machine-specific NVSHMEM / Gloo env vars;
     // emit them as commented hints above the env block so users know to check.
     let cmd = base;
+    if (recipe === "cp") {
+      cmd =
+        `# NOTE: --enable-nsa-prefill-context-parallel / --nsa-prefill-cp-mode were\n` +
+        `# renamed to --enable-dsa-prefill-context-parallel / --dsa-prefill-cp-mode\n` +
+        `# in PR #25821 (merged 2026-05-20). The cookbook emits the old nsa-* names\n` +
+        `# because the :latest release image predates that PR. If you're running\n` +
+        `# SGLang built from main, replace nsa- with dsa- in the two flags below.\n` +
+        cmd;
+    }
     if (hardware === "gb200" && multinode) {
       cmd =
         `# The following env vars may be needed depending on your cluster:\n` +
@@ -1011,6 +1063,13 @@ export const DeepSeekV4Deployment = () => {
         } else {
           flags.push("  --max-running-requests 256");
         }
+        // Reasoning / tool-call parsers are the OpenAI response formatter
+        // running in serving_chat.py. The PD HTTP router (sgl-model-gateway
+        // pd_router.rs::execute_dual_dispatch) returns the decode server's
+        // response to the client and discards prefill's, so the parsers only
+        // need to be set on decode. Adding them to prefill would be inert.
+        if (values.toolcall === "enabled") flags.push("  --tool-call-parser deepseekv4");
+        if (values.reasoningParser === "enabled") flags.push("  --reasoning-parser deepseek-v4");
       }
       flags.push("  --host 0.0.0.0");
       flags.push(`  --port ${port}`);


### PR DESCRIPTION
## Summary

Five small fixes to the DSV4 deployment-command generator (`docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx`).

### 1. Blackwell + Balanced + MegaMoE → cap per-rank dispatch buffer at 4096
Balanced recipe always runs MTP (1/1/2); the draft pass needs more GMEM headroom than max-throughput's `=8320`. Adds `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=4096` whenever `megamoe !== \"disabled\" && recipe === \"balanced\"` (megamoe is already gated to Blackwell HW).

### 2. H200 Pro (FP4) Low-Latency: `--mem-fraction-static` 0.88 → 0.83
Pro runs flashinfer_mxfp4 + MTP 3/1/4 and needs more headroom for draft-model + MTP buffers than the balanced / max-throughput recipes. Other H200 FP4 Pro recipes keep 0.88.

### 3. Context-Parallel: revert flag names to `nsa-*` for `:latest` image compatibility
The `--enable-nsa-prefill-context-parallel` → `--enable-dsa-prefill-context-parallel` rename landed in [#25821](https://github.com/sgl-project/sglang/pull/25821) on 2026-05-20. The `:latest` release image predates that PR. To avoid breaking the published cookbook for users on `:latest`, emit the deprecated `nsa-*` names and prepend a user-visible shell-comment block to the generated command pointing main-branch users to swap `nsa-` → `dsa-`.

```bash
# NOTE: --enable-nsa-prefill-context-parallel / --nsa-prefill-cp-mode were
# renamed to --enable-dsa-prefill-context-parallel / --dsa-prefill-cp-mode
# in PR #25821 (merged 2026-05-20). The cookbook emits the old nsa-* names
# because the :latest release image predates that PR. If you're running
# SGLang built from main, replace nsa- with dsa- in the two flags below.
```

### 4. PD-Disagg: grey out HiCache + MegaMoE in the UI
`buildPDDisaggCommand` never read `values.hicache` / `values.megamoe`, so picking L2 / W4A8 / W4A4 with PD-Disagg silently produced an unchanged command. Add `pd-disagg` to `MEGAMOE_UNSUPPORTED_RECIPES`, add a new `HICACHE_UNSUPPORTED_RECIPES`, surface tooltips explaining the limitation, and auto-flip both toggles to Disabled on `handleRadioChange(\"recipe\", \"pd-disagg\")`.

### 5. PD-Disagg: emit parser flags on the decode role
The PD HTTP router ([`sgl-model-gateway/src/routers/http/pd_router.rs::execute_dual_dispatch`](https://github.com/sgl-project/sglang/blob/main/sgl-model-gateway/src/routers/http/pd_router.rs)) returns the decode server's response to the client and discards prefill's. So the OpenAI response formatting (`serving_chat.py` / `serving_responses.py`) runs on decode, which is where `--reasoning-parser` / `--tool-call-parser` need to live. Adds both to `buildRole(\"decode\", …)` when the user enables them in the cookbook UI.

## Test plan

- [ ] Cookbook UI renders identically when no PD-Disagg / no MegaMoE / no HiCache toggles touched (regression check on Blackwell low-latency / balanced / max-throughput / cp)
- [ ] Blackwell + Balanced + MegaMoE W4A8/W4A4: env block contains `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=4096` (and the W4A4 FP4-acts envs for w4a4)
- [ ] H200 + FP4 + Pro + Low-Latency: command shows `--mem-fraction-static 0.83`; other H200 FP4 Pro recipes still show `0.88`
- [ ] Any Blackwell / H200-FP8 + Context-Parallel: command output starts with the 5-line `nsa-*` → `dsa-*` rename note and uses `--enable-nsa-prefill-context-parallel` + `--nsa-prefill-cp-mode round-robin-split`
- [ ] PD-Disagg on any HW: HiCache `L2` chip and MegaMoE `W4A8` / `W4A4` chips are greyed out with a tooltip; switching from another recipe with those toggles enabled auto-flips them to Disabled
- [ ] PD-Disagg + Reasoning Parser Enabled: decode role command contains `--reasoning-parser deepseek-v4`; prefill role does not
- [ ] PD-Disagg + Tool Call Parser Enabled: decode role command contains `--tool-call-parser deepseekv4`; prefill role does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26328710247](https://github.com/sgl-project/sglang/actions/runs/26328710247)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26328710211](https://github.com/sgl-project/sglang/actions/runs/26328710211)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->