### PR TITLE
Fix EAGLE chunked-prefill chain divergence in draft rotation

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1467,6 +1467,17 @@ def set_mamba_track_indices_from_reqs(batch):
     )
 
 
+def _compute_chunked_req_next_prompt_token(
+    chunked_req: Optional[Req],
+) -> Optional[int]:
+    if chunked_req is None:
+        return None
+    fill_len = len(chunked_req.fill_ids)
+    if fill_len >= len(chunked_req.origin_input_ids):
+        return None
+    return int(chunked_req.origin_input_ids[fill_len])
+
+
 @dataclasses.dataclass
 class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     """Store all information of a batch on the scheduler."""
@@ -1489,6 +1500,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # For chunked prefill in PP
     chunked_req: Optional[Req] = None
+    # Snapshot at batch ctor of `origin_input_ids[len(fill_ids)]` for the chunked
+    # req when it still has prompt tokens remaining; consumed by the EAGLE prefill
+    # rotation (see PR #26329).
+    chunked_req_next_prompt_token: Optional[int] = None
 
     # Sampling info
     sampling_info: SamplingBatchInfo = None
@@ -1657,6 +1672,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             return_indexer_topk=any(req.return_indexer_topk for req in reqs),
             is_prefill_only=all(req.is_prefill_only for req in reqs),
             chunked_req=chunked_req,
+            chunked_req_next_prompt_token=_compute_chunked_req_next_prompt_token(
+                chunked_req
+            ),
             dllm_config=dllm_config,
         )
         return batch

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1500,9 +1500,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # For chunked prefill in PP
     chunked_req: Optional[Req] = None
-    # Snapshot at batch ctor of `origin_input_ids[len(fill_ids)]` for the chunked
-    # req when it still has prompt tokens remaining; consumed by the EAGLE prefill
-    # rotation (see PR #26329).
     chunked_req_next_prompt_token: Optional[int] = None
 
     # Sampling info

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -52,17 +52,9 @@ def apply_eagle_prefill_input_rotation(
 ) -> None:
     """EAGLE input rotation for draft prefill.
 
-    Each req's slice [t_0..t_{n-1}] -> [t_1..t_{n-1}, t_n] with
-    t_n = next_token_ids[i]. Aligns draft's position-i hidden with
-    target's label at i+1 — the basis of EAGLE chain prediction.
-    Vectorized: one whole-tensor left shift + scatter at segment tails.
-
-    Non-final-chunk override: when a req is mid-chunked-prefill (more prompt
-    tokens remain after this chunk), the seg-end's t_n is the next *prompt*
-    token, not the target's next_token_id. Without this override, the DRAFT
-    pool's stored token at the chunk-1 seg end differs from a single-chunk
-    prefill of the same prompt, which breaks the canary chain invariant after
-    radix-fold merges per-req slot tables across writers.
+    Each req's slice [t_0..t_{n-1}] -> [t_1..t_{n-1}, t_n]. t_n is target's
+    predicted next_token, except for non-final chunks of a chunked req where it
+    is the next prompt token (see `_eagle_prefill_tail_tokens`).
     """
     if batch.forward_mode.is_idle():
         return
