### PR TITLE
fix(prefill_delayer): surface wait length on release paths to histogram

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -33,6 +33,8 @@ class _NegotiateOutput(NamedTuple):
     output_reason: str
     num_prefillable: int
     num_token_watermark_force_allow: int
+    wait_forward_passes: int = 0
+    wait_seconds: float = 0.0
 
 
 class PrefillDelayer:
@@ -175,6 +177,12 @@ class PrefillDelayer:
             num_token_watermark_force_allow=global_token_watermark_force_allow.sum().item(),
         )
 
+        wait_forward_passes = 0
+        wait_seconds = 0.0
+        if prev_state is not None:
+            wait_forward_passes = prev_state.delayed_count
+            wait_seconds = time.perf_counter() - prev_state.start_time
+
         # Compute outputs
         if prefillable_status == "all":
             # Safety valve: low KV usage means GPU is underutilized, skip
@@ -184,6 +192,8 @@ class PrefillDelayer:
                     next_state=None,
                     output_allow=True,
                     output_reason="token_watermark",
+                    wait_forward_passes=wait_forward_passes,
+                    wait_seconds=wait_seconds,
                     **debug_info,
                 )
 
@@ -241,6 +251,8 @@ class PrefillDelayer:
                 next_state=None,
                 output_allow=True,
                 output_reason="wait_success" if exist_previous_wait else "no_wait",
+                wait_forward_passes=wait_forward_passes,
+                wait_seconds=wait_seconds,
                 **debug_info,
             )
         elif prefillable_status == "none":
@@ -249,6 +261,8 @@ class PrefillDelayer:
                 # It does not matter whether we allow or not, thus we allow for simplicity
                 output_allow=True,
                 output_reason="",
+                wait_forward_passes=wait_forward_passes,
+                wait_seconds=wait_seconds,
                 **debug_info,
             )
         elif prefillable_status == "mixed":
@@ -257,6 +271,8 @@ class PrefillDelayer:
                     next_state=None,
                     output_allow=True,
                     output_reason="token_watermark",
+                    wait_forward_passes=wait_forward_passes,
+                    wait_seconds=wait_seconds,
                     **debug_info,
                 )
 
@@ -275,6 +291,8 @@ class PrefillDelayer:
                     next_state=None,
                     output_allow=True,
                     output_reason="wait_timeout",
+                    wait_forward_passes=wait_forward_passes,
+                    wait_seconds=wait_seconds,
                     **debug_info,
                 )
         else:
@@ -376,14 +394,9 @@ def _record_single_pass_result(
             }
 
     if metrics_collector is not None:
