### PR TITLE
[SRT] minor: reuse req input id array for unpadded ids

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -690,10 +690,12 @@ class Req(ReqDllmMixin):
     ):
         # Input and output info
         self.rid = rid
-        self.origin_input_ids_unpadded = array(
-            "q", origin_input_ids_unpadded or origin_input_ids
-        )  # Before image padding
         self.origin_input_ids = array("q", origin_input_ids)
+        self.origin_input_ids_unpadded = (
+            array("q", origin_input_ids_unpadded)
+            if origin_input_ids_unpadded
+            else self.origin_input_ids
+        )  # Before image padding
         # Each decode stage's output ids
         self.output_ids = array("q")
         # fill_ids = origin_input_ids + output_ids. Updated if chunked.


### PR DESCRIPTION
## Summary
- Reuse `Req.origin_input_ids` for `origin_input_ids_unpadded` when no separate unpadded ids are provided.
- Avoid a duplicate `array("q")` conversion/allocation for the common request construction path.

## Tests
- `pre-commit run --files python/sglang/srt/managers/schedule_batch.py`









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26372162059](https://github.com/sgl-project/sglang/actions/runs/26372162059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26372162016](https://github.com/sgl-project/sglang/actions/runs/26372162016)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->