### PR TITLE
Revert "Use triton_attn as default vision attention on B300 (SM103)"

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -951,7 +951,7 @@ class VisionAttention(nn.Module):
             major, minor = get_device_capability()
             if major == 9:
                 backend = "fa3"
-            elif major == 10 and minor != 3:
+            elif major == 10:
                 backend = "fa4"
             else:
                 backend = "triton_attn"


### PR DESCRIPTION
Reverts sgl-project/sglang#25570

main fixed this bug. (installs nvidia-cutlass-dsl[cu13] instead of nvidia-cutlass-dsl)

@mickqian 



















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26365992596](https://github.com/sgl-project/sglang/actions/runs/26365992596)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26365992560](https://github.com/sgl-project/sglang/actions/runs/26365992560)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->