### PR TITLE
Split DP cache affinity from load balancing

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -233,6 +233,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | --- | --- | --- | --- |
 | `--data-parallel-size`<br>`--dp-size` | The data parallelism size. | `1` | Type: int |
 | `--load-balance-method` | The load balancing strategy for data parallelism. The `total_tokens` algorithm can only be used when DP attention is applied. This algorithm performs load balancing based on the real-time token load of the DP workers. | `auto` | `auto`, `round_robin`, `follow_bootstrap_room`, `total_requests`, `total_tokens` |
+| `--dp-cache-affinity` | The cache affinity strategy for data parallel dispatch. `routing_key` keeps requests with the same routing key on the same DP rank before falling back to `--load-balance-method` for new keys. | `none` | `none`, `routing_key` |
 
 ## Multi-node distributed serving
 | Argument | Description | Defaults | Options |

--- a/docs_new/docs/advanced_features/server_arguments.mdx
+++ b/docs_new/docs/advanced_features/server_arguments.mdx
@@ -982,6 +982,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>` auto`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>` auto`, `round_robin`, `follow_bootstrap_room`, `total_requests`, `total_tokens`</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>` --dp-cache-affinity`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The cache affinity strategy for data parallel dispatch. `routing_key` keeps requests with the same routing key on the same DP rank before falling back to `--load-balance-method` for new keys.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>` none`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>` none`, `routing_key`</td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -395,6 +395,7 @@ class CommonKVManager(BaseKVManager):
             "page_size": self.kv_args.page_size,
             "kv_cache_dtype": self.server_args.kv_cache_dtype,
             "load_balance_method": self.server_args.load_balance_method,
+            "dp_cache_affinity": self.server_args.dp_cache_affinity,
         }
 
         max_retries, initial_delay, max_delay = 5, 1.0, 30.0
