### PR TITLE
Cleanup IDLE replay branch and `alloc_extend_swa_tail` mapping

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -816,14 +816,15 @@ class DeepseekV4AttnBackend(
                 f"local_seq_lens_len={len(seq_lens)}, "
                 f"has_graph={bs in self.cuda_graph_metadata_of_bucket_and_bs[_GraphBucket.DECODE_OR_IDLE]}"
             )
-            device = seq_lens.device
-            seq_lens = torch.ones(bs, dtype=seq_lens.dtype, device=device)
+            # GPU buffers (seq_lens, req_pool_indices, out_cache_loc) are
+            # already filled with safe IDLE defaults by populate_from_forward_batch
+            # when bs != raw_bs. The local re-assignments here used to allocate
+            # fresh tensors that never reached the captured graph (which reads
+            # from the original buffer slices), so this branch only needs to
+            # fix up CPU-side state.
             seq_lens_cpu = torch.ones(bs, dtype=torch.int64)
             seq_lens_sum = bs
-            req_pool_indices = torch.zeros(
-                bs, dtype=req_pool_indices.dtype, device=device
-            )
-            out_cache_loc = torch.zeros(bs, dtype=torch.int64, device=device)
+            out_cache_loc = torch.zeros(bs, dtype=torch.int64, device=seq_lens.device)
 
         assert seq_lens_cpu is not None
         seq_lens = seq_lens[:bs]

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -816,12 +816,9 @@ class DeepseekV4AttnBackend(
                 f"local_seq_lens_len={len(seq_lens)}, "
                 f"has_graph={bs in self.cuda_graph_metadata_of_bucket_and_bs[_GraphBucket.DECODE_OR_IDLE]}"
             )
-            # GPU buffers (seq_lens, req_pool_indices, out_cache_loc) are
-            # already filled with safe IDLE defaults by populate_from_forward_batch
-            # when bs != raw_bs. The local re-assignments here used to allocate
-            # fresh tensors that never reached the captured graph (which reads
-            # from the original buffer slices), so this branch only needs to
-            # fix up CPU-side state.
+            # GPU buffers (seq_lens, req_pool_indices) are already filled
+            # with safe IDLE defaults by populate_from_forward_batch; only
+            # CPU-side state needs fix-up here.
             seq_lens_cpu = torch.ones(bs, dtype=torch.int64)
             seq_lens_sum = bs
             out_cache_loc = torch.zeros(bs, dtype=torch.int64, device=seq_lens.device)

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -539,6 +539,10 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert alloc_full_indices is not None
 
         if swa_tail_len == 0:
+            # Mirror the prefix-mapping reset below for consistency: every
+            # slot returned from this call has no SWA mapping when the
+            # caller asked for tail_len=0.
+            self.full_to_swa_index_mapping[alloc_full_indices] = 0
             return alloc_full_indices
 
         device = self.device

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -539,9 +539,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert alloc_full_indices is not None
 
         if swa_tail_len == 0:
-            # Mirror the prefix-mapping reset below for consistency: every
-            # slot returned from this call has no SWA mapping when the
-            # caller asked for tail_len=0.
+            # tail_len=0: no slot has a SWA mapping. Mirror the prefix-reset below.
             self.full_to_swa_index_mapping[alloc_full_indices] = 0
             return alloc_full_indices
 


### PR DESCRIPTION
Two small cleanups following up on #26292:

1. **dsv4 backend IDLE replay branch** — the local re-assignments to `seq_lens`/`req_pool_indices`/`out_cache_loc` allocated fresh tensors that never reached the captured graph (which reads from the original buffer slices). After #26292 paired `req_pool_indices.zero_()` with `seq_lens.fill_()` in `populate_from_forward_batch`, those GPU buffers are already filled with safe IDLE defaults. Drop the dead writes and keep only the CPU-side / Python-int fix-up.

2. **`alloc_extend_swa_tail` `swa_tail_len == 0`** — the non-zero branch explicitly resets the prefix portion of `full_to_swa_index_mapping` to 0. Mirror that on the early-return path so every slot the function hands back has its SWA mapping reset, regardless of `tail_len`.

## Test plan
- [ ] CI green



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26396575386](https://github.com/sgl-project/sglang/actions/runs/26396575386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26396575213](https://github.com/sgl-project/sglang/actions/runs/26396575213)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->