### PR TITLE
ci: add nightly Docker workflow for experimental sgl-router

### DIFF
--- a/.github/workflows/nightly-experimental-sgl-router-docker.yml
+++ b/.github/workflows/nightly-experimental-sgl-router-docker.yml
@@ -1,4 +1,4 @@
-name: Nightly Release sgl-router Docker Image
+name: Nightly Experimental sgl-router Docker Image
 
 on:
   schedule:

--- a/.github/workflows/nightly-release-sgl-router-docker.yml
+++ b/.github/workflows/nightly-release-sgl-router-docker.yml
@@ -1,0 +1,34 @@
+name: Nightly Release sgl-router Docker Image
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push
+        run: |
+          docker buildx build . -f docker/sgl-router.Dockerfile \
+            --platform linux/amd64 \
+            -t lmsysorg/sglang-staging:experimental-router-dev \
+            --push


### PR DESCRIPTION
## Summary

- Add `.github/workflows/nightly-release-sgl-router-docker.yml` to build and publish the experimental Rust `sgl-router` Docker image to `lmsysorg/sglang-staging:experimental-router-dev` once per day at 02:00 UTC.
- Lets downstream users pin a stable nightly tag while the router is still incubating under `experimental/`.
- Reuses the existing `docker/sgl-router.Dockerfile`; amd64-only to keep build time short. `workflow_dispatch` is available for on-demand rebuilds.

## Changes

- `.github/workflows/nightly-release-sgl-router-docker.yml` — new workflow:
  - Triggers: `schedule: cron '0 2 * * *'` + `workflow_dispatch`
  - Concurrency group on workflow name (`cancel-in-progress: true`)
  - `if: github.repository == 'sgl-project/sglang'` guard to skip on forks
  - `runs-on: ubuntu-24.04` with `docker/setup-buildx-action@v3`
  - Logs into Docker Hub using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (same secrets used by `release-docker-gateway.yml`)
  - `docker buildx build . -f docker/sgl-router.Dockerfile --platform linux/amd64 -t lmsysorg/sglang-staging:experimental-router-dev --push`

## Test Plan

- After merge, trigger the workflow manually via Actions → "Nightly Release sgl-router Docker Image" → Run workflow to confirm a successful first build and push.
- Verify the image appears on Docker Hub at `lmsysorg/sglang-staging:experimental-router-dev`.
- Smoke-test: `docker run --rm lmsysorg/sglang-staging:experimental-router-dev --help`.
- Subsequent runs will fire automatically at 02:00 UTC daily.























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26390640296](https://github.com/sgl-project/sglang/actions/runs/26390640296)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26390640274](https://github.com/sgl-project/sglang/actions/runs/26390640274)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->