### PR TITLE
[DSV4] Fix continue_final_message prefill rendering

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -567,6 +567,12 @@ class ChatCompletionMessageGenericParam(BaseModel):
     reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])
+    # DSV4-encoder-specific: when True, render this assistant turn without the
+    # trailing end-of-sentence token so generation can continue from it. Only
+    # honored by the deepseek-v4 chat encoder; ignored by other encoders.
+    # Server may default this to True for the final assistant turn when
+    # continue_final_message is requested on a DSV4 deployment.
+    wo_eos: Optional[bool] = None
 
     @field_validator("role", mode="before")
     @classmethod

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -567,11 +567,9 @@ class ChatCompletionMessageGenericParam(BaseModel):
     reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])
-    # DSV4-encoder-specific: when True, render this assistant turn without the
-    # trailing end-of-sentence token so generation can continue from it. Only
-    # honored by the deepseek-v4 chat encoder; ignored by other encoders.
-    # Server may default this to True for the final assistant turn when
-    # continue_final_message is requested on a DSV4 deployment.
+    # DSV4 only: render this turn without the trailing EOS token so
+    # generation can continue from it. Server defaults to True on the
+    # final turn for continue_final_message; ignored by other encoders.
     wo_eos: Optional[bool] = None
 
     @field_validator("role", mode="before")

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -568,8 +568,8 @@ class ChatCompletionMessageGenericParam(BaseModel):
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])
     # DSV4 only: render this turn without the trailing EOS token so
-    # generation can continue from it. Server defaults to True on the
-    # final turn for continue_final_message; ignored by other encoders.
+    # generation can continue from it. Defaults to True on DSV4 +
+    # continue_final_message; non-DSV4 encoders ignore the field.
     wo_eos: Optional[bool] = None
 
     @field_validator("role", mode="before")

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -224,11 +224,9 @@ class OpenAIServingChat(OpenAIServingBase):
             if isinstance(last_content, str):
                 if request.continue_final_message:
                     if self.chat_encoding_spec == "dsv4":
-                        # DSV4 must render the prefill inside the encoder so the
-                        # thinking block closes before visible content and any
-                        # reasoning_content on the final message is preserved.
-                        # Default wo_eos to True for the final turn; an explicit
-                        # False falls through to the legacy strip-and-append path.
+                        # Let the encoder render the prefill (it closes
+                        # </think> first); wo_eos=False opts out to the
+                        # legacy strip-and-append path below.
                         wo_eos = messages[-1].get("wo_eos")
                         if wo_eos is None:
                             messages[-1]["wo_eos"] = wo_eos = True

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -224,9 +224,11 @@ class OpenAIServingChat(OpenAIServingBase):
             if isinstance(last_content, str):
                 if request.continue_final_message:
                     if self.chat_encoding_spec == "dsv4":
-                        # Let the encoder render the prefill (it closes
-                        # </think> first); wo_eos=False opts out to the
-                        # legacy strip-and-append path below.
+                        # Let the encoder position the prefill after </think>
+                        # (closed by the user-turn transition in chat mode,
+                        # by the assistant turn's wo_eos render in thinking
+                        # mode). wo_eos=False opts out to the legacy
+                        # strip-and-append path below.
                         wo_eos = messages[-1].get("wo_eos")
                         if wo_eos is None:
                             messages[-1]["wo_eos"] = wo_eos = True

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -223,6 +223,17 @@ class OpenAIServingChat(OpenAIServingBase):
             # Only process string content, ignore multimodal content (lists)
             if isinstance(last_content, str):
                 if request.continue_final_message:
+                    if self.chat_encoding_spec == "dsv4":
+                        # DSV4 must render the prefill inside the encoder so the
+                        # thinking block closes before visible content and any
+                        # reasoning_content on the final message is preserved.
+                        # Default wo_eos to True for the final turn; an explicit
+                        # False falls through to the legacy strip-and-append path.
+                        wo_eos = messages[-1].get("wo_eos")
+                        if wo_eos is None:
+                            messages[-1]["wo_eos"] = wo_eos = True
+                        if wo_eos:
+                            return messages, None
                     # Extract content and remove the assistant message
                     assistant_prefix = last_content
                     messages = messages[:-1]

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -667,13 +667,14 @@ class ReasoningParser:
             kwargs["continue_final_message"] = True
             last_message = request.messages[-1]
             previous_content = last_message.content
