### PR TITLE
amd/deepseek_v4 33/N remove BF16-to-FP32 elementwise cast from compressor GEMM on HIP

### DIFF
--- a/python/sglang/srt/layers/attention/compressed/fused_compress_triton.py
+++ b/python/sglang/srt/layers/attention/compressed/fused_compress_triton.py
@@ -585,12 +585,15 @@ def _check_common(
 ) -> None:
     coff = 2 if compress_ratio == 4 else 1
     assert kv_score_input.is_cuda and kv_score_buffer.is_cuda
-    assert kv_score_input.dim() == 2 and kv_score_input.dtype == torch.float32
+    assert kv_score_input.dim() == 2 and kv_score_input.dtype in (
+        torch.float32,
+        torch.bfloat16,
+    )
     assert kv_score_input.shape[1] == 2 * coff * head_dim
     assert kv_score_buffer.dim() == 3 and kv_score_buffer.dtype == torch.float32
     assert kv_score_buffer.shape[1:] == (compress_ratio, 2 * coff * head_dim)
     assert out.shape == (kv_score_input.shape[0], head_dim)
-    assert out.dtype == torch.float32 and out.is_cuda
+    assert out.is_cuda and out.dtype in (torch.float32, torch.bfloat16)
     assert ape.shape == (compress_ratio * coff, head_dim)
     assert ape.dtype == torch.float32 and ape.is_cuda
     assert indices.dtype == torch.int32 and indices.is_cuda

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -100,6 +100,7 @@ _is_gfx95_supported = is_gfx95_supported()
 
 if _use_aiter:
     from aiter import rope_rotate_activation
+    from aiter.tuned_gemm import tgemm as _tgemm
 
     if is_gfx95_supported():
         from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
@@ -972,7 +973,10 @@ class Compressor(nn.Module):
 
         self.forward_mode = forward_batch.forward_mode
 
