### PR TITLE
Add DeepGEMM MXFP8 MoE backend

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -2,7 +2,7 @@ import logging
 import os
 from contextlib import contextmanager, nullcontext
 from enum import IntEnum, auto
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 from tqdm import tqdm
@@ -14,7 +14,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 from sglang.srt.environ import envs
 from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import ceil_div, get_available_gpu_memory, is_musa
+from sglang.srt.utils import ceil_align, ceil_div, get_available_gpu_memory, is_musa
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,20 @@ class DeepGemmKernelType(IntEnum):
     GEMM_NT_BF16BF16F32 = auto()
 
 
-_INITIALIZATION_DICT: Dict[Tuple[DeepGemmKernelType, int, int, int], bool] = dict()
+_INITIALIZATION_DICT: Dict[
+    Tuple[
+        DeepGemmKernelType,
+        int,
+        int,
+        int,
+        Optional[Tuple[int, int, int]],
+        Optional[Tuple[int, int]],
+        Optional[Tuple[int, int]],
+        Optional[torch.dtype],
+        Optional[torch.dtype],
+    ],
+    bool,
+] = dict()
 
 
 # TODO improve code
@@ -112,11 +125,26 @@ def _maybe_compile_deep_gemm_one_type_all(
     n: int,
     k: int,
     num_groups: int,
+    recipe: Optional[Tuple[int, int, int]] = None,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+    sf_dtype_a: Optional[torch.dtype] = None,
+    sf_dtype_b: Optional[torch.dtype] = None,
 ) -> None:
     global _INITIALIZATION_DICT
     global _BUILTIN_M_LIST
 
-    query_key = (kernel_type, n, k, num_groups)
+    query_key = (
+        kernel_type,
+        n,
+        k,
+        num_groups,
+        recipe,
+        recipe_a,
+        recipe_b,
+        sf_dtype_a,
+        sf_dtype_b,
+    )
     if (
         _ENABLE_JIT_DEEPGEMM_PRECOMPILE
         and _DO_COMPILE_ALL
@@ -138,7 +166,9 @@ def _maybe_compile_deep_gemm_one_type_all(
 
         logger.info(
             f"Try DeepGEMM JIT Compiling for "
-            f"<{kernel_type.name}> N={n}, K={k}, num_groups={num_groups} with all Ms."
+            f"<{kernel_type.name}> N={n}, K={k}, num_groups={num_groups}, "
+            f"recipe={recipe}, recipe_a={recipe_a}, recipe_b={recipe_b}, "
+            f"sf_dtype_a={sf_dtype_a}, sf_dtype_b={sf_dtype_b} with all Ms."
             f"{' It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep_gemm`. ' if not _IN_PRECOMPILE_STAGE else ''}"
         )
 
@@ -148,6 +178,11 @@ def _maybe_compile_deep_gemm_one_type_all(
             k=k,
             num_groups=num_groups,
             m_list=_BUILTIN_M_LIST,
+            recipe=recipe,
+            recipe_a=recipe_a,
+            recipe_b=recipe_b,
+            sf_dtype_a=sf_dtype_a,
+            sf_dtype_b=sf_dtype_b,
         )
 
 
@@ -158,6 +193,11 @@ def _compile_deep_gemm_one_type_all(
     k: int,
     num_groups: int,
     m_list: List[int],
+    recipe: Optional[Tuple[int, int, int]] = None,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+    sf_dtype_a: Optional[torch.dtype] = None,
+    sf_dtype_b: Optional[torch.dtype] = None,
 ) -> None:
     # Symmetric memory allocation performs a collective operation across all the GPUs.
     # Temporary disable symmetric memory during compilation since it only runs on the first rank.
@@ -198,7 +238,16 @@ def _compile_deep_gemm_one_type_all(
 
         # Need some methods to estimate needed memory for warmup
         executor = _BaseWarmupExecutor.create(
-            kernel_type, max_m=max_m, n=n, k=k, num_groups=num_groups
+            kernel_type,
+            max_m=max_m,
+            n=n,
+            k=k,
+            num_groups=num_groups,
+            recipe=recipe,
+            recipe_a=recipe_a,
+            recipe_b=recipe_b,
+            sf_dtype_a=sf_dtype_a,
+            sf_dtype_b=sf_dtype_b,
         )
 
         has_compile_mode_api = hasattr(deep_gemm, "get_compile_mode") and hasattr(
@@ -273,35 +322,125 @@ class _BaseWarmupExecutor:
         raise NotImplementedError
 
 
-def _empty_token_fp8(size):
-    *dims, k = size
-    return (
-        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
-        torch.empty(
-            (*dims, ceil_div(k, _BLOCK_SIZE)), device="cuda", dtype=torch.float32
-        ),
-    )
-
-
-def _empty_block_fp8(size):
-    *dims, n, k = size
-    return (
-        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
-        torch.empty(
-            (*dims, ceil_div(n, _BLOCK_SIZE), ceil_div(k, _BLOCK_SIZE)),
-            device="cuda",
-            dtype=torch.float32,
-        ),
-    )
-
-
 _BLOCK_SIZE = 128
 
 
+def _normalize_sf_dtype(sf_dtype: Optional[torch.dtype]) -> torch.dtype:
+    return torch.float32 if sf_dtype is None else sf_dtype
+
+
+def _is_packed_ue8m0_dtype(sf_dtype: Optional[torch.dtype]) -> bool:
+    return _normalize_sf_dtype(sf_dtype) in (torch.int, torch.int32)
+
+
+def _resolve_fp8_recipes(
+    recipe: Optional[Tuple[int, int, int]],
+    recipe_a: Optional[Tuple[int, int]],
+    recipe_b: Optional[Tuple[int, int]],
+    sf_dtype_b: Optional[torch.dtype],
+) -> Tuple[
+    Optional[Tuple[int, int, int]],
+    Optional[Tuple[int, int]],
+    Optional[Tuple[int, int]],
+    Tuple[int, int],
+    Tuple[int, int],
+]:
+    if recipe is None and recipe_a is None:
+        recipe = (
+            (1, 1, _BLOCK_SIZE)
+            if _is_packed_ue8m0_dtype(sf_dtype_b)
+            else (
+                1,
+                _BLOCK_SIZE,
+                _BLOCK_SIZE,
+            )
+        )
+
+    if recipe is not None:
+        return recipe, None, None, (recipe[0], recipe[2]), (recipe[1], recipe[2])
+
+    assert recipe_a is not None and recipe_b is not None
+    return None, recipe_a, recipe_b, recipe_a, recipe_b
+
+
+def _fp8_recipe_kwargs(
+    recipe: Optional[Tuple[int, int, int]],
+    recipe_a: Optional[Tuple[int, int]],
+    recipe_b: Optional[Tuple[int, int]],
+) -> Dict[str, Tuple[int, ...]]:
+    kwargs: Dict[str, Tuple[int, ...]] = {}
+    if recipe is not None:
+        kwargs["recipe"] = recipe
+    if recipe_a is not None:
+        kwargs["recipe_a"] = recipe_a
+    if recipe_b is not None:
+        kwargs["recipe_b"] = recipe_b
+    return kwargs
+
+
+def _empty_fp8_scale(
+    size: Tuple[int, ...],
+    operand_recipe: Tuple[int, int],
+    sf_dtype: Optional[torch.dtype],
+):
+    *dims, mn, k = size
+    gran_mn, gran_k = operand_recipe
+    sf_mn = ceil_div(mn, gran_mn)
+    sf_k = ceil_div(k, gran_k)
+    sf_dtype = _normalize_sf_dtype(sf_dtype)
+
+    if sf_dtype == torch.float32:
+        return torch.empty((*dims, sf_mn, sf_k), device="cuda", dtype=sf_dtype)
+
+    assert sf_dtype in (torch.int, torch.int32)
+    aligned_mn = ceil_align(sf_mn, 4)
+    aligned_k = ceil_align(sf_k, 4)
+    return torch.empty(
+        (*dims, aligned_k // 4, aligned_mn), device="cuda", dtype=torch.int
+    ).transpose(-1, -2)[..., :sf_mn, :]
+
+
+def _empty_token_fp8(
+    size,
+    operand_recipe: Tuple[int, int] = (1, _BLOCK_SIZE),
+    sf_dtype: Optional[torch.dtype] = None,
+):
+    return (
+        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
+        _empty_fp8_scale(size, operand_recipe, sf_dtype),
+    )
+
+
+def _empty_block_fp8(
+    size,
+    operand_recipe: Tuple[int, int] = (_BLOCK_SIZE, _BLOCK_SIZE),
+    sf_dtype: Optional[torch.dtype] = None,
+):
+    return (
+        torch.empty(size, device="cuda", dtype=torch.float8_e4m3fn),
+        _empty_fp8_scale(size, operand_recipe, sf_dtype),
+    )
+
+
 class _NormalWarmupExecutor(_BaseWarmupExecutor):
-    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
-        self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k))
-        self.rhs_q, self.rhs_s = _empty_block_fp8((n, k))
+    def __init__(
+        self,
+        max_m: int,
+        n: int,
+        k: int,
+        num_groups: int,
+        recipe: Optional[Tuple[int, int, int]] = None,
+        recipe_a: Optional[Tuple[int, int]] = None,
+        recipe_b: Optional[Tuple[int, int]] = None,
+        sf_dtype_a: Optional[torch.dtype] = None,
+        sf_dtype_b: Optional[torch.dtype] = None,
+    ):
+        recipe, recipe_a, recipe_b, lhs_recipe, rhs_recipe = _resolve_fp8_recipes(
+            recipe, recipe_a, recipe_b, sf_dtype_b
+        )
+        self.recipe_kwargs = _fp8_recipe_kwargs(recipe, recipe_a, recipe_b)
+        self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k), lhs_recipe, sf_dtype_a)
+        self.rhs_q, self.rhs_s = _empty_block_fp8((n, k), rhs_recipe, sf_dtype_b)
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
 
     def execute(self, m):
@@ -309,13 +448,31 @@ class _NormalWarmupExecutor(_BaseWarmupExecutor):
             (self.lhs_q[:m], self.lhs_s[:m]),
             (self.rhs_q, self.rhs_s),
             self.out[:m],
+            **self.recipe_kwargs,
         )
 
 
 class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
