### PR TITLE
[2/14] Expose true-on-policy serving arguments

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -460,7 +460,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--scheduler-recv-interval` | The interval to poll requests in scheduler. Can be set to >1 to reduce the overhead of this. | `1` | Type: int |
 | `--numa-node` | Sets the numa node for the subprocesses. i-th element corresponds to i-th subprocess. | `None` | List[int] |
 | `--enable-deterministic-inference` | Enable deterministic inference mode with batch invariant ops. | `False` | bool flag (set to enable) |
-| `--rl-on-policy-target` | The training system that SGLang needs to match for true on-policy. | `None` | `fsdp` |
+| `--true-on-policy-contract` | The typed true-on-policy runtime contract SGLang should follow. | `None` | Type: str |
 | `--enable-attn-tp-input-scattered` | Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent. | `False` | bool flag (set to enable) |
 | `--enable-nsa-prefill-context-parallel` | Enable context parallelism used in the long sequence prefill phase of DeepSeek v3.2. | `False` | bool flag (set to enable) |
 | `--nsa-prefill-cp-mode` | Token splitting mode for the prefill phase of DeepSeek v3.2 under context parallelism. Optional values: `round-robin-split`(default),`in-seq-split`. `round-robin-split` distributes tokens across ranks based on `token_idx % cp_size`. It supports multi-batch prefill, fused MoE, and FP8 KV cache. | `in-seq-split` | `in-seq-split`, `round-robin-split` |

--- a/docs/platforms/ascend/ascend_npu_support_features.md
+++ b/docs/platforms/ascend/ascend_npu_support_features.md
@@ -368,7 +368,7 @@ click [Server Arguments](https://docs.sglang.io/advanced_features/server_argumen
 | `--scheduler-recv-`<br/>`interval`                      | `1`      | Type: int                                                                                                            |      A2, A3      |
 | `--numa-node`                                           | `None`   | List[int]                                                                                                            |      A2, A3      |
 | `--enable-deterministic-`<br/>`inference`               | `False`  | bool flag<br/> (set to enable)                                                                                       |     Planned      |
-| `--rl-on-policy-target`                                 | `None`   | `fsdp`                                                                                                               |     Planned      |
+| `--true-on-policy-`<br/>`contract`                      | `None`   | Type: str                                                                                                            |     Planned      |
 | `--enable-layerwise-`<br/>`nvtx-marker`                 | `False`  | bool flag<br/> (set to enable)                                                                                       | Special for GPU  |
 | `--enable-attn-tp-`<br/>`input-scattered`               | `False`  | bool flag<br/> (set to enable)                                                                                       |   Experimental   |
 | `--enable-nsa-prefill-`<br/>`context-parallel`          | `False`  | bool flag<br/> (set to enable)                                                                                       |      A2, A3      |

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -164,6 +164,7 @@ class BaseTpWorker(ABC):
                 recv_req.serialized_named_tensors[self.tp_rank]
             ),
             load_format=recv_req.load_format,
+            weight_version=recv_req.weight_version,
         )
         return success, message
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -238,8 +238,6 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
 
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 
-RL_ON_POLICY_TARGET_CHOICES = ["fsdp", "fsdp_tp"]
-
 LORA_BACKEND_CHOICES = ["triton", "csgmv", "ascend", "torch_native"]
 
 ENCODER_TRANSFER_BACKEND_CHOICES = ["zmq_to_scheduler", "zmq_to_tokenizer", "mooncake"]
@@ -310,10 +308,6 @@ def add_fp4_gemm_runner_backend_choices(choices):
 
 def add_radix_eviction_policy_choices(choices):
     RADIX_EVICTION_POLICY_CHOICES.extend(choices)
-
-
-def add_rl_on_policy_target_choices(choices):
-    RL_ON_POLICY_TARGET_CHOICES.extend(choices)
 
 
 def add_linear_attn_kernel_backend_choices(choices):
@@ -771,8 +765,6 @@ class ServerArgs:
     scheduler_recv_interval: int = 1
     numa_node: Optional[List[int]] = None
     enable_deterministic_inference: bool = False
-    enable_prefill_only_deterministic_inference: bool = False
-    rl_on_policy_target: Optional[str] = None
     true_on_policy_contract: Optional[str] = None
     enable_attn_tp_input_scattered: bool = False
     gc_threshold: Optional[List[int]] = None
@@ -4310,15 +4302,6 @@ class ServerArgs:
     def _handle_deterministic_inference(self):
         validate_true_on_policy_contract(self)
 
-        if self.enable_prefill_only_deterministic_inference:
-            self.enable_deterministic_inference = True
-
-        if self.rl_on_policy_target is not None:
-            logger.warning(
-                "Enable deterministic inference because of legacy rl_on_policy_target."
-            )
-            self.enable_deterministic_inference = True
-
         if self.true_on_policy_contract is not None:
             logger.warning(
                 "Enable deterministic inference because of true_on_policy_contract."
@@ -4328,10 +4311,9 @@ class ServerArgs:
             # For VLM
             envs.SGLANG_VLM_CACHE_SIZE_MB.set(0)
 
+            true_on_policy_policy = resolve_true_on_policy_runtime_policy(self)
             if (
-                resolve_true_on_policy_runtime_policy(
-                    self
-                ).disable_flashinfer_allreduce_fusion
+                true_on_policy_policy.disable_flashinfer_allreduce_fusion
                 and self.enable_flashinfer_allreduce_fusion
             ):
                 self.enable_flashinfer_allreduce_fusion = False
@@ -4429,9 +4411,10 @@ class ServerArgs:
                 else:
                     # CUDA: use NCCL tree algorithm
                     os.environ["NCCL_ALGO"] = "allreduce:tree"
+                    os.environ["NCCL_NVLS_ENABLE"] = "0"
                     self.disable_custom_all_reduce = True
                     logger.warning(
-                        "NCCL_ALGO is set to 'allreduce:tree' and custom all reduce is disabled for deterministic inference when TP size > 1."
+                        "NCCL_ALGO is set to 'allreduce:tree', NCCL_NVLS_ENABLE is set to '0', and custom all reduce is disabled for deterministic inference when TP size > 1."
                     )
 
     def _handle_dllm_inference(self):
@@ -6796,18 +6779,6 @@ class ServerArgs:
             "--enable-deterministic-inference",
             action="store_true",
             help="Enable deterministic inference mode with batch invariant ops.",
-        )
-        parser.add_argument(
-            "--enable-prefill-only-deterministic-inference",
-            action="store_true",
-            help="Enable prefill-only deterministic inference mode with batch invariant ops.",
-        )
-        parser.add_argument(
-            "--rl-on-policy-target",
-            type=str,
-            default=ServerArgs.rl_on_policy_target,
-            choices=RL_ON_POLICY_TARGET_CHOICES,
-            help="The training system that SGLang needs to match for true on-policy.",
         )
         parser.add_argument(
             "--true-on-policy-contract",


### PR DESCRIPTION
Stacked split of #24408, rebuilt after rebasing onto latest `sglang-miles`.

Base branch: `split/pr24408-01-contracts`
Head branch: `split/pr24408-02-server-args`

This is PR 2 of 14. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->