### PR TITLE
[fix] Handle JSON dict format in _validate_ib_devices (fixes #20241 regression)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3754,10 +3754,16 @@ class ServerArgs:
         Validate IB devices before passing to mooncake.
 
         Args:
-            device_str: Comma-separated IB device names (e.g., "mlx5_0,mlx5_1")
+            device_str: Either a comma-separated string of IB device names
+                (e.g., "mlx5_0,mlx5_1") or a JSON dict mapping GPU IDs to
+                per-GPU device strings (e.g., '{"0":"mlx5_0,mlx5_1","1":"mlx5_2,mlx5_3"}').
+                The JSON dict format allows assigning different IB devices to
+                different GPU/TP/DP ranks and was introduced in PR #12817.
 
         Returns:
-            Normalized comma-separated string of validated device names, or None if input is None.
+            The validated device string unchanged (for JSON dict format) or a
+            normalized comma-separated string (for flat format), or None if
+            input is None.
         """
         if device_str is None:
             logger.warning(
@@ -3765,7 +3771,43 @@ class ServerArgs:
             )
             return None
 
-        # Strip whitespace from device names
+        # JSON dict format: per-GPU device mapping, e.g. '{"0":"mlx5_0,mlx5_1","1":"mlx5_2"}'.
+        # Deduplication across GPU entries is intentional (e.g. two GPUs sharing
+        # the same HCA), so we skip the flat-format dedup check and validate each
+        # per-GPU device list independently.
+        stripped = device_str.strip()
+        if stripped.startswith("{"):
+            try:
+                gpu_device_map = json.loads(stripped)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"Invalid JSON format for IB devices: {device_str!r}"
+                ) from e
+            if not isinstance(gpu_device_map, dict):
+                raise ValueError(
+                    f"IB device JSON must be a dict mapping GPU IDs to device strings, got: {device_str!r}"
+                )
+            # Validate each per-GPU device list
+            ib_sysfs_path = "/sys/class/infiniband"
+            if os.path.isdir(ib_sysfs_path):
+                available_devices = set(os.listdir(ib_sysfs_path))
+                all_devices = [
+                    d.strip()
+                    for v in gpu_device_map.values()
+                    for d in str(v).split(",")
+                    if d.strip()
+                ]
+                invalid_devices = [
+                    d for d in all_devices if d not in available_devices
+                ]
+                if invalid_devices:
+                    raise ValueError(
+                        f"Invalid IB devices specified: {invalid_devices}. "
+                        f"Available devices: {sorted(available_devices)}"
+                    )
+            return device_str
+
+        # Flat comma-separated format: "mlx5_0,mlx5_1"
         devices = [d.strip() for d in device_str.split(",") if d.strip()]
         if len(devices) == 0:
             raise ValueError("No valid IB devices specified")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -477,5 +477,66 @@ class TestNgramExternalSamArgs(CustomTestCase):
         self.assertIn("external-corpus-max-tokens", str(context.exception))
 
 
+class TestValidateIbDevices(unittest.TestCase):
+    """Tests for ServerArgs._validate_ib_devices (fixes #20241 regression)."""
+
+    def _make_args(self) -> ServerArgs:
+        return ServerArgs(model_path="dummy")
+
+    def test_none_returns_none(self):
+        args = self._make_args()
+        self.assertIsNone(args._validate_ib_devices(None))
+
+    def test_flat_format_returned_unchanged(self):
+        args = self._make_args()
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", return_value=["mlx5_0", "mlx5_1"]),
+        ):
+            result = args._validate_ib_devices("mlx5_0,mlx5_1")
+        self.assertEqual(result, "mlx5_0,mlx5_1")
+
+    def test_flat_format_deduplicates(self):
+        args = self._make_args()
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", return_value=["mlx5_0", "mlx5_1"]),
+        ):
+            result = args._validate_ib_devices("mlx5_0,mlx5_1,mlx5_0")
+        self.assertEqual(result, "mlx5_0,mlx5_1")
+
+    def test_json_format_returned_unchanged(self):
+        # Regression test for #20241: JSON dict format with duplicate device names
+        # across GPU entries must not raise ValueError.
+        args = self._make_args()
+        device_str = '{"0":"mlx5_0,mlx5_1","1":"mlx5_0,mlx5_1","2":"mlx5_2,mlx5_3","3":"mlx5_2,mlx5_3"}'
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch(
+                "os.listdir",
+                return_value=["mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3"],
+            ),
+        ):
+            result = args._validate_ib_devices(device_str)
+        self.assertEqual(result, device_str)
+
+    def test_json_format_invalid_device_raises(self):
+        args = self._make_args()
+        device_str = '{"0":"mlx5_0,mlx5_bad"}'
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", return_value=["mlx5_0"]),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                args._validate_ib_devices(device_str)
+        self.assertIn("mlx5_bad", str(ctx.exception))
+
+    def test_json_format_malformed_raises(self):
+        args = self._make_args()
+        with self.assertRaises(ValueError) as ctx:
+            args._validate_ib_devices("{not valid json")
+        self.assertIn("Invalid JSON", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #20241 — regression introduced by PR #17598 (`feat: validate ib devices in server args`).

### Root cause

`_validate_ib_devices` was designed for the flat comma-separated format (`"mlx5_0,mlx5_1"`), but PR #12817 also introduced a per-GPU JSON dict format (`{"0":"mlx5_0,mlx5_1","1":"mlx5_0,mlx5_1"}`). The validation logic naively split the entire JSON string on commas, then flagged the per-GPU device names as duplicates — raising a spurious `ValueError: Duplicate IB devices specified` even though the same HCA shared by multiple GPUs is a valid and common configuration.

### Fix

Detect JSON dict input (`stripped.startswith("{")`), parse it with `json.loads`, skip inter-GPU dedup (intentional sharing), and validate individual device names per GPU entry against sysfs when available. The flat-format code path is unchanged.

### Tests

Added `TestValidateIbDevices` to `test/registered/unit/server_args/test_server_args.py`:
- `test_none_returns_none`
- `test_flat_format_returned_unchanged`
- `test_flat_format_deduplicates`
- `test_json_format_returned_unchanged` — the regression case from #20241
- `test_json_format_invalid_device_raises`
- `test_json_format_malformed_raises`

### Why this is not duplicate

No open PR addresses #20241. The three PRs for the adjacent #26286 (`top_logprobs` tensor crash in PD mode) are unrelated.

> AI assistance (Claude) was used to write this fix. I reviewed all changed lines and confirmed the logic against the original bug report and the two PRs (#12817, #17598) involved.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->