-    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
-        self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k))
-        self.rhs_q, self.rhs_s = _empty_block_fp8((num_groups, n, k))
+    def __init__(
+        self,
+        max_m: int,
+        n: int,
+        k: int,
+        num_groups: int,
+        recipe: Optional[Tuple[int, int, int]] = None,
+        recipe_a: Optional[Tuple[int, int]] = None,
+        recipe_b: Optional[Tuple[int, int]] = None,
+        sf_dtype_a: Optional[torch.dtype] = None,
+        sf_dtype_b: Optional[torch.dtype] = None,
+    ):
+        recipe, recipe_a, recipe_b, lhs_recipe, rhs_recipe = _resolve_fp8_recipes(
+            recipe, recipe_a, recipe_b, sf_dtype_b
+        )
+        self.recipe_kwargs = _fp8_recipe_kwargs(recipe, recipe_a, recipe_b)
+        self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k), lhs_recipe, sf_dtype_a)
+        self.rhs_q, self.rhs_s = _empty_block_fp8(
+            (num_groups, n, k), rhs_recipe, sf_dtype_b
+        )
         self.m_indices = torch.zeros((max_m,), device="cuda", dtype=torch.int32)
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
 
@@ -325,11 +482,12 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
             (self.rhs_q, self.rhs_s),
             self.out[:m],
             self.m_indices[:m],
+            **self.recipe_kwargs,
         )
 
 
 class _BF16GroupedContWarmupExecutor(_BaseWarmupExecutor):
-    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int, **_):
         self.a = torch.empty((max_m, k), device="cuda", dtype=torch.bfloat16)
         self.b = torch.empty((num_groups, n, k), device="cuda", dtype=torch.bfloat16)
         self.m_indices = torch.zeros((max_m,), device="cuda", dtype=torch.int32)
@@ -345,9 +503,28 @@ class _BF16GroupedContWarmupExecutor(_BaseWarmupExecutor):
 
 
 class _GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
-    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
-        self.lhs_q, self.lhs_s = _empty_token_fp8((num_groups, max_m, k))
-        self.rhs_q, self.rhs_s = _empty_block_fp8((num_groups, n, k))
+    def __init__(
+        self,
+        max_m: int,
+        n: int,
+        k: int,
+        num_groups: int,
+        recipe: Optional[Tuple[int, int, int]] = None,
+        recipe_a: Optional[Tuple[int, int]] = None,
+        recipe_b: Optional[Tuple[int, int]] = None,
+        sf_dtype_a: Optional[torch.dtype] = None,
+        sf_dtype_b: Optional[torch.dtype] = None,
+    ):
+        recipe, recipe_a, recipe_b, lhs_recipe, rhs_recipe = _resolve_fp8_recipes(
+            recipe, recipe_a, recipe_b, sf_dtype_b
+        )
+        self.recipe_kwargs = _fp8_recipe_kwargs(recipe, recipe_a, recipe_b)
+        self.lhs_q, self.lhs_s = _empty_token_fp8(
+            (num_groups, max_m, k), lhs_recipe, sf_dtype_a
+        )
+        self.rhs_q, self.rhs_s = _empty_block_fp8(
+            (num_groups, n, k), rhs_recipe, sf_dtype_b
+        )
         self.masked_m = torch.zeros((num_groups,), device="cuda", dtype=torch.int32)
         self.out = torch.empty(
             (num_groups, max_m, n), device="cuda", dtype=torch.bfloat16
@@ -361,11 +538,12 @@ class _GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
             masked_m=self.masked_m,
             # DeepGEMM uses `expect_m` instead of input shape for `get_best_config`
             expected_m=m,
+            **self.recipe_kwargs,
         )
 
 
 class _BF16F32WarmupExecutor(_BaseWarmupExecutor):
-    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int, **_):
         self.lhs = torch.empty((max_m, k), device="cuda", dtype=torch.bfloat16)
         self.rhs = torch.empty((n, k), device="cuda", dtype=torch.bfloat16)
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.float32)
@@ -375,7 +553,7 @@ class _BF16F32WarmupExecutor(_BaseWarmupExecutor):
 
 
 class _BF16GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
-    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int, **_):
         self.a = torch.empty(
             (num_groups, max_m, k), device="cuda", dtype=torch.bfloat16
         )
@@ -397,18 +575,57 @@ class _BF16GroupedMaskedWarmupExecutor(_BaseWarmupExecutor):
 
 
 def deep_gemm_execution_hook(
-    m: int, n: int, k: int, num_groups: int, kernel_type: DeepGemmKernelType
+    m: int,
+    n: int,
+    k: int,
+    num_groups: int,
+    kernel_type: DeepGemmKernelType,
+    recipe: Optional[Tuple[int, int, int]] = None,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+    sf_dtype_a: Optional[torch.dtype] = None,
+    sf_dtype_b: Optional[torch.dtype] = None,
 ):
     if _is_musa:
         return nullcontext()
 
-    return _deep_gemm_execution_hook(m, n, k, num_groups, kernel_type)
+    return _deep_gemm_execution_hook(
+        m,
+        n,
+        k,
+        num_groups,
+        kernel_type,
+        recipe=recipe,
+        recipe_a=recipe_a,
+        recipe_b=recipe_b,
+        sf_dtype_a=sf_dtype_a,
+        sf_dtype_b=sf_dtype_b,
+    )
 
 
 @contextmanager
 def _deep_gemm_execution_hook(
-    m: int, n: int, k: int, num_groups: int, kernel_type: DeepGemmKernelType
+    m: int,
+    n: int,
+    k: int,
+    num_groups: int,
+    kernel_type: DeepGemmKernelType,
+    recipe: Optional[Tuple[int, int, int]] = None,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+    sf_dtype_a: Optional[torch.dtype] = None,
+    sf_dtype_b: Optional[torch.dtype] = None,
 ):
     if m > 0:
