### PR TITLE
[Bug Fix] Fix tensor dump not saving when model uses .forward() calls

### DIFF
--- a/python/sglang/srt/debug_utils/tensor_dump_forward_hook.py
+++ b/python/sglang/srt/debug_utils/tensor_dump_forward_hook.py
@@ -131,7 +131,6 @@ class TensorDumper:
                 for item in input:
                     if isinstance(item, ForwardBatch):
                         self.add_tensor(tensor_name, item)
-                self.dump_current_tensors()
             if output is not None:
                 self.add_tensor(tensor_name, output)
 
@@ -161,4 +160,9 @@ def register_forward_hook_for_model(
     assert (
         model_top_level_module_matched
     ), f"model should have a module named {top_level_module_name}"
+
+    def _root_dump_hook(module, input, output):
+        tensor_dumper.dump_current_tensors()
+
+    model.register_forward_hook(_root_dump_hook)
     return tensor_dumper

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2693,7 +2693,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if not self.is_generation:
                 kwargs["get_embedding"] = True
 
-            logits_output_or_pp_proxy_tensors = self.model.forward(
+            logits_output_or_pp_proxy_tensors = self.model(
                 buffers.input_ids,
                 forward_batch.positions,
                 forward_batch,
@@ -3015,7 +3015,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         )
 
         def _do_forward():
-            return self.model.forward(
+            return self.model(
                 forward_batch.input_ids,
                 forward_batch.positions,
                 forward_batch,
@@ -3090,7 +3090,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             else contextlib.nullcontext()
         )
         with ctx:
-            ret = self.model.forward(
+            ret = self.model(
                 forward_batch.input_ids,
                 forward_batch.positions,
                 forward_batch,
@@ -3116,7 +3116,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             else contextlib.nullcontext()
         )
         with ctx:
-            return self.model.forward(
+            return self.model(
                 forward_batch.input_ids,
                 forward_batch.positions,
                 forward_batch,


### PR DESCRIPTION

Fixes #26269

Fix by:
1. Moving the dump trigger from the inner top-level module hook to a new root hook registered on the outermost model (guaranteed to fire since model_runner now uses `__call__()`)
2. Changing all `self.model.forward(...)` calls in model_runner to `self.model(...)` so the root hook triggers via `__call__()`

## Motivation

The `--debug-tensor-dump-output-folder` feature silently fails to produce any `.pt` files for models that internally call submodules via `.forward()` (e.g., DeepSeek-V4). The dump directory structure is created but remains empty.
  **Root cause**: PyTorch's `register_forward_hook` only fires when a module is invoked via `__call__()`. In `model_runner.py`, the outermost model is called with `self.model.forward(...)`, which bypasses `__call__()` and prevents the top-level dump hook from triggering. The leaf-node hooks collect tensors into `_current_tensors`, but `dump_current_tensors()` is never called — data is gathered but never written to disk.

  Models like Llama that use `self.model(...)` internally are unaffected since the hook fires normally.

## Modifications

**`python/sglang/srt/debug_utils/tensor_dump_forward_hook.py`**:
  - Remove `self.dump_current_tensors()` from the inner `_dump_hook` (it was unreachable for `.forward()`-style models anyway)
  - Add a `_root_dump_hook` registered on the outermost model passed to `register_forward_hook_for_model()`, which calls `dump_current_tensors()` after all sub-hooks have collected their data

  **`python/sglang/srt/model_executor/model_runner.py`**:
  - Change 4 occurrences of `self.model.forward(...)` to `self.model(...)` so the outermost model is invoked via `__call__()`, ensuring the root hook fires

## Verification

  After the fix, tensor dump works correctly for DeepSeek-V4-Flash:
  **TP0 (Rank0)**:
  
<img width="1144" height="286" alt="image" src="https://github.com/user-attachments/assets/c7381a1b-dbe1-4ae8-ae09-0666ca9d5e3b" />

  **TP1 (Rank1)**:
 
<img width="1140" height="284" alt="image" src="https://github.com/user-attachments/assets/ec2334b4-3783-41fd-964d-236cde11a558" />

 **Before vs After**:

  | Metric | Before | After |
  |--------|--------|-------|
  | Directory creation | ✅ Normal | ✅ Normal |
  | `.pt` file generation | ❌ Empty directory | ✅ One file per forward pass |
  | Multi-TP rank | ❌ No files on any rank | ✅ Each rank generates complete files independently |

  **Data completeness per `.pt` file**:

  | Model type | Before | After |
  |------------|--------|-------|
  | Llama (uses `__call__()`) | ✅ Works, but `logits_processor` delayed to next file | ✅ Works, all data in same file |
  | DeepSeek V4 (uses `.forward()`) | ❌ No `.pt` files at all | ✅ All data in same file |

  - `.pt` files generated as expected (Pass00000.pt, Pass00001.pt, ...)
  - All tensor data complete and saved in correct per-pass files

  Models using `__call__()` internally (e.g., Llama) continue to work identically — the root hook simply takes over the dump responsibility from the inner hook, with no change in behavior or output.

## Accuracy Tests

This change does not affect model outputs — it only fixes the tensor dump I/O path. The model forward computation is identical.

## Speed Tests and Profiling

No performance impact — the only added overhead is one additional `register_forward_hook` call on the outermost model, which is negligible.

## Checklist

- [x] Format: `pre-commit run --all-files`
- [x] The fix is model-agnostic — no changes to any `models/*.py` file
- [x] Backward compatible: models that already worked (e.g., Llama) continue to work identically
- [x] Bonus: `logits_processor` output is now saved in the same `.pt` file as the rest of the forward pass (previously it was delayed to the
  next file)

 ## Additional context

  Reproducible with any model that uses `.forward()` internally (confirmed on DeepSeek-V4-Flash with `--disable-cuda-graph`). The issue is
  hidden when CUDA Graph is enabled because the graph replay path doesn't go through the Python forward hooks at all.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26390502994](https://github.com/sgl-project/sglang/actions/runs/26390502994)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26390502878](https://github.com/sgl-project/sglang/actions/runs/26390502878)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->