### PR TITLE
Fix vllm import robustness in fp8_kernel and marlin_utils

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -90,8 +90,11 @@ if _is_hip:
             import vllm._C  # noqa: F401
 
             _has_vllm = True
-        except ImportError:
-            # Fallback: vllm not available, will use native PyTorch implementation
+        except (ImportError, OSError, RuntimeError):
+            # ImportError: vllm._C not installed.
+            # OSError: shared library (.so) failed to load (e.g., CUDA version mismatch).
+            # RuntimeError: custom ops initialization failed.
+            # Catching bare Exception would mask programming errors.
             _has_vllm = False
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -34,10 +34,27 @@ if TYPE_CHECKING:
 
 from sglang.srt.compilation.piecewise_context_manager import get_forward_context
 
-try:
-    from vllm import _custom_ops as ops
-except ImportError:
-    ops = None
+ops = None  # vllm._custom_ops loaded lazily on first use
+
+_vllm_ops_loaded = False
+
+
+def _get_vllm_ops():
+    """Lazy-load vllm._custom_ops to avoid crash on incompatible vllm builds."""
+    global ops, _vllm_ops_loaded
+    if not _vllm_ops_loaded:
+        _vllm_ops_loaded = True
+        try:
+            from vllm import _custom_ops as _ops
+
+            ops = _ops
+        except (ImportError, OSError, RuntimeError):
+            # ImportError: vllm not installed.
+            # OSError: shared library (.so) failed to load (e.g., CUDA version mismatch).
+            # RuntimeError: custom ops initialization failed.
+            # Catching bare Exception would mask programming errors.
+            ops = None
+    return ops
 
 
 _is_cuda = is_cuda()
@@ -848,7 +865,13 @@ class MarlinLinearMethod(LinearMethodBase):
         size_k = x_2d.shape[1]
         size_n = scales.shape[1]
 
-        output_2d = ops.marlin_gemm(
+        _ops = _get_vllm_ops()
+        if _ops is None:
+            raise RuntimeError(
+                "marlin_gemm requires vllm._custom_ops, but vllm is not installed "
+                "or its custom ops could not be loaded."
+            )
+        output_2d = _ops.marlin_gemm(
             x_2d, qweight, scales, workspace, size_m, size_n, size_k
         )
 

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -43,7 +43,6 @@ def _get_vllm_ops():
     """Lazy-load vllm._custom_ops to avoid crash on incompatible vllm builds."""
     global ops, _vllm_ops_loaded
     if not _vllm_ops_loaded:
-        _vllm_ops_loaded = True
         try:
             from vllm import _custom_ops as _ops
 
@@ -54,6 +53,7 @@ def _get_vllm_ops():
             # RuntimeError: custom ops initialization failed.
             # Catching bare Exception would mask programming errors.
             ops = None
+        _vllm_ops_loaded = True
     return ops
 
 


### PR DESCRIPTION
## Problem

Both `fp8_kernel.py` and `marlin_utils.py` catch only `ImportError` when loading `vllm._C` / `vllm._custom_ops`. On systems where vllm is installed but built against a different CUDA version (a common scenario in multi-framework environments), the import raises:

- `OSError`: shared library (`.so`) fails to load due to CUDA version mismatch
- `RuntimeError`: custom ops initialization fails

These exceptions propagate as unhandled errors at module import time, crashing the process even when vllm is not needed for the current workload.

## Changes

**`fp8_kernel.py`**
- Extend `except ImportError` → `except (ImportError, OSError, RuntimeError)`
- Improve inline comment to explain each exception type

**`marlin_utils.py`**
- Convert eager top-level import to a lazy `_get_vllm_ops()` helper, deferring the import attempt until `MarlinLinearMethod.apply` is actually called
- Extend except clause to `(ImportError, OSError, RuntimeError)`
- Raise `RuntimeError` with an actionable message if `marlin_gemm` is called without vllm available, rather than `AttributeError: 'NoneType' object has no attribute 'marlin_gemm'`

## Why not catch bare Exception

Catching `Exception` would mask programming errors (e.g., `NameError`, `TypeError`) that indicate real bugs. The three specific exception types cover all known failure modes for shared library loading.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26358974932](https://github.com/sgl-project/sglang/actions/runs/26358974932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26358974911](https://github.com/sgl-project/sglang/actions/runs/26358974911)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->