### PR TITLE
[SRT] Reuse precomputed multimodal padded input ids

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -321,6 +321,10 @@ class MultiModalityDataPaddingPatternMultimodalTokens(MultiModalityDataPaddingPa
         """
         if not input_ids or not mm_inputs.mm_items:
             return input_ids
+        if isinstance(mm_inputs.padded_input_ids, list) and len(
+            mm_inputs.padded_input_ids
+        ) == len(input_ids):
+            return mm_inputs.padded_input_ids
 
         input_ids_tensor = torch.as_tensor(input_ids)
 


### PR DESCRIPTION
## Summary
- Return precomputed `MultimodalInputs.padded_input_ids` when it already matches the current input length.
- Avoid recomputing padded multimodal ids via tensor conversion and offset writes on the scheduler path.

## Tests
- `pre-commit run --files python/sglang/srt/managers/mm_utils.py`











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26372376550](https://github.com/sgl-project/sglang/actions/runs/26372376550)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26372376481](https://github.com/sgl-project/sglang/actions/runs/26372376481)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->