### PR TITLE
docs: fix CLI arg examples and default values in server_arguments.md

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -25,19 +25,19 @@ You can find all arguments by `python3 -m sglang.launch_server --help`
   python -m sglang.launch_server --config config.yaml
   ```
 
-- To enable multi-GPU tensor parallelism, add `--tp 2`. If it reports the error "peer access is not supported between these two devices", add `--enable-p2p-check` to the server launch command.
+- To enable multi-GPU tensor parallelism, add `--tp-size 2`. If it reports the error "peer access is not supported between these two devices", add `--enable-p2p-check` to the server launch command.
 
   ```bash
-  python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --tp 2
+  python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --tp-size 2
   ```
 
-- To enable multi-GPU data parallelism, add `--dp 2`. Data parallelism is better for throughput if there is enough memory. It can also be used together with tensor parallelism. The following command uses 4 GPUs in total. We recommend [SGLang Model Gateway (former Router)](../advanced_features/sgl_model_gateway.md) for data parallelism.
+- To enable multi-GPU data parallelism, add `--dp-size 2`. Data parallelism is better for throughput if there is enough memory. It can also be used together with tensor parallelism. The following command uses 4 GPUs in total. We recommend [SGLang Model Gateway (former Router)](../advanced_features/sgl_model_gateway.md) for data parallelism.
 
   ```bash
-  python -m sglang_router.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --dp 2 --tp 2
+  python -m sglang_router.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --dp-size 2 --tp-size 2
   ```
 
-- If you see out-of-memory errors during serving, try to reduce the memory usage of the KV cache pool by setting a smaller value of `--mem-fraction-static`. The default value is `0.9`.
+- If you see out-of-memory errors during serving, try to reduce the memory usage of the KV cache pool by setting a smaller value of `--mem-fraction-static`. The default value is computed automatically based on GPU memory capacity and model configuration.
 
   ```bash
   python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --mem-fraction-static 0.7
@@ -60,7 +60,7 @@ You can find all arguments by `python3 -m sglang.launch_server --help`
   # Node 0
   python -m sglang.launch_server \
     --model-path meta-llama/Meta-Llama-3-8B-Instruct \
-    --tp 4 \
+    --tp-size 4 \
     --dist-init-addr sgl-dev-0:50000 \
     --nnodes 2 \
     --node-rank 0
@@ -68,7 +68,7 @@ You can find all arguments by `python3 -m sglang.launch_server --help`
   # Node 1
   python -m sglang.launch_server \
     --model-path meta-llama/Meta-Llama-3-8B-Instruct \
-    --tp 4 \
+    --tp-size 4 \
     --dist-init-addr sgl-dev-0:50000 \
     --nnodes 2 \
     --node-rank 1
@@ -146,7 +146,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--prefill-delayer-max-delay-passes` | Maximum forward passes to delay prefill. | `30` | Type: int |
 | `--prefill-delayer-token-usage-low-watermark` | Token usage low watermark for prefill delayer. | `None` | Type: float |
 | `--prefill-delayer-queue-min-ratio` | Opt-in to the adaptive queue-based delay trigger (independent of the slot-based one). Defers prefill until the waiting queue reaches `min(running_req * ratio, max_prefill_bs)` so small fragments batch into a larger prefill. Unset keeps the original slot-only behavior. Typical: `0.1`–`0.5`. | `None` | Type: float |
-| `--prefill-delayer-max-delay-ms` | Wall-clock cap (ms) on a single queue-trigger delay; once exceeded, prefill is force-released to bound worst-case TTFT. Only consulted when `--prefill-delayer-queue-min-ratio` is set. Typical: `1000`–`5000`. | `5000` | Type: float |
+| `--prefill-delayer-max-delay-ms` | Wall-clock cap (ms) on a single queue-trigger delay; once exceeded, prefill is force-released to bound worst-case TTFT. Only consulted when `--prefill-delayer-queue-min-ratio` is set. Typical: `1000`–`5000`. | `None` | Type: float |
 | `--prefill-delayer-forward-passes-buckets` | Custom buckets for prefill delayer forward passes histogram. 0 and max_delay_passes-1 will be auto-added. | `None` | List[float] |
 | `--prefill-delayer-wait-seconds-buckets` | Custom buckets for prefill delayer wait seconds histogram. 0 will be auto-added. | `None` | List[float] |
 
@@ -464,7 +464,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--rl-on-policy-target` | The training system that SGLang needs to match for true on-policy. | `None` | `fsdp` |
 | `--enable-attn-tp-input-scattered` | Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent. | `False` | bool flag (set to enable) |
 | `--enable-dsa-prefill-context-parallel` | Enable context parallelism used in the long sequence prefill phase of DeepSeek v3.2. (`--enable-nsa-prefill-context-parallel` is a deprecated alias.) | `False` | bool flag (set to enable) |