@@ -531,10 +532,9 @@ class CommonKVManager(BaseKVManager):
         """
         start_layer = self.kv_args.prefill_start_layer
         end_layer = getattr(self.kv_args, "prefill_end_layer", None)
-        assert end_layer is not None, (
-            "KVArgs.prefill_end_layer must be set when using "
-            "compressed-MLA PD with PP"
-        )
+        assert (
+            end_layer is not None
+        ), "KVArgs.prefill_end_layer must be set when using compressed-MLA PD with PP"
 
         c4_full = sum(1 for r in mla_ratios if r == 4)
         c128_full = sum(1 for r in mla_ratios if r == 128)
@@ -711,7 +711,10 @@ class CommonKVSender(BaseKVSender):
 
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
         if self.kv_mgr.server_args.dp_size > 1:
-            if self.kv_mgr.server_args.load_balance_method != "follow_bootstrap_room":
+            if (
+                self.kv_mgr.server_args.load_balance_method != "follow_bootstrap_room"
+                or self.kv_mgr.server_args.dp_cache_affinity != "none"
+            ):
                 self._register_prefill_dp_rank()
             elif (
                 self.kv_mgr.attn_dp_rank
@@ -1185,7 +1188,11 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             load_balance_method = data.get(
                 "load_balance_method", "follow_bootstrap_room"
             )
-            self.follow_bootstrap_room = load_balance_method == "follow_bootstrap_room"
+            dp_cache_affinity = data.get("dp_cache_affinity", "none")
+            self.follow_bootstrap_room = (
+                load_balance_method == "follow_bootstrap_room"
+                and dp_cache_affinity == "none"
+            )
 
         if system_dp_size == 1:
             dp_group = attn_dp_rank

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -86,6 +86,21 @@ class LoadBalanceMethod(Enum):
             raise ValueError(f"Invalid load balance method: {method}") from exc
 
 
+class DPCacheAffinityMethod(Enum):
+    """DP cache affinity method."""
+
+    NONE = auto()
+    ROUTING_KEY = auto()
+
+    @classmethod
+    def from_str(cls, method: str):
+        method = method.upper()
+        try:
+            return cls[method]
+        except KeyError as exc:
+            raise ValueError(f"Invalid DP cache affinity method: {method}") from exc
+
+
 class DPBudget:
     def __init__(self, dp_size: int):
         self.dp_size = dp_size
@@ -117,6 +132,10 @@ class DPBudget:
         self.total_tokens[target_rank] += estimated_tokens
         return target_rank
 
+    def record_dispatch(self, dp_rank: int, estimated_tokens: int = 0):
+        self.total_requests[dp_rank] += 1
+        self.total_tokens[dp_rank] += estimated_tokens
+
 
 class DataParallelController:
     """A controller that dispatches requests to multiple data parallel workers."""
@@ -132,6 +151,9 @@ class DataParallelController:
         self.port_args = port_args
         self.load_balance_method = LoadBalanceMethod.from_str(
             server_args.load_balance_method
+        )
+        self.dp_cache_affinity_method = DPCacheAffinityMethod.from_str(
+            server_args.dp_cache_affinity
         )
         self.run_scheduler_process_func = run_scheduler_process_func
 
@@ -154,6 +176,7 @@ class DataParallelController:
 
         # Load balance budget
         self.dp_budget = DPBudget(server_args.dp_size)
+        self.routing_key_to_dp_rank: dict[str, int] = {}
 
         # To protect changing env vars to set CUDA_VISIBLE_DEVICES.
         self.env_lock = threading.Lock()
@@ -565,18 +588,62 @@ class DataParallelController:
             return True
         return False
 
+    def is_healthy_rank(self, dp_rank: int):
+        return 0 <= dp_rank < len(self.workers) and self.status[dp_rank]
+
+    def dispatch_with_cache_affinity(self, req: Req, select_base_rank: Callable):
+        target_rank = self.get_cache_affinity_rank(req)
+        if target_rank is None:
+            target_rank = select_base_rank(req)
+            self.remember_cache_affinity_rank(req, target_rank)
+        else:
+            estimated_tokens = (
+                len(req.input_ids)
+                if self.load_balance_method == LoadBalanceMethod.TOTAL_TOKENS
+                else 0
+            )
+            self.dp_budget.record_dispatch(target_rank, estimated_tokens)
+
+        self.workers[target_rank].send_pyobj(req)
+
+    def get_cache_affinity_rank(self, req: Req):
+        if self.dp_cache_affinity_method == DPCacheAffinityMethod.NONE:
+            return None
+
+        if (
+            self.dp_cache_affinity_method == DPCacheAffinityMethod.ROUTING_KEY
+            and req.routing_key
+        ):
+            target_rank = self.routing_key_to_dp_rank.get(req.routing_key)
+            if target_rank is None:
+                return None
+            if self.is_healthy_rank(target_rank):
+                return target_rank
+            del self.routing_key_to_dp_rank[req.routing_key]
+
+        return None
+
+    def remember_cache_affinity_rank(self, req: Req, target_rank: int):
+        if self.dp_cache_affinity_method != DPCacheAffinityMethod.ROUTING_KEY:
+            return
+        if req.routing_key:
+            self.routing_key_to_dp_rank[req.routing_key] = target_rank
+
     def round_robin_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
 
+        self.dispatch_with_cache_affinity(req, self.select_round_robin_rank)
+
+    def select_round_robin_rank(self, req: Req):
         while True:
             if self.status[self.round_robin_counter]:
                 logger.debug(f"Choose worker {self.round_robin_counter}")
-                self.workers[self.round_robin_counter].send_pyobj(req)
+                target_rank = self.round_robin_counter
                 self.round_robin_counter = (self.round_robin_counter + 1) % len(
                     self.workers
                 )
-                break
+                return target_rank
             self.round_robin_counter = (self.round_robin_counter + 1) % len(
                 self.workers
             )
@@ -585,27 +652,33 @@ class DataParallelController:
         if self.maybe_external_dp_rank_routing(req):
             return
 
+        self.dispatch_with_cache_affinity(req, self.select_follow_bootstrap_room_rank)
+
+    def select_follow_bootstrap_room_rank(self, req: Req):
         assert req.bootstrap_room is not None, (
             "req.bootstrap_room should not be None. Do not send requests directly to "
             "prefill or decode instances; send to the router instead."
         )
-        target_rank = req.bootstrap_room % len(self.workers)
-        self.workers[target_rank].send_pyobj(req)
+        return req.bootstrap_room % len(self.workers)
 
     def total_requests_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
-        target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
-        self.workers[target_worker].send_pyobj(req)
+        self.dispatch_with_cache_affinity(req, self.select_total_requests_rank)
+
+    def select_total_requests_rank(self, req: Req):
+        return self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
 
     def total_tokens_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
+        self.dispatch_with_cache_affinity(req, self.select_total_tokens_rank)
+
+    def select_total_tokens_rank(self, req: Req):
         estimated_tokens = len(req.input_ids)
-        target_worker = self.dp_budget.dispatch(
+        return self.dp_budget.dispatch(
             LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
         )
-        self.workers[target_worker].send_pyobj(req)
 
     def event_loop(self):
         while True:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -499,6 +499,7 @@ class ServerArgs:
     # Data parallelism
     dp_size: int = 1
     load_balance_method: str = "auto"
+    dp_cache_affinity: str = "none"
 
     attn_cp_size: int = 1
     moe_dp_size: int = 1
@@ -5238,6 +5239,7 @@ class ServerArgs:
         # Data parallelism
         parser.add_argument(
             "--data-parallel-size",
+            "--dp",
             "--dp-size",
             type=int,
             default=ServerArgs.dp_size,
@@ -5254,6 +5256,16 @@ class ServerArgs:
                 "follow_bootstrap_room",
                 "total_requests",
                 "total_tokens",
+            ],
+        )
+        parser.add_argument(
+            "--dp-cache-affinity",
+            type=str,
+            default=ServerArgs.dp_cache_affinity,
+            help="The cache affinity strategy for data parallel dispatch.",
+            choices=[
+                "none",
+                "routing_key",
             ],
         )
         parser.add_argument(

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -165,6 +165,8 @@ class TestRegisterToBootstrap(CustomTestCase):
             "rank_port",
             "page_size",
             "kv_cache_dtype",
+            "load_balance_method",
+            "dp_cache_affinity",
         ]
         for field in required_fields:
             self.assertIn(field, payload)
@@ -218,6 +220,7 @@ class TestRegisterToBootstrap(CustomTestCase):
         mgr.server_args = MagicMock()
         mgr.server_args.kv_cache_dtype = "auto"
         mgr.server_args.load_balance_method = "follow_bootstrap_room"
+        mgr.server_args.dp_cache_affinity = "none"
 
         return mgr
 

--- a/test/registered/unit/managers/test_dp_budget.py
+++ b/test/registered/unit/managers/test_dp_budget.py
@@ -8,13 +8,19 @@ retested here — it's covered by DP balance integration tests.
 
 import dataclasses
 import unittest
+from types import SimpleNamespace
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.data_parallel_controller import DPBudget
+from sglang.srt.managers.data_parallel_controller import (
+    DataParallelController,
+    DPBudget,
+    DPCacheAffinityMethod,
+    LoadBalanceMethod,
+)
 from sglang.srt.managers.io_struct import GetLoadsReqOutput, WatchLoadUpdateReq
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
@@ -85,6 +91,85 @@ class TestDPBudgetUpdateBudget(CustomTestCase):
         )
         self.assertEqual(budget.total_requests, [10, 2, 30])
         self.assertEqual(budget.total_tokens, [100, 50, 300])
+
+
+class FakeWorker:
+    def __init__(self):
+        self.reqs = []
+
+    def send_pyobj(self, req):
+        self.reqs.append(req)
+
+
+def _controller(method=LoadBalanceMethod.TOTAL_TOKENS):
+    controller = DataParallelController.__new__(DataParallelController)
+    controller.workers = [FakeWorker(), FakeWorker()]
+    controller.status = [True, True]
+    controller.round_robin_counter = 0
+    controller.dp_budget = DPBudget(dp_size=2)
+    controller.load_balance_method = method
+    controller.dp_cache_affinity_method = DPCacheAffinityMethod.ROUTING_KEY
+    controller.routing_key_to_dp_rank = {}
+    return controller
+
+
+def _req(
+    routing_key=None,
+    routed_dp_rank=None,
+    bootstrap_room=0,
+    input_ids=None,
+):
+    return SimpleNamespace(
+        routing_key=routing_key,
+        routed_dp_rank=routed_dp_rank,
+        bootstrap_room=bootstrap_room,
+        input_ids=input_ids or [1],
+    )
+
+
+class TestDPRoutingKeyCacheAffinity(CustomTestCase):
+    def test_same_routing_key_routes_to_same_dp_rank(self):
+        controller = _controller()
+        controller.dp_budget.total_tokens = [10, 0]
+
+        controller.total_tokens_scheduler(_req(routing_key="session-a", input_ids=[1]))
+        controller.dp_budget.total_tokens = [0, 10]
+        controller.total_tokens_scheduler(_req(routing_key="session-a", input_ids=[2]))
+
+        self.assertEqual([len(w.reqs) for w in controller.workers], [0, 2])
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 1)
+
+    def test_new_routing_keys_use_base_load_balancer(self):
+        controller = _controller()
+        controller.dp_budget.total_tokens = [10, 0]
+        controller.total_tokens_scheduler(_req(routing_key="session-a"))
+
+        controller.dp_budget.total_tokens = [0, 10]
+        controller.total_tokens_scheduler(_req(routing_key="session-b"))
+
+        self.assertEqual([len(w.reqs) for w in controller.workers], [1, 1])
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 1)
+        self.assertEqual(controller.routing_key_to_dp_rank["session-b"], 0)
+
+    def test_missing_routing_key_falls_back_to_base_load_balancer(self):
+        controller = _controller()
+        controller.dp_budget.total_tokens = [10, 0]
+
+        controller.total_tokens_scheduler(_req())
+
+        self.assertEqual([len(w.reqs) for w in controller.workers], [0, 1])
+        self.assertEqual(controller.routing_key_to_dp_rank, {})
+
+    def test_routed_dp_rank_overrides_cache_affinity(self):
+        controller = _controller()
+        controller.routing_key_to_dp_rank["session-a"] = 0
+
+        controller.total_tokens_scheduler(
+            _req(routing_key="session-a", routed_dp_rank=1)
+        )
+
+        self.assertEqual([len(w.reqs) for w in controller.workers], [0, 1])
+        self.assertEqual(controller.routing_key_to_dp_rank["session-a"], 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -48,6 +48,25 @@ class TestLoadBalanceMethod(unittest.TestCase):
         server_args = ServerArgs(model_path="dummy", disaggregation_mode="decode")
         self.assertEqual(server_args.load_balance_method, "round_robin")
 
+    def test_dp_cache_affinity_defaults_to_none(self):
+        server_args = ServerArgs(model_path="dummy")
+        self.assertEqual(server_args.dp_cache_affinity, "none")
+
+    def test_dp_shorthand_works_with_dp_cache_affinity_flag(self):
+        server_args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--dp",
+                "2",
+                "--dp-cache-affinity",
+                "routing_key",
+            ]
+        )
+
+        self.assertEqual(server_args.dp_size, 2)
+        self.assertEqual(server_args.dp_cache_affinity, "routing_key")
+
     def test_pd_decode_radix_cache_rejects_hisparse(self):
         with self.assertRaises(ValueError) as context:
             ServerArgs(
@@ -126,7 +145,6 @@ class TestPortArgs(unittest.TestCase):
         self.assertIsInstance(port_args.nccl_port, int)
 
     def test_init_new_with_single_node_dp_attention(self):
-
         server_args = ServerArgs(model_path="dummy")
         server_args.port = 30000
         server_args.nccl_port = None


### PR DESCRIPTION
## Summary
- add `--dp-cache-affinity routing_key` as an optional DP dispatch override layered on top of `--load-balance-method`
- keep explicit `routed_dp_rank` routing highest priority
- make PD prefill/decode rank discovery use the existing bootstrap rank query path when cache affinity can override `follow_bootstrap_room`
- document the new flag in both server argument docs

Fixes #26066

## Tests
- `python -m py_compile python/sglang/srt/managers/data_parallel_controller.py python/sglang/srt/server_args.py python/sglang/srt/disaggregation/common/conn.py test/registered/unit/managers/test_dp_budget.py test/registered/unit/server_args/test_server_args.py test/registered/unit/disaggregation/test_register_to_bootstrap.py`
- Runpod B200 pod: `CUDA_VISIBLE_DEVICES=9 PYTHONPATH=python pytest test/registered/unit/managers/test_dp_budget.py test/registered/unit/server_args/test_server_args.py test/registered/unit/disaggregation/test_register_to_bootstrap.py -q` -> 68 passed, 4 subtests passed























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26346277063](https://github.com/sgl-project/sglang/actions/runs/26346277063)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26346277029](https://github.com/sgl-project/sglang/actions/runs/26346277029)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->