### PR TITLE
[RL] bf16 flashinfer_trtllm weight update fix

### DIFF
--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -268,6 +268,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
+            # Cached permutation indices live outside model parameters/buffers; after
+            # memory-saver offload/onload without CPU backup they must be rebuilt.
+            self._cache_permute_indices.clear()
+
             from flashinfer.fused_moe.core import (
                 _maybe_get_cached_w3_w1_permute_indices,
                 convert_to_block_layout,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -353,10 +353,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         block layout. During weight update, checkpoint tensors are in
         canonical layout and need a temporary shape restore for copy.
         """
-        backend = get_moe_runner_backend()
-        if not (
-            backend.is_flashinfer_trtllm_routed() or backend.is_flashinfer_trtllm()
-        ):
+        if not self.use_flashinfer_trtllm_moe:
             return
 
         expected_shape = None

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -353,7 +353,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
         block layout. During weight update, checkpoint tensors are in
         canonical layout and need a temporary shape restore for copy.
         """
-        if not get_moe_runner_backend().is_flashinfer_trtllm_routed():
+        backend = get_moe_runner_backend()
+        if not (
+            backend.is_flashinfer_trtllm_routed() or backend.is_flashinfer_trtllm()
+        ):
             return
 
         expected_shape = None


### PR DESCRIPTION
## Fix BF16 FlashInfer TRTLLM MoE Colocated Weight Update


 Fix colocated BF16 Qwen3 MoE weight update on B200 with FlashInfer TRTLLM MoE backends.

Depends on: https://github.com/sgl-project/sglang/pull/24657

  ### Reproduction

  Reproduces with:

  - Hardware: B200
  - Precision: BF16
  - MoE backend: `flashinfer_trtllm` or `flashinfer_trtllm_routed`
  - Runtime: colocated SGLang + Megatron weight update
  - Parallelism: tp = pp = ep = 1
  - Flow:

  ```text
  offload_weights -> onload_weights -> update_weights_from_tensor -> post_process_weights
  ```

  ### Root Cause

  There were two BF16 FlashInfer TRTLLM MoE issues:

  1. The non-routed `flashinfer_trtllm` backend skipped BF16 shape restore during online weight update, leaving expert params in 4-D
  block layout while incoming tensors were canonical BF16 checkpoint tensors. This could fail with shape errors like:

  ```text
  The size of tensor a (64) must match the size of tensor b (2048)
  ```

  2. BF16 MoE repacking reused cached GPU permutation indices. After torch-memory-saver offload/onload without CPU backup, those cache tensors can be stale because they live outside model parameters/buffers, producing incorrect expert weights.

broken:
```
snapshot -> reset -> offload weights -> offload kv -> onload weights
 -> IPC weight update -> post_process_weights -> compare -> onload kv
```  

not broken:
```
snapshot -> reset -> IPC weight update -> post_process_weights -> compare -> onload kv
```
