### PR TITLE
Fix DP-aware PD router worker URLs

### DIFF
--- a/sgl-model-gateway/src/core/worker_builder.rs
+++ b/sgl-model-gateway/src/core/worker_builder.rs
@@ -124,6 +124,18 @@ impl BasicWorkerBuilder {
         self
     }
 
+    fn url_for_bootstrap_metadata(url: &str) -> &str {
+        let Some((base_url, rank)) = url.rsplit_once('@') else {
+            return url;
+        };
+
+        if rank.parse::<usize>().is_ok() {
+            base_url
+        } else {
+            url
+        }
+    }
+
     /// Build the BasicWorker instance
     pub fn build(self) -> BasicWorker {
         use std::sync::{
@@ -133,15 +145,16 @@ impl BasicWorkerBuilder {
 
         use tokio::sync::OnceCell;
 
-        let bootstrap_host = match url::Url::parse(&self.url) {
+        let metadata_url = Self::url_for_bootstrap_metadata(&self.url);
+        let bootstrap_host = match url::Url::parse(metadata_url) {
             Ok(parsed) => parsed.host_str().unwrap_or("localhost").to_string(),
-            Err(_) if !self.url.contains("://") => {
-                match url::Url::parse(&format!("http://{}", self.url)) {
+            Err(_) if !metadata_url.contains("://") => {
+                match url::Url::parse(&format!("http://{}", metadata_url)) {
                     Ok(parsed) => parsed.host_str().unwrap_or("localhost").to_string(),
                     Err(_) => {
                         tracing::warn!(
                             "Failed to parse URL '{}', defaulting to localhost",
-                            self.url
+                            metadata_url
                         );
                         "localhost".to_string()
                     }
@@ -150,7 +163,7 @@ impl BasicWorkerBuilder {
             Err(_) => {
                 tracing::warn!(
                     "Failed to parse URL '{}', defaulting to localhost",
-                    self.url
+                    metadata_url
                 );
                 "localhost".to_string()
             }
@@ -474,6 +487,7 @@ mod tests {
         let worker = DPAwareWorkerBuilder::new("http://localhost:8080", 2, 8).build();
 
         assert_eq!(worker.url(), "http://localhost:8080@2");
+        assert_eq!(worker.bootstrap_host(), "localhost");
         assert_eq!(worker.dp_rank(), Some(2));
         assert_eq!(worker.dp_size(), Some(8));
         assert_eq!(worker.worker_type(), &WorkerType::Regular);
@@ -504,6 +518,8 @@ mod tests {
             .build();
 
         assert_eq!(worker.url(), "http://localhost:8080@3");
+        assert_eq!(worker.bootstrap_host(), "localhost");
+        assert_eq!(worker.bootstrap_port(), Some(9090));
         assert_eq!(worker.dp_rank(), Some(3));
         assert_eq!(worker.dp_size(), Some(16));
         assert_eq!(worker.metadata().labels, labels);
@@ -538,6 +554,7 @@ mod tests {
             .build();
 
         assert_eq!(worker.url(), "grpc://cluster.local@1");
+        assert_eq!(worker.bootstrap_host(), "cluster.local");
         assert_eq!(worker.dp_rank(), Some(1));
         assert_eq!(worker.dp_size(), Some(4));
         assert_eq!(worker.worker_type(), &WorkerType::Decode);
@@ -549,5 +566,18 @@ mod tests {
             worker.metadata().labels.get("transport"),
             Some(&"grpc".to_string())
         );
+    }
+
+    #[test]
+    fn test_dp_aware_worker_builder_ipv4_bootstrap_host_uses_base_url() {
+        let worker = DPAwareWorkerBuilder::new("http://10.66.5.115:20664", 3, 4)
+            .worker_type(WorkerType::Prefill {
+                bootstrap_port: Some(8998),
+            })
+            .build();
+
+        assert_eq!(worker.url(), "http://10.66.5.115:20664@3");
+        assert_eq!(worker.bootstrap_host(), "10.66.5.115");
+        assert_eq!(worker.bootstrap_port(), Some(8998));
     }
 }

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::{borrow::Cow, sync::Arc, time::Instant};
 
 use async_trait::async_trait;
 use axum::{
@@ -83,10 +83,10 @@ impl PDRouter {
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
         let workers = self.worker_registry.get_prefill_workers();
-        let first_worker_url = workers.first().map(|w| w.url().to_string());
 
-        if let Some(worker_url) = first_worker_url {
-            self.proxy_to_worker(worker_url, endpoint, headers).await
+        if let Some(worker) = workers.first() {
+            self.proxy_to_worker(worker.as_ref(), endpoint, headers)
+                .await
         } else {
             error::service_unavailable("no_prefill_servers", "No prefill servers available")
         }
@@ -94,11 +94,11 @@ impl PDRouter {
 
     async fn proxy_to_worker(
         &self,
-        worker_url: String,
+        worker: &dyn Worker,
         endpoint: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
-        let url = format!("{}/{}", worker_url, endpoint);
+        let url = api_path(worker.base_url(), endpoint);
         let mut request_builder = self.client.get(&url);
 
         if let Some(headers) = headers {
@@ -587,22 +587,34 @@ impl PDRouter {
         let headers = Some(&headers_with_trace);
 
         // Build both requests
-        let prefill_request = self.build_post_with_headers(
-            &self.client,
-            prefill.url(),
-            context.route,
-            &json_request,
-            headers,
-            false,
-        );
-        let decode_request = self.build_post_with_headers(
-            &self.client,
-            decode.url(),
-            context.route,
-            &json_request,
-            headers,
-            false,
-        );
+        let prefill_request = match self
+            .build_post_with_headers(
+                &self.client,
+                prefill.as_ref(),
+                context.route,
+                &json_request,
+                headers,
+                false,
+            )
+            .await
+        {
+            Ok(request) => request,
+            Err(e) => return error::internal_error("prepare_worker_request_failed", e),
+        };
+        let decode_request = match self
+            .build_post_with_headers(
+                &self.client,
+                decode.as_ref(),
+                context.route,
+                &json_request,
+                headers,
+                false,
+            )
+            .await
+        {
+            Ok(request) => request,
+            Err(e) => return error::internal_error("prepare_worker_request_failed", e),
+        };
 
         // Send both requests concurrently and wait for both
         // Note: Using borrowed references avoids heap allocation
@@ -1176,16 +1188,28 @@ impl PDRouter {
         Ok((prefill_status, prefill_body))
     }
 
-    fn build_post_with_headers(
+    async fn build_post_with_headers(
         &self,
         client: &Client,
-        url: &str,
+        worker: &dyn Worker,
         route: &'static str,
         json_request: &Value,
         headers: Option<&HeaderMap>,
         connection_close: bool,
-    ) -> reqwest::RequestBuilder {
-        let mut request = client.post(api_path(url, route)).json(json_request);
+    ) -> Result<reqwest::RequestBuilder, String> {
+        let request_body = if worker.is_dp_aware() {
+            Cow::Owned(
+                worker
+                    .prepare_request(json_request.clone())
+                    .await
+                    .map_err(|e| e.to_string())?,
+            )
+        } else {
+            Cow::Borrowed(json_request)
+        };
+        let mut request = client
+            .post(api_path(worker.base_url(), route))
+            .json(&request_body);
         if connection_close {
             request = request.header("Connection", "close");
         }
@@ -1198,7 +1222,7 @@ impl PDRouter {
                 }
             }
         }
-        request
+        Ok(request)
     }
 
     // Helper to merge logprobs from prefill and decode responses
@@ -1293,12 +1317,11 @@ impl RouterTrait for PDRouter {
             }
         };
 
-        let prefill_url = format!("{}/health_generate", prefill.url());
+        let prefill_url = api_path(prefill.base_url(), "health_generate");
+        let decode_url = api_path(decode.base_url(), "health_generate");
         let (prefill_result, decode_result) = tokio::join!(
             self.client.get(&prefill_url).send(),
-            self.client
-                .get(format!("{}/health_generate", decode.url()))
-                .send()
+            self.client.get(&decode_url).send()
         );
 
         // Check results


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`--dp-aware` expands one physical worker endpoint into virtual workers whose router identities are suffixed with the target DP rank, for example `http://10.66.4.202:28714@0`.

Before this PR, the PD router still used that synthetic identity as a real HTTP backend URL in several paths. In AA-RWLT run `1860558`, this caused repeated dispatch failures because reqwest parsed the `@rank` suffix as URL userinfo and sent the request to a bogus `0.0.0.<rank>` host instead of the physical worker endpoint.

Before-fix log excerpt from `1860558`:

```text
old_invalid_url_count=112
Decode request failed decode_url=http://10.66.4.202:28714@0 error=error sending request for url (http://0.0.0.0/v1/chat/completions)
Decode request failed decode_url=http://10.66.4.202:28714@1 error=error sending request for url (http://0.0.0.1/v1/chat/completions)
Decode request failed decode_url=http://10.66.4.202:28714@2 error=error sending request for url (http://0.0.0.2/v1/chat/completions)
```

After applying this PR in AA-RWLT run `1860752`, the same invalid dispatch pattern disappeared:

```text
new_invalid_url_count=0
Prefill bootstrap failed ... follow_bootstrap_room conflict: dispatched to dp_rank 2 but bootstrap_room ... implies dp_rank 3.
Set SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK=1 to allow mixed routing.
```

So this PR fixes the router URL/request-preparation layer. It does not change the later SGLang disaggregation bootstrap policy.

## Modifications

- Keep `url@rank` as the router-internal identity for DP-aware workers.
- Use `worker.base_url()` for real HTTP dispatch, `/health_generate`, and proxied metadata endpoints.
- Call `worker.prepare_request(...)` before dispatching a request to a DP-aware worker so the selected DP rank is injected into the request body.
- Strip only numeric `@rank` suffixes when deriving bootstrap metadata host, while preserving normal non-DP-aware URLs unchanged.
- Add worker-builder tests for DP-aware HTTP, gRPC, and IPv4 bootstrap host parsing.

## Accuracy Tests

## Speed Tests and Profiling

No speed impact is expected from this PR by itself. It is a prerequisite for DP-aware PD routing.

Validation from the AA-RWLT investigation:

- Before fix, run `1860558` hit `112` invalid synthetic-url dispatch failures such as `http://0.0.0.0/v1/chat/completions`.
- After fix, run `1860752` hit `0` of those invalid synthetic-url dispatch failures; it progressed to a separate SGLang disaggregation bootstrap-room guard.
- With this fix plus the stacked terminal-prefix affinity follow-up (#26236), AA-RWLT run `1893100` reached cache hit `96.5%`, server output TPS `1077.6`, and client output TPS `1145.0`.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26375286840](https://github.com/sgl-project/sglang/actions/runs/26375286840)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26375286805](https://github.com/sgl-project/sglang/actions/runs/26375286805)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
