### PR TITLE
[dsv4] fix multi-step draft on non-cuda-graph path

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -676,11 +676,27 @@ class DeepseekV4AttnBackend(
         max_seq_len = int(seq_lens_cpu.max().item())
 
         if forward_batch.forward_mode.is_decode_or_idle():
+            # Multi-step EAGLE draft (topk > 0, num_steps > 1) shares one
+            # out_cache_loc buffer across all draft steps; layout matches
+            # EagleWorkerV2.draft_forward: [bs, topk, num_steps] flattened.
+            # Pick this step's slice so the per-step backend sees a buffer
+            # whose length matches its own seq_lens.
+            out_cache_loc = forward_batch.out_cache_loc
+            if self.topk > 0 and self.speculative_num_steps > 1:
+                out_cache_loc = (
+                    out_cache_loc.view(
+                        forward_batch.batch_size,
+                        self.topk,
+                        self.speculative_num_steps,
+                    )
+                    .permute(2, 0, 1)[self.speculative_step_id]
+                    .reshape(-1)
+                )
             metadata = self.init_forward_metadata_decode(
                 max_seq_len=max_seq_len,
                 req_pool_indices=req_pool_indices,
                 seq_lens=seq_lens,
-                out_cache_loc=forward_batch.out_cache_loc,
+                out_cache_loc=out_cache_loc,
             )
         elif forward_batch.forward_mode.is_target_verify():
             metadata = self.init_forward_metadata_target_verify(
@@ -1199,31 +1215,8 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
             )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        # forward_batch.out_cache_loc carries the full multi-step write buffer
-        # with layout [bs, topk, num_steps] flattened. Match the per-step view
-        # produced by EagleWorkerV2.draft_forward (which does the same reshape
-        # before each step's model forward): permute to [num_steps, bs * topk]
-        # and feed step i's slice to attn_backends[i] so the single-step
-        # init_forward_metadata_decode sees out_cache_loc.shape[0] == bs * topk
-        # (matching its assert rather than bs * topk * num_steps).
-        full_out_cache_loc = forward_batch.out_cache_loc
-        if self.speculative_num_steps > 1 and full_out_cache_loc is not None:
-            bs = forward_batch.batch_size
-            per_step = (
-                full_out_cache_loc.reshape(bs, self.topk, self.speculative_num_steps)
-                .permute(2, 0, 1)
-                .reshape(self.speculative_num_steps, -1)
-            )
-        else:
-            per_step = None
-
-        try:
-            for i in range(self.speculative_num_steps - 1):
-                if per_step is not None:
-                    forward_batch.out_cache_loc = per_step[i]
-                self.attn_backends[i].init_forward_metadata(forward_batch)
-        finally:
-            forward_batch.out_cache_loc = full_out_cache_loc
+        for i in range(self.speculative_num_steps - 1):
+            self.attn_backends[i].init_forward_metadata(forward_batch)
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -677,10 +677,9 @@ class DeepseekV4AttnBackend(
         max_seq_len = int(seq_lens_cpu.max().item())
 
         if forward_batch.forward_mode.is_decode_or_idle():
-            # In multi-step EAGLE draft, the per-step backend metadata bakes
-            # in this step's KV write target (c4/c128 out_loc). The shared
-            # out_cache_loc buffer must be sliced via the EAGLE per-step
-            # convention -- see per_step_draft_out_cache_loc.
+            # DSv4 bakes this step's KV write target (c4/c128) into metadata,
+            # so slice the shared multi-step out_cache_loc now rather than at
+            # forward time.
             out_cache_loc = forward_batch.out_cache_loc
             if self.topk > 0 and self.speculative_num_steps > 1:
                 out_cache_loc = per_step_draft_out_cache_loc(

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1199,8 +1199,31 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
             )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        for i in range(self.speculative_num_steps - 1):
-            self.attn_backends[i].init_forward_metadata(forward_batch)
+        # forward_batch.out_cache_loc carries the full multi-step write buffer
+        # with layout [bs, topk, num_steps] flattened. Match the per-step view
+        # produced by EagleWorkerV2.draft_forward (which does the same reshape
+        # before each step's model forward): permute to [num_steps, bs * topk]
+        # and feed step i's slice to attn_backends[i] so the single-step
+        # init_forward_metadata_decode sees out_cache_loc.shape[0] == bs * topk
+        # (matching its assert rather than bs * topk * num_steps).
+        full_out_cache_loc = forward_batch.out_cache_loc
+        if self.speculative_num_steps > 1 and full_out_cache_loc is not None:
+            bs = forward_batch.batch_size
+            per_step = (
+                full_out_cache_loc.reshape(bs, self.topk, self.speculative_num_steps)
+                .permute(2, 0, 1)
+                .reshape(self.speculative_num_steps, -1)
+            )
+        else:
+            per_step = None
+
+        try:
+            for i in range(self.speculative_num_steps - 1):
+                if per_step is not None:
+                    forward_batch.out_cache_loc = per_step[i]
+                self.attn_backends[i].init_forward_metadata(forward_batch)
+        finally:
+            forward_batch.out_cache_loc = full_out_cache_loc
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         for i in range(self.speculative_num_steps):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -53,6 +53,7 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import ceil_align
 
@@ -676,22 +677,18 @@ class DeepseekV4AttnBackend(
         max_seq_len = int(seq_lens_cpu.max().item())
 
         if forward_batch.forward_mode.is_decode_or_idle():
-            # Multi-step EAGLE draft (topk > 0, num_steps > 1) shares one
-            # out_cache_loc buffer across all draft steps; layout matches
-            # EagleWorkerV2.draft_forward: [bs, topk, num_steps] flattened.
-            # Pick this step's slice so the per-step backend sees a buffer
-            # whose length matches its own seq_lens.
+            # In multi-step EAGLE draft, the per-step backend metadata bakes
+            # in this step's KV write target (c4/c128 out_loc). The shared
+            # out_cache_loc buffer must be sliced via the EAGLE per-step
+            # convention -- see per_step_draft_out_cache_loc.
             out_cache_loc = forward_batch.out_cache_loc
             if self.topk > 0 and self.speculative_num_steps > 1:
-                out_cache_loc = (
-                    out_cache_loc.view(
-                        forward_batch.batch_size,
-                        self.topk,
-                        self.speculative_num_steps,
-                    )
-                    .permute(2, 0, 1)[self.speculative_step_id]
-                    .reshape(-1)
-                )
+                out_cache_loc = per_step_draft_out_cache_loc(
+                    out_cache_loc,
+                    forward_batch.batch_size,
+                    self.topk,
+                    self.speculative_num_steps,
+                )[self.speculative_step_id]
             metadata = self.init_forward_metadata_decode(
                 max_seq_len=max_seq_len,
                 req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -29,15 +29,11 @@ def per_step_draft_out_cache_loc(
     topk: int,
     num_steps: int,
 ) -> torch.Tensor:
-    """Return per-step view of the multi-step EAGLE draft out_cache_loc buffer.
+    """Per-step slice of the multi-step EAGLE draft out_cache_loc buffer.
 
-    Single source of truth for the layout convention shared between:
-      - EagleWorkerV2.draft_forward (per-step write target)
-      - DeepseekV4AttnBackend.init_forward_metadata (per-step compression
-        write target baked into metadata)
-
-    Layout: out_cache_loc is flat with elements ordered `[bs, topk, num_steps]`.
-    Returns a [num_steps, bs * topk] view where row i is step i's slice.
+    Single source of truth for the layout shared by EagleWorkerV2.draft_forward
+    (per-step write target) and DeepseekV4AttnBackend (per-step compression
+    write target baked into metadata).
     """
     expected = batch_size * topk * num_steps
     assert out_cache_loc.shape[0] == expected, (

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -23,6 +23,34 @@ if _is_cuda or _is_hip or _is_musa:
     )
 
 
+def per_step_draft_out_cache_loc(
+    out_cache_loc: torch.Tensor,
+    batch_size: int,
+    topk: int,
+    num_steps: int,
+) -> torch.Tensor:
+    """Return per-step view of the multi-step EAGLE draft out_cache_loc buffer.
+
+    Single source of truth for the layout convention shared between:
+      - EagleWorkerV2.draft_forward (per-step write target)
+      - DeepseekV4AttnBackend.init_forward_metadata (per-step compression
+        write target baked into metadata)
+
+    Layout: out_cache_loc is flat with elements ordered `[bs, topk, num_steps]`.
+    Returns a [num_steps, bs * topk] view where row i is step i's slice.
+    """
+    expected = batch_size * topk * num_steps
+    assert out_cache_loc.shape[0] == expected, (
+        f"out_cache_loc.shape[0]={out_cache_loc.shape[0]} != "
+        f"batch_size * topk * num_steps = {batch_size}*{topk}*{num_steps}={expected}"
+    )
+    return (
+        out_cache_loc.view(batch_size, topk, num_steps)
+        .permute(2, 0, 1)
+        .reshape(num_steps, -1)
+    )
+
+
 def apply_eagle_prefill_input_rotation(
     batch: ScheduleBatch, next_token_ids: torch.Tensor
 ) -> None:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -53,7 +53,11 @@ from sglang.srt.speculative.eagle_info_v2 import (
     fill_accepted_out_cache_loc,
     fill_bonus_tokens,
 )
-from sglang.srt.speculative.eagle_utils import TreeMaskMode, build_tree_kernel_efficient
+from sglang.srt.speculative.eagle_utils import (
+    TreeMaskMode,
+    build_tree_kernel_efficient,
+    per_step_draft_out_cache_loc,
+)
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
     draft_tp_context,
@@ -438,11 +442,11 @@ class EagleDraftWorker(BaseDraftWorker):
         if self.hot_token_id is not None:
             topk_index = self.hot_token_id[topk_index]
 
-        out_cache_loc = out_cache_loc.reshape(
-            forward_batch.batch_size, self.topk, self.speculative_num_steps
-        )
-        out_cache_loc = out_cache_loc.permute((2, 0, 1)).reshape(
-            self.speculative_num_steps, -1
+        out_cache_loc = per_step_draft_out_cache_loc(
+            out_cache_loc,
+            forward_batch.batch_size,
+            self.topk,
+            self.speculative_num_steps,
         )
 
         # Return values


### PR DESCRIPTION
## Summary
- Fix DSv4 EAGLE multi-step draft on the non-cuda-graph path (`init_forward_metadata`); the assert `req_pool_indices.shape[0] == seq_lens.shape[0] == out_cache_loc.shape[0]` in `init_forward_metadata_decode` previously fired with `out_cache_loc.shape=[bs * topk * num_steps]` vs `seq_lens.shape=[bs]`
- Introduce a shared per-step layout helper so `EagleWorkerV2.draft_forward` and `DeepseekV4AttnBackend` agree on the slice convention

## Background
- DSv4 backend bakes per-step KV write targets (`c4_out_loc` / `c128_out_loc`) into the attention metadata at `init_forward_metadata` time — unlike FlashMLA / FlashInfer / Triton, which consume `out_cache_loc` only in `forward_*`
- The default cuda-graph capture/replay route bypasses `init_forward_metadata`, so the bug was only reachable with `--disable-cuda-graph`. PR #23882 introduced the path; not exercised by CI

## Fix
- `per_step_draft_out_cache_loc` in `eagle_utils.py`: single source of truth for the `[bs, topk, num_steps] -> [num_steps, bs * topk]` view, with a shape assert
- `EagleWorkerV2.draft_forward`: call the helper instead of inline reshape
- `DeepseekV4AttnBackend.init_forward_metadata`: when running as a multi-step draft sub-backend (`topk > 0 and speculative_num_steps > 1`), select this step's slice via the helper before calling `init_forward_metadata_decode`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26375990774](https://github.com/sgl-project/sglang/actions/runs/26375990774)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26375990700](https://github.com/sgl-project/sglang/actions/runs/26375990700)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->