### PR TITLE
[Bugfix] normalize tensor slots in detokenize_top_logprobs_tokens (PD mode crash, fixes #26286)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2133,19 +2133,29 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
     def detokenize_top_logprobs_tokens(
         self,
-        token_logprobs_val: List[float],
-        token_logprobs_idx: List[int],
+        token_logprobs_val,
+        token_logprobs_idx,
         decode_to_text: bool,
     ):
         # TODO: The current implementation only batches the detokenization for top-k tokens per single position.
         # We should batch all top-k tokens in all positions.
+        # PD / disaggregated mode runs the sampler with
+        # ``no_copy_to_cpu=True`` (see ``layers/sampler.py``), so each
+        # per-position slot arrives here as ``torch.Tensor`` for both
+        # values and indices rather than ``List[float]`` / ``List[int]``.
+        # Normalize at this boundary -- see #26286 for the cascading
+        # detokenizer SIGQUIT the unnormalized truthiness check caused.
         ret = []
         for i in range(len(token_logprobs_val)):
-            if token_logprobs_val[i]:
+            val_slot = token_logprobs_val[i]
+            idx_slot = token_logprobs_idx[i]
+            if isinstance(val_slot, torch.Tensor):
+                val_slot = val_slot.tolist()
+            if isinstance(idx_slot, torch.Tensor):
+                idx_slot = idx_slot.tolist()
+            if val_slot:
                 ret.append(
-                    self.detokenize_logprob_tokens(
-                        token_logprobs_val[i], token_logprobs_idx[i], decode_to_text
-                    )
+                    self.detokenize_logprob_tokens(val_slot, idx_slot, decode_to_text)
                 )
             else:
                 ret.append(None)

--- a/test/registered/unit/managers/test_tokenizer_manager_top_logprobs.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_top_logprobs.py
@@ -1,0 +1,200 @@
+"""Unit tests for ``TokenizerManager.detokenize_top_logprobs_tokens``.
+
+Regression for https://github.com/sgl-project/sglang/issues/26286 — in
+PD / disaggregated mode the sampler runs with ``no_copy_to_cpu=True``,
+so per-position slots in both ``token_logprobs_val`` and
+``token_logprobs_idx`` arrive as ``torch.Tensor`` rather than
+``List[float]`` / ``List[int]``. The previous truthiness check
+(``if token_logprobs_val[i]:``) raised ``RuntimeError: Boolean value
+of Tensor with more than one value is ambiguous``, took down
+``TokenizerManager``, and cascaded to a detokenizer SIGQUIT.
+
+These tests pin five contracts:
+  - PD-shape tensor val (only) does not crash and round-trips.
+  - PD-shape tensor val + tensor idx normalizes both before
+    delegating to the tokenizer.
+  - Non-PD list slots keep the legacy behavior byte-for-byte.
+  - Empty / None slots resolve to ``None`` in the output.
+  - ``decode_to_text=True`` path forwards plain Python ints to
+    ``tokenizer.batch_decode`` (catches the index-half of the bug).
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _bare_tokenizer_manager() -> TokenizerManager:
+    """Bypass ``__init__`` so we can call the pure detokenize helper
+    without spinning a real tokenizer / scheduler. Mirrors the minimal
+    repro from issue #26286.
+    """
+    return TokenizerManager.__new__(TokenizerManager)
+
+
+class TestDetokenizeTopLogprobsTokensTensorTruthiness(CustomTestCase):
+    def test_pd_tensor_val_does_not_raise_and_round_trips_values(self) -> None:
+        """The minimal repro from the issue: per-position values arrive
+        as a multi-element tensor. Before the fix this raised
+        ``RuntimeError: Boolean value of Tensor with more than one
+        value is ambiguous`` at the truthiness check.
+        """
+        manager = _bare_tokenizer_manager()
+        token_logprobs_val = [torch.tensor([-0.1, -0.2])]
+        token_logprobs_idx = [[1, 2]]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            token_logprobs_val, token_logprobs_idx, decode_to_text=False
+        )
+
+        self.assertEqual(len(result), 1)
+        slot = result[0]
+        self.assertIsNotNone(slot)
+        # Tensor values must round-trip into plain Python floats so the
+        # downstream JSON serializer doesn't choke on tensor instances.
+        self.assertEqual(len(slot), 2)
+        self.assertAlmostEqual(slot[0][0], -0.1, places=5)
+        self.assertEqual(slot[0][1], 1)
+        self.assertIsNone(slot[0][2])
+        self.assertAlmostEqual(slot[1][0], -0.2, places=5)
+        self.assertEqual(slot[1][1], 2)
+        self.assertIsNone(slot[1][2])
+
+    def test_pd_tensor_val_and_tensor_idx_both_normalized(self) -> None:
+        """In PD mode the producer (``get_top_logprobs(..., no_copy_to_cpu=True)``)
+        returns *both* values and indices as tensors. Normalizing only
+        ``token_logprobs_val`` would still yield ``(float, tensor(1), None)``
+        for ``decode_to_text=False`` and ``batch_decode([[tensor(1)]...])``
+        for ``decode_to_text=True``. Pin that both halves are normalized
+        to plain Python types before delegation.
+        """
+        manager = _bare_tokenizer_manager()
+        token_logprobs_val = [torch.tensor([-0.1, -0.2])]
+        token_logprobs_idx = [torch.tensor([1, 2])]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            token_logprobs_val, token_logprobs_idx, decode_to_text=False
+        )
+
+        self.assertEqual(len(result), 1)
+        slot = result[0]
+        self.assertEqual(len(slot), 2)
+        # Both halves are plain Python types -- assert the idx is a
+        # raw int, not a 0-d tensor that quietly serializes wrong.
+        self.assertIsInstance(slot[0][1], int)
+        self.assertIsInstance(slot[1][1], int)
+        self.assertEqual(slot[0][1], 1)
+        self.assertEqual(slot[1][1], 2)
+
+    def test_non_pd_list_slot_keeps_legacy_behavior(self) -> None:
+        """Non-PD callers still pass ``List[float]`` per slot. The fix
+        must not alter that path: a non-empty list still flows through
+        ``detokenize_logprob_tokens``, and an empty list still resolves
+        to ``None``.
+        """
+        manager = _bare_tokenizer_manager()
+        token_logprobs_val = [[-0.5, -0.7], []]
+        token_logprobs_idx = [[3, 4], []]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            token_logprobs_val, token_logprobs_idx, decode_to_text=False
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertIsNotNone(result[0])
+        self.assertEqual(len(result[0]), 2)
+        self.assertAlmostEqual(result[0][0][0], -0.5, places=5)
+        self.assertEqual(result[0][0][1], 3)
+        self.assertIsNone(result[1])
+
+    def test_empty_tensor_slot_resolves_to_none(self) -> None:
+        """A zero-element tensor (no top logprobs at this position)
+        must resolve to ``None`` in the output, matching the empty-list
+        signal in the non-PD path. Without ``.tolist()`` the truthiness
+        on a zero-element tensor is also ambiguous.
+        """
+        manager = _bare_tokenizer_manager()
+        token_logprobs_val = [torch.tensor([], dtype=torch.float32)]
+        token_logprobs_idx = [torch.tensor([], dtype=torch.int64)]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            token_logprobs_val, token_logprobs_idx, decode_to_text=False
+        )
+
+        self.assertEqual(result, [None])
+
+    def test_mixed_tensor_and_none_slots(self) -> None:
+        """The output preserves slot order: a real tensor slot
+        produces a populated list, a ``None`` slot stays ``None``, an
+        empty-tensor slot also stays ``None``.
+        """
+        manager = _bare_tokenizer_manager()
+        token_logprobs_val = [
+            torch.tensor([-0.05]),
+            None,
+            torch.tensor([], dtype=torch.float32),
+            torch.tensor([-0.9, -1.1]),
+        ]
+        token_logprobs_idx = [
+            torch.tensor([7]),
+            None,
+            torch.tensor([], dtype=torch.int64),
+            torch.tensor([10, 11]),
+        ]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            token_logprobs_val, token_logprobs_idx, decode_to_text=False
+        )
+
+        self.assertEqual(len(result), 4)
+        self.assertIsNotNone(result[0])
+        self.assertIsNone(result[1])
+        self.assertIsNone(result[2])
+        self.assertIsNotNone(result[3])
+        self.assertEqual(len(result[3]), 2)
+
+    def test_decode_to_text_path_forwards_plain_ints_to_tokenizer(self) -> None:
+        """When ``decode_to_text=True`` the helper calls
+        ``self.tokenizer.batch_decode`` once per slot. Pin that the
+        idx values reaching the tokenizer are plain Python ints, not
+        0-d tensors -- otherwise a real tokenizer would either raise
+        or silently mis-decode. This catches the index-half of the
+        bug that value-only normalization would miss.
+        """
+        manager = _bare_tokenizer_manager()
+        # ``side_effect`` so we can assert the per-slot batch_decode
+        # call args are plain Python ints (not torch scalars).
+        manager.tokenizer = MagicMock()
+        manager.tokenizer.batch_decode = MagicMock(return_value=["foo", "bar"])
+
+        token_logprobs_val = [torch.tensor([-0.1, -0.2])]
+        token_logprobs_idx = [torch.tensor([1, 2])]
+
+        result = manager.detokenize_top_logprobs_tokens(
+            token_logprobs_val, token_logprobs_idx, decode_to_text=True
+        )
+
+        # Exactly one batch_decode call (one slot), with plain-int ids
+        # wrapped in single-element lists per upstream convention.
+        manager.tokenizer.batch_decode.assert_called_once_with([[1], [2]])
+        # And the returned shape is the full per-token tuple.
+        self.assertEqual(len(result), 1)
+        slot = result[0]
+        self.assertEqual(len(slot), 2)
+        self.assertAlmostEqual(slot[0][0], -0.1, places=5)
+        self.assertEqual(slot[0][1], 1)
+        self.assertEqual(slot[0][2], "foo")
+        self.assertAlmostEqual(slot[1][0], -0.2, places=5)
+        self.assertEqual(slot[1][1], 2)
+        self.assertEqual(slot[1][2], "bar")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #26286.

In PD / disaggregated mode the sampler runs with `no_copy_to_cpu=True` (`layers/sampler.py`), so each per-position slot in `token_logprobs_val` and `token_logprobs_idx` arrives at `TokenizerManager.detokenize_top_logprobs_tokens` as `torch.Tensor` rather than `List[float]` / `List[int]`.

The previous `if token_logprobs_val[i]:` truthiness check then raised `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`. Once that fired, `TokenizerManager` exited the async loop, the detokenizer subprocess was killed by SIGQUIT, and peer prefill workers cascaded to `Connection reset by peer` on the gloo TCP pair. Net effect: a single non-streaming `/v1/chat/completions` request with `logprobs=true` and `top_logprobs>0` in PD mode could take out the prefill leader.

## Reproduction (from #26286 reporter)

```python
import torch
from sglang.srt.managers.tokenizer_manager import TokenizerManager

obj = object.__new__(TokenizerManager)
TokenizerManager.detokenize_top_logprobs_tokens(
    obj, [torch.tensor([-0.1, -0.2])], [[1, 2]], False
)
# Before this PR: RuntimeError: Boolean value of Tensor with more than one value is ambiguous
# After this PR:  returns the per-token (logprob, idx, None) tuple list cleanly
```

## Fix

Normalize both `val` and `idx` slots via `.tolist()` at the `detokenize_top_logprobs_tokens` boundary. `TokenizerManager` is the last hop before JSON / tokenizer serialization, so converting tensor slots to plain Python lists here fixes the truthiness crash and also prevents tensor-typed token ids from leaking through `batch_decode([[tensor(123)], ...])` on the `decode_to_text=True` path.

Both halves of the slot need to be normalized — `get_top_logprobs(..., no_copy_to_cpu=True)` returns *both* values and indices as tensors, and value-only normalization would still ship `(float, tensor(1), None)` to the JSON serializer or feed tensor scalars to `tokenizer.batch_decode`.

## Test plan

- [x] `pre-commit run --files <both files>` → all 24 hooks pass.
- [x] 6 CPU unit tests under `test/registered/unit/managers/test_tokenizer_manager_top_logprobs.py` (registered with `register_cpu_ci(est_time=2, suite="base-a-test-cpu")`):
  - PD-shape tensor val (only) does not crash + round-trips floats.
  - PD-shape tensor val + tensor idx normalizes both halves; idx output is plain `int`, not 0-d tensor.
  - Non-PD list slots keep legacy behavior byte-for-byte.
  - Empty / None / mixed slots resolve to `None` in the right positions, preserving slot order.
  - `decode_to_text=True` forwards plain Python ints to `tokenizer.batch_decode` (asserts call args = `[[1], [2]]`) so the index-half of the bug is caught.
- [ ] Awaiting CI `run-ci` label for full GPU suite.

## Notes

- Type hints on `detokenize_top_logprobs_tokens` were already inaccurate (`List[float]` / `List[int]` is the per-slot interior shape, not the outer); loosened to remove the misleading per-element annotation.
- Considered pushing the normalization upstream into `logprob_result_processor`. Kept it at `TokenizerManager` because this is the documented JSON/tokenizer boundary and the input/output top-logprobs paths converge here at the helper. Happy to also tighten `logprob_result_processor` in a follow-up if a reviewer prefers.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26395098181](https://github.com/sgl-project/sglang/actions/runs/26395098181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26395098042](https://github.com/sgl-project/sglang/actions/runs/26395098042)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->