@@ -82,15 +74,10 @@ def apply_eagle_prefill_input_rotation(
 def _eagle_prefill_tail_tokens(
     batch: ScheduleBatch, next_token_ids: torch.Tensor
 ) -> torch.Tensor:
-    """Resolve the per-seq tail token that the EAGLE prefill rotation writes
-    at each segment's last position.
-
-    The default is the target model's predicted next_token_id. For a req that
-    is mid-chunked-prefill (more prompt tokens remain after this chunk's last
-    seq position), use the next prompt token instead. This keeps the DRAFT
-    pool's stored token at the chunk boundary byte-identical to a single-chunk
-    prefill of the same prompt, so the canary chain invariant survives the
-    radix-fold step that merges per-req slot tables across writers.
+    """Per-seq tail token for the EAGLE prefill rotation. Default is the target's
+    predicted `next_token_ids[i]`; for a non-final chunk of a chunked req the
+    next prompt token is used instead, so the chunk-boundary DRAFT KV matches a
+    single-chunk prefill of the same prompt.
     """
     tail_tokens = next_token_ids.to(batch.input_ids.dtype)
     next_prompt_token = batch.chunked_req_next_prompt_token

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -56,6 +56,13 @@ def apply_eagle_prefill_input_rotation(
     t_n = next_token_ids[i]. Aligns draft's position-i hidden with
     target's label at i+1 — the basis of EAGLE chain prediction.
     Vectorized: one whole-tensor left shift + scatter at segment tails.
+
+    Non-final-chunk override: when a req is mid-chunked-prefill (more prompt
+    tokens remain after this chunk), the seg-end's t_n is the next *prompt*
+    token, not the target's next_token_id. Without this override, the DRAFT
+    pool's stored token at the chunk-1 seg end differs from a single-chunk
+    prefill of the same prompt, which breaks the canary chain invariant after
+    radix-fold merges per-req slot tables across writers.
     """
     if batch.forward_mode.is_idle():
         return
@@ -66,8 +73,37 @@ def apply_eagle_prefill_input_rotation(
     seg_ends = extend_lens.cumsum(0) - 1
     rotated = torch.empty_like(batch.input_ids)
     rotated[:-1] = batch.input_ids[1:]
-    rotated[seg_ends] = next_token_ids.to(batch.input_ids.dtype)
+
+    tail_tokens = _eagle_prefill_tail_tokens(batch, next_token_ids)
+    rotated[seg_ends] = tail_tokens
     batch.input_ids = rotated
+
+
+def _eagle_prefill_tail_tokens(
+    batch: ScheduleBatch, next_token_ids: torch.Tensor
+) -> torch.Tensor:
+    """Resolve the per-seq tail token that the EAGLE prefill rotation writes
+    at each segment's last position.
+
+    The default is the target model's predicted next_token_id. For a req that
+    is mid-chunked-prefill (more prompt tokens remain after this chunk's last
+    seq position), use the next prompt token instead. This keeps the DRAFT
+    pool's stored token at the chunk boundary byte-identical to a single-chunk
+    prefill of the same prompt, so the canary chain invariant survives the
+    radix-fold step that merges per-req slot tables across writers.
+    """
+    tail_tokens = next_token_ids.to(batch.input_ids.dtype)
+    chunked_req = batch.chunked_req
+    if chunked_req is not None and len(chunked_req.fill_ids) < len(
+        chunked_req.origin_input_ids
+    ):
+        next_prompt_token = int(chunked_req.origin_input_ids[len(chunked_req.fill_ids)])
+        for i, r in enumerate(batch.reqs):
+            if r is chunked_req:
+                tail_tokens = tail_tokens.clone()
+                tail_tokens[i] = next_prompt_token
+                break
+    return tail_tokens
 
 
 def organize_draft_results(

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -93,13 +93,10 @@ def _eagle_prefill_tail_tokens(
     radix-fold step that merges per-req slot tables across writers.
     """
     tail_tokens = next_token_ids.to(batch.input_ids.dtype)
-    chunked_req = batch.chunked_req
-    if chunked_req is not None and len(chunked_req.fill_ids) < len(
-        chunked_req.origin_input_ids
-    ):
-        next_prompt_token = int(chunked_req.origin_input_ids[len(chunked_req.fill_ids)])
+    next_prompt_token = batch.chunked_req_next_prompt_token
+    if next_prompt_token is not None:
         for i, r in enumerate(batch.reqs):
-            if r is chunked_req:
+            if r is batch.chunked_req:
                 tail_tokens = tail_tokens.clone()
                 tail_tokens[i] = next_prompt_token
                 break

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -55,6 +55,7 @@ from sglang.srt.speculative.eagle_info_v2 import (
 )
 from sglang.srt.speculative.eagle_utils import (
     TreeMaskMode,
+    _eagle_prefill_tail_tokens,
     build_tree_kernel_efficient,
     per_step_draft_out_cache_loc,
 )
@@ -552,11 +553,16 @@ class EagleDraftWorker(BaseDraftWorker):
         """
         # Construct input_ids
         if not batch.forward_mode.is_idle():
+            # Chunked-prefill-aware tail tokens: non-final chunks of a chunked req
+            # must put the next prompt token at the seg end (not the target's
+            # next_token_id) so the DRAFT canary chain stays consistent across
+            # writers post-radix-fold.
+            tail_tokens = _eagle_prefill_tail_tokens(batch, next_token_ids)
             pt = 0
             for i, extend_len in enumerate(batch.extend_lens):
                 input_ids = batch.input_ids[pt : pt + extend_len]
                 batch.input_ids[pt : pt + extend_len] = torch.cat(
-                    (input_ids[1:], next_token_ids[i].reshape(1))
+                    (input_ids[1:], tail_tokens[i].reshape(1))
                 )
                 pt += extend_len
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -553,10 +553,6 @@ class EagleDraftWorker(BaseDraftWorker):
         """
         # Construct input_ids
         if not batch.forward_mode.is_idle():
-            # Chunked-prefill-aware tail tokens: non-final chunks of a chunked req
-            # must put the next prompt token at the seg end (not the target's
-            # next_token_id) so the DRAFT canary chain stays consistent across
-            # writers post-radix-fold.
             tail_tokens = _eagle_prefill_tail_tokens(batch, next_token_ids)
             pt = 0
             for i, extend_len in enumerate(batch.extend_lens):

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -407,6 +407,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         forward_batch = ForwardBatch.init_new(batch, self.draft_runner_list[0])
 
         # Construct input_ids
+        # TODO: same chunked-prefill chain divergence applies to this Triton path.
         if not batch.forward_mode.is_idle():
             rotate_input_ids_triton(
                 forward_batch.input_ids,


### PR DESCRIPTION
TODO: put in pr chain

TODO: real fix may need to wait for liangsheng's / tom's refactor?

TODO: do not rely on Req in this place

below are by agents

----

## Problem

In EAGLE speculative decoding, `_draft_extend_for_prefill` (used by `EAGLEWorkerV2`, the default `enable_overlap=True` path) and `apply_eagle_prefill_input_rotation` (used by the non-overlap `EAGLEWorker` and `MultiLayerEagleWorker`) left-shift each request's `input_ids` and write `next_token_ids[i]` (target's predicted token) at the segment end.

For single-chunk prefill this honours the natural EAGLE invariant *"draft at position k sees the next real token t_{k+1}"*:

- single-chunk prefill of an N-token prompt: `rotated[k] = prompt[k+1]` for `k < N-1`, `rotated[N-1] = next_token_ids[i]` = target's prediction at end of full prompt.

But for **chunked prefill**, the chunk-1 seg end (seq position `K1-1`) gets the same `next_token_ids[i]` value, even though the real next token at position `K1` is `prompt[K1]`, not the target's chunk-1 prediction. The chunked path therefore writes a different token at the chunk boundary than the single-chunk path writes at the same seq position:

| Path | rotated[K1-1] |
|---|---|
| single-chunk | `prompt[K1]` |
| chunked chunk-1 | `next_token_ids[i]` (target's prediction at end of chunk 1) |

When the same prompt is prefilled both ways concurrently — common in multi-request batches with radix cache — the DRAFT KV cache slot at seq pos `K1-1` ends up holding different K/V tensors depending on which writer's slot survives the radix-fold race. Subsequent cache-hitting requests inherit whichever wins, so DRAFT KV becomes non-deterministic and the EAGLE chain-prediction invariant is broken across the chunk boundary.

The break propagates: once `rotated[K1-1]` diverges, all DRAFT KV at positions `K1..N-1` are computed from a sequence with one mismatched token, so the entire tail of the chain (and any subsequent verify-step hidden state read from those slots) carries the pollution.

## Symptoms

End-user impact:

- Final output token correctness is unaffected — TARGET pool stays clean (TARGET never goes through the EAGLE rotation), and the target model verifies/corrects any wrong draft candidate.
- DRAFT model accept rate / throughput degrades whenever target's chunk-1 prediction differs from `prompt[K1]`. On benchmark prompts where target's greedy prediction is close to `prompt[K1]`, the effect is small; on unusual content (code, multilingual, low-probability sequences) it can drop a few percentage points of accept rate.
- Same prompt scheduled chunked vs single-chunk produces different DRAFT KV → run-to-run variance in accept rate and end-to-end latency.
- Tree pollution persists until LRU eviction or explicit cache flush — every cache-hit on the polluted prefix continues to read the bad slot.

Detected by `test/registered/kv_canary/test_self_e2e_pr_25015.py::TestEaglePositionsMatchWithFix`: with `prompt = \"The quick brown fox jumps over the lazy dog. \" * 700` × 20 parallel requests, the canary's chain-hash check fires 52–60 violations per run at slot ~21028, position 6999, DRAFT pool. The stored chain hash varies per run (depends on target's chunk-1 prediction) while the expected hash is a stable function of the single-chunk path's KV — a precise signature of the chunked-vs-single-chunk divergence at the seg end.

## Fix

Extract `_eagle_prefill_tail_tokens(batch, next_token_ids)` and route both EAGLE prefill rotation paths through it:

```python
def _eagle_prefill_tail_tokens(batch, next_token_ids):
    tail_tokens = next_token_ids.to(batch.input_ids.dtype)
    chunked_req = batch.chunked_req
    if chunked_req is not None and len(chunked_req.fill_ids) < len(
        chunked_req.origin_input_ids
    ):
        next_prompt_token = int(chunked_req.origin_input_ids[len(chunked_req.fill_ids)])
        for i, r in enumerate(batch.reqs):
            if r is chunked_req:
                tail_tokens = tail_tokens.clone()
                tail_tokens[i] = next_prompt_token
                break
    return tail_tokens
```

Activation:

- \`batch.chunked_req is not None\` — this forward is a non-final chunk. The scheduler clears \`self.chunked_req\` to \`None\` when \`add_chunked_req\` decides this is the last chunk (extend fits in remaining budget), so single-chunk prefill and final chunks fall through unchanged.
- \`len(r.fill_ids) < len(r.origin_input_ids)\` — more prompt tokens still remain after this chunk. Defensive: if a chunked req somehow has \`fill_ids == origin_input_ids\` (final chunk), the override is skipped.

Callers updated:

- \`apply_eagle_prefill_input_rotation\` in \`eagle_utils.py\` — non-overlap \`EAGLEWorker\` and \`MultiLayerEagleWorker\`.
- \`_draft_extend_for_prefill\` inline rotation in \`eagle_worker_v2.py\` — default overlap \`EAGLEWorkerV2\`.

For non-chunked or final-chunk forwards, the helper returns \`next_token_ids[i]\` unchanged, so behaviour is identical to before. The override only kicks in for the specific non-final-chunk seg end where the bug fires.

## Test

\`test/registered/kv_canary/test_self_e2e_pr_25015.py\`:

| Test | Before | After |
|---|---|---|
| \`TestEaglePositionsMatchWithFix\` | 52–60 chain_hash violations | **0 violations** |
| \`TestEaglePositionsMisalignRegression\` (revert PR #25015) | position bit fires | **still fires** |

The misalign-regression companion still triggers correctly, confirming the fix doesn't mask the position-bit detection it was paired with.

Also clean: full kv_canary suite (119 unit + 21 e2e tests across baseline, perturb, PD, bench_speed) all pass post-fix on H200.

## Not addressed (follow-up)

\`MultiLayerEagleWorkerV2._draft_extend_for_prefill\` rotates via the \`rotate_input_ids_triton\` Triton kernel, which still passes \`next_token_ids[i]\` unconditionally as the seg-end \`new_token\`. The same accuracy issue exists there for MTP workloads with chunked prefill, but the regression test in this PR doesn't exercise it. Equivalent fix (either pre-compute the per-seq tail tensor in Python and pass it to the kernel, or thread the chunked context into the kernel) should land in a follow-up.



























<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26428204136](https://github.com/sgl-project/sglang/actions/runs/26428204136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26428204040](https://github.com/sgl-project/sglang/actions/runs/26428204040)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->