### PR TITLE
[Bug Fix][HiCache] TreeNode.get_prefix_hash_values @lru_cache can return mutated list

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -22,7 +22,6 @@ The radix tree data structure for managing the hybrid (full and Mamba) KV cache.
 import heapq
 from array import array
 from collections import defaultdict
-from functools import lru_cache
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
@@ -148,7 +147,6 @@ class TreeNode:
             return None
         return self.hash_value[-1]
 
-    @lru_cache(maxsize=1)
     def get_prefix_hash_values(self, node: "TreeNode") -> List[str]:
         if node is None or node.hash_value is None:
             return []

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -28,7 +28,6 @@ import sys
 import time
 from array import array
 from collections import defaultdict
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Tuple, Union
 
 import torch
@@ -258,7 +257,6 @@ class TreeNode:
             return None
         return self.hash_value[-1]
 
-    @lru_cache(maxsize=1)
     def get_prefix_hash_values(self, node: TreeNode) -> List[str]:
         if node is None or node.hash_value is None:
             return []

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -39,6 +39,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
+from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 
 # Test constants
@@ -225,6 +226,38 @@ class TestTreeNode(unittest.TestCase):
 
         node.hash_value = ["hash1", "hash2", "hash3"]
         self.assertEqual(node.get_last_hash_value(), "hash3")
+
+    def test_get_prefix_hash_values_not_shared_across_calls(self):
+        """Regression guard for cached mutable prefix hash lists."""
+        for node_cls in (TreeNode, MambaTreeNode):
+            with self.subTest(node_cls=node_cls.__module__):
+                root = node_cls()
+                n1 = node_cls()
+                n1.parent = root
+                n1.hash_value = ["h1"]
+                n2 = node_cls()
+                n2.parent = n1
+                n2.hash_value = ["h2"]
+                n3 = node_cls()
+                n3.parent = n2
+                n3.hash_value = ["h3"]
+
+                first = n3.get_prefix_hash_values(n2)
+                self.assertEqual(first, ["h1", "h2"])
+
+                # Downstream storage code extends prefix_keys in place while
+                # processing pages. A cached list must not be observable by a
+                # later call.
+                first += ["h3"]
+
+                second = n3.get_prefix_hash_values(n2)
+                self.assertEqual(second, ["h1", "h2"])
+                self.assertIsNot(second, first)
+
+                n4 = node_cls()
+                n4.parent = n3
+                n4.hash_value = ["h4"]
+                self.assertEqual(n4.get_prefix_hash_values(n3), ["h1", "h2", "h3"])
 
     def test_lt_comparison(self):
         """Test less than comparison based on last_access_time."""


### PR DESCRIPTION
## Motivation

`TreeNode.get_prefix_hash_values` in both `radix_cache.py` and `mamba_radix_cache.py` was decorated with `@lru_cache(maxsize=1)`, but the helper returns a mutable `List[str]`.

That list can be passed as `operation.prefix_keys` into HiCache storage paths. Some of those paths extend `prefix_keys` in place while processing page batches:

```python
prefix_keys = operation.prefix_keys
...
if prefix_keys and len(prefix_keys) > 0:
    prefix_keys += batch_hashes
```

This can mutate the same list object stored by `lru_cache`. In the linear prefix-extension case, this is observable:

```text
1. n3.get_prefix_hash_values(n2) returns and caches [h1, h2].
2. A storage path extends that returned list in place with [h3].
3. A later n4.get_prefix_hash_values(n3) recursively calls n3.get_prefix_hash_values(n2).
4. If the maxsize=1 entry is still present, it reads the mutated [h1, h2, h3] and returns [h1, h2, h3, h3].
```

So the same locality that could make the cache useful can also expose the mutated cached value.

For reference, `_storage_hit_query` in `cache_controller.py` already copies `operation.prefix_keys` before its own `+=` loop, so the in-place extension pattern already coexists with `.copy()` defenses in part of this file. This change removes the underlying mutable shared state so callers no longer need to think about it.

Fixes #26173.

cc @hzh0425 (picks up the fix discussed in #26173).

## Modifications

- Remove `@lru_cache(maxsize=1)` from `TreeNode.get_prefix_hash_values` in `python/sglang/srt/mem_cache/radix_cache.py`.
- Remove the same decorator from the mamba-side `TreeNode` in `python/sglang/srt/mem_cache/mamba_radix_cache.py`.
- Drop the now-unused `from functools import lru_cache` imports.
- Add a regression test in `test/registered/unit/mem_cache/test_radix_cache_unit.py` (`TestTreeNode.test_get_prefix_hash_values_not_shared_across_calls`) that runs against both `radix_cache.TreeNode` and `mamba_radix_cache.TreeNode` via `self.subTest`. It mutates the returned list to mimic downstream `prefix_keys += batch_hashes`, then verifies later calls — including the `n4.get_prefix_hash_values(n3)` recursion that previously read the mutated cached entry — still return fresh, unpolluted prefix hash lists.

## Tests

- Ran `pre-commit run --files <the three touched files>` locally — all hooks pass.
- Ran `python3 -m compileall -q python/sglang/srt/mem_cache/radix_cache.py python/sglang/srt/mem_cache/mamba_radix_cache.py test/registered/unit/mem_cache/test_radix_cache_unit.py`.
- Focused `pytest` was not run locally because the full SGLang test/runtime dependency set is not installed in this environment. The new regression test is CPU-only and should be covered by CI.
- Verified the failure mode with a standalone repro that toggles `@lru_cache` on/off.

## Speed Tests and Profiling

N/A. This is a correctness fix. The removed cache had `maxsize=1` and only helped a narrow temporal-locality case; this helper is used for optional HiCache storage `prefix_keys`, where the cost is expected to be negligible relative to L3 storage I/O.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests.
- [ ] Update documentation as needed, including docstrings or example tutorials. (N/A)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (N/A — static correctness fix)
- [ ] For reviewer assignment, see the Reviewer Assignment Guide.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26366855971](https://github.com/sgl-project/sglang/actions/runs/26366855971)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26366855933](https://github.com/sgl-project/sglang/actions/runs/26366855933)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->