### PR TITLE
Use full chat history for PD cache-aware routing text

### DIFF
--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
     protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+        chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         common::{InputIds, StringOrArray},
         completion::CompletionRequest,
@@ -209,6 +209,19 @@ impl PDRouter {
             }
         }
         None
+    }
+
+    fn build_chat_cache_request_text(req: &ChatCompletionRequest) -> Option<String> {
+        if req.messages.is_empty() {
+            return None;
+        }
+
+        let mut text = String::new();
+        for message in &req.messages {
+            text.push_str(&serde_json::to_string(message).ok()?);
+            text.push('\n');
+        }
+        Some(text)
     }
 
     fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
@@ -1421,22 +1434,10 @@ impl RouterTrait for PDRouter {
         let is_stream = body.stream;
         let return_logprob = body.logprobs;
 
-        let request_text = if self.policies_need_request_text() {
-            body.messages.first().and_then(|msg| match msg {
-                ChatMessage::User { content, .. } => match content {
-                    MessageContent::Text(text) => Some(text.clone()),
-                    MessageContent::Parts(_) => None,
-                },
-                ChatMessage::Developer { content, .. } => match content {
-                    MessageContent::Text(text) => Some(text.clone()),
-                    MessageContent::Parts(_) => None,
-                },
-                ChatMessage::System { content, .. } => Some(content.to_simple_string()),
-                _ => None,
-            })
-        } else {
-            None
-        };
+        let request_text = self
+            .policies_need_request_text()
+            .then(|| Self::build_chat_cache_request_text(body))
+            .flatten();
 
         // Calculate batch size
         let batch_size = Self::get_chat_batch_size(body);
@@ -1550,7 +1551,10 @@ impl RouterTrait for PDRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{BasicWorkerBuilder, WorkerType};
+    use crate::{
+        core::{BasicWorkerBuilder, WorkerType},
+        protocols::chat::{ChatMessage, MessageContent},
+    };
 
     fn create_test_pd_router() -> PDRouter {
         let worker_registry = Arc::new(WorkerRegistry::new());
@@ -1573,6 +1577,79 @@ mod tests {
             .build();
         worker.set_healthy(healthy);
         Box::new(worker)
+    }
+
+    #[test]
+    fn test_chat_cache_request_text_includes_all_messages() {
+        let req = ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![
+                ChatMessage::System {
+                    content: MessageContent::Text("system prompt".to_string()),
+                    name: None,
+                },
+                ChatMessage::User {
+                    content: MessageContent::Text("first user turn".to_string()),
+                    name: None,
+                },
+                ChatMessage::Assistant {
+                    content: Some(MessageContent::Text("assistant answer".to_string())),
+                    name: None,
+                    tool_calls: None,
+                    reasoning_content: Some("hidden reasoning".to_string()),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let text = PDRouter::build_chat_cache_request_text(&req).unwrap();
+
+        assert!(text.contains("system prompt"));
+        assert!(text.contains("first user turn"));
+        assert!(text.contains("assistant answer"));
+        assert!(text.contains("hidden reasoning"));
+        assert_eq!(text.lines().count(), 3);
+    }
+
+    #[test]
+    fn test_chat_cache_request_text_preserves_expanding_prefix() {
+        let first_turn = ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![
+                ChatMessage::System {
+                    content: MessageContent::Text("system prompt".to_string()),
+                    name: None,
+                },
+                ChatMessage::User {
+                    content: MessageContent::Text("first user turn".to_string()),
+                    name: None,
+                },
+            ],
+            ..Default::default()
+        };
+        let mut second_turn = first_turn.clone();
+        second_turn.messages.push(ChatMessage::Assistant {
+            content: Some(MessageContent::Text("assistant answer".to_string())),
+            name: None,
+            tool_calls: None,
+            reasoning_content: None,
+        });
+
+        let first_text = PDRouter::build_chat_cache_request_text(&first_turn).unwrap();
+        let second_text = PDRouter::build_chat_cache_request_text(&second_turn).unwrap();
+
+        assert!(second_text.starts_with(&first_text));
+    }
+
+    #[test]
+    fn test_chat_cache_request_text_empty_messages() {
+        let req = ChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![],
+            ..Default::default()
+        };
+
+        assert!(PDRouter::build_chat_cache_request_text(&req).is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

PD router cache-aware routing currently builds the chat `request_text` from only the first chat message. For multi-turn chat/completions requests, that usually captures only the shared system prompt and misses the growing conversation history. This weakens the cache-aware signal because different conversations can look identical to the router even though their actual prompts diverge after the first message.

Relationship to #26245: this PR is a standalone fix on `main`. The benchmark below was run together with #26245 because #26245 enables DP-aware PD dispatch.

## Modifications

- Build chat cache-aware `request_text` from the full ordered chat history instead of `messages[0]`.
- Serialize each `ChatMessage` as one JSON line. This keeps later turns prefix-compatible with earlier turns while avoiding a hand-maintained copy of the chat schema.
- Return `None` for empty chat message lists, matching the previous no-text behavior for requests without an extractable first message.
- Add unit coverage that verifies all messages are included, a later turn preserves the earlier turn as a prefix, and empty message lists do not create cache text.

## Accuracy Tests

Not run. This only changes the text used by router policy selection; it does not modify the request payload sent to workers or model forward logic.

## Speed Tests and Profiling

Agentic benchmark on GB300, DeepSeek-V4-Pro, DEP4 prefill -> DEP8 decode, c32, `prefill_policy=cache_aware`, `decode_policy=round_robin`, `--dp-aware`. Dataset is a private multi-turn coding-agent trajectory set with tool-call/chat history.

| Run | Job | Measured | OK / Err | Cache hit | Server output TPS | Client output TPS | TTFT p50 / p95 / p99 | E2E p95 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| #26245 only | 1899536 | 3826 | 3821 / 5 | 93.89% | 1125.5 | 1189.4 | 1.142 / 6.268 / 9.155s | 34.920s |
| #26245 + this PR | 1900073 | 4152 | 4151 / 1 | 95.29% | 1152.4 | 1227.2 | 0.916 / 3.421 / 6.085s | 32.173s |
| Conversation-key sticky baseline | 1899538 | 4089 | 4088 / 1 | 95.81% | 1167.2 | 1237.5 | 0.674 / 2.364 / 4.205s | 35.520s |

This improves cache hit rate by +1.40 pp, server output TPS by +2.4%, and TTFT p95 by about 45% versus #26245 alone in this setup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26411767231](https://github.com/sgl-project/sglang/actions/runs/26411767231)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26411767173](https://github.com/sgl-project/sglang/actions/runs/26411767173)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->