-            # Avoid len(None)/`in` TypeError for reasoning-only prefills.
+            # Avoid len(None)/`in` TypeError when the prefill carries
+            # only reasoning_content or tool_calls (content=None).
             if previous_content is None:
                 previous_content = ""
-            # Mirror the DSV4 encoder's wo_eos render (which injects
-            # </think> ahead of visible content) so _in_reasoning starts
-            # past the boundary. wo_eos=False routes to legacy
-            # strip-and-append where no </think> is emitted.
+            # The DSV4 encoder positions </think> ahead of visible content
+            # on the wo_eos path; prepend it to previous_content so
+            # _in_reasoning starts past that boundary. wo_eos=False routes
+            # to legacy strip-and-append where no </think> is emitted.
             if (
                 model_type.lower() == "deepseek-v4"
                 and getattr(last_message, "wo_eos", None) is not False

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -667,17 +667,13 @@ class ReasoningParser:
             kwargs["continue_final_message"] = True
             last_message = request.messages[-1]
             previous_content = last_message.content
-            # Normalize None to "" so the detector's len()/`in` checks don't
-            # blow up on reasoning-only or tool-call-only prefills. The dsv4
-            # encoder path applies the same normalization before rendering.
+            # Avoid len(None)/`in` TypeError for reasoning-only prefills.
             if previous_content is None:
                 previous_content = ""
-            # DSV4-only: the encoder's wo_eos render (default for
-            # continue_final_message) injects </think> ahead of visible
-            # content, so prepend it here to keep _in_reasoning aligned with
-            # the actual prompt boundary. Skip when wo_eos was explicitly
-            # disabled — that path falls back to legacy strip-and-append and
-            # the prompt no longer has the encoder-injected </think>.
+            # Mirror the DSV4 encoder's wo_eos render (which injects
+            # </think> ahead of visible content) so _in_reasoning starts
+            # past the boundary. wo_eos=False routes to legacy
+            # strip-and-append where no </think> is emitted.
             if (
                 model_type.lower() == "deepseek-v4"
                 and getattr(last_message, "wo_eos", None) is not False

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -665,7 +665,26 @@ class ReasoningParser:
             and request.messages[-1].role == "assistant"
         ):
             kwargs["continue_final_message"] = True
-            kwargs["previous_content"] = request.messages[-1].content
+            last_message = request.messages[-1]
+            previous_content = last_message.content
+            # Normalize None to "" so the detector's len()/`in` checks don't
+            # blow up on reasoning-only or tool-call-only prefills. The dsv4
+            # encoder path applies the same normalization before rendering.
+            if previous_content is None:
+                previous_content = ""
+            # DSV4-only: the encoder's wo_eos render (default for
+            # continue_final_message) injects </think> ahead of visible
+            # content, so prepend it here to keep _in_reasoning aligned with
+            # the actual prompt boundary. Skip when wo_eos was explicitly
+            # disabled — that path falls back to legacy strip-and-append and
+            # the prompt no longer has the encoder-injected </think>.
+            if (
+                model_type.lower() == "deepseek-v4"
+                and getattr(last_message, "wo_eos", None) is not False
+                and isinstance(previous_content, str)
+            ):
+                previous_content = "</think>" + previous_content
+            kwargs["previous_content"] = previous_content
 
         chat_template_kwargs = getattr(request, "chat_template_kwargs", None) or {}
         if chat_template_kwargs.get("force_nonempty_content") is True:

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -887,6 +887,102 @@ class ServingChatTestCase(unittest.TestCase):
         )
         self.assertIn("<｜Assistant｜>", out)
 
