### PR TITLE
[7/14] Wire invariant collectives into execution

### DIFF
--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -21,13 +21,27 @@ from .parallel_state import (
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
     if should_use_tp_invariant_tree_all_reduce():
-        return tree_all_reduce_sum(input_, device_group=get_tp_group().device_group)
+        return tensor_model_parallel_tree_all_reduce(input_)
     return get_tp_group().all_reduce(input_)
 
 
 def tensor_model_parallel_quant_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
     return get_tp_group().quant_all_reduce(input_)
+
+
+def tensor_model_parallel_tree_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across model parallel group in fixed tree order."""
+    group = get_tp_group()
+    return tree_all_reduce_sum(input_, device_group=group.device_group)
+
+
+def attention_tensor_model_parallel_tree_all_reduce(
+    input_: torch.Tensor,
+) -> torch.Tensor:
+    """All-reduce the input tensor across attention TP group in fixed tree order."""
+    group = get_attn_tp_group()
+    return tree_all_reduce_sum(input_, device_group=group.device_group)
 
 
 def tensor_model_parallel_fused_allreduce_rmsnorm(
@@ -70,9 +84,7 @@ def broadcast_tensor_dict(
 def attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across attention parallel group."""
     if should_use_tp_invariant_tree_all_reduce():
-        return tree_all_reduce_sum(
-            input_, device_group=get_attn_tp_group().device_group
-        )
+        return attention_tensor_model_parallel_tree_all_reduce(input_)
     return get_attn_tp_group().all_reduce(input_)
 
 
@@ -91,3 +103,9 @@ def moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
 def moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe expert parallel group."""
     return get_moe_ep_group().all_reduce(input_)
+
+
+def moe_expert_parallel_tree_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across moe expert parallel group in fixed tree order."""
+    group = get_moe_ep_group()
+    return tree_all_reduce_sum(input_, device_group=group.device_group)

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -696,7 +696,7 @@ class LayerCommunicator:
             residual=residual,
             forward_batch=forward_batch,
             context=self._context,
-            allow_reduce_scatter=self.allow_reduce_scatter,
+            allow_reduce_scatter=self.should_use_reduce_scatter(forward_batch),
         )
 
     def should_use_reduce_scatter(self, forward_batch: ForwardBatch):
@@ -993,7 +993,7 @@ class CommunicateWithAllReduceAndLayerNormFn:
                 hidden_states += residual
 
             hidden_states, local_hidden_states = (
-                get_global_dp_buffer(get_tp_group()),
+                get_global_dp_buffer(get_tp_group(), dtype=hidden_states.dtype),
                 hidden_states,
             )
             dp_gather_partial(hidden_states, local_hidden_states, forward_batch)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -72,7 +72,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.true_on_policy import (
-    patch_prefill_only_deterministic_inference_for_cuda_graph,
+    should_force_bfloat16_lm_head,
 )
 from sglang.srt.utils import (
     empty_context,
@@ -914,30 +914,23 @@ class CudaGraphRunner:
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.
-        with patch_prefill_only_deterministic_inference_for_cuda_graph(
-            self.model_runner.server_args,
-            attn_backend=getattr(self.model_runner, "attn_backend", None),
-            dvr_target_verify_cuda_graph=getattr(
-                self.model_runner, "enable_dvr_target_verify_cuda_graph", False
-            ),
-        ):
-            with freeze_gc(self.model_runner.server_args.enable_cudagraph_gc):
-                if not self.enable_pdmux:
+        with freeze_gc(self.model_runner.server_args.enable_cudagraph_gc):
+            if not self.enable_pdmux:
+                with (
+                    graph_capture() as graph_capture_context,
+                    profile_context as prof,
+                ):
+                    self.stream = graph_capture_context.stream
+                    _capture_one_stream()
+            else:
+                set_pdmux_status(False)
+                for i, sg in enumerate(self.stream_groups):
                     with (
-                        graph_capture() as graph_capture_context,
+                        graph_capture(stream=sg[1]) as graph_capture_context,
                         profile_context as prof,
                     ):
                         self.stream = graph_capture_context.stream
-                        _capture_one_stream()
-                else:
-                    set_pdmux_status(False)
-                    for i, sg in enumerate(self.stream_groups):
-                        with (
-                            graph_capture(stream=sg[1]) as graph_capture_context,
-                            profile_context as prof,
-                        ):
-                            self.stream = graph_capture_context.stream
-                            _capture_one_stream(i)
+                        _capture_one_stream(i)
 
         _set_capture_lora_variant(None)
 
@@ -1383,6 +1376,13 @@ class CudaGraphRunner:
                     if output.next_token_logits is not None
                     else None
                 )
+                if next_token_logits is not None and should_force_bfloat16_lm_head(
+                    server_args=self.model_runner.server_args,
+                    use_fp32_lm_head=getattr(
+                        self.model_runner.server_args, "enable_fp32_lm_head", False
+                    ),
+                ):
+                    next_token_logits = next_token_logits.to(torch.bfloat16)
 
             return LogitsProcessorOutput(
                 next_token_logits=next_token_logits,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -756,7 +756,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             from sglang.srt.batch_invariant_ops import enable_batch_invariant_mode
 
             enable_batch_invariant_mode()
-        if is_tp_invariant_target():
+        if is_tp_invariant_target(server_args):
             from sglang.srt.tp_invariant_ops import enable_tp_invariant_mode
 
             enable_tp_invariant_mode()
@@ -2133,12 +2133,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self,
         named_tensors: List[Tuple[str, Union[torch.Tensor, "LocalSerializedTensor"]]],
         load_format: Optional[str] = None,
+        weight_version: Optional[str] = None,
     ):
         monkey_patch_torch_reductions()
         if load_format == "flattened_bucket":
             # Handle flattened bucket format
             return self._update_weights_from_flattened_bucket(
-                flattened_tensor_bucket_dict=named_tensors
+                flattened_tensor_bucket_dict=named_tensors,
+                weight_version=weight_version,
             )
 
         # We need to get device after patch otherwise the device would be wrong
@@ -2163,6 +2165,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _update_weights_from_flattened_bucket(
         self,
         flattened_tensor_bucket_dict,
+        weight_version: Optional[str] = None,
     ):
         """Handle flattened bucket format for weight updates"""
         flattened_tensor = flattened_tensor_bucket_dict["flattened_tensor"]


### PR DESCRIPTION
Stacked split of #24408, rebuilt after rebasing onto latest `sglang-miles`.

Base branch: `split/pr24408-06-tp-invariant-tests`
Head branch: `split/pr24408-07-collective-wiring`

This is PR 7 of 14. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->