### PR TITLE
Eliminate per-layer overhead in Qwen3VL ViT forward

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -484,9 +484,15 @@ class VisionFlash4Attention(nn.Module):
                 )
             cu_seqlens = cu_seqlens.get_data()
 
-        cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-        max_seqlen = seq_lens.max().item()
+        _precomputed_max = kwargs.get("max_seqlen", None)
+        if _precomputed_max is not None:
+            max_seqlen = int(_precomputed_max) if not isinstance(_precomputed_max, int) else _precomputed_max
+            if cu_seqlens.dtype != torch.int32 or cu_seqlens.device != q.device:
+                cu_seqlens = cu_seqlens.to(dtype=torch.int32, device=q.device)
+        else:
+            cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
+            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+            max_seqlen = seq_lens.max().item()
 
         output = flash_attn_varlen_func(
             q,
@@ -1035,11 +1041,14 @@ class VisionAttention(nn.Module):
     ) -> torch.Tensor:
         r"""
         Args:
-            x: [b, s, embed_dim]
+            x: [b, s, embed_dim] or [s, b, embed_dim] if input_layout="sb"
             cu_seqlens: [b]
         Returns:
-             [s, b, head * head_size]
+             [b, s, head * head_size] or [s, b, head * head_size] if input_layout="sb"
         """
+        input_layout = kwargs.pop("input_layout", None)
+        if input_layout == "sb":
+            x = x.transpose(0, 1)
         if x.dim() == 2:
             x = x.unsqueeze(0)
         assert x.dim() == 3, x.shape
@@ -1205,5 +1214,8 @@ class VisionAttention(nn.Module):
 
             # [s, b, h * head_size] --> [b, s, h * head_size]
             output = output.view(bsz, s, -1)