+    # ------------- dsv4 continue_final_message prefill -------------
+    def _setup_dsv4_prompt_capture(self):
+        """Configure self.chat as a DSV4 server whose tokenizer echoes each char.
+
+        After setUp, the generic mock points at Llama. Switch architectures to
+        DeepseekV4ForCausalLM, then stub tokenizer.encode so prompt_ids becomes
+        a list-of-chars round-trippable via ''.join(). bos_token_id is a
+        sentinel that never appears in DSV4 output, so the BOS-strip path in
+        _append_assistant_prefix_to_prompt_ids is a no-op when exercised.
+        """
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.model_config.hf_config.architectures = ["DeepseekV4ForCausalLM"]
+        self.tm.tokenizer.encode.side_effect = lambda text, *args, **kwargs: list(text)
+        self.tm.tokenizer.bos_token_id = "\0"
+        self.chat = OpenAIServingChat(self.tm, self.template_manager)
+        self.assertEqual(self.chat.chat_encoding_spec, "dsv4")
+        self.tm.tokenizer.encode.reset_mock()
+
+    @staticmethod
+    def _dsv4_continue_request(assistant):
+        """Build a DSV4 continue_final_message request with the given assistant message."""
+        return ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Return JSON."}, assistant],
+            continue_final_message=True,
+            chat_template_kwargs={"thinking": True},
+        )
+
+    def test_dsv4_continue_final_message_prefill_closes_think_before_content(self):
+        """Thinking-mode prefill must close <think> before the visible content."""
+        self._setup_dsv4_prompt_capture()
+        req = self._dsv4_continue_request(
+            {"role": "assistant", "content": '{"answer":'}
+        )
+
+        result = self.chat._process_messages(req, is_multimodal=False)
+        prompt = "".join(result.prompt_ids)
+
+        self.assertIn('<｜Assistant｜><think></think>{"answer":', prompt)
+        self.assertNotIn('<｜Assistant｜><think>{"answer":', prompt)
+
+    def test_dsv4_continue_final_message_prefill_preserves_reasoning_content(self):
+        """Final assistant reasoning_content stays inside <think>...</think>."""
+        self._setup_dsv4_prompt_capture()
+        req = self._dsv4_continue_request(
+            {
+                "role": "assistant",
+                "reasoning_content": "Need answer as JSON.",
+                "content": '{"answer":',
+            }
+        )
+
+        result = self.chat._process_messages(req, is_multimodal=False)
+        prompt = "".join(result.prompt_ids)
+
+        self.assertIn(
+            '<｜Assistant｜><think>Need answer as JSON.</think>{"answer":',
+            prompt,
+        )
+
+    def test_dsv4_continue_final_message_prefill_uses_single_encoder_pass(self):
+        """DSV4 prefill renders in one pass — no second tokenizer.encode for the prefix."""
+        self._setup_dsv4_prompt_capture()
+        req = self._dsv4_continue_request(
+            {"role": "assistant", "content": '{"answer":'}
+        )
+
+        self.chat._process_messages(req, is_multimodal=False)
+
+        self.assertEqual(self.tm.tokenizer.encode.call_count, 1)
+
+    def test_dsv4_continue_final_message_honors_explicit_wo_eos_true(self):
+        """Client-supplied wo_eos=True on the assistant turn flows through to the encoder."""
+        self._setup_dsv4_prompt_capture()
+        req = self._dsv4_continue_request(
+            {"role": "assistant", "content": '{"answer":', "wo_eos": True}
+        )
+
+        result = self.chat._process_messages(req, is_multimodal=False)
+        prompt = "".join(result.prompt_ids)
+        self.assertIn('<｜Assistant｜><think></think>{"answer":', prompt)
+
+    def test_dsv4_continue_final_message_explicit_wo_eos_false_falls_back_to_strip(self):
+        """wo_eos=False opts out of the wo_eos render and falls back to the
+        legacy strip-and-append path (two encode calls)."""
+        self._setup_dsv4_prompt_capture()
+        req = self._dsv4_continue_request(
+            {"role": "assistant", "content": '{"answer":', "wo_eos": False}
+        )
+
+        self.chat._process_messages(req, is_multimodal=False)
+
+        # Legacy path: encoder pass + a second encode for the raw prefix.
+        self.assertEqual(self.tm.tokenizer.encode.call_count, 2)
+
     def test_streaming_abort_yields_error(self):
         """Test that an abort finish reason during streaming correctly yields an error and stops."""
         err_msg = "Aborted by scheduler"

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -970,7 +970,9 @@ class ServingChatTestCase(unittest.TestCase):
         prompt = "".join(result.prompt_ids)
         self.assertIn('<｜Assistant｜><think></think>{"answer":', prompt)
 