-        kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
+        if _use_aiter:
+            kv_score = _tgemm.mm(x, self.wkv_gate.weight, otype=x.dtype)
+        else:
+            kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
         return self.compress_dispatch(kv_score, forward_batch)
 
     def compress_extend_old(


### PR DESCRIPTION
Update amd/deepseek_v4 integration branch

Merging to main is WIP, we use this PR and upstream amd/deepseek_v4 branch to integrate in parallel.

Original PRs at Day-0:
https://github.com/sgl-project/sglang/pull/23600
https://github.com/sgl-project/sglang/pull/23608


## Motivation

On MI355/HIP, `Compressor.forward()` calls `linear_bf16_fp32()` which does:
```python
return tgemm.mm(x, y, otype=x.dtype).float()
```
The `.float()` triggers a separate `bfloat16tofloat32_copy_kernel_cuda` elementwise kernel (~4.2 us each). This fires once per compressor GEMM call:
- C-type layers (compress_ratio=4): 2 compressor GEMMs -> 2 cast kernels
- B-type layers (compress_ratio=128): 1 compressor GEMM -> 1 cast kernel
- A-type layers (compress_ratio=0): no compressor -> 0 cast kernels

Total: 30x2 + 30x1 = 90 cast kernels per iteration, ~384 us (~1.87% of ITL).

### Why B200 doesn't have this problem

`linear_bf16_fp32()` dispatches to different GEMM backends depending on the platform:

| Path | Method | FP32 output? |
|------|--------|-------------|
| B200 `deep_gemm` | `bf16_gemm_nt(x, y, z)` — output tensor `z` is pre-allocated as FP32, GEMM writes FP32 directly | Native, no extra kernel |
| B200 `cublas` | JIT CUDA module outputs FP32 directly | Native, no extra kernel |
| MI355 `aiter` | `tgemm.mm(x, y, otype=x.dtype)` — tuned flydsl configs only support BF16 output | Requires separate `.float()` cast |

B200's GEMM kernels natively support FP32 output in a single kernel launch. MI355's tuned flydsl kernels only support BF16 output, so the FP32 cast requires a separate elementwise kernel.

### Why removing the cast is safe on HIP

`linear_bf16_fp32()` has an FP32-output contract used by multiple paths (cublas, deep_gemm, torch fallback). Rather than breaking this contract, the compressor call site on HIP/aiter bypasses it and calls `tgemm.mm()` directly to get BF16 output.

This is safe because all downstream fused Triton compress kernels (`_c4_decode_kernel`, `_c128_decode_kernel`, `_compress_norm_rope_kernel`) already promote to FP32 internally via `.to(tl.float32)`. The GEMM itself uses FP32 accumulators internally -- the BF16 output simply avoids the unnecessary BF16->FP32->BF16->FP32 round-trip (GEMM accumulates in FP32, truncates to BF16 output, `.float()` casts back to FP32, then Triton loads and promotes to FP32 again).

The `CompressStatePool` buffer remains FP32 (`pool_configurator.py` sets `state_dtype=torch.float32`). Triton handles the mixed-dtype scenario (BF16 input stored into FP32 buffer) correctly via automatic type promotion.

## Modifications

- **`python/sglang/srt/models/deepseek_v4.py`**:
  - In `Compressor.forward()`, the aiter/HIP path now calls `_tgemm.mm()` directly (returns BF16), bypassing `linear_bf16_fp32()` and its `.float()` cast. The non-aiter path is unchanged.
  - Added `from aiter.tuned_gemm import tgemm as _tgemm` under the `if _use_aiter:` gate.

- **`python/sglang/srt/layers/attention/compressed/fused_compress_triton.py`**:
  - Relaxed FP32-only assertions in `_check_common()` to accept BF16 input (`kv_score_input` and `out`), since BF16 `kv_score` now flows through `compress_dispatch()` into the fused Triton kernels. The `kv_score_buffer` assertion remains FP32-only (state pool is always FP32).

## Accuracy Tests

| Benchmark | Score | Threshold | Status |
|-----------|-------|-----------|--------|
| GSM8K (2000 questions, 5-shot, parallel=1000) | 0.908 | 0.88 | PASS |

## Benchmarking and Profiling

### Kernel Replacement (per C-type layer, decode)

| Before | Time (us) | After | Time (us) |
|--------|-----------|-------|-----------|
| `hgemm_bf16` (C4 GEMM) | 8.8 | `hgemm_bf16` (C4 GEMM) | 8.8 |
| `bfloat16tofloat32_copy` | 4.4 | *(eliminated)* | -- |
| `hgemm_bf16` (C128 GEMM) | 9.3 | `hgemm_bf16` (C128 GEMM) | 9.3 |
| `bfloat16tofloat32_copy` | 4.2 | *(eliminated)* | -- |
| **Total** | **26.7** | **Total** | **18.1** |

### Kernel-to-E2E Impact Analysis

| Layer Type | Layers/iter | Kernel Savings/Layer | Total Savings |
|------------|-------------|---------------------|---------------|
| C-type (MLA+Compressor+MoE) | 30 | 8.6 us | 258 us |
| B-type (MoE) | 30 | 4.2 us | 126 us |
| A-type (MLA+Dense) | 61 | 0 us | 0 us |
| **Total** | | | **384 us** |

Expected ITL improvement: 384 us / 20,590 us = **1.87%** (~0.38 ms).

TTFT impact: Negligible -- prefill is dominated by large GEMMs.

### End-to-End Benchmark (il8k_ol1k, concurrency=4, 32 prompts)

| Metric | Baseline | After | Delta |
|--------|----------|-------|-------|
| Total throughput (tok/s) | 1,558.2 | 1,591.2 | +2.1% |
| Output throughput (tok/s) | 173.1 | 176.8 | +2.1% |
| Median E2E Latency (ms) | 23,109.0 | 22,969.5 | -0.6% |
| Median TTFT (ms) | 1,546.1 | 1,535.9 | -0.7% |
| Median ITL (ms) | 20.59 | 20.46 | -0.6% |
| Median TPOT (ms) | 21.54 | 20.99 | -2.6% |

### Configuration

- Model: DeepSeek-V4-Pro, TP=8, MI355
- Attention backend: compressed
- Page size: 256, chunked prefill: 8192

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.