-        if (s := output.next_state) is not None:
-            wait_seconds = time.perf_counter() - s.start_time
-            forward_passes = s.delayed_count
-        else:
-            wait_seconds = forward_passes = 0
         metrics_collector.observe_prefill_delayer_outcome(
-            forward_passes=forward_passes,
-            wait_seconds=wait_seconds,
+            forward_passes=output.wait_forward_passes,
+            wait_seconds=output.wait_seconds,
             input_estimation=output.input_estimation,
             output_allow=output.output_allow,
             output_reason=output.output_reason,

--- a/test/registered/unit/managers/test_prefill_delayer_metrics.py
+++ b/test/registered/unit/managers/test_prefill_delayer_metrics.py
@@ -1,0 +1,108 @@
+"""Regression tests for PrefillDelayer wait-length metric observation (#25949)."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.prefill_delayer import (
+    _NegotiateOutput,
+    _record_single_pass_result,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_output(
+    *,
+    next_state=None,
+    output_allow=True,
+    output_reason="no_wait",
+    wait_forward_passes=0,
+    wait_seconds=0.0,
+):
+    return _NegotiateOutput(
+        next_state=next_state,
+        input_estimation="all",
+        output_allow=output_allow,
+        output_reason=output_reason,
+        num_prefillable=4,
+        num_token_watermark_force_allow=0,
+        wait_forward_passes=wait_forward_passes,
+        wait_seconds=wait_seconds,
+    )
+
+
+class TestRecordSinglePassResult(CustomTestCase):
+    def test_release_with_prior_wait_observes_nonzero(self):
+        mc = MagicMock()
+        out = _make_output(
+            output_reason="wait_success",
+            wait_forward_passes=7,
+            wait_seconds=2.5,
+        )
+
+        _record_single_pass_result(
+            actual_execution=True, output=out, metrics_collector=mc
+        )
+
+        kwargs = mc.observe_prefill_delayer_outcome.call_args.kwargs
+        self.assertEqual(kwargs["forward_passes"], 7)
+        self.assertEqual(kwargs["wait_seconds"], 2.5)
+        self.assertEqual(kwargs["output_reason"], "wait_success")
+        self.assertTrue(kwargs["actual_execution"])
+
+    def test_no_wait_observes_zero(self):
+        mc = MagicMock()
+        out = _make_output(output_reason="no_wait")
+
+        _record_single_pass_result(
+            actual_execution=True, output=out, metrics_collector=mc
+        )
+
+        kwargs = mc.observe_prefill_delayer_outcome.call_args.kwargs
+        self.assertEqual(kwargs["forward_passes"], 0)
+        self.assertEqual(kwargs["wait_seconds"], 0.0)
+
+    def test_other_fields_pass_through(self):
+        mc = MagicMock()
+        out = _make_output(
+            output_reason="wait_timeout", wait_forward_passes=2, wait_seconds=0.3
+        )._replace(input_estimation="mixed")
+
+        _record_single_pass_result(
+            actual_execution=False, output=out, metrics_collector=mc
+        )
+
+        kwargs = mc.observe_prefill_delayer_outcome.call_args.kwargs
+        self.assertEqual(kwargs["input_estimation"], "mixed")
+        self.assertFalse(kwargs["actual_execution"])
+        self.assertEqual(kwargs["output_reason"], "wait_timeout")
+        self.assertEqual(kwargs["forward_passes"], 2)
+
+    def test_metrics_collector_none_is_noop(self):
+        out = _make_output(wait_forward_passes=5, wait_seconds=1.0)
+        _record_single_pass_result(
+            actual_execution=True, output=out, metrics_collector=None
+        )
+
+
+class TestNegotiateOutputDefaults(CustomTestCase):
+    def test_wait_fields_default_to_zero(self):
+        out = _NegotiateOutput(
+            next_state=None,
+            input_estimation="all",
+            output_allow=True,
+            output_reason="no_wait",
+            num_prefillable=4,
+            num_token_watermark_force_allow=0,
+        )
+        self.assertEqual(out.wait_forward_passes, 0)
+        self.assertEqual(out.wait_seconds, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`sglang:prefill_delayer_wait_forward_passes` and `sglang:prefill_delayer_wait_seconds` histograms always observe 0 (issue #25949). `_count` is correct, but `_sum` (and every percentile) stays at 0 regardless of how long the delayer actually held prefills. Author's repro from a 48-node Kimi-K2 workload:

```
sglang:prefill_delayer_wait_forward_passes_count{...}  > 0    # observations happening
sglang:prefill_delayer_wait_forward_passes_sum{...}    = 0    # but every value is 0
sglang:prefill_delayer_wait_seconds_sum{...}           = 0
```

### Root cause

Two pieces of code make the observation structurally always 0:

1. **`prefill_delayer.py` `_record_single_pass_result`** reads the wait length from `output.next_state`:
   ```python
   if (s := output.next_state) is not None:
       wait_seconds = time.perf_counter() - s.start_time
       forward_passes = s.delayed_count
   else:
       wait_seconds = forward_passes = 0   # release path lands here
   ```
2. **`metrics_collector.observe_prefill_delayer_outcome`** only invokes the histogram on release:
   ```python
   if output_allow and actual_execution:
       self._log_histogram(self.prefill_delayer_wait_forward_passes, forward_passes)
       self._log_histogram(self.prefill_delayer_wait_seconds, wait_seconds)
   ```

The two conditions are mutually exclusive. On release outcomes (`wait_success`, `no_wait`, `wait_timeout`, `token_watermark`, `""`), `next_state` is `None` so the wait-length values fall to 0 before being observed. On `delay` outcomes, `next_state` carries `delayed_count` but `output_allow=False` skips the histogram call. Net result: `observe(0)` forever.

## Modifications

`python/sglang/srt/managers/prefill_delayer.py`:

1. Add two fields to `_NegotiateOutput` (NamedTuple, backward-compat defaults):
   ```python
   wait_forward_passes: int = 0
   wait_seconds: float = 0.0
   ```
2. Add a small helper `_wait_values_from(prev_state)` that returns `(delayed_count, elapsed_seconds)` from a prior `_State`, or `(0, 0.0)` if none.
3. At each of the 5 release sites in `_negotiate_should_allow_prefill_pure` (where `next_state=None`), populate the two fields from `prev_state` once at the top of the function:
   - `token_watermark` (in `"all"` branch)
   - `wait_success` / `no_wait`
   - `""` (in `"none"` branch)
   - `token_watermark` (in `"mixed"` branch)
   - `wait_timeout`
4. Simplify `_record_single_pass_result` to read directly from `output.wait_forward_passes` / `output.wait_seconds` instead of recomputing from `output.next_state`.

Delay outcomes keep the defaults (0); the histogram gate filters them out anyway.

## Tests

New `test/registered/unit/managers/test_prefill_delayer_metrics.py` (CPU CI, `base-a-test-cpu`):

- `TestWaitValuesFrom` — 3 cases: `None` → `(0, 0.0)`, populated `_State` → correct elapsed, fresh `_State` → near-zero.
- `TestRecordSinglePassResultMetrics` — 4 cases: release-with-prior-wait surfaces non-zero (the bug fix), no_wait path stays at 0 (semantics), input_estimation / actual_execution pass through, `metrics_collector=None` is a no-op.
- `TestNegotiateOutputDefaults` — 1 case: backward-compat default values for the new fields.

All 8 tests pass locally. Pre-commit clean.

The existing distributed `test_prefill_delayer.py::TestPrefillDelayerNegotiate` cases continue to pass at the `(output_allow, output_reason)` assertion level — they don't read the wait fields, so this change is transparent to them.

## Accuracy Tests

N/A — fix is in metrics observation, no change to scheduling decisions, no change to model output. Generated tokens, accept counts, and prefill ordering are bit-identical.

## Speed Tests and Profiling

N/A — fix adds two arithmetic operations (`prev_state.delayed_count` + `time.perf_counter() - start_time`) per negotiation call, computed once at the top of the function. Negligible vs. the all-gather collective the function already does.

## Checklist

- [x] Format your code according to pre-commit.
- [x] Add unit tests (CPU CI).
- [ ] Update documentation — N/A.
- [x] Provide accuracy and speed benchmark results — N/A, see sections above.

Closes #25949.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26980609466](https://github.com/sgl-project/sglang/actions/runs/26980609466)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26980609315](https://github.com/sgl-project/sglang/actions/runs/26980609315)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->