-    def test_dsv4_continue_final_message_explicit_wo_eos_false_falls_back_to_strip(self):
+    def test_dsv4_continue_final_message_explicit_wo_eos_false_falls_back_to_strip(
+        self,
+    ):
         """wo_eos=False opts out of the wo_eos render and falls back to the
         legacy strip-and-append path (two encode calls)."""
         self._setup_dsv4_prompt_capture()

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1390,9 +1390,7 @@ class TestReasoningParserAdvanced(CustomTestCase):
             model="test",
             messages=[
                 ChatCompletionMessageUserParam(role="user", content="Hi"),
-                ChatCompletionMessageGenericParam(
-                    role="assistant", **assistant_kwargs
-                ),
+                ChatCompletionMessageGenericParam(role="assistant", **assistant_kwargs),
             ],
             continue_final_message=True,
         )
@@ -1423,7 +1421,9 @@ class TestReasoningParserAdvanced(CustomTestCase):
         self.assertEqual(parser.detector.previous_content, "</think>")
         self.assertFalse(parser.detector._in_reasoning)
 
-    def test_continue_final_message_deepseek_v4_explicit_wo_eos_false_skips_prepend(self):
+    def test_continue_final_message_deepseek_v4_explicit_wo_eos_false_skips_prepend(
+        self,
+    ):
         """Explicit wo_eos=False routes to legacy strip-and-append, so parser must not prepend."""
         request = self._make_continue_request(content='{"answer":', wo_eos=False)
         parser = ReasoningParser("deepseek-v4", request=request)

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1428,6 +1428,11 @@ class TestReasoningParserAdvanced(CustomTestCase):
         request = self._make_continue_request(content='{"answer":', wo_eos=False)
         parser = ReasoningParser("deepseek-v4", request=request)
         self.assertEqual(parser.detector.previous_content, '{"answer":')
+        # No </think> in previous_content, so _in_reasoning must reflect
+        # the detector default (False for the DSV4/Qwen3 chain). Locks
+        # against future drift that drops the prepend but flips the
+        # default — both halves matter.
+        self.assertFalse(parser.detector._in_reasoning)
 
     def test_continue_final_message_other_models_keep_previous_content_verbatim(self):
         """Only deepseek-v4 gets the </think> prepend — other parsers unaffected."""

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1376,6 +1376,65 @@ class TestReasoningParserAdvanced(CustomTestCase):
         parser = ReasoningParser("qwen3", request=request)
         self.assertTrue(parser.detector.continue_final_message)
 
