### PR TITLE
Add scheduler-pressure adaptive EAGLE mode

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2343,6 +2343,8 @@ class Scheduler(
             if self.running_batch.is_empty():
                 self.running_batch.batch_is_full = False
 
+        self._maybe_update_speculative_pressure()
+
         if self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm()
         else:
@@ -2389,6 +2391,15 @@ class Scheduler(
                 ret.fpm_start_time = self._fpm_batch_t0
 
         return ret
+
+    def _maybe_update_speculative_pressure(self) -> None:
+        on_pressure = getattr(self.model_worker, "on_scheduler_pressure_cpu", None)
+        if on_pressure is not None:
+            on_pressure(
+                len(self.running_batch.reqs),
+                len(self.waiting_queue),
+                self.max_running_requests,
+            )
 
     def get_num_allocatable_reqs(self, running_bs):
         res = get_global_server_args().pp_max_micro_batch_size - running_bs

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -108,6 +108,18 @@ class AdaptiveController:
         if self.params.update(num_correct_drafts_per_req):
             self._activate(self.params.current_steps)
 
+    def on_scheduler_pressure(
+        self,
+        running_reqs: int,
+        waiting_reqs: int,
+        max_running_requests: int,
+    ) -> None:
+        """Feed scheduler pressure; switch runtime state if queue pressure warrants it."""
+        if self.params.update_pressure(
+            running_reqs, waiting_reqs, max_running_requests
+        ):
+            self._activate(self.params.current_steps)
+
     def _activate(self, speculative_num_steps: int) -> None:
         state = self._states.get(speculative_num_steps)
         if state is None:

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -57,7 +57,10 @@ def load_adaptive_config(path: str | None) -> dict[str, object]:
 
     The file may contain any subset of the following keys:
         ema_alpha, update_interval, warmup_batches,
-        down_hysteresis, up_hysteresis, candidate_steps
+        down_hysteresis, up_hysteresis, candidate_steps,
+        queue_pressure_adaptive, pressure_running_threshold,
+        pressure_queue_threshold, pressure_restore_threshold,
+        pressure_target_steps, pressure_max_accept_len
 
     Returns an empty dict when *path* is ``None``.
     """
@@ -131,8 +134,31 @@ class AdaptiveSpeculativeParams:
         self.warmup_batches = cfg.get("warmup_batches", 10)
         self.down_hysteresis = cfg.get("down_hysteresis", -0.25)
         self.up_hysteresis = cfg.get("up_hysteresis", 0.0)
+        self.queue_pressure_adaptive = bool(cfg.get("queue_pressure_adaptive", False))
+        self.pressure_running_threshold = float(
+            cfg.get("pressure_running_threshold", 0.75)
+        )
+        self.pressure_queue_threshold = float(
+            cfg.get("pressure_queue_threshold", 0.75)
+        )
+        self.pressure_restore_threshold = float(
+            cfg.get("pressure_restore_threshold", 0.50)
+        )
+        self.pressure_target_steps = int(
+            cfg.get("pressure_target_steps", self.candidate_steps[0])
+        )
+        self.pressure_max_accept_len = cfg.get("pressure_max_accept_len")
+        if self.pressure_max_accept_len is not None:
+            self.pressure_max_accept_len = float(self.pressure_max_accept_len)
+        if self.pressure_target_steps not in self.candidate_steps:
+            raise ValueError(
+                "pressure_target_steps must be included in candidate_steps; "
+                f"got {self.pressure_target_steps}, candidates={self.candidate_steps}"
+            )
 
         self.current_steps = initial_steps
+        self.pressure_active = False
+        self._pre_pressure_steps = initial_steps
 
         # Initialize EMA at current steps - 1 (neutral starting point)
         self.ema_accept_len = float(self.current_steps - 1)
@@ -162,10 +188,60 @@ class AdaptiveSpeculativeParams:
         if self._batch_count <= self.warmup_batches:
             return False
 
+        if self.pressure_active:
+            return False
+
         if (self._batch_count - self.warmup_batches) % self.update_interval != 0:
             return False
 
         return self._recompute_params()
+
+    def update_pressure(
+        self,
+        running_reqs: int,
+        waiting_reqs: int,
+        max_running_requests: int,
+    ) -> bool:
+        if not self.queue_pressure_adaptive or max_running_requests <= 0:
+            return False
+
+        running_pressure = running_reqs / max_running_requests
+        queue_pressure = (running_reqs + waiting_reqs) / max_running_requests
+        overloaded = (
+            running_pressure >= self.pressure_running_threshold
+            or queue_pressure >= self.pressure_queue_threshold
+        )
+        if self.pressure_max_accept_len is not None:
+            overloaded = (
+                overloaded and self.ema_accept_len <= self.pressure_max_accept_len
+            )
+        relieved = (
+            running_pressure <= self.pressure_restore_threshold
+            and queue_pressure <= self.pressure_restore_threshold
+        )
+
+        old_steps = self.current_steps
+        if overloaded and not self.pressure_active:
+            self._pre_pressure_steps = self.current_steps
+            self.current_steps = self.pressure_target_steps
+            self.pressure_active = True
+            log_info_on_rank0(
+                logger,
+                f"Adaptive spec pressure active: steps {old_steps} -> "
+                f"{self.current_steps} (running={running_reqs}, "
+                f"waiting={waiting_reqs}, max={max_running_requests})",
+            )
+        elif self.pressure_active and relieved:
+            self.current_steps = self._pre_pressure_steps
+            self.pressure_active = False
+            log_info_on_rank0(
+                logger,
+                f"Adaptive spec pressure relieved: steps {old_steps} -> "
+                f"{self.current_steps} (running={running_reqs}, "
+                f"waiting={waiting_reqs}, max={max_running_requests})",
+            )
+
+        return self.current_steps != old_steps
 
     def _recompute_params(self) -> bool:
         """Recompute steps from EMA. Returns True if params changed."""

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -40,3 +40,11 @@ class BaseSpecWorker(ABC):
         controller without forcing a GPU→CPU sync in the worker hot path.
         """
         pass
+
+    def on_scheduler_pressure_cpu(
+        self,
+        running_reqs: int,
+        waiting_reqs: int,
+        max_running_requests: int,
+    ) -> None:
+        pass

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -347,6 +347,17 @@ class EAGLEWorker(TpModelWorker):
             state.speculative_num_draft_tokens
         )
 
+    def on_scheduler_pressure_cpu(
+        self,
+        running_reqs: int,
+        waiting_reqs: int,
+        max_running_requests: int,
+    ) -> None:
+        if self.adaptive_controller is not None:
+            self.adaptive_controller.on_scheduler_pressure(
+                running_reqs, waiting_reqs, max_running_requests
+            )
+
     def build_adaptive_runtime_state(
         self, speculative_num_steps: int, speculative_num_draft_tokens: int
     ) -> SpecRuntimeState:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -838,6 +838,17 @@ class EAGLEWorkerV2(BaseSpecWorker):
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(num_correct_drafts_per_req)
 
+    def on_scheduler_pressure_cpu(
+        self,
+        running_reqs: int,
+        waiting_reqs: int,
+        max_running_requests: int,
+    ) -> None:
+        if self.adaptive_controller is not None:
+            self.adaptive_controller.on_scheduler_pressure(
+                running_reqs, waiting_reqs, max_running_requests
+            )
+
     # -- Adaptive speculative decoding protocol --
 
     def build_adaptive_runtime_state(

--- a/test/registered/unit/spec/test_adaptive_spec_params.py
+++ b/test/registered/unit/spec/test_adaptive_spec_params.py
@@ -218,6 +218,61 @@ class TestAdaptiveSpeculativeParams(unittest.TestCase):
         self.assertEqual(params.current_steps, 1)
         self.assertEqual(params.ema_accept_len, 0.375)
 
+    def test_queue_pressure_forces_low_steps_and_restores(self):
+        params = self._make_params_from_config(
+            3,
+            {
+                "candidate_steps": [1, 3],
+                "queue_pressure_adaptive": True,
+                "pressure_running_threshold": 0.75,
+                "pressure_queue_threshold": 0.75,
+                "pressure_restore_threshold": 0.5,
+                "pressure_target_steps": 1,
+                "warmup_batches": 0,
+                "update_interval": 1,
+            },
+        )
+
+        self.assertTrue(params.update_pressure(12, 18, 32))
+        self.assertTrue(params.pressure_active)
+        self.assertEqual(params.current_steps, 1)
+
+        self.assertFalse(params.update([3, 3]))
+        self.assertEqual(params.current_steps, 1)
+
+        self.assertTrue(params.update_pressure(2, 0, 32))
+        self.assertFalse(params.pressure_active)
+        self.assertEqual(params.current_steps, 3)
+
+    def test_queue_pressure_can_be_disabled(self):
+        params = self._make_params_from_config(
+            3,
+            {
+                "candidate_steps": [1, 3],
+                "queue_pressure_adaptive": False,
+            },
+        )
+
+        self.assertFalse(params.update_pressure(32, 32, 32))
+        self.assertEqual(params.current_steps, 3)
+
+    def test_queue_pressure_respects_acceptance_gate(self):
+        params = self._make_params_from_config(
+            3,
+            {
+                "candidate_steps": [1, 3],
+                "queue_pressure_adaptive": True,
+                "pressure_max_accept_len": 1.0,
+            },
+        )
+
+        self.assertFalse(params.update_pressure(32, 32, 32))
+        self.assertEqual(params.current_steps, 3)
+
+        params.ema_accept_len = 0.5
+        self.assertTrue(params.update_pressure(32, 32, 32))
+        self.assertEqual(params.current_steps, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Draft experimental PR.

This adds an opt-in scheduler-pressure signal to the existing adaptive EAGLE controller. The existing acceptance-rate adaptive path stays unchanged unless `queue_pressure_adaptive` is enabled in the adaptive config.

Validation on RunPod 2x B200, `Qwen/Qwen3-8B` + `Tengyunw/qwen3_8b_eagle3`, `tp=2`, EAGLE3 `3/1/4`, `max_running_requests=8`, 2048 prompt words/request:

- Unit: `python test/registered/unit/spec/test_adaptive_spec_params.py` -> 14 tests OK.
- Runtime smoke: forced pressure config logged `Adaptive spec pressure active: steps 3 -> 1`.
- 64 requests / 32 workers:
  - fixed `3/1/4`: p50 TTFT 383 ms, p95 489 ms.
  - forced `1/1/2` under pressure: p50 439 ms, p95 558 ms, worse.
  - gated config did not switch, as intended when accept EMA was above gate.
- 256 requests / 128 workers:
  - fixed repeat: p50 1249-1268 ms, p95 1618-1638 ms.
  - default 0.75 pressure config did not switch and was effectively unchanged.
  - lower 0.1 pressure config switched at waiting=1/max=8 and was mixed: one run improved p50/p95 materially, one matched p50 and worsened p95.

Conclusion: plumbing works, but the policy is not ready as a default. Keeping this draft/experimental so we can tune the pressure policy or combine it with acceptance-rate gating before considering merge.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26355546587](https://github.com/sgl-project/sglang/actions/runs/26355546587)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26355546546](https://github.com/sgl-project/sglang/actions/runs/26355546546)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->