### PR TITLE
[Fix] Fix per-tensor FP8 MoE weight scale format on Blackwell (SM100) with DeepGEMM

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -174,12 +174,21 @@ class DeepEPBuffer:
 
         num_nvl_bytes, num_rdma_bytes = 0, 0
         if deepep_mode.enable_normal():
-            hidden_bytes = hidden_size * param_bytes
-            for config in (
-                DeepEPConfig.get_instance().normal_dispatch_config
-                or Buffer.get_dispatch_config(group.size()),
-                DeepEPConfig.get_instance().normal_combine_config
-                or Buffer.get_combine_config(group.size()),
+            dispatch_hidden_bytes = hidden_size * param_bytes
+            # combine() receives BF16 expert outputs regardless of dispatch dtype,
+            # so the combine NVL buffer must be sized for 2 bytes per element.
+            combine_hidden_bytes = hidden_size * 2
+            for config, hidden_bytes in (
+                (
+                    DeepEPConfig.get_instance().normal_dispatch_config
+                    or Buffer.get_dispatch_config(group.size()),
+                    dispatch_hidden_bytes,
+                ),
+                (
+                    DeepEPConfig.get_instance().normal_combine_config
+                    or Buffer.get_combine_config(group.size()),
+                    combine_hidden_bytes,
+                ),
             ):
                 num_nvl_bytes = max(
                     config.get_nvl_buffer_size_hint(hidden_bytes, group.size()),

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -330,7 +330,16 @@ class _DeepEPDispatcherImplBase:
         self.params_dtype = params_dtype
         self.deepep_mode = deepep_mode
 
-        self.params_bytes = 2
+        self.set_deepep_dispatcher_dtype()
+        # Set params_bytes based on the actual dispatch dtype so buffer size
+        # calculations are correct. FP8/INT8/NVFP4 use 1 byte, BF16 uses 2.
+        _dtype_to_bytes = {
+            DeepEPOutputDtype.BF16: 2,
+            DeepEPOutputDtype.FP8: 1,
+            DeepEPOutputDtype.INT8: 1,
+            DeepEPOutputDtype.NVFP4: 1,
+        }
+        self.params_bytes = _dtype_to_bytes.get(self.deepep_output_dtype, 2)
         # A large value will lead to large memory occupation, thus users should change it accordingly
         self.num_max_dispatch_tokens_per_rank = (
             envs.SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
@@ -345,8 +354,6 @@ class _DeepEPDispatcherImplBase:
 
         self.overlap_args: Optional[CombineOverlapArgs] = None
         self.meta_overlap_args: Optional[dict] = None
-
-        self.set_deepep_dispatcher_dtype()
 
     def dispatch_a(
         self,

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -330,6 +330,11 @@ class _DeepEPDispatcherImplBase:
         self.params_dtype = params_dtype
         self.deepep_mode = deepep_mode
 
+        self.handle = None
+        self.quant_config: Optional[dict] = None
+        self.overlap_args: Optional[CombineOverlapArgs] = None
+        self.meta_overlap_args: Optional[dict] = None
+
         self.set_deepep_dispatcher_dtype()
         # Set params_bytes based on the actual dispatch dtype so buffer size
         # calculations are correct. FP8/INT8/NVFP4 use 1 byte, BF16 uses 2.
@@ -347,13 +352,6 @@ class _DeepEPDispatcherImplBase:
         # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=1024
         # and the logic requires num-tokens-sent-from-one-rank-to-another-rank less than it
         assert self.num_max_dispatch_tokens_per_rank <= 1024
-
-        self.handle = None
-
-        self.quant_config: Optional[dict] = None
-
-        self.overlap_args: Optional[CombineOverlapArgs] = None
-        self.meta_overlap_args: Optional[dict] = None
 
     def dispatch_a(
         self,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1571,6 +1571,42 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
 
+            # On Blackwell (DEEPGEMM_SCALE_UE8M0), DeepGEMM requires weight scales in
+            # UE8M0 packed format. Per-tensor FP8 stores a single float32 scale per
+            # expert, which DeepGEMM misinterprets as UE8M0 on Blackwell.
+            # Convert to per-block UE8M0 format at load time.
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            if (
+                not _is_hip
+                and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+                and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+                and self.is_deepgemm_moe_runner_backend_enabled()
+            ):
+                from sglang.srt.layers.quantization.fp8_utils import (
+                    quant_weight_ue8m0,
+                    transform_scale_ue8m0,
+                )
+
+                weight_block_size = [128, 128]
+                for w_param, s_param_name in [
+                    (layer.w13_weight, "w13_weight_scale"),
+                    (layer.w2_weight, "w2_weight_scale"),
+                ]:
+                    w = w_param.data  # (E, N, K) fp8
+                    s = getattr(layer, s_param_name).data  # (E,) float32 per-tensor
+                    num_experts = w.shape[0]
+                    # Dequantize per-tensor fp8 → bf16, requantize to per-block UE8M0
+                    w_bf16 = torch.empty_like(w, dtype=torch.bfloat16)
+                    for e in range(num_experts):
+                        w_bf16[e] = w[e].to(torch.bfloat16) * s[e]
+                    new_w, new_s = quant_weight_ue8m0(w_bf16, weight_block_size)
+                    new_s = transform_scale_ue8m0(new_s, mn=new_w.shape[-2])
+                    w_param.data = new_w
+                    scale_inv_param = torch.nn.Parameter(new_s, requires_grad=False)
+                    scale_inv_param.format_ue8m0 = True
+                    setattr(layer, s_param_name + "_inv", scale_inv_param)
+
         # If checkpoint is fp8, we need to handle that the
         # MoE kernels require single activation scale and single weight
         # scale for w13 per expert.
@@ -1663,6 +1699,42 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 )
 
                 align_fp8_moe_weights_for_flashinfer_trtllm(layer)
+
+            # On Blackwell (DEEPGEMM_SCALE_UE8M0), DeepGEMM requires weight scales in
+            # UE8M0 packed format. Per-tensor FP8 stores a single float32 scale per
+            # expert, which DeepGEMM misinterprets as UE8M0 on Blackwell.
+            # Convert to per-block UE8M0 format at load time.
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            if (
+                not _is_hip
+                and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+                and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+                and self.is_deepgemm_moe_runner_backend_enabled()
+            ):
+                from sglang.srt.layers.quantization.fp8_utils import (
+                    quant_weight_ue8m0,
+                    transform_scale_ue8m0,
+                )
+
+                weight_block_size = [128, 128]
+                for w_param, s_param_name in [
+                    (layer.w13_weight, "w13_weight_scale"),
+                    (layer.w2_weight, "w2_weight_scale"),
+                ]:
+                    w = w_param.data  # (E, N, K) fp8
+                    s = getattr(layer, s_param_name).data  # (E,) float32 per-tensor
+                    num_experts = w.shape[0]
+                    # Dequantize per-tensor fp8 → bf16, requantize to per-block UE8M0
+                    w_bf16 = torch.empty_like(w, dtype=torch.bfloat16)
+                    for e in range(num_experts):
+                        w_bf16[e] = w[e].to(torch.bfloat16) * s[e]
+                    new_w, new_s = quant_weight_ue8m0(w_bf16, weight_block_size)
+                    new_s = transform_scale_ue8m0(new_s, mn=new_w.shape[-2])
+                    w_param.data = new_w
+                    scale_inv_param = torch.nn.Parameter(new_s, requires_grad=False)
+                    scale_inv_param.format_ue8m0 = True
+                    setattr(layer, s_param_name + "_inv", scale_inv_param)
 
         if hasattr(layer, "dispatcher"):
             layer.dispatcher.set_quant_config({"weight_dtype": layer.w13_weight.dtype})
@@ -1883,6 +1955,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if self.block_quant:
                 block_shape = self.quant_config.weight_block_size
+                w13_scale = layer.w13_weight_scale_inv
+                w2_scale = layer.w2_weight_scale_inv
+            elif (
+                hasattr(layer, "w13_weight_scale_inv")
+                and getattr(layer.w13_weight_scale_inv, "format_ue8m0", False)
+            ):
+                # Per-tensor FP8 on Blackwell: weights were already requantized to
+                # per-block UE8M0 format during process_weights_after_loading.
+                block_shape = [128, 128]
                 w13_scale = layer.w13_weight_scale_inv
                 w2_scale = layer.w2_weight_scale_inv
             else:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1957,9 +1957,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 block_shape = self.quant_config.weight_block_size
                 w13_scale = layer.w13_weight_scale_inv
                 w2_scale = layer.w2_weight_scale_inv
-            elif (
-                hasattr(layer, "w13_weight_scale_inv")
-                and getattr(layer.w13_weight_scale_inv, "format_ue8m0", False)
+            elif hasattr(layer, "w13_weight_scale_inv") and getattr(
+                layer.w13_weight_scale_inv, "format_ue8m0", False
             ):
                 # Per-tensor FP8 on Blackwell: weights were already requantized to
                 # per-block UE8M0 format during process_weights_after_loading.


### PR DESCRIPTION
## Problem

On Blackwell GPUs (SM100, `DEEPGEMM_SCALE_UE8M0=True`), DeepGEMM requires weight scales to be in **UE8M0 packed integer format** rather than float32. When running a BF16 model (e.g. GLM-4.5-Air) with `--quantization fp8 --moe-runner-backend deep_gemm --moe-a2a-backend deepep`, the output is garbled (`!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`).

### Root cause

For block-quantized FP8 checkpoints, `requant_weight_ue8m0_inplace` correctly converts weights and scales to UE8M0 format. But **per-tensor FP8** (BF16 models loaded with `--quantization fp8`) is gated out because `should_deepgemm_weight_requant_ue8m0` returns `False` when `weight_block_size is None`.

As a result, the float32 per-expert scale `(E,)` is expanded into `(E, N_blocks, K_blocks)` float32 and passed directly to DeepGEMM, which misinterprets it as UE8M0 packed integers on Blackwell — producing garbage output.

## Fix

### 1. `Fp8MoEMethod.process_weights_after_loading` (`fp8.py`)

After per-tensor FP8 weight finalization (both BF16-checkpoint and FP8-serialized checkpoint branches), add Blackwell-specific conversion when `DEEPGEMM_SCALE_UE8M0` is set:
- Dequantize per-tensor FP8 weights to BF16 using the per-expert scale
- Requantize to FP8 with per-block `[128, 128]` scales via `quant_weight_ue8m0`
- Convert scales to UE8M0 packed format via `transform_scale_ue8m0`
- Store as `w13_weight_scale_inv` / `w2_weight_scale_inv` with `format_ue8m0=True`

### 2. `Fp8MoEMethod.apply` (`fp8.py`)

In the DeepGEMM branch, add an `elif` path: when `w13_weight_scale_inv.format_ue8m0` is `True` (pre-converted at load time), use the UE8M0 scales directly with `block_shape=[128, 128]`. The original float32 expand path is kept as fallback for non-Blackwell hardware.

### 3. `DeepEPDispatcher.__init__` (`deepep.py`)

Fix `self.params_bytes` hardcoded to `2` (BF16 size) before `set_deepep_dispatcher_dtype()` is called. Move the call earlier and derive `params_bytes` from the actual output dtype (FP8/INT8/NVFP4 → 1 byte, BF16 → 2 bytes).

## Test

Verified on 8×GPU (EP=8, DP=8, TP=8) Blackwell node with GLM-4.5-Air:
```bash
python3 -m sglang.launch_server \
    --model-path ${model_path} \
    --tokenizer-path ${model_path} \
    --host 0.0.0.0 \
    --port 8908 \
    --served-model-name GLM \
    --trust-remote-code \
    --enable-dp-attention \
    --dp 8 --ep 8 --tp 8 \
    --moe-dense-tp-size 1 \
    --moe-runner-backend deep_gemm \
    --moe-a2a-backend deepep \
    --deepep-mode auto \
    --context-length 65536 \
    --max-running-requests 256 \
    --allow-auto-truncate \
    --sampling-defaults openai \
    --cuda-graph-max-bs 32 \
    --nccl-port 8484 \
    --enable-metrics \
    --quantization "fp8" 
```
Before fix: output is `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`  
After fix: correct Chinese output ✓













































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26438367848](https://github.com/sgl-project/sglang/actions/runs/26438367848)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26642828212](https://github.com/sgl-project/sglang/actions/runs/26642828212)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->