### PR TITLE
fix(ci): enforce legacy docs/ gate in Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -21,6 +23,20 @@ jobs:
         run: |
           python -m pip install pre-commit
           pre-commit install
+
+      - name: Reject changes under legacy docs/
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.base_ref }}"
+          git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || \
+            git fetch --no-tags origin "$BASE_REF"
+          if [ -z "$(git diff --name-only --diff-filter=ACMRDTUXB "origin/${BASE_REF}...HEAD")" ]; then
+            echo "No changed files vs origin/${BASE_REF}; skipping."
+            exit 0
+          fi
+          git diff -z --name-only --diff-filter=ACMRDTUXB "origin/${BASE_REF}...HEAD" \
+            | xargs -0 python3 scripts/ci/check_no_docs_changes.py
 
       - name: Run pre-commit checks
         run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,16 +14,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-
-      - name: Install pre-commit hook
-        run: |
-          python -m pip install pre-commit
-          pre-commit install
-
       - name: Reject changes under legacy docs/
         if: github.event_name == 'pull_request'
         run: |
@@ -37,6 +27,16 @@ jobs:
           fi
           git diff -z --name-only --diff-filter=ACMRDTUXB "origin/${BASE_REF}...HEAD" \
             | xargs -0 python3 scripts/ci/check_no_docs_changes.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install pre-commit hook
+        run: |
+          python -m pip install pre-commit
+          pre-commit install
 
       - name: Run pre-commit checks
         run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,21 @@ jobs:
         run: |
           set -euo pipefail
           BASE_REF="${{ github.base_ref }}"
-          git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || \
-            git fetch --no-tags origin "$BASE_REF"
-          if [ -z "$(git diff --name-only --diff-filter=ACMRDTUXB "origin/${BASE_REF}...HEAD")" ]; then
+          # Refresh origin/<base_ref> with full history; --depth=1 would
+          # shallow the ref and break the merge-base used by `...`.
+          git fetch --no-tags origin "$BASE_REF"
+          # First, verify the diff itself succeeds and check whether any
+          # files changed. A silent failure here would let docs/ changes
+          # through, so the explicit `if !` guard is important.
+          if ! CHANGED=$(git diff --name-only --diff-filter=ACMRDTUXB "origin/${BASE_REF}...HEAD"); then
+            echo "git diff origin/${BASE_REF}...HEAD failed; aborting." >&2
+            exit 2
+          fi
+          if [ -z "$CHANGED" ]; then
             echo "No changed files vs origin/${BASE_REF}; skipping."
             exit 0
           fi
+          # Re-emit with -z so xargs can safely handle whitespace in paths.
           git diff -z --name-only --diff-filter=ACMRDTUXB "origin/${BASE_REF}...HEAD" \
             | xargs -0 python3 scripts/ci/check_no_docs_changes.py
 


### PR DESCRIPTION
## Motivation

The pre-commit hook `check-no-docs-changes` (added in 8750885e1) was meant to reject changes under the legacy `docs/` tree, but it has been silently bypassed on every PR since it landed. Recent examples include #24593, #23329, #25120, #19290, #24491, #24874, #24716, #23708, #24330, #20922, #24005, #24329, #24188, and #23199 — all merged with `docs/` modifications despite the hook being "enabled".

Root cause: the hook reads `git diff --cached --name-only`, which is empty on a fresh CI checkout. `pre-commit run --all-files` in the `Lint` workflow therefore runs the script with no staged paths and the script exits 0. The hook only enforces the rule locally for contributors with pre-commit installed; everyone else (or anyone using `--no-verify`) bypasses it.

## Modifications

`.github/workflows/lint.yml`:
- `actions/checkout@v4`: set `fetch-depth: 0` so the merge base is available for the three-dot diff.
- New step **Reject changes under legacy docs/**: on `pull_request` events, diffs `origin/<base_ref>...HEAD` and feeds the changed paths to the existing `scripts/ci/check_no_docs_changes.py`. Placed before Python setup so we fail fast without paying for irrelevant tooling.
- Guards against silent failures: an explicit `if !` around the diff capture aborts on `git diff` errors (e.g., missing merge base) instead of treating empty stdout as "no changes". `git fetch` no longer uses `--depth=1`, which could shallow `origin/<base_ref>` and break the merge base — discovered while validating this PR with `act`.

Not modified: `.pre-commit-config.yaml` (the local hook continues to enforce on developer machines), `scripts/ci/check_no_docs_changes.py` (already accepts paths via `sys.argv`, so the allowlist — `docs/conf.py`, `docs/_static/css/custom_log.css`, `docs/_static/js/deprecation_banner.js` — is honored automatically).

## Accuracy Tests

N/A (CI workflow change).

## Speed Tests and Profiling

N/A.

## Verification

- `actionlint .github/workflows/lint.yml` reports no new findings (one pre-existing `setup-python@v4` warning unrelated to this PR).
- Local script harness:
  - `docs/foo.md` → exits 1 with rejection message.
  - `docs/conf.py` → exits 0 (allowlist).
  - `python/sglang/srt/__init__.py` → exits 0.
- End-to-end with `act` + Docker (catthehacker/ubuntu:act-latest runner): a probe commit modifying `docs/references/environment_variables.md` causes the new step to exit non-zero with:
  ```
  Changes under the legacy docs/ directory are not allowed.
  Detected legacy docs/ changes:
    - docs/references/environment_variables.md
  ```
  This run also surfaced the shallow-fetch / silent-diff-failure bug that the third commit hardens.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). _N/A — workflow change validated with actionlint and act._
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). _N/A._
- [ ] Provide accuracy and speed benchmark results. _N/A._
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26421412193](https://github.com/sgl-project/sglang/actions/runs/26421412193)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26421412119](https://github.com/sgl-project/sglang/actions/runs/26421412119)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->