### PR TITLE
Add router terminal prefix affinity for DP-aware routing

### DIFF
--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -39,6 +39,36 @@ static WORKER_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
         .expect("Failed to create worker HTTP client")
 });
 
+pub(crate) fn parse_bootstrap_host_from_url(url: &str) -> String {
+    let metadata_url = match url.rsplit_once('@') {
+        Some((base_url, rank)) if rank.parse::<usize>().is_ok() => base_url,
+        _ => url,
+    };
+
+    match url::Url::parse(metadata_url) {
+        Ok(parsed) => parsed.host_str().unwrap_or("localhost").to_string(),
+        Err(_) if !metadata_url.contains("://") => {
+            match url::Url::parse(&format!("http://{}", metadata_url)) {
+                Ok(parsed) => parsed.host_str().unwrap_or("localhost").to_string(),
+                Err(_) => {
+                    tracing::warn!(
+                        "Failed to parse URL '{}', defaulting to localhost",
+                        metadata_url
+                    );
+                    "localhost".to_string()
+                }
+            }
+        }
+        Err(_) => {
+            tracing::warn!(
+                "Failed to parse URL '{}', defaulting to localhost",
+                metadata_url
+            );
+            "localhost".to_string()
+        }
+    }
+}
+
 pub struct WorkerRoutingKeyLoad {
     url: String,
     active_routing_keys: dashmap::DashMap<String, usize>,
@@ -963,6 +993,8 @@ pub struct DPAwareWorker {
     dp_size: usize,
     /// Base URL without DP suffix
     base_url: String,
+    /// Bootstrap host parsed from the real base URL, not the virtual DP URL.
+    bootstrap_host: String,
 }
 
 impl DPAwareWorker {
@@ -974,11 +1006,13 @@ impl DPAwareWorker {
         dp_rank: usize,
         dp_size: usize,
     ) -> Self {
+        let bootstrap_host = parse_bootstrap_host_from_url(&base_url);
         Self {
             base_worker,
             dp_rank,
             dp_size,
             base_url,
+            bootstrap_host,
         }
     }
 }
@@ -999,6 +1033,10 @@ impl Worker for DPAwareWorker {
 
     fn connection_mode(&self) -> &ConnectionMode {
         self.base_worker.connection_mode()
+    }
+
+    fn bootstrap_host(&self) -> &str {
+        &self.bootstrap_host
     }
 
     fn is_healthy(&self) -> bool {
@@ -1273,6 +1311,22 @@ mod tests {
         circuit_breaker::{CircuitBreakerConfig, CircuitState},
         DPAwareWorkerBuilder,
     };
+
+    #[test]
+    fn test_parse_bootstrap_host_strips_dp_rank_suffix() {
+        assert_eq!(
+            parse_bootstrap_host_from_url("http://10.66.5.115:20664@3"),
+            "10.66.5.115"
+        );
+        assert_eq!(
+            parse_bootstrap_host_from_url("grpc://cluster.local@1"),
+            "cluster.local"
+        );
+        assert_eq!(
+            parse_bootstrap_host_from_url("localhost:8080@2"),
+            "localhost"
+        );
+    }
 
     #[test]
     fn test_worker_type_display() {
@@ -1679,6 +1733,7 @@ mod tests {
 
         assert_eq!(dp_worker.url(), "http://worker1:8080@2");
         assert_eq!(dp_worker.base_url(), "http://worker1:8080");
+        assert_eq!(dp_worker.bootstrap_host(), "worker1");
         assert!(dp_worker.is_dp_aware());
         assert_eq!(dp_worker.dp_rank(), Some(2));
         assert_eq!(dp_worker.dp_size(), Some(4));
@@ -1694,6 +1749,8 @@ mod tests {
             .build();
 
         assert_eq!(dp_worker.url(), "http://worker1:8080@1");
+        assert_eq!(dp_worker.bootstrap_host(), "worker1");
+        assert_eq!(dp_worker.bootstrap_port(), Some(9090));
         assert!(dp_worker.is_dp_aware());
         assert_eq!(
             dp_worker.worker_type(),
@@ -1712,6 +1769,23 @@ mod tests {
         assert_eq!(dp_worker.url(), "http://worker1:8080@0");
         assert!(dp_worker.is_dp_aware());
         assert_eq!(dp_worker.worker_type(), &WorkerType::Decode);
+    }
+
+    #[test]
+    fn test_dp_aware_worker_bootstrap_host_uses_base_url() {
+        let dp_worker = DPAwareWorkerBuilder::new("http://10.66.5.240:21686", 1, 4)
+            .worker_type(WorkerType::Prefill {
+                bootstrap_port: None,
+            })
+            .build();
+
+        assert_eq!(dp_worker.url(), "http://10.66.5.240:21686@1");
+        assert_eq!(
+            dp_worker.endpoint_url("/generate"),
+            "http://10.66.5.240:21686/generate"
+        );
+        assert_eq!(dp_worker.bootstrap_host(), "10.66.5.240");
+        assert_eq!(dp_worker.bootstrap_port(), None);
     }
 
     #[tokio::test]

--- a/sgl-model-gateway/src/core/worker_builder.rs
+++ b/sgl-model-gateway/src/core/worker_builder.rs
@@ -5,8 +5,8 @@ use super::{
     model_card::ModelCard,
     model_type::ModelType,
     worker::{
-        BasicWorker, ConnectionMode, DPAwareWorker, HealthConfig, RuntimeType, WorkerMetadata,
-        WorkerRoutingKeyLoad, WorkerType,
+        parse_bootstrap_host_from_url, BasicWorker, ConnectionMode, DPAwareWorker, HealthConfig,
+        RuntimeType, WorkerMetadata, WorkerRoutingKeyLoad, WorkerType,
     },
 };
 use crate::{observability::metrics::Metrics, routers::grpc::client::GrpcClient};
@@ -133,28 +133,7 @@ impl BasicWorkerBuilder {
 
         use tokio::sync::OnceCell;
 
-        let bootstrap_host = match url::Url::parse(&self.url) {
-            Ok(parsed) => parsed.host_str().unwrap_or("localhost").to_string(),
-            Err(_) if !self.url.contains("://") => {
-                match url::Url::parse(&format!("http://{}", self.url)) {
-                    Ok(parsed) => parsed.host_str().unwrap_or("localhost").to_string(),
-                    Err(_) => {
-                        tracing::warn!(
-                            "Failed to parse URL '{}', defaulting to localhost",
-                            self.url
-                        );
-                        "localhost".to_string()
-                    }
-                }
-            }
-            Err(_) => {
-                tracing::warn!(
-                    "Failed to parse URL '{}', defaulting to localhost",
-                    self.url
-                );
-                "localhost".to_string()
-            }
-        };
+        let bootstrap_host = parse_bootstrap_host_from_url(&self.url);
 
         let bootstrap_port = match self.worker_type {
             WorkerType::Prefill { bootstrap_port } => bootstrap_port,

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -3,53 +3,46 @@
 
     This router combines two strategies to optimize both cache utilization and request distribution:
 
-    1. Cache-Aware Routing (Approximate Tree)
-    2. Load Balancing (Shortest Queue with Balance Thresholds)
+    1. Terminal-prefix affinity (Approximate Tree)
+    2. Round-robin first placement
 
-    The router dynamically switches between these strategies based on load conditions:
-    - Uses load balancing when the system is imbalanced
-    - Uses cache-aware routing when the system is balanced
-
-    A system is considered imbalanced if both conditions are met:
-    1. (max - min) > abs_threshold
-    2. max > rel_threshold * min
+    Established conversations are routed back to the worker that owns a complete
+    request-boundary prefix. New conversations are placed round-robin so common
+    shared system/tool prefixes do not collapse first placement onto one worker.
 
     Strategy Details:
 
-    1. Cache-Aware Routing (Approximate Tree)
-    -------------------------------------------
+    1. Terminal-prefix affinity (Approximate Tree)
+    ----------------------------------------------
     This strategy maintains an approximate radix tree for each worker based on request history,
     eliminating the need for direct cache state queries. The tree stores raw text characters
     instead of token IDs to avoid tokenization overhead.
 
     Process:
     a. For each request, find the worker with the highest prefix match
-    b. If match rate > cache_threshold:
-    Route to the worker with highest match (likely has relevant data cached)
-    c. If match rate ≤ cache_threshold:
-    Route to the worker with smallest tree size (most available cache capacity)
+    b. If the match lands on a terminal request-boundary node:
+    Route to the worker that owns that terminal prefix
+    c. Otherwise:
+    Route to the next healthy worker by round-robin and insert that owner
     d. Background maintenance:
     Periodically evict least recently used leaf nodes to prevent memory overflow
 
-    2. Load Balancing (Shortest Queue)
-    -------------------------------------------
-    This strategy tracks pending request counts per worker and routes new requests
-    to the least busy worker when the system is detected to be imbalanced.
+    2. Round-robin first placement
+    ------------------------------
+    This strategy spreads new cache entries fairly across healthy workers. Later
+    terminal-prefix hits preserve the owner chosen for that initial placement.
 
     Configuration Parameters:
     ------------------------
     1. cache_threshold: (float, 0.0 to 1.0)
-    Minimum prefix match ratio to use highest-match routing.
-    Below this threshold, routes to worker with most available cache space.
+    Retained for config compatibility; terminal-only affinity ignores
+    non-terminal match rate when selecting an owner.
 
     2. balance_abs_threshold: (integer)
-    Absolute difference threshold for load imbalance detection.
-    System is potentially imbalanced if (max_load - min_load) > abs_threshold
+    Retained for config compatibility.
 
     3. balance_rel_threshold: (float)
-    Relative ratio threshold for load imbalance detection.
-    System is potentially imbalanced if max_load > min_load * rel_threshold
-    Used in conjunction with abs_threshold to determine final imbalance state.
+    Retained for config compatibility.
 
     4. eviction_interval_secs: (integer)
     Interval between LRU eviction cycles for the approximate trees.
@@ -411,11 +404,6 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         });
         let min_load = if min_load == usize::MAX { 0 } else { min_load };
 
-        // Check if load is imbalanced. A terminal prefix hit is evaluated before this
-        // redirects the request, so established request-boundary affinity stays stable.
-        let is_imbalanced = max_load.saturating_sub(min_load) > self.config.balance_abs_threshold
-            && (max_load as f32) > (min_load as f32 * self.config.balance_rel_threshold);
-
         let text = request_text.unwrap_or("");
 
         // Get the tree reference without locking the entire HashMap
@@ -431,17 +419,14 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
 
         if let Some(tree) = tree {
             // Now we work with the tree without holding the HashMap lock
-            // Use prefix_match_with_counts to avoid redundant chars().count() calls
             let result = tree.prefix_match_with_counts(text);
-            let match_rate = if result.input_char_count == 0 {
-                0.0
-            } else {
-                result.matched_char_count as f32 / result.input_char_count as f32
-            };
             let terminal_prefix_hit =
                 !result.ended_on_partial_match && result.matched_node_is_terminal;
-            let cache_hit = match_rate > self.config.cache_threshold;
-            let should_try_cache_owner = terminal_prefix_hit || (!is_imbalanced && cache_hit);
+            // Only a complete request-boundary prefix should carry affinity. A
+            // non-terminal shared-prefix hit can be a common system/tool prompt
+            // across unrelated conversations; using its owner here makes first
+            // placement collapse onto whichever DP rank inserted that prefix.
+            let should_try_cache_owner = terminal_prefix_hit;
 
             // Select worker without String allocation
             let selected_idx = if should_try_cache_owner {
@@ -647,6 +632,55 @@ mod tests {
             let idx = policy.select_worker(&workers, &info).await.unwrap();
             assert_eq!(idx, expected_idx);
         }
+    }
+
+    #[tokio::test]
+    async fn test_cache_aware_shared_prefix_miss_uses_round_robin() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            cache_threshold: 0.1,
+            balance_abs_threshold: 1000,
+            balance_rel_threshold: 1000.0,
+            eviction_interval_secs: 0,
+            max_tree_size: 10000,
+        });
+
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        let first = SelectWorkerInfo {
+            request_text: Some("shared-prefix conversation-a turn 1"),
+            ..Default::default()
+        };
+        let first_owner = policy.select_worker(&workers, &first).await.unwrap();
+        assert_eq!(first_owner, 0);
+
+        let second = SelectWorkerInfo {
+            request_text: Some("shared-prefix conversation-b turn 1"),
+            ..Default::default()
+        };
+        let second_owner = policy.select_worker(&workers, &second).await.unwrap();
+        assert_eq!(second_owner, 1);
+
+        let first_continuation = SelectWorkerInfo {
+            request_text: Some("shared-prefix conversation-a turn 1 plus more history"),
+            ..Default::default()
+        };
+        let selected = policy
+            .select_worker(&workers, &first_continuation)
+            .await
+            .unwrap();
+        assert_eq!(selected, first_owner);
     }
 
     #[tokio::test]

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -59,11 +59,13 @@
     during the next eviction cycle.
 */
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use rand::Rng;
 use smg_mesh::{tree_ops::TreeOperation, OptionalMeshSyncManager};
 use tracing::{debug, warn};
 
@@ -112,6 +114,7 @@ pub struct CacheAwarePolicy {
     config: CacheAwareConfig,
     trees: Arc<DashMap<String, Arc<Tree>>>,
     mesh_sync: OptionalMeshSyncManager,
+    miss_counter: AtomicUsize,
     _eviction_task: Option<PeriodicTask>,
 }
 
@@ -152,6 +155,7 @@ impl CacheAwarePolicy {
             config,
             trees,
             mesh_sync: None,
+            miss_counter: AtomicUsize::new(0),
             _eviction_task: eviction_task,
         }
     }
@@ -306,7 +310,16 @@ impl CacheAwarePolicy {
         }
     }
 
-    fn select_worker_min_load(
+    fn select_worker_round_robin(&self, healthy_indices: &[usize]) -> Option<usize> {
+        if healthy_indices.is_empty() {
+            return None;
+        }
+
+        let count = self.miss_counter.fetch_add(1, Ordering::Relaxed);
+        Some(healthy_indices[count % healthy_indices.len()])
+    }
+
+    fn select_worker_for_miss(
         &self,
         workers: &[Arc<dyn Worker>],
         request_text: &Option<&str>,
@@ -319,26 +332,24 @@ impl CacheAwarePolicy {
         if tracing::enabled!(tracing::Level::DEBUG) {
             let worker_loads: Vec<(&str, usize)> =
                 workers.iter().map(|w| (w.url(), w.load())).collect();
-            debug!(
-                "Load balancing triggered | max: {} | min: {} | workers: {:?}",
-                max_load, min_load, worker_loads
-            );
+            debug!("Cache miss placement | max: {max_load} | min: {min_load} | workers: {worker_loads:?}");
         }
 
-        // Use shortest queue when imbalanced
-        let min_load_idx = healthy_indices
-            .iter()
-            .min_by_key(|&&idx| workers[idx].load())
-            .copied()?;
+        // New cache entries should be spread fairly. If we use min-load here,
+        // transient zero/under-counted streaming load can collapse many first
+        // turns onto one DP rank, and later terminal-prefix hits will pin those
+        // conversations to that bad initial placement.
+        let idx = self.select_worker_round_robin(healthy_indices)?;
 
-        // Even in imbalanced mode, update the tree to maintain cache state
+        // Insert the miss under the selected worker so subsequent exact
+        // terminal-prefix hits return to the same owner.
         if let Some(text) = request_text {
             // Get the tree reference without locking the entire HashMap
             // DashMap only locks the specific shard containing this key
             let tree = self.trees.get(tree_key).map(|entry| entry.value().clone());
 
             if let Some(tree) = tree {
-                let worker_url = workers[min_load_idx].url();
+                let worker_url = workers[idx].url();
                 self.insert_tree_tenant(&tree, tree_key, text, worker_url);
             } else {
                 warn!(
@@ -351,9 +362,9 @@ impl CacheAwarePolicy {
         }
 
         // Increment processed counter
-        workers[min_load_idx].increment_processed();
+        workers[idx].increment_processed();
 
-        Some(min_load_idx)
+        Some(idx)
     }
 
     fn insert_tree_tenant(&self, tree: &Tree, tree_key: &str, text: &str, tenant_url: &str) {
@@ -473,7 +484,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                 }
             }
 
-            self.select_worker_min_load(
+            self.select_worker_for_miss(
                 workers,
                 &request_text,
                 &healthy_indices,
@@ -490,9 +501,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                  clears",
                 tree_key
             );
-            let mut rng = rand::rng();
-            let random_idx = rng.random_range(0..healthy_indices.len());
-            Some(healthy_indices[random_idx])
+            self.select_worker_round_robin(&healthy_indices)
         }
     }
 
@@ -514,6 +523,10 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
 
     fn needs_request_text(&self) -> bool {
         true // Cache-aware policy needs request text for cache affinity
+    }
+
+    fn reset(&self) {
+        self.miss_counter.store(0, Ordering::Relaxed);
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -598,7 +611,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cache_aware_with_imbalanced_load() {
+    async fn test_cache_aware_miss_uses_round_robin_even_when_imbalanced() {
         let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
             cache_threshold: 0.5,
             balance_abs_threshold: 5,
@@ -623,14 +636,16 @@ mod tests {
         let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(worker1), Arc::new(worker2)];
         policy.init_workers(&workers);
 
-        // Should select worker2 (lower load) despite cache affinity
-        let info = SelectWorkerInfo {
-            request_text: Some("test"),
-            ..Default::default()
-        };
-        for _ in 0..5 {
+        // New cache entries should be spread fairly. They should not all collapse
+        // onto the current min-load worker, because later terminal-prefix hits
+        // will preserve whatever owner the first request selected.
+        for (request_text, expected_idx) in [("alpha", 0), ("beta", 1), ("gamma", 0)] {
+            let info = SelectWorkerInfo {
+                request_text: Some(request_text),
+                ..Default::default()
+            };
             let idx = policy.select_worker(&workers, &info).await.unwrap();
-            assert_eq!(idx, 1); // Should always pick worker2
+            assert_eq!(idx, expected_idx);
         }
     }
 

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -339,21 +339,7 @@ impl CacheAwarePolicy {
 
             if let Some(tree) = tree {
                 let worker_url = workers[min_load_idx].url();
-                // Now we can work with the tree without holding the HashMap lock
-                tree.insert(text, worker_url);
-
-                // Sync insert operation to mesh if enabled (no-op if mesh is not enabled)
-                if let Some(ref mesh_sync) = self.mesh_sync {
-                    use smg_mesh::tree_ops::TreeInsertOp;
-                    let op = TreeOperation::Insert(TreeInsertOp {
-                        text: text.to_string(),
-                        tenant: worker_url.to_string(),
-                    });
-                    let mesh_key = Self::normalize_mesh_model_id(tree_key);
-                    if let Err(e) = mesh_sync.sync_tree_operation(mesh_key.to_string(), op) {
-                        warn!("Failed to sync tree insert operation to mesh: {}", e);
-                    }
-                }
+                self.insert_tree_tenant(&tree, tree_key, text, worker_url);
             } else {
                 warn!(
                     "cache_aware: no tree found for key '{}', skipping cache update — \
@@ -368,6 +354,23 @@ impl CacheAwarePolicy {
         workers[min_load_idx].increment_processed();
 
         Some(min_load_idx)
+    }
+
+    fn insert_tree_tenant(&self, tree: &Tree, tree_key: &str, text: &str, tenant_url: &str) {
+        tree.insert(text, tenant_url);
+
+        // Sync insert operation to mesh if enabled (no-op if mesh is not enabled)
+        if let Some(ref mesh_sync) = self.mesh_sync {
+            use smg_mesh::tree_ops::TreeInsertOp;
+            let op = TreeOperation::Insert(TreeInsertOp {
+                text: text.to_string(),
+                tenant: tenant_url.to_string(),
+            });
+            let mesh_key = Self::normalize_mesh_model_id(tree_key);
+            if let Err(e) = mesh_sync.sync_tree_operation(mesh_key.to_string(), op) {
+                warn!("Failed to sync tree insert operation to mesh: {}", e);
+            }
+        }
     }
 }
 
@@ -397,27 +400,23 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         });
         let min_load = if min_load == usize::MAX { 0 } else { min_load };
 
-        // Check if load is imbalanced
+        // Check if load is imbalanced. A terminal prefix hit is evaluated before this
+        // redirects the request, so established request-boundary affinity stays stable.
         let is_imbalanced = max_load.saturating_sub(min_load) > self.config.balance_abs_threshold
             && (max_load as f32) > (min_load as f32 * self.config.balance_rel_threshold);
 
-        if is_imbalanced {
-            return self.select_worker_min_load(
-                workers,
-                &request_text,
-                &healthy_indices,
-                &tree_key,
-                max_load,
-                min_load,
-            );
-        }
-
-        // Use cache-aware routing when balanced
         let text = request_text.unwrap_or("");
 
         // Get the tree reference without locking the entire HashMap
         // DashMap only locks the specific shard containing this key
-        let tree = self.trees.get(&tree_key).map(|entry| entry.value().clone());
+        let tree = self
+            .trees
+            .get(&tree_key)
+            .map(|entry| entry.value().clone())
+            .or_else(|| {
+                self.init_workers(workers);
+                self.trees.get(&tree_key).map(|entry| entry.value().clone())
+            });
 
         if let Some(tree) = tree {
             // Now we work with the tree without holding the HashMap lock
@@ -428,9 +427,13 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             } else {
                 result.matched_char_count as f32 / result.input_char_count as f32
             };
+            let terminal_prefix_hit =
+                !result.ended_on_partial_match && result.matched_node_is_terminal;
+            let cache_hit = match_rate > self.config.cache_threshold;
+            let should_try_cache_owner = terminal_prefix_hit || (!is_imbalanced && cache_hit);
 
             // Select worker without String allocation
-            let selected_idx = if match_rate > self.config.cache_threshold {
+            let selected_idx = if should_try_cache_owner {
                 // Cache hit path: find worker by URL (compare &str directly, no allocation)
                 let tenant_url: &str = &result.tenant;
                 workers
@@ -438,29 +441,12 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                     .position(|w| w.url() == tenant_url)
                     .filter(|&idx| workers[idx].is_healthy())
             } else {
-                // Low cache match: use worker with minimum load
-                healthy_indices
-                    .iter()
-                    .min_by_key(|&&idx| workers[idx].load())
-                    .copied()
+                None
             };
 
             if let Some(idx) = selected_idx {
                 // Update the tree with this request (use worker URL directly, no allocation)
-                tree.insert(text, workers[idx].url());
-
-                // Sync insert operation to mesh if enabled (no-op if mesh is not enabled)
-                if let Some(ref mesh_sync) = self.mesh_sync {
-                    use smg_mesh::tree_ops::TreeInsertOp;
-                    let op = TreeOperation::Insert(TreeInsertOp {
-                        text: text.to_string(),
-                        tenant: workers[idx].url().to_string(),
-                    });
-                    let mesh_key = Self::normalize_mesh_model_id(&tree_key);
-                    if let Err(e) = mesh_sync.sync_tree_operation(mesh_key.to_string(), op) {
-                        warn!("Failed to sync tree insert operation to mesh: {}", e);
-                    }
-                }
+                self.insert_tree_tenant(&tree, &tree_key, text, workers[idx].url());
 
                 // Increment processed counter
                 workers[idx].increment_processed();
@@ -469,7 +455,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             }
 
             // Selected worker no longer exists or unhealthy, remove stale tenant from tree
-            if match_rate > self.config.cache_threshold {
+            if should_try_cache_owner {
                 let tenant_url: &str = &result.tenant;
                 tree.remove_tenant(tenant_url);
                 debug!("Removed stale worker {} from cache tree", tenant_url);
@@ -487,8 +473,14 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
                 }
             }
 
-            // Fallback to first healthy worker
-            healthy_indices.first().copied()
+            self.select_worker_min_load(
+                workers,
+                &request_text,
+                &healthy_indices,
+                &tree_key,
+                max_load,
+                min_load,
+            )
         } else {
             warn!(
                 "cache_aware: no tree found for key '{}', falling back to random \
@@ -640,6 +632,48 @@ mod tests {
             let idx = policy.select_worker(&workers, &info).await.unwrap();
             assert_eq!(idx, 1); // Should always pick worker2
         }
+    }
+
+    #[tokio::test]
+    async fn test_cache_aware_keeps_terminal_prefix_hit_when_imbalanced() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 0,
+            balance_rel_threshold: 1.0,
+            eviction_interval_secs: 0,
+            max_tree_size: 10000,
+        });
+
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        let first_turn = SelectWorkerInfo {
+            request_text: Some("conversation-prefix turn 1"),
+            ..Default::default()
+        };
+        let cache_owner = policy.select_worker(&workers, &first_turn).await.unwrap();
+
+        for _ in 0..20 {
+            workers[cache_owner].increment_load();
+        }
+
+        let next_turn = SelectWorkerInfo {
+            request_text: Some("conversation-prefix turn 1 plus more history"),
+            ..Default::default()
+        };
+        let selected = policy.select_worker(&workers, &next_turn).await.unwrap();
+        assert_eq!(selected, cache_owner);
     }
 
     #[tokio::test]

--- a/sgl-model-gateway/src/policies/tree.rs
+++ b/sgl-model-gateway/src/policies/tree.rs
@@ -35,6 +35,12 @@ fn new_tenant_map() -> DashMap<TenantId, u64> {
     DashMap::with_shard_amount(NODE_SHARD_COUNT)
 }
 
+/// Create a terminal tenant DashMap for non-root nodes.
+#[inline]
+fn new_terminal_tenant_map() -> DashMap<TenantId, ()> {
+    DashMap::with_shard_amount(NODE_SHARD_COUNT)
+}
+
 /// Interned tenant ID to avoid repeated string allocations.
 /// Using Arc<str> allows cheap cloning and comparison.
 pub type TenantId = Arc<str>;
@@ -48,6 +54,10 @@ pub struct PrefixMatchResult {
     pub matched_char_count: usize,
     /// Total number of characters in the input text
     pub input_char_count: usize,
+    /// True when the match stopped inside a radix node instead of at a node boundary.
+    pub ended_on_partial_match: bool,
+    /// True when the matched node is the terminal boundary of an inserted request.
+    pub matched_node_is_terminal: bool,
 }
 
 /// A fast identity hasher for single-character keys (used in children DashMap).
@@ -235,6 +245,8 @@ struct Node {
     text: RwLock<NodeText>,
     /// Per-tenant last access epoch for LRU ordering. Using TenantId (Arc<str>) for cheap cloning.
     tenant_last_access_time: DashMap<TenantId, u64>,
+    /// Tenants for which this node is an exact inserted request boundary.
+    terminal_tenants: DashMap<TenantId, ()>,
     /// Parent pointer for upward traversal during timestamp updates
     parent: RwLock<Option<NodeRef>>,
     /// Cached last-accessed tenant for O(1) lookup during prefix match.
@@ -352,6 +364,7 @@ impl Tree {
                 ),
                 text: RwLock::new(NodeText::empty()),
                 tenant_last_access_time: DashMap::with_shard_amount(ROOT_SHARD_COUNT),
+                terminal_tenants: DashMap::with_shard_amount(ROOT_SHARD_COUNT),
                 parent: RwLock::new(None),
                 last_tenant: parking_lot::RwLock::new(None),
             }),
@@ -405,6 +418,7 @@ impl Tree {
                         children: new_children_map(),
                         text: RwLock::new(NodeText::new(remaining.to_string())),
                         tenant_last_access_time: new_tenant_map(),
+                        terminal_tenants: new_terminal_tenant_map(),
                         parent: RwLock::new(Some(Arc::clone(&prev))),
                         last_tenant: parking_lot::RwLock::new(Some(Arc::clone(&tenant_id))),
                     });
@@ -417,6 +431,7 @@ impl Tree {
                     new_node
                         .tenant_last_access_time
                         .insert(Arc::clone(&tenant_id), epoch);
+                    new_node.terminal_tenants.insert(Arc::clone(&tenant_id), ());
 
                     entry.insert(new_node);
                     InsertStep::Done
@@ -446,6 +461,7 @@ impl Tree {
                             children: new_children_map(),
                             parent: RwLock::new(Some(Arc::clone(&prev))),
                             tenant_last_access_time: matched_node.tenant_last_access_time.clone(),
+                            terminal_tenants: new_terminal_tenant_map(),
                             last_tenant: parking_lot::RwLock::new(
                                 matched_node.last_tenant.read().clone(),
                             ),
@@ -524,6 +540,9 @@ impl Tree {
         let epoch = get_epoch();
         prev.tenant_last_access_time
             .insert(Arc::clone(&tenant_id), epoch);
+        if !text.is_empty() {
+            prev.terminal_tenants.insert(Arc::clone(&tenant_id), ());
+        }
     }
 
     /// Performs prefix matching and returns detailed result with char counts.
@@ -532,6 +551,7 @@ impl Tree {
         let mut remaining = text;
         let mut matched_chars = 0;
         let mut prev = Arc::clone(&self.root);
+        let mut ended_on_partial_match = false;
 
         while !remaining.is_empty() {
             let first_char = remaining.chars().next().unwrap();
@@ -555,6 +575,7 @@ impl Tree {
                     // Partial match - still use this node for tenant selection
                     matched_chars += shared_count;
                     prev = matched_node;
+                    ended_on_partial_match = true;
                     break;
                 }
             } else {
@@ -564,12 +585,34 @@ impl Tree {
         }
 
         let curr = prev;
+        let matched_node_is_terminal =
+            matched_chars > 0 && !ended_on_partial_match && !curr.terminal_tenants.is_empty();
 
         // Try cached tenant first (O(1)) before falling back to O(shards) DashMap iteration.
         // The cache is valid if the tenant still exists in tenant_last_access_time.
         let tenant: TenantId = {
             let cached = curr.last_tenant.read();
-            if let Some(ref t) = *cached {
+            let terminal_cached = if let Some(ref t) = *cached {
+                curr.terminal_tenants
+                    .contains_key(t.as_ref())
+                    .then(|| Arc::clone(t))
+            } else {
+                None
+            };
+
+            if let Some(t) = terminal_cached {
+                t
+            } else if matched_node_is_terminal {
+                drop(cached);
+                let t = curr
+                    .terminal_tenants
+                    .iter()
+                    .next()
+                    .map(|kv| Arc::clone(kv.key()))
+                    .unwrap_or_else(|| Arc::from("empty"));
+                *curr.last_tenant.write() = Some(Arc::clone(&t));
+                t
+            } else if let Some(ref t) = *cached {
                 if curr.tenant_last_access_time.contains_key(t.as_ref()) {
                     Arc::clone(t)
                 } else {
@@ -615,6 +658,8 @@ impl Tree {
             tenant,
             matched_char_count: matched_chars,
             input_char_count,
+            ended_on_partial_match,
+            matched_node_is_terminal,
         }
     }
 
@@ -775,12 +820,16 @@ impl Tree {
 
             // Remove tenant from node
             node.tenant_last_access_time.remove(tenant.as_ref());
+            node.terminal_tenants.remove(tenant.as_ref());
 
             // Get parent reference outside of the borrow scope
             let parent_opt = node.parent.read().unwrap().clone();
 
             // Remove empty nodes
-            if node.children.is_empty() && node.tenant_last_access_time.is_empty() {
+            if node.children.is_empty()
+                && node.tenant_last_access_time.is_empty()
+                && node.terminal_tenants.is_empty()
+            {
                 if let Some(ref parent) = parent_opt {
                     if let Some(fc) = node.text.read().unwrap().first_char() {
                         parent.children.remove(&fc);
@@ -855,12 +904,16 @@ impl Tree {
         while let Some(curr) = queue.pop_front() {
             // Remove tenant from node
             curr.tenant_last_access_time.remove(tenant_id.as_ref());
+            curr.terminal_tenants.remove(tenant_id.as_ref());
 
             // Get parent reference outside of the borrow scope
             let parent_opt = curr.parent.read().unwrap().clone();
 
             // Remove empty nodes
-            if curr.children.is_empty() && curr.tenant_last_access_time.is_empty() {
+            if curr.children.is_empty()
+                && curr.tenant_last_access_time.is_empty()
+                && curr.terminal_tenants.is_empty()
+            {
                 if let Some(ref parent) = parent_opt {
                     if let Some(fc) = curr.text.read().unwrap().first_char() {
                         parent.children.remove(&fc);
@@ -1846,6 +1899,44 @@ mod tests {
         let result = tree.prefix_match_with_counts("goodbye");
         assert_eq!(result.matched_char_count, 0);
         assert_eq!(result.input_char_count, 7);
+        assert!(!result.matched_node_is_terminal);
+    }
+
+    #[test]
+    fn test_prefix_match_reports_terminal_boundary() {
+        let tree = Tree::new();
+
+        tree.insert("hello", "tenant1");
+        tree.insert("hello world", "tenant2");
+
+        let result = tree.prefix_match_with_counts("hello");
+        assert_eq!(result.matched_char_count, 5);
+        assert_eq!(result.input_char_count, 5);
+        assert!(result.matched_node_is_terminal);
+        assert!(!result.ended_on_partial_match);
+        assert_eq!(&*result.tenant, "tenant1");
+
+        let result = tree.prefix_match_with_counts("hello world and more");
+        assert_eq!(result.matched_char_count, 11);
+        assert!(result.matched_node_is_terminal);
+        assert_eq!(&*result.tenant, "tenant2");
+
+        let result = tree.prefix_match_with_counts("helipad");
+        assert_eq!(result.matched_char_count, 3);
+        assert!(result.ended_on_partial_match);
+        assert!(!result.matched_node_is_terminal);
+    }
+
+    #[test]
+    fn test_empty_insert_does_not_make_zero_match_terminal() {
+        let tree = Tree::new();
+
+        tree.insert("", "tenant1");
+        tree.insert("hello", "tenant2");
+
+        let result = tree.prefix_match_with_counts("goodbye");
+        assert_eq!(result.matched_char_count, 0);
+        assert!(!result.matched_node_is_terminal);
     }
 
     #[test]

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1762,10 +1762,7 @@ mod tests {
         assert_eq!(decode_request.body["data_parallel_rank"], 1);
         assert_eq!(decode_request.body["disagg_prefill_dp_rank"], 2);
         assert_eq!(decode_request.body["bootstrap_room"], 1234);
-        assert!(matches!(
-            prefill_request.body,
-            std::borrow::Cow::Owned(_)
-        ));
+        assert!(matches!(prefill_request.body, std::borrow::Cow::Owned(_)));
         assert!(matches!(decode_request.body, std::borrow::Cow::Owned(_)));
     }
 
@@ -1805,10 +1802,7 @@ mod tests {
             prefill_request.body,
             std::borrow::Cow::Borrowed(_)
         ));
-        assert!(matches!(
-            decode_request.body,
-            std::borrow::Cow::Borrowed(_)
-        ));
+        assert!(matches!(decode_request.body, std::borrow::Cow::Borrowed(_)));
     }
 
     #[test]

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::{borrow::Cow, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
 use axum::{
@@ -56,6 +56,11 @@ pub struct PDRouter {
     pub enable_igw: bool,
 }
 
+struct PreparedWorkerRequest<'a> {
+    endpoint_url: String,
+    body: Cow<'a, Value>,
+}
+
 #[derive(Clone)]
 struct PDRequestContext<'a> {
     route: &'static str,
@@ -77,16 +82,20 @@ struct PDRequestContext<'a> {
 struct BreakerOutcomesRecorded;
 
 impl PDRouter {
+    fn worker_endpoint_url(worker: &dyn Worker, endpoint: &str) -> String {
+        api_path(worker.base_url(), endpoint)
+    }
+
     async fn proxy_to_first_prefill_worker(
         &self,
         endpoint: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
         let workers = self.worker_registry.get_prefill_workers();
-        let first_worker_url = workers.first().map(|w| w.url().to_string());
 
-        if let Some(worker_url) = first_worker_url {
-            self.proxy_to_worker(worker_url, endpoint, headers).await
+        if let Some(worker) = workers.first() {
+            self.proxy_to_worker(worker.as_ref(), endpoint, headers)
+                .await
         } else {
             error::service_unavailable("no_prefill_servers", "No prefill servers available")
         }
@@ -94,11 +103,11 @@ impl PDRouter {
 
     async fn proxy_to_worker(
         &self,
-        worker_url: String,
+        worker: &dyn Worker,
         endpoint: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
-        let url = format!("{}/{}", worker_url, endpoint);
+        let url = Self::worker_endpoint_url(worker, endpoint);
         let mut request_builder = self.client.get(&url);
 
         if let Some(headers) = headers {
@@ -224,6 +233,7 @@ impl PDRouter {
     const BOOTSTRAP_HOST_KEY: &'static str = "bootstrap_host";
     const BOOTSTRAP_PORT_KEY: &'static str = "bootstrap_port";
     const BOOTSTRAP_ROOM_KEY: &'static str = "bootstrap_room";
+    const DISAGG_PREFILL_DP_RANK_KEY: &'static str = "disagg_prefill_dp_rank";
 
     fn inject_bootstrap_into_value(
         mut original: Value,
@@ -283,6 +293,73 @@ impl PDRouter {
             );
         }
         Ok(original)
+    }
+
+    fn inject_prefill_dp_rank_for_decode<'a>(
+        decode_request: Cow<'a, Value>,
+        prefill_worker: &dyn Worker,
+    ) -> Result<Cow<'a, Value>, String> {
+        let Some(prefill_dp_rank) = prefill_worker.dp_rank() else {
+            return Ok(decode_request);
+        };
+
+        let mut decode_request = decode_request.into_owned();
+        let Some(obj) = decode_request.as_object_mut() else {
+            return Err(
+                "Failed to insert disagg_prefill_dp_rank because request body is not an object"
+                    .to_string(),
+            );
+        };
+
+        obj.insert(
+            Self::DISAGG_PREFILL_DP_RANK_KEY.to_string(),
+            Value::from(prefill_dp_rank as u64),
+        );
+        Ok(Cow::Owned(decode_request))
+    }
+
+    async fn prepare_worker_request<'a>(
+        route: &'static str,
+        worker: &dyn Worker,
+        json_request: Cow<'a, Value>,
+    ) -> Result<PreparedWorkerRequest<'a>, String> {
+        let body = if worker.is_dp_aware() {
+            Cow::Owned(
+                worker
+                    .prepare_request(json_request.into_owned())
+                    .await
+                    .map_err(|err| {
+                        format!(
+                            "Failed to prepare request for worker {}: {}",
+                            worker.url(),
+                            err
+                        )
+                    })?,
+            )
+        } else {
+            json_request
+        };
+
+        Ok(PreparedWorkerRequest {
+            endpoint_url: Self::worker_endpoint_url(worker, route),
+            body,
+        })
+    }
+
+    async fn prepare_pd_worker_requests<'a>(
+        route: &'static str,
+        json_request: &'a Value,
+        prefill: &dyn Worker,
+        decode: &dyn Worker,
+    ) -> Result<(PreparedWorkerRequest<'a>, PreparedWorkerRequest<'a>), String> {
+        let prefill_request =
+            Self::prepare_worker_request(route, prefill, Cow::Borrowed(json_request)).await?;
+        let decode_json_request =
+            Self::inject_prefill_dp_rank_for_decode(Cow::Borrowed(json_request), prefill)?;
+        let decode_request =
+            Self::prepare_worker_request(route, decode, decode_json_request).await?;
+
+        Ok((prefill_request, decode_request))
     }
 
     async fn execute_dual_dispatch<T: Serialize + Clone>(
@@ -586,20 +663,33 @@ impl PDRouter {
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
 
+        let (prepared_prefill, prepared_decode) = match Self::prepare_pd_worker_requests(
+            context.route,
+            &json_request,
+            prefill.as_ref(),
+            decode.as_ref(),
+        )
+        .await
+        {
+            Ok(requests) => requests,
+            Err(e) => {
+                error!("Failed to prepare PD worker requests: {}", e);
+                return error::internal_error("pd_request_preparation_failed", e);
+            }
+        };
+
         // Build both requests
         let prefill_request = self.build_post_with_headers(
             &self.client,
-            prefill.url(),
-            context.route,
-            &json_request,
+            &prepared_prefill.endpoint_url,
+            &prepared_prefill.body,
             headers,
             false,
         );
         let decode_request = self.build_post_with_headers(
             &self.client,
-            decode.url(),
-            context.route,
-            &json_request,
+            &prepared_decode.endpoint_url,
+            &prepared_decode.body,
             headers,
             false,
         );
@@ -1179,13 +1269,12 @@ impl PDRouter {
     fn build_post_with_headers(
         &self,
         client: &Client,
-        url: &str,
-        route: &'static str,
+        endpoint_url: &str,
         json_request: &Value,
         headers: Option<&HeaderMap>,
         connection_close: bool,
     ) -> reqwest::RequestBuilder {
-        let mut request = client.post(api_path(url, route)).json(json_request);
+        let mut request = client.post(endpoint_url).json(json_request);
         if connection_close {
             request = request.header("Connection", "close");
         }
@@ -1293,12 +1382,11 @@ impl RouterTrait for PDRouter {
             }
         };
 
-        let prefill_url = format!("{}/health_generate", prefill.url());
+        let prefill_url = Self::worker_endpoint_url(prefill.as_ref(), "health_generate");
+        let decode_url = Self::worker_endpoint_url(decode.as_ref(), "health_generate");
         let (prefill_result, decode_result) = tokio::join!(
             self.client.get(&prefill_url).send(),
-            self.client
-                .get(format!("{}/health_generate", decode.url()))
-                .send()
+            self.client.get(&decode_url).send()
         );
 
         // Check results
@@ -1550,7 +1638,7 @@ impl RouterTrait for PDRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{BasicWorkerBuilder, WorkerType};
+    use crate::core::{BasicWorkerBuilder, DPAwareWorkerBuilder, WorkerType};
 
     fn create_test_pd_router() -> PDRouter {
         let worker_registry = Arc::new(WorkerRegistry::new());
@@ -1617,6 +1705,110 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("No prefill workers available"));
+    }
+
+    #[test]
+    fn test_worker_endpoint_url_uses_base_url_for_dp_aware_worker() {
+        let worker = DPAwareWorkerBuilder::new("http://prefill:30000", 2, 4)
+            .worker_type(WorkerType::Prefill {
+                bootstrap_port: Some(8998),
+            })
+            .build();
+
+        assert_eq!(
+            PDRouter::worker_endpoint_url(&worker, "health_generate"),
+            "http://prefill:30000/health_generate"
+        );
+        assert_eq!(
+            PDRouter::worker_endpoint_url(&worker, "/v1/models"),
+            "http://prefill:30000/v1/models"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prepare_pd_worker_requests_uses_dp_aware_rank() {
+        let prefill = DPAwareWorkerBuilder::new("http://prefill:30000", 2, 4)
+            .worker_type(WorkerType::Prefill {
+                bootstrap_port: Some(8998),
+            })
+            .build();
+        let decode = DPAwareWorkerBuilder::new("http://decode:30001", 1, 4)
+            .worker_type(WorkerType::Decode)
+            .build();
+        let request = json!({
+            "prompt": "shared prefix",
+            "max_tokens": 8,
+            "bootstrap_host": "prefill",
+            "bootstrap_port": 8998,
+            "bootstrap_room": 1234,
+        });
+
+        let (prefill_request, decode_request) =
+            PDRouter::prepare_pd_worker_requests("/v1/completions", &request, &prefill, &decode)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            prefill_request.endpoint_url,
+            "http://prefill:30000/v1/completions"
+        );
+        assert_eq!(prefill_request.body["data_parallel_rank"], 2);
+        assert!(prefill_request.body.get("disagg_prefill_dp_rank").is_none());
+
+        assert_eq!(
+            decode_request.endpoint_url,
+            "http://decode:30001/v1/completions"
+        );
+        assert_eq!(decode_request.body["data_parallel_rank"], 1);
+        assert_eq!(decode_request.body["disagg_prefill_dp_rank"], 2);
+        assert_eq!(decode_request.body["bootstrap_room"], 1234);
+        assert!(matches!(
+            prefill_request.body,
+            std::borrow::Cow::Owned(_)
+        ));
+        assert!(matches!(decode_request.body, std::borrow::Cow::Owned(_)));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_pd_worker_requests_preserves_non_dp_workers() {
+        let prefill = BasicWorkerBuilder::new("http://prefill:30000")
+            .worker_type(WorkerType::Prefill {
+                bootstrap_port: Some(8998),
+            })
+            .build();
+        let decode = BasicWorkerBuilder::new("http://decode:30001")
+            .worker_type(WorkerType::Decode)
+            .build();
+        let request = json!({
+            "prompt": "shared prefix",
+            "max_tokens": 8,
+            "bootstrap_room": 1234,
+        });
+
+        let (prefill_request, decode_request) =
+            PDRouter::prepare_pd_worker_requests("/v1/completions", &request, &prefill, &decode)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            prefill_request.endpoint_url,
+            "http://prefill:30000/v1/completions"
+        );
+        assert_eq!(
+            decode_request.endpoint_url,
+            "http://decode:30001/v1/completions"
+        );
+        assert!(prefill_request.body.get("data_parallel_rank").is_none());
+        assert!(decode_request.body.get("data_parallel_rank").is_none());
+        assert!(decode_request.body.get("disagg_prefill_dp_rank").is_none());
+        assert!(matches!(
+            prefill_request.body,
+            std::borrow::Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            decode_request.body,
+            std::borrow::Cow::Borrowed(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

**Stacked PR:** this PR depends on #26245 for DP-aware PD router dispatch. The latest benchmark also includes #26285, which builds cache-aware chat `request_text` from the full ordered chat history. Merge/rebase order should be #26245 -> #26285 -> this PR.

For multi-turn agent workloads without explicit conversation IDs, later turns often contain an earlier turn's full request as a complete prefix. The cache-aware router already computes prefix matches in its radix tree, but ordinary shared-prefix matches can be ambiguous: a large common system/tool prefix may be shared by many unrelated conversations.

This PR adds router-side terminal-prefix affinity so complete-prefix hits can stay on the matched DP-aware worker without requiring the benchmark/client to send a conversation routing key. In the latest validation stack, only terminal-prefix hits are allowed to use the cached owner directly; non-terminal/shared-prefix cases fall back to round-robin first placement to avoid concentrating unrelated conversations on one prefill DP rank.

## Modifications

- Record inserted-request terminal boundaries in the router cache-aware radix tree.
- Extend prefix-match metadata so cache-aware routing can distinguish terminal-prefix hits from ordinary partial-prefix matches.
- Keep terminal-prefix hits sticky to the matched DP-aware worker.
- Let non-terminal/shared-prefix matches fall through to round-robin first placement, so large shared prompts do not collapse onto a single prefill DP rank.
- Add unit coverage for terminal-prefix detection and the shared-prefix/new-conversation fallback behavior.

## Accuracy Tests

Not run. This changes router policy selection only; it does not modify request payloads sent to workers or model forward logic.

## Speed Tests and Profiling

### Setup

Private AA-RWLT coding-agent workload on GB300:

- Model: DeepSeek-V4-Pro
- Serving shape: SGLang PD disaggregation, DEP4 prefill -> DEP8 decode
- Router: `sglang_router` with PD disaggregation, `--dp-aware`, `prefill_policy=cache_aware`, `decode_policy=round_robin`
- Benchmark: c32 full run, no explicit conversation routing headers for this PR's main result
- Latest validation stack: #26245 + #26285 + this PR's strict terminal-owner behavior
- Validation branch/commit for the latest result: `yangmin/pr26245-fullchat-terminal-strict-rr`, commit `a9b947897`

### Results

Superseded early numbers from older/wrong configs and timeout-heavy ablations have been removed. The table below keeps the latest comparable c32 results only.

| Run | Job | Measured | OK / Err | Cache hit | Server output TPS | Client output TPS | TTFT p50 / p95 / p99 |
|---|---:|---:|---:|---:|---:|---:|---:|
| #26245 + #26285 FullChat baseline | 1900073 | 4152 | 4151 / 1 | 95.3% | 1152.4 | 1227.2 | 0.916 / 3.421 / 6.085s |
| Explicit conversation-key sticky baseline | 1899538 | 4089 | 4088 / 1 | 95.8% | 1167.2 | 1237.5 | 0.674 / 2.364 / 4.205s |
| #26245 + #26285 + this PR, strict terminal owner | 1909355 | 4119 | 4116 / 3 | 96.1% | 1201.0 | 1252.1 | 0.629 / 2.040 / 3.480s |

Compared with the FullChat baseline, the latest terminal-owner result improves:

- cache hit rate: `95.3% -> 96.1%`
- server output TPS: `1152.4 -> 1201.0` (`+4.2%`)
- TTFT p95: `3.421s -> 2.040s` (`-40.4%`)
- TTFT p99: `6.085s -> 3.480s` (`-42.8%`)

Compared with the explicit conversation-key sticky baseline, the latest terminal-owner result is also slightly better in this c32 run:

- server output TPS: `1167.2 -> 1201.0` (`+2.9%`)
- TTFT p95: `2.364s -> 2.040s`
- TTFT p99: `4.205s -> 3.480s`

### Rank Distribution Check

The main regression risk for terminal-prefix affinity is prefill DP-rank collapse. The latest strict terminal-owner result does not show that collapse.

Post-measurement prefill batch counts for job `1909355`:

```text
DP0: 1067
DP1:  869
DP2: 1264
DP3:  927
```

Post-measurement decode batch counts were also balanced:

```text
DP0: 1917
DP1: 1913
DP2: 1918
DP3: 1923
DP4: 1926
DP5: 1915
DP6: 1913
DP7: 1922
```

The three measured errors in job `1909355` were `No output (stream completed but no content chunks)` during hard-timeout/grace-period shutdown; there was no worker crash or router failure.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26461745340](https://github.com/sgl-project/sglang/actions/runs/26461745340)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26461745191](https://github.com/sgl-project/sglang/actions/runs/26461745191)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
