### PR TITLE
[NPU] [BUGFIX] Modelslim mapping fix

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -65,7 +65,6 @@ from sglang.srt.layers.attention.dsa.utils import (
     dsa_use_prefill_cp,
     is_dsa_enable_prefill_cp,
 )
-from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
 from sglang.srt.layers.communicator import (
     LayerCommunicator,
     LayerScatterModes,
@@ -117,6 +116,7 @@ from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_kernel import (
     create_per_token_group_quant_fp8_output_scale,
 )
+from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
@@ -2463,7 +2463,11 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         # Quant configs like Quark may rely on the model to provide fused-module
         # mappings so exclusion checks can unfuse derived names back to the
         # checkpoint's source layer names.
-        if quant_config is not None and not isinstance(quant_config, ModelSlimConfig) and hasattr(quant_config, "packed_modules_mapping"):
+        if (
+            quant_config is not None
+            and not isinstance(quant_config, ModelSlimConfig)
+            and hasattr(quant_config, "packed_modules_mapping")
+        ):
             quant_config.packed_modules_mapping = self.packed_modules_mapping
 
         self.pp_group = get_pp_group()

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2462,7 +2462,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         # Quant configs like Quark may rely on the model to provide fused-module
         # mappings so exclusion checks can unfuse derived names back to the
         # checkpoint's source layer names.
-        if quant_config is not None and not isinstance(quant_config, ModelSlimConfig) and hasattr(quant_config, "packed_modules_mapping")
+        if quant_config is not None and not isinstance(quant_config, ModelSlimConfig) and hasattr(quant_config, "packed_modules_mapping"):
             quant_config.packed_modules_mapping = self.packed_modules_mapping
 
         self.pp_group = get_pp_group()

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -65,6 +65,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     dsa_use_prefill_cp,
     is_dsa_enable_prefill_cp,
 )
+from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
 from sglang.srt.layers.communicator import (
     LayerCommunicator,
     LayerScatterModes,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2462,7 +2462,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         # Quant configs like Quark may rely on the model to provide fused-module
         # mappings so exclusion checks can unfuse derived names back to the
         # checkpoint's source layer names.
-        if quant_config is not None and hasattr(quant_config, "packed_modules_mapping"):
+        if quant_config is not None and not isinstance(quant_config, ModelSlimConfig) and hasattr(quant_config, "packed_modules_mapping")
             quant_config.packed_modules_mapping = self.packed_modules_mapping
 
         self.pp_group = get_pp_group()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fixes #26307. When loading a Kimi K2.5 model with ModelSlim quantization on NPU/Ascend, the scheduler crashed during model initialization. The error occurred because `ModelSlimLinearMethod.create_weights()` assumed `layer.scheme` was always set, but `ModelSlimConfig.get_linear_scheme()` returned `None` for `fused_qkv_a_proj_with_mqa` and `gate_up_proj` layers.

A recent change in PR #25390 introduced a new packed-modules mapping. The mapping code in `deepseek_v2.py` looked for weight schemes via `quant_config.quant_description`, but for ModelSlim-quantized layers, this method isn't applicable and the necessary `scheme` attribute was never assigned (which looks strange, need to investigate why).

Thanks @khalil2ji3mp6 for finding and proposing a solution

## Modifications

<!-- Detail the changes made in this pull request. -->

The relevant check in `deepseek_v2.py` now reads:

```if quant_config is not None and not isinstance(quant_config, ModelSlimConfig) and hasattr(quant_config, "packed_modules_mapping"):```

## Accuracy Tests

The model now loads correctly without crashing. However, note two known limitations:

- [ ] The w4a8 quantized accuracy is currently zero – this is a pre‑existing issue, not introduced by this PR.
- [ ] Deep‑EP mode does not work with Kimi-K2.5-w4a8; the model only runs without expert‑parallel dispatch for now (need to investigate why).

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
The model can now load, unfortunately the accuracy is at w4a8 0, but this is an old problem. The model did not start in deep-ep mode.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















































































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26588147311](https://github.com/sgl-project/sglang/actions/runs/26588147311)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26588147798](https://github.com/sgl-project/sglang/actions/runs/26588147798)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->