### PR TITLE
[Bug Fix] [Step3p5] Check if the fused prefix itself is in the ignore…

### DIFF
--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -85,10 +85,7 @@ def is_layer_skipped(
         # Check if the fused prefix itself is in the ignored list.
         # modules_to_not_convert may use fused names (e.g. gate_up_proj,
         # qkv_proj) directly, so check prefix as-is before unfusing.
-        is_fused_skipped = any(
-            _module_path_match(ignored, prefix) for ignored in ignored_layers
-        )
-        if is_fused_skipped:
+        if any(_module_path_match(ignored, prefix) for ignored in ignored_layers):
             return True
 
         shard_prefixes = [

--- a/python/sglang/srt/layers/quantization/utils.py
+++ b/python/sglang/srt/layers/quantization/utils.py
@@ -82,6 +82,15 @@ def is_layer_skipped(
         fused_mapping if proj_name in fused_mapping else _FALLBACK_FUSED_SHARDS
     )
     if proj_name in effective_fused:
+        # Check if the fused prefix itself is in the ignored list.
+        # modules_to_not_convert may use fused names (e.g. gate_up_proj,
+        # qkv_proj) directly, so check prefix as-is before unfusing.
+        is_fused_skipped = any(
+            _module_path_match(ignored, prefix) for ignored in ignored_layers
+        )
+        if is_fused_skipped:
+            return True
+
         shard_prefixes = [
             prefix.replace(proj_name, shard_proj_name)
             for shard_proj_name in effective_fused[proj_name]


### PR DESCRIPTION
Check if the fused prefix itself is in the ignored list.modules_to_not_convert may use fused names (e.g. gate_up_proj, qkv_proj) directly, so check prefix as-is before unfusing.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

 When quantization_config.modules_to_not_convert in a model's config.json uses fused layer names (e.g., gate_up_proj, qkv_proj), the is_layer_skipped function fails to recognize them, causing
  layers that should remain in BF16 to be incorrectly quantized to FP8.

  This leads to two failures when serving models like Step-3.5-Flash-FP8 with --tp 4 --quantization fp8:
  1. ValueError: Weight output_partition_size = 320 is not divisible by weight quantization block_n = 128 — because the shared expert's gate_up_proj (intermediate_size=1280, TP=4 → partition=320)
   gets FP8 block quantization applied when it shouldn't.
  2. AssertionError: Some parameters are not loaded: {...weight_scale_inv...} — because weight_scale_inv parameters are created for layers that the checkpoint stores as BF16 (no scale data
  exists).

## Modifications

File: python/sglang/srt/layers/quantization/utils.py

  In is_layer_skipped, added an early check for the fused prefix itself before unfusing into shards. The existing logic unfuses gate_up_proj → [gate_proj, up_proj] and qkv_proj → [q_proj, k_proj,
   v_proj], then checks if the unfused names are in the ignored list. But when modules_to_not_convert contains the fused name directly, this matching fails.

  The fix adds a direct match of the fused prefix against the ignored list before attempting shard-level matching:


      if proj_name in effective_fused:
              # Check if the fused prefix itself is in the ignored list.
              # modules_to_not_convert may use fused names (e.g. gate_up_proj,
              # qkv_proj) directly, so check prefix as-is before unfusing.
              if any(
                  _module_path_match(ignored, prefix) for ignored in ignored_layers
              ):
                  return True

## Accuracy Tests

No change to model outputs. This fix only affects which layers are skipped during quantization, restoring the intended behavior specified by modules_to_not_convert. Layers that should remain
  BF16 now correctly stay BF16.

  Verified with Step-3.5-Flash-FP8 (--tp 4 --ep 4 --quantization fp8): model loads successfully, KV cache allocated, CUDA graph capture proceeds normally.

  Speed Tests and Profiling

  No performance impact. The fix adds a single any(...) check over the ignored list before the existing shard-level loop — negligible cost during model initialization only.

## Speed Tests and Profiling

 No performance impact. The fix adds a single any(...) check over the ignored list before the existing shard-level loop — negligible cost during model initialization only.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26357129561](https://github.com/sgl-project/sglang/actions/runs/26357129561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26357129493](https://github.com/sgl-project/sglang/actions/runs/26357129493)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->