### PR TITLE
fix: avoid allocator cold start in bench_serving cache flush

### DIFF
--- a/docs_new/docs/developer_guide/bench_serving.mdx
+++ b/docs_new/docs/developer_guide/bench_serving.mdx
@@ -171,7 +171,8 @@ python3 -m sglang.bench_serving \
 - `--extra-request-body '&#123;"top_p":0.9,"temperature":0.6&#125;'`: merged into payload (sampling params, etc.)
 - `--disable-ignore-eos`: pass through EOS behavior (varies by backend)
 - `--warmup-requests N`: run warmup requests with short output first (default 1)
-- `--flush-cache`: call `/flush_cache` (sglang) before main run
+- `--flush-cache`: call `/flush_cache` (sglang) before main run without emptying the device allocator cache by default
+- `--flush-cache-empty-cache`: when used with `--flush-cache`, also empty the device allocator cache to preserve the older benchmark flush behavior
 - `--profile`: call `/start_profile` and `/stop_profile` (requires server to enable profiling, e.g., `SGLANG_TORCH_PROFILER_DIR`)
 - `--lora-name name1 name2 ...`: randomly pick one per request and pass to backend (e.g., `lora_path` for sglang)
 - `--tokenize-prompt`: send integer IDs instead of text (currently supports `--backend sglang` only)

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1215,6 +1215,7 @@ async def benchmark(
     profile: bool,
     pd_separated: bool = False,
     flush_cache: bool = False,
+    flush_cache_empty_cache: bool = False,
     warmup_requests: int = 1,
     use_trace_timestamps: bool = False,
     mooncake_slowdown_factor=1.0,
@@ -1319,7 +1320,12 @@ async def benchmark(
 
     # Flush cache
     if ("sglang" in backend and _get_bool_env_var("SGLANG_IS_IN_CI")) or flush_cache:
-        requests.post(base_url + "/flush_cache", headers=get_auth_headers())
+        await asyncio.to_thread(
+            requests.post,
+            base_url + "/flush_cache",
+            headers=get_auth_headers(),
+            params={"empty_cache": flush_cache_empty_cache},
+        )
 
     time.sleep(1.0)
 
@@ -1891,6 +1897,8 @@ def run_benchmark(args_: argparse.Namespace):
     # compatible with SimpleNamespace
     if not hasattr(args, "flush_cache"):
         args.flush_cache = False
+    if not hasattr(args, "flush_cache_empty_cache"):
+        args.flush_cache_empty_cache = False
 
     # Prepare LoRA arguments
     lora_request_distribution = (
@@ -1921,6 +1929,7 @@ def run_benchmark(args_: argparse.Namespace):
             profile=args.profile,
             pd_separated=args.pd_separated,
             flush_cache=args.flush_cache,
+            flush_cache_empty_cache=args.flush_cache_empty_cache,
             warmup_requests=args.warmup_requests,
             use_trace_timestamps=args.use_trace_timestamps,
             mooncake_slowdown_factor=args.mooncake_slowdown_factor,
@@ -2332,7 +2341,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--flush-cache",
         action="store_true",
-        help="Flush the cache before running the benchmark",
+        help="Flush server-side caches before running the benchmark.",
+    )
+    parser.add_argument(
+        "--flush-cache-empty-cache",
+        action="store_true",
+        help=(
+            "Also empty the device allocator cache while flushing. This is off "
+            "by default so the benchmark does not include allocator cold-start latency."
+        ),
     )
     parser.add_argument(
         "--warmup-requests",

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -769,9 +769,14 @@ async def classify_request(obj: EmbeddingReqInput, request: Request):
 
 @app.api_route("/flush_cache", methods=["GET", "POST"])
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
-async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
+async def flush_cache(
+    timeout: float = Query(0.0, ge=0.0),
+    empty_cache: bool = Query(True),
+):
     """Flush the radix cache."""
-    ret = await _global_state.tokenizer_manager.flush_cache(timeout_s=timeout)
+    ret = await _global_state.tokenizer_manager.flush_cache(
+        timeout_s=timeout, empty_cache=empty_cache
+    )
     if ret.success:
         content = (
             "Cache flushed.\nPlease check backend logs for more details. "

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1267,6 +1267,7 @@ class ClearHiCacheReqOutput(BaseReq):
 @dataclass
 class FlushCacheReqInput(BaseReq):
     timeout_s: Optional[float] = None
+    empty_cache: bool = True
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler_components/flush_wrapper.py
+++ b/python/sglang/srt/managers/scheduler_components/flush_wrapper.py
@@ -12,7 +12,7 @@ class SchedulerFlushWrapper:
     def __init__(
         self,
         *,
-        flush_cache: Callable[[], bool],
+        flush_cache: Callable[[bool], bool],
         is_fully_idle: Callable[[], bool],
         ipc_channels: SchedulerIpcChannels,
     ) -> None:
@@ -30,10 +30,10 @@ class SchedulerFlushWrapper:
 
         timeout_s = float(recv_req.timeout_s or 0.0)
         if timeout_s <= 0.0:
-            return FlushCacheReqOutput(success=self._flush_cache())
+            return FlushCacheReqOutput(success=self._flush_cache(recv_req.empty_cache))
 
         if self._is_fully_idle():
-            return FlushCacheReqOutput(success=self._flush_cache())
+            return FlushCacheReqOutput(success=self._flush_cache(recv_req.empty_cache))
 
         self._pending = (recv_req, time.monotonic() + timeout_s)
         return None
@@ -45,7 +45,7 @@ class SchedulerFlushWrapper:
         pending_req, deadline = self._pending
 
         if self._is_fully_idle():
-            success = self._flush_cache()
+            success = self._flush_cache(pending_req.empty_cache)
             self._pending = None
             self._ipc_channels.send_to_tokenizer.send_output(
                 FlushCacheReqOutput(success=success), pending_req

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -247,11 +247,15 @@ class TokenizerControlMixin:
         )
 
     async def flush_cache(
-        self: TokenizerManager, timeout_s: Optional[float] = None
+        self: TokenizerManager,
+        timeout_s: Optional[float] = None,
+        empty_cache: bool = True,
     ) -> FlushCacheReqOutput:
         self.auto_create_handle_loop()
         return (
-            await self.flush_cache_communicator(FlushCacheReqInput(timeout_s=timeout_s))
+            await self.flush_cache_communicator(
+                FlushCacheReqInput(timeout_s=timeout_s, empty_cache=empty_cache)
+            )
         )[0]
 
     async def clear_hicache_storage(self: TokenizerManager) -> ClearHiCacheReqOutput:

--- a/test/registered/bench_fn/test_bench_serving_functionality.py
+++ b/test/registered/bench_fn/test_bench_serving_functionality.py
@@ -1,12 +1,18 @@
+import asyncio
 import json
+import os
 import tempfile
 import threading
 import time
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from sglang.bench_serving import run_benchmark
+import sglang.bench_serving as bench_serving
+from sglang.bench_serving import RequestFuncOutput, run_benchmark
+from sglang.benchmark.datasets import DatasetRow
 from sglang.benchmark.utils import parse_custom_headers
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.utils import kill_process_tree
@@ -185,6 +191,81 @@ class TestBenchServingCustomHeaders(CustomTestCase):
         headers = generate_reqs[0]["headers"]
         self.assertEqual(headers.get("X-Custom-Test"), "TestValue123")
         self.assertEqual(headers.get("X-Another"), "AnotherVal")
+
+
+    def test_flush_cache_keeps_allocator_cache_by_default(self):
+        """bench_serving --flush-cache should pass empty_cache=False by default."""
+
+        async def fake_request(request_func_input, pbar=None):
+            return RequestFuncOutput(
+                generated_text="ok",
+                success=True,
+                latency=0.02,
+                ttft=0.01,
+                itl=[0.01],
+                prompt_len=request_func_input.prompt_len,
+                output_len=2,
+                start_time=time.perf_counter(),
+            )
+
+        class FakeTokenizer:
+            def encode(self, text, add_special_tokens=False):
+                return [1, 2]
+
+        class FakeResponse:
+            status_code = 404
+
+            def json(self):
+                return {}
+
+        previous_request_func = bench_serving.ASYNC_REQUEST_FUNCS["sglang"]
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            output_file = f.name
+        bench_serving.args = SimpleNamespace(
+            backend="sglang",
+            dataset_name="random",
+            sharegpt_output_len=None,
+            random_input_len=8,
+            random_output_len=2,
+            random_range_ratio=0.0,
+            num_prompts=1,
+            warmup_requests=0,
+            output_file=output_file,
+            output_details=False,
+            plot_throughput=False,
+        )
+
+        try:
+            bench_serving.ASYNC_REQUEST_FUNCS["sglang"] = fake_request
+            with patch.object(bench_serving.requests, "post") as post, patch.object(
+                bench_serving.requests, "get", return_value=FakeResponse()
+            ):
+                asyncio.run(
+                    bench_serving.benchmark(
+                        backend="sglang",
+                        api_url="http://127.0.0.1:30000/generate",
+                        base_url="http://127.0.0.1:30000",
+                        model_id="dummy",
+                        tokenizer=FakeTokenizer(),
+                        input_requests=[DatasetRow("hi", 1, 2)],
+                        request_rate=float("inf"),
+                        max_concurrency=None,
+                        disable_tqdm=True,
+                        lora_names=[],
+                        lora_request_distribution=None,
+                        lora_zipf_alpha=None,
+                        extra_request_body={},
+                        profile=False,
+                        flush_cache=True,
+                        warmup_requests=0,
+                    )
+                )
+
+            post.assert_called_once()
+            self.assertEqual(post.call_args.kwargs["params"], {"empty_cache": False})
+        finally:
+            bench_serving.ASYNC_REQUEST_FUNCS["sglang"] = previous_request_func
+            os.remove(output_file)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -49,6 +49,17 @@ class TestSchedulerFlushCache(unittest.TestCase):
         self.assertTrue(output.success)
         scheduler.flush_cache.assert_called_once()
 
+    def test_flush_can_skip_emptying_allocator_cache(self):
+        """empty_cache=False is forwarded to the underlying flush_cache callable."""
+        scheduler = self._new_scheduler()
+
+        output = scheduler.flush_wrapper.handle(
+            FlushCacheReqInput(timeout_s=None, empty_cache=False)
+        )
+
+        self.assertTrue(output.success)
+        scheduler.flush_cache.assert_called_once_with(False)
+
     def test_defers_when_busy(self):
         """Positive timeout + busy → defers, returns None."""
         scheduler = self._new_scheduler()


### PR DESCRIPTION
## Motivation

`bench_serving --flush-cache` currently calls `/flush_cache` before the measured run. That also clears the device allocator cache, so the first measured requests can include allocator cold-start time that does not show up in the engine decode-throughput logs.

Fixes #3050.

## Modifications

- Add an `empty_cache` option to `/flush_cache`, defaulting to the old behavior.
- Use `empty_cache=false` for the benchmark setup flush.
- Keep `--flush-cache-empty-cache` for the old benchmark behavior.
- Run the benchmark-triggered flush request off the event loop.
- Add coverage for the scheduler wrapper and benchmark request path.

## Accuracy Tests

Not applicable. This does not change model execution, kernels, sampling, or outputs.

## Speed Tests and Profiling

No GPU benchmark run for this PR. The change only controls whether benchmark setup also empties the allocator cache.

## Checklist

- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26872888903](https://github.com/sgl-project/sglang/actions/runs/26872888903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26872888700](https://github.com/sgl-project/sglang/actions/runs/26872888700)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
