### PR TITLE
[SRT] Disable consecutive prefill overlap by default

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -34,7 +34,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD` | Sets the threshold for enabling chunked prefix caching | `8192` |
 | `SGLANG_MAX_KV_CHUNK_CAPACITY` | Maximum number of tokens in each KV chunk for DeepSeek MHA chunked prefix cache | `131072` |
 | `SGLANG_FUSED_MLA_ENABLE_ROPE_FUSION` | Enable RoPE fusion in Fused Multi-Layer Attention | `1` |
-| `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP` | Disable overlap schedule for consecutive prefill batches | `false` |
+| `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP` | Disable overlap schedule for consecutive prefill batches | `true` |
 | `SGLANG_SCHEDULER_MAX_RECV_PER_POLL` | Set the maximum number of requests per poll, with a negative value indicating no limit | `-1` |
 | `SGLANG_DISABLE_FA4_WARMUP` | Disable Flash Attention 4 warmup passes (set to `1`, `true`, `yes`, or `on` to disable) | `false` |
 | `SGLANG_DATA_PARALLEL_BUDGET_INTERVAL` | Interval for DPBudget updates | `1` |

--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -150,7 +150,7 @@ SGLang supports various environment variables that can be used to configure its 
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Disable overlap schedule for consecutive prefill batches</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`false`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`true`</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`SGLANG_SCHEDULER_MAX_RECV_PER_POLL`</td>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -287,7 +287,7 @@ class Envs:
 
     # Scheduler: others:
     SGLANG_EMPTY_CACHE_INTERVAL = EnvFloat(-1)  # in seconds. Set if you observe high memory accumulation over a long serving period.
-    SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(False)
+    SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(True)
     SGLANG_SCHEDULER_MAX_RECV_PER_POLL = EnvInt(-1)
     SGLANG_EXPERIMENTAL_CPP_RADIX_TREE = EnvBool(False)
     SGLANG_RADIX_FORCE_MISS = EnvBool(False)


### PR DESCRIPTION
## Summary
- Disable consecutive prefill overlap by default.
- Keep `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP=0` as the opt-out for the old overlap behavior.
- Update both env-var docs.

## Benchmark
H200, Qwen3.5-397B-A17B TP8, SMG CUDA IPC, OCRBench samples 100-199 after 100 warmup, concurrency 100, max_tokens=5, cache_read_tokens=0.

- main default (`b6f71d5`): TTFT 3.966s, E2E 4.061s.
- main with `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP=1`: TTFT 2.831s, E2E 3.131s.
- default enabled in source, with #26224 FlashInfer compatibility patch: TTFT 2.317s, E2E 2.651s.
- same-machine vLLM baseline: TTFT 1.542s, E2E 1.956s.

## Validation
- `pre-commit run --files python/sglang/srt/environ.py docs/references/environment_variables.md docs_new/docs/references/environment_variables.mdx`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26368332601](https://github.com/sgl-project/sglang/actions/runs/26368332601)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26368332559](https://github.com/sgl-project/sglang/actions/runs/26368332559)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->