### PR TITLE
[11/16] Update LoRA memory and virtual expert handling

### DIFF
--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -284,55 +284,6 @@ class LoRAMemoryPool:
             f"Expected dict or 3D torch.Tensor, got {type(weights).__name__}."
         )
 
-    def _row_parallel_shard_tp(
-        self, module_name: str, base_model: torch.nn.Module, layer_idx: int
-    ) -> int:
-        """Shard count for a non-MoE row-parallel module's activation axis.
-
-        Probes the base module's ``input_size // input_size_per_partition`` so
-        the LoRA buffer matches the actual shard regardless of which TP group
-        owns it — covers DP-attention (``o_proj`` uses ``attn_tp_size``) and
-        shared-expert dense-vs-MoE per-layer-TP differences. Falls back to
-        ``self.tp_size``. Cached per ``(module_name, layer_idx)``.
-
-        MoE-internal names go through ``self.moe_tp_size`` upstream.
-        """
-        cache = getattr(self, "_row_parallel_tp_cache", None)
-        if cache is None:
-            cache = {}
-            setattr(self, "_row_parallel_tp_cache", cache)
-        key = (module_name, layer_idx)
-        if key in cache:
-            return cache[key]
-
-        layer_markers = (f".layers.{layer_idx}.", f"layers.{layer_idx}.")
-
-        def _probe(m):
-            in_size = getattr(m, "input_size", None)
-            per_part = getattr(m, "input_size_per_partition", None)
-            if in_size is not None and per_part is not None and per_part > 0:
-                return max(1, in_size // per_part)
-            inner = getattr(m, "base_layer", None)
-            if inner is not None and inner is not m:
-                return _probe(inner)
-            return None
-
-        suffix = f".{module_name}"
-        found = None
-        for _name, module in base_model.named_modules():
-            if not _name.endswith(suffix):
-                continue
-            if not any(marker in _name for marker in layer_markers):
-                continue
-            r = _probe(module)
-            if r is not None:
-                found = r
-                break
-
-        out = found if found is not None else self.tp_size
-        cache[key] = out
-        return out
-
     def _get_standard_shape(
         self,
         module_name: str,
@@ -345,12 +296,8 @@ class LoRAMemoryPool:
             module_name, self.base_hf_config, base_model, layer_idx
         )
         c = get_stacked_multiply(module_name, base_model)
-        # Non-MoE row-parallel modules: probe the actual shard size so o_proj /
-        # down_proj match attn_tp under DP-attention and the shared-experts
-        # dense-vs-MoE per-layer-TP differences.
-        row_tp = self._row_parallel_shard_tp(module_name, base_model, layer_idx)
-        if row_tp > 1 and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES:
-            input_dim = divide(input_dim, row_tp)
+        if self.tp_size > 1 and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES:
+            input_dim = divide(input_dim, self.tp_size)
         return (self.max_loras_per_batch, max_lora_dim * c, input_dim)
 
     def get_lora_A_shape(
@@ -371,12 +318,9 @@ class LoRAMemoryPool:
             module_name, self.base_hf_config, base_model, layer_idx
         )
         c = get_stacked_multiply(module_name, base_model)
-        # MoE modules shard along `moe_tp_size`; non-MoE row-parallel modules
-        # use a probed shard that may be attn_tp under DP-attention.
+        # MoE modules shard along `moe_tp_size`, not the outer `tp_size`.
         effective_tp_size = (
-            self.moe_tp_size
-            if self.is_moe_module(module_name)
-            else self._row_parallel_shard_tp(module_name, base_model, layer_idx)
+            self.moe_tp_size if self.is_moe_module(module_name) else self.tp_size
         )
         if (
             effective_tp_size > 1
@@ -468,12 +412,9 @@ class LoRAMemoryPool:
         _, output_dim = get_hidden_dim(
             module_name, self.base_hf_config, base_model, layer_idx
         )
-        # MoE modules shard along `moe_tp_size`; non-MoE column-parallel modules
-        # use a probed shard that may be attn_tp under DP-attention.
+        # MoE modules shard along `moe_tp_size`, not the outer `tp_size`.
         effective_tp_size = (
-            self.moe_tp_size
-            if self.is_moe_module(module_name)
-            else self._row_parallel_shard_tp(module_name, base_model, layer_idx)
+            self.moe_tp_size if self.is_moe_module(module_name) else self.tp_size
         )
         if (
             effective_tp_size > 1
@@ -824,22 +765,16 @@ class LoRAMemoryPool:
                 expert_match = re.search(r"experts\.(\d+)\.", name)
 
                 if expert_match:
-                    # Per-expert MoE weight — 2D tensors, one per expert.
-                    # Init A and B independently: under ``experts_shared_outer_loras``,
-                    # fc1 has shared A (Tensor in temp_A_buffer) + per-expert B
-                    # (dict in temp_B_buffer), and fc2 has the opposite. A shared
-                    # init on both would either clobber the shared Tensor or leave
-                    # the per-expert side as None.
+                    # Per-expert MoE weight — 2D tensors, one per expert
                     target_module = target_module + "_moe"
+                    if temp_A_buffer[target_module] is None:
+                        temp_A_buffer[target_module] = {}
+                        temp_B_buffer[target_module] = {}
 
                     expert_id = int(expert_match.group(1))
                     if "lora_A" in name:
-                        if temp_A_buffer[target_module] is None:
-                            temp_A_buffer[target_module] = {}
                         temp_A_buffer[target_module][expert_id] = weights
                     else:
-                        if temp_B_buffer[target_module] is None:
-                            temp_B_buffer[target_module] = {}
                         temp_B_buffer[target_module][expert_id] = weights
                 elif "experts" in name and weights.dim() == 3:
                     # Shared outer MoE weight — 3D tensor [expert_dim, rank, hidden]

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -515,7 +515,7 @@ def _merged_experts_fused_moe_lora_add_impl(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
     lora_a: torch.Tensor,
-    lora_b: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
+    lora_b: torch.Tensor,
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     token_lora_mapping: torch.Tensor,
@@ -524,30 +524,13 @@ def _merged_experts_fused_moe_lora_add_impl(
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
 ) -> None:
-    """Fused virtual-experts LoRA delta add.
-
-    ``lora_b`` accepts either a single tensor or a sequence of tensors stacked
-    along the output dim. Length-2 is the gate_up case where A has rank ``2*r``
-    (gate's A and up's A concatenated along rank) and each B has rank ``r``.
-    The shrink runs once over the full ``2*r`` rank; the expand runs once per
-    B, each reading its half of the intermediate and writing to its slice of
-    ``output``.
     """
-    lora_b_list: list[torch.Tensor] = (
-        list(lora_b) if isinstance(lora_b, (list, tuple)) else [lora_b]
-    )
-    n_b = len(lora_b_list)
-    assert n_b in (1, 2), f"lora_b must be length 1 or 2, got {n_b}"
-    b_rank = lora_b_list[0].shape[3]
-    for b in lora_b_list[1:]:
-        assert b.shape == lora_b_list[0].shape, (
-            f"all lora_b tensors must share shape; got {[tuple(t.shape) for t in lora_b_list]}"
-        )
-
+    1. Prepare virtual expert routing metadata from topk_ids + token_lora_mapping * num_experts.
+    2. Flatten LoRA weights from [max_loras, num_experts, ...] to [max_loras * num_experts, ...].
+    3. Run regular SGLang fused-MoE kernels for LoRA A and LoRA B.
+    4. Mask out tokens with token_lora_mapping == -1 on the add path.
+    """
     max_loras, _, max_lora_rank, _ = lora_a.shape
-    assert max_lora_rank == n_b * b_rank, (
-        f"lora_a rank {max_lora_rank} != n_b ({n_b}) * lora_b rank {b_rank}"
-    )
     input_top_k = 1 if hidden_states.shape[0] == topk_ids.numel() else topk_ids.shape[1]
 
     def _merge_lora_expert_weight(t: torch.Tensor) -> torch.Tensor:
@@ -659,10 +642,9 @@ def _merged_experts_fused_moe_lora_add_impl(
     )
 
     lora_a_virtual = _merge_lora_expert_weight(lora_a)
-    lora_b_virtuals = [_merge_lora_expert_weight(b) for b in lora_b_list]
+    lora_b_virtual = _merge_lora_expert_weight(lora_b)
     num_experts_a = lora_a.shape[1]
-    num_experts_b = lora_b_list[0].shape[1]
-    half_out = lora_b_list[0].shape[2]
+    num_experts_b = lora_b.shape[1]
 
     intermediate = torch.zeros(
         [token_lora_mapping.shape[0], topk_ids.shape[1], max_lora_rank],
@@ -696,7 +678,7 @@ def _merged_experts_fused_moe_lora_add_impl(
         a_stage_config,
     )
 
-    b_stage_config = _get_stage_config(lora_b_virtuals[0], 1)
+    b_stage_config = _get_stage_config(lora_b_virtual, 1)
     (
         sorted_token_ids,
         expert_ids,
@@ -710,47 +692,33 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    # n_b expands. For len 1: K=b_rank covers full intermediate, write full output.
-    # For len 2 (gate_up): split intermediate along rank into [gate, up] halves
-    # (each contiguous, K=b_rank=r) and output along last dim into [gate, up]
-    # halves (each of width half_out). Each B in lora_b_virtuals is its own
-    # half's weight tensor, naturally K=b_rank.
-    for b_idx, b_virtual in enumerate(lora_b_virtuals):
-        if n_b == 1:
-            inter_arg = intermediate.view(-1, b_rank)
-            out_arg = output
-        else:
-            inter_arg = intermediate[..., b_idx * b_rank : (b_idx + 1) * b_rank].contiguous().view(-1, b_rank)
-            out_arg = output[..., b_idx * half_out : (b_idx + 1) * half_out].contiguous()
-        invoke_fused_moe_kernel(
-            inter_arg,
-            b_virtual,
-            None,
-            out_arg,
-            None,
-            None,
-            None,
-            topk_weights,
-            topk_ids,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            mul_routed_weight,
-            1,
-            b_stage_config,
-            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-            False,
-            False,
-            False,
-            False,
-            False,
-            None,
-            fuse_add_to_output=True,
-            add_output_mask=token_lora_mask,
-            router_topk=topk_ids.shape[1],
-        )
-        if n_b != 1:
-            output[..., b_idx * half_out : (b_idx + 1) * half_out].copy_(out_arg)
+    invoke_fused_moe_kernel(
+        intermediate.view(-1, max_lora_rank),
+        lora_b_virtual,
+        None,
+        output,
+        None,
+        None,
+        None,
+        topk_weights,
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        1,
+        b_stage_config,
+        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+        False,
+        False,
+        False,
+        False,
+        False,
+        None,
+        fuse_add_to_output=True,
+        add_output_mask=token_lora_mask,
+        router_topk=topk_ids.shape[1],
+    )
 
 
 def _merged_experts_fused_moe_lora_add_op(
@@ -793,7 +761,7 @@ def merged_experts_fused_moe_lora_add(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
     lora_a: torch.Tensor,
-    lora_b: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
+    lora_b: torch.Tensor,
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     token_lora_mapping: torch.Tensor,
@@ -802,12 +770,7 @@ def merged_experts_fused_moe_lora_add(
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
 ) -> None:
-    """Public API: wraps the registered op with routing_cache support.
-
-    ``lora_b`` accepts a sequence of length 2 for the gate_up case (each B
-    holds one half of the stacked output, rank ``r``, with A's rank ``2*r``);
-    a single tensor is used for the down case.
-    """
+    """Public API: wraps the registered op with routing_cache support."""
     _merged_experts_fused_moe_lora_add_impl(
         output,
         hidden_states,


### PR DESCRIPTION
Stacked split of #24408.

Base branch: `split/pr24408-10-lora-routing`
Head branch: `split/pr24408-11-lora-memory`

This is PR 11 of 16. The stack is cumulative; the final branch matches the original PR head.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->