### PR TITLE
fix: correct tool parser for Qwen 3.5 (Qwen3)

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -257,6 +257,7 @@ class Qwen3Detector(BaseReasoningFormatDetector):
             think_excluded_tokens=think_excluded_tokens,
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
+            tool_start_token="<tool_call>",
             continue_final_message=continue_final_message,
             previous_content=previous_content,
             thinks_internally=True,

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1684,7 +1684,7 @@ class TestQwen3AutoToolCallsAfterReasoning(unittest.TestCase):
         ]
 
         self.assertEqual(tool_deltas[0]["function"]["name"], "get_current_weather")
-        arguments = "".join(delta["function"]["arguments"] for delta in tool_deltas)
+        arguments = "".join(t_delta["function"]["arguments"] or "" for t_delta in tool_deltas)
         self.assertEqual(json.loads(arguments), {"location": "Boston"})
 
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1567,6 +1567,127 @@ class TestProcessToolCallsWithRequiredToolChoice(unittest.TestCase):
         self.assertIsNone(tool_calls)
 
 
+class TestQwen3AutoToolCallsAfterReasoning(unittest.TestCase):
+    def setUp(self):
+        tm = _MockTokenizerManager()
+        tm.server_args.reasoning_parser = "qwen3"
+        tm.server_args.tool_call_parser = "qwen3_coder"
+        self.chat = OpenAIServingChat(tm, _MockTemplateManager())
+
+    def test_non_streaming_tool_call_is_not_swallowed_by_reasoning(self):
+        request = ChatCompletionRequest(
+            model="qwen",
+            messages=[{"role": "user", "content": "Weather in Boston?"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
+        )
+        ret_item = {
+            "text": (
+                "<tool_call>\n"
+                "<function=get_current_weather>\n"
+                "<parameter=location>\nBoston\n</parameter>\n"
+                "</function>\n"
+                "</tool_call>"
+            ),
+            "meta_info": {
+                "id": f"chatcmpl-{uuid.uuid4()}",
+                "prompt_tokens": 10,
+                "completion_tokens": 26,
+                "weight_version": "default",
+                "finish_reason": {"type": "stop", "matched": None},
+            },
+            "index": 0,
+        }
+
+        response = self.chat._build_chat_response(request, [ret_item], created=0)
+        choice = response.choices[0]
+        message = choice.message
+
+        self.assertIsNone(message.reasoning_content)
+        self.assertIsNone(message.content)
+        self.assertEqual(choice.finish_reason, "tool_calls")
+        self.assertEqual(len(message.tool_calls), 1)
+        self.assertEqual(
+            message.tool_calls[0].function.name,
+            "get_current_weather",
+        )
+        self.assertEqual(
+            json.loads(message.tool_calls[0].function.arguments),
+            {"location": "Boston"},
+        )
+
+    def test_streaming_tool_call_reaches_tool_parser_after_reasoning(self):
+        request = ChatCompletionRequest(
+            model="qwen",
+            messages=[{"role": "user", "content": "Weather in Boston?"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_current_weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+            tool_choice="auto",
+            stream=True,
+        )
+        xml = (
+            "<tool_call>\n"
+            "<function=get_current_weather>\n"
+            "<parameter=location>\nBoston\n</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+
+        reasoning, delta = self.chat._process_reasoning_stream(
+            index=0,
+            delta=xml,
+            reasoning_parser_dict={},
+            content={"meta_info": {"id": "chatcmpl-test"}},
+            request=request,
+        )
+        self.assertEqual(reasoning, "")
+        self.assertEqual(delta, xml)
+
+        async def collect_tool_chunks():
+            chunks = []
+            async for emitted in self.chat._process_tool_call_stream(
+                index=0,
+                delta=delta,
+                parser_dict={},
+                content={"meta_info": {"id": "chatcmpl-test"}},
+                request=request,
+                has_tool_calls={},
+            ):
+                chunks.append(json.loads(emitted[len("data: ") :]))
+            return chunks
+
+        loop = get_or_create_event_loop()
+        chunks = loop.run_until_complete(collect_tool_chunks())
+        tool_deltas = [
+            chunk["choices"][0]["delta"]["tool_calls"][0] for chunk in chunks
+        ]
+
+        self.assertEqual(tool_deltas[0]["function"]["name"], "get_current_weather")
+        arguments = "".join(delta["function"]["arguments"] for delta in tool_deltas)
+        self.assertEqual(json.loads(arguments), {"location": "Boston"})
+
+
 class TestNormalizeToolContent(unittest.TestCase):
     """Unit tests for normalize_tool_content()."""
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -224,6 +224,12 @@ class TestQwen3Detector(CustomTestCase):
         self.assertEqual(result.normal_text, text)
         self.assertEqual(result.reasoning_text, "")
 
+    def test_detect_and_parse_tool_interrupt(self):
+        text = "<think>I should call a tool<tool_call>tool call data"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "I should call a tool")
+        self.assertEqual(result.normal_text, "<tool_call>tool call data")
+
 
 class TestQwen3ForcedReasoningDetector(CustomTestCase):
     def setUp(self):
@@ -253,6 +259,12 @@ class TestQwen3ForcedReasoningDetector(CustomTestCase):
         self.assertEqual(result.reasoning_text, "I need to think about this.")
         self.assertEqual(result.normal_text, "The answer is 42.")
 
+    def test_detect_and_parse_tool_only_output(self):
+        text = "<tool_call>\n<function=get_weather></function>\n</tool_call>"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, text)
+
     def test_streaming_qwen3_forced_reasoning_format(self):
         """Test streaming parse of Qwen3-ForcedReasoning format."""
         # First chunk without <think> start
@@ -269,6 +281,19 @@ class TestQwen3ForcedReasoningDetector(CustomTestCase):
         result = self.detector.parse_streaming_increment("</think>The answer is 42.")
         self.assertEqual(result.reasoning_text, "")  # Buffer cleared
         self.assertEqual(result.normal_text, "The answer is 42.")
+
+    def test_streaming_tool_interrupt(self):
+        result = self.detector.parse_streaming_increment("I need a weather lookup")
+        self.assertEqual(result.reasoning_text, "I need a weather lookup")
+
+        result = self.detector.parse_streaming_increment("<tool_call>")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "<tool_call>")
+        self.assertFalse(self.detector._in_reasoning)
+
+        result = self.detector.parse_streaming_increment("<function=get_weather>")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "<function=get_weather>")
 
 
 class TestKimiDetector(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fixes incorrect tool calling parsing for Qwen 3.5 (Qwen3) models.
Previously, the parser incorrectly classified tool calls as part of the reasoning block (reasoning content), causing the tool invocation to be ignored or treated as plain text. This led to failed tool calls and broken agent workflows.
This PR updates the parser logic to correctly distinguish between reasoning steps and tool calls, ensuring that tool invocations are properly extracted and executed.

sglang serve
`--tool-call-parser qwen3_coder`
`--reasoning-parser qwen3`

before
```
{'id': 'ee461f280734411e8f9c338787be4a9b', 'object': 'chat.completion', 'created': 1779344467, 'model': 'qwen', 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': None, 'reasoning_content': '<tool_call>\n<function=get_current_weather>\n<parameter=location>\nBoston, MA\n</parameter>\n</function>\n</tool_call>', 'tool_calls': None}, 'logprobs': None, 'finish_reason': 'stop', 'matched_stop': 248046}], 'usage': {'prompt_tokens': 330, 'total_tokens': 359, 'completion_tokens': 29, 'prompt_tokens_details': None, 'reasoning_tokens': 29}, 'metadata': {'weight_version': 'default'}}
```
after
```
{'id': '5b95d85e1a394961b0c0ed9a3d2cca54', 'object': 'chat.completion', 'created': 1779449347, 'model': 'qwen', 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': None, 'reasoning_content': None, 'tool_calls': [{'id': 'call_954a3074c78b423c8413ddbe', 'index': 0, 'type': 'function', 'function': {'name': 'get_current_weather', 'arguments': '{"location": "Boston, MA"}'}}]}, 'logprobs': None, 'finish_reason': 'tool_calls', 'matched_stop': None}], 'usage': {'prompt_tokens': 330, 'total_tokens': 359, 'completion_tokens': 29, 'prompt_tokens_details': None, 'reasoning_tokens': 29}, 'metadata': {'weight_version': 'default'}}
```

Closes #25242

## Modifications

<!-- Detail the changes made in this pull request. -->
1. **Updated `python/sglang/srt/parser/reasoning_parser.py`**:
   - Added `tool_start_token="<tool_call>"` to the `ReasoningParser` initialization for Qwen3.
   - This allows the parser to recognize the start of a tool call and correctly split the output into `reasoning_text` and `normal_text` (which contains the tool call).

2. **Added Unit Tests**:
   - **`test/registered/unit/entrypoints/openai/test_serving_chat.py`**:
     - `TestQwen3AutoToolCallsAfterReasoning`: Verifies that in non-streaming mode, tool calls are correctly extracted and `reasoning_content` is empty when a tool is called.
     - Verified streaming behavior where tool deltas are correctly emitted after reasoning.
   - **`test/registered/unit/parser/test_reasoning_parser.py`**:
     - `test_detect_and_parse_tool_interrupt`: Ensures that if a `<tool_call>` appears inside `<think>`, the reasoning stops and the tool tag is preserved.
     - `test_streaming_tool_interrupt`: Verifies that streaming chunks correctly transition from reasoning state to tool parsing state upon encountering `<tool_call>`.
     - `test_detect_and_parse_tool_only_output`: Ensures pure tool outputs (without reasoning) are handled correctly.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26331089472](https://github.com/sgl-project/sglang/actions/runs/26331089472)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26331089445](https://github.com/sgl-project/sglang/actions/runs/26331089445)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->