### PR TITLE
[Bug Fix][Scheduler] retract on transient prefill KV OOM instead of SIGQUIT

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -219,7 +219,12 @@ from sglang.srt.managers.utils import (
     validate_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
-from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
+from sglang.srt.mem_cache.base_prefix_cache import DecLockRefParams
+from sglang.srt.mem_cache.common import (
+    KVPoolOOMError,
+    maybe_cache_unfinished_req,
+    release_kv_cache,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardMode, PPProxyTensors
 from sglang.srt.model_loader.utils import get_resolved_model_impl
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin
@@ -2516,6 +2521,12 @@ class Scheduler(
             waiting_queue_len=len(self.waiting_queue),
         )
 
+        # Snapshot for the alloc-failure retract path below.
+        pre_admit_chunked_req = self.chunked_req
+        pre_admit_chunked_req_scheduled_last_iter = (
+            self._chunked_req_scheduled_last_iter
+        )
+
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
             self.chunked_req = adder.add_chunked_req(self.chunked_req)
@@ -2642,7 +2653,20 @@ class Scheduler(
                 self.tree_cache.ready_to_load_host_cache()
             )
 
-        new_batch.prepare_for_extend()
+        try:
+            new_batch.prepare_for_extend()
+        except KVPoolOOMError:
+            # Mirror decode-side ``retract_decode``: a transient KV
+            # exhaustion is not grounds for SIGQUIT. Roll back admission
+            # and let the next tick retry once active reqs free space.
+            if not self.server_args.retry_prefill_on_kv_oom:
+                raise
+            self._retract_prefill_admission(
+                can_run_list,
+                pre_admit_chunked_req,
+                pre_admit_chunked_req_scheduled_last_iter,
+            )
+            return None
 
         # Record prefill stats for logging after forward.
         new_batch.prefill_stats = PrefillStats.from_adder(
@@ -2679,6 +2703,51 @@ class Scheduler(
             new_batch.decoding_reqs = None
 
         return new_batch
+
+    def _retract_prefill_admission(
+        self,
+        admitted_reqs: List[Req],
+        pre_admit_chunked_req: Optional[Req],
+        pre_admit_chunked_req_scheduled_last_iter: bool,
+    ) -> None:
+        """Roll back a prefill admission cycle whose KV alloc failed.
+
+        Inverse of admission's mutations: undoes ``_req_inc_lock_ref``,
+        the ``add_chunked_req`` swap and ``inflight_middle_chunks`` bump,
+        and the eager ``waiting_queue`` removal. Host-loaded prefix
+        tokens pulled in by ``init_load_back`` are left in the tree
+        cache so the retry can reuse them.
+        """
+        for req in admitted_reqs:
+            if self.is_hybrid_swa:
+                self.tree_cache.dec_lock_ref(
+                    req.last_node,
+                    DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock),
+                )
+            else:
+                self.tree_cache.dec_lock_ref(req.last_node)
+
+        if self.chunked_req is not None:
+            self.chunked_req.inflight_middle_chunks -= 1
+        self.chunked_req = pre_admit_chunked_req
+        self._chunked_req_scheduled_last_iter = (
+            pre_admit_chunked_req_scheduled_last_iter
+        )
+
+        # Prepend to preserve FCFS: these reqs were ahead of everyone
+        # else in this cycle, so they must stay ahead on the next tick.
+        # Exclude any pre-existing chunked req: it was already in
+        # ``can_run_list`` via ``add_chunked_req``, but we just restored
+        # it as ``self.chunked_req``, so the next tick's chunked-req
+        # branch will re-process it. Re-queueing it would cause it to
+        # be admitted twice on the same tick.
+        self.waiting_queue[:0] = [
+            r for r in admitted_reqs if r is not pre_admit_chunked_req
+        ]
+
+        # ``batch_is_full`` may have been latched mid-admission; the
+        # next tick must be free to re-evaluate.
+        self.running_batch.batch_is_full = False
 
     def _can_schedule_lora_req(
         self, req: Req, running_loras: set[Optional[str]]

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -27,6 +27,20 @@ MAMBA_STATE_PER_REQ_NO_CACHE = 1
 logger = logging.getLogger(__name__)
 
 
+class KVPoolOOMError(RuntimeError):
+    """KV pool could not satisfy an allocation. Subclasses ``RuntimeError``
+    so existing ``except RuntimeError`` catches still work; callers that
+    treat OOM as transient (e.g. the scheduler's prefill admission cycle)
+    can catch this specific type and retract instead of crashing."""
+
+
+def _raise_kv_oom(error_msg: str, tree_cache: BasePrefixCache | None) -> None:
+    logger.error(error_msg)
+    if tree_cache is not None:
+        tree_cache.pretty_print()
+    raise KVPoolOOMError(error_msg)
+
+
 def kv_to_page_indices(kv_indices: np.ndarray, page_size: int):
     # The page is guaranteed to be full except the last page.
     if page_size == 1:
@@ -314,15 +328,12 @@ def alloc_token_slots(
     out_cache_loc = allocator.alloc(num_tokens)
 
     if out_cache_loc is None:
-        error_msg = (
+        _raise_kv_oom(
             f"Out of memory. Try to lower your batch size.\n"
             f"Try to allocate {num_tokens} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}"
+            f"{available_and_evictable_str(tree_cache)}",
+            tree_cache,
         )
-        logger.error(error_msg)
-        if tree_cache is not None:
-            tree_cache.pretty_print()
-        raise RuntimeError(error_msg)
 
     return (out_cache_loc, state) if backup_state else out_cache_loc
 
@@ -382,15 +393,12 @@ def alloc_paged_token_slots_extend(
     )
 
     if out_cache_loc is None:
-        error_msg = (
+        _raise_kv_oom(
             f"Prefill out of memory. Try to lower your batch size.\n"
             f"Try to allocate {extend_num_tokens} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}"
+            f"{available_and_evictable_str(tree_cache)}",
+            tree_cache,
         )
-        logger.error(error_msg)
-        if tree_cache is not None:
-            tree_cache.pretty_print()
-        raise RuntimeError(error_msg)
 
     return (out_cache_loc, state) if backup_state else out_cache_loc
 
@@ -436,6 +444,12 @@ def alloc_for_extend(
         out_cache_loc: allocated cache locations
         req_pool_indices_device: request pool indices at a device tensor
         req_pool_indices: request pool indices as list
+
+    Raises ``KVPoolOOMError`` on KV exhaustion. The freshly-allocated
+    req_pool slots are released before the exception propagates, so a
+    caller that catches and retries (e.g. the scheduler's prefill
+    retract path) starts from a clean state. Slots reused by an
+    in-flight chunked prefill are preserved.
     """
     # free out-of-window swa tokens
     batch.maybe_evict_swa()
@@ -448,33 +462,37 @@ def alloc_for_extend(
     prefix_lens_device = prefix_lens_cpu.to(batch.device, non_blocking=True)
     extend_lens_device = extend_lens_cpu.to(batch.device, non_blocking=True)
 
-    # Allocate req slots
+    # Capture freshly-allocated reqs *before* alloc_req_slots assigns
+    # req_pool_idx, so the rollback path knows which to free.
+    fresh_alloc_reqs = [r for r in batch.reqs if r.req_pool_idx is None]
     req_pool_indices = alloc_req_slots(
         batch.req_to_token_pool, batch.reqs, batch.tree_cache
     )
     req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
     req_pool_indices_device = req_pool_indices_cpu.to(batch.device, non_blocking=True)
 
-    # Allocate KV cache (throws exception on failure)
-    if batch.tree_cache.page_size == 1:
-        out_cache_loc = alloc_token_slots(batch.tree_cache, batch.extend_num_tokens)
-    else:
-        # Paged allocation - build last_loc
-        last_loc = [
-            (t[-1:] if len(t) > 0 else torch.tensor([-1], device=batch.device))
-            for t in prefix_tensors
-        ]
-        out_cache_loc = alloc_paged_token_slots_extend(
-            tree_cache=batch.tree_cache,
-            prefix_lens=prefix_lens_device,
-            prefix_lens_cpu=prefix_lens_cpu,
-            seq_lens=batch.seq_lens,
-            seq_lens_cpu=batch.seq_lens_cpu,
-            last_loc=torch.cat(last_loc),
-            extend_num_tokens=batch.extend_num_tokens,
-        )
+    try:
+        if batch.tree_cache.page_size == 1:
+            out_cache_loc = alloc_token_slots(batch.tree_cache, batch.extend_num_tokens)
+        else:
+            last_loc = [
+                (t[-1:] if len(t) > 0 else torch.tensor([-1], device=batch.device))
+                for t in prefix_tensors
+            ]
+            out_cache_loc = alloc_paged_token_slots_extend(
+                tree_cache=batch.tree_cache,
+                prefix_lens=prefix_lens_device,
+                prefix_lens_cpu=prefix_lens_cpu,
+                seq_lens=batch.seq_lens,
+                seq_lens_cpu=batch.seq_lens_cpu,
+                last_loc=torch.cat(last_loc),
+                extend_num_tokens=batch.extend_num_tokens,
+            )
+    except KVPoolOOMError:
+        for r in fresh_alloc_reqs:
+            batch.req_to_token_pool.free(r)
+        raise
 
-    # Write to req_to_token_pool
     write_cache_indices(
         out_cache_loc,
         req_pool_indices_device,
@@ -508,15 +526,12 @@ def alloc_paged_token_slots_decode(
     out_cache_loc = allocator.alloc_decode(seq_lens, seq_lens_cpu, last_loc)
 
     if out_cache_loc is None:
-        error_msg = (
+        _raise_kv_oom(
             f"Decode out of memory. Try to lower your batch size.\n"
             f"Try to allocate {len(seq_lens) * token_per_req} tokens.\n"
-            f"{available_and_evictable_str(tree_cache)}"
+            f"{available_and_evictable_str(tree_cache)}",
+            tree_cache,
         )
-        logger.error(error_msg)
-        if tree_cache is not None:
-            tree_cache.pretty_print()
-        raise RuntimeError(error_msg)
 
     return out_cache_loc
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -689,6 +689,11 @@ class ServerArgs:
     # placeholder token. See MIS_DELIMITER_TOKEN_ID for details.
     enable_mis: bool = False
 
+    # Treat prefill KV-pool exhaustion as a transient signal: retract the
+    # admission cycle and retry on the next scheduler tick instead of
+    # crashing the scheduler with SIGQUIT. Mirrors decode-side retract.
+    retry_prefill_on_kv_oom: bool = True
+
     # Optimization/debug options
     disable_radix_cache: bool = False
     cuda_graph_max_bs: Optional[int] = None

--- a/test/registered/unit/managers/test_prefill_oom_retract.py
+++ b/test/registered/unit/managers/test_prefill_oom_retract.py
@@ -1,0 +1,252 @@
+"""Tests for graceful prefill KV-OOM handling.
+
+Covers two surfaces introduced when the scheduler stopped fail-stopping
+on transient prefill KV-pool exhaustion:
+
+1. ``alloc_for_extend`` raises ``KVPoolOOMError`` on KV exhaustion and
+   releases the freshly-allocated req_pool slots before doing so, so
+   the scheduler's catch path starts from a clean state.
+2. ``Scheduler._retract_prefill_admission`` rolls back lock refs,
+   chunked_req state, and the waiting queue so the next scheduler tick
+   can retry cleanly.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.mem_cache.base_prefix_cache import DecLockRefParams
+from sglang.srt.mem_cache.common import KVPoolOOMError
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_admitted_req(rid: str, swa_uuid: object = None) -> SimpleNamespace:
+    """Minimal stand-in for a Req that admission has already locked."""
+    return SimpleNamespace(
+        rid=rid,
+        last_node=SimpleNamespace(node_id=rid),
+        swa_uuid_for_lock=swa_uuid,
+    )
+
+
+def _scheduler_for_retract(*, is_hybrid_swa: bool, chunked_req=None) -> Scheduler:
+    s = Scheduler.__new__(Scheduler)
+    s.is_hybrid_swa = is_hybrid_swa
+    s.tree_cache = MagicMock()
+    s.chunked_req = chunked_req
+    s._chunked_req_scheduled_last_iter = False
+    s.waiting_queue = []
+    s.running_batch = MagicMock()
+    s.running_batch.batch_is_full = True
+    return s
+
+
+class TestRetractPrefillAdmissionNonSWA(CustomTestCase):
+    def test_dec_lock_ref_called_per_req_without_swa_params(self):
+        s = _scheduler_for_retract(is_hybrid_swa=False)
+        req_a = _make_admitted_req("a")
+        req_b = _make_admitted_req("b")
+
+        s._retract_prefill_admission(
+            admitted_reqs=[req_a, req_b],
+            pre_admit_chunked_req=None,
+            pre_admit_chunked_req_scheduled_last_iter=False,
+        )
+
+        # Non-SWA path: dec_lock_ref(node) with no params kwarg.
+        self.assertEqual(s.tree_cache.dec_lock_ref.call_count, 2)
+        for call in s.tree_cache.dec_lock_ref.call_args_list:
+            args, kwargs = call
+            self.assertEqual(len(args), 1)  # only the node, no DecLockRefParams
+            self.assertEqual(kwargs, {})
+
+    def test_admitted_reqs_returned_to_waiting_queue_head(self):
+        s = _scheduler_for_retract(is_hybrid_swa=False)
+        existing = SimpleNamespace(rid="existing")
+        s.waiting_queue = [existing]
+        req_a = _make_admitted_req("a")
+        req_b = _make_admitted_req("b")
+
+        s._retract_prefill_admission(
+            admitted_reqs=[req_a, req_b],
+            pre_admit_chunked_req=None,
+            pre_admit_chunked_req_scheduled_last_iter=False,
+        )
+
+        self.assertEqual(s.waiting_queue, [req_a, req_b, existing])
+
+    def test_batch_is_full_cleared(self):
+        s = _scheduler_for_retract(is_hybrid_swa=False)
+        s.running_batch.batch_is_full = True
+
+        s._retract_prefill_admission(
+            admitted_reqs=[],
+            pre_admit_chunked_req=None,
+            pre_admit_chunked_req_scheduled_last_iter=False,
+        )
+
+        self.assertFalse(s.running_batch.batch_is_full)
+
+
+class TestRetractPrefillAdmissionSWA(CustomTestCase):
+    def test_dec_lock_ref_passes_swa_uuid_per_req(self):
+        s = _scheduler_for_retract(is_hybrid_swa=True)
+        req_a = _make_admitted_req("a", swa_uuid="uuid-a")
+        req_b = _make_admitted_req("b", swa_uuid="uuid-b")
+
+        s._retract_prefill_admission(
+            admitted_reqs=[req_a, req_b],
+            pre_admit_chunked_req=None,
+            pre_admit_chunked_req_scheduled_last_iter=False,
+        )
+
+        self.assertEqual(s.tree_cache.dec_lock_ref.call_count, 2)
+        seen_uuids = []
+        for call in s.tree_cache.dec_lock_ref.call_args_list:
+            args, _ = call
+            self.assertEqual(len(args), 2)
+            params = args[1]
+            self.assertIsInstance(params, DecLockRefParams)
+            seen_uuids.append(params.swa_uuid_for_lock)
+        self.assertEqual(sorted(seen_uuids), ["uuid-a", "uuid-b"])
+
+
+class TestRetractPrefillAdmissionChunkedReqRollback(CustomTestCase):
+    def test_inflight_decrement_and_chunked_req_restored(self):
+        original = SimpleNamespace(rid="original", inflight_middle_chunks=3)
+        new_chunked = SimpleNamespace(rid="new", inflight_middle_chunks=1)
+        # Mid-cycle state: scheduler swapped chunked_req to new and bumped its
+        # inflight_middle_chunks. Retract must walk this back.
+        s = _scheduler_for_retract(is_hybrid_swa=False, chunked_req=new_chunked)
+        s._chunked_req_scheduled_last_iter = True
+
+        s._retract_prefill_admission(
+            admitted_reqs=[],
+            pre_admit_chunked_req=original,
+            pre_admit_chunked_req_scheduled_last_iter=False,
+        )
+
+        # The req that was current at retract time gets its counter rolled back.
+        self.assertEqual(new_chunked.inflight_middle_chunks, 0)
+        # Original inflight count untouched (we never bumped it this cycle).
+        self.assertEqual(original.inflight_middle_chunks, 3)
+        # chunked_req identity restored.
+        self.assertIs(s.chunked_req, original)
+        self.assertFalse(s._chunked_req_scheduled_last_iter)
+
+    def test_no_chunked_req_means_no_decrement(self):
+        s = _scheduler_for_retract(is_hybrid_swa=False, chunked_req=None)
+
+        # Should not crash trying to decrement a None chunked_req.
+        s._retract_prefill_admission(
+            admitted_reqs=[],
+            pre_admit_chunked_req=None,
+            pre_admit_chunked_req_scheduled_last_iter=False,
+        )
+
+        self.assertIsNone(s.chunked_req)
+
+    def test_pre_existing_chunked_req_not_duplicated_in_waiting_queue(self):
+        # A pre-existing chunked req is in ``can_run_list`` (admission
+        # called ``add_chunked_req`` which appends it). Retract restores
+        # ``self.chunked_req`` to that same req. If we also re-queued it
+        # at the head of ``waiting_queue``, the next tick would process
+        # it through both the chunked-req branch and the waiting-queue
+        # loop, causing double-admission.
+        chunked = _make_admitted_req("chunked")
+        regular = _make_admitted_req("regular")
+        s = _scheduler_for_retract(is_hybrid_swa=False, chunked_req=chunked)
+
+        s._retract_prefill_admission(
+            admitted_reqs=[chunked, regular],
+            pre_admit_chunked_req=chunked,
+            pre_admit_chunked_req_scheduled_last_iter=True,
+        )
+
+        self.assertIs(s.chunked_req, chunked)
+        self.assertEqual(s.waiting_queue, [regular])
+        self.assertNotIn(chunked, s.waiting_queue)
+
+
+class TestAllocForExtendOOMReleasesFreshSlots(CustomTestCase):
+    """``alloc_for_extend`` raises ``KVPoolOOMError`` on KV exhaustion
+    and releases the freshly-allocated req_pool slots before raising,
+    so the scheduler's catch path starts from a clean state."""
+
+    def _make_batch_returning_oom(self):
+        import torch
+
+        from sglang.srt.mem_cache.common import alloc_for_extend
+
+        allocator = MagicMock()
+        allocator.alloc.return_value = None
+        allocator.page_size = 1
+        allocator.available_size.return_value = 0
+
+        tree_cache = MagicMock()
+        tree_cache.token_to_kv_pool_allocator = allocator
+        tree_cache.page_size = 1
+        tree_cache.is_chunk_cache.return_value = False
+        tree_cache.evict = MagicMock()
+
+        req_to_token_pool = MagicMock()
+        req_to_token_pool.alloc.return_value = [10, 11]
+        req_to_token_pool.available_size.return_value = 64
+
+        # ``req_pool_idx is None`` marks the req as freshly allocated
+        # this cycle; the rollback path frees only those.
+        req_a = SimpleNamespace(
+            prefix_indices=torch.empty(0, dtype=torch.int64),
+            req_pool_idx=None,
+            inflight_middle_chunks=0,
+            kv_committed_len=0,
+        )
+        req_b = SimpleNamespace(
+            prefix_indices=torch.empty(0, dtype=torch.int64),
+            req_pool_idx=None,
+            inflight_middle_chunks=0,
+            kv_committed_len=0,
+        )
+
+        batch = SimpleNamespace(
+            reqs=[req_a, req_b],
+            tree_cache=tree_cache,
+            req_to_token_pool=req_to_token_pool,
+            device="cpu",
+            prefix_lens=[0, 0],
+            extend_lens=[4, 4],
+            seq_lens=torch.tensor([4, 4], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([4, 4], dtype=torch.int64),
+            extend_num_tokens=8,
+            maybe_evict_swa=lambda: None,
+        )
+        return batch, alloc_for_extend, req_to_token_pool
+
+    def test_raises_kv_pool_oom_and_frees_fresh_req_slots(self):
+        batch, alloc_for_extend, req_to_token_pool = self._make_batch_returning_oom()
+
+        with self.assertRaises(KVPoolOOMError):
+            alloc_for_extend(batch)
+
+        self.assertEqual(req_to_token_pool.free.call_count, 2)
+        freed_reqs = [c.args[0] for c in req_to_token_pool.free.call_args_list]
+        self.assertIs(freed_reqs[0], batch.reqs[0])
+        self.assertIs(freed_reqs[1], batch.reqs[1])
+
+    def test_kv_pool_oom_is_a_runtime_error(self):
+        # Existing ``except RuntimeError`` callers must keep working.
+        batch, alloc_for_extend, _ = self._make_batch_returning_oom()
+
+        with self.assertRaises(RuntimeError):
+            alloc_for_extend(batch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Prefill KV-pool exhaustion currently kills the engine. `alloc_paged_token_slots_extend` raises `RuntimeError`, the exception propagates uncaught through `prepare_for_extend` → `_get_new_batch_prefill_raw` → `event_loop_overlap`, and the only catch in `run_scheduler_process` converts it into a `SIGQUIT` that takes down the scheduler process.

A condition that should be transient (active reqs are holding all evictable KV — the next decode tick will free some) is treated identically to a fatal bug. The decode side already does this right: `ScheduleBatch.retract_decode` explicitly comments "*Even the last remaining request cannot fit in memory. Instead of crashing the scheduler, gracefully abort it.*" This PR brings the prefill side to parity.

Fixes #26265.

## Modifications

### 1. Typed exception for KV pool exhaustion (`mem_cache/common.py`)

- New `KVPoolOOMError(RuntimeError)`. Subclassing `RuntimeError` keeps existing `except RuntimeError` callers working.
- New `_raise_kv_oom(error_msg, tree_cache)` helper. The three KV-alloc sites (`alloc_token_slots`, `alloc_paged_token_slots_extend`, `alloc_paged_token_slots_decode`) now route through the helper instead of duplicating the `logger.error` + `tree_cache.pretty_print()` + `raise` block.
- `alloc_for_extend` wraps the alloc call in `try/except KVPoolOOMError`. On exception it releases the freshly-allocated `req_pool` slots (computed from `req_pool_idx is None` *before* `alloc_req_slots` runs), then re-raises. Slots that are reused by an in-flight chunked prefill are preserved. `prepare_for_extend` is unchanged.

### 2. Scheduler-side retract path (`managers/scheduler.py`)

- `_get_new_batch_prefill_raw` snapshots `chunked_req` + `_chunked_req_scheduled_last_iter` before admission. If `prepare_for_extend` raises `KVPoolOOMError`, it calls a new helper `_retract_prefill_admission` and returns `None` — the standard "no batch this tick" signal. The next tick runs decode, frees pool capacity, and admission retries naturally.
- `_retract_prefill_admission` mirrors `retract_decode`'s design:
  * Decrements `tree_cache.dec_lock_ref` for each admitted req (uses `DecLockRefParams(swa_uuid_for_lock=...)` on hybrid SWA).
  * Rolls back `chunked_req` identity and `inflight_middle_chunks` to their pre-admit values.
  * Re-queues admitted reqs at the head of `waiting_queue` (FCFS-preserving: they were ahead of everyone else in this cycle and must stay ahead next tick).
  * Clears `running_batch.batch_is_full` so the next tick re-evaluates freely.

### 3. Opt-out flag (`server_args.py`)

`retry_prefill_on_kv_oom: bool = True`. The new behavior is the default. Setting `False` re-raises `KVPoolOOMError` and restores legacy SIGQUIT semantics for users who depend on fail-stop.

### 4. Out of scope (intentionally not changed)

- **`alloc_paged_token_slots_decode`**: only the `_raise_kv_oom` call site is harmonized; no behavioral change. Decode OOM has different recovery semantics (preempt active reqs, see `retract_decode` and `release_req`) and is already covered.
- **`alloc_req_slots`**: keeps raising. A `req_pool` exhaustion implies admission's `max_running_requests` accounting is broken (not a transient pool condition), so fail-stop is appropriate there.
- **Admission budget accuracy**: whether SWA `evictable_size_` is over-optimistic under page fragmentation, or whether `HiRadixCache.init_load_back` consumes SWA tokens not modeled by `_swa_budget_for_req`, is a separate question. With this PR, those manifest as transient retracts (observable, recoverable) instead of engine deaths, which is precisely the kind of signal needed to investigate them.

## Accuracy Tests

N/A — this PR does not modify any kernel, model forward, or token-output code path. The retract path takes effect only when KV alloc fails; it neither changes which tokens are produced nor changes the order of successful prefill batches (FCFS preserved by re-queueing at the head of `waiting_queue`).

## Speed Tests and Profiling

N/A — the success path is unchanged. Per-cycle overhead added on the success path is two attribute reads (the snapshot of `chunked_req` + `_chunked_req_scheduled_last_iter`) and one O(batch_size) list comprehension in `alloc_for_extend` to capture freshly-allocated reqs (used only in the rare exception path). Both are negligible relative to the rest of admission.

The retract path itself fires only when KV alloc would have raised today (i.e. the engine would already be dead). Its cost is bounded: O(N) `dec_lock_ref` calls + an in-place `waiting_queue[:0] = ...` prepend. No additional allocations or device sync.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). New file: `test/registered/unit/managers/test_prefill_oom_retract.py` — registered for the `base-a-test-cpu` CPU CI suite. Covers the helper rollback for non-SWA / SWA / chunked-req cases, and verifies `alloc_for_extend` releases freshly-allocated `req_pool` slots on `KVPoolOOMError`.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A — no user-facing API changed; the new `server_args.retry_prefill_on_kv_oom` flag is documented inline at the field definition.
- [x] Provide accuracy and speed benchmark results — N/A as explained above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Happy to iterate. Open questions for reviewers:

1. **Default value of `retry_prefill_on_kv_oom`** — the patch defaults to `True` (graceful retry). If the project prefers `False` (preserve legacy SIGQUIT until explicitly opted in), changing the default is a one-line edit.
2. **Surfacing the retract event** — the natural addition is a Prometheus counter (`scheduler_prefill_oom_retract_ct`). Held off until I see what counters the scheduler currently exports and what naming/registration convention to follow. Happy to add as a follow-up commit on this PR.
3. **Scope of `_raise_kv_oom`** — it is currently used at all three KV-alloc sites for consistency. If reviewers prefer the decode site to keep raising bare `RuntimeError` (to minimize behavioral change), I can revert that one site.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26389253604](https://github.com/sgl-project/sglang/actions/runs/26389253604)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26389253391](https://github.com/sgl-project/sglang/actions/runs/26389253391)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->