### PR TITLE
[SRT] fix flashInfer allreduce fusion not used on blackwell

### DIFF
--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -1,4 +1,5 @@
 import contextlib
+import inspect
 import logging
 import platform
 from typing import Optional, Tuple
@@ -30,6 +31,9 @@ logger = logging.getLogger(__name__)
 _flashinfer_comm = None
 _TorchDistBackend = None
 _flashinfer_allreduce_unavailable = False
+_flashinfer_create_workspace_supports_group = False
+_flashinfer_create_workspace_supports_comm_backend = False
+_flashinfer_allreduce_supports_trigger_completion = False
 _posix_transport_override_logged = False
 
 
@@ -106,6 +110,17 @@ if is_flashinfer_available():
             comm, "create_allreduce_fusion_workspace"
         ):
             _flashinfer_comm = comm
+            workspace_params = inspect.signature(
+                comm.create_allreduce_fusion_workspace
+            ).parameters
+            allreduce_params = inspect.signature(comm.allreduce_fusion).parameters
+            _flashinfer_create_workspace_supports_group = "group" in workspace_params
+            _flashinfer_create_workspace_supports_comm_backend = (
+                "comm_backend" in workspace_params
+            )
+            _flashinfer_allreduce_supports_trigger_completion = (
+                "trigger_completion_at_end" in allreduce_params
+            )
         else:
             _flashinfer_allreduce_unavailable = True
             logger.warning(
@@ -383,14 +398,15 @@ class FlashInferWorkspaceManager:
                 hidden_dim=hidden_dim,
                 dtype=dtype,
                 force_oneshot_support=bool(use_oneshot),
-                # Pin the symmetric-memory rendezvous to the actual
-                # subgroup. Without this, flashinfer >=0.6.10 falls back
-                # to WORLD and TP/EP/CP subgroup peers get addressed
-                # incorrectly (kernel hangs in cuda-graph warmup).
-                group=device_group,
             )
+            create_workspace = _flashinfer_comm.create_allreduce_fusion_workspace
+            if _flashinfer_create_workspace_supports_group:
+                # Pin the symmetric-memory rendezvous to the actual subgroup.
+                # Older FlashInfer releases only support comm_backend.
+                kwargs["group"] = device_group
             if (
                 _TorchDistBackend is not None
+                and _flashinfer_create_workspace_supports_comm_backend
                 and device_group is not None
                 and cpu_group is not None
             ):
@@ -398,9 +414,7 @@ class FlashInferWorkspaceManager:
                     device_group=device_group, cpu_group=cpu_group
                 )
             with _flashinfer_posix_fd_transport_override_if_needed():
-                self.workspace = _flashinfer_comm.create_allreduce_fusion_workspace(
-                    **kwargs
-                )
+                self.workspace = create_workspace(**kwargs)
         except Exception as e:
             _flashinfer_allreduce_unavailable = True
             logger.warning(
@@ -669,12 +683,11 @@ def flashinfer_allreduce_residual_rmsnorm(
     norm_out = torch.empty_like(input_tensor)
 
     workspace_manager = _get_workspace_manager(use_attn_tp_group)
-    _flashinfer_comm.allreduce_fusion(
+    kwargs = dict(
         input=input_tensor,
         workspace=workspace_manager.workspace,
         pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
         launch_with_pdl=True,
-        trigger_completion_at_end=trigger_completion_at_end,
         residual_out=residual_out,
         norm_out=norm_out,
         residual_in=residual,
@@ -683,6 +696,9 @@ def flashinfer_allreduce_residual_rmsnorm(
         use_oneshot=use_oneshot,
         fp32_acc=fp32_acc,
     )
+    if _flashinfer_allreduce_supports_trigger_completion:
+        kwargs["trigger_completion_at_end"] = trigger_completion_at_end
+    _flashinfer_comm.allreduce_fusion(**kwargs)
 
     return norm_out, residual_out
 


### PR DESCRIPTION
## Summary

- Detect FlashInfer allreduce-fusion API capabilities before passing version-specific kwargs.
- Keep subgroup rendezvous on newer FlashInfer while allowing older builds to use comm-backend-only workspace creation.

## Analysis

It fixes the TP8 runtime communication path used by the Qwen3.5 397B Blackwell benchmark.

In the tested B200 environment, SGLang was launched with `--enable-flashinfer-allreduce-fusion`, but the installed FlashInfer build rejected newer kwargs such as `group` and `trigger_completion_at_end`. SGLang then logged the error and disabled FlashInfer allreduce fusion, so the benchmark was not actually exercising the requested fusion path.

This PR checks the installed FlashInfer signatures once and only passes supported kwargs. Newer FlashInfer keeps subgroup rendezvous; older builds keep using allreduce fusion instead of silently falling back.

Latency distribution after this change shows that the remaining OCRBench TTFT gap vs vLLM is mostly first-serving-batch/cold runtime, not the gRPC preprocessed-pixel path: SGLang OCRBench first 100 requests average about 6.36s TTFT, while later requests average about 1.66s. The same-env vLLM run is about 3.91s / 3.55s for the same split. Text-only is still a separate baseline gap where SGLang remains slower than vLLM.

## Benchmark Results

Qwen3.5 397B FP8, TP8, B200, SMG gRPC, cuda-ipc enabled, `limit=200`, `concurrency=100`, `max_tokens=5`. Baseline includes the gRPC preprocessed-input hash/dispatch PR (#26105); this PR is measured on top.

| Scenario | Baseline TTFT mean | This PR TTFT mean | Change |
| --- | ---: | ---: | ---: |
| ocrbench-text | 1.037s | 0.690s | -33.5% |
| synthetic-text | 0.807s | 0.685s | -15.1% |
| ocrbench | 4.111s | 4.010s | -2.5% |

Same-env vLLM reference: OCRBench TTFT mean is 3.730s, E2E is 4.057s. With this PR SGLang is still slower on OCRBench TTFT at 4.010s, but close on E2E at 4.099s and faster on TPOT at 0.0165s vs vLLM 0.0773s.

## Tests

- `uvx ruff@0.15.1 check --select=F401,F821 --fix python/sglang/srt/layers/flashinfer_comm_fusion.py`
- `uvx black==26.1.0 --check python/sglang/srt/layers/flashinfer_comm_fusion.py`
- `pre-commit run --files python/sglang/srt/layers/flashinfer_comm_fusion.py`





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26351895714](https://github.com/sgl-project/sglang/actions/runs/26351895714)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26351895662](https://github.com/sgl-project/sglang/actions/runs/26351895662)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->