### PR TITLE
[4/14] Route layernorm through batch-invariant RMSNorm

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -23,6 +23,7 @@ import torch.nn.functional as F
 from sglang.srt.batch_invariant_ops import (
     is_batch_invariant_mode_enabled,
     rms_norm_batch_invariant,
+    true_on_policy_rms_norm,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.utils import MultiPlatformOp
@@ -53,6 +54,9 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_xpu = is_xpu()
 _flashinfer_layernorm_available = False
+_enable_true_on_policy_fused_rms_norm = get_bool_env_var(
+    "SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM"
+)
 
 if _is_cuda or _is_xpu or _is_musa:
     if _is_flashinfer_available:
@@ -243,6 +247,25 @@ class RMSNorm(MultiPlatformOp):
             x = x.contiguous().reshape(-1, original_shape[-1])
         if self.variance_size_override is not None:
             return self.forward_native(x, residual, post_residual_addition)
+        if (
+            _enable_true_on_policy_fused_rms_norm
+            and is_true_on_policy_enabled()
+            and self.has_weight
+            and self.weight.dtype == torch.float32
+            and (residual is None or self.fp32_residual)
+        ):
+            orig_dtype = self.override_orig_dtype or x.dtype
+            return true_on_policy_rms_norm(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+                residual=residual,
+                post_residual_addition=post_residual_addition,
+                cast_x_before_out_mul=self.cast_x_before_out_mul,
+                norm_cast_dtype=orig_dtype,
+                weight_cast_dtype=self.weight.dtype,
+                residual_dtype=orig_dtype,
+            )
         if (
             self.weight.dtype != x.dtype
             or self.cast_x_before_out_mul
@@ -469,9 +492,8 @@ class RMSNorm(MultiPlatformOp):
         if self.variance_size_override is not None:
             return self.forward_native(x, residual, post_residual_addition)
         if is_batch_invariant_mode_enabled():
-            if (
-                residual is not None
-                or get_global_server_args().rl_on_policy_target == "fsdp"
+            if residual is not None or is_true_on_policy_enabled(
+                get_global_server_args()
             ):
                 return self.forward_native(x, residual, post_residual_addition)
             return rms_norm_batch_invariant(

--- a/test/manual/layers/test_layernorm.py
+++ b/test/manual/layers/test_layernorm.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 
+from sglang.srt.batch_invariant_ops import true_on_policy_rms_norm
 from sglang.srt.layers.layernorm import GemmaRMSNorm, LayerNorm, RMSNorm
 from sglang.test.test_utils import CustomTestCase
 
@@ -75,6 +76,83 @@ class TestRMSNorm(CustomTestCase):
 
         self.assertEqual(out.dtype, torch.float32)
         self.assertTrue(torch.equal(out, ref_out))
+
+    def test_true_on_policy_fused_rms_norm_qk_dtype_boundary(self):
+        torch.manual_seed(0)
+
+        hidden_size = 128
+        x = torch.randn(13, hidden_size, dtype=torch.bfloat16)
+        weight = torch.randn(hidden_size, dtype=torch.float32)
+
+        actual = true_on_policy_rms_norm(
+            x,
+            weight,
+            eps=1e-6,
+            cast_x_before_out_mul=True,
+            norm_cast_dtype=torch.bfloat16,
+            weight_cast_dtype=torch.float32,
+        )
+
+        x_float = x.float()
+        expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+        expected = weight * expected.to(torch.bfloat16)
+
+        self.assertEqual(actual.dtype, torch.float32)
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    def test_true_on_policy_fused_rms_norm_residual_pair_dtype_boundary(self):
+        torch.manual_seed(0)
+
+        hidden_size = 128
+        x = torch.randn(13, hidden_size, dtype=torch.bfloat16)
+        residual = torch.randn_like(x)
+        post_residual = torch.randn_like(x)
+        weight = torch.randn(hidden_size, dtype=torch.float32)
+
+        actual, actual_residual = true_on_policy_rms_norm(
+            x,
+            weight,
+            eps=1e-6,
+            residual=residual,
+            post_residual_addition=post_residual,
+            cast_x_before_out_mul=True,
+            norm_cast_dtype=torch.float32,
+            weight_cast_dtype=torch.float32,
+            residual_dtype=torch.float32,
+        )
+
+        x_float = x.float() + residual.float() + post_residual.float()
+        expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+        expected = weight * expected
+
+        self.assertEqual(actual.dtype, torch.float32)
+        self.assertEqual(actual_residual.dtype, torch.float32)
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(actual_residual, x_float)
+
+    def test_true_on_policy_fused_rms_norm_final_norm_dtype_boundary(self):
+        torch.manual_seed(0)
+
+        hidden_size = 128
+        x = torch.randn(13, hidden_size, dtype=torch.float32)
+        weight = torch.randn(hidden_size, dtype=torch.float32)
+
+        actual = true_on_policy_rms_norm(
+            x,
+            weight,
+            eps=1e-6,
+            cast_x_before_out_mul=True,
+            norm_cast_dtype=torch.bfloat16,
+            weight_cast_dtype=torch.bfloat16,
+            output_dtype=torch.bfloat16,
+        )
+
+        x_float = x.float()
+        expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+        expected = weight.to(torch.bfloat16) * expected.to(torch.bfloat16)
+
+        self.assertEqual(actual.dtype, torch.bfloat16)
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
 
 class TestGemmaRMSNorm(CustomTestCase):


### PR DESCRIPTION
Stacked split of #24408, rebuilt after rebasing onto latest `sglang-miles`.

Base branch: `split/pr24408-03-batch-invariant-ops`
Head branch: `split/pr24408-04-layernorm-batch-tests`

This is PR 4 of 14. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->