-        _maybe_compile_deep_gemm_one_type_all(kernel_type, n, k, num_groups)
+        _maybe_compile_deep_gemm_one_type_all(
+            kernel_type,
+            n,
+            k,
+            num_groups,
+            recipe=recipe,
+            recipe_a=recipe_a,
+            recipe_b=recipe_b,
+            sf_dtype_a=sf_dtype_a,
+            sf_dtype_b=sf_dtype_b,
+        )
     yield

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -393,11 +393,25 @@ def _empty_fp8_scale(
         return torch.empty((*dims, sf_mn, sf_k), device="cuda", dtype=sf_dtype)
 
     assert sf_dtype in (torch.int, torch.int32)
-    aligned_mn = ceil_align(sf_mn, 4)
+    from deep_gemm.utils import get_tma_aligned_size
+
+    aligned_mn = get_tma_aligned_size(sf_mn, 4)
     aligned_k = ceil_align(sf_k, 4)
     return torch.empty(
         (*dims, aligned_k // 4, aligned_mn), device="cuda", dtype=torch.int
     ).transpose(-1, -2)[..., :sf_mn, :]
+
+
+def _slice_token_fp8_scale(
+    scale: torch.Tensor,
+    m: int,
+    k: int,
+    operand_recipe: Tuple[int, int],
+    sf_dtype: Optional[torch.dtype],
+) -> torch.Tensor:
+    if _is_packed_ue8m0_dtype(sf_dtype):
+        return _empty_fp8_scale((m, k), operand_recipe, sf_dtype)
+    return scale[:m]
 
 
 def _empty_token_fp8(
@@ -438,14 +452,20 @@ class _NormalWarmupExecutor(_BaseWarmupExecutor):
         recipe, recipe_a, recipe_b, lhs_recipe, rhs_recipe = _resolve_fp8_recipes(
             recipe, recipe_a, recipe_b, sf_dtype_b
         )
+        self.k = k
+        self.lhs_recipe = lhs_recipe
+        self.sf_dtype_a = sf_dtype_a
         self.recipe_kwargs = _fp8_recipe_kwargs(recipe, recipe_a, recipe_b)
         self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k), lhs_recipe, sf_dtype_a)
         self.rhs_q, self.rhs_s = _empty_block_fp8((n, k), rhs_recipe, sf_dtype_b)
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
 
     def execute(self, m):
+        lhs_s = _slice_token_fp8_scale(
+            self.lhs_s, m, self.k, self.lhs_recipe, self.sf_dtype_a
+        )
         deep_gemm.fp8_gemm_nt(
-            (self.lhs_q[:m], self.lhs_s[:m]),
+            (self.lhs_q[:m], lhs_s),
             (self.rhs_q, self.rhs_s),
             self.out[:m],
             **self.recipe_kwargs,
@@ -468,6 +488,9 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
         recipe, recipe_a, recipe_b, lhs_recipe, rhs_recipe = _resolve_fp8_recipes(
             recipe, recipe_a, recipe_b, sf_dtype_b
         )
+        self.k = k
+        self.lhs_recipe = lhs_recipe
+        self.sf_dtype_a = sf_dtype_a
         self.recipe_kwargs = _fp8_recipe_kwargs(recipe, recipe_a, recipe_b)
         self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k), lhs_recipe, sf_dtype_a)
         self.rhs_q, self.rhs_s = _empty_block_fp8(
@@ -477,8 +500,11 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
 
     def execute(self, m):
+        lhs_s = _slice_token_fp8_scale(
+            self.lhs_s, m, self.k, self.lhs_recipe, self.sf_dtype_a
+        )
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
-            (self.lhs_q[:m], self.lhs_s[:m]),
+            (self.lhs_q[:m], lhs_s),
             (self.rhs_q, self.rhs_s),
             self.out[:m],
             self.m_indices[:m],

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -108,7 +108,10 @@ def grouped_gemm_nt_bf16_masked(
     with compile_utils.deep_gemm_execution_hook(
         expected_m, n, k, num_groups, kernel_type
     ):
-        return deep_gemm.m_grouped_bf16_gemm_nt_masked(
+        fn = getattr(deep_gemm, "m_grouped_bf16_gemm_nt_masked", None)
+        if fn is None:
+            fn = getattr(deep_gemm, "bf16_m_grouped_gemm_nt_masked")
+        return fn(
             a,
             b,
             d,
@@ -166,6 +169,10 @@ def grouped_gemm_nt_bf16_contig(
 
     with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
         deep_gemm.m_grouped_bf16_gemm_nt_contiguous(a, b, d, m_indices)
+
+
+def has_grouped_gemm_nt_bf16_contig() -> bool:
+    return hasattr(deep_gemm, "m_grouped_bf16_gemm_nt_contiguous")
 
 
 def gemm_nt_f8f8bf16(

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import contextmanager
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Sequence, Tuple
 
 import torch
 
@@ -161,18 +161,60 @@ def grouped_gemm_nt_f8f8bf16_contig(
 
 
 def grouped_gemm_nt_bf16_contig(
-    a: torch.Tensor, b: torch.Tensor, d: torch.Tensor, m_indices: torch.Tensor
+    a: torch.Tensor,
+    b: torch.Tensor,
+    d: torch.Tensor,
+    m_indices: torch.Tensor,
+    num_tokens_per_expert: Optional[Sequence[int]] = None,
 ):
     m, k = a.shape
     num_groups, n, _ = b.shape
     kernel_type = compile_utils.DeepGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG
 
-    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
-        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(a, b, d, m_indices)
+    grouped_fn = getattr(deep_gemm, "m_grouped_bf16_gemm_nt_contiguous", None)
+    if grouped_fn is not None:
+        with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+            grouped_fn(a, b, d, m_indices)
+        return
+
+    if num_tokens_per_expert is None:
+        raise AttributeError(
+            "The installed deep_gemm package does not expose "
+            "m_grouped_bf16_gemm_nt_contiguous, and num_tokens_per_expert was "
+            "not provided for the per-expert BF16 fallback."
+        )
+
+    _grouped_gemm_nt_bf16_contig_fallback(a, b, d, num_tokens_per_expert)
 
 
-def has_grouped_gemm_nt_bf16_contig() -> bool:
-    return hasattr(deep_gemm, "m_grouped_bf16_gemm_nt_contiguous")
+def _grouped_gemm_nt_bf16_contig_fallback(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    d: torch.Tensor,
+    num_tokens_per_expert: Sequence[int],
+) -> None:
+    if len(num_tokens_per_expert) != b.shape[0]:
+        raise ValueError(
+            "num_tokens_per_expert length must match the number of expert groups: "
+            f"{len(num_tokens_per_expert)} != {b.shape[0]}."
+        )
+
+    start = 0
+    for expert_id, count in enumerate(num_tokens_per_expert):
+        end = start + int(count)
+        if end > start:
+            gemm_nt_bf16bf16f32(
+                a[start:end],
+                b[expert_id],
+                d[start:end],
+            )
+        start = end
+
+    if start != a.shape[0]:
+        raise ValueError(
+            "num_tokens_per_expert does not sum to the grouped BF16 input tokens: "
+            f"{start} != {a.shape[0]}."
+        )
 
 
 def gemm_nt_f8f8bf16(

--- a/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py
@@ -46,7 +46,15 @@ def grouped_gemm_nt_f8f8bf16_masked(
     rhs = _ensure_cuda(rhs)
 
     with compile_utils.deep_gemm_execution_hook(
-        expected_m, n, k, num_groups, kernel_type
+        expected_m,
+        n,
+        k,
+        num_groups,
+        kernel_type,
+        recipe_a=recipe_a,
+        recipe_b=recipe_b,
+        sf_dtype_a=lhs[1].dtype,
+        sf_dtype_b=rhs[1].dtype,
     ):
         with configure_deep_gemm_num_sms(
             overlap_args.num_sms if overlap_args is not None else None
@@ -133,7 +141,17 @@ def grouped_gemm_nt_f8f8bf16_contig(
     if recipe_b is not None:
         fp4_kwargs["recipe_b"] = recipe_b
 
-    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+    with compile_utils.deep_gemm_execution_hook(
+        m,
+        n,
+        k,
+        num_groups,
+        kernel_type,
+        recipe_a=recipe_a,
+        recipe_b=recipe_b,
+        sf_dtype_a=lhs[1].dtype,
+        sf_dtype_b=rhs[1].dtype,
+    ):
         deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
             lhs, rhs, out, m_indices, **fp4_kwargs
         )
@@ -154,6 +172,11 @@ def gemm_nt_f8f8bf16(
     lhs: Tuple[torch.Tensor, torch.Tensor],
     rhs: Tuple[torch.Tensor, torch.Tensor],
     out: torch.Tensor,
+    recipe: Optional[Tuple[int, int, int]] = None,
+    recipe_a: Optional[Tuple[int, int]] = None,
+    recipe_b: Optional[Tuple[int, int]] = None,
+    compiled_dims: str = "nk",
+    disable_ue8m0_cast: bool = False,
 ):
     m, k = lhs[0].shape
     n, _ = rhs[0].shape
@@ -163,11 +186,35 @@ def gemm_nt_f8f8bf16(
     _sanity_check_input(lhs)
     _sanity_check_input(rhs)
 
-    with compile_utils.deep_gemm_execution_hook(m, n, k, num_groups, kernel_type):
+    fp8_kwargs = {}
+    if recipe is not None:
+        fp8_kwargs["recipe"] = recipe
+    if recipe_a is not None:
+        fp8_kwargs["recipe_a"] = recipe_a
+    if recipe_b is not None:
+        fp8_kwargs["recipe_b"] = recipe_b
+    if compiled_dims != "nk":
+        fp8_kwargs["compiled_dims"] = compiled_dims
+    if disable_ue8m0_cast:
+        fp8_kwargs["disable_ue8m0_cast"] = disable_ue8m0_cast
+
+    with compile_utils.deep_gemm_execution_hook(
+        m,
+        n,
+        k,
+        num_groups,
+        kernel_type,
+        recipe=recipe,
+        recipe_a=recipe_a,
+        recipe_b=recipe_b,
+        sf_dtype_a=lhs[1].dtype,
+        sf_dtype_b=rhs[1].dtype,
+    ):
         deep_gemm.fp8_gemm_nt(
             lhs,
             rhs,
             out,
+            **fp8_kwargs,
         )
 
 

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -842,16 +842,16 @@ def ep_scatter(
     m_indices: torch.Tensor,
     output_index: torch.Tensor,
     scale_ue8m0: bool = False,
+    quant_group_size: int = 128,
 ):
     BLOCK_E = 128  # token num of per expert is aligned to 128
-    BLOCK_D = 128  # block size of quantization
     num_warps = 8
     num_experts = num_recv_tokens_per_expert.shape[0]
     hidden_size = recv_x.shape[1]
-    # grid = (triton.cdiv(hidden_size, BLOCK_D), num_experts)
     grid = num_experts
 
-    scale_hidden_size = hidden_size // BLOCK_D
+    assert hidden_size % quant_group_size == 0
+    scale_hidden_size = hidden_size // quant_group_size
     if scale_ue8m0:
         # ue8m0 scales are packed here (4 scales per int32),
         # hence the effective size of this dimension is divided by 4.
@@ -1172,6 +1172,7 @@ def moe_ep_deepgemm_preprocess(
     top_k: int,
     block_shape,
     output_dtype: torch.dtype = torch.float8_e4m3fn,
+    scale_ue8m0: bool = False,
 ):
     reorder_topk_ids, reorder_ids = torch.sort(topk_ids.view(-1), stable=True)
     seg_indptr = torch.zeros(
@@ -1212,7 +1213,13 @@ def moe_ep_deepgemm_preprocess(
     block_n, block_k = block_shape[0], block_shape[1]
 
     # TODO: fuse this with the preprocess
-    hidden_states, scale = per_token_group_quant_fp8(hidden_states, block_k)
+    if scale_ue8m0:
+        from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
+
+        assert block_k == 32, f"{block_k=} must be 32 for MXFP8 UE8M0 scales"
+        hidden_states, scale = mxfp8_group_quantize(hidden_states)
+    else:
+        hidden_states, scale = per_token_group_quant_fp8(hidden_states, block_k)
 
     gateup_input_scale = torch.empty(
         (gateup_input.size(0), gateup_input.size(1), scale.size(1)),
@@ -1232,6 +1239,13 @@ def moe_ep_deepgemm_preprocess(
         scale.size(1),
         BLOCK_SIZE=1024,
     )
+
+    if scale_ue8m0:
+        from sglang.srt.layers.quantization.fp8_utils import (
+            transform_mxfp8_scale_ue8m0,
+        )
+
+        gateup_input_scale = transform_mxfp8_scale_ue8m0(gateup_input_scale)
 
     return (
         masked_m,

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -119,6 +119,22 @@ class DeepGemmMoeQuantInfo(MoeQuantInfo):
     block_shape: Optional[List[int]] = None
     # DSV4 mxfp4 layout flag; selects recipe_a=(1,128)/recipe_b=(1,32) downstream.
     is_fp4_experts: bool = False
+    # MXFP8 uses 1D1D FP8 recipes with UE8M0 scales every 32 K elements.
+    is_mxfp8: bool = False
+
+
+def _fp8_recipes(
+    quant_info: DeepGemmMoeQuantInfo,
+) -> Tuple[Optional[Tuple[int, int]], Optional[Tuple[int, int]]]:
+    if quant_info.is_fp4_experts:
+        return (1, 128), (1, 32)
+    if quant_info.is_mxfp8:
+        return (1, 32), (1, 32)
+    return None, None
+
+
+def _fp8_activation_group_size(quant_info: DeepGemmMoeQuantInfo) -> int:
+    return 32 if quant_info.is_mxfp8 else 128
 
 
 class DeepGemmRunnerCore(MoeRunnerCore):
@@ -183,11 +199,8 @@ class DeepGemmRunnerCore(MoeRunnerCore):
 
         N = quant_info.w13_weight.size(1)
         K = hidden_states_shape[1]
-        scale_block_size = 128
-
-        recipe_a, recipe_b = (
-            ((1, 128), (1, 32)) if quant_info.is_fp4_experts else (None, None)
-        )
+        scale_block_size = _fp8_activation_group_size(quant_info)
+        recipe_a, recipe_b = _fp8_recipes(quant_info)
 
         w13_weight_fp8 = (
             quant_info.w13_weight,
@@ -377,9 +390,8 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         w13_scale = quant_info.w13_scale
         w2_scale = quant_info.w2_scale
 
-        recipe_a, recipe_b = (
-            ((1, 128), (1, 32)) if quant_info.is_fp4_experts else (None, None)
-        )
+        recipe_a, recipe_b = _fp8_recipes(quant_info)
+        scale_block_size = _fp8_activation_group_size(quant_info)
 
         hidden_states_device = running_state["hidden_states_device"]
 
@@ -443,7 +455,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         down_input, down_input_scale = _varlen_deep_gemm_silu_mul_quant(
             gateup_output,
             masked_m,
-            group_size=128,
+            group_size=scale_block_size,
             topk=self.config.top_k,
             swiglu_limit=swiglu_limit_arg,
             swizzle=self.use_swizzle,
@@ -592,6 +604,7 @@ def pre_permute_standard_to_deep_gemm(
             hidden_states,
             runner_config.top_k,
             quant_info.block_shape,
+            scale_ue8m0=quant_info.is_mxfp8 and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
         )
     )
 
@@ -661,6 +674,12 @@ def pre_permute_deepep_ll_to_deep_gemm(
     runner_config: MoeRunnerConfig,
     running_state: dict,
 ) -> DeepGemmRunnerInput:
+    if quant_info.is_mxfp8:
+        raise NotImplementedError(
+            "DeepGEMM MXFP8 MoE does not support DeepEP low-latency dispatch yet; "
+            "use the standard or DeepEP normal dispatcher."
+        )
+
     hidden_states, hidden_states_scale, topk_ids, topk_weights, masked_m, expected_m = (
         dispatch_output
     )
@@ -734,10 +753,16 @@ def pre_permute_deepep_normal_to_deep_gemm(
         device=hidden_states.device,
         dtype=hidden_states.dtype,
     )
-    if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+    scale_group_size = _fp8_activation_group_size(quant_info)
+    scale_ue8m0 = deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+    scale_size = (
+        ceil_div(K // scale_group_size, 4) if scale_ue8m0 else K // scale_group_size
+    )
+
+    if scale_ue8m0:
         # TODO check whether need `zeros`
         input_tensor_scale = torch.zeros(
-            (ceil_div(K // 128, 4), all_tokens),
+            (scale_size, all_tokens),
             device=hidden_states.device,
             dtype=torch.int,
         ).transpose(0, 1)
@@ -773,7 +798,8 @@ def pre_permute_deepep_normal_to_deep_gemm(
         input_tensor_scale,
         m_indices,
         output_index,
-        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        scale_ue8m0=scale_ue8m0,
+        quant_group_size=scale_group_size,
     )
     dispose_tensor(hidden_states)
     if hidden_states_scale is not None:

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -333,11 +333,12 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             dtype=torch.bfloat16,
         )
 
-        deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
+        self._run_bf16_contiguous_grouped_gemm(
             hidden_states,
             w13_weight,
             gateup_output,
             m_indices,
+            running_state,
         )
 
         dispose_tensor(hidden_states)
@@ -363,14 +364,51 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             device=hidden_states_device,
             dtype=torch.bfloat16,
         )
-        deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
+        self._run_bf16_contiguous_grouped_gemm(
             down_input,
             w2_weight,
             down_output,
             m_indices,
+            running_state,
         )
 
         return down_output
+
+    @staticmethod
+    def _run_bf16_contiguous_grouped_gemm(
+        hidden_states: torch.Tensor,
+        weight: torch.Tensor,
+        output: torch.Tensor,
+        m_indices: torch.Tensor,
+        running_state: dict,
+    ) -> None:
+        if deep_gemm_wrapper.has_grouped_gemm_nt_bf16_contig():
+            deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
+                hidden_states,
+                weight,
+                output,
+                m_indices,
+            )
+            return
+
+        num_tokens_per_expert = running_state.get("num_recv_tokens_per_expert")
+        if num_tokens_per_expert is None:
+            raise AttributeError(
+                "The installed deep_gemm package does not expose "
+                "m_grouped_bf16_gemm_nt_contiguous, and token counts were not "
+                "provided for the per-expert BF16 fallback."
+            )
+
+        start = 0
+        for expert_id, count in enumerate(num_tokens_per_expert):
+            end = start + int(count)
+            if end > start:
+                deep_gemm_wrapper.gemm_nt_bf16bf16f32(
+                    hidden_states[start:end],
+                    weight[expert_id],
+                    output[start:end],
+                )
+            start = end
 
     def _run_masked_gemm(
         self,
@@ -747,6 +785,7 @@ def pre_permute_deepep_normal_to_deep_gemm(
     running_state["hidden_states_dtype"] = hidden_states_dtype
     running_state["topk_ids"] = topk_ids
     running_state["topk_weights"] = topk_weights
+    running_state["num_recv_tokens_per_expert"] = num_recv_tokens_per_expert
 
     input_tensor = torch.empty(
         (all_tokens, K),

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -333,12 +333,12 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             dtype=torch.bfloat16,
         )
 
-        self._run_bf16_contiguous_grouped_gemm(
+        deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
             hidden_states,
             w13_weight,
             gateup_output,
             m_indices,
-            running_state,
+            running_state.get("num_recv_tokens_per_expert"),
         )
 
         dispose_tensor(hidden_states)
@@ -364,51 +364,15 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             device=hidden_states_device,
             dtype=torch.bfloat16,
         )
-        self._run_bf16_contiguous_grouped_gemm(
+        deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
             down_input,
             w2_weight,
             down_output,
             m_indices,
-            running_state,
+            running_state.get("num_recv_tokens_per_expert"),
         )
 
         return down_output
-
-    @staticmethod
-    def _run_bf16_contiguous_grouped_gemm(
-        hidden_states: torch.Tensor,
-        weight: torch.Tensor,
-        output: torch.Tensor,
-        m_indices: torch.Tensor,
-        running_state: dict,
-    ) -> None:
-        if deep_gemm_wrapper.has_grouped_gemm_nt_bf16_contig():
-            deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
-                hidden_states,
-                weight,
-                output,
-                m_indices,
-            )
-            return
-
-        num_tokens_per_expert = running_state.get("num_recv_tokens_per_expert")
-        if num_tokens_per_expert is None:
-            raise AttributeError(
-                "The installed deep_gemm package does not expose "
-                "m_grouped_bf16_gemm_nt_contiguous, and token counts were not "
-                "provided for the per-expert BF16 fallback."
-            )
-
-        start = 0
-        for expert_id, count in enumerate(num_tokens_per_expert):
-            end = start + int(count)
-            if end > start:
-                deep_gemm_wrapper.gemm_nt_bf16bf16f32(
-                    hidden_states[start:end],
-                    weight[expert_id],
-                    output[start:end],
-                )
-            start = end
 
     def _run_masked_gemm(
         self,

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -470,10 +470,10 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
         topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
         topk_ids = topk_ids.to(torch.int64)
         if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and self.use_fp8:
-            # TODO hard code 128 block quant,use fp8 communication
+            quant_group_size = self.quant_config.get("fp8_activation_group_size", 128)
             hidden_states = sglang_per_token_group_quant_fp8(
                 hidden_states,
-                128,
+                quant_group_size,
                 column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
                 scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
                 scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1435,10 +1435,37 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         ):
             num_experts, m, k = weight_shape
             aligned_m = ((m + 127) // 128) * 128
-            scale = scale.view(num_experts, aligned_m, k // 32)
+            expected_k_groups = k // 32
+            scale = scale.contiguous()
+            scale_mn = num_experts * aligned_m
+            if scale.numel() % scale_mn != 0:
+                raise ValueError(
+                    "MXFP8 MoE scale size is not divisible by the padded expert rows: "
+                    f"scale_numel={scale.numel()} {scale_mn=} {weight_shape=} "
+                    f"scale_shape={tuple(scale.shape)}."
+                )
+            actual_k_groups = scale.numel() // scale_mn
+            if actual_k_groups < expected_k_groups:
+                raise ValueError(
+                    "MXFP8 MoE scale has fewer K groups than the weight shard: "
+                    f"{actual_k_groups=} {expected_k_groups=} {weight_shape=} "
+                    f"scale_shape={tuple(scale.shape)}."
+                )
+            scale = scale.view(num_experts, aligned_m, actual_k_groups)
+            if actual_k_groups > expected_k_groups:
+                scale = scale[:, :, :expected_k_groups].contiguous()
             num_warps = 8
             scale = _swizzle_mxfp8_sf(scale, num_warps)
-            scale = scale.data.view(num_experts, aligned_m, k // 32)
+            actual_k_groups = scale.data.numel() // scale_mn
+            if actual_k_groups < expected_k_groups:
+                raise ValueError(
+                    "MXFP8 MoE swizzled scale has fewer K groups than the weight shard: "
+                    f"{actual_k_groups=} {expected_k_groups=} {weight_shape=} "
+                    f"scale_shape={tuple(scale.data.shape)}."
+                )
+            scale = scale.data.view(num_experts, aligned_m, actual_k_groups)
+            if actual_k_groups > expected_k_groups:
+                scale = scale[:, :, :expected_k_groups].contiguous()
             return scale
 
         def _quantize_and_swizzle_with_triton_kernel(weight: torch.Tensor):

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -64,6 +64,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_weight_ue8m0_inplace,
+    transform_mxfp8_scale_ue8m0,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
@@ -607,6 +608,12 @@ class Fp8LinearMethod(LinearMethodBase):
                 "weight_scale_inv_swizzled",
                 block_scale_interleave(scale_u8.contiguous()).contiguous(),
             )
+        elif get_fp8_gemm_runner_backend().is_deep_gemm():
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_inv_deepgemm",
+                transform_mxfp8_scale_ue8m0(layer.weight_scale_inv.data),
+            )
         else:
             # Triton path consumes canonical 2D UE8M0 scales directly.
             return
@@ -759,7 +766,9 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if self.use_mxfp8:
-            if get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
+            if get_fp8_gemm_runner_backend().is_deep_gemm():
+                weight_scale = layer.weight_scale_inv_deepgemm
+            elif get_fp8_gemm_runner_backend().is_flashinfer_cutlass():
                 weight_scale = layer.weight_scale_inv_swizzled
             else:
                 weight_scale = layer.weight_scale_inv

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -859,6 +859,13 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             assert (
                 is_sm100_supported() or is_sm90_supported() or is_sm120_supported()
             ), "cutlass_fp8 MoE requires SM90, SM100, or SM120 GPUs"
+        if self.use_mxfp8 and get_moe_runner_backend().is_deep_gemm():
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            assert (
+                deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            ), "DeepGEMM MXFP8 MoE requires the deep_gemm package."
+            assert is_sm100_supported(), "DeepGEMM MXFP8 MoE requires SM100 GPUs."
 
     @staticmethod
     def is_deepgemm_moe_runner_backend_enabled() -> bool:
@@ -1480,6 +1487,61 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             scale = _swizzle_with_triton_kernel(weight.shape, scale)
             return qweight, scale
 
+        def _canonical_mxfp8_scale_for_weight(
+            weight_shape: tuple[int, int, int],
+            scale: torch.Tensor,
+        ) -> torch.Tensor:
+            num_experts, n, k = weight_shape
+            assert k % 32 == 0, f"{k=} must be divisible by 32 for MXFP8"
+            expected_k_groups = k // 32
+            scale = scale.contiguous()
+            scale_mn = num_experts * n
+            aligned_n = ((n + 127) // 128) * 128
+            aligned_scale_mn = num_experts * aligned_n
+            if scale.numel() % scale_mn == 0:
+                scale_n = n
+            elif scale.numel() % aligned_scale_mn == 0:
+                scale_n = aligned_n
+                scale_mn = aligned_scale_mn
+            else:
+                raise ValueError(
+                    "MXFP8 MoE scale size is not divisible by expert rows: "
+                    f"scale_numel={scale.numel()} scale_mn={num_experts * n} "
+                    f"aligned_scale_mn={aligned_scale_mn} {weight_shape=} "
+                    f"scale_shape={tuple(scale.shape)}."
+                )
+            actual_k_groups = scale.numel() // scale_mn
+            if actual_k_groups < expected_k_groups:
+                raise ValueError(
+                    "MXFP8 MoE scale has fewer K groups than the weight shard: "
+                    f"{actual_k_groups=} {expected_k_groups=} {weight_shape=} "
+                    f"scale_shape={tuple(scale.shape)}."
+                )
+            scale = scale.view(num_experts, scale_n, actual_k_groups)
+            if scale_n != n:
+                scale = scale[:, :n, :]
+            if actual_k_groups > expected_k_groups:
+                scale = scale[:, :, :expected_k_groups].contiguous()
+            return scale
+
+        def _pack_deepgemm_mxfp8_scale(
+            weight_shape: tuple[int, int, int],
+            scale: torch.Tensor,
+        ) -> torch.Tensor:
+            return transform_mxfp8_scale_ue8m0(
+                _canonical_mxfp8_scale_for_weight(weight_shape, scale)
+            )
+
+        def _quantize_with_deepgemm(weight: torch.Tensor):
+            weight = weight.contiguous()
+            _, _, k = weight.shape
+            assert k % 32 == 0, f"{k=} must be divisible by 32 for MXFP8"
+
+            weight_flat = weight.view(-1, k).contiguous()
+            qweight, scale = mxfp8_group_quantize(weight_flat)
+            qweight = qweight.view_as(weight)
+            return qweight, scale
+
         def _quantize_with_flashinfer_trtllm(weight: torch.Tensor):
             weight = weight.contiguous()
             num_experts, m, k = weight.shape
@@ -1510,6 +1572,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 # 2) do row/layout shuffling in align_mxfp8_moe_weights_for_flashinfer_trtllm.
                 w13_q, w13_s = _quantize_with_flashinfer_trtllm(layer.w13_weight.data)
                 w2_q, w2_s = _quantize_with_flashinfer_trtllm(layer.w2_weight.data)
+            elif get_moe_runner_backend().is_deep_gemm():
+                w13_q, w13_s = _quantize_with_deepgemm(layer.w13_weight.data)
+                w2_q, w2_s = _quantize_with_deepgemm(layer.w2_weight.data)
             else:
                 w13_q, w13_s = _quantize_and_swizzle_with_triton_kernel(
                     layer.w13_weight.data
@@ -1522,6 +1587,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 get_moe_runner_backend().is_flashinfer_trtllm()
                 or get_moe_runner_backend().is_flashinfer_trtllm_routed()
             ):
+                w13_q = layer.w13_weight.data
+                w2_q = layer.w2_weight.data
+                w13_s = layer.w13_weight_scale_inv.data
+                w2_s = layer.w2_weight_scale_inv.data
+            elif get_moe_runner_backend().is_deep_gemm():
                 w13_q = layer.w13_weight.data
                 w2_q = layer.w2_weight.data
                 w13_s = layer.w13_weight_scale_inv.data
@@ -1551,6 +1621,17 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         _copy_or_rebind(layer.w2_weight, w2_q)
         _copy_or_rebind(layer.w13_weight_scale_inv, w13_s)
         _copy_or_rebind(layer.w2_weight_scale_inv, w2_s)
+        if get_moe_runner_backend().is_deep_gemm():
+            copy_or_rebind_param(
+                layer,
+                "w13_weight_scale_inv_deepgemm",
+                _pack_deepgemm_mxfp8_scale(layer.w13_weight.data.shape, w13_s),
+            )
+            copy_or_rebind_param(
+                layer,
+                "w2_weight_scale_inv_deepgemm",
+                _pack_deepgemm_mxfp8_scale(layer.w2_weight.data.shape, w2_s),
+            )
         layer.w13_weight.requires_grad_(False)
         layer.w2_weight.requires_grad_(False)
         layer.w13_weight_scale_inv.requires_grad_(False)
@@ -1701,7 +1782,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 align_fp8_moe_weights_for_flashinfer_trtllm(layer)
 
         if hasattr(layer, "dispatcher"):
-            layer.dispatcher.set_quant_config({"weight_dtype": layer.w13_weight.dtype})
+            dispatcher_quant_config = {"weight_dtype": layer.w13_weight.dtype}
+            if (
+                self.use_mxfp8
+                and hasattr(self, "runner")
+                and self.runner.runner_backend.is_deep_gemm()
+            ):
+                dispatcher_quant_config["fp8_activation_group_size"] = 32
+            layer.dispatcher.set_quant_config(dispatcher_quant_config)
 
     def process_weights_hip_int4(self, layer: Module):
         # TODO: _use_aiter: add after triton kernel added
@@ -1919,8 +2007,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if self.block_quant:
                 block_shape = self.quant_config.weight_block_size
-                w13_scale = layer.w13_weight_scale_inv
-                w2_scale = layer.w2_weight_scale_inv
+                if self.use_mxfp8:
+                    w13_scale = layer.w13_weight_scale_inv_deepgemm
+                    w2_scale = layer.w2_weight_scale_inv_deepgemm
+                else:
+                    w13_scale = layer.w13_weight_scale_inv
+                    w2_scale = layer.w2_weight_scale_inv
             else:
                 # Convert per-tensor quant to per-block quant by repeating scales for forward_deepgemm
                 scale_block_size = 128
@@ -1949,6 +2041,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 w2_scale=w2_scale,
                 block_shape=block_shape,
                 is_fp4_experts=self.is_fp4_expert,
+                is_mxfp8=self.use_mxfp8,
             )
         elif (
             self.runner.runner_backend.is_flashinfer_trtllm()

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -265,7 +265,9 @@ class Fp8Config(QuantizationConfig):
                 prefix, self.ignored_layers, fused_mapping=self.packed_modules_mapping
             ):
                 return UnquantizedFusedMoEMethod(
-                    layer.use_triton_kernels, layer.use_flashinfer_trtllm_moe
+                    layer.use_triton_kernels,
+                    layer.use_flashinfer_trtllm_moe,
+                    layer.use_deep_gemm,
                 )
 
             fp8_method = Fp8MoEMethod(self)

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -462,7 +462,8 @@ def create_per_token_group_quant_fp8_output_scale(
     if scale_ue8m0:
         assert column_major_scales and scale_tma_aligned
         *x_batch, x_q_mn, x_q_k = x_shape
-        x_s_mn, x_s_k = x_q_mn, x_q_k // 128
+        assert x_q_k % group_size == 0
+        x_s_mn, x_s_k = x_q_mn, x_q_k // group_size
         aligned_mn = ceil_align(x_s_mn, 4)
         aligned_k = ceil_align(x_s_k, 4)
         # TODO(FIXME): Fix cuda kernel and recover here to empty.

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -451,6 +451,10 @@ def per_token_group_quant_8bit(
         )
 
 
+def _get_tma_aligned_size(mn: int, element_size: int) -> int:
+    return ceil_align(mn, 16 // element_size)
+
+
 def create_per_token_group_quant_fp8_output_scale(
     x_shape,
     device,
@@ -460,13 +464,11 @@ def create_per_token_group_quant_fp8_output_scale(
     scale_ue8m0: bool,
 ):
     if scale_ue8m0:
-        from deep_gemm.utils import get_tma_aligned_size
-
         assert column_major_scales and scale_tma_aligned
         *x_batch, x_q_mn, x_q_k = x_shape
         assert x_q_k % group_size == 0
         x_s_mn, x_s_k = x_q_mn, x_q_k // group_size
-        aligned_mn = get_tma_aligned_size(x_s_mn, 4)
+        aligned_mn = _get_tma_aligned_size(x_s_mn, 4)
         aligned_k = ceil_align(x_s_k, 4)
         # TODO(FIXME): Fix cuda kernel and recover here to empty.
         return torch.empty(
@@ -587,9 +589,8 @@ def sglang_per_token_group_quant_fp8_ue8m0(
 
     x_s_mn = x_q_mn
     x_s_k = x_q_k // group_size
-    from deep_gemm.utils import get_tma_aligned_size
 
-    aligned_mn = get_tma_aligned_size(x_s_mn, 4)
+    aligned_mn = _get_tma_aligned_size(x_s_mn, 4)
     aligned_k = ceil_align(x_s_k, 4)
     x_s = torch.empty(
         (*x_batch, aligned_k // 4, aligned_mn),

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -460,11 +460,13 @@ def create_per_token_group_quant_fp8_output_scale(
     scale_ue8m0: bool,
 ):
     if scale_ue8m0:
+        from deep_gemm.utils import get_tma_aligned_size
+
         assert column_major_scales and scale_tma_aligned
         *x_batch, x_q_mn, x_q_k = x_shape
         assert x_q_k % group_size == 0
         x_s_mn, x_s_k = x_q_mn, x_q_k // group_size
-        aligned_mn = ceil_align(x_s_mn, 4)
+        aligned_mn = get_tma_aligned_size(x_s_mn, 4)
         aligned_k = ceil_align(x_s_k, 4)
         # TODO(FIXME): Fix cuda kernel and recover here to empty.
         return torch.empty(
@@ -585,7 +587,9 @@ def sglang_per_token_group_quant_fp8_ue8m0(
 
     x_s_mn = x_q_mn
     x_s_k = x_q_k // group_size
-    aligned_mn = ceil_align(x_s_mn, 4)
+    from deep_gemm.utils import get_tma_aligned_size
+
+    aligned_mn = get_tma_aligned_size(x_s_mn, 4)
     aligned_k = ceil_align(x_s_k, 4)
     x_s = torch.empty(
         (*x_batch, aligned_k // 4, aligned_mn),

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1117,6 +1117,9 @@ def deepgemm_w8a8_mxfp8_linear(
         else:
             raise TypeError("DeepGEMM MXFP8 input_scale must be uint8 or int32.")
 
+    if q_input.dtype != torch.float8_e4m3fn:
+        raise TypeError("DeepGEMM MXFP8 input must be FP8 E4M3.")
+
     if x_scale.shape != (m, k // 128):
         raise ValueError(
             "DeepGEMM MXFP8 input scale must have shape "

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -368,14 +368,23 @@ def dispatch_w8a8_block_fp8_linear() -> Callable:
 def dispatch_w8a8_mxfp8_linear() -> Callable:
     """Dispatch MXFP8 linear kernel by --fp8-gemm-backend.
 
-    For MXFP8, Triton remains the default path. We only route to FlashInfer
-    when backend is explicitly set to flashinfer_cutlass or flashinfer_trtllm.
+    For MXFP8, Triton remains the default path. We only route to another
+    backend when it is explicitly requested.
     """
     backend = get_fp8_gemm_runner_backend()
     if backend.is_flashinfer_trtllm():
         return flashinfer_mxfp8_blockscaled_linear
     elif backend.is_flashinfer_cutlass():
         return flashinfer_mxfp8_blockscaled_linear
+    elif backend.is_deep_gemm():
+        if not deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
+            raise RuntimeError(
+                "DeepGEMM MXFP8 requested via --fp8-gemm-backend=deep_gemm, "
+                "but DeepGEMM is not available. This usually means the deep_gemm "
+                "package is not installed or has been disabled via "
+                "SGLANG_ENABLE_JIT_DEEPGEMM=0."
+            )
+        return deepgemm_w8a8_mxfp8_linear
     return triton_mxfp8_blockscaled_linear
 
 
@@ -1023,6 +1032,109 @@ def triton_mxfp8_blockscaled_linear(
     )
 
 
+@register_custom_op(
+    op_name="deepgemm_mxfp8_block_scaled_matmul",
+    mutates_args=[],
+    fake_impl=lambda q_input, weight, x_scale, weight_scale, output_dtype: (
+        q_input.new_empty((q_input.shape[0], weight.shape[0]), dtype=output_dtype)
+    ),
+)
+def deepgemm_mxfp8_block_scaled_matmul(
+    q_input: torch.Tensor,
+    weight: torch.Tensor,
+    x_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    output = q_input.new_empty((q_input.shape[0], weight.shape[0]), dtype=output_dtype)
+    deep_gemm_wrapper.gemm_nt_f8f8bf16(
+        (q_input, x_scale),
+        (weight, weight_scale),
+        output,
+        recipe_a=(1, 32),
+        recipe_b=(1, 32),
+    )
+    return output
+
+
+def deepgemm_w8a8_mxfp8_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    input_scale: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """MXFP8 dense linear via DeepGEMM's SM100 1D1D FP8 kernel."""
+    if not (_is_cuda and _is_sm100_supported):
+        raise RuntimeError("DeepGEMM MXFP8 dense linear requires SM100 GPUs.")
+
+    input_2d = input.view(-1, input.shape[-1]).contiguous()
+    output_shape = [*input.shape[:-1], weight.shape[0]]
+
+    m, k = input_2d.shape
+    n, k_w = weight.shape
+    if k != k_w:
+        raise ValueError(f"Input K={k} does not match weight K={k_w}.")
+    if k % 128 != 0:
+        raise ValueError(f"K={k} must be divisible by 128 for DeepGEMM MXFP8.")
+    if weight.dtype != torch.float8_e4m3fn:
+        raise TypeError("MXFP8 weight must be FP8 E4M3.")
+    if weight_scale.dtype != torch.int32:
+        raise TypeError("DeepGEMM MXFP8 weight_scale must be packed UE8M0 int32.")
+    if weight_scale.shape != (n, k // 128):
+        raise ValueError(
+            "DeepGEMM MXFP8 weight_scale must have shape "
+            f"{(n, k // 128)}, got {tuple(weight_scale.shape)}."
+        )
+
+    if output_dtype is None:
+        output_dtype = (
+            input_2d.dtype if input_2d.dtype == torch.bfloat16 else torch.bfloat16
+        )
+    if output_dtype != torch.bfloat16:
+        raise TypeError("DeepGEMM MXFP8 dense linear currently supports BF16 output.")
+
+    if input_scale is None:
+        q_input, x_scale = sglang_per_token_group_quant_fp8(
+            input_2d,
+            32,
+            column_major_scales=True,
+            scale_tma_aligned=True,
+            scale_ue8m0=True,
+        )
+    else:
+        q_input = input_2d
+        if input_scale.dtype == torch.uint8:
+            if input_scale.shape != (m, k // 32):
+                raise ValueError(
+                    "Canonical MXFP8 input_scale must have shape "
+                    f"{(m, k // 32)}, got {tuple(input_scale.shape)}."
+                )
+            x_scale = transform_mxfp8_scale_ue8m0(input_scale)
+        elif input_scale.dtype == torch.int32:
+            x_scale = input_scale
+        else:
+            raise TypeError("DeepGEMM MXFP8 input_scale must be uint8 or int32.")
+
+    if x_scale.shape != (m, k // 128):
+        raise ValueError(
+            "DeepGEMM MXFP8 input scale must have shape "
+            f"{(m, k // 128)}, got {tuple(x_scale.shape)}."
+        )
+
+    output = deepgemm_mxfp8_block_scaled_matmul(
+        q_input,
+        weight,
+        x_scale,
+        weight_scale,
+        output_dtype,
+    )
+    if bias is not None:
+        output += bias
+    return output.to(dtype=output_dtype).view(*output_shape)
+
+
 def flashinfer_mxfp8_blockscaled_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -1274,19 +1386,9 @@ def transform_scale_ue8m0_inplace(param, mn):
     param.data = transform_scale_ue8m0(param.data, mn=mn)
 
 
-# NOTE copy and modified from DeepGEMM
-def transform_scale_ue8m0(sf, mn, use_torch_impl: bool = False):
-    import deep_gemm.utils.layout
-
-    get_mn_major_tma_aligned_packed_ue8m0_tensor = (
-        _get_mn_major_tma_aligned_packed_ue8m0_tensor_torch_impl
-        if use_torch_impl
-        else deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor
-    )
-
-    sf = sf.index_select(-2, torch.arange(mn, device=sf.device) // 128)
-    sf = get_mn_major_tma_aligned_packed_ue8m0_tensor(sf)
-
+def _fix_packed_ue8m0_tma_stride(
+    sf: torch.Tensor, use_torch_impl: bool
+) -> torch.Tensor:
     # In sgl-deep-gemm, the C++ deepgemm path returns through DLPack which collapses the stride
     # of size-1 trailing dims to 1 (happens when packed_sf_k == 1, i.e.
     # K <= block_k * 4). Restore the TMA-aligned stride so the deepgemm
@@ -1300,6 +1402,45 @@ def transform_scale_ue8m0(sf, mn, use_torch_impl: bool = False):
             new_stride[-1] = aligned_mn
             sf = sf.as_strided(sf.shape, tuple(new_stride))
     return sf
+
+
+# NOTE copy and modified from DeepGEMM
+def transform_scale_ue8m0(sf, mn, use_torch_impl: bool = False):
+    import deep_gemm.utils.layout
+
+    get_mn_major_tma_aligned_packed_ue8m0_tensor = (
+        _get_mn_major_tma_aligned_packed_ue8m0_tensor_torch_impl
+        if use_torch_impl
+        else deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor
+    )
+
+    sf = sf.index_select(-2, torch.arange(mn, device=sf.device) // 128)
+    sf = get_mn_major_tma_aligned_packed_ue8m0_tensor(sf)
+
+    return _fix_packed_ue8m0_tma_stride(sf, use_torch_impl)
+
+
+def transform_mxfp8_scale_ue8m0(
+    sf_u8: torch.Tensor,
+    use_torch_impl: bool = False,
+) -> torch.Tensor:
+    """Pack canonical MXFP8 UE8M0 uint8 scales for DeepGEMM SM100 kernels."""
+    if sf_u8.dtype == torch.int32:
+        return sf_u8
+    assert sf_u8.dtype == torch.uint8, f"{sf_u8.dtype=}"
+    assert sf_u8.dim() in (2, 3), f"{sf_u8.shape=}"
+
+    import deep_gemm.utils.layout
+
+    get_mn_major_tma_aligned_packed_ue8m0_tensor = (
+        _get_mn_major_tma_aligned_packed_ue8m0_tensor_torch_impl
+        if use_torch_impl
+        else deep_gemm.utils.layout.get_mn_major_tma_aligned_packed_ue8m0_tensor
+    )
+
+    sf_fp32 = (sf_u8.contiguous().to(torch.int32) << 23).view(torch.float32)
+    sf = get_mn_major_tma_aligned_packed_ue8m0_tensor(sf_fp32)
+    return _fix_packed_ue8m0_tma_stride(sf, use_torch_impl)
 
 
 # Copied from DeepGEMM tests

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -18,7 +18,6 @@ from sglang.srt.layers.moe import (
     MoeRunner,
     MoeRunnerBackend,
     MoeRunnerConfig,
-    get_deepep_mode,
     get_moe_a2a_backend,
     get_moe_runner_backend,
 )
@@ -259,7 +258,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             self.use_deep_gemm
             and layer.w13_weight.dtype == torch.bfloat16
             and get_moe_a2a_backend().is_deepep()
-            and get_deepep_mode().enable_low_latency()
             and not _is_npu
             and not _is_hip
             and hasattr(layer, "dispatcher")
@@ -457,9 +455,10 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             w2_weight = layer.w2_weight
             from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
 
-            # Only use_fp8=False when SGLANG_DEEPEP_BF16_DISPATCH is true,
-            # otherwise use_fp8=True for FP8 dispatch path
-            use_fp8 = not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+            use_fp8 = (
+                layer.w13_weight.dtype != torch.bfloat16
+                and not envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
+            )
             quant_info = DeepGemmMoeQuantInfo(
                 w13_weight=w13_weight,
                 w2_weight=w2_weight,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3189,6 +3189,16 @@ class ServerArgs:
                         "captures large per-expert scratch buffers."
                     )
                 self.disable_piecewise_cuda_graph = True
+            if (
+                self.moe_runner_backend == "deep_gemm"
+                and self.moe_a2a_backend == "deepep"
+                and self.deepep_mode == "auto"
+            ):
+                logger.warning(
+                    "DeepGEMM MXFP8 MoE uses DeepEP normal mode because "
+                    "DeepEP low-latency dispatch is not supported for MXFP8 scales."
+                )
+                self.deepep_mode = "normal"
 
         if self.moe_runner_backend == "flashinfer_cutlass":
             assert self.quantization in [

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3168,15 +3168,27 @@ class ServerArgs:
                 self.moe_runner_backend = "flashinfer_trtllm"
             elif self.moe_runner_backend not in [
                 "cutlass",
+                "deep_gemm",
                 "flashinfer_trtllm",
                 "flashinfer_trtllm_routed",
             ]:
                 logger.warning(
-                    "mxfp8 quantization supports only cutlass, flashinfer_trtllm, "
-                    "or flashinfer_trtllm_routed backends. "
+                    "mxfp8 quantization supports only cutlass, deep_gemm, "
+                    "flashinfer_trtllm, or flashinfer_trtllm_routed backends. "
                     f"Overriding {self.moe_runner_backend!r}."
                 )
                 self.moe_runner_backend = "flashinfer_trtllm"
+            if (
+                self.moe_runner_backend == "deep_gemm"
+                and not self.enforce_piecewise_cuda_graph
+            ):
+                if not self.disable_piecewise_cuda_graph:
+                    logger.warning(
+                        "Disabling piecewise CUDA graph for mxfp8 with "
+                        "--moe-runner-backend deep_gemm because DeepGEMM MoE "
+                        "captures large per-expert scratch buffers."
+                    )
+                self.disable_piecewise_cuda_graph = True
 
         if self.moe_runner_backend == "flashinfer_cutlass":
             assert self.quantization in [

--- a/test/manual/quant/test_block_fp8_deep_gemm_blackwell.py
+++ b/test/manual/quant/test_block_fp8_deep_gemm_blackwell.py
@@ -5,6 +5,11 @@ from typing import List, Tuple
 import torch
 from deep_gemm import fp8_gemm_nt
 
+from sglang.srt.layers.quantization.fp8_utils import (
+    deepgemm_w8a8_mxfp8_linear,
+    mxfp8_group_quantize,
+    transform_mxfp8_scale_ue8m0,
+)
 from sglang.test.test_utils import CustomTestCase
 
 _is_cuda = torch.cuda.is_available() and torch.version.cuda
@@ -165,6 +170,18 @@ def block_quant_dequant(
     return x_dq_block
 
 
+def mxfp8_dequant(
+    x_q: torch.Tensor,
+    x_s_u8: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    *batch_dims, k = x_q.shape
+    assert x_s_u8.shape == (*batch_dims, k // 32)
+    x_s = (x_s_u8.to(torch.int32) << 23).view(torch.float32)
+    x_dq = x_q.to(torch.float32).view(*batch_dims, -1, 32) * x_s.unsqueeze(-1)
+    return x_dq.view_as(x_q).to(dtype)
+
+
 class TestDeepGemmBlackwell(CustomTestCase):
 
     if not _is_cuda:
@@ -245,6 +262,33 @@ class TestDeepGemmBlackwell(CustomTestCase):
                 seed=params[4],
             ):
                 self._test_deep_gemm_blackwell(*params)
+
+    def test_deep_gemm_mxfp8_linear(self):
+        torch.manual_seed(0)
+        m, n, k = 128, 2112, 7168
+        a = torch.empty((m, k), dtype=torch.bfloat16).normal_(0, 0.2)
+        b = torch.empty((n, k), dtype=torch.bfloat16).normal_(0, 0.2)
+
+        a_q, a_s = mxfp8_group_quantize(a)
+        b_q, b_s = mxfp8_group_quantize(b)
+        b_s_deepgemm = transform_mxfp8_scale_ue8m0(b_s)
+
+        with torch.inference_mode():
+            out = deepgemm_w8a8_mxfp8_linear(
+                a_q,
+                b_q,
+                b_s_deepgemm,
+                input_scale=a_s,
+                output_dtype=torch.bfloat16,
+            )
+            ref_out = (
+                mxfp8_dequant(a_q, a_s, torch.float32)
+                @ mxfp8_dequant(b_q, b_s, torch.float32).t()
+            )
+
+        torch.testing.assert_close(
+            out, ref_out.to(torch.bfloat16), atol=1e-1, rtol=1e-2
+        )
 
 
 if __name__ == "__main__":

--- a/test/manual/quant/test_block_fp8_deep_gemm_blackwell.py
+++ b/test/manual/quant/test_block_fp8_deep_gemm_blackwell.py
@@ -5,6 +5,7 @@ from typing import List, Tuple
 import torch
 from deep_gemm import fp8_gemm_nt
 
+from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.quantization.fp8_utils import (
     deepgemm_w8a8_mxfp8_linear,
     mxfp8_group_quantize,
@@ -289,6 +290,55 @@ class TestDeepGemmBlackwell(CustomTestCase):
         torch.testing.assert_close(
             out, ref_out.to(torch.bfloat16), atol=1e-1, rtol=1e-2
         )
+
+    def test_deep_gemm_mxfp8_masked_grouped_moe(self):
+        torch.manual_seed(1)
+        num_groups, max_m, n, k = 4, 256, 512, 1024
+        expected_m = 160
+        masked_m = torch.tensor([17, 64, 0, 129], dtype=torch.int32, device="cuda")
+
+        a = torch.empty(
+            (num_groups, max_m, k), dtype=torch.bfloat16, device="cuda"
+        ).normal_(0, 0.2)
+        b = torch.empty(
+            (num_groups, n, k), dtype=torch.bfloat16, device="cuda"
+        ).normal_(0, 0.2)
+
+        a_q, a_s = mxfp8_group_quantize(a.view(-1, k))
+        a_q = a_q.view_as(a)
+        a_s = a_s.view(num_groups, max_m, k // 32)
+        b_q, b_s = mxfp8_group_quantize(b.view(-1, k))
+        b_q = b_q.view_as(b)
+        b_s = b_s.view(num_groups, n, k // 32)
+
+        a_s_deepgemm = transform_mxfp8_scale_ue8m0(a_s)
+        b_s_deepgemm = transform_mxfp8_scale_ue8m0(b_s)
+
+        out = torch.empty((num_groups, max_m, n), dtype=torch.bfloat16, device="cuda")
+        with torch.inference_mode():
+            deep_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+                (a_q, a_s_deepgemm),
+                (b_q, b_s_deepgemm),
+                out,
+                masked_m,
+                expected_m,
+                recipe_a=(1, 32),
+                recipe_b=(1, 32),
+            )
+
+            for group_id, m in enumerate(masked_m.tolist()):
+                if m == 0:
+                    continue
+                ref_out = (
+                    mxfp8_dequant(a_q[group_id, :m], a_s[group_id, :m], torch.float32)
+                    @ mxfp8_dequant(b_q[group_id], b_s[group_id], torch.float32).t()
+                )
+                torch.testing.assert_close(
+                    out[group_id, :m],
+                    ref_out.to(torch.bfloat16),
+                    atol=1e-1,
+                    rtol=1e-2,
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -173,7 +173,7 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
             ),
         },
         {
-            "name": "deep_gemm_mxfp8",
+            "name": "deep_gemm_deepep_mxfp8",
             "other_args": (
                 "--base-gpu-id",
                 "0",
@@ -183,6 +183,8 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
                 "deep_gemm",
                 "--moe-runner-backend",
                 "deep_gemm",
+                "--moe-a2a-backend",
+                "deepep",
             ),
         },
     )

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -173,7 +173,7 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
             ),
         },
         {
-            "name": "deep_gemm_dense_flashinfer_trtllm_routed_mxfp8",
+            "name": "deep_gemm_mxfp8",
             "other_args": (
                 "--base-gpu-id",
                 "0",
@@ -182,7 +182,7 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
                 "--fp8-gemm-backend",
                 "deep_gemm",
                 "--moe-runner-backend",
-                "flashinfer_trtllm_routed",
+                "deep_gemm",
             ),
         },
     )

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -173,7 +173,7 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
             ),
         },
         {
-            "name": "deep_gemm_dense_cutlass_mxfp8",
+            "name": "deep_gemm_dense_flashinfer_trtllm_routed_mxfp8",
             "other_args": (
                 "--base-gpu-id",
                 "0",
@@ -182,7 +182,7 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
                 "--fp8-gemm-backend",
                 "deep_gemm",
                 "--moe-runner-backend",
-                "cutlass",
+                "flashinfer_trtllm_routed",
             ),
         },
     )

--- a/test/registered/rl/test_update_weights_from_disk_blackwell.py
+++ b/test/registered/rl/test_update_weights_from_disk_blackwell.py
@@ -1,6 +1,6 @@
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=320, stage="extra-b", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=640, stage="extra-b", runner_config="4-gpu-b200")
 
 import unittest
 
@@ -170,6 +170,19 @@ class TestServerUpdateWeightsFromDiskMXFP8(UpdateWeightsFromDiskBase, CustomTest
                 "flashinfer_trtllm",
                 "--moe-runner-backend",
                 "flashinfer_trtllm_routed",
+            ),
+        },
+        {
+            "name": "deep_gemm_dense_cutlass_mxfp8",
+            "other_args": (
+                "--base-gpu-id",
+                "0",
+                "--tp-size",
+                "4",
+                "--fp8-gemm-backend",
+                "deep_gemm",
+                "--moe-runner-backend",
+                "cutlass",
             ),
         },
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
@humansand
## Motivation

Add DeepGEMM support for MXFP8 dense GEMM and MXFP8 MoE execution on Blackwell.

This is needed for MXFP8 checkpoints where the dense layers and routed expert weights use MXFP8 E4M3 data with MXFP-style scale layouts. Those scale contracts are different from block-scaled FP8 and per-tensor/per-expert FP8, so this PR adds explicit DeepGEMM MXFP8 packing, swizzling, validation, and load/update handling instead of reusing the existing FP8 paths interchangeably.

The MoE path supports `--moe-runner-backend deep_gemm` with the standard local routed path and the DeepEP normal all-to-all path. DeepEP low-latency remains unsupported for this backend because its current scale layout contract differs from the normal DeepEP path.

## Modifications

- Add DeepGEMM MXFP8 dense linear support behind `--fp8-gemm-backend deep_gemm`.
- Add DeepGEMM MXFP8 MoE support behind `--moe-runner-backend deep_gemm`.
- Add MXFP8 weight/scale packing helpers for DeepGEMM dense and grouped MoE kernels.
- Add DeepGEMM JIT warmup/cache handling for MXFP8 dense, grouped, and masked grouped kernels.
- Wire MXFP8 scale packing/swizzling into model load and `/update_weights_from_disk`, so reloaded weights keep the DeepGEMM backend layout contract.
- Support DeepEP normal dispatch for the DeepGEMM MXFP8 MoE backend via `--moe-a2a-backend deepep` without requiring users to manually set `--deepep-mode normal`.
- Raise a clear error for DeepEP low-latency with this backend for now.
- Keep older DeepGEMM BF16 grouped-GEMM compatibility inside `deep_gemm_wrapper` rather than in the MoE runner, so the runner calls wrapper APIs and backend-version details stay localized.
- Add B200 manual tests for DeepGEMM MXFP8 dense and masked grouped MoE paths.
- Add registered `/update_weights_from_disk` coverage for the DeepGEMM MXFP8 MoE DeepEP configuration.

## Accuracy Tests

Local/static checks:

```bash
python3 -m py_compile \
  python/sglang/srt/layers/deep_gemm_wrapper/entrypoint.py \
  python/sglang/srt/layers/moe/moe_runner/deep_gemm.py \
  python/sglang/srt/layers/quantization/fp8_utils.py

git diff --check upstream/main..HEAD
pre-commit run --all-files
```

B200 manual kernel tests:

```bash
python3 test/manual/quant/test_block_fp8_deep_gemm_blackwell.py \
  TestDeepGemmBlackwell.test_deep_gemm_mxfp8_linear \
  TestDeepGemmBlackwell.test_deep_gemm_mxfp8_masked_grouped_moe \
  -v
```

Result:

```text
test_deep_gemm_mxfp8_linear ... ok
test_deep_gemm_mxfp8_masked_grouped_moe ... ok
Ran 2 tests in 0.492s
OK
```

B200 SGLang smoke on the rebased branch:

```bash
python3 -m sglang.launch_server \
  --model-path zianglih/Qwen3-30B-A3B-Instruct-2507-MXFP8-last-8-BF16 \
  --host 127.0.0.1 --port 30000 \
  --base-gpu-id 0 --tp-size 4 \
  --fp8-gemm-backend deep_gemm \
  --moe-runner-backend deep_gemm \
  --moe-a2a-backend deepep
```

Result:

- Server reached `/health_generate` and `/model_info` readiness.
- Baseline deterministic generation succeeded.
- `/update_weights_from_disk` succeeded with `flush_cache=true`.
- Generation after `flush_cache=true` matched baseline text, token ids, and output logprobs.
- `/update_weights_from_disk` succeeded with `flush_cache=false`.
- Generation after `flush_cache=false` matched baseline text, token ids, and output logprobs.
- This launch intentionally did not set `--deepep-mode`; the backend used the default DeepEP mode normalization.

Local log copies from the B200 runs are retained under:

- `/Users/ziangli/playground/mxfp8-deepgemm/logs/deepgemm_mxfp8_moe_manual_20260525_202727/run.log`
- `/Users/ziangli/playground/mxfp8-deepgemm/logs/deepgemm_mxfp8_deepep_upstream_20260526_041834/`

## Speed Tests and Profiling

Dedicated throughput benchmarks and profiling have not been run yet. This PR is still draft and currently reports correctness/smoke validation only; no speedup claim is made in this PR description.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not updated yet; this PR is draft.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy/smoke results are included above; speed benchmarks are pending.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
