### PR TITLE
[SRT] Default SM90 GDN linear attention to FlashInfer

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2410,6 +2410,19 @@ class ServerArgs:
                     support_mamba_cache_extra_buffer=True,
                     sm100_default_attention_backend=sm100_default_attn_backend,
                 )
+                if (
+                    is_sm90_supported()
+                    and self.speculative_algorithm is None
+                    and self.mamba_ssm_dtype in (None, "float32")
+                    and self.linear_attn_backend == "triton"
+                    and self.linear_attn_decode_backend is None
+                    and self.linear_attn_prefill_backend is None
+                ):
+                    # sm90 FlashInfer GDN supports extend and decode with fp32 state
+                    self.linear_attn_backend = "flashinfer"
+                    logger.info(
+                        f"Use flashinfer as linear attention backend on sm90 for {model_arch}"
+                    )
 
         elif model_arch == "MiniCPMV4_6ForConditionalGeneration":
             # 4.6 wraps a Qwen3.5 hybrid GDN backbone, so it needs the same


### PR DESCRIPTION
## Summary

- Default Qwen3.5 / InternS2Preview hybrid GDN linear attention to FlashInfer on SM90 when no per-mode linear-attention backend is selected.
- Keep speculative decoding and non-fp32 Mamba state on the existing default.

## Why

vLLM uses FlashInfer GDN on the same H200 OCRBench repro, while SGLang was still defaulting to Triton GDN on SM90 unless the backend was set manually.

## Validation

- `pre-commit run --files python/sglang/srt/server_args.py`
- H200, Qwen3.5-397B-A17B TP8, SMG CUDA IPC, OCRBench samples 100-199 after 100 warmup, concurrency 100, `max_tokens=5`:
  - baseline (#26224 + #26226): TTFT 2.1108s, E2E 2.4546s
  - `--linear-attn-backend flashinfer`: TTFT 2.0042s, E2E 2.3692s
  - delta: TTFT -0.1066s (~5.0%), E2E -0.0854s (~3.5%)

Same-machine vLLM baseline is still faster (TTFT 1.5419s, E2E 1.9560s), so this is a partial improvement rather than the full gap close.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26369962411](https://github.com/sgl-project/sglang/actions/runs/26369962411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26369962344](https://github.com/sgl-project/sglang/actions/runs/26369962344)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->