+    @staticmethod
+    def _make_continue_request(**assistant_kwargs):
+        """Build a ChatCompletionRequest with a user turn + one assistant turn
+        carrying the given kwargs, with continue_final_message=True."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionMessageGenericParam,
+            ChatCompletionMessageUserParam,
+            ChatCompletionRequest,
+        )
+
+        return ChatCompletionRequest(
+            model="test",
+            messages=[
+                ChatCompletionMessageUserParam(role="user", content="Hi"),
+                ChatCompletionMessageGenericParam(
+                    role="assistant", **assistant_kwargs
+                ),
+            ],
+            continue_final_message=True,
+        )
+
+    def test_continue_final_message_deepseek_v4_prepends_think_end(self):
+        """DSV4 prepends </think> so detector starts past the reasoning boundary."""
+        request = self._make_continue_request(content='{"answer":')
+        parser = ReasoningParser("deepseek-v4", request=request)
+        self.assertTrue(parser.detector.continue_final_message)
+        self.assertEqual(parser.detector.previous_content, '</think>{"answer":')
+        self.assertFalse(parser.detector._in_reasoning)
+
+        reasoning, normal = parser.parse_non_stream(" 5}")
+        self.assertEqual(normal, " 5}")
+        self.assertFalse(reasoning)
+
+    def test_continue_final_message_none_content_does_not_crash(self):
+        """content=None (reasoning/tool-only prefill) must not blow up len()/`in` checks."""
+        request = self._make_continue_request(reasoning_content="thinking...")
+
+        # qwen3: no DSV4 prepend, previous_content normalized to ""
+        parser = ReasoningParser("qwen3", request=request)
+        self.assertEqual(parser.detector.previous_content, "")
+        self.assertEqual(parser.detector.previous_count, 0)
+
+        # deepseek-v4: previous_content normalized then </think> prepended
+        parser = ReasoningParser("deepseek-v4", request=request)
+        self.assertEqual(parser.detector.previous_content, "</think>")
+        self.assertFalse(parser.detector._in_reasoning)
+
+    def test_continue_final_message_deepseek_v4_explicit_wo_eos_false_skips_prepend(self):
+        """Explicit wo_eos=False routes to legacy strip-and-append, so parser must not prepend."""
+        request = self._make_continue_request(content='{"answer":', wo_eos=False)
+        parser = ReasoningParser("deepseek-v4", request=request)
+        self.assertEqual(parser.detector.previous_content, '{"answer":')
+
+    def test_continue_final_message_other_models_keep_previous_content_verbatim(self):
+        """Only deepseek-v4 gets the </think> prepend — other parsers unaffected."""
+        request = self._make_continue_request(content='{"answer":')
+        parser = ReasoningParser("qwen3", request=request)
+        self.assertEqual(parser.detector.previous_content, '{"answer":')
+
     def test_force_nonempty_content_via_chat_template_kwargs(self):
         """Test that force_nonempty_content is passed via chat_template_kwargs."""
         from sglang.srt.entrypoints.openai.protocol import (


### PR DESCRIPTION
## Summary

Fix DSV4 `continue_final_message` prefill so visible-answer prefixes are rendered after the thinking boundary instead of being appended inside an open `<think>` block.

Previously, the generic continuation path removed the final assistant message and raw-appended its `content` after the DSV4 encoder had already emitted `<｜Assistant｜><think>`. For JSON-style prefills such as `{"answer":`, the generated suffix could then be classified as `reasoning_content` instead of visible `content`.

## Changes

- In `serving_chat.py`, keep the final assistant turn on the DSV4 encoder path and default it to `wo_eos=True`, so `encoding_dsv4.render_message()` emits the correct partial-assistant boundary.
- In `reasoning_parser.py`, seed DSV4 `continue_final_message` parsing with the matching `</think>` boundary and normalize `content=None` to avoid crashes for reasoning/tool-only assistant prefills.
- In `protocol.py`, expose optional assistant-message `wo_eos` so callers can explicitly keep or opt out of the DSV4 no-EOS continuation path.
- Add unit coverage for default DSV4 prefill, explicit `wo_eos=True`, explicit `wo_eos=False`, preserved `reasoning_content`, and `content=None` parser handling.

## Validation

- `PYTHONPATH=python pytest test/registered/unit/entrypoints/openai/test_serving_chat.py -q`
- `PYTHONPATH=python pytest test/registered/unit/parser/test_reasoning_parser.py -q`
- End-to-end on 4xGB300 with DeepSeek-V4-Flash served via `--tool-call-parser deepseekv4 --reasoning-parser deepseek-v4`: default and `wo_eos=True` paths return the generated suffix in `content`; explicit `wo_eos=False` reproduces the legacy behavior as an opt-out sanity check.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35703925475](https://github.com/sgl-project/sglang/actions/runs/35703925475)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35703925113](https://github.com/sgl-project/sglang/actions/runs/35703925113)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35703925384](https://github.com/sgl-project/sglang/actions/runs/35703925384)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->