### PR TITLE
Fix min_new_tokens stop handling

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1199,10 +1199,9 @@ class Req(ReqDllmMixin):
         if self.sampling_params.ignore_eos:
             return False
 
-        # Check stop token ids
-        matched_eos = False
-
         for i, token_id in enumerate(new_accepted_tokens):
+            matched_eos = False
+            matched_pos = len(self.output_ids) - len(new_accepted_tokens) + i
             if self.sampling_params.stop_token_ids:
                 matched_eos |= token_id in self.sampling_params.stop_token_ids
             if self.eos_token_ids:
@@ -1212,14 +1211,18 @@ class Req(ReqDllmMixin):
                 if self.tokenizer.additional_stop_token_ids:
                     matched_eos |= token_id in self.tokenizer.additional_stop_token_ids
             if matched_eos:
+                if matched_pos + 1 < self.sampling_params.min_new_tokens:
+                    continue
                 self.finished_reason = FINISH_MATCHED_TOKEN(matched=token_id)
-                matched_pos = len(self.output_ids) - len(new_accepted_tokens) + i
                 self.finished_len = matched_pos + 1
                 return True
 
         return False
 
     def _check_str_based_finish(self):
+        if len(self.output_ids) < self.sampling_params.min_new_tokens:
+            return False
+
         if (
             len(self.sampling_params.stop_strs) > 0
             or len(self.sampling_params.stop_regex_strs) > 0

--- a/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
+++ b/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
@@ -3,6 +3,28 @@ import torch
 from sglang.srt.sampling.penaltylib.orchestrator import _BatchedPenalizer
 
 
+def _get_token_based_stop_ids(req):
+    stop_ids = set(req.sampling_params.stop_token_ids or ())
+
+    tokenizer = getattr(req, "tokenizer", None)
+    if tokenizer is not None:
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if eos_token_id is not None:
+            stop_ids.add(eos_token_id)
+
+        additional_stop_token_ids = getattr(
+            tokenizer, "additional_stop_token_ids", None
+        )
+        if additional_stop_token_ids:
+            stop_ids.update(additional_stop_token_ids)
+
+    eos_token_ids = getattr(req, "eos_token_ids", None)
+    if eos_token_ids:
+        stop_ids.update(eos_token_ids)
+
+    return list(stop_ids)
+
+
 class BatchedMinNewTokensPenalizer(_BatchedPenalizer):
     """
     Min new tokens penalizer penalizes tokens based on the length of the output.
@@ -25,13 +47,7 @@ class BatchedMinNewTokensPenalizer(_BatchedPenalizer):
         padded_stop_token_ids = torch.nn.utils.rnn.pad_sequence(
             sequences=[
                 torch.tensor(
-                    data=(
-                        list(
-                            (req.sampling_params.stop_token_ids or set())
-                            | (req.tokenizer.additional_stop_token_ids or set())
-                            | {req.tokenizer.eos_token_id}
-                        )
-                    ),
+                    data=_get_token_based_stop_ids(req),
                     dtype=torch.int64,
                     device=self.orchestrator.device,
                 )

--- a/python/sglang/test/test_min_new_tokens.py
+++ b/python/sglang/test/test_min_new_tokens.py
@@ -1,0 +1,137 @@
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.penaltylib.min_new_tokens import (
+    BatchedMinNewTokensPenalizer,
+)
+from sglang.srt.sampling.penaltylib.orchestrator import BatchedPenalizerOrchestrator
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+
+class FakeBatch:
+    pass
+
+
+def _sampling_params(**kwargs):
+    params = SamplingParams(**kwargs)
+    params.normalize(tokenizer=None)
+    return params
+
+
+def _req(params, *, eos_token_ids=None):
+    req = Req(
+        rid="rid",
+        origin_input_text="",
+        origin_input_ids=[1],
+        sampling_params=params,
+        eos_token_ids=eos_token_ids,
+        vocab_size=128,
+    )
+    req.tokenizer = SimpleNamespace(
+        eos_token_id=99,
+        additional_stop_token_ids=None,
+        decode=lambda ids: "stop",
+    )
+    return req
+
+
+def test_min_new_tokens_penalizer_masks_all_token_stop_sources():
+    params = _sampling_params(
+        max_new_tokens=8,
+        min_new_tokens=2,
+        stop_token_ids=[42],
+    )
+    req = SimpleNamespace(
+        sampling_params=params,
+        tokenizer=SimpleNamespace(
+            eos_token_id=43,
+            additional_stop_token_ids={44},
+        ),
+        eos_token_ids={45},
+    )
+    batch = FakeBatch()
+    batch.reqs = [req]
+    batch.device = "cpu"
+
+    orchestrator = BatchedPenalizerOrchestrator(
+        vocab_size=128,
+        batch=batch,
+        penalizers={BatchedMinNewTokensPenalizer},
+    )
+    logits = torch.zeros((1, 128), dtype=torch.float32)
+
+    orchestrator.apply(logits)
+
+    for token_id in (42, 43, 44, 45):
+        assert logits[0, token_id].item() == float("-inf")
+    assert logits[0, 46].item() == 0
+
+
+def test_update_finish_state_ignores_token_stop_before_min_new_tokens():
+    req = _req(
+        _sampling_params(
+            max_new_tokens=8,
+            min_new_tokens=2,
+            stop_token_ids=[42],
+        )
+    )
+
+    req.output_ids = [42]
+    req.update_finish_state()
+    assert req.finished_reason is None
+
+    req.output_ids.append(42)
+    req.update_finish_state()
+    assert req.finished_reason.to_json() == {"type": "stop", "matched": 42}
+    assert req.finished_len == 2
+
+
+def test_update_finish_state_skips_early_stop_inside_speculative_acceptance():
+    req = _req(
+        _sampling_params(
+            max_new_tokens=8,
+            min_new_tokens=2,
+            stop_token_ids=[42],
+        )
+    )
+
+    req.output_ids = [42, 42]
+    req.update_finish_state(new_accepted_len=2)
+
+    assert req.finished_reason.to_json() == {"type": "stop", "matched": 42}
+    assert req.finished_len == 2
+
+
+def test_update_finish_state_does_not_carry_early_stop_to_later_token():
+    req = _req(
+        _sampling_params(
+            max_new_tokens=8,
+            min_new_tokens=2,
+            stop_token_ids=[42],
+        )
+    )
+
+    req.output_ids = [42, 7]
+    req.update_finish_state(new_accepted_len=2)
+
+    assert req.finished_reason is None
+
+
+def test_update_finish_state_ignores_string_stop_before_min_new_tokens():
+    req = _req(
+        _sampling_params(
+            max_new_tokens=8,
+            min_new_tokens=2,
+            stop="stop",
+        )
+    )
+
+    req.output_ids = [7]
+    req.update_finish_state()
+    assert req.finished_reason is None
+
+    req.output_ids.append(8)
+    req.update_finish_state()
+    assert req.finished_reason.to_json() == {"type": "stop", "matched": "stop"}


### PR DESCRIPTION
## Summary
- honor `min_new_tokens` before token/EOS/additional-stop termination
- honor `min_new_tokens` before string/regex stop checks
- reset token-stop matching for each accepted token in speculative decoding batches
- include request EOS IDs in the min-new-token stop-token penalizer
- add focused unit coverage for token, speculative, and string-stop behavior

## Test
- `TORCHDYNAMO_DISABLE=1 python -m pytest python/sglang/test/test_min_new_tokens.py -q`
- `python -m py_compile python/sglang/srt/managers/schedule_batch.py python/sglang/srt/sampling/penaltylib/min_new_tokens.py python/sglang/test/test_min_new_tokens.py`
- `git diff --check upstream/main...HEAD`







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26343023747](https://github.com/sgl-project/sglang/actions/runs/26343023747)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26343023707](https://github.com/sgl-project/sglang/actions/runs/26343023707)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->