### PR TITLE
[Bug Fix] TypeError in bench_one_batch --correct mode

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -383,7 +383,7 @@ def prepare_extend_inputs_for_correctness_test(
 ):
     for i in range(len(reqs)):
         req: Req = reqs[i]
-        req.fill_ids += input_ids[i][bench_args.cut_len :]
+        req.fill_ids.extend(input_ids[i][bench_args.cut_len:])
         if model_runner is not None:
             req.prefix_indices = model_runner.req_to_token_pool.req_to_token[
                 i, : bench_args.cut_len


### PR DESCRIPTION
## Motivation

  `python -m sglang.bench_one_batch --correct` crashes during the extend (chunked prefill) phase with:

  File "bench_one_batch.py", line 386, in prepare_extend_inputs_for_correctness_test
      req.fill_ids += input_ids[i][bench_args.cut_len :]
  TypeError: can only extend array with array (not "list")

  `req.fill_ids` was changed to `array("q")` for memory efficiency, but `bench_one_batch.py` still extends it with a plain `list` from `tokenizer.encode()`.

  ### Reproduce

  ```bash
  python -m sglang.bench_one_batch \
      --model-path Qwen/Qwen2-0.5B \
      --load-format dummy \
      --correct
  ```
  ## Modifications
 Replaced `+=` with `extend()` when appending sliced input IDs to `req.fill_ids` in `prepare_extend_inputs_for_correctness_test()` to avoid a TypeError caused by list/array concatenation.

 ## Accuracy Tests

  N/A — this fixes a crash in a test utility script, no change to model output.

  Speed Tests and Profiling

  N/A — no impact on inference speed.

  ## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26397386264](https://github.com/sgl-project/sglang/actions/runs/26397386264)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26397386177](https://github.com/sgl-project/sglang/actions/runs/26397386177)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->