### PR TITLE
fix(swa): downgrade translate_loc_from_full_to_swa key-change log from warning to debug

### DIFF
--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -173,7 +173,7 @@ class SWAKVPool(BaseSWAKVPool):
         key = (kv_indices.data_ptr(), kv_indices.numel())
         if key != self._cached_loc_key:
             if self._cached_loc_key is not None:
-                logger.warning(
+                logger.debug(
                     "translate_loc_from_full_to_swa: loc tensor changed mid-forward "
                     "without invalidate_loc_cache() — possible missing call site"
                 )


### PR DESCRIPTION
## Motivation

The `translate_loc_from_full_to_swa` cache-miss message fires whenever two different tensors are translated in the same logical pass — e.g. `page_table` (in `init_forward_metadata`) followed by `out_cache_loc` (in `set_kv_buffer`), or after a radix-cache insert. This is expected behaviour given the current design; it is not a correctness issue.

`WARNING` level floods production logs on every hybrid-SWA forward and triggered spurious CI failures when we temporarily promoted it to `RuntimeError` in #26184.

## Modifications

One line: `logger.warning` → `logger.debug`.  The message remains reachable with `--log-level debug` for diagnostics.

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/sgl-project/sglang/blob/main/CONTRIBUTING.md)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26368234524](https://github.com/sgl-project/sglang/actions/runs/26368234524)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26368234458](https://github.com/sgl-project/sglang/actions/runs/26368234458)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->