### PR TITLE
[Test] Add unit tests for OpenAI SSE utilities

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_sse_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_sse_utils.py
@@ -1,0 +1,154 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for OpenAI SSE chunk utilities."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.sse_utils import build_sse_content
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestBuildSseContent(CustomTestCase):
+    def _decode_sse_payload(self, sse_content: str) -> dict:
+        self.assertTrue(sse_content.startswith("data: "))
+        self.assertTrue(sse_content.endswith("\n\n"))
+        return json.loads(sse_content[len("data: ") : -2])
+
+    def test_builds_role_chunk_with_sse_framing(self):
+        payload = self._decode_sse_payload(
+            build_sse_content(
+                chunk_id="chatcmpl-test",
+                created=123,
+                model="test-model",
+                index=0,
+                role="assistant",
+                content="",
+            )
+        )
+
+        self.assertEqual(payload["id"], "chatcmpl-test")
+        self.assertEqual(payload["object"], "chat.completion.chunk")
+        self.assertEqual(payload["created"], 123)
+        self.assertEqual(payload["model"], "test-model")
+        self.assertNotIn("usage", payload)
+
+        self.assertEqual(len(payload["choices"]), 1)
+        choice = payload["choices"][0]
+        self.assertEqual(choice["index"], 0)
+        self.assertIsNone(choice["finish_reason"])
+        self.assertIsNone(choice["matched_stop"])
+        self.assertIsNone(choice["logprobs"])
+        self.assertEqual(
+            choice["delta"],
+            {
+                "reasoning_content": None,
+                "role": "assistant",
+                "content": "",
+            },
+        )
+
+    def test_reasoning_content_key_is_preserved_when_none(self):
+        payload = self._decode_sse_payload(
+            build_sse_content(
+                chunk_id="chatcmpl-test",
+                created=123,
+                model="test-model",
+                index=0,
+                content="visible text",
+            )
+        )
+
+        delta = payload["choices"][0]["delta"]
+        self.assertIn("reasoning_content", delta)
+        self.assertIsNone(delta["reasoning_content"])
+        self.assertEqual(delta["content"], "visible text")
+        self.assertNotIn("role", delta)
+
+    def test_reasoning_delta_omits_content_when_absent(self):
+        payload = self._decode_sse_payload(
+            build_sse_content(
+                chunk_id="chatcmpl-test",
+                created=123,
+                model="test-model",
+                index=1,
+                reasoning_content="thinking",
+            )
+        )
+
+        self.assertEqual(
+            payload["choices"][0]["delta"],
+            {"reasoning_content": "thinking"},
+        )
+
+    def test_finish_chunk_includes_string_matched_stop(self):
+        payload = self._decode_sse_payload(
+            build_sse_content(
+                chunk_id="chatcmpl-test",
+                created=123,
+                model="test-model",
+                index=2,
+                finish_reason="stop",
+                matched_stop="</s>",
+            )
+        )
+
+        choice = payload["choices"][0]
+        self.assertEqual(choice["finish_reason"], "stop")
+        self.assertEqual(choice["matched_stop"], "</s>")
+        self.assertEqual(choice["delta"], {"reasoning_content": None})
+
+    def test_finish_chunk_accepts_integer_matched_stop(self):
+        payload = self._decode_sse_payload(
+            build_sse_content(
+                chunk_id="chatcmpl-test",
+                created=123,
+                model="test-model",
+                index=3,
+                finish_reason="length",
+                matched_stop=151643,
+            )
+        )
+
+        choice = payload["choices"][0]
+        self.assertEqual(choice["finish_reason"], "length")
+        self.assertEqual(choice["matched_stop"], 151643)
+
+    def test_optional_usage_and_logprobs_are_serialized(self):
+        usage = {
+            "prompt_tokens": 4,
+            "completion_tokens": 2,
+            "total_tokens": 6,
+        }
+        logprobs = {
+            "content": [
+                {
+                    "token": "hello",
+                    "logprob": -0.1,
+                    "bytes": [104, 101, 108, 108, 111],
+                    "top_logprobs": [],
+                }
+            ]
+        }
+
+        payload = self._decode_sse_payload(
+            build_sse_content(
+                chunk_id="chatcmpl-test",
+                created=123,
+                model="test-model",
+                index=0,
+                content="hello",
+                logprobs=logprobs,
+                usage=usage,
+            )
+        )
+
+        self.assertEqual(payload["usage"], usage)
+        self.assertEqual(payload["choices"][0]["logprobs"], logprobs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Improve unit test coverage for `srt/entrypoints/openai/sse_utils.py`.

This is part of #20865. The tested utility builds OpenAI-compatible SSE chunks for chat completion streaming, including reasoning deltas, finish chunks, usage, logprobs, and matched stop metadata.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Added CPU-only unit tests for `build_sse_content()` covering:

- SSE `data: ...\n\n` framing
- OpenAI chat completion chunk fields
- `reasoning_content=None` serialized as JSON `null`
- reasoning-only deltas
- finish chunks with string and integer `matched_stop`
- optional `usage` and `logprobs` serialization

References #20865.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
N/A. This PR only adds unit tests and does not change model output behavior.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
N/A. This PR only adds unit tests and does not affect inference performance.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Test

```bash
PYTHONPATH=python pytest test/registered/unit/entrypoints/openai/test_sse_utils.py -v
6 passed, 3 warnings in 16.95s
python/sglang/srt/entrypoints/openai/sse_utils.py: 28 Stmts, 0 Miss, 100%
```
## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #27179249898](https://github.com/sgl-project/sglang/actions/runs/27179249898)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27179249820](https://github.com/sgl-project/sglang/actions/runs/27179249820)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->