### PR TITLE
[8/14] Preserve DP attention shape and dtype under contract

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -69,6 +69,12 @@ class DpPaddingMode(IntEnum):
     ) -> DpPaddingMode:
         dp_size = get_attention_dp_size()
 
+        if dp_size > 1:
+            from sglang.srt.true_on_policy import is_true_on_policy_enabled
+
+            if is_true_on_policy_enabled():
+                return cls.MAX_LEN
+
         # When is_extend_in_batch and dp_size > 1, use SUM_LEN to avoid padding
         # overhead from uneven token distribution.
         # For dp_size=1, max_len equals sum_len, so prefer MAX_LEN mode
@@ -126,21 +132,33 @@ class _DpGatheredBufferWrapper:
         cls._global_num_tokens = global_num_tokens
 
     @classmethod
-    def get_global_dp_buffer(cls, group: GroupCoordinator) -> torch.Tensor:
-        with use_symmetric_memory(group, disabled=not cls._dp_max_padding):
+    def get_global_dp_buffer(
+        cls,
+        group: Optional[GroupCoordinator] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        with use_symmetric_memory(
+            group or get_tp_group(), disabled=not cls._dp_max_padding
+        ):
             buffer = torch.empty(
                 (cls._global_dp_buffer_len, cls._hidden_size),
-                dtype=cls._dtype,
+                dtype=dtype or cls._dtype,
                 device=cls._device,
             )
         return buffer
 
     @classmethod
-    def get_local_dp_buffer(cls, group: GroupCoordinator) -> torch.Tensor:
-        with use_symmetric_memory(group, disabled=not cls._dp_max_padding):
+    def get_local_dp_buffer(
+        cls,
+        group: Optional[GroupCoordinator] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        with use_symmetric_memory(
+            group or get_tp_group(), disabled=not cls._dp_max_padding
+        ):
             buffer = torch.empty(
                 (cls._local_dp_buffer_len, cls._hidden_size),
-                dtype=cls._dtype,
+                dtype=dtype or cls._dtype,
                 device=cls._device,
             )
         return buffer
@@ -193,12 +211,18 @@ def set_dp_buffer_len(
     )
 
 
-def get_global_dp_buffer(group: GroupCoordinator) -> torch.Tensor:
-    return _DpGatheredBufferWrapper.get_global_dp_buffer(group=group)
+def get_global_dp_buffer(
+    group: Optional[GroupCoordinator] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    return _DpGatheredBufferWrapper.get_global_dp_buffer(group=group, dtype=dtype)
 
 
-def get_local_dp_buffer(group: GroupCoordinator) -> torch.Tensor:
-    return _DpGatheredBufferWrapper.get_local_dp_buffer(group=group)
+def get_local_dp_buffer(
+    group: Optional[GroupCoordinator] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    return _DpGatheredBufferWrapper.get_local_dp_buffer(group=group, dtype=dtype)
 
 
 def get_global_dp_buffer_len() -> int:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -490,7 +490,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             dimensions=batch.dimensions,
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
-            rids=[req.rid for req in batch.reqs],
+            rids=(
+                [req.rid for req in batch.reqs]
+                if model_runner.server_args.debug_tensor_dump_output_folder is not None
+                else None
+            ),
         )
         device = model_runner.device
 
@@ -892,7 +896,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             or self.forward_mode.is_draft_extend(include_v2=True)
             or self.forward_mode.is_idle()
         ):
-            if self.is_extend_in_batch and dp_padding_mode.is_max_len():
+            if (
+                self.is_extend_in_batch
+                and dp_padding_mode.is_max_len()
+                and self.batch_size > 0
+            ):
                 setattr(self, "_original_forward_mode", self.forward_mode)
                 self.forward_mode = ForwardMode.EXTEND
                 self.extend_num_tokens = bs
@@ -1068,6 +1076,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 self.out_cache_loc = self.output_cache_loc_backup
 
         elif self.forward_mode.is_decode() or self.forward_mode.is_idle():
+            self.positions = self.positions[:bs]
+            self.seq_lens = self.seq_lens[:bs]
+            self.req_pool_indices = self.req_pool_indices[:bs]
+            if self.seq_lens_cpu is not None:
+                self.seq_lens_cpu = self.seq_lens_cpu[:bs]
             logits_output.next_token_logits = logits_output.next_token_logits[:bs]
             if logits_output.hidden_states is not None:
                 logits_output.hidden_states = logits_output.hidden_states[:bs]


### PR DESCRIPTION
Stacked split of #24408, rebuilt after rebasing onto latest `sglang-miles`.

Base branch: `split/pr24408-07-collective-wiring`
Head branch: `split/pr24408-08-dp-attention-padding`

This is PR 8 of 14. The stack is cumulative; the final branch is the rebased equivalent of the original PR head without stale-base reversions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->