### PR TITLE
Support mixed chunk prefill with EAGLE spec v2

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -291,11 +291,11 @@ def _handle_eagle_family(server_args: "ServerArgs") -> None:
             "Spec v2 is enabled by default for eagle/eagle3/standalone speculative decoding."
         )
 
-    if server_args.enable_mixed_chunk:
+    if server_args.enable_mixed_chunk and server_args.disable_overlap_schedule:
         server_args.enable_mixed_chunk = False
         logger.warning(
             "Mixed chunked prefill is disabled because of using "
-            "eagle speculative decoding."
+            "eagle speculative decoding without spec v2."
         )
 
     model_arch = server_args.get_model_config().hf_config.architectures[0]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2190,25 +2190,41 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req.fill_ids = req.origin_input_ids + req.output_ids
             req.set_extend_input_len(1)
 
-        input_ids = torch.cat([self.input_ids, running_batch.input_ids])
-        out_cache_loc = torch.cat([self.out_cache_loc, running_batch.out_cache_loc])
+        running_prefix_lens = [
+            len(req.origin_input_ids)
+            + len(req.output_ids)
+            + (0 if self.enable_overlap else -1)
+            for req in running_batch.reqs
+        ]
+        running_input_ids = torch.tensor(
+            [
+                req.output_ids[-1] if len(req.output_ids) else req.origin_input_ids[-1]
+                for req in running_batch.reqs
+            ],
+            dtype=torch.int64,
+            device=self.device,
+        )
+        if running_batch.is_spec_v2:
+            running_prefix_lens_tensor = torch.tensor(
+                running_prefix_lens, dtype=torch.int64, device=self.device
+            )
+            running_out_cache_loc = running_batch.req_to_token_pool.req_to_token[
+                running_batch.req_pool_indices, running_prefix_lens_tensor
+            ]
+        else:
+            running_out_cache_loc = running_batch.out_cache_loc
+        input_ids = torch.cat([self.input_ids, running_input_ids])
+        out_cache_loc = torch.cat([self.out_cache_loc, running_out_cache_loc])
 
         self.merge_batch(running_batch)
         self.input_ids = input_ids
         self.out_cache_loc = out_cache_loc
 
-        # For overlap scheduler, the output_ids has one step delay
-        delta = 0 if self.enable_overlap else -1
-
         # NOTE: prefix_indices is what has been cached, but we don't cache each decode step
-        self.prefix_lens.extend(
-            [
-                len(r.origin_input_ids) + len(r.output_ids) + delta
-                for r in running_batch.reqs
-            ]
-        )
+        self.prefix_lens.extend(running_prefix_lens)
         self.extend_lens.extend([1] * running_bs)
         self.extend_num_tokens += running_bs
+        assert len(self.input_ids) == len(self.out_cache_loc) == self.extend_num_tokens
         # TODO (lianmin): Revisit this. It should be seq_len - 1
         self.extend_logprob_start_lens.extend([0] * running_bs)
         self.is_prefill_only = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7064,9 +7064,15 @@ class ServerArgs:
 
         # Check speculative decoding
         if self.speculative_algorithm is not None:
+            mixed_chunk_supported = (
+                self.speculative_algorithm in ("EAGLE", "EAGLE3", "STANDALONE")
+                and self.speculative_eagle_topk == 1
+                and not self.disable_overlap_schedule
+                and envs.SGLANG_ENABLE_SPEC_V2.get()
+            )
             assert (
-                not self.enable_mixed_chunk
-            ), "enable_mixed_chunk is required for speculative decoding"
+                not self.enable_mixed_chunk or mixed_chunk_supported
+            ), "enable_mixed_chunk with speculative decoding requires EAGLE spec v2 topk=1"
 
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).


### PR DESCRIPTION
## Summary

This draft PR enables `--enable-mixed-chunk` for EAGLE/EAGLE3 spec-v2 under the safe constraints:

- speculative algorithm is `EAGLE`, `EAGLE3`, or `STANDALONE`
- `speculative_eagle_topk == 1`
- overlap schedule is enabled
- `SGLANG_ENABLE_SPEC_V2=1`

It also fixes the underlying mixed-chunk + spec-v2/EAGLE crash by using one decode token/cache location per running request when mixing running decode requests into a prefill batch.

## Root Cause

The previous compatibility hook disabled mixed chunk whenever EAGLE was enabled. When forced on, `ScheduleBatch.mix_with_running()` reused `running_batch.out_cache_loc` for spec-v2 running batches.

In EAGLE/spec-v2 that tensor can contain multi-token speculative cache locations, while mixed chunk only forwards one decode token per running request. This can produce stale shape/cache-location mismatches.

The fix constructs `running_input_ids` directly from each running request's last token and gathers exactly one `running_out_cache_loc` per request from `req_to_token_pool` at the running prefix length.

## Validation

Ran on isolated 2x B200 RunPod with:

- model: `Qwen/Qwen3-8B`
- draft: `Tengyunw/qwen3_8b_eagle3`
- tp=2
- EAGLE3 `3/1/4`
- synthetic burst: 32 requests, 16 workers

Checks:

- `python -m py_compile` over changed modules -> OK
- `git diff --check` -> OK
- passing benchmark logs checked for `ERROR|Traceback|AssertionError|RuntimeError` -> none

Heavier prefill test, ~3k prompt tokens/request, fixed EAGLE3 `3/1/4`:

| config | avg prompt tok/s | p50 TTFT | p95 TTFT |
| --- | ---: | ---: | ---: |
| mixed chunk off | 30.1k | 1018 ms | 1516 ms |
| mixed chunk on | 37.5k | 999 ms | 1091 ms |

That is roughly +24.6% prompt throughput in this setup, with a better p95 TTFT.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26354894408](https://github.com/sgl-project/sglang/actions/runs/26354894408)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26354894315](https://github.com/sgl-project/sglang/actions/runs/26354894315)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->