### PR TITLE
Fix stale forward_metadata leak in DP attn unpadded idle batch

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3101,11 +3101,17 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def forward_idle(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        # In DP Attention, IDLE batches are padded (batch_size > 0) for MLP sync.
-        # in this case, we need to reinit the forward metadata, otherwise the stale
-        # metadata causes batch_size mismatch in attention kernel(e.g. DSA Indexer).
+        # In DP Attention, IDLE batches may be padded (batch_size > 0) for MLP
+        # sync. Reinit metadata for the padded case so attention kernels see
+        # the right batch_size (e.g. DSA Indexer). For the unpadded case
+        # (batch_size == 0) explicitly drop any stale forward_metadata left
+        # over from the previous forward — without this, attention layers
+        # called from the idle path can re-read a prior batch's req_pool
+        # indices and trigger SWA mapping use-after-free.
         if forward_batch.batch_size > 0:
             self.attn_backend.init_forward_metadata(forward_batch)
+        else:
+            self.attn_backend.forward_metadata = None
 
         kwargs = {}
         if self.support_pp:


### PR DESCRIPTION
## Motivation

PR https://github.com/sgl-project/sglang/pull/26157 added a debug canary on the SWA `full→swa` mapping_stack and exposed a pre-existing race in DSv4 disaggregation with DP-attention. The canary fires `mapping_stack[full_slot] == (producer=0, canary=SENTINEL)` — i.e. a full-slot is being gathered after `free_swa` has already written the sentinel into the mapping.

After narrowing the trigger surface (EAGLE off, PD off, write_through_selective off, one at a time), the race reproduces **iff DP-attention is enabled**. None of EAGLE / PD-disagg / write_through_selective is necessary or sufficient.

## Root cause

DP-attention requires every rank to enter `forward` for the MLP all-gather, so a rank with no local work executes `ModelRunner.forward_idle`. In the **unpadded** case (`batch_size == 0`, MLP-sync doesn't pad this rank), `forward_idle` skipped `init_forward_metadata` entirely. That leaves `attn_backend.forward_metadata` holding the **previous forward's stale `DSV4RawDecodeMetadata`** — e.g. warmup-A's last decode at `req_pool_indices=[1]`, `seq_lens=[13]`, `out_cache_loc=[268]`.

`DeepseekV4Model.forward` then runs this **unconditional** pre-layer call (`deepseek_v4.py:1270`):

```python
# Upgrade lazy raw metadata on the main stream once before any layer
# forks alt-streams; later per-layer calls become no-ops.
get_attn_backend()._maybe_upgrade_forward_metadata()
```

The call lives outside any per-layer module, so the existing `self_attn.forward` `x.shape[0] == 0` early-return does **not** protect it. With stale `DSV4RawDecodeMetadata` still attached, the upgrade proceeds and `make_forward_metadata_from_raw_decode(rpi=[1], seq_lens=[13])`:

1. Re-reads `req_to_token[1, :13]` — still holds full-slots `[256..268]` (`req_to_token` is not cleared on `free`).
2. Calls `translate_loc_from_full_to_swa(...)` on those slots.
3. Warmup-A's `free_swa` has already written `(producer=0, canary=SENTINEL)` into `mapping_stack[256..268]`.
4. Canary fires; in production this is a silent cross-rank use-after-free once the freed slots are reallocated to another request.

This is the chain that drives the gsm8k regression observed in disagg + DP-attention runs.

## Modifications

Drop the stale `forward_metadata` in the unpadded IDLE branch of `ModelRunner.forward_idle`:

```python
if forward_batch.batch_size > 0:
    self.attn_backend.init_forward_metadata(forward_batch)
else:
    self.attn_backend.forward_metadata = None
```

`_maybe_upgrade_forward_metadata` already no-ops on `None` (both `isinstance(None, DSV4RawDecodeMetadata / DSV4Metadata)` branches fail), so no backend-side guard is needed. The padded IDLE path (`batch_size > 0`, e.g. DSA Indexer that needs a real batch_size view) is unchanged.

For non-DSv4 backends this is also safe: `AttentionBackend.forward` early-returns on `forward_batch.forward_mode.is_idle()` before touching `forward_metadata` (`base_attn_backend.py:101`), so a `None` value is never dereferenced.

## Accuracy

DeepSeek-V4-Flash-FP8, disagg + DP-attention + EAGLE, 8×H200, gsm8k via `benchmark/gsm8k/bench_sglang.py`:

main (with the #26157 canary instrumented):
```
Accuracy: 0.010
Latency: 142.31 s
```

this PR (same canary instrumented, never fires):
```
Accuracy: 0.975
Latency:  14.12 s
```

5/5 reproduction iterations: canary fires on main, zero fires on this branch.













<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26409091486](https://github.com/sgl-project/sglang/actions/runs/26409091486)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #26409353810](https://github.com/sgl-project/sglang/actions/runs/26409353810)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->