### PR TITLE
fix(responses): four correctness fixes for the Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1347,6 +1347,13 @@ class ResponsesRequest(BaseModel):
     min_p: float = 0.0
     repetition_penalty: float = 1.0
 
+    @field_validator("max_output_tokens")
+    @classmethod
+    def validate_max_output_tokens_non_negative(cls, v):
+        if v is not None and v < 0:
+            raise ValueError("max_output_tokens must be non-negative")
+        return v
+
     # Default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
         "temperature": 0.7,
@@ -1369,8 +1376,9 @@ class ResponsesRequest(BaseModel):
         else:
             max_tokens = default_max_tokens
 
-        # Avoid exceed the context length by minus 2 token
-        max_tokens -= 2
+        # Reserve 2 tokens to avoid exceeding the context length, but never
+        # let the value go negative (e.g. when max_output_tokens is 0, 1, or 2).
+        max_tokens = max(0, max_tokens - 2)
 
         # Get parameters with defaults
         temperature = self.temperature

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -648,6 +648,38 @@ class OpenAIServingResponses(OpenAIServingChat):
             messages.extend(request.input)  # type: ignore
         return messages
 
+    def _build_harmony_system_messages(
+        self, request: "ResponsesRequest"
+    ) -> tuple["OpenAIMessage", "OpenAIMessage"]:
+        """Build the system and developer messages for a Harmony request.
+
+        Extracted to avoid duplicating this logic between the first-turn and
+        continuation branches of _construct_input_messages_with_harmony.
+        """
+        reasoning_effort = request.reasoning.effort if request.reasoning else None
+        tool_types = [tool.type for tool in request.tools]
+        enable_browser = (
+            "web_search_preview" in tool_types and self.tool_server is not None
+        )
+        enable_code_interpreter = (
+            "code_interpreter" in tool_types and self.tool_server is not None
+        )
+        sys_msg = get_system_message(
+            reasoning_effort=reasoning_effort,
+            browser_description=(
+                self.tool_server.get_tool_description("browser")
+                if self.tool_server and enable_browser
+                else None
+            ),
+            python_description=(
+                self.tool_server.get_tool_description("python")
+                if self.tool_server and enable_code_interpreter
+                else None
+            ),
+        )
+        dev_msg = get_developer_message(request.instructions, request.tools)
+        return sys_msg, dev_msg
+
     def _construct_input_messages_with_harmony(
         self,
         request: ResponsesRequest,
@@ -656,58 +688,23 @@ class OpenAIServingResponses(OpenAIServingChat):
         messages: list["OpenAIMessage"] = []
         if prev_response is None:
             # New conversation.
-            reasoning_effort = request.reasoning.effort if request.reasoning else None
-            tool_types = [tool.type for tool in request.tools]
-            enable_browser = (
-                "web_search_preview" in tool_types and self.tool_server is not None
-            )
-            enable_code_interpreter = (
-                "code_interpreter" in tool_types and self.tool_server is not None
-            )
-            sys_msg = get_system_message(
-                reasoning_effort=reasoning_effort,
-                browser_description=(
-                    self.tool_server.get_tool_description("browser")
-                    if self.tool_server and enable_browser
-                    else None
-                ),
-                python_description=(
-                    self.tool_server.get_tool_description("python")
-                    if self.tool_server and enable_code_interpreter
-                    else None
-                ),
-            )
+            sys_msg, dev_msg = self._build_harmony_system_messages(request)
             messages.append(sys_msg)
-            dev_msg = get_developer_message(request.instructions, request.tools)
             messages.append(dev_msg)
         else:
             # Continue the previous conversation.
             # Re-build sys_msg and dev_msg from the current request so that
             # updated instructions, reasoning effort, or tools take effect on
             # this turn (previously they were silently ignored).
-            reasoning_effort = request.reasoning.effort if request.reasoning else None
-            tool_types = [tool.type for tool in request.tools]
-            enable_browser = (
-                "web_search_preview" in tool_types and self.tool_server is not None
-            )
-            enable_code_interpreter = (
-                "code_interpreter" in tool_types and self.tool_server is not None
-            )
-            fresh_sys_msg = get_system_message(
-                reasoning_effort=reasoning_effort,
-                browser_description=(
-                    self.tool_server.get_tool_description("browser")
-                    if self.tool_server and enable_browser
-                    else None
-                ),
-                python_description=(
-                    self.tool_server.get_tool_description("python")
-                    if self.tool_server and enable_code_interpreter
-                    else None
-                ),
-            )
-            fresh_dev_msg = get_developer_message(request.instructions, request.tools)
-            prev_msgs = self.msg_store[prev_response.id]
+            fresh_sys_msg, fresh_dev_msg = self._build_harmony_system_messages(request)
+            if prev_response.id not in self.msg_store:
+                raise ValueError(
+                    f"Conversation history for response ID {prev_response.id} not found. "
+                    "Ensure 'store=True' was used in the previous request."
+                )
+            # Use a shallow copy so we do not destructively mutate the stored
+            # history (important for branching / multi-fork scenarios).
+            prev_msgs = list(self.msg_store[prev_response.id])
             # Replace the stored sys_msg (index 0) and dev_msg (index 1) so
             # the new turn uses the caller's current params.
             if len(prev_msgs) >= 2:
@@ -715,6 +712,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                 prev_msgs[1] = fresh_dev_msg
             elif len(prev_msgs) == 1:
                 prev_msgs[0] = fresh_sys_msg
+                prev_msgs.append(fresh_dev_msg)
+            else:
+                prev_msgs = [fresh_sys_msg, fresh_dev_msg]
             # Remove the previous chain-of-thoughts if there is a new "final"
             # message.
             if (

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -57,6 +57,7 @@ from sglang.srt.entrypoints.openai.protocol import (
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
 from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import ServerStatus
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils import random_uuid
 
@@ -168,8 +169,12 @@ class OpenAIServingResponses(OpenAIServingChat):
         if not self.tokenizer_manager:
             return self.create_error_response("Model not loaded")
 
-        # FIXME: If the engine is dead, raise an error
-        # This is required for the streaming case
+        if self.tokenizer_manager.server_status == ServerStatus.UnHealthy:
+            return self.create_error_response(
+                "The engine is not healthy and cannot serve requests.",
+                err_type="InternalServerError",
+                status_code=503,
+            )
 
         # Handle the previous response ID
         prev_response_id = request.previous_response_id
@@ -259,6 +264,22 @@ class OpenAIServingResponses(OpenAIServingChat):
                     # Account for reserved tokens (e.g., EAGLE speculative decoding slots)
                     # that the tokenizer_manager adds during validation
                     num_reserved_tokens = self.tokenizer_manager.num_reserved_tokens
+
+                    # Enforce truncation="disabled": reject requests whose prompt
+                    # already exceeds the available context window.  When
+                    # truncation="auto" the engine silently clamps, which is the
+                    # existing behaviour.
+                    if request.truncation == "disabled":
+                        available_tokens = context_len - num_reserved_tokens
+                        if prompt_length > available_tokens:
+                            return self.create_error_response(
+                                f"Input length ({prompt_length} tokens) exceeds the "
+                                f"model's context length ({context_len} tokens). "
+                                "Set truncation='auto' to allow automatic truncation.",
+                                err_type="BadRequestError",
+                                status_code=400,
+                            )
+
                     default_max_tokens = max(
                         context_len - prompt_length - num_reserved_tokens, 512
                     )  # Ensure minimum 512 tokens
@@ -661,9 +682,39 @@ class OpenAIServingResponses(OpenAIServingChat):
             messages.append(dev_msg)
         else:
             # Continue the previous conversation.
-            # FIXME: Currently, request params like reasoning and
-            # instructions are ignored.
+            # Re-build sys_msg and dev_msg from the current request so that
+            # updated instructions, reasoning effort, or tools take effect on
+            # this turn (previously they were silently ignored).
+            reasoning_effort = request.reasoning.effort if request.reasoning else None
+            tool_types = [tool.type for tool in request.tools]
+            enable_browser = (
+                "web_search_preview" in tool_types and self.tool_server is not None
+            )
+            enable_code_interpreter = (
+                "code_interpreter" in tool_types and self.tool_server is not None
+            )
+            fresh_sys_msg = get_system_message(
+                reasoning_effort=reasoning_effort,
+                browser_description=(
+                    self.tool_server.get_tool_description("browser")
+                    if self.tool_server and enable_browser
+                    else None
+                ),
+                python_description=(
+                    self.tool_server.get_tool_description("python")
+                    if self.tool_server and enable_code_interpreter
+                    else None
+                ),
+            )
+            fresh_dev_msg = get_developer_message(request.instructions, request.tools)
             prev_msgs = self.msg_store[prev_response.id]
+            # Replace the stored sys_msg (index 0) and dev_msg (index 1) so
+            # the new turn uses the caller's current params.
+            if len(prev_msgs) >= 2:
+                prev_msgs[0] = fresh_sys_msg
+                prev_msgs[1] = fresh_dev_msg
+            elif len(prev_msgs) == 1:
+                prev_msgs[0] = fresh_sys_msg
             # Remove the previous chain-of-thoughts if there is a new "final"
             # message.
             if (


### PR DESCRIPTION
## Summary

Four targeted fixes in the `/v1/responses` path (`serving_responses.py` and `protocol.py`), each addressing a distinct correctness gap found during a codebase audit.

---

## Fix 1 — Reject requests when the engine is unhealthy

**File:** `serving_responses.py`

`create_responses` had an open `# FIXME: If the engine is dead, raise an error` comment. Without this guard, streaming requests would hang or produce opaque errors after a health-check failure had already marked the engine `UnHealthy`. The fix adds an early `503` return before any request processing.

```python
if self.tokenizer_manager.server_status == ServerStatus.UnHealthy:
    return self.create_error_response(
        "The engine is not healthy and cannot serve requests.",
        err_type="InternalServerError",
        status_code=503,
    )
```

---

## Fix 2 — Enforce `truncation="disabled"` (the spec default)

**File:** `serving_responses.py`

The `truncation` field was accepted and echoed in responses but never enforced. Per the OpenAI Responses spec, `truncation="disabled"` (the default) means the server **must** reject requests whose input exceeds the context window. Previously, SGLang silently clamped `default_max_tokens` to 512 and continued. The fix returns a `400` with a clear message when `truncation="disabled"` and the prompt is too long. `truncation="auto"` preserves the existing clamp behaviour.

---

## Fix 3 — Floor `max_new_tokens` at 0 in `to_sampling_params`

**File:** `protocol.py`

`to_sampling_params` subtracted 2 from `max_output_tokens` unconditionally:

```python
# before
max_tokens -= 2
```

With `max_output_tokens` in `{0, 1, 2}` this produced a negative `max_new_tokens`, which causes undefined scheduler behaviour. The fix floors at 0 and adds a `field_validator` to reject negative `max_output_tokens` at request-parse time.

```python
# after
max_tokens = max(0, max_tokens - 2)
```

---

## Fix 4 — Re-apply `instructions` / `reasoning` on Harmony continuation turns

**File:** `serving_responses.py`

`_construct_input_messages_with_harmony` had a `# FIXME: Currently, request params like reasoning and instructions are ignored` comment on the continuation branch. The stored `prev_msgs[0]` (system message) and `prev_msgs[1]` (developer message) were left as-is from the previous turn, so clients could not update system guidance mid-session. The fix rebuilds both messages from the current request before extending the history.

---

## Testing

- `isort`, `ruff` (no new errors introduced), and `black` all pass on the changed files.
- Unit tests can be added as a follow-up; the changes are isolated to early-exit guards and message-list mutation with clear preconditions.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26690710910](https://github.com/sgl-project/sglang/actions/runs/26690710910)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26690710871](https://github.com/sgl-project/sglang/actions/runs/26690710871)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->