### PR TITLE
[SRT] Store Req input ids as arrays

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -680,12 +680,10 @@ class Req(ReqDllmMixin):
     ):
         # Input and output info
         self.rid = rid
-        self.origin_input_ids_unpadded = (
-            origin_input_ids_unpadded
-            if origin_input_ids_unpadded
-            else origin_input_ids  # Before image padding
-        )
-        self.origin_input_ids = origin_input_ids
+        self.origin_input_ids_unpadded = array(
+            "q", origin_input_ids_unpadded or origin_input_ids
+        )  # Before image padding
+        self.origin_input_ids = array("q", origin_input_ids)
         # Each decode stage's output ids
         self.output_ids = array("q")
         # fill_ids = origin_input_ids + output_ids. Updated if chunked.


### PR DESCRIPTION
## Summary
- Store `Req.origin_input_ids` and `Req.origin_input_ids_unpadded` in `array("q")`, matching the existing decode `output_ids` representation.
- Reduce Python `list[int]` overhead for long prompt inputs, especially multimodal requests with many padded image tokens.
- Keep the existing unpadded-input fallback semantics unchanged.

## Motivation
`Req.output_ids` already uses `array("q")`, while the original prompt ids were kept as Python lists. Using the same compact integer-array representation avoids carrying per-int Python object overhead after request construction and keeps prompt/output id storage consistent.

## Risk
- Intended to be a storage-only change; common sequence operations such as `len`, indexing, slicing, iteration, `append`, and `extend` remain supported.
- The main compatibility risk is code that relies on `list`-specific behavior, direct JSON/msgpack serialization of these fields, or equality checks against plain lists.

## Validation
- `pre-commit run --files python/sglang/srt/managers/schedule_batch.py`
- SMG cuda-ipc smoke on H200 Kimi-K2.5 TP8



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26328855899](https://github.com/sgl-project/sglang/actions/runs/26328855899)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26328855814](https://github.com/sgl-project/sglang/actions/runs/26328855814)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->