### PR TITLE
[Spec] fix EAGLE v2 verify metadata init order on non-cuda-graph path

### DIFF
--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -306,11 +306,15 @@ class EagleVerifyInputV2Mixin:
         )
         if can_run_cuda_graph:
             target_worker.model_runner.graph_runner.replay_prepare(verify_forward_batch)
-        else:
-            if not batch.forward_mode.is_idle():
-                target_worker.model_runner.attn_backend.init_forward_metadata(
-                    verify_forward_batch
-                )
+        # Non-cuda-graph path: do NOT init_forward_metadata here. The forward
+        # batch has not yet been padded by `_forward_raw -> prepare_mlp_sync_batch`,
+        # so metadata built now uses pre-pad shapes while the actual forward
+        # consumes post-pad input_ids / out_cache_loc. Backends that bake those
+        # shapes into metadata (e.g. DSv4 indexer's c4/c128 write targets +
+        # the symbolic-shape TVM kernel) then crash on shape mismatch.
+        # Defer init to forward_extend, which runs after prepare_mlp_sync_batch
+        # -- the caller (`eagle_worker_v2.verify`) now passes
+        # `skip_attn_backend_init=can_run_cuda_graph` instead of always True.
 
         return verify_forward_batch, can_run_cuda_graph
 

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -306,15 +306,9 @@ class EagleVerifyInputV2Mixin:
         )
         if can_run_cuda_graph:
             target_worker.model_runner.graph_runner.replay_prepare(verify_forward_batch)
-        # Non-cuda-graph path: do NOT init_forward_metadata here. The forward
-        # batch has not yet been padded by `_forward_raw -> prepare_mlp_sync_batch`,
-        # so metadata built now uses pre-pad shapes while the actual forward
-        # consumes post-pad input_ids / out_cache_loc. Backends that bake those
-        # shapes into metadata (e.g. DSv4 indexer's c4/c128 write targets +
-        # the symbolic-shape TVM kernel) then crash on shape mismatch.
-        # Defer init to forward_extend, which runs after prepare_mlp_sync_batch
-        # -- the caller (`eagle_worker_v2.verify`) now passes
-        # `skip_attn_backend_init=can_run_cuda_graph` instead of always True.
+        # Non-cuda-graph: defer init to forward_extend, which runs after
+        # `_forward_raw -> prepare_mlp_sync_batch` pads the batch. Initing
+        # here would use pre-pad shapes and trip DSv4 indexer shape match.
 
         return verify_forward_batch, can_run_cuda_graph
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1040,10 +1040,8 @@ class EAGLEWorkerV2(BaseSpecWorker):
             ).cpu()
 
         # Run target verify batch in the main compute stream (GPU compute).
-        # skip_attn_backend_init only when cuda-graph already ran
-        # replay_prepare inside prepare_for_v2_verify. For the non-cuda-graph
-        # path, metadata must be initialized inside forward_extend after
-        # _forward_raw's prepare_mlp_sync_batch pads the forward batch.
+        # Only skip metadata init when cuda-graph already ran replay_prepare;
+        # the non-cuda-graph path needs forward_extend's init (post-pad).
         forward_batch_output = self.target_worker.forward_batch_generation(
             batch=None,
             forward_batch=verify_forward_batch,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1039,12 +1039,16 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 verify_input.retrieve_next_token.shape
             ).cpu()
 
-        # Run target verify batch in the main compute stream (GPU compute)
+        # Run target verify batch in the main compute stream (GPU compute).
+        # skip_attn_backend_init only when cuda-graph already ran
+        # replay_prepare inside prepare_for_v2_verify. For the non-cuda-graph
+        # path, metadata must be initialized inside forward_extend after
+        # _forward_raw's prepare_mlp_sync_batch pads the forward batch.
         forward_batch_output = self.target_worker.forward_batch_generation(
             batch=None,
             forward_batch=verify_forward_batch,
             is_verify=True,
-            skip_attn_backend_init=True,
+            skip_attn_backend_init=can_run_cuda_graph,
         )
         logits_output = forward_batch_output.logits_output
 


### PR DESCRIPTION
## Summary
- `EagleVerifyInput.prepare_for_v2_verify` called `init_forward_metadata` on the non-cuda-graph path **before** `_forward_raw -> prepare_mlp_sync_batch` padded the forward batch
- `eagle_worker_v2.verify` then passed `skip_attn_backend_init=True` unconditionally, so the eventual `forward_extend` skipped re-init
- Metadata reflected pre-pad shapes while the actual forward consumed post-pad `input_ids` / `out_cache_loc`; backends that bake those shapes into metadata (DSv4 indexer's c4/c128 write targets + symbolic-shape TVM kernel) crashed on shape mismatch

## Fix
- `eagle_info_v2.py`: drop the eager `init_forward_metadata` in the non-cuda-graph branch (cuda-graph branch still runs `replay_prepare` in `plan_stream`)
- `eagle_worker_v2.py`: pass `skip_attn_backend_init=can_run_cuda_graph` so the non-cuda-graph path inits in `forward_extend` after `prepare_mlp_sync_batch`. Same pattern as `model_runner.forward_idle:3104-3108`

## Impact
- cuda-graph path (default): unchanged
- non-cuda-graph path: correctness restored; minor perf cost (init moves off `plan_stream`). Manual reproducer (`test_disaggregation_dsv4.py` + `--disable-cuda-graph`) now passes GSM8K (score 0.965)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26378829892](https://github.com/sgl-project/sglang/actions/runs/26378829892)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26378829846](https://github.com/sgl-project/sglang/actions/runs/26378829846)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->