-| `--dsa-prefill-cp-mode` | Token splitting mode for the prefill phase of DeepSeek v3.2 under context parallelism. Optional values: `round-robin-split`(default),`in-seq-split`. `round-robin-split` distributes tokens across ranks based on `token_idx % cp_size`. It supports multi-batch prefill, fused MoE, and FP8 KV cache. (`--nsa-prefill-cp-mode` is a deprecated alias.) | `in-seq-split` | `in-seq-split`, `round-robin-split` |
+| `--dsa-prefill-cp-mode` | Token splitting mode for the prefill phase of DeepSeek v3.2 under context parallelism. Optional values: `round-robin-split`(default),`in-seq-split`. `round-robin-split` distributes tokens across ranks based on `token_idx % cp_size`. It supports multi-batch prefill, fused MoE, and FP8 KV cache. (`--nsa-prefill-cp-mode` is a deprecated alias.) | `round-robin-split` | `in-seq-split`, `round-robin-split` |
 | `--enable-fused-qk-norm-rope` | Enable fused qk normalization and rope rotary embedding. | `False` | bool flag (set to enable) |
 | `--enable-precise-embedding-interpolation` | Enable corner alignment for resize of embeddings grid to ensure more accurate(but slower) evaluation of interpolated embedding values. | `False` | bool flag (set to enable) |
 

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -25,16 +25,16 @@ You can find all arguments by `python3 -m sglang.launch_server --help`
   python -m sglang.launch_server --config config.yaml
   ```
 
-- To enable multi-GPU tensor parallelism, add `--tp-size 2`. If it reports the error "peer access is not supported between these two devices", add `--enable-p2p-check` to the server launch command.
+- To enable multi-GPU tensor parallelism, add `--tp 2`. If it reports the error "peer access is not supported between these two devices", add `--enable-p2p-check` to the server launch command.
 
   ```bash
-  python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --tp-size 2
+  python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --tp 2
   ```
 
-- To enable multi-GPU data parallelism, add `--dp-size 2`. Data parallelism is better for throughput if there is enough memory. It can also be used together with tensor parallelism. The following command uses 4 GPUs in total. We recommend [SGLang Model Gateway (former Router)](../advanced_features/sgl_model_gateway.md) for data parallelism.
+- To enable multi-GPU data parallelism, add `--dp 2`. Data parallelism is better for throughput if there is enough memory. It can also be used together with tensor parallelism. The following command uses 4 GPUs in total. We recommend [SGLang Model Gateway (former Router)](../advanced_features/sgl_model_gateway.md) for data parallelism.
 
   ```bash
-  python -m sglang_router.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --dp-size 2 --tp-size 2
+  python -m sglang_router.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --dp 2 --tp 2
   ```
 
 - If you see out-of-memory errors during serving, try to reduce the memory usage of the KV cache pool by setting a smaller value of `--mem-fraction-static`. The default value is computed automatically based on GPU memory capacity and model configuration.
@@ -60,7 +60,7 @@ You can find all arguments by `python3 -m sglang.launch_server --help`
   # Node 0
   python -m sglang.launch_server \
     --model-path meta-llama/Meta-Llama-3-8B-Instruct \
-    --tp-size 4 \
+    --tp 4 \
     --dist-init-addr sgl-dev-0:50000 \
     --nnodes 2 \
     --node-rank 0
@@ -68,7 +68,7 @@ You can find all arguments by `python3 -m sglang.launch_server --help`
   # Node 1
   python -m sglang.launch_server \
     --model-path meta-llama/Meta-Llama-3-8B-Instruct \
-    --tp-size 4 \
+    --tp 4 \
     --dist-init-addr sgl-dev-0:50000 \
     --nnodes 2 \
     --node-rank 1


### PR DESCRIPTION
## Problem

Three concrete discrepancies between `docs/advanced_features/server_arguments.md` and the actual code in `python/sglang/srt/server_args.py`:

### 1. `--dsa-prefill-cp-mode` default column contradicts its own description text

The description text in the same cell correctly states `round-robin-split(default)`, but the **Default** column shows `in-seq-split`. The code confirms `round-robin-split` is the actual default:
```python
# server_args.py line 753
dsa_prefill_cp_mode: str = "round-robin-split"
```

### 2. `--prefill-delayer-max-delay-ms` wrong default value

The table lists a default of `5000`, but the code default is `None`:
```python
# server_args.py line 417
prefill_delayer_max_delay_ms: Optional[float] = None
```

### 3. `--mem-fraction-static` incorrectly documented as defaulting to `0.9`

The docs state "The default value is `0.9`." but the field is `Optional[float] = None` and is computed dynamically from GPU memory capacity, chunked prefill size, cuda graph buffer sizes, and model type. When GPU info is unavailable the fallback is `0.88`, not `0.9`.

## Changes

- Fix `--dsa-prefill-cp-mode` default column: `in-seq-split` → `round-robin-split`
- Fix `--prefill-delayer-max-delay-ms` default: `5000` → `None`
- Replace static "default value is `0.9`" with accurate description of dynamic computation

## Verification

All fixes cross-checked directly against `python/sglang/srt/server_args.py`:
- `dsa_prefill_cp_mode: str = "round-robin-split"` (line 753)
- `prefill_delayer_max_delay_ms: Optional[float] = None` (line 417)
- `mem_fraction_static: Optional[float] = None` (line 391), dynamic computation at lines 1526–1573, fallback `0.88` at line 1572





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26338179061](https://github.com/sgl-project/sglang/actions/runs/26338179061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26338179019](https://github.com/sgl-project/sglang/actions/runs/26338179019)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->