+
+        if input_layout == "sb":
+            output = output.transpose(0, 1)
 
         return output

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -147,6 +147,19 @@ def resolve_seqlens(
     return resolved_seqlens
 
 
+@dataclasses.dataclass
+class VisionAttentionMetadata:
+    """Pre-computed metadata for vision attention, avoiding per-layer recomputation."""
+
+    cu_seqlens: torch.Tensor  # [B+1] cumulative sequence lengths
+    max_seqlen: int  # pre-computed max sequence length (no .item())
+    rotary_pos_emb_cos: Optional[torch.Tensor] = None  # [num_tokens, head_dim]
+    rotary_pos_emb_sin: Optional[torch.Tensor] = None
+    output_ws: Optional[torch.Tensor] = None  # output workspace (flashinfer_cudnn)
+    sequence_lengths: Optional[torch.Tensor] = None  # padded seq lengths (flashinfer)
+    input_layout: Optional[str] = None  # "sb" for (s,b,d) input
+
+
 class VisionSdpaAttention(nn.Module):
     r"""
     Scaled Dot Product Attention inner product
@@ -242,6 +255,7 @@ class VisionSdpaAttention(nn.Module):
         cu_seqlens: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -250,6 +264,9 @@ class VisionSdpaAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
+        if forward_metadata is not None and cu_seqlens is None:
+            cu_seqlens = forward_metadata.cu_seqlens
+
         if self.flatten_batch:
             assert bsz == 1, "flatten_batch is True, bsz must be 1"
 
@@ -331,6 +348,7 @@ class VisionTritonAttention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -340,6 +358,9 @@ class VisionTritonAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
+        if forward_metadata is not None and cu_seqlens is None:
+            cu_seqlens = forward_metadata.cu_seqlens
+
         if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
             if "output_ws" not in kwargs:
                 raise RuntimeError("output_ws should be prepared for cuda-graph mode")
@@ -404,6 +425,7 @@ class VisionFlash3Attention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -412,6 +434,9 @@ class VisionFlash3Attention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
+        if forward_metadata is not None and cu_seqlens is None:
+            cu_seqlens = forward_metadata.cu_seqlens
+
         window_size = kwargs.get("window_size", (-1, -1))
         s_aux = kwargs.get("s_aux", None)
 
@@ -467,6 +492,7 @@ class VisionFlash4Attention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -476,7 +502,10 @@ class VisionFlash4Attention(nn.Module):
              [b * s, h, head_size]
         """
         if cu_seqlens is None:
-            cu_seqlens = _get_cu_seqlens_for_shape(bsz, seq_len, device=q.device)
+            if forward_metadata is not None:
+                cu_seqlens = forward_metadata.cu_seqlens
+            else:
+                cu_seqlens = _get_cu_seqlens_for_shape(bsz, seq_len, device=q.device)
         elif isinstance(cu_seqlens, SingletonCache):
             if cu_seqlens.empty():
                 cu_seqlens.set_data(
@@ -484,15 +513,21 @@ class VisionFlash4Attention(nn.Module):
                 )
             cu_seqlens = cu_seqlens.get_data()
 
-        _precomputed_max = kwargs.get("max_seqlen", None)
-        if _precomputed_max is not None:
-            max_seqlen = int(_precomputed_max) if not isinstance(_precomputed_max, int) else _precomputed_max
+        # Resolve max_seqlen: forward_metadata > kwargs > compute from cu_seqlens
+        if forward_metadata is not None:
+            max_seqlen = forward_metadata.max_seqlen
             if cu_seqlens.dtype != torch.int32 or cu_seqlens.device != q.device:
                 cu_seqlens = cu_seqlens.to(dtype=torch.int32, device=q.device)
         else:
-            cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-            max_seqlen = seq_lens.max().item()
+            _precomputed_max = kwargs.get("max_seqlen", None)
+            if _precomputed_max is not None:
+                max_seqlen = int(_precomputed_max) if not isinstance(_precomputed_max, int) else _precomputed_max
+                if cu_seqlens.dtype != torch.int32 or cu_seqlens.device != q.device:
+                    cu_seqlens = cu_seqlens.to(dtype=torch.int32, device=q.device)
+            else:
+                cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
+                seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+                max_seqlen = seq_lens.max().item()
 
         output = flash_attn_varlen_func(
             q,
@@ -530,6 +565,7 @@ class VisionFlashInferAttention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -538,17 +574,22 @@ class VisionFlashInferAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
-        if "sequence_lengths" not in kwargs:
-            raise RuntimeError(
-                "sequence_lengths should be prepared for vision flashinfer_cudnn attention backend"
-            )
-        if "max_seqlen" not in kwargs:
-            raise RuntimeError(
-                "max_seqlen should be prepared for vision flashinfer_cudnn attention backend"
-            )
-
-        sequence_lengths = kwargs["sequence_lengths"]  # (B_padded,) or (B_padded,1,1,1)
-        max_seqlen = kwargs["max_seqlen"]
+        if forward_metadata is not None:
+            sequence_lengths = forward_metadata.sequence_lengths
+            max_seqlen = forward_metadata.max_seqlen
+            if cu_seqlens is None:
+                cu_seqlens = forward_metadata.cu_seqlens
+        else:
+            if "sequence_lengths" not in kwargs:
+                raise RuntimeError(
+                    "sequence_lengths should be prepared for vision flashinfer_cudnn attention backend"
+                )
+            if "max_seqlen" not in kwargs:
+                raise RuntimeError(
+                    "max_seqlen should be prepared for vision flashinfer_cudnn attention backend"
+                )
+            sequence_lengths = kwargs["sequence_lengths"]  # (B_padded,) or (B_padded,1,1,1)
+            max_seqlen = kwargs["max_seqlen"]
 
         # max_seqlen must be python int
         if isinstance(max_seqlen, torch.Tensor):
@@ -658,8 +699,12 @@ class VisionAiterAttention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
+        if forward_metadata is not None and cu_seqlens is None:
+            cu_seqlens = forward_metadata.cu_seqlens
+
         cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
 
         cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
@@ -697,6 +742,7 @@ class VisionAscendAttention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -705,6 +751,9 @@ class VisionAscendAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
+        if forward_metadata is not None and cu_seqlens is None:
+            cu_seqlens = forward_metadata.cu_seqlens
+
         if envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
             if "output_ws" not in kwargs:
                 raise RuntimeError("output_ws should be prepared for npu-graph mode")
@@ -1037,16 +1086,35 @@ class VisionAttention(nn.Module):
         rotary_pos_emb_sin: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         full_attn: bool = True,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
         Args:
             x: [b, s, embed_dim] or [s, b, embed_dim] if input_layout="sb"
             cu_seqlens: [b]
+            forward_metadata: pre-computed metadata (preferred over kwargs)
         Returns:
              [b, s, head * head_size] or [s, b, head * head_size] if input_layout="sb"
         """
-        input_layout = kwargs.pop("input_layout", None)
+        # Resolve from forward_metadata or kwargs
+        if forward_metadata is not None:
+            input_layout = forward_metadata.input_layout
+            if cu_seqlens is None:
+                cu_seqlens = forward_metadata.cu_seqlens
+            if rotary_pos_emb_cos is None:
+                rotary_pos_emb_cos = forward_metadata.rotary_pos_emb_cos
+            if rotary_pos_emb_sin is None:
+                rotary_pos_emb_sin = forward_metadata.rotary_pos_emb_sin
+            attn_output_ws = forward_metadata.output_ws
+            max_seqlen = forward_metadata.max_seqlen
+            sequence_lengths = forward_metadata.sequence_lengths
+        else:
+            input_layout = kwargs.pop("input_layout", None)
+            attn_output_ws = kwargs.get("output_ws")
+            max_seqlen = kwargs.get("max_seqlen")
+            sequence_lengths = kwargs.get("sequence_lengths")
+
         if input_layout == "sb":
             x = x.transpose(0, 1)
         if x.dim() == 2:
@@ -1065,12 +1133,6 @@ class VisionAttention(nn.Module):
         bsz, s, _ = x_shape
         head = self.num_attention_heads_per_partition
         kv_head = self.num_attention_kv_heads_per_partition
-
-        attn_output_ws = kwargs["output_ws"] if "output_ws" in kwargs else None
-        max_seqlen = kwargs["max_seqlen"] if "max_seqlen" in kwargs else None
-        sequence_lengths = (
-            kwargs["sequence_lengths"] if "sequence_lengths" in kwargs else None
-        )
         if self.use_qkv_parallel:
             # [b, s, embed_dim] --> [b, s, embed_dim]
             qkv, _ = self.qkv_proj(x)
@@ -1187,6 +1249,7 @@ class VisionAttention(nn.Module):
             seq_len=s,
             cu_seqlens=cu_seqlens,
             attention_mask=attention_mask,
+            forward_metadata=forward_metadata,
             sequence_lengths=sequence_lengths,
             max_seqlen=max_seqlen,
             output_ws=attn_output_ws,

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -35,6 +35,7 @@ from sglang.srt.layers.attention.vision import (
     FLASHINFER_MAX_SEQLEN_BUCKETS,
     FLASHINFER_WORKSPACE_SIZE_BYTES,
     VisionAttention,
+    VisionAttentionMetadata,
 )
 from sglang.srt.layers.conv import Conv3dLayer
 from sglang.srt.layers.dp_attention import (
@@ -219,24 +220,10 @@ class Qwen3_VisionBlock(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        cu_seqlens: torch.Tensor,
-        rotary_pos_emb_cos: torch.Tensor,
-        rotary_pos_emb_sin: torch.Tensor,
-        output_ws: Optional[torch.Tensor] = None,
-        max_seqlen: Optional[torch.Tensor] = None,
-        sequence_lengths: Optional[torch.Tensor] = None,
+        forward_metadata: VisionAttentionMetadata,
     ) -> torch.Tensor:
         hidden_states = self.norm1(x)
-        attn = self.attn(
-            hidden_states,
-            cu_seqlens=cu_seqlens,
-            rotary_pos_emb_cos=rotary_pos_emb_cos,
-            rotary_pos_emb_sin=rotary_pos_emb_sin,
-            output_ws=output_ws,
-            max_seqlen=max_seqlen,
-            sequence_lengths=sequence_lengths,
-            input_layout="sb",
-        )
+        attn = self.attn(hidden_states, forward_metadata=forward_metadata)
         x += attn
         norm2 = self.norm2(x)
         mlp = self.mlp(norm2)
@@ -838,18 +825,21 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             rotary_pos_emb_cos = torch.cat([rotary_pos_emb_cos, rotary_pos_emb_cos], dim=-1)
             rotary_pos_emb_sin = torch.cat([rotary_pos_emb_sin, rotary_pos_emb_sin], dim=-1)
 
+        # Build metadata once for all layers
+        forward_metadata = VisionAttentionMetadata(
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            rotary_pos_emb_cos=rotary_pos_emb_cos,
+            rotary_pos_emb_sin=rotary_pos_emb_sin,
+            sequence_lengths=sequence_lengths,
+            input_layout="sb",
+        )
+
         deepstack_feature_lists = []
         num_deepstack_captured = 0
 
         for layer_num, blk in enumerate(self.blocks):
-            x = blk(
-                x,
-                cu_seqlens=cu_seqlens,
-                rotary_pos_emb_cos=rotary_pos_emb_cos,
-                rotary_pos_emb_sin=rotary_pos_emb_sin,
-                max_seqlen=max_seqlen,
-                sequence_lengths=sequence_lengths,
-            )
+            x = blk(x, forward_metadata=forward_metadata)
 
             if layer_num in self.deepstack_visual_indexes:
                 deepstack_feature = self.deepstack_merger_list[num_deepstack_captured](

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -227,7 +227,6 @@ class Qwen3_VisionBlock(nn.Module):
         sequence_lengths: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         hidden_states = self.norm1(x)
-        hidden_states = rearrange(hidden_states, "s b ... -> b s ...")
         attn = self.attn(
             hidden_states,
             cu_seqlens=cu_seqlens,
@@ -236,8 +235,8 @@ class Qwen3_VisionBlock(nn.Module):
             output_ws=output_ws,
             max_seqlen=max_seqlen,
             sequence_lengths=sequence_lengths,
+            input_layout="sb",
         )
-        attn = rearrange(attn, "b s ... -> s b ...")
         x += attn
         norm2 = self.norm2(x)
         mlp = self.mlp(norm2)
@@ -825,11 +824,19 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
                 cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
             else:
                 cu_seqlens = cu_seqlens.to("cpu")
-            max_seqlen = None
+            # Pre-compute max_seqlen once to avoid per-layer .item() sync
+            _seq_lens_np = token_cu_seqlens[1:] - token_cu_seqlens[:-1]
+            max_seqlen = int(_seq_lens_np.max()) if len(_seq_lens_np) > 0 else 0
 
         x = x.unsqueeze(1)
 
         cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
+
+        # Pre-expand cos/sin for half-dim rotary to avoid per-layer torch.cat
+        head_dim = self.hidden_size // self.num_heads
+        if rotary_pos_emb_cos.size(-1) * 2 == head_dim:
+            rotary_pos_emb_cos = torch.cat([rotary_pos_emb_cos, rotary_pos_emb_cos], dim=-1)
+            rotary_pos_emb_sin = torch.cat([rotary_pos_emb_sin, rotary_pos_emb_sin], dim=-1)
 
         deepstack_feature_lists = []
         num_deepstack_captured = 0


### PR DESCRIPTION
## Summary

Eliminate redundant per-layer operations in Qwen3VL ViT forward pass. The 27-layer transformer block loop currently executes 160 unnecessary operations per forward:

1. **Per-layer `.item()` GPU→CPU sync (FA4 backend)**: `max_seqlen = seq_lens.max().item()` forces `cudaStreamSynchronize` on every layer — 27 GPU→CPU round-trips per forward.
2. **Per-layer `torch.cat` for rotary cos/sin**: Half-dim rotary embeddings are expanded via `torch.cat([cos, cos], dim=-1)` on every layer — 54 redundant cat operations.
3. **Per-layer `rearrange` copy in VisionBlock**: `rearrange("s b -> b s")` before attention and back after triggers memory copies for non-contiguous tensors — 54 copies.

**Fixes:**
- Pre-compute `max_seqlen` once from numpy `cu_seqlens` before the block loop (no GPU sync)
- Pre-expand cos/sin once before the loop; per-layer size check becomes False automatically
- Add `input_layout="sb"` to `VisionAttention` — uses `transpose(0,1)` which is a zero-copy view for bsz=1 (ViT always concatenates tokens along seq dim)

| Operation | Before | After | Eliminated |
|-----------|--------|-------|------------|
| `.item()` GPU→CPU sync | 27 | 0 | 27 |
| `torch.cat` (cos/sin) | 54 | 2 | 52 |
| `rearrange` copy | 54 | 0 | 54 |
| `cu_seqlens` diff | 27 | 0 | 27 |
| **Total** | **162** | **2** | **160** |

## Results

**Hardware**: 8× NVIDIA B200, Qwen3.5-397B-A17B (MoE), TP=8, FA4 attention backend

### bench_serving with images (1000 prompts, 1 image 360p, 20 input tokens, 5 output tokens, concurrency=100)

| Metric | Baseline | Fix | Delta |
|--------|----------|-----|-------|
| Duration | 12.86s | 11.68s | **-9.2%** |
| Request throughput | 77.76 req/s | 85.51 req/s | **+10.0%** |
| Mean TTFT | 1,277ms | 1,153ms | **-9.7%** |

### torch.profiler trace (single ViT forward, bs=64, TP rank 0)

Compute kernels unchanged (GEMM, FlashAttn, LayerNorm identical). Overhead reduced:

| Operation | Baseline | Fix | Delta |
|-----------|----------|-----|-------|
| aten::cat | 249 calls / 593us | 197 calls / 419us | -21% calls, -29% CUDA time |
| aten::sub | 411 calls / 677us | 384 calls / 640us | -7% calls |
| **Self CPU total** | **46.25ms** | **40.08ms** | **-13%** |

### ViT micro-benchmark (single image repeated N times)

| bs | Baseline | Fix | Delta |
|----|----------|-----|-------|
| 1 | 12.66ms | 10.34ms | -18% |
| 32 | 26.99ms | 22.02ms | -18% |
| 64 | 43.83ms | 39.54ms | -10% |
| 100 | 63.93ms | 59.90ms | -6% |







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26336187176](https://github.com/sgl-project/sglang/actions/runs/26336187176)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26336187073](https://github.com/sgl-project/sglang/actions/runs/26336187073)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->