### PR TITLE
[10/16] Simplify LoRA routing for true-on-policy paths

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -460,7 +460,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--scheduler-recv-interval` | The interval to poll requests in scheduler. Can be set to >1 to reduce the overhead of this. | `1` | Type: int |
 | `--numa-node` | Sets the numa node for the subprocesses. i-th element corresponds to i-th subprocess. | `None` | List[int] |
 | `--enable-deterministic-inference` | Enable deterministic inference mode with batch invariant ops. | `False` | bool flag (set to enable) |
-| `--rl-on-policy-target` | The training system that SGLang needs to match for true on-policy. | `None` | `fsdp` |
+| `--true-on-policy-contract` | The typed true-on-policy runtime contract SGLang should follow. | `None` | Type: str |
 | `--enable-attn-tp-input-scattered` | Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent. | `False` | bool flag (set to enable) |
 | `--enable-nsa-prefill-context-parallel` | Enable context parallelism used in the long sequence prefill phase of DeepSeek v3.2. | `False` | bool flag (set to enable) |
 | `--nsa-prefill-cp-mode` | Token splitting mode for the prefill phase of DeepSeek v3.2 under context parallelism. Optional values: `round-robin-split`(default),`in-seq-split`. `round-robin-split` distributes tokens across ranks based on `token_idx % cp_size`. It supports multi-batch prefill, fused MoE, and FP8 KV cache. | `in-seq-split` | `in-seq-split`, `round-robin-split` |

--- a/docs/platforms/ascend/ascend_npu_support_features.md
+++ b/docs/platforms/ascend/ascend_npu_support_features.md
@@ -368,7 +368,7 @@ click [Server Arguments](https://docs.sglang.io/advanced_features/server_argumen
 | `--scheduler-recv-`<br/>`interval`                      | `1`      | Type: int                                                                                                            |      A2, A3      |
 | `--numa-node`                                           | `None`   | List[int]                                                                                                            |      A2, A3      |
 | `--enable-deterministic-`<br/>`inference`               | `False`  | bool flag<br/> (set to enable)                                                                                       |     Planned      |
-| `--rl-on-policy-target`                                 | `None`   | `fsdp`                                                                                                               |     Planned      |
+| `--true-on-policy-`<br/>`contract`                      | `None`   | Type: str                                                                                                            |     Planned      |
 | `--enable-layerwise-`<br/>`nvtx-marker`                 | `False`  | bool flag<br/> (set to enable)                                                                                       | Special for GPU  |
 | `--enable-attn-tp-`<br/>`input-scattered`               | `False`  | bool flag<br/> (set to enable)                                                                                       |   Experimental   |
 | `--enable-nsa-prefill-`<br/>`context-parallel`          | `False`  | bool flag<br/> (set to enable)                                                                                       |      A2, A3      |

--- a/python/sglang/srt/batch_invariant_ops/__init__.py
+++ b/python/sglang/srt/batch_invariant_ops/__init__.py
@@ -11,6 +11,7 @@ from .batch_invariant_ops import (
     mean_dim,
     rms_norm_batch_invariant,
     set_batch_invariant_mode,
+    true_on_policy_rms_norm,
 )
 
 __version__ = "0.1.0"
@@ -26,4 +27,5 @@ __all__ = [
     "get_batch_invariant_attention_block_size",
     "AttentionBlockSize",
     "rms_norm_batch_invariant",
+    "true_on_policy_rms_norm",
 ]

--- a/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+++ b/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
@@ -1,6 +1,7 @@
 # Adapted from https://github.com/thinking-machines-lab/batch_invariant_ops/blob/main/batch_invariant_ops/batch_invariant_ops.py
 
 import contextlib
+import os
 from collections import namedtuple
 from collections.abc import Callable
 from typing import Any, Dict, Tuple
@@ -39,7 +40,31 @@ __all__ = [
     "is_batch_invariant_mode_enabled",
     "disable_batch_invariant_mode",
     "enable_batch_invariant_mode",
+    "true_on_policy_rms_norm",
 ]
+
+_TRUE_ON_POLICY_RMSNORM_DTYPE_FP32 = 0
+_TRUE_ON_POLICY_RMSNORM_DTYPE_BF16 = 1
+_TRUE_ON_POLICY_RMSNORM_DTYPE_FP16 = 2
+
+
+def _true_on_policy_rms_norm_dtype_code(dtype: torch.dtype) -> int:
+    if dtype == torch.float32:
+        return _TRUE_ON_POLICY_RMSNORM_DTYPE_FP32
+    if dtype == torch.bfloat16:
+        return _TRUE_ON_POLICY_RMSNORM_DTYPE_BF16
+    if dtype == torch.float16:
+        return _TRUE_ON_POLICY_RMSNORM_DTYPE_FP16
+    raise TypeError(f"Unsupported true-on-policy RMSNorm dtype: {dtype}")
+
+
+def _true_on_policy_rms_norm_result_dtype(
+    lhs_dtype: torch.dtype, rhs_dtype: torch.dtype
+) -> torch.dtype:
+    return torch.result_type(
+        torch.empty((), dtype=lhs_dtype),
+        torch.empty((), dtype=rhs_dtype),
+    )
 
 
 def _matmul_launch_metadata(
@@ -910,6 +935,208 @@ def rms_norm(
         BLOCK_SIZE=BLOCK_SIZE,
     )
     return output.reshape(original_shape)
+
+
+@triton.jit
+def _true_on_policy_rms_norm_kernel(
+    input_ptr,
+    weight_ptr,
+    residual_ptr,
+    post_residual_ptr,
+    output_ptr,
+    residual_out_ptr,
+    input_row_stride: tl.constexpr,
+    output_row_stride: tl.constexpr,
+    residual_row_stride: tl.constexpr,
+    post_residual_row_stride: tl.constexpr,
+    residual_out_row_stride: tl.constexpr,
+    n_cols: tl.constexpr,
+    eps: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_POST_RESIDUAL: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    CAST_NORM_TO_ORIG_DTYPE_BEFORE_WEIGHT: tl.constexpr,
+    NORM_CAST_DTYPE: tl.constexpr,
+    WEIGHT_CAST_DTYPE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    input_row = input_ptr + row_idx * input_row_stride
+    output_row = output_ptr + row_idx * output_row_stride
+
+    sum_sq = tl.zeros([1], dtype=tl.float32)
+    for col_offset in range(0, n_cols, BLOCK_SIZE):
+        col_idx = col_offset + tl.arange(0, BLOCK_SIZE)
+        mask = col_idx < n_cols
+        x = tl.load(input_row + col_idx, mask=mask, other=0.0).to(tl.float32)
+
+        if HAS_RESIDUAL:
+            residual_row = residual_ptr + row_idx * residual_row_stride
+            residual = tl.load(residual_row + col_idx, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            x += residual
+
+        if HAS_POST_RESIDUAL:
+            post_residual_row = post_residual_ptr + row_idx * post_residual_row_stride
+            post_residual = tl.load(
+                post_residual_row + col_idx, mask=mask, other=0.0
+            ).to(tl.float32)
+            x += post_residual
+
+        sum_sq += tl.sum(tl.where(mask, x * x, 0.0))
+
+    inv_rms = tl.rsqrt(sum_sq / n_cols + eps)
+
+    for col_offset in range(0, n_cols, BLOCK_SIZE):
+        col_idx = col_offset + tl.arange(0, BLOCK_SIZE)
+        mask = col_idx < n_cols
+        x = tl.load(input_row + col_idx, mask=mask, other=0.0).to(tl.float32)
+
+        if HAS_RESIDUAL:
+            residual_row = residual_ptr + row_idx * residual_row_stride
+            residual = tl.load(residual_row + col_idx, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            x += residual
+
+        if HAS_POST_RESIDUAL:
+            post_residual_row = post_residual_ptr + row_idx * post_residual_row_stride
+            post_residual = tl.load(
+                post_residual_row + col_idx, mask=mask, other=0.0
+            ).to(tl.float32)
+            x += post_residual
+
+        if STORE_RESIDUAL_OUT:
+            residual_out_row = residual_out_ptr + row_idx * residual_out_row_stride
+            tl.store(residual_out_row + col_idx, x, mask=mask)
+
+        normed = x * inv_rms
+        weight = tl.load(weight_ptr + col_idx, mask=mask, other=1.0).to(tl.float32)
+
+        if CAST_NORM_TO_ORIG_DTYPE_BEFORE_WEIGHT:
+            if NORM_CAST_DTYPE == 1:
+                normed = normed.to(tl.bfloat16)
+            elif NORM_CAST_DTYPE == 2:
+                normed = normed.to(tl.float16)
+
+        if WEIGHT_CAST_DTYPE == 1:
+            weight = weight.to(tl.bfloat16)
+        elif WEIGHT_CAST_DTYPE == 2:
+            weight = weight.to(tl.float16)
+
+        output = weight * normed
+        tl.store(output_row + col_idx, output, mask=mask)
+
+
+def true_on_policy_rms_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float = 1e-6,
+    *,
+    residual: torch.Tensor | None = None,
+    post_residual_addition: torch.Tensor | None = None,
+    cast_x_before_out_mul: bool = True,
+    norm_cast_dtype: torch.dtype | None = None,
+    weight_cast_dtype: torch.dtype | None = None,
+    output_dtype: torch.dtype | None = None,
+    residual_dtype: torch.dtype | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Fused forward for the strict true-on-policy RMSNorm formula.
+
+    This intentionally mirrors ``RMSNorm.forward_native`` for the Qwen3
+    true-on-policy contract: residual math is fp32, variance is reduced in a
+    fixed per-row order, and ``cast_x_before_out_mul`` controls the dtype
+    boundary before multiplying the fp32 weight.
+    """
+    assert input.is_cuda, "true_on_policy_rms_norm requires CUDA input"
+    assert weight.dim() == 1, "weight must be 1-dimensional"
+    assert input.shape[-1] == weight.shape[0], (
+        f"Input last dimension ({input.shape[-1]}) must match "
+        f"weight dimension ({weight.shape[0]})"
+    )
+    if input.shape[-1] > 8192:
+        raise ValueError("true_on_policy_rms_norm supports hidden size <= 8192")
+    if residual is not None and residual.shape != input.shape:
+        raise ValueError("residual must match input shape")
+    if (
+        post_residual_addition is not None
+        and post_residual_addition.shape != input.shape
+    ):
+        raise ValueError("post_residual_addition must match input shape")
+
+    original_shape = input.shape
+    input_2d = input.reshape(-1, input.shape[-1]).contiguous()
+    weight = weight.contiguous()
+    residual_2d = (
+        residual.reshape(-1, residual.shape[-1]).contiguous()
+        if residual is not None
+        else None
+    )
+    post_residual_2d = (
+        post_residual_addition.reshape(-1, post_residual_addition.shape[-1]).contiguous()
+        if post_residual_addition is not None
+        else None
+    )
+
+    norm_cast_dtype = norm_cast_dtype or input.dtype
+    weight_cast_dtype = weight_cast_dtype or weight.dtype
+    norm_cast_code = _true_on_policy_rms_norm_dtype_code(norm_cast_dtype)
+    weight_cast_code = _true_on_policy_rms_norm_dtype_code(weight_cast_dtype)
+
+    if output_dtype is None:
+        if cast_x_before_out_mul:
+            output_dtype = _true_on_policy_rms_norm_result_dtype(
+                norm_cast_dtype, weight_cast_dtype
+            )
+        else:
+            output_dtype = norm_cast_dtype
+    output_2d = torch.empty(
+        (input_2d.shape[0], input_2d.shape[1]), device=input.device, dtype=output_dtype
+    )
+
+    residual_out_2d = None
+    if residual is not None:
+        residual_out_2d = torch.empty(
+            (input_2d.shape[0], input_2d.shape[1]),
+            device=input.device,
+            dtype=residual_dtype or input.dtype,
+        )
+
+    n_rows, n_cols = input_2d.shape
+    max_block_size = int(os.getenv("SGLANG_TRUE_ON_POLICY_RMSNORM_BLOCK_SIZE", "1024"))
+    if max_block_size <= 0 or max_block_size & (max_block_size - 1):
+        raise ValueError(
+            "SGLANG_TRUE_ON_POLICY_RMSNORM_BLOCK_SIZE must be a positive power of two"
+        )
+    block_size = min(max_block_size, triton.next_power_of_2(n_cols))
+    _true_on_policy_rms_norm_kernel[(n_rows,)](
+        input_2d,
+        weight,
+        residual_2d,
+        post_residual_2d,
+        output_2d,
+        residual_out_2d,
+        input_2d.stride(0),
+        output_2d.stride(0),
+        residual_2d.stride(0) if residual_2d is not None else 0,
+        post_residual_2d.stride(0) if post_residual_2d is not None else 0,
+        residual_out_2d.stride(0) if residual_out_2d is not None else 0,
+        n_cols,
+        eps,
+        HAS_RESIDUAL=residual_2d is not None,
+        HAS_POST_RESIDUAL=post_residual_2d is not None,
+        STORE_RESIDUAL_OUT=residual_out_2d is not None,
+        CAST_NORM_TO_ORIG_DTYPE_BEFORE_WEIGHT=cast_x_before_out_mul,
+        NORM_CAST_DTYPE=norm_cast_code,
+        WEIGHT_CAST_DTYPE=weight_cast_code,
+        BLOCK_SIZE=block_size,
+    )
+
+    output = output_2d.reshape(original_shape)
+    if residual_out_2d is None:
+        return output
+    return output, residual_out_2d.reshape(original_shape)
 
 
 def rms_norm_batch_invariant(

--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -21,13 +21,25 @@ from .parallel_state import (
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
     if should_use_tp_invariant_tree_all_reduce():
-        return tree_all_reduce_sum(input_, device_group=get_tp_group().device_group)
+        return tensor_model_parallel_tree_all_reduce(input_)
     return get_tp_group().all_reduce(input_)
 
 
 def tensor_model_parallel_quant_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
     return get_tp_group().quant_all_reduce(input_)
+
+
+def tensor_model_parallel_tree_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across model parallel group in fixed tree order."""
+    group = get_tp_group()
+    return tree_all_reduce_sum(input_, device_group=group.device_group)
+
+
+def attention_tensor_model_parallel_tree_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across attention TP group in fixed tree order."""
+    group = get_attn_tp_group()
+    return tree_all_reduce_sum(input_, device_group=group.device_group)
 
 
 def tensor_model_parallel_fused_allreduce_rmsnorm(
@@ -70,9 +82,7 @@ def broadcast_tensor_dict(
 def attention_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across attention parallel group."""
     if should_use_tp_invariant_tree_all_reduce():
-        return tree_all_reduce_sum(
-            input_, device_group=get_attn_tp_group().device_group
-        )
+        return attention_tensor_model_parallel_tree_all_reduce(input_)
     return get_attn_tp_group().all_reduce(input_)
 
 
@@ -91,3 +101,9 @@ def moe_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
 def moe_expert_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across moe expert parallel group."""
     return get_moe_ep_group().all_reduce(input_)
+
+
+def moe_expert_parallel_tree_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across moe expert parallel group in fixed tree order."""
+    group = get_moe_ep_group()
+    return tree_all_reduce_sum(input_, device_group=group.device_group)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1133,16 +1133,15 @@ class Engine(EngineScoreMixin, EngineBase):
         load_format: Optional[str] = None,
     ):
         if load_format == "flattened_bucket":
-            serialized_named_tensors = list(tensors)
+            serialized_tensors = tensors
         else:
-            serialized_named_tensors = [
-                MultiprocessingSerializer.serialize(tensors, output_str=True)
-                for _ in range(self.server_args.tp_size)
-            ]
+            serialized_tensors = MultiprocessingSerializer.serialize(
+                tensors, output_str=True
+            )
         lora_req = LoadLoRAAdapterFromTensorsReqInput(
             lora_name=lora_name,
             config_dict=config_dict,
-            serialized_named_tensors=serialized_named_tensors,
+            serialized_tensors=serialized_tensors,
             load_format=load_format,
         )
         return self.loop.run_until_complete(

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -696,7 +696,7 @@ class LayerCommunicator:
             residual=residual,
             forward_batch=forward_batch,
             context=self._context,
-            allow_reduce_scatter=self.allow_reduce_scatter,
+            allow_reduce_scatter=self.should_use_reduce_scatter(forward_batch),
         )
 
     def should_use_reduce_scatter(self, forward_batch: ForwardBatch):
@@ -993,7 +993,7 @@ class CommunicateWithAllReduceAndLayerNormFn:
                 hidden_states += residual
 
             hidden_states, local_hidden_states = (
-                get_global_dp_buffer(get_tp_group()),
+                get_global_dp_buffer(get_tp_group(), dtype=hidden_states.dtype),
                 hidden_states,
             )
             dp_gather_partial(hidden_states, local_hidden_states, forward_batch)

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -69,6 +69,12 @@ class DpPaddingMode(IntEnum):
     ) -> DpPaddingMode:
         dp_size = get_attention_dp_size()
 
+        if dp_size > 1:
+            from sglang.srt.true_on_policy import is_true_on_policy_enabled
+
+            if is_true_on_policy_enabled():
+                return cls.MAX_LEN
+
         # When is_extend_in_batch and dp_size > 1, use SUM_LEN to avoid padding
         # overhead from uneven token distribution.
         # For dp_size=1, max_len equals sum_len, so prefer MAX_LEN mode
@@ -126,21 +132,29 @@ class _DpGatheredBufferWrapper:
         cls._global_num_tokens = global_num_tokens
 
     @classmethod
-    def get_global_dp_buffer(cls, group: GroupCoordinator) -> torch.Tensor:
-        with use_symmetric_memory(group, disabled=not cls._dp_max_padding):
+    def get_global_dp_buffer(
+        cls,
+        group: Optional[GroupCoordinator] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        with use_symmetric_memory(group or get_tp_group(), disabled=not cls._dp_max_padding):
             buffer = torch.empty(
                 (cls._global_dp_buffer_len, cls._hidden_size),
-                dtype=cls._dtype,
+                dtype=dtype or cls._dtype,
                 device=cls._device,
             )
         return buffer
 
     @classmethod
-    def get_local_dp_buffer(cls, group: GroupCoordinator) -> torch.Tensor:
-        with use_symmetric_memory(group, disabled=not cls._dp_max_padding):
+    def get_local_dp_buffer(
+        cls,
+        group: Optional[GroupCoordinator] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        with use_symmetric_memory(group or get_tp_group(), disabled=not cls._dp_max_padding):
             buffer = torch.empty(
                 (cls._local_dp_buffer_len, cls._hidden_size),
-                dtype=cls._dtype,
+                dtype=dtype or cls._dtype,
                 device=cls._device,
             )
         return buffer
@@ -193,12 +207,18 @@ def set_dp_buffer_len(
     )
 
 
-def get_global_dp_buffer(group: GroupCoordinator) -> torch.Tensor:
-    return _DpGatheredBufferWrapper.get_global_dp_buffer(group=group)
+def get_global_dp_buffer(
+    group: Optional[GroupCoordinator] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    return _DpGatheredBufferWrapper.get_global_dp_buffer(group=group, dtype=dtype)
 
 
-def get_local_dp_buffer(group: GroupCoordinator) -> torch.Tensor:
-    return _DpGatheredBufferWrapper.get_local_dp_buffer(group=group)
+def get_local_dp_buffer(
+    group: Optional[GroupCoordinator] = None,
+    dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    return _DpGatheredBufferWrapper.get_local_dp_buffer(group=group, dtype=dtype)
 
 
 def get_global_dp_buffer_len() -> int:

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -23,6 +23,7 @@ import torch.nn.functional as F
 from sglang.srt.batch_invariant_ops import (
     is_batch_invariant_mode_enabled,
     rms_norm_batch_invariant,
+    true_on_policy_rms_norm,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.utils import MultiPlatformOp
@@ -53,6 +54,9 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_xpu = is_xpu()
 _flashinfer_layernorm_available = False
+_enable_true_on_policy_fused_rms_norm = get_bool_env_var(
+    "SGLANG_TRUE_ON_POLICY_FUSED_RMSNORM"
+)
 
 if _is_cuda or _is_xpu or _is_musa:
     if _is_flashinfer_available:
@@ -243,6 +247,25 @@ class RMSNorm(MultiPlatformOp):
             x = x.contiguous().reshape(-1, original_shape[-1])
         if self.variance_size_override is not None:
             return self.forward_native(x, residual, post_residual_addition)
+        if (
+            _enable_true_on_policy_fused_rms_norm
+            and is_true_on_policy_enabled()
+            and self.has_weight
+            and self.weight.dtype == torch.float32
+            and (residual is None or self.fp32_residual)
+        ):
+            orig_dtype = self.override_orig_dtype or x.dtype
+            return true_on_policy_rms_norm(
+                x,
+                self.weight.data,
+                self.variance_epsilon,
+                residual=residual,
+                post_residual_addition=post_residual_addition,
+                cast_x_before_out_mul=self.cast_x_before_out_mul,
+                norm_cast_dtype=orig_dtype,
+                weight_cast_dtype=self.weight.dtype,
+                residual_dtype=orig_dtype,
+            )
         if (
             self.weight.dtype != x.dtype
             or self.cast_x_before_out_mul
@@ -469,9 +492,8 @@ class RMSNorm(MultiPlatformOp):
         if self.variance_size_override is not None:
             return self.forward_native(x, residual, post_residual_addition)
         if is_batch_invariant_mode_enabled():
-            if (
-                residual is not None
-                or get_global_server_args().rl_on_policy_target == "fsdp"
+            if residual is not None or is_true_on_policy_enabled(
+                get_global_server_args()
             ):
                 return self.forward_native(x, residual, post_residual_addition)
             return rms_norm_batch_invariant(

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -19,7 +19,6 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
     def __init__(self, max_loras_per_batch: int, device: torch.device):
         self.max_loras_per_batch = max_loras_per_batch
         self.device = device
-        self.batch_info = None
         self.init_lm_head_config()
 
     def run_lora_a_embedding(
@@ -177,12 +176,10 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         """
         base = moe_layer.base_layer
         top_k = base.top_k
-        # Derive dims from the base FusedMoE rather than quant-specific tensors,
-        # so this works for any scheme (FP, WNA16, Marlin-packed, etc.).
-        E = base.num_local_experts
-        hidden_dim = base.hidden_size
-        N = 2 * base.intermediate_size_per_partition
-        device = next(base.parameters()).device
+        qinfo = moe_layer._quant_info
+        E, N, _ = qinfo.w13_weight.shape
+        hidden_dim = qinfo.w2_weight.shape[1]
+        device = qinfo.w13_weight.device
         dtype = compute_dtype
         num_experts = base.num_experts
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -41,15 +41,6 @@ class BaseLayerWithLoRA(nn.Module):
             self.weight = self.base_layer.weight
         if hasattr(self.base_layer, "bias") and self.base_layer.bias is not None:
             self.bias = self.base_layer.bias
-        if hasattr(self.base_layer, "reduce_results"):
-            self.reduce_results = self.base_layer.reduce_results
-        # Alias remaining base-layer parameters onto the wrapper so
-        # `named_parameters(remove_duplicate=True)` yields them at the outer
-        # path — weight loaders (e.g. FusedMoE's `w13_weight_packed`) lookup
-        # names without the `.base_layer.` segment.
-        for _name, _param in base_layer.named_parameters(recurse=False):
-            if not hasattr(self, _name):
-                setattr(self, _name, _param)
 
     def forward(self, x: torch.Tensor):
         return self.base_layer.forward(x)
@@ -216,9 +207,8 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         ):
             base_output = self.extra_token_embedding(input_, base_output)
 
-        # Apply LoRA if configured. Skip if no batch_info (DP-attention idle
-        # forward): the base path is correct because no real tokens need LoRA.
-        if self.set_lora and self.lora_backend.batch_info is not None:
+        # Apply LoRA if configured
+        if self.set_lora:
             # The backend's run_lora_a_embedding now handles both regular
             # and extra tokens efficiently with CUDA graph support
             base_output = self.apply_lora(base_output, input_, batch_info)
@@ -383,8 +373,8 @@ class ParallelLMHeadWithLoRA(BaseLayerWithLoRA):
             hidden_states, self.weight, bias=getattr(self.base_layer, "bias", None)
         )
 
-        # Apply LoRA if set. Skip in DP-attention idle forward (batch_info unset).
-        if self.set_lora and self.lora_backend.batch_info is not None:
+        # Apply LoRA if set
+        if self.set_lora:
             base_output = self.apply_lora(base_output, hidden_states)
 
         return base_output
@@ -473,7 +463,7 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
             self.base_layer, input_, bias
         )
 
-        if self.set_lora and self.lora_backend.batch_info is not None:
+        if self.set_lora:
             output_parallel = self.apply_lora(output_parallel, input_)
 
         if self.base_layer.gather_output:
@@ -487,13 +477,9 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         return A
 
     def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
-        # See RowParallelLinearWithLoRA.slice_lora_a_weights for why base_layer.tp_rank
-        # is authoritative: DP-attention makes output_partition_sizes attn_tp-local while
-        # the caller passes global tp_rank.
-        local_tp_rank = getattr(self.base_layer, "tp_rank", tp_rank)
         shard_size = self.base_layer.output_partition_sizes[0]
-        start_idx = local_tp_rank * shard_size
-        end_idx = (local_tp_rank + 1) * shard_size
+        start_idx = tp_rank * shard_size
+        end_idx = (tp_rank + 1) * shard_size
         B = B[start_idx:end_idx, :]
         return B
 
@@ -587,15 +573,12 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         return A
 
     def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
-        # base_layer.tp_rank is authoritative under DP-attention: the caller passes
-        # the global tp_rank but output_partition_sizes is attn_tp-local.
-        local_tp_rank = getattr(self.base_layer, "tp_rank", tp_rank)
         partition_sizes = self.base_layer.output_partition_sizes
         output_sizes = self.base_layer.output_sizes
         slices = []
         offset = 0
         for full_size, part_size in zip(output_sizes, partition_sizes):
-            start_idx = local_tp_rank * part_size
+            start_idx = tp_rank * part_size
             end_idx = start_idx + part_size
             slices.append(B[offset + start_idx : offset + end_idx, :])
             offset += full_size
@@ -662,14 +645,11 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         q_proj_shard_size = base_layer.q_proj_shard_size
         kv_proj_shard_size = base_layer.kv_proj_shard_size
         num_kv_head_replicas = base_layer.num_kv_head_replicas
-        # See RowParallelLinearWithLoRA.slice_lora_a_weights for why base_layer.tp_rank
-        # is authoritative under DP-attention.
-        local_tp_rank = getattr(base_layer, "tp_rank", tp_rank)
 
-        q_start_idx = q_proj_shard_size * local_tp_rank
+        q_start_idx = q_proj_shard_size * tp_rank
         q_end_idx = q_start_idx + q_proj_shard_size
 
-        kv_shard_id = local_tp_rank // num_kv_head_replicas
+        kv_shard_id = tp_rank // num_kv_head_replicas
         kv_start_idx = kv_proj_shard_size * kv_shard_id
         kv_end_idx = kv_start_idx + kv_proj_shard_size
 
@@ -751,9 +731,7 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
             and not skip_all_reduce
         )
 
-        # LoRA skipped when batch_info is None (DP-attention idle forward).
-        have_batch_info = self.lora_backend.batch_info is not None
-        if self.set_lora and have_batch_info and should_reduce:
+        if self.set_lora and should_reduce:
             lora_a_output = self.lora_backend.run_lora_a_sgemm(
                 input_parallel, self.A_buffer
             )
@@ -767,7 +745,7 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
                 base_output=output_,
             )
         else:
-            if self.set_lora and have_batch_info:
+            if self.set_lora:
                 output_parallel = self.apply_lora(output_parallel, input_parallel)
             if should_reduce:
                 output_ = tensor_model_parallel_all_reduce(output_parallel)
@@ -778,15 +756,9 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
         return output_, output_bias
 
     def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
-        # Use base_layer.tp_rank (not the argument) so the slicing rank matches
-        # the partition group the base layer was built on. For MLA o_proj under
-        # DP-attention, base_layer.tp_rank is attn_tp_rank while the caller
-        # passes the global tp_rank; input_size_per_partition is already
-        # attn_tp-sized, so using global tp_rank overshoots to empty.
-        local_tp_rank = getattr(self.base_layer, "tp_rank", tp_rank)
         shard_size = self.base_layer.input_size_per_partition
-        start_idx = local_tp_rank * shard_size
-        end_idx = (local_tp_rank + 1) * shard_size
+        start_idx = tp_rank * shard_size
+        end_idx = (tp_rank + 1) * shard_size
         A = A[:, start_idx:end_idx].contiguous()
         return A
 
@@ -872,7 +844,7 @@ class ReplicatedLinearWithLoRA(BaseLayerWithLoRA):
     def forward(self, x: torch.Tensor):
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
         output = self.base_layer.quant_method.apply(self.base_layer, x, bias)
-        if self.set_lora and self.lora_backend.batch_info is not None:
+        if self.set_lora:
             output = self.apply_lora(output, x)
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
@@ -906,19 +878,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         self.experts_shared_outer_loras: bool = False
         self.lora_use_virtual_experts: bool = False
-        # Forward for the model's own forward-path dispatch — the outer model
-        # reads several FusedMoE attributes (e.g. `self.experts.moe_runner_config`,
-        # `self.experts.dispatcher`, `self.experts.num_local_experts`,
-        # `self.experts.quant_method`) directly on the wrapper. Quant
-        # post-processing iterators skip LoRA wrappers via
-        # `isinstance(module, BaseLayerWithLoRA)` so the packed params on the
-        # inner FusedMoE get processed there, not here.
         self.quant_method = base_layer.quant_method
-        self.moe_runner_config = base_layer.moe_runner_config
-        self.dispatcher = base_layer.dispatcher
-        self.num_local_experts = base_layer.num_local_experts
-        if hasattr(base_layer, "scheme"):
-            self.scheme = base_layer.scheme
 
         self.tp_size = getattr(base_layer, "moe_tp_size", 1)
         self.tp_rank = getattr(base_layer, "moe_tp_rank", 0)
@@ -943,12 +903,6 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             and base_layer.quant_method.runner is not None
         ):
             runner_backend = base_layer.quant_method.runner.runner_backend
-        elif (
-            hasattr(base_layer, "scheme")
-            and hasattr(base_layer.scheme, "runner")
-            and base_layer.scheme.runner is not None
-        ):
-            runner_backend = base_layer.scheme.runner.runner_backend
         else:
             runner_backend = MoeRunnerBackend.TRITON
 
@@ -1053,8 +1007,6 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         1. After gate_up projection, before activation
         2. After down projection, before final reduction
         """
-        if self.lora_backend.batch_info is None:
-            return self.base_layer.forward(hidden_states, topk_output, **kwargs)
 
         # Build LoRA info for this batch
         lora_info = self._get_lora_info()
@@ -1082,9 +1034,6 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
-        quant_info.expert_map = getattr(
-            base_layer.dispatcher, "local_expert_mapping", None
-        )
 
         # Run the only lora moe runner (Triton)
         combine_input = self._lora_runner.run(

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -205,14 +205,7 @@ def _compute_token_lora_mapping(
     hidden_states: torch.Tensor,
     lora_info: LoRAInfo,
 ) -> torch.Tensor:
-    """Map each token to its LoRA adapter index (-1 for no LoRA).
-
-    Under DP-attention, `hidden_states` is the gathered batch (local + foreign
-    tokens) but `seg_indptr` / `req_to_lora` cover only local requests, so
-    `searchsorted` on foreign positions would index one past the end. Pad
-    `req_to_lora` with a -1 sentinel; foreign outputs are discarded by the
-    DP-attention scatter anyway.
-    """
+    """Map each token to its LoRA adapter index (-1 for no LoRA)."""
     token_positions = torch.arange(
         hidden_states.shape[0], device=hidden_states.device, dtype=torch.int32
     )
@@ -221,11 +214,7 @@ def _compute_token_lora_mapping(
         token_positions,
         right=True,
     )
-    req_to_lora = lora_info.req_to_lora.to(torch.int32)
-    req_to_lora_padded = torch.cat(
-        [req_to_lora, req_to_lora.new_full((1,), -1)], dim=0
-    )
-    return req_to_lora_padded[req_indices]
+    return lora_info.req_to_lora.to(torch.int32)[req_indices]
 
 
 def _compute_lora_alignment(
@@ -360,6 +349,7 @@ def _add_lora_gate_up_delta(
     r = lora_info.max_lora_rank
     gate_up_a = lora_info.gate_up_lora_a_weights
     gate_up_b = lora_info.gate_up_lora_b_weights
+
     if lora_info.experts_shared_outer_loras and not lora_info.lora_use_virtual_experts:
         gate_up_a = gate_up_a.expand(-1, lora_info.num_experts, -1, -1)
 
@@ -369,8 +359,6 @@ def _add_lora_gate_up_delta(
     if is_gated:
         inter_size = gate_up_b.shape[2] // 2
         lora_a_stacked = [gate_up_a[:, :, :r, :], gate_up_a[:, :, r : 2 * r, :]]
-        # B halves are also the tuple form the virtual-experts kernel wants
-        # (one shrink at K=2*r, two expands at K=r each).
         lora_b_stacked = [
             gate_up_b[:, :, :inter_size, :],
             gate_up_b[:, :, inter_size:, :],
@@ -384,7 +372,7 @@ def _add_lora_gate_up_delta(
             output=intermediate_cache,
             hidden_states=hidden_states,
             lora_a=gate_up_a,
-            lora_b=tuple(lora_b_stacked) if is_gated else gate_up_b,
+            lora_b=gate_up_b,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             token_lora_mapping=token_lora_mapping,
@@ -459,8 +447,6 @@ def _add_lora_down_delta(
     down_lora_a = lora_info.down_lora_a_weights
     down_lora_b = lora_info.down_lora_b_weights
     if lora_info.experts_shared_outer_loras and not lora_info.lora_use_virtual_experts:
-        # fused_moe_lora requires B's expert_dim to match A's; expand the
-        # shared B view.
         down_lora_b = down_lora_b.expand(-1, lora_info.num_experts, -1, -1)
 
     if lora_info.fully_sharded and lora_info.tp_size > 1:

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1915,7 +1915,7 @@ class UnloadLoRAAdapterReqInput(BaseReq):
 class LoadLoRAAdapterFromTensorsReqInput(BaseReq):
     lora_name: str
     config_dict: Dict[str, Any]
-    serialized_named_tensors: List[Union[str, bytes]]
+    serialized_tensors: str
     pinned: bool = False
     added_tokens_config: Optional[Dict[str, Any]] = None
     lora_id: Optional[str] = None

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -586,9 +586,11 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
+            # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
+            # with dp_size > 1.
             assert (
-                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
-            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
+                self.server_args.dp_size == 1
+            ), "dp_size must be 1 for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter. Lora name=%s, path=%s",
                 obj.lora_name,
@@ -663,8 +665,8 @@ class TokenizerControlMixin:
                 )
 
             assert (
-                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
-            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
+                self.server_args.dp_size == 1
+            ), "dp_size must be 1 for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter from tensors. Lora name=%s",
                 obj.lora_name,
@@ -736,9 +738,11 @@ class TokenizerControlMixin:
                 obj.lora_name is not None
             ), "lora_name must be provided to unload LoRA adapter"
 
+            # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
+            # with dp_size > 1.
             assert (
-                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
-            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
+                self.server_args.dp_size == 1
+            ), "dp_size must be 1 for dynamic lora loading"
             logger.info(
                 "Start unload Lora adapter. Lora name=%s",
                 obj.lora_name,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -164,6 +164,7 @@ class BaseTpWorker(ABC):
                 recv_req.serialized_named_tensors[self.tp_rank]
             ),
             load_format=recv_req.load_format,
+            weight_version=recv_req.weight_version,
         )
         return success, message
 
@@ -194,23 +195,19 @@ class BaseTpWorker(ABC):
     def load_lora_adapter_from_tensors(
         self, recv_req: LoadLoRAAdapterFromTensorsReqInput
     ):
-        # TP sharding for LoRA happens inside the lora module (see
-        # lora/layers.py:46-49 and mem_pool.py:437-440). Each TP rank
-        # deserializes its own producer's bytes — same convention as
-        # ``update_weights_from_tensor`` above. One producer per one
-        # consumer means the CUDA-IPC ref counter on the producer's
-        # bucket drops cleanly each cycle.
-        monkey_patch_torch_reductions()
-        serialized = recv_req.serialized_named_tensors[self.tp_rank]
+        # The LoRA code handles TP sharding internally using slice_lora_a_weights
+        # and slice_lora_b_weights methods (see lora/layers.py:46-49, mem_pool.py:437-440).
         if recv_req.load_format == "flattened_bucket":
-            flattened_data = MultiprocessingSerializer.deserialize(serialized)
+            flattened_data = MultiprocessingSerializer.deserialize(
+                recv_req.serialized_tensors
+            )
             bucket = FlattenedTensorBucket(
                 flattened_tensor=flattened_data["flattened_tensor"],
                 metadata=flattened_data["metadata"],
             )
             tensors = dict(bucket.reconstruct_tensors())
         else:
-            tensors = MultiprocessingSerializer.deserialize(serialized)
+            tensors = MultiprocessingSerializer.deserialize(recv_req.serialized_tensors)
         result = self.model_runner.load_lora_adapter_from_tensors(
             recv_req.to_ref(),
             tensors,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -72,7 +72,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.true_on_policy import (
-    patch_prefill_only_deterministic_inference_for_cuda_graph,
+    should_force_bfloat16_lm_head,
 )
 from sglang.srt.utils import (
     empty_context,
@@ -914,30 +914,23 @@ class CudaGraphRunner:
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.
-        with patch_prefill_only_deterministic_inference_for_cuda_graph(
-            self.model_runner.server_args,
-            attn_backend=getattr(self.model_runner, "attn_backend", None),
-            dvr_target_verify_cuda_graph=getattr(
-                self.model_runner, "enable_dvr_target_verify_cuda_graph", False
-            ),
-        ):
-            with freeze_gc(self.model_runner.server_args.enable_cudagraph_gc):
-                if not self.enable_pdmux:
+        with freeze_gc(self.model_runner.server_args.enable_cudagraph_gc):
+            if not self.enable_pdmux:
+                with (
+                    graph_capture() as graph_capture_context,
+                    profile_context as prof,
+                ):
+                    self.stream = graph_capture_context.stream
+                    _capture_one_stream()
+            else:
+                set_pdmux_status(False)
+                for i, sg in enumerate(self.stream_groups):
                     with (
-                        graph_capture() as graph_capture_context,
+                        graph_capture(stream=sg[1]) as graph_capture_context,
                         profile_context as prof,
                     ):
                         self.stream = graph_capture_context.stream
-                        _capture_one_stream()
-                else:
-                    set_pdmux_status(False)
-                    for i, sg in enumerate(self.stream_groups):
-                        with (
-                            graph_capture(stream=sg[1]) as graph_capture_context,
-                            profile_context as prof,
-                        ):
-                            self.stream = graph_capture_context.stream
-                            _capture_one_stream(i)
+                        _capture_one_stream(i)
 
         _set_capture_lora_variant(None)
 
@@ -1383,6 +1376,13 @@ class CudaGraphRunner:
                     if output.next_token_logits is not None
                     else None
                 )
+                if next_token_logits is not None and should_force_bfloat16_lm_head(
+                    server_args=self.model_runner.server_args,
+                    use_fp32_lm_head=getattr(
+                        self.model_runner.server_args, "enable_fp32_lm_head", False
+                    ),
+                ):
+                    next_token_logits = next_token_logits.to(torch.bfloat16)
 
             return LogitsProcessorOutput(
                 next_token_logits=next_token_logits,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -490,7 +490,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             dimensions=batch.dimensions,
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
-            rids=[req.rid for req in batch.reqs],
+            rids=(
+                [req.rid for req in batch.reqs]
+                if model_runner.server_args.debug_tensor_dump_output_folder is not None
+                else None
+            ),
         )
         device = model_runner.device
 
@@ -892,7 +896,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             or self.forward_mode.is_draft_extend(include_v2=True)
             or self.forward_mode.is_idle()
         ):
-            if self.is_extend_in_batch and dp_padding_mode.is_max_len():
+            if (
+                self.is_extend_in_batch
+                and dp_padding_mode.is_max_len()
+                and self.batch_size > 0
+            ):
                 setattr(self, "_original_forward_mode", self.forward_mode)
                 self.forward_mode = ForwardMode.EXTEND
                 self.extend_num_tokens = bs
@@ -1068,6 +1076,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 self.out_cache_loc = self.output_cache_loc_backup
 
         elif self.forward_mode.is_decode() or self.forward_mode.is_idle():
+            self.positions = self.positions[:bs]
+            self.seq_lens = self.seq_lens[:bs]
+            self.req_pool_indices = self.req_pool_indices[:bs]
+            if self.seq_lens_cpu is not None:
+                self.seq_lens_cpu = self.seq_lens_cpu[:bs]
             logits_output.next_token_logits = logits_output.next_token_logits[:bs]
             if logits_output.hidden_states is not None:
                 logits_output.hidden_states = logits_output.hidden_states[:bs]

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -756,7 +756,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             from sglang.srt.batch_invariant_ops import enable_batch_invariant_mode
 
             enable_batch_invariant_mode()
-        if is_tp_invariant_target():
+        if is_tp_invariant_target(server_args):
             from sglang.srt.tp_invariant_ops import enable_tp_invariant_mode
 
             enable_tp_invariant_mode()
@@ -2133,12 +2133,14 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self,
         named_tensors: List[Tuple[str, Union[torch.Tensor, "LocalSerializedTensor"]]],
         load_format: Optional[str] = None,
+        weight_version: Optional[str] = None,
     ):
         monkey_patch_torch_reductions()
         if load_format == "flattened_bucket":
             # Handle flattened bucket format
             return self._update_weights_from_flattened_bucket(
-                flattened_tensor_bucket_dict=named_tensors
+                flattened_tensor_bucket_dict=named_tensors,
+                weight_version=weight_version,
             )
 
         # We need to get device after patch otherwise the device would be wrong
@@ -2163,6 +2165,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
     def _update_weights_from_flattened_bucket(
         self,
         flattened_tensor_bucket_dict,
+        weight_version: Optional[str] = None,
     ):
         """Handle flattened bucket format for weight updates"""
         flattened_tensor = flattened_tensor_bucket_dict["flattened_tensor"]
@@ -3723,15 +3726,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             if hasattr(self.model, "post_load_weights"):
                 self.model.post_load_weights()
 
-        # LoRA wrappers forward `quant_method` for forward-path dispatch but
-        # don't own the packed params; skip them here so the inner base layer
-        # (yielded separately by `named_modules`) handles post-processing.
-        from sglang.srt.lora.layers import BaseLayerWithLoRA
-
         if recv_req.restore_weights_before_load:
             for _, module in self.model.named_modules():
-                if isinstance(module, BaseLayerWithLoRA):
-                    continue
                 quant_method = getattr(module, "quant_method", None)
                 if quant_method is not None and hasattr(
                     quant_method, "restore_weights_before_loading"
@@ -3741,8 +3737,6 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if recv_req.post_process_quantization:
             for _, module in self.model.named_modules():
-                if isinstance(module, BaseLayerWithLoRA):
-                    continue
                 quant_method = getattr(module, "quant_method", None)
                 if quant_method is not None and hasattr(
                     quant_method, "process_weights_after_loading"

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -130,15 +130,7 @@ class DeepseekV2WeightLoaderMixin:
             weights, NVFP4_CKPT_FP8_ATTN_QUANT_MODULES, nextn_conf
         )
 
-        # Persist across calls: chunked weight updates can split q_a_proj and
-        # kv_a_proj_with_mqa for the same layer into different chunks, and
-        # the fusion only fires once both halves have been seen.
-        if self.fuse_qkv_a_proj:
-            if not hasattr(self, "_persistent_cached_a_proj"):
-                self._persistent_cached_a_proj = {}
-            cached_a_proj = self._persistent_cached_a_proj
-        else:
-            cached_a_proj = None
+        cached_a_proj = {} if self.fuse_qkv_a_proj else None
 
         if self.num_fused_shared_experts > 0:
             assert self.num_fused_shared_experts == 1
@@ -269,10 +261,9 @@ class DeepseekV2WeightLoaderMixin:
                         if self.fuse_qkv_a_proj and (
                             "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                         ):
-                            # Clone: `loaded_weight` may be a view into an IPC
-                            # bucket that gets reused by the next chunk, and
-                            # the RunAI streamer also relies on cloning.
-                            cached_a_proj[name] = loaded_weight.detach().clone()
+                            cached_a_proj[name] = _clone_if_runai_streamed_tensor(
+                                loaded_weight
+                            )
                             q_a_proj_name = (
                                 name
                                 if "q_a_proj" in name

--- a/python/sglang/srt/models/moss_vl.py
+++ b/python/sglang/srt/models/moss_vl.py
@@ -47,6 +47,7 @@ from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.server_args import get_global_server_args
+from sglang.srt.true_on_policy import is_true_on_policy_enabled
 from sglang.srt.utils import add_prefix
 
 logger = logging.getLogger(__name__)
@@ -863,7 +864,7 @@ class MossVLSelfAttentionDecoderLayer(nn.Module):
                 override_orig_dtype=torch.float32,
                 fp32_residual=True,
             )
-            if get_global_server_args().rl_on_policy_target is not None
+            if is_true_on_policy_enabled(get_global_server_args())
             else {}
         )
         self.input_layernorm = RMSNorm(

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -35,6 +35,7 @@ from sglang.srt.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     moe_expert_parallel_all_reduce,
+    moe_expert_parallel_tree_all_reduce,
     moe_tensor_model_parallel_all_reduce,
 )
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -62,7 +63,7 @@ from sglang.srt.layers.moe.utils import (
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.rotary_embedding import MRotaryEmbedding, get_rope
+from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils import get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
     can_cp_split,
@@ -83,7 +84,7 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.true_on_policy import (
     get_on_policy_rms_norm_kwargs,
     is_true_on_policy_enabled,
-    should_disable_fused_qk_norm_mrope,
+    should_force_bfloat16_dense_tensor_math,
 )
 from sglang.srt.utils import (
     LazyValue,
@@ -99,7 +100,6 @@ _is_cuda = is_cuda()
 
 if _is_cuda:
     from sglang.jit_kernel.fused_qknorm_rope import (
-        can_use_fused_qk_norm_rope,
         fused_qk_norm_rope,
     )
 
@@ -115,6 +115,12 @@ _is_npu = is_npu()
 
 if _is_npu:
     from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
+
+
+from sglang.srt.tp_invariant_ops import (
+    stable_topk as _stable_topk,
+    stable_topk_softmax as _stable_topk_softmax,
+)
 
 
 def compute_yarn_parameters(
@@ -266,6 +272,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             use_grouped_topk=False,
             layer_id=layer_id,
         )
+        self.top_k = config.num_experts_per_tok
 
         self.experts = get_moe_impl_class(quant_config)(
             num_experts=config.num_experts
@@ -293,7 +300,6 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             self.num_experts = (
                 config.num_experts + get_global_server_args().ep_num_redundant_experts
             )
-            self.top_k = config.num_experts_per_tok
 
     def forward(
         self,
@@ -333,14 +339,16 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states)
+        router_hidden_states = hidden_states
+        gate_weight = getattr(self.gate, "weight", None)
+        if gate_weight is not None and router_hidden_states.dtype != gate_weight.dtype:
+            router_hidden_states = router_hidden_states.to(gate_weight.dtype)
+        router_logits, _ = self.gate(router_hidden_states)
         if is_true_on_policy_enabled():
-            routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-            routing_weights, selected_experts = torch.topk(
-                routing_weights, self.top_k, dim=-1
+            routing_weights, selected_experts = _stable_topk_softmax(
+                router_logits, self.top_k, ids_dtype=torch.int32
             )
-            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
-            routing_weights = routing_weights.to(hidden_states.dtype)
+            routing_weights = routing_weights.to(router_hidden_states.dtype)
             topk_output = StandardTopKOutput(
                 topk_weights=routing_weights,
                 topk_ids=selected_experts,
@@ -348,14 +356,26 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             )
         else:
             topk_output = self.topk(hidden_states, router_logits)
-        final_hidden_states = self.experts(hidden_states, topk_output)
+
+        expert_hidden_states = router_hidden_states
+        expert_weight = getattr(self.experts, "w13_weight", None)
+        if expert_weight is not None and expert_hidden_states.dtype != expert_weight.dtype:
+            expert_hidden_states = expert_hidden_states.to(expert_weight.dtype)
+        final_hidden_states = self.experts(expert_hidden_states, topk_output)
 
         if self.ep_size > 1 and not should_skip_post_experts_all_reduce(
             is_tp_path=False,
             use_reduce_scatter=use_reduce_scatter,
             should_allreduce_fusion=should_allreduce_fusion,
         ):
-            final_hidden_states = moe_expert_parallel_all_reduce(final_hidden_states)
+            if is_true_on_policy_enabled():
+                final_hidden_states = moe_expert_parallel_tree_all_reduce(
+                    final_hidden_states
+                )
+            else:
+                final_hidden_states = moe_expert_parallel_all_reduce(
+                    final_hidden_states
+                )
 
         if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
             is_tp_path=True,
@@ -535,24 +555,11 @@ class Qwen3MoeAttention(nn.Module):
             rope_scaling=rope_scaling,
             dual_chunk_attention_config=dual_chunk_attention_config,
         )
-        self.compatible_with_fused_kv_buffer = (
-            False if isinstance(self.rotary_emb, MRotaryEmbedding) else True
-        ) and not is_true_on_policy_enabled()
-        self.compatible_with_fused_qk_norm_rope = not isinstance(
-            self.rotary_emb, MRotaryEmbedding
-        ) and self.head_dim in (64, 128, 256)
-        _yarn_factor, _, _, _ = compute_yarn_parameters(config)
+        self.compatible_with_fused_kv_buffer = False
+        self.compatible_with_fused_qk_norm_rope = False
         self.use_fused_qk_norm_rope = (
             get_global_server_args().enable_fused_qk_norm_rope
             and self.compatible_with_fused_qk_norm_rope
-            and _is_cuda
-            and can_use_fused_qk_norm_rope(
-                self.head_dim,
-                self.rotary_emb.is_neox_style,
-                torch.bfloat16,
-                _yarn_factor != 1.0,
-            )
-            and not should_disable_fused_qk_norm_mrope()
         )
         self._used_fused_qk_norm_rope_last_call = False
 
@@ -565,7 +572,10 @@ class Qwen3MoeAttention(nn.Module):
             prefix=add_prefix("attn", prefix),
         )
 
-        norm_kwargs = get_on_policy_rms_norm_kwargs(fp32_residual=False)
+        norm_kwargs = get_on_policy_rms_norm_kwargs(
+            fp32_residual=False,
+            weight_dtype=torch.float32,
+        )
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps, **norm_kwargs)
         self.alt_stream = alt_stream
@@ -689,6 +699,11 @@ class Qwen3MoeAttention(nn.Module):
             not _is_npu
             or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
         ):
+            if (
+                should_force_bfloat16_dense_tensor_math()
+                and hidden_states.dtype != self.qkv_proj.weight.dtype
+            ):
+                hidden_states = hidden_states.to(self.qkv_proj.weight.dtype)
             return self.forward_prepare_native(
                 positions=positions,
                 hidden_states=hidden_states,
@@ -707,6 +722,9 @@ class Qwen3MoeAttention(nn.Module):
             return hidden_states
 
         q, k, v, fb = inner_state
+        if should_force_bfloat16_dense_tensor_math() and q.dtype != v.dtype:
+            q = q.to(v.dtype)
+            k = k.to(v.dtype)
 
         must_save_kv = self._used_fused_qk_norm_rope_last_call
         save_kv_cache = must_save_kv or not (
@@ -811,7 +829,11 @@ class Qwen3MoeDecoderLayer(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("mlp", prefix),
             )
-        norm_kwargs = get_on_policy_rms_norm_kwargs(fp32_residual=False)
+        norm_kwargs = get_on_policy_rms_norm_kwargs(
+            fp32_residual=True,
+            weight_dtype=torch.float32,
+            override_orig_dtype=torch.float32,
+        )
         self.input_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps, **norm_kwargs
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -238,8 +238,6 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
 
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
 
-RL_ON_POLICY_TARGET_CHOICES = ["fsdp", "fsdp_tp"]
-
 LORA_BACKEND_CHOICES = ["triton", "csgmv", "ascend", "torch_native"]
 
 ENCODER_TRANSFER_BACKEND_CHOICES = ["zmq_to_scheduler", "zmq_to_tokenizer", "mooncake"]
@@ -310,10 +308,6 @@ def add_fp4_gemm_runner_backend_choices(choices):
 
 def add_radix_eviction_policy_choices(choices):
     RADIX_EVICTION_POLICY_CHOICES.extend(choices)
-
-
-def add_rl_on_policy_target_choices(choices):
-    RL_ON_POLICY_TARGET_CHOICES.extend(choices)
 
 
 def add_linear_attn_kernel_backend_choices(choices):
@@ -771,8 +765,6 @@ class ServerArgs:
     scheduler_recv_interval: int = 1
     numa_node: Optional[List[int]] = None
     enable_deterministic_inference: bool = False
-    enable_prefill_only_deterministic_inference: bool = False
-    rl_on_policy_target: Optional[str] = None
     true_on_policy_contract: Optional[str] = None
     enable_attn_tp_input_scattered: bool = False
     gc_threshold: Optional[List[int]] = None
@@ -4310,15 +4302,6 @@ class ServerArgs:
     def _handle_deterministic_inference(self):
         validate_true_on_policy_contract(self)
 
-        if self.enable_prefill_only_deterministic_inference:
-            self.enable_deterministic_inference = True
-
-        if self.rl_on_policy_target is not None:
-            logger.warning(
-                "Enable deterministic inference because of legacy rl_on_policy_target."
-            )
-            self.enable_deterministic_inference = True
-
         if self.true_on_policy_contract is not None:
             logger.warning(
                 "Enable deterministic inference because of true_on_policy_contract."
@@ -4328,10 +4311,9 @@ class ServerArgs:
             # For VLM
             envs.SGLANG_VLM_CACHE_SIZE_MB.set(0)
 
+            true_on_policy_policy = resolve_true_on_policy_runtime_policy(self)
             if (
-                resolve_true_on_policy_runtime_policy(
-                    self
-                ).disable_flashinfer_allreduce_fusion
+                true_on_policy_policy.disable_flashinfer_allreduce_fusion
                 and self.enable_flashinfer_allreduce_fusion
             ):
                 self.enable_flashinfer_allreduce_fusion = False
@@ -4429,9 +4411,10 @@ class ServerArgs:
                 else:
                     # CUDA: use NCCL tree algorithm
                     os.environ["NCCL_ALGO"] = "allreduce:tree"
+                    os.environ["NCCL_NVLS_ENABLE"] = "0"
                     self.disable_custom_all_reduce = True
                     logger.warning(
-                        "NCCL_ALGO is set to 'allreduce:tree' and custom all reduce is disabled for deterministic inference when TP size > 1."
+                        "NCCL_ALGO is set to 'allreduce:tree', NCCL_NVLS_ENABLE is set to '0', and custom all reduce is disabled for deterministic inference when TP size > 1."
                     )
 
     def _handle_dllm_inference(self):
@@ -6796,18 +6779,6 @@ class ServerArgs:
             "--enable-deterministic-inference",
             action="store_true",
             help="Enable deterministic inference mode with batch invariant ops.",
-        )
-        parser.add_argument(
-            "--enable-prefill-only-deterministic-inference",
-            action="store_true",
-            help="Enable prefill-only deterministic inference mode with batch invariant ops.",
-        )
-        parser.add_argument(
-            "--rl-on-policy-target",
-            type=str,
-            default=ServerArgs.rl_on_policy_target,
-            choices=RL_ON_POLICY_TARGET_CHOICES,
-            help="The training system that SGLang needs to match for true on-policy.",
         )
         parser.add_argument(
             "--true-on-policy-contract",

--- a/python/sglang/srt/tp_invariant_ops/__init__.py
+++ b/python/sglang/srt/tp_invariant_ops/__init__.py
@@ -6,6 +6,8 @@ from .tp_invariant_ops import (
     matmul_tp_persistent,
     moe_sum_tree_reduce,
     set_tp_invariant_mode,
+    stable_topk,
+    stable_topk_softmax,
     tree_all_reduce_sum,
 )
 
@@ -15,6 +17,8 @@ __all__ = [
     "matmul_tp_persistent",
     "matmul_tp_inv",
     "moe_sum_tree_reduce",
+    "stable_topk",
+    "stable_topk_softmax",
     "tree_all_reduce_sum",
     "set_tp_invariant_mode",
     "is_tp_invariant_mode_enabled",

--- a/python/sglang/srt/tp_invariant_ops/tp_invariant_ops.py
+++ b/python/sglang/srt/tp_invariant_ops/tp_invariant_ops.py
@@ -556,8 +556,222 @@ def matmul_tp_persistent_optim(
     )
 
 
+def _stable_topk_torch(
+    scores: torch.Tensor, top_k: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    expert_ids = torch.arange(scores.shape[-1], device=scores.device, dtype=torch.float32)
+    scores_fp32 = scores.float()
+    tie_step = torch.finfo(torch.float32).eps * scores_fp32.abs().clamp_min(
+        1.0 / scores.shape[-1]
+    )
+    scores_for_topk = scores_fp32 - expert_ids.view(1, -1) * tie_step
+    _, selected_ids = torch.topk(scores_for_topk, top_k, dim=-1)
+    return torch.gather(scores, dim=-1, index=selected_ids), selected_ids
+
+
+@triton.jit
+def _stable_topk_kernel(
+    scores_ptr,
+    values_ptr,
+    ids_ptr,
+    n_cols: tl.constexpr,
+    top_k: tl.constexpr,
+    scores_row_stride: tl.constexpr,
+    values_row_stride: tl.constexpr,
+    ids_row_stride: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+
+    scores = tl.load(
+        scores_ptr + row * scores_row_stride + offsets,
+        mask=mask,
+        other=-float("inf"),
+    )
+    scores_f32 = scores.to(tl.float32)
+    expert_ids = offsets.to(tl.float32)
+    min_scale = 1.0 / n_cols
+    tie_step = 1.1920928955078125e-7 * tl.maximum(tl.abs(scores_f32), min_scale)
+    adjusted = scores_f32 - expert_ids * tie_step
+    adjusted = tl.where(mask, adjusted, -float("inf"))
+
+    for topk_idx in range(0, top_k):
+        best_adjusted = tl.max(adjusted, axis=0)
+        is_best = adjusted == best_adjusted
+        best_col = tl.min(tl.where(is_best, offsets, BLOCK_SIZE), axis=0)
+        value = tl.load(scores_ptr + row * scores_row_stride + best_col)
+
+        tl.store(values_ptr + row * values_row_stride + topk_idx, value)
+        tl.store(ids_ptr + row * ids_row_stride + topk_idx, best_col)
+
+        adjusted = tl.where(offsets == best_col, -float("inf"), adjusted)
+
+
+def _stable_topk_triton(
+    scores: torch.Tensor, top_k: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scores.dim() != 2:
+        raise ValueError(f"stable_topk expects a 2D tensor, got {scores.shape}")
+    if top_k <= 0 or top_k > scores.shape[-1]:
+        raise ValueError(f"top_k must be in [1, {scores.shape[-1]}], got {top_k}")
+
+    scores_2d = scores.contiguous()
+    n_rows, n_cols = scores_2d.shape
+    block_size = triton.next_power_of_2(n_cols)
+    if block_size > 1024:
+        return _stable_topk_torch(scores, top_k)
+
+    values = torch.empty((n_rows, top_k), device=scores.device, dtype=scores.dtype)
+    ids = torch.empty((n_rows, top_k), device=scores.device, dtype=torch.long)
+    _stable_topk_kernel[(n_rows,)](
+        scores_2d,
+        values,
+        ids,
+        n_cols,
+        top_k,
+        scores_2d.stride(0),
+        values.stride(0),
+        ids.stride(0),
+        BLOCK_SIZE=block_size,
+    )
+    return values, ids
+
+
+@triton.jit
+def _stable_topk_softmax_kernel(
+    logits_ptr,
+    values_ptr,
+    ids_ptr,
+    n_cols: tl.constexpr,
+    top_k: tl.constexpr,
+    logits_row_stride: tl.constexpr,
+    values_row_stride: tl.constexpr,
+    ids_row_stride: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+
+    logits = tl.load(
+        logits_ptr + row * logits_row_stride + offsets,
+        mask=mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    logits = tl.where(mask, logits, -float("inf"))
+    row_max = tl.max(logits, axis=0)
+    exp_logits = tl.exp(logits - row_max)
+    exp_logits = tl.where(mask, exp_logits, 0.0)
+    denom = tl.sum(exp_logits, axis=0)
+    scores = exp_logits / denom
+
+    expert_ids = offsets.to(tl.float32)
+    min_scale = 1.0 / n_cols
+    tie_step = 1.1920928955078125e-7 * tl.maximum(tl.abs(scores), min_scale)
+    adjusted = scores - expert_ids * tie_step
+    adjusted = tl.where(mask, adjusted, -float("inf"))
+
+    topk_sum = tl.full((), 0.0, tl.float32)
+    for topk_idx in range(0, top_k):
+        best_adjusted = tl.max(adjusted, axis=0)
+        is_best = adjusted == best_adjusted
+        best_col = tl.min(tl.where(is_best, offsets, BLOCK_SIZE), axis=0)
+        value = tl.max(tl.where(offsets == best_col, scores, 0.0), axis=0)
+
+        topk_sum += value
+        tl.store(values_ptr + row * values_row_stride + topk_idx, value)
+        tl.store(ids_ptr + row * ids_row_stride + topk_idx, best_col)
+
+        adjusted = tl.where(offsets == best_col, -float("inf"), adjusted)
+
+    for topk_idx in range(0, top_k):
+        value = tl.load(values_ptr + row * values_row_stride + topk_idx)
+        tl.store(values_ptr + row * values_row_stride + topk_idx, value / topk_sum)
+
+
+def _stable_topk_softmax_triton(
+    logits: torch.Tensor, top_k: int, ids_dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if logits.dim() != 2:
+        raise ValueError(f"stable_topk_softmax expects a 2D tensor, got {logits.shape}")
+    if top_k <= 0 or top_k > logits.shape[-1]:
+        raise ValueError(f"top_k must be in [1, {logits.shape[-1]}], got {top_k}")
+
+    logits_2d = logits.contiguous()
+    n_rows, n_cols = logits_2d.shape
+    block_size = triton.next_power_of_2(n_cols)
+    if block_size > 1024:
+        scores = torch.softmax(logits, dim=-1, dtype=torch.float32)
+        topk_values, topk_ids = stable_topk(scores, top_k)
+        return topk_values / topk_values.sum(dim=-1, keepdim=True), topk_ids
+
+    values = torch.empty((n_rows, top_k), device=logits.device, dtype=torch.float32)
+    ids = torch.empty((n_rows, top_k), device=logits.device, dtype=ids_dtype)
+    _stable_topk_softmax_kernel[(n_rows,)](
+        logits_2d,
+        values,
+        ids,
+        n_cols,
+        top_k,
+        logits_2d.stride(0),
+        values.stride(0),
+        ids.stride(0),
+        BLOCK_SIZE=block_size,
+    )
+    return values, ids
+
+
+def stable_topk(scores: torch.Tensor, top_k: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Deterministic, batch-invariant top-k with stable expert-id tie-break.
+
+    Subtracts ``expert_id * eps * |score|`` from each score so equal scores are
+    broken by the smaller expert id. Megatron keeps the same formula locally so
+    core routing does not depend on importing SGLang.
+
+    Returns the gathered original-precision scores and selected expert indices.
+    """
+    if (
+        scores.is_cuda
+        and scores.dim() == 2
+        and not (torch.is_grad_enabled() and scores.requires_grad)
+        and os.getenv("SGLANG_TRUE_ON_POLICY_STABLE_TOPK_TRITON", "1") != "0"
+    ):
+        return _stable_topk_triton(scores, top_k)
+
+    return _stable_topk_torch(scores, top_k)
+
+
+def stable_topk_softmax(
+    logits: torch.Tensor, top_k: int, *, ids_dtype: torch.dtype = torch.long
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Deterministic fused softmax + stable top-k for MoE routing.
+
+    This keeps routing per-token deterministic without materializing the full
+    softmax matrix in Python.  The selected weights are renormalized over the
+    selected experts, matching the Qwen3-MoE routing contract used by SGLang and
+    Megatron's exact forward path when the opt-in env var is enabled.
+    """
+    if (
+        logits.is_cuda
+        and logits.dim() == 2
+        and not (torch.is_grad_enabled() and logits.requires_grad)
+        and os.getenv("SGLANG_TRUE_ON_POLICY_STABLE_TOPK_SOFTMAX", "0") != "0"
+    ):
+        return _stable_topk_softmax_triton(logits, top_k, ids_dtype)
+
+    scores = torch.softmax(logits, dim=-1, dtype=torch.float32)
+    topk_values, topk_ids = stable_topk(scores, top_k)
+    if topk_ids.dtype != ids_dtype:
+        topk_ids = topk_ids.to(ids_dtype)
+    return topk_values / topk_values.sum(dim=-1, keepdim=True), topk_ids
+
+
 def tree_all_reduce_sum(x: torch.Tensor, device_group=None) -> torch.Tensor:
-    rank = dist.get_rank(device_group)
+    if not dist.is_initialized():
+        return x.clone()
+
     world_size = dist.get_world_size(device_group)
 
     if world_size & (world_size - 1) != 0:
@@ -588,7 +802,6 @@ def tree_all_reduce_sum_optim(x: torch.Tensor, device_group=None) -> torch.Tenso
     if world_size & (world_size - 1) != 0:
         raise ValueError("world_size must be a power of 2.")
 
-    # cache
     if not hasattr(tree_all_reduce_sum, "_cache"):
         tree_all_reduce_sum._cache = {}
 
@@ -1893,8 +2106,13 @@ def moe_sum_tree_reduce_v2(
         )
         return output
 
-    # fallback: keep your existing generic path here
-    return output
+    return moe_sum_tree_reduce_v1(
+        input=input,
+        output=output,
+        curr_topk_ids=curr_topk_ids,
+        routed_scaling_factor=routed_scaling_factor,
+        E=E,
+    )
 
 
 def moe_sum_tree_reduce(
@@ -1905,7 +2123,10 @@ def moe_sum_tree_reduce(
     E: int,
 ):
     curr_topk_ids = curr_topk_ids.to(torch.int32)
-    if os.environ.get("SGLANG_MOE_TREE_REDUCE_USE_V2", "0") == "1":
+    if (
+        os.environ.get("SGLANG_MOE_TREE_REDUCE_USE_V2", "0") == "1"
+        and input.shape[1] in (8, 10)
+    ):
         return moe_sum_tree_reduce_v2(
             input=input,
             output=output,
@@ -1936,6 +2157,3 @@ def moe_sum_tree_reduce(
 #     print("using optimized moe_sum_tree_reduce_optim")
 # else:
 #     print("using original moe_sum_tree_reduce_original")
-
-if os.getenv("TREE_ALL_REDUCE_OPTIM", "0") == "1":
-    tree_all_reduce_sum = tree_all_reduce_sum_optim

--- a/python/sglang/srt/true_on_policy/__init__.py
+++ b/python/sglang/srt/true_on_policy/__init__.py
@@ -2,22 +2,24 @@
 
 from .config import (
     ROW_LINEAR_INV_BLOCK_K,
+    get_moe_topk_tiebreak,
     get_on_policy_rms_norm_kwargs,
-    get_rl_on_policy_target,
     is_tp_invariant_target,
     is_true_on_policy_enabled,
-    patch_prefill_only_deterministic_inference_for_cuda_graph,
     should_disable_flashinfer_allreduce_fusion,
     should_disable_fused_qk_norm_mrope,
     should_disable_mlp_allreduce_fusion_for_on_policy,
     should_disable_reduce_scatter_for_on_policy,
     should_force_bfloat16_dense_tensor_math,
     should_force_bfloat16_lm_head,
+    should_use_deterministic_moe_combine,
+    should_use_deterministic_moe_routing,
     should_use_tp_invariant_row_linear,
     should_use_tp_invariant_tree_all_reduce,
 )
 from .contracts import (
     QWEN3_DENSE_TRUE_ON_POLICY_V1,
+    QWEN3_MOE_TRUE_ON_POLICY_V1,
     SGLangTrueOnPolicyContract,
     SGLangTrueOnPolicyRuntimePolicy,
     get_true_on_policy_contract,
@@ -27,15 +29,15 @@ from .contracts import (
 
 __all__ = [
     "QWEN3_DENSE_TRUE_ON_POLICY_V1",
+    "QWEN3_MOE_TRUE_ON_POLICY_V1",
     "ROW_LINEAR_INV_BLOCK_K",
     "SGLangTrueOnPolicyContract",
     "SGLangTrueOnPolicyRuntimePolicy",
     "get_true_on_policy_contract",
     "get_on_policy_rms_norm_kwargs",
-    "get_rl_on_policy_target",
+    "get_moe_topk_tiebreak",
     "is_tp_invariant_target",
     "is_true_on_policy_enabled",
-    "patch_prefill_only_deterministic_inference_for_cuda_graph",
     "resolve_true_on_policy_runtime_policy",
     "validate_true_on_policy_contract",
     "should_disable_flashinfer_allreduce_fusion",
@@ -44,6 +46,8 @@ __all__ = [
     "should_disable_reduce_scatter_for_on_policy",
     "should_force_bfloat16_dense_tensor_math",
     "should_force_bfloat16_lm_head",
+    "should_use_deterministic_moe_combine",
+    "should_use_deterministic_moe_routing",
     "should_use_tp_invariant_row_linear",
     "should_use_tp_invariant_tree_all_reduce",
 ]

--- a/python/sglang/srt/true_on_policy/config.py
+++ b/python/sglang/srt/true_on_policy/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import contextlib
-from typing import Any, Iterator, Optional
+from typing import Any, Optional
 
 import torch
 
@@ -10,75 +9,102 @@ from sglang.srt.true_on_policy.contracts import resolve_true_on_policy_runtime_p
 ROW_LINEAR_INV_BLOCK_K = 128
 
 
-def _get_global_server_args() -> Any:
+def _get_server_args(server_args: Optional[Any] = None) -> Any:
+    if server_args is not None:
+        return server_args
+
     from sglang.srt.server_args import get_global_server_args
 
     return get_global_server_args()
 
 
-def get_rl_on_policy_target() -> Optional[str]:
-    return getattr(_get_global_server_args(), "rl_on_policy_target", None)
+def is_true_on_policy_enabled(server_args: Optional[Any] = None) -> bool:
+    return resolve_true_on_policy_runtime_policy(_get_server_args(server_args)).enabled
 
 
-def is_true_on_policy_enabled() -> bool:
-    return resolve_true_on_policy_runtime_policy(_get_global_server_args()).enabled
-
-
-def is_tp_invariant_target() -> bool:
+def is_tp_invariant_target(server_args: Optional[Any] = None) -> bool:
     return resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).tp_invariant_row_linear
 
 
-def should_disable_reduce_scatter_for_on_policy() -> bool:
+def should_disable_reduce_scatter_for_on_policy(
+    server_args: Optional[Any] = None,
+) -> bool:
     return resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).disable_reduce_scatter
 
 
-def should_disable_mlp_allreduce_fusion_for_on_policy() -> bool:
+def should_disable_mlp_allreduce_fusion_for_on_policy(
+    server_args: Optional[Any] = None,
+) -> bool:
     return resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).disable_mlp_allreduce_fusion
 
 
-def should_disable_flashinfer_allreduce_fusion() -> bool:
+def should_disable_flashinfer_allreduce_fusion(
+    server_args: Optional[Any] = None,
+) -> bool:
     return resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).disable_flashinfer_allreduce_fusion
 
 
-def should_force_bfloat16_dense_tensor_math() -> bool:
+def should_force_bfloat16_dense_tensor_math(
+    server_args: Optional[Any] = None,
+) -> bool:
     return resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).force_bfloat16_dense_tensor_math
 
 
 def should_force_bfloat16_lm_head(
     *,
+    server_args: Optional[Any] = None,
     use_fp32_lm_head: bool = False,
 ) -> bool:
     return (
         resolve_true_on_policy_runtime_policy(
-            _get_global_server_args()
+            _get_server_args(server_args)
         ).force_bfloat16_lm_head
         and not use_fp32_lm_head
     )
 
 
-def should_disable_fused_qk_norm_mrope() -> bool:
+def should_disable_fused_qk_norm_mrope(
+    server_args: Optional[Any] = None,
+) -> bool:
     return resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).disable_fused_qk_norm_mrope
 
 
+def should_use_deterministic_moe_routing(server_args: Optional[Any] = None) -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_server_args(server_args)
+    ).deterministic_moe_routing
+
+
+def should_use_deterministic_moe_combine(server_args: Optional[Any] = None) -> bool:
+    return resolve_true_on_policy_runtime_policy(
+        _get_server_args(server_args)
+    ).deterministic_moe_combine
+
+
+def get_moe_topk_tiebreak(server_args: Optional[Any] = None) -> Optional[str]:
+    return resolve_true_on_policy_runtime_policy(_get_server_args(server_args)).moe_topk_tiebreak
+
+
 def get_on_policy_rms_norm_kwargs(
+    server_args: Optional[Any] = None,
     *,
     weight_dtype: Optional[torch.dtype] = None,
     override_orig_dtype: Optional[torch.dtype] = None,
     fp32_residual: bool = False,
 ) -> dict[str, Any]:
-    if not is_true_on_policy_enabled():
+    if not is_true_on_policy_enabled(server_args):
         return {}
 
     kwargs: dict[str, Any] = {
@@ -94,10 +120,11 @@ def get_on_policy_rms_norm_kwargs(
 
 def should_use_tp_invariant_row_linear(
     k_size: int,
+    server_args: Optional[Any] = None,
     row_linear_enable_inv: Optional[bool] = None,
 ) -> bool:
     policy_enabled = resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).tp_invariant_row_linear
     if row_linear_enable_inv is not None:
         policy_enabled = policy_enabled and row_linear_enable_inv
@@ -110,41 +137,13 @@ def should_use_tp_invariant_row_linear(
 
 
 def should_use_tp_invariant_tree_all_reduce(
+    server_args: Optional[Any] = None,
     accl_binary_tree_enabled: Optional[bool] = None,
 ) -> bool:
     policy_enabled = resolve_true_on_policy_runtime_policy(
-        _get_global_server_args()
+        _get_server_args(server_args)
     ).deterministic_tree_all_reduce
     if accl_binary_tree_enabled is not None:
         policy_enabled = policy_enabled and not accl_binary_tree_enabled
 
     return policy_enabled
-
-
-@contextlib.contextmanager
-def patch_prefill_only_deterministic_inference_for_cuda_graph(
-    server_args: Any,
-    *,
-    attn_backend: Optional[Any] = None,
-    dvr_target_verify_cuda_graph: bool = False,
-) -> Iterator[bool]:
-    enabled = (
-        getattr(server_args, "enable_prefill_only_deterministic_inference", False)
-        and not dvr_target_verify_cuda_graph
-    )
-    if not enabled:
-        yield False
-        return
-
-    saved_num_splits = None
-    if attn_backend is not None and hasattr(attn_backend, "num_splits"):
-        saved_num_splits = attn_backend.num_splits
-
-    try:
-        if attn_backend is not None and hasattr(attn_backend, "num_splits"):
-            attn_backend.num_splits = 0
-
-        yield True
-    finally:
-        if attn_backend is not None and hasattr(attn_backend, "num_splits"):
-            attn_backend.num_splits = saved_num_splits

--- a/python/sglang/srt/true_on_policy/contracts.py
+++ b/python/sglang/srt/true_on_policy/contracts.py
@@ -5,11 +5,13 @@ from typing import Any, Optional
 
 from sglang.srt.true_on_policy.schema import (
     QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
+    QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA,
     TrueOnPolicyContractName,
     TrueOnPolicyContractSchema,
 )
 
 QWEN3_DENSE_TRUE_ON_POLICY_V1 = QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA.name
+QWEN3_MOE_TRUE_ON_POLICY_V1 = QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA.name
 
 
 @dataclass(frozen=True)
@@ -26,6 +28,11 @@ class SGLangTrueOnPolicyRuntimePolicy:
     tp_invariant_row_linear: bool
     deterministic_tree_all_reduce: bool
     disable_fused_qk_norm_mrope: bool
+    deterministic_moe_routing: bool
+    moe_topk_tiebreak: Optional[str]
+    deterministic_moe_dispatch: bool
+    deterministic_moe_combine: bool
+    ep_invariant_moe: bool
 
 
 DEFAULT_RUNTIME_POLICY = SGLangTrueOnPolicyRuntimePolicy(
@@ -39,6 +46,11 @@ DEFAULT_RUNTIME_POLICY = SGLangTrueOnPolicyRuntimePolicy(
     tp_invariant_row_linear=False,
     deterministic_tree_all_reduce=False,
     disable_fused_qk_norm_mrope=False,
+    deterministic_moe_routing=False,
+    moe_topk_tiebreak=None,
+    deterministic_moe_dispatch=False,
+    deterministic_moe_combine=False,
+    ep_invariant_moe=False,
 )
 
 
@@ -54,6 +66,8 @@ class SGLangTrueOnPolicyContract:
 
     def policy_for(self, server_args: Any) -> SGLangTrueOnPolicyRuntimePolicy:
         uses_tp_invariant_rollout = getattr(server_args, "tp_size", 1) > 1
+        uses_ep_invariant_moe = getattr(server_args, "ep_size", 1) > 1
+        is_moe = self.schema.model_family == "qwen3_moe"
         return SGLangTrueOnPolicyRuntimePolicy(
             contract_name=self.name,
             enabled=True,
@@ -65,6 +79,11 @@ class SGLangTrueOnPolicyContract:
             tp_invariant_row_linear=uses_tp_invariant_rollout,
             deterministic_tree_all_reduce=uses_tp_invariant_rollout,
             disable_fused_qk_norm_mrope=True,
+            deterministic_moe_routing=is_moe,
+            moe_topk_tiebreak="stable_sort" if is_moe else None,
+            deterministic_moe_dispatch=is_moe and uses_ep_invariant_moe,
+            deterministic_moe_combine=is_moe and uses_ep_invariant_moe,
+            ep_invariant_moe=is_moe and uses_ep_invariant_moe,
         )
 
 
@@ -72,11 +91,15 @@ QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT = SGLangTrueOnPolicyContract(
     schema=QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA,
 )
 
+QWEN3_MOE_TRUE_ON_POLICY_CONTRACT = SGLangTrueOnPolicyContract(
+    schema=QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA,
+)
+
 
 _CONTRACT_BY_NAME = {
     QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT.name: QWEN3_DENSE_TRUE_ON_POLICY_CONTRACT,
+    QWEN3_MOE_TRUE_ON_POLICY_CONTRACT.name: QWEN3_MOE_TRUE_ON_POLICY_CONTRACT,
 }
-
 
 def get_true_on_policy_contract(contract_name: str) -> SGLangTrueOnPolicyContract:
     try:

--- a/python/sglang/srt/true_on_policy/schema.py
+++ b/python/sglang/srt/true_on_policy/schema.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-TrueOnPolicyContractName = Literal["qwen3_dense_true_on_policy_v1"]
+TrueOnPolicyContractName = Literal[
+    "qwen3_dense_true_on_policy_v1",
+    "qwen3_moe_true_on_policy_v1",
+]
 ModelFamily = Literal["qwen3_dense", "qwen3_moe", "qwen3_next"]
-KernelContract = Literal["qwen3_dense_sglang_math"]
+KernelContract = Literal["qwen3_dense_sglang_math", "qwen3_moe_sglang_math"]
 LogprobContract = Literal["sglang_prefill"]
 
 
@@ -26,6 +29,16 @@ QWEN3_DENSE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
     name="qwen3_dense_true_on_policy_v1",
     model_family="qwen3_dense",
     required_kernel_contracts=("qwen3_dense_sglang_math",),
+    logprob_contract="sglang_prefill",
+    sglang_attention_backend="fa3",
+    fsdp_attention_implementation="flash_attention_3",
+    disable_megatron_sequence_parallel=True,
+)
+
+QWEN3_MOE_TRUE_ON_POLICY_V1_SCHEMA = TrueOnPolicyContractSchema(
+    name="qwen3_moe_true_on_policy_v1",
+    model_family="qwen3_moe",
+    required_kernel_contracts=("qwen3_dense_sglang_math", "qwen3_moe_sglang_math"),
     logprob_contract="sglang_prefill",
     sglang_attention_backend="fa3",
     fsdp_attention_implementation="flash_attention_3",

--- a/test/manual/layers/test_layernorm.py
+++ b/test/manual/layers/test_layernorm.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 
+from sglang.srt.batch_invariant_ops import true_on_policy_rms_norm
 from sglang.srt.layers.layernorm import GemmaRMSNorm, LayerNorm, RMSNorm
 from sglang.test.test_utils import CustomTestCase
 
@@ -75,6 +76,83 @@ class TestRMSNorm(CustomTestCase):
 
         self.assertEqual(out.dtype, torch.float32)
         self.assertTrue(torch.equal(out, ref_out))
+
+    def test_true_on_policy_fused_rms_norm_qk_dtype_boundary(self):
+        torch.manual_seed(0)
+
+        hidden_size = 128
+        x = torch.randn(13, hidden_size, dtype=torch.bfloat16)
+        weight = torch.randn(hidden_size, dtype=torch.float32)
+
+        actual = true_on_policy_rms_norm(
+            x,
+            weight,
+            eps=1e-6,
+            cast_x_before_out_mul=True,
+            norm_cast_dtype=torch.bfloat16,
+            weight_cast_dtype=torch.float32,
+        )
+
+        x_float = x.float()
+        expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+        expected = weight * expected.to(torch.bfloat16)
+
+        self.assertEqual(actual.dtype, torch.float32)
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    def test_true_on_policy_fused_rms_norm_residual_pair_dtype_boundary(self):
+        torch.manual_seed(0)
+
+        hidden_size = 128
+        x = torch.randn(13, hidden_size, dtype=torch.bfloat16)
+        residual = torch.randn_like(x)
+        post_residual = torch.randn_like(x)
+        weight = torch.randn(hidden_size, dtype=torch.float32)
+
+        actual, actual_residual = true_on_policy_rms_norm(
+            x,
+            weight,
+            eps=1e-6,
+            residual=residual,
+            post_residual_addition=post_residual,
+            cast_x_before_out_mul=True,
+            norm_cast_dtype=torch.float32,
+            weight_cast_dtype=torch.float32,
+            residual_dtype=torch.float32,
+        )
+
+        x_float = x.float() + residual.float() + post_residual.float()
+        expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+        expected = weight * expected
+
+        self.assertEqual(actual.dtype, torch.float32)
+        self.assertEqual(actual_residual.dtype, torch.float32)
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(actual_residual, x_float)
+
+    def test_true_on_policy_fused_rms_norm_final_norm_dtype_boundary(self):
+        torch.manual_seed(0)
+
+        hidden_size = 128
+        x = torch.randn(13, hidden_size, dtype=torch.float32)
+        weight = torch.randn(hidden_size, dtype=torch.float32)
+
+        actual = true_on_policy_rms_norm(
+            x,
+            weight,
+            eps=1e-6,
+            cast_x_before_out_mul=True,
+            norm_cast_dtype=torch.bfloat16,
+            weight_cast_dtype=torch.bfloat16,
+            output_dtype=torch.bfloat16,
+        )
+
+        x_float = x.float()
+        expected = x_float * torch.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + 1e-6)
+        expected = weight.to(torch.bfloat16) * expected.to(torch.bfloat16)
+
+        self.assertEqual(actual.dtype, torch.bfloat16)
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
 
 class TestGemmaRMSNorm(CustomTestCase):

--- a/test/registered/core/test_tp_invariant_ops.py
+++ b/test/registered/core/test_tp_invariant_ops.py
@@ -16,6 +16,7 @@ All bitwise assertions use torch.equal, never approximate tolerances.
 import os
 import random
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
@@ -28,6 +29,7 @@ from sglang.srt.tp_invariant_ops import (
     matmul_tp_persistent,
     moe_sum_tree_reduce,
     set_tp_invariant_mode,
+    stable_topk,
     tree_all_reduce_sum,
 )
 from sglang.srt.tp_invariant_ops.tp_invariant_ops import (
@@ -389,6 +391,37 @@ class TestBFloat16Ops(unittest.TestCase):
         expected = torch.tensor([[4.0, 6.0]], dtype=torch.bfloat16)
         torch.testing.assert_close(output, expected)
 
+    def test_moe_sum_tree_reduce_v2_env_falls_back_for_unsupported_topk(self):
+        input_tensor = torch.zeros(1, 3, 2)
+        curr_topk_ids = torch.tensor([[0, 1, 2]], dtype=torch.int64)
+        output = torch.empty(1, 2)
+
+        def fake_v1(**kwargs):
+            kwargs["output"].fill_(7.0)
+            return kwargs["output"]
+
+        with (
+            patch.dict(os.environ, {"SGLANG_MOE_TREE_REDUCE_USE_V2": "1"}),
+            patch(
+                "sglang.srt.tp_invariant_ops.tp_invariant_ops.moe_sum_tree_reduce_v1",
+                side_effect=fake_v1,
+            ) as mocked_v1,
+            patch(
+                "sglang.srt.tp_invariant_ops.tp_invariant_ops.moe_sum_tree_reduce_v2"
+            ) as mocked_v2,
+        ):
+            result = moe_sum_tree_reduce(
+                input=input_tensor,
+                output=output,
+                curr_topk_ids=curr_topk_ids,
+                routed_scaling_factor=1.0,
+                E=4,
+            )
+
+        mocked_v2.assert_not_called()
+        mocked_v1.assert_called_once()
+        self.assertTrue(torch.equal(result, torch.full_like(output, 7.0)))
+
 
 # ---------------------------------------------------------------------------
 # MoE tree reduce: EP/slot invariance
@@ -574,7 +607,6 @@ class TestTreeAllReduceNonDistributed(unittest.TestCase):
             shards = [torch.tensor([float(i + 1)]) for i in range(n)]
             result = _fixed_tree_sum_tensors(shards)
             self.assertAlmostEqual(result.item(), n * (n + 1) / 2, places=5)
-
 
 # ---------------------------------------------------------------------------
 # MoE reduce: order-matters proof
@@ -824,6 +856,7 @@ class TestDistributedTreeAllReduce(unittest.TestCase):
             if own_pg:
                 dist.destroy_process_group()
 
+
     @unittest.skipUnless(
         int(os.environ.get("WORLD_SIZE", "1")) > 1,
         "requires torchrun with WORLD_SIZE > 1",
@@ -860,6 +893,68 @@ class TestDistributedTreeAllReduce(unittest.TestCase):
         finally:
             if own_pg:
                 dist.destroy_process_group()
+
+
+class TestStableTopK(unittest.TestCase):
+    """stable_topk must break ties by smaller expert id and match SGLang ↔ Megatron."""
+
+    def test_exact_ties_resolved_by_smaller_expert_id(self):
+        scores = torch.zeros(1, 8)
+        _, ids = stable_topk(scores, top_k=4)
+        self.assertTrue(torch.equal(ids[0].sort().values, torch.tensor([0, 1, 2, 3])))
+
+    def test_partial_ties_preserve_real_ordering(self):
+        scores = torch.tensor([[0.1, 0.5, 0.5, 0.2, 0.5, 0.05, 0.5, 0.0]])
+        _, ids = stable_topk(scores, top_k=3)
+        self.assertEqual(set(ids[0].tolist()), {1, 2, 4})
+
+    def test_returns_original_precision_scores(self):
+        scores = torch.tensor([[0.9, 0.1, 0.7, 0.4]], dtype=torch.bfloat16)
+        gathered, ids = stable_topk(scores, top_k=2)
+        self.assertEqual(gathered.dtype, scores.dtype)
+        self.assertTrue(torch.equal(ids[0].sort().values, torch.tensor([0, 2])))
+
+    def test_deterministic_across_runs(self):
+        torch.manual_seed(0)
+        scores = torch.randn(64, 128)
+        a_vals, a_ids = stable_topk(scores, top_k=8)
+        b_vals, b_ids = stable_topk(scores, top_k=8)
+        self.assertTrue(torch.equal(a_vals, b_vals))
+        self.assertTrue(torch.equal(a_ids, b_ids))
+
+    def test_cuda_triton_matches_torch_fallback(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+        torch.manual_seed(0)
+        scores = torch.randn(64, 128, device="cuda", dtype=torch.float32)
+        scores[0, :8] = 0.5
+        scores[1, :4] = scores[1, 4:8]
+
+        old_flag = os.environ.get("SGLANG_TRUE_ON_POLICY_STABLE_TOPK_TRITON")
+        try:
+            os.environ["SGLANG_TRUE_ON_POLICY_STABLE_TOPK_TRITON"] = "0"
+            ref_vals, ref_ids = stable_topk(scores, top_k=8)
+            os.environ["SGLANG_TRUE_ON_POLICY_STABLE_TOPK_TRITON"] = "1"
+            vals, ids = stable_topk(scores, top_k=8)
+        finally:
+            if old_flag is None:
+                os.environ.pop("SGLANG_TRUE_ON_POLICY_STABLE_TOPK_TRITON", None)
+            else:
+                os.environ["SGLANG_TRUE_ON_POLICY_STABLE_TOPK_TRITON"] = old_flag
+
+        self.assertTrue(torch.equal(vals, ref_vals))
+        self.assertTrue(torch.equal(ids, ref_ids))
+
+    def test_cuda_requires_grad_uses_autograd_path(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+        scores = torch.randn(4, 16, device="cuda", requires_grad=True)
+        vals, _ = stable_topk(scores, top_k=4)
+        self.assertIsNotNone(vals.grad_fn)
+        vals.sum().backward()
+        self.assertIsNotNone(scores.grad)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked split of #24408.

Base branch: `split/pr24408-09-qwen3-moe-model`
Head branch: `split/pr24408-10-lora-routing`

This is PR 10 of 16. The stack is cumulative; the final branch matches the original PR head.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->