### PR TITLE
Zero `req_pool_indices` padding in cuda-graph populate

### DIFF
--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -786,6 +786,9 @@ class CPUGraphRunner:
         assert captured_forward_batch is not None
         captured_forward_batch.seq_lens.fill_(self.seq_len_fill_value)
         captured_forward_batch.out_cache_loc.zero_()
+        # Pair with seq_lens fill: padded rows must point at reserved
+        # req_pool slot 0 (req_to_token[0, :] is all zeros from init).
+        captured_forward_batch.req_pool_indices.zero_()
         captured_forward_batch.input_ids[:raw_num_token].copy_(forward_batch.input_ids)
         captured_forward_batch.req_pool_indices[:raw_bs].copy_(
             forward_batch.req_pool_indices

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -286,6 +286,11 @@ class DecodeInputBuffers(ForwardInputBuffers):
         if bs != raw_bs:
             self.seq_lens.fill_(seq_len_fill_value)
             self.out_cache_loc.zero_()
+            # Pair with seq_lens fill: padded rows must point at reserved
+            # req_pool slot 0 (req_to_token[0, :] is all zeros from init),
+            # so dummy attention reads land on slot 0 instead of a stale
+            # req_to_token row left by an earlier replay.
+            self.req_pool_indices.zero_()
             if self.mamba_track_indices is not None:
                 self.mamba_track_indices.zero_()
             if self.mamba_track_mask is not None:

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -460,6 +460,9 @@ class EAGLEDraftExtendCudaGraphRunner:
             buffers.seq_lens.fill_(self.seq_len_fill_value)
             buffers.out_cache_loc.zero_()
             buffers.positions.zero_()
+            # Pair with seq_lens fill: padded rows must point at reserved
+            # req_pool slot 0 (req_to_token[0, :] is all zeros from init).
+            buffers.req_pool_indices.zero_()
             buffers.num_correct_drafts.fill_(self.num_tokens_per_bs)
             buffers.num_accept_tokens.fill_(self.num_tokens_per_bs)
             buffers.extend_seq_lens.fill_(self.num_tokens_per_bs)

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -352,6 +352,9 @@ class FrozenKVMTPCudaGraphRunner:
         if bs != raw_bs:
             buffers.seq_lens.fill_(self.seq_len_fill_value)
             buffers.positions.zero_()
+            # Pair with seq_lens fill: padded rows must point at reserved
+            # req_pool slot 0 (req_to_token[0, :] is all zeros from init).
+            buffers.req_pool_indices.zero_()
 
         num_tokens = expanded_bs
         buffers.seq_lens[:raw_expanded_bs].copy_(forward_batch.seq_lens)


### PR DESCRIPTION
Pair `seq_lens.fill_(seq_len_fill_value)` with `req_pool_indices.zero_()` in cuda-graph populate. Padded rows then resolve to the reserved `req_pool` slot 0 whose `req_to_token[0, :]` row stays all-zero from init, so captured attention's dummy reads land on slot 0 instead of stale `req_to_token` left by an earlier replay.

Already done in `eagle_draft_cuda_graph_runner.py`; applies the same pairing to the four runners that missed it: `cuda_graph_runner`, `cpu_graph_runner`, `eagle_draft_extend_cuda_graph_runner`, `frozen_kv_mtp_cuda_graph_runner`.

## Test plan
- [ ] CI green











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26393864411](https://github.com/sgl-project/sglang/actions/runs/26393864411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26393864303](https://github.com/sgl-project/sglang/actions/runs/26393864303)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->