### PR TITLE
[diffusion] Use model-aware VAE channels_last_3d policy

### DIFF
--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     # model loading
     SGLANG_USE_RUNAI_MODEL_STREAMER: bool = True
     SGLANG_DIFFUSION_FLASHINFER_FP4_GEMM_BACKEND: str | None = None
-    SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D: bool = True
+    SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D: str = "auto"
     SGLANG_USE_CUDA_HUNYUANVIDEO_GROUP_NORM_SILU: bool = False
     SGLANG_USE_ROCM_VAE: bool = False
     SGLANG_USE_ROCM_CUDNN_BENCHMARK: bool = False
@@ -250,8 +250,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, sgl_diffusion will enable stage logging, which will print the time
     # taken for each stage
     "SGLANG_DIFFUSION_STAGE_LOGGING": _lazy_bool("SGLANG_DIFFUSION_STAGE_LOGGING"),
-    "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": _lazy_bool(
-        "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D", "true"
+    "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": _lazy_str(
+        "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D", "auto"
     ),
     # ================== cache-dit Env Vars ==================
     # Enable cache-dit acceleration for DiT inference

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -60,7 +60,9 @@ def _convert_conv3d_weights_to_channels_last_3d(module: nn.Module) -> int:
     return num_converted
 
 
-def _should_use_channels_last_3d(server_args: ServerArgs, component_name: str) -> bool:
+def _should_use_channels_last_3d(
+    server_args: ServerArgs | None, component_name: str
+) -> bool:
     if component_name not in (
         "vae",
         "video_vae",
@@ -68,9 +70,18 @@ def _should_use_channels_last_3d(server_args: ServerArgs, component_name: str) -
         return False
 
     override = os.getenv(VAE_CHANNELS_LAST_3D_ENV)
-    if override is None or override.strip().lower() == "auto":
+    if override is not None and override.strip().lower() != "auto":
+        return get_bool_env_var(VAE_CHANNELS_LAST_3D_ENV)
+
+    if server_args is None:
+        return False
+
+    pipeline_name = server_args.pipeline_config.__class__.__name__
+    if pipeline_name.startswith("QwenImage"):
         return True
-    return get_bool_env_var(VAE_CHANNELS_LAST_3D_ENV)
+    if "Wan" in pipeline_name and server_args.num_gpus == 1:
+        return True
+    return False
 
 
 class VAELoader(ComponentLoader):

--- a/python/sglang/multimodal_gen/test/server/test_component_accuracy_1_gpu.py
+++ b/python/sglang/multimodal_gen/test/server/test_component_accuracy_1_gpu.py
@@ -15,7 +15,9 @@ from sglang.multimodal_gen.test.server.accuracy_utils import (
 )
 from sglang.multimodal_gen.test.server.component_accuracy import AccuracyEngine
 
-VAE_CHANNELS_LAST_3D_PARITY_CASE_IDS = {"wan2_1_t2v_1.3b"}
+VAE_CHANNELS_LAST_3D_PARITY_CASE_IDS = {
+    "wan2_1_t2v_1.3b",
+}
 VAE_CHANNELS_LAST_3D_PARITY_CASES = [
     case
     for case in ACCURACY_ONE_GPU_CASES

--- a/python/sglang/multimodal_gen/test/server/test_component_accuracy_2_gpu.py
+++ b/python/sglang/multimodal_gen/test/server/test_component_accuracy_2_gpu.py
@@ -15,7 +15,9 @@ from sglang.multimodal_gen.test.server.accuracy_utils import (
 )
 from sglang.multimodal_gen.test.server.component_accuracy import AccuracyEngine
 
-VAE_CHANNELS_LAST_3D_PARITY_CASE_IDS = {"wan2_2_i2v_a14b_2gpu"}
+VAE_CHANNELS_LAST_3D_PARITY_CASE_IDS = {
+    "wan2_2_i2v_a14b_2gpu",
+}
 VAE_CHANNELS_LAST_3D_PARITY_CASES = [
     case
     for case in ACCURACY_TWO_GPU_CASES

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "5b728ad6dee869c0c720ef3b668ac7a0d98b0f9a"
+SGL_TEST_FILES_CI_DATA_REVISION = "c6b7dea9437814580814986d6abff0fa3a8d5644"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-SGL_TEST_FILES_CI_DATA_REVISION = "c6b7dea9437814580814986d6abff0fa3a8d5644"
+SGL_TEST_FILES_CI_DATA_REVISION = "b7455318873fc5af399c8447b3bb0d9471a5084c"
 SGL_TEST_FILES_CONSISTENCY_GT_ROOT = (
     "https://raw.githubusercontent.com/"
     f"sgl-project/ci-data/{SGL_TEST_FILES_CI_DATA_REVISION}/"

--- a/python/sglang/multimodal_gen/test/unit/test_vae_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_loader.py
@@ -3,10 +3,38 @@ from unittest.mock import patch
 
 import torch
 
+from sglang.multimodal_gen.runtime.loader.component_loaders import vae_loader
 from sglang.multimodal_gen.runtime.loader.component_loaders.vae_loader import (
     _backfill_ltx2_audio_vae_latent_stats,
+    _should_use_channels_last_3d,
 )
 from sglang.multimodal_gen.runtime.models.vaes.parallel import wan_common_utils
+
+
+class _FakeServerArgs:
+    def __init__(self, pipeline_config, num_gpus=1):
+        self.pipeline_config = pipeline_config
+        self.num_gpus = num_gpus
+
+
+class QwenImagePipelineConfig:
+    pass
+
+
+class WanT2V480PConfig:
+    pass
+
+
+class FastWan2_2_TI2V_5B_Config:
+    pass
+
+
+class Wan2_2_I2V_A14B_Config:
+    pass
+
+
+class LTX2PipelineConfig:
+    pass
 
 
 class TestVAELoader(unittest.TestCase):
@@ -44,6 +72,101 @@ class TestVAELoader(unittest.TestCase):
 
         self.assertNotIn("latents_mean", loaded)
         self.assertNotIn("latents_std", loaded)
+
+    def test_channels_last_3d_defaults_true_for_qwen_image_on_cuda(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(QwenImagePipelineConfig())
+            self.assertTrue(_should_use_channels_last_3d(server_args, "vae"))
+
+    def test_channels_last_3d_defaults_true_for_single_gpu_wan_on_cuda(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(WanT2V480PConfig(), num_gpus=1)
+            self.assertTrue(_should_use_channels_last_3d(server_args, "video_vae"))
+
+    def test_channels_last_3d_defaults_true_for_single_gpu_fast_wan_on_cuda(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(FastWan2_2_TI2V_5B_Config(), num_gpus=1)
+            self.assertTrue(_should_use_channels_last_3d(server_args, "video_vae"))
+
+    def test_channels_last_3d_defaults_false_for_multi_gpu_wan_on_cuda(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(Wan2_2_I2V_A14B_Config(), num_gpus=2)
+            self.assertFalse(_should_use_channels_last_3d(server_args, "video_vae"))
+
+    def test_channels_last_3d_defaults_false_for_ltx_on_cuda(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(LTX2PipelineConfig(), num_gpus=2)
+            self.assertFalse(_should_use_channels_last_3d(server_args, "video_vae"))
+
+    def test_channels_last_3d_can_be_disabled_by_env(self):
+        with (
+            patch.dict(
+                "os.environ", {"SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": "false"}
+            ),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(QwenImagePipelineConfig())
+            self.assertFalse(_should_use_channels_last_3d(server_args, "vae"))
+
+    def test_channels_last_3d_can_be_enabled_by_env(self):
+        with (
+            patch.dict("os.environ", {"SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": "true"}),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(LTX2PipelineConfig(), num_gpus=2)
+            self.assertTrue(_should_use_channels_last_3d(server_args, "video_vae"))
+
+    def test_channels_last_3d_auto_uses_model_policy(self):
+        with (
+            patch.dict("os.environ", {"SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": "auto"}),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            wan_args = _FakeServerArgs(WanT2V480PConfig(), num_gpus=1)
+            ltx_args = _FakeServerArgs(LTX2PipelineConfig(), num_gpus=2)
+
+            self.assertTrue(_should_use_channels_last_3d(wan_args, "video_vae"))
+            self.assertFalse(_should_use_channels_last_3d(ltx_args, "video_vae"))
+
+    def test_channels_last_3d_skips_non_video_vae_components(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=True),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(QwenImagePipelineConfig())
+            self.assertFalse(_should_use_channels_last_3d(server_args, "audio_vae"))
+
+    def test_channels_last_3d_skips_unsupported_platforms(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch.object(vae_loader.current_platform, "is_cuda", return_value=False),
+            patch.object(vae_loader.current_platform, "is_rocm", return_value=False),
+        ):
+            server_args = _FakeServerArgs(QwenImagePipelineConfig())
+            self.assertFalse(_should_use_channels_last_3d(server_args, "vae"))
 
     @unittest.skipUnless(
         hasattr(torch, "channels_last_3d"), "channels_last_3d is unavailable"


### PR DESCRIPTION
## Summary
- Default `SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D` to `auto` instead of globally forcing `true`.
- In `auto`, enable channels_last_3d only for QwenImage and single-GPU Wan/Wan variants.
- Keep multi-GPU Wan, LTX, Hunyuan/FastHunyuan, Helios/Joy/MOVA on the false path unless explicitly overridden.
- Keep explicit env `true`/`false` behavior, so users can still force either path for experiments.
- Keep the Wan VAE channels_last_3d parity guard in per-pr-ci-test.

## Experiment Setup
- Base commit for probes: `6447596501`.
- Hardware: H100 CUDA environment.
- Probe target: VAE decode only, comparing `SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D=false` vs `true`.
- Measurement: CUDA-event median latency after warmup.
- Layout counters record Conv3d calls where inputs or weights are already `channels_last_3d`; `mixed` means weight is `channels_last_3d` but input is not.
- Shapes are representative latent shapes used by the corresponding pipelines.

## Experiment Results

| Case | Topology | Shape | false median | true median | true/false | Layout signal | Winner |
| --- | --- | --- | ---: | ---: | ---: | --- | --- |
| `qwen_image_t2i` | 1 GPU | image 1024 | 68.480 ms | 64.618 ms | 0.944 | false mixed 2/32, true mixed 6/32 | true |
| `wan2_1_t2v_1.3b` | 1 GPU | 640x384, 17f | 244.689 ms | 222.498 ms | 0.909 | true input/weight 164/164, mixed 0 | true |
| `wan2_1_t2v_1.3b` | 1 GPU | 832x480, 81f | 1852.731 ms | 1674.080 ms | 0.904 | true input/weight 692/692, mixed 0 | true |
| `wan2_2_ti2v_5b` | 1 GPU | 640x384, 17f | 923.933 ms | 846.510 ms | 0.916 | true input/weight 169/169, mixed 0 | true |
| `wan2_2_ti2v_5b` | 1 GPU | 832x480, 81f | 7198.994 ms | 6450.609 ms | 0.896 | true input/weight 713/713, mixed 0 | true |
| `wan2_2_i2v_a14b_2gpu` | 2 GPU | 640x384, 17f | 151.893 ms | 202.672 ms | 1.334 | no mixed, but distributed path slower with true | false |
| `wan2_2_i2v_a14b_2gpu` | 2 GPU | 832x480, 81f | 1079.762 ms | 1584.866 ms | 1.468 | no mixed, but distributed path slower with true | false |
| `ltx_2_two_stage_t2v` | 2 GPU | 640x384, 17f | 27.729 ms | 32.406 ms | 1.169 | true creates 45/45 mixed Conv3d calls | false |
| `fast_hunyuan_video` | 1 GPU | 640x384, 17f | 568.666 ms | 926.523 ms | 1.629 | true creates 576/576 mixed Conv3d calls | false |

## E2E A/B Results

| Case | Topology | Env false E2E | Env true E2E | true/false | Decode stage false/true | Result |
| --- | --- | ---: | ---: | ---: | --- | --- |
| `qwen_image_t2i` | 1 GPU | 12738.30 ms | 12728.21 ms | 0.999 | 57.40 / 57.42 ms | effectively neutral |
| `wan2_1_t2v_1.3b` | 1 GPU | 8599.91 ms | 8547.87 ms | 0.994 | 598.20 / 560.50 ms | true slightly faster |
| `wan2_2_ti2v_5b` | 1 GPU | 17783.90 ms | 17691.09 ms | 0.995 | 1624.59 / 1520.02 ms | true slightly faster |

## Policy Decision
- QwenImage defaults to true because the measured decode path is faster and E2E is not slower in targeted A/B; the E2E delta itself is noise-level because denoising dominates.
- Single-GPU Wan and Wan variants default to true because both decode-only probes and targeted E2E A/B are faster, and there is no mixed Conv3d layout.
- Multi-GPU Wan defaults to false because the distributed VAE path is significantly slower with true, even without mixed layout.
- LTX defaults to false because true creates mixed Conv3d layout and is slower on realistic latent shapes.
- Hunyuan/FastHunyuan defaults to false because true keeps inputs contiguous while converting all Conv3d weights, creating a fully mixed layout and a large slowdown.
- Helios/Joy/MOVA default to false for now even though they use Wan-style VAE configs, because they were not part of the measured fast path and should not inherit a risky default.

## Validation
- `pre-commit run --files python/sglang/multimodal_gen/envs.py python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py python/sglang/multimodal_gen/test/unit/test_vae_loader.py python/sglang/multimodal_gen/test/server/test_component_accuracy_1_gpu.py python/sglang/multimodal_gen/test/server/test_component_accuracy_2_gpu.py`
- H100 VAE decode probes summarized above.
- H100 targeted 1-GPU E2E on PR commit `11b5d81f9`: `qwen_image_t2i`, `wan2_1_t2v_1.3b`, `wan2_2_ti2v_5b`, `fast_hunyuan_video` all passed consistency and perf checks.
- H100 targeted 1-GPU E2E true/false A/B on PR commit `11b5d81f9`: QwenImage is neutral (`12738.30ms -> 12728.21ms`), Wan2.1 is slightly faster (`8599.91ms -> 8547.87ms`), Wan2.2 TI2V is slightly faster (`17783.90ms -> 17691.09ms`). All passed consistency.
- H100 targeted 2-GPU E2E on PR commit `11b5d81f9`: `ltx_2_two_stage_t2v`, `qwen_image_t2i_2_gpus`, `zimage_image_t2i_2_gpus` all passed consistency and perf checks. Qwen 2GPU median denoise was 187.86ms; ZImage 2GPU average denoise was 62.81ms.
- H100 targeted 2-GPU E2E for `wan2_2_i2v_a14b_2gpu` failed consistency with channels_last_3d explicitly disabled. The same command on base commit `6447596501` reproduced the same metrics (`min SSIM=0.5917`, `min PSNR=18.0045`, `max mean_abs_diff=15.3330`), so this is not introduced by this PR.
- GitHub Actions run `26359577247` has one failing 2-GPU partition. It includes the same base-reproducible `wan2_2_i2v_a14b_2gpu` consistency failure; `qwen_image_t2i_2_gpus` and `zimage_image_t2i_2_gpus` only failed perf thresholds in that partition and passed targeted reruns above.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26365215910](https://github.com/sgl-project/sglang/actions/runs/26365215910)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26365215844](https://github.com/sgl-project/sglang/actions/runs/26365215844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->