### PR TITLE
[SMG] Fix --prefill-policy/--decode-policy ignored in IGW mode

### DIFF
--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -114,10 +114,24 @@ impl RouterManager {
 
             info!("PD disaggregation auto-enabled for IGW mode, creating PD routers");
 
+            // Extract PD-specific policies from routing mode config.
+            // RoutingMode::PrefillDecode carries optional per-pool policies
+            // parsed from --prefill-policy / --decode-policy CLI args.
+            // When present they override the top-level --policy for the
+            // respective worker pool.
+            let (prefill_policy_cfg, decode_policy_cfg) = match &config.router_config.mode {
+                RoutingMode::PrefillDecode {
+                    prefill_policy,
+                    decode_policy,
+                    ..
+                } => (prefill_policy.clone(), decode_policy.clone()),
+                _ => (None, None),
+            };
+
             // Create HTTP PD router
             match RouterFactory::create_pd_router(
-                None,
-                None,
+                prefill_policy_cfg.as_ref(),
+                decode_policy_cfg.as_ref(),
                 &config.router_config.policy,
                 app_context,
             )
@@ -134,8 +148,8 @@ impl RouterManager {
 
             // Create gRPC PD router
             match RouterFactory::create_grpc_pd_router(
-                None,
-                None,
+                prefill_policy_cfg.as_ref(),
+                decode_policy_cfg.as_ref(),
                 &config.router_config.policy,
                 app_context,
             )


### PR DESCRIPTION
## Motivation

In IGW (multi-router) mode — which is auto-enabled whenever `--service-discovery` is used — `RouterManager::from_config` creates PD routers with hardcoded `None` for both `prefill_policy_config` and `decode_policy_config`:

```rust
// router_manager.rs L118-122
RouterFactory::create_pd_router(
    None,  // prefill_policy_config
    None,  // decode_policy_config
    &config.router_config.policy,
    app_context,
)
```

Because `create_pd_router` in `factory.rs` falls back to `main_policy_config` when these are `None`, the `--prefill-policy` and `--decode-policy` CLI arguments are silently ignored, and both worker pools receive `--policy` (the top-level policy) instead.

## Impact

### Intended vs Actual behavior

| CLI args | Intended | Actual (bug) |
|----------|----------|--------------|
| `--policy cache_aware` | top-level fallback | ✅ applied |
| `--prefill-policy cache_aware` | prefill: cache_aware (L1/L2 cache locality) | ❌ ignored → cache_aware (from --policy) |
| `--decode-policy power_of_two` | decode: power_of_two (load-based even distribution) | ❌ ignored → cache_aware (from --policy) |

The `--prefill-policy` happens to match `--policy` in this example, so prefill behavior is accidentally correct. But decode receives `cache_aware` instead of `power_of_two`. Confirmed by debug log:

```
DEBUG smg::policies::registry: Initializing decode cache-aware policy with 23 workers
```

### Decode load skew caused by cache_aware on decode pool

The cache-aware policy on the decode pool routes same-prefix requests to the same decode worker via radix tree matching, causing **severe decode load skew**:

- **10-prefill, 22-decode production cluster**: only 6 out of 22 decoders received traffic; 16 were completely idle (0 TPS for 5+ minutes)
- **Top decode**: 154 tok/s vs **19 decoders at 0 tok/s**

With the intended `power_of_two` policy, decode workers are selected based on load (pick 2 random, choose the one with lower load), which distributes traffic evenly regardless of request prefix.

### Why round_robin as workaround is not ideal

Setting `--policy round_robin` (for all pools) eliminates the skew but sacrifices L1/L2 KV cache locality on the prefill side. With hierarchical caching (hicache with Mooncake L3 RDMA storage), cross-prefill cache sharing is partially recovered at the **L3 layer** through RDMA-based KV transfer. However, **L2 (host memory) cache hits are lost** since each prefill maintains its own host-memory radix cache independently. In our production measurement with `round_robin`, L3 Mooncake accounted for only ~0.06% of cache hits (788 tokens/s out of 1.27M tokens/s total), meaning L3 does not meaningfully compensate for the lost L2 locality.

The intended configuration — `cache_aware` for prefill (preserving L1/L2 locality) + `power_of_two` for decode (even distribution) — requires this fix.

## Fix

Extract `prefill_policy` and `decode_policy` from `RoutingMode::PrefillDecode` config (which already stores CLI-parsed values via `self.prefill_policy.as_ref().map(|p| self.parse_policy(p))` in `main.rs`) and forward them to both `create_pd_router` and `create_grpc_pd_router`. When CLI args are not provided, `unwrap_or(main_policy_config)` in the factory still provides backward-compatible fallback.

## Test plan

- [ ] Verify `--decode-policy power_of_two` is respected in IGW mode (check debug log: should show `Initializing decode power-of-two policy`, NOT `cache-aware`)
- [ ] Verify decode load distribution is even across workers with `power_of_two`
- [ ] Verify backward compatibility: omitting `--prefill-policy`/`--decode-policy` falls back to `--policy`
