### PR TITLE
[Bug Fix] Add missing update_verify_buffers_to_fill_after_draft to TRTLLMHAAttnBackend

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -546,6 +546,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """Get the fill value for sequence lengths in CUDA graph."""
         return 1
 
+    def update_verify_buffers_to_fill_after_draft(
+        self, spec_info: SpecInput, cuda_graph_bs: Optional[int]
+    ):
+        pass
+
     def _should_use_fused_fp8_path(self, save_kv_cache: bool, k: torch.Tensor) -> bool:
         """Check if we should use the fused FP8 KV cache write path."""
         return save_kv_cache and k is not None and self.data_type == torch.float8_e4m3fn


### PR DESCRIPTION
## Summary
- Add missing `update_verify_buffers_to_fill_after_draft` stub method to `TRTLLMHAAttnBackend`
- The base class `AttentionBackend` defines this method and other backends (Triton, AITER) already implement it, but TRT-LLM MHA was missing it, causing errors when speculative decoding calls this method

## Test plan
- [ ] Verify TRT-LLM MHA backend works with speculative decoding without `AttributeError`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26341413379](https://github.com/sgl-project/sglang/actions/runs/26341413379)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26341413337](https://github.com/sgl-project/sglang/actions/runs/26341413337)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->