### PR TITLE
bench_serving: add Zipfian shared-prefix sampling to generated-shared-prefix

### DIFF
--- a/docs_new/docs/developer_guide/bench_serving.mdx
+++ b/docs_new/docs/developer_guide/bench_serving.mdx
@@ -82,6 +82,8 @@ Generated Shared Prefix flags (for `generated-shared-prefix`):
 - `--gsp-system-prompt-len`
 - `--gsp-question-len`
 - `--gsp-output-len`
+- `--gsp-group-distribution {uniform,zipf}`: per-request prefix-group sampling distribution (default: `uniform`). With `zipf`, each request's group is sampled by rank with `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)`; rank starts at 1 and group index 0 is the hottest. The on-disk dataset cache is bypassed in `zipf` mode.
+- `--gsp-zipf-alpha FLOAT`: Zipf exponent for `--gsp-group-distribution=zipf`. Must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups. Required when the distribution is `zipf`; must be omitted otherwise.
 
 Image dataset flags (for `image`):
 
@@ -293,6 +295,26 @@ python3 -m sglang.bench_serving \
   --gsp-system-prompt-len 2048 --gsp-question-len 128 --gsp-output-len 256 \
   --num-prompts 1024
 ```
+
+Zipfian / power-law prefix popularity (opt-in via `--gsp-group-distribution=zipf`):
+
+```bash Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --host 127.0.0.1 --port 30000 \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --dataset-name generated-shared-prefix \
+  --gsp-num-groups 64 --gsp-prompts-per-group 16 \
+  --gsp-system-prompt-len 2048 --gsp-question-len 128 --gsp-output-len 256 \
+  --gsp-group-distribution zipf --gsp-zipf-alpha 1.2 \
+  --seed 42
+```
+
+`zipf` mode samples each request's prefix group from the rank-based distribution `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)` with rank starting at 1, so group index 0 is the hottest. The total request count stays `num_groups * prompts_per_group` — identical to `uniform` mode — and only the per-request group assignment changes. `alpha` must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups.
+
+In `zipf` mode the on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` is bypassed (neither read nor written), so each run regenerates the workload fresh. This avoids any risk of silently reusing a `uniform`-mode cache payload for a `zipf` invocation, or vice versa.
+
+This flag controls prefix-popularity shape only. It does not by itself reproduce any production trace or guarantee an observed cache-hit rate for a given engine.
 
 6) Tokenized prompts (ids) for strict length control (sglang only):
 

--- a/docs_new/docs/developer_guide/bench_serving.mdx
+++ b/docs_new/docs/developer_guide/bench_serving.mdx
@@ -82,7 +82,7 @@ Generated Shared Prefix flags (for `generated-shared-prefix`):
 - `--gsp-system-prompt-len`
 - `--gsp-question-len`
 - `--gsp-output-len`
-- `--gsp-group-distribution {uniform,zipf}`: per-request prefix-group sampling distribution (default: `uniform`). With `zipf`, each request's group is sampled by rank with `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)`; rank starts at 1 and group index 0 is the hottest. The on-disk dataset cache is bypassed in `zipf` mode.
+- `--gsp-group-distribution {uniform,zipf}`: per-request prefix-group sampling distribution (default: `uniform`). With `zipf`, each request's group is sampled by rank with `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)`; rank starts at 1 and group index 0 is the hottest. The on-disk dataset cache uses a distinct key per `(group_distribution, zipf_alpha)`, so uniform-mode caches are never mixed with zipf-mode caches.
 - `--gsp-zipf-alpha FLOAT`: Zipf exponent for `--gsp-group-distribution=zipf`. Must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups. Required when the distribution is `zipf`; must be omitted otherwise.
 
 Image dataset flags (for `image`):
@@ -312,7 +312,7 @@ python3 -m sglang.bench_serving \
 
 `zipf` mode samples each request's prefix group from the rank-based distribution `p(rank) = (1/rank**alpha) / sum_k(1/k**alpha)` with rank starting at 1, so group index 0 is the hottest. The total request count stays `num_groups * prompts_per_group` — identical to `uniform` mode — and only the per-request group assignment changes. `alpha` must be a finite float strictly greater than 0; larger values concentrate requests on lower-ranked (hotter) groups.
 
-In `zipf` mode the on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` is bypassed (neither read nor written), so each run regenerates the workload fresh. This avoids any risk of silently reusing a `uniform`-mode cache payload for a `zipf` invocation, or vice versa.
+The on-disk dataset cache at `~/.cache/sglang/benchmark/gen_shared_prefix_*.pkl` includes `group_distribution` and `zipf_alpha` in its key, so uniform-mode and zipf-mode runs (or two zipf runs with different alpha) never share a cache file. Uniform-mode filenames are unchanged from the legacy format, so existing caches remain valid.
 
 This flag controls prefix-popularity shape only. It does not by itself reproduce any production trace or guarantee an observed cache-hit rate for a given engine.
 

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1931,6 +1931,33 @@ def run_benchmark(args_: argparse.Namespace):
     )
 
 
+def _validate_parsed_gsp_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """Reject malformed GSP distribution/alpha combinations at parse time.
+
+    This is invoked from the CLI entry point right after ``parser.parse_args()``
+    so users see a clear argparse-style error before any server, model, or
+    tokenizer setup runs and masks the real cause with an unrelated network
+    failure. The equivalent defensive checks in
+    ``GeneratedSharedPrefixDataset.from_args`` remain in place for in-process
+    callers that bypass this entry point.
+    """
+    distribution = getattr(args, "gsp_group_distribution", None)
+    alpha = getattr(args, "gsp_zipf_alpha", None)
+    if distribution == "zipf" and alpha is None:
+        parser.error(
+            "--gsp-group-distribution=zipf requires --gsp-zipf-alpha "
+            "(a finite float > 0)"
+        )
+    if distribution == "uniform" and alpha is not None:
+        parser.error(
+            "--gsp-zipf-alpha is only meaningful with "
+            "--gsp-group-distribution=zipf; remove --gsp-zipf-alpha "
+            "or set --gsp-group-distribution=zipf"
+        )
+
+
 class LoRAPathAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, [])
@@ -2428,4 +2455,5 @@ if __name__ == "__main__":
         help="Custom HTTP headers in Key=Value format. Example: --header MyHeader=MY_VALUE MyAnotherHeader=myanothervalue",
     )
     args = parser.parse_args()
+    _validate_parsed_gsp_args(parser, args)
     run_benchmark(args)

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -39,6 +39,7 @@ from tqdm.asyncio import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets import DatasetRow, get_dataset
+from sglang.benchmark.datasets.generated_shared_prefix import _finite_positive_float
 from sglang.benchmark.datasets.mooncake import get_mooncake_request_over_time
 from sglang.benchmark.utils import (
     get_tokenizer,
@@ -2351,6 +2352,34 @@ if __name__ == "__main__":
         "--gsp-ordered",
         action="store_true",
         help="Keep requests in order without shuffling. By default, requests are shuffled randomly.",
+    )
+    group.add_argument(
+        "--gsp-group-distribution",
+        type=str,
+        choices=["uniform", "zipf"],
+        default="uniform",
+        help=(
+            "Prefix-group sampling distribution for generated-shared-prefix. "
+            "'uniform' (default) assigns each group an equal number of requests. "
+            "'zipf' samples each request's group by rank with "
+            "p(rank) = (1/rank**alpha) / sum_k(1/k**alpha); rank starts at 1 "
+            "and group index 0 is the hottest. Requires --gsp-zipf-alpha "
+            "(a finite float > 0) when set to 'zipf'. Total request count is "
+            "still num_groups * prompts_per_group, identical to uniform mode; "
+            "only the per-request group assignment changes. In 'zipf' mode the "
+            "on-disk dataset cache is bypassed."
+        ),
+    )
+    group.add_argument(
+        "--gsp-zipf-alpha",
+        type=_finite_positive_float,
+        default=None,
+        help=(
+            "Zipf exponent alpha for --gsp-group-distribution=zipf, with "
+            "p(rank) = (1/rank**alpha) / sum_k(1/k**alpha) and rank starting "
+            "at 1. Must be a finite float strictly greater than 0; larger "
+            "values concentrate requests on lower-ranked (hotter) groups."
+        ),
     )
     mooncake_group = parser.add_argument_group("mooncake dataset arguments")
     mooncake_group.add_argument(

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2406,8 +2406,11 @@ if __name__ == "__main__":
             "and group index 0 is the hottest. Requires --gsp-zipf-alpha "
             "(a finite float > 0) when set to 'zipf'. Total request count is "
             "still num_groups * prompts_per_group, identical to uniform mode; "
-            "only the per-request group assignment changes. In 'zipf' mode the "
-            "on-disk dataset cache is bypassed."
+            "only the per-request group assignment changes. The on-disk "
+            "dataset cache uses a distinct key per (group_distribution, "
+            "zipf_alpha), so uniform-mode caches are never mixed with "
+            "zipf-mode caches and zipf runs with different alpha use "
+            "separate files."
         ),
     )
     group.add_argument(

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1949,12 +1949,10 @@ def _validate_parsed_gsp_args(
 ) -> None:
     """Reject malformed GSP distribution/alpha combinations at parse time.
 
-    This is invoked from the CLI entry point right after ``parser.parse_args()``
-    so users see a clear argparse-style error before any server, model, or
+    Invoked from the CLI entry point right after ``parser.parse_args()`` so
+    users see a clear argparse-style error before any server, model, or
     tokenizer setup runs and masks the real cause with an unrelated network
-    failure. The equivalent defensive checks in
-    ``GeneratedSharedPrefixDataset.from_args`` remain in place for in-process
-    callers that bypass this entry point.
+    failure.
     """
     distribution = getattr(args, "gsp_group_distribution", None)
     alpha = getattr(args, "gsp_zipf_alpha", None)

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -17,6 +17,7 @@ import asyncio
 import copy
 import importlib.util
 import json
+import math
 import os
 import random
 import shutil
@@ -39,7 +40,6 @@ from tqdm.asyncio import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets import DatasetRow, get_dataset
-from sglang.benchmark.datasets.generated_shared_prefix import _finite_positive_float
 from sglang.benchmark.datasets.mooncake import get_mooncake_request_over_time
 from sglang.benchmark.utils import (
     get_tokenizer,
@@ -1929,6 +1929,19 @@ def run_benchmark(args_: argparse.Namespace):
             profile_decode_url=getattr(args, "profile_decode_url", None),
         )
     )
+
+
+def _finite_positive_float(value) -> float:
+    """argparse type for a finite, strictly positive float."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected a finite float > 0, got {value!r}"
+        ) from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a finite float > 0, got {value!r}")
+    return parsed
 
 
 def _validate_parsed_gsp_args(

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -1,3 +1,5 @@
+import argparse
+import math
 import pickle
 import random
 import uuid
@@ -5,7 +7,7 @@ from argparse import Namespace
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from tqdm.asyncio import tqdm
@@ -17,6 +19,39 @@ from sglang.benchmark.datasets.common import (
     compute_random_lens,
     gen_prompt,
 )
+
+
+def _finite_positive_float(value) -> float:
+    """argparse-compatible type for a finite, strictly positive float.
+
+    Rejects NaN, infinities, zero, and negatives. Also used as a
+    defensive check in GeneratedSharedPrefixDataset.from_args.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected a finite float > 0, got {value!r}"
+        ) from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a finite float > 0, got {value!r}")
+    return parsed
+
+
+def _zipf_group_probs(num_groups: int, alpha: float) -> np.ndarray:
+    """Rank-based Zipf probability vector with rank starting at 1.
+
+    weight(rank)      = 1 / rank ** alpha       (rank in 1..num_groups)
+    probability(rank) = weight(rank) / sum_over_all_ranks(weight)
+
+    The returned array has length num_groups; element i corresponds to
+    group index i (rank i + 1), so group 0 is the hottest.
+    """
+    if num_groups <= 0:
+        raise ValueError(f"num_groups must be > 0, got {num_groups}")
+    ranks = np.arange(1, num_groups + 1, dtype=np.float64)
+    weights = 1.0 / (ranks**alpha)
+    return weights / weights.sum()
 
 
 @dataclass
@@ -32,10 +67,38 @@ class GeneratedSharedPrefixDataset(BaseDataset):
     send_routing_key: bool
     num_turns: int
     ordered: bool
+    group_distribution: str = "uniform"
+    zipf_alpha: Optional[float] = None
 
     @classmethod
     def from_args(cls, args: Namespace) -> "GeneratedSharedPrefixDataset":
         assert not getattr(args, "tokenize_prompt", False)
+        group_distribution = getattr(args, "gsp_group_distribution", "uniform")
+        zipf_alpha = getattr(args, "gsp_zipf_alpha", None)
+
+        if group_distribution not in ("uniform", "zipf"):
+            raise ValueError(
+                f"--gsp-group-distribution must be 'uniform' or 'zipf', "
+                f"got {group_distribution!r}"
+            )
+        if group_distribution == "zipf":
+            if zipf_alpha is None:
+                raise ValueError(
+                    "--gsp-group-distribution=zipf requires --gsp-zipf-alpha "
+                    "(a finite float > 0)"
+                )
+            if not math.isfinite(zipf_alpha) or zipf_alpha <= 0:
+                raise ValueError(
+                    f"--gsp-zipf-alpha must be a finite float > 0, got {zipf_alpha!r}"
+                )
+        else:
+            if zipf_alpha is not None:
+                raise ValueError(
+                    "--gsp-zipf-alpha is only meaningful with "
+                    "--gsp-group-distribution=zipf; remove --gsp-zipf-alpha "
+                    "or set --gsp-group-distribution=zipf"
+                )
+
         return cls(
             num_groups=args.gsp_num_groups,
             prompts_per_group=args.gsp_prompts_per_group,
@@ -48,6 +111,8 @@ class GeneratedSharedPrefixDataset(BaseDataset):
             send_routing_key=getattr(args, "gsp_send_routing_key", False),
             num_turns=getattr(args, "gsp_num_turns", 1),
             ordered=getattr(args, "gsp_ordered", False),
+            group_distribution=group_distribution,
+            zipf_alpha=zipf_alpha,
         )
 
     def load(
@@ -66,6 +131,8 @@ class GeneratedSharedPrefixDataset(BaseDataset):
             num_turns=self.num_turns,
             fast_prepare=self.fast_prepare,
             ordered=self.ordered,
+            group_distribution=self.group_distribution,
+            zipf_alpha=self.zipf_alpha,
         )
 
 
@@ -102,8 +169,37 @@ def sample_generated_shared_prefix_requests(
     num_turns: int = 1,
     fast_prepare: bool = False,
     ordered: bool = False,
+    group_distribution: str = "uniform",
+    zipf_alpha: Optional[float] = None,
 ) -> List[DatasetRow]:
-    """Generate benchmark requests with shared system prompts using random tokens and caching."""
+    """Generate benchmark requests with shared system prompts using random tokens and caching.
+
+    When group_distribution is "uniform" (default), each group receives exactly
+    prompts_per_group requests; behavior matches the legacy generator.
+
+    When group_distribution is "zipf", each request's group is sampled by rank
+    with probability 1/rank**zipf_alpha / sum_k(1/k**zipf_alpha); rank starts at
+    1 and group index 0 is the hottest. The on-disk cache is bypassed in this
+    mode. Sampling uses an isolated numpy.random.default_rng(seed) so the
+    shared question/system-prompt pool stays byte-identical to uniform mode for
+    the same seed and other args.
+    """
+    if group_distribution not in ("uniform", "zipf"):
+        raise ValueError(
+            f"group_distribution must be 'uniform' or 'zipf', got {group_distribution!r}"
+        )
+    if group_distribution == "zipf":
+        if zipf_alpha is None:
+            raise ValueError(
+                "group_distribution='zipf' requires zipf_alpha (a finite float > 0)"
+            )
+        if not math.isfinite(zipf_alpha) or zipf_alpha <= 0:
+            raise ValueError(
+                f"zipf_alpha must be a finite float > 0, got {zipf_alpha!r}"
+            )
+    elif zipf_alpha is not None:
+        raise ValueError("zipf_alpha is only meaningful with group_distribution='zipf'")
+
     cache_path = get_gen_prefix_cache_path(
         seed,
         num_groups,
@@ -113,17 +209,22 @@ def sample_generated_shared_prefix_requests(
         output_len,
         tokenizer,
     )
-    should_cache = (range_ratio == 1) and not send_routing_key and num_turns == 1
+    should_cache = (
+        group_distribution == "uniform"
+        and range_ratio == 1
+        and not send_routing_key
+        and num_turns == 1
+    )
 
-    # Try to load from cache first
-    if cache_path.exists() and should_cache:
+    # Try to load from cache first (only when caching is enabled).
+    if should_cache and cache_path.exists():
         print(f"\nLoading cached generated input data from {cache_path}")
         with open(cache_path, "rb") as f:
             return pickle.load(f)
 
     print(
         f"\nGenerating new input data... "
-        f"({num_groups=}, {prompts_per_group}, {system_prompt_len=}, {question_len=}, {output_len=}, {range_ratio=}, {num_turns=})"
+        f"({num_groups=}, {prompts_per_group}, {system_prompt_len=}, {question_len=}, {output_len=}, {range_ratio=}, {num_turns=}, {group_distribution=}, {zipf_alpha=})"
     )
 
     run_random_str = uuid.uuid4().hex[:8]
@@ -172,23 +273,39 @@ def sample_generated_shared_prefix_requests(
     total_input_tokens = 0
     total_output_tokens = 0
 
-    for group_idx in tqdm(range(num_groups), desc="Generating system prompt"):
-        system_prompt = system_prompts[group_idx]
-        routing_key = (
-            f"{run_random_str}_{run_start_timestamp}_{group_idx}"
-            if send_routing_key
-            else None
-        )
-        for prompt_idx in tqdm(
-            range(prompts_per_group), desc="Generating questions", leave=False
+    if group_distribution == "zipf":
+        # Isolated RNG: never perturbs the module-level random / numpy.random
+        # state that compute_random_lens / gen_prompt rely on. This keeps the
+        # generated system-prompt and question pool byte-identical to uniform
+        # mode for the same seed and other args.
+        rng = np.random.default_rng(seed)
+        probs = _zipf_group_probs(num_groups, zipf_alpha)
+        total_slots = num_groups * prompts_per_group
+        sampled_groups = rng.choice(num_groups, size=total_slots, replace=True, p=probs)
+
+        for slot_idx in tqdm(
+            range(total_slots), desc="Generating zipf-sampled prompts"
         ):
-            turn_questions = questions[group_idx][prompt_idx]
+            # Source slot index in the uniform enumeration: walks the question
+            # pool in the same order uniform mode does, so the per-slot
+            # question text is reproducibly identical.
+            src_g = slot_idx // prompts_per_group
+            src_p = slot_idx % prompts_per_group
+            sampled_g = int(sampled_groups[slot_idx])
+
+            system_prompt = system_prompts[sampled_g]
+            routing_key = (
+                f"{run_random_str}_{run_start_timestamp}_{sampled_g}"
+                if send_routing_key
+                else None
+            )
+            turn_questions = questions[src_g][src_p]
             turn_prompts = [f"{system_prompt}\n\n{turn_questions[0]}"] + turn_questions[
                 1:
             ]
             full_prompt = turn_prompts[0] if num_turns == 1 else turn_prompts
             prompt_len = 1 if fast_prepare else len(tokenizer.encode(turn_prompts[0]))
-            output_len_val = int(output_lens[group_idx, prompt_idx])
+            output_len_val = int(output_lens[src_g, src_p])
 
             input_requests.append(
                 DatasetRow(
@@ -200,6 +317,37 @@ def sample_generated_shared_prefix_requests(
             )
             total_input_tokens += prompt_len
             total_output_tokens += output_len_val
+    else:
+        for group_idx in tqdm(range(num_groups), desc="Generating system prompt"):
+            system_prompt = system_prompts[group_idx]
+            routing_key = (
+                f"{run_random_str}_{run_start_timestamp}_{group_idx}"
+                if send_routing_key
+                else None
+            )
+            for prompt_idx in tqdm(
+                range(prompts_per_group), desc="Generating questions", leave=False
+            ):
+                turn_questions = questions[group_idx][prompt_idx]
+                turn_prompts = [
+                    f"{system_prompt}\n\n{turn_questions[0]}"
+                ] + turn_questions[1:]
+                full_prompt = turn_prompts[0] if num_turns == 1 else turn_prompts
+                prompt_len = (
+                    1 if fast_prepare else len(tokenizer.encode(turn_prompts[0]))
+                )
+                output_len_val = int(output_lens[group_idx, prompt_idx])
+
+                input_requests.append(
+                    DatasetRow(
+                        prompt=full_prompt,
+                        prompt_len=prompt_len,
+                        output_len=output_len_val,
+                        routing_key=routing_key,
+                    )
+                )
+                total_input_tokens += prompt_len
+                total_output_tokens += output_len_val
 
     if not ordered:
         random.shuffle(input_requests)
@@ -209,6 +357,9 @@ def sample_generated_shared_prefix_requests(
     print(f"Number of groups: {num_groups}")
     print(f"Prompts per group: {prompts_per_group}")
     print(f"Number of turns: {num_turns}")
+    print(f"Group distribution: {group_distribution}")
+    if group_distribution == "zipf":
+        print(f"Zipf alpha: {zipf_alpha}")
     print(f"Total prompts: {len(input_requests)}")
     if not fast_prepare:
         print(f"Total input tokens: {total_input_tokens}")
@@ -221,7 +372,7 @@ def sample_generated_shared_prefix_requests(
             f"Average question length: {sum(len(tokenizer.encode(q)) for q in all_questions) / len(all_questions):.1f} tokens\n"
         )
 
-    # Save to cache
+    # Save to cache (only when caching is enabled).
     if should_cache:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         print(f"Caching generated input data to {cache_path}")

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -179,10 +179,6 @@ def sample_generated_shared_prefix_requests(
     stays byte-identical to uniform mode for the same seed and other args.
     Zipf mode is cached on disk under a distinct key per (group_distribution,
     zipf_alpha) value.
-
-    Validation of group_distribution / zipf_alpha is enforced at the CLI
-    parse boundary in bench_serving.py and in
-    GeneratedSharedPrefixDataset.from_args for in-process callers.
     """
     cache_path = get_gen_prefix_cache_path(
         seed,
@@ -200,7 +196,6 @@ def sample_generated_shared_prefix_requests(
     # meaningless to cache. Bypass for these pre-existing reasons only.
     should_cache = range_ratio == 1 and not send_routing_key and num_turns == 1
 
-    # Try to load from cache first (only when caching is enabled).
     if should_cache and cache_path.exists():
         print(f"\nLoading cached generated input data from {cache_path}")
         with open(cache_path, "rb") as f:
@@ -238,12 +233,11 @@ def sample_generated_shared_prefix_requests(
     ).reshape(num_groups, prompts_per_group)
     del system_prompt_len, question_len, output_len
 
-    # Generate system prompts for each group
     system_prompts = [
         gen_prompt(tokenizer, system_prompt_lens[i]) for i in range(num_groups)
     ]
 
-    # Generate questions: shape (num_groups, prompts_per_group, num_turns)
+    # shape: (num_groups, prompts_per_group, num_turns)
     questions = [
         [
             [
@@ -306,7 +300,6 @@ def sample_generated_shared_prefix_requests(
     if not ordered:
         random.shuffle(input_requests)
 
-    # Print statistics
     print(f"\nGenerated shared prefix dataset statistics:")
     print(f"Number of groups: {num_groups}")
     print(f"Prompts per group: {prompts_per_group}")
@@ -326,7 +319,6 @@ def sample_generated_shared_prefix_requests(
             f"Average question length: {sum(len(tokenizer.encode(q)) for q in all_questions) / len(all_questions):.1f} tokens\n"
         )
 
-    # Save to cache (only when caching is enabled).
     if should_cache:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         print(f"Caching generated input data to {cache_path}")

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -1,3 +1,4 @@
+import math
 import pickle
 import random
 import uuid
@@ -54,6 +55,34 @@ class GeneratedSharedPrefixDataset(BaseDataset):
     @classmethod
     def from_args(cls, args: Namespace) -> "GeneratedSharedPrefixDataset":
         assert not getattr(args, "tokenize_prompt", False)
+        group_distribution = args.gsp_group_distribution
+        zipf_alpha = args.gsp_zipf_alpha
+
+        # Defensive validation for in-process callers that construct a
+        # Namespace by hand and bypass the argparse boundary in
+        # bench_serving.py. The CLI hook enforces the same rules first.
+        if group_distribution not in ("uniform", "zipf"):
+            raise ValueError(
+                f"--gsp-group-distribution must be 'uniform' or 'zipf', "
+                f"got {group_distribution!r}"
+            )
+        if group_distribution == "zipf":
+            if zipf_alpha is None:
+                raise ValueError(
+                    "--gsp-group-distribution=zipf requires --gsp-zipf-alpha "
+                    "(a finite float > 0)"
+                )
+            if not math.isfinite(zipf_alpha) or zipf_alpha <= 0:
+                raise ValueError(
+                    f"--gsp-zipf-alpha must be a finite float > 0, got {zipf_alpha!r}"
+                )
+        elif zipf_alpha is not None:
+            raise ValueError(
+                "--gsp-zipf-alpha is only meaningful with "
+                "--gsp-group-distribution=zipf; remove --gsp-zipf-alpha "
+                "or set --gsp-group-distribution=zipf"
+            )
+
         return cls(
             num_groups=args.gsp_num_groups,
             prompts_per_group=args.gsp_prompts_per_group,
@@ -66,8 +95,8 @@ class GeneratedSharedPrefixDataset(BaseDataset):
             send_routing_key=getattr(args, "gsp_send_routing_key", False),
             num_turns=getattr(args, "gsp_num_turns", 1),
             ordered=getattr(args, "gsp_ordered", False),
-            group_distribution=args.gsp_group_distribution,
-            zipf_alpha=args.gsp_zipf_alpha,
+            group_distribution=group_distribution,
+            zipf_alpha=zipf_alpha,
         )
 
     def load(
@@ -151,8 +180,9 @@ def sample_generated_shared_prefix_requests(
     Zipf mode is cached on disk under a distinct key per (group_distribution,
     zipf_alpha) value.
 
-    Validation of group_distribution / zipf_alpha is enforced at the CLI parse
-    boundary in bench_serving.py.
+    Validation of group_distribution / zipf_alpha is enforced at the CLI
+    parse boundary in bench_serving.py and in
+    GeneratedSharedPrefixDataset.from_args for in-process callers.
     """
     cache_path = get_gen_prefix_cache_path(
         seed,

--- a/python/sglang/benchmark/datasets/generated_shared_prefix.py
+++ b/python/sglang/benchmark/datasets/generated_shared_prefix.py
@@ -1,5 +1,3 @@
-import argparse
-import math
 import pickle
 import random
 import uuid
@@ -19,23 +17,6 @@ from sglang.benchmark.datasets.common import (
     compute_random_lens,
     gen_prompt,
 )
-
-
-def _finite_positive_float(value) -> float:
-    """argparse-compatible type for a finite, strictly positive float.
-
-    Rejects NaN, infinities, zero, and negatives. Also used as a
-    defensive check in GeneratedSharedPrefixDataset.from_args.
-    """
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError) as exc:
-        raise argparse.ArgumentTypeError(
-            f"expected a finite float > 0, got {value!r}"
-        ) from exc
-    if not math.isfinite(parsed) or parsed <= 0:
-        raise argparse.ArgumentTypeError(f"expected a finite float > 0, got {value!r}")
-    return parsed
 
 
 def _zipf_group_probs(num_groups: int, alpha: float) -> np.ndarray:
@@ -73,32 +54,6 @@ class GeneratedSharedPrefixDataset(BaseDataset):
     @classmethod
     def from_args(cls, args: Namespace) -> "GeneratedSharedPrefixDataset":
         assert not getattr(args, "tokenize_prompt", False)
-        group_distribution = getattr(args, "gsp_group_distribution", "uniform")
-        zipf_alpha = getattr(args, "gsp_zipf_alpha", None)
-
-        if group_distribution not in ("uniform", "zipf"):
-            raise ValueError(
-                f"--gsp-group-distribution must be 'uniform' or 'zipf', "
-                f"got {group_distribution!r}"
-            )
-        if group_distribution == "zipf":
-            if zipf_alpha is None:
-                raise ValueError(
-                    "--gsp-group-distribution=zipf requires --gsp-zipf-alpha "
-                    "(a finite float > 0)"
-                )
-            if not math.isfinite(zipf_alpha) or zipf_alpha <= 0:
-                raise ValueError(
-                    f"--gsp-zipf-alpha must be a finite float > 0, got {zipf_alpha!r}"
-                )
-        else:
-            if zipf_alpha is not None:
-                raise ValueError(
-                    "--gsp-zipf-alpha is only meaningful with "
-                    "--gsp-group-distribution=zipf; remove --gsp-zipf-alpha "
-                    "or set --gsp-group-distribution=zipf"
-                )
-
         return cls(
             num_groups=args.gsp_num_groups,
             prompts_per_group=args.gsp_prompts_per_group,
@@ -111,8 +66,8 @@ class GeneratedSharedPrefixDataset(BaseDataset):
             send_routing_key=getattr(args, "gsp_send_routing_key", False),
             num_turns=getattr(args, "gsp_num_turns", 1),
             ordered=getattr(args, "gsp_ordered", False),
-            group_distribution=group_distribution,
-            zipf_alpha=zipf_alpha,
+            group_distribution=args.gsp_group_distribution,
+            zipf_alpha=args.gsp_zipf_alpha,
         )
 
     def load(
@@ -144,13 +99,24 @@ def get_gen_prefix_cache_path(
     question_len: int,
     output_len: int,
     tokenizer,
+    group_distribution: str = "uniform",
+    zipf_alpha: Optional[float] = None,
 ):
-    """Create cache directory under ~/.cache/sglang/benchmark"""
+    """Create cache directory under ~/.cache/sglang/benchmark.
+
+    The uniform-mode filename is preserved exactly as before so existing
+    on-disk caches remain valid. Non-default sampling modes get an extra
+    suffix encoding the parameters that affect the cached payload.
+    """
     cache_dir = Path.home() / ".cache" / "sglang" / "benchmark"
+
+    suffix = ""
+    if group_distribution != "uniform":
+        suffix = f"_{group_distribution}_{zipf_alpha}"
 
     cache_key = (
         f"gen_shared_prefix_{seed}_{num_groups}_{prompts_per_group}_"
-        f"{system_prompt_len}_{question_len}_{output_len}_"
+        f"{system_prompt_len}_{question_len}_{output_len}{suffix}_"
         f"{tokenizer.__class__.__name__}.pkl"
     )
     return cache_dir / cache_key
@@ -179,27 +145,15 @@ def sample_generated_shared_prefix_requests(
 
     When group_distribution is "zipf", each request's group is sampled by rank
     with probability 1/rank**zipf_alpha / sum_k(1/k**zipf_alpha); rank starts at
-    1 and group index 0 is the hottest. The on-disk cache is bypassed in this
-    mode. Sampling uses an isolated numpy.random.default_rng(seed) so the
-    shared question/system-prompt pool stays byte-identical to uniform mode for
-    the same seed and other args.
-    """
-    if group_distribution not in ("uniform", "zipf"):
-        raise ValueError(
-            f"group_distribution must be 'uniform' or 'zipf', got {group_distribution!r}"
-        )
-    if group_distribution == "zipf":
-        if zipf_alpha is None:
-            raise ValueError(
-                "group_distribution='zipf' requires zipf_alpha (a finite float > 0)"
-            )
-        if not math.isfinite(zipf_alpha) or zipf_alpha <= 0:
-            raise ValueError(
-                f"zipf_alpha must be a finite float > 0, got {zipf_alpha!r}"
-            )
-    elif zipf_alpha is not None:
-        raise ValueError("zipf_alpha is only meaningful with group_distribution='zipf'")
+    1 and group index 0 is the hottest. Sampling uses an isolated
+    numpy.random.default_rng(seed) so the shared question/system-prompt pool
+    stays byte-identical to uniform mode for the same seed and other args.
+    Zipf mode is cached on disk under a distinct key per (group_distribution,
+    zipf_alpha) value.
 
+    Validation of group_distribution / zipf_alpha is enforced at the CLI parse
+    boundary in bench_serving.py.
+    """
     cache_path = get_gen_prefix_cache_path(
         seed,
         num_groups,
@@ -208,19 +162,22 @@ def sample_generated_shared_prefix_requests(
         question_len,
         output_len,
         tokenizer,
+        group_distribution=group_distribution,
+        zipf_alpha=zipf_alpha,
     )
-    should_cache = (
-        group_distribution == "uniform"
-        and range_ratio == 1
-        and not send_routing_key
-        and num_turns == 1
-    )
+    # range_ratio != 1 / num_turns > 1 perturb the payload but are not in the
+    # cache key; send_routing_key embeds a per-run uuid + timestamp that is
+    # meaningless to cache. Bypass for these pre-existing reasons only.
+    should_cache = range_ratio == 1 and not send_routing_key and num_turns == 1
 
     # Try to load from cache first (only when caching is enabled).
     if should_cache and cache_path.exists():
         print(f"\nLoading cached generated input data from {cache_path}")
         with open(cache_path, "rb") as f:
             return pickle.load(f)
+
+    if not should_cache:
+        print(f"\nCache bypassed ({range_ratio=}, {send_routing_key=}, {num_turns=})")
 
     print(
         f"\nGenerating new input data... "
@@ -268,86 +225,53 @@ def sample_generated_shared_prefix_requests(
         for g in range(num_groups)
     ]
 
-    # Combine system prompts with questions
+    # Per-slot group assignment. Uniform mode is the identity assignment
+    # [0,0,...,1,1,...,N-1,N-1]; zipf mode samples from the rank distribution
+    # using an isolated RNG so the module-level random / numpy.random state
+    # that compute_random_lens / gen_prompt rely on is never perturbed -- this
+    # keeps the system-prompt and question pool byte-identical to uniform mode
+    # for the same seed and other args.
+    total_slots = num_groups * prompts_per_group
+    if group_distribution == "uniform":
+        assignment = np.repeat(np.arange(num_groups), prompts_per_group)
+    else:  # "zipf"
+        rng = np.random.default_rng(seed)
+        probs = _zipf_group_probs(num_groups, zipf_alpha)
+        assignment = rng.choice(num_groups, size=total_slots, replace=True, p=probs)
+
     input_requests = []
     total_input_tokens = 0
     total_output_tokens = 0
+    for slot_idx, sampled_g in enumerate(
+        tqdm(assignment, desc="Generating shared-prefix prompts")
+    ):
+        # src_(g,p) walks the question pool in uniform-enumeration order, so
+        # per-slot question text is reproducibly identical across modes.
+        src_g, src_p = divmod(slot_idx, prompts_per_group)
+        sampled_g = int(sampled_g)
 
-    if group_distribution == "zipf":
-        # Isolated RNG: never perturbs the module-level random / numpy.random
-        # state that compute_random_lens / gen_prompt rely on. This keeps the
-        # generated system-prompt and question pool byte-identical to uniform
-        # mode for the same seed and other args.
-        rng = np.random.default_rng(seed)
-        probs = _zipf_group_probs(num_groups, zipf_alpha)
-        total_slots = num_groups * prompts_per_group
-        sampled_groups = rng.choice(num_groups, size=total_slots, replace=True, p=probs)
+        system_prompt = system_prompts[sampled_g]
+        routing_key = (
+            f"{run_random_str}_{run_start_timestamp}_{sampled_g}"
+            if send_routing_key
+            else None
+        )
+        turn_questions = questions[src_g][src_p]
+        turn_prompts = [f"{system_prompt}\n\n{turn_questions[0]}"] + turn_questions[1:]
+        full_prompt = turn_prompts[0] if num_turns == 1 else turn_prompts
+        prompt_len = 1 if fast_prepare else len(tokenizer.encode(turn_prompts[0]))
+        output_len_val = int(output_lens[src_g, src_p])
 
-        for slot_idx in tqdm(
-            range(total_slots), desc="Generating zipf-sampled prompts"
-        ):
-            # Source slot index in the uniform enumeration: walks the question
-            # pool in the same order uniform mode does, so the per-slot
-            # question text is reproducibly identical.
-            src_g = slot_idx // prompts_per_group
-            src_p = slot_idx % prompts_per_group
-            sampled_g = int(sampled_groups[slot_idx])
-
-            system_prompt = system_prompts[sampled_g]
-            routing_key = (
-                f"{run_random_str}_{run_start_timestamp}_{sampled_g}"
-                if send_routing_key
-                else None
+        input_requests.append(
+            DatasetRow(
+                prompt=full_prompt,
+                prompt_len=prompt_len,
+                output_len=output_len_val,
+                routing_key=routing_key,
             )
-            turn_questions = questions[src_g][src_p]
-            turn_prompts = [f"{system_prompt}\n\n{turn_questions[0]}"] + turn_questions[
-                1:
-            ]
-            full_prompt = turn_prompts[0] if num_turns == 1 else turn_prompts
-            prompt_len = 1 if fast_prepare else len(tokenizer.encode(turn_prompts[0]))
-            output_len_val = int(output_lens[src_g, src_p])
-
-            input_requests.append(
-                DatasetRow(
-                    prompt=full_prompt,
-                    prompt_len=prompt_len,
-                    output_len=output_len_val,
-                    routing_key=routing_key,
-                )
-            )
-            total_input_tokens += prompt_len
-            total_output_tokens += output_len_val
-    else:
-        for group_idx in tqdm(range(num_groups), desc="Generating system prompt"):
-            system_prompt = system_prompts[group_idx]
-            routing_key = (
-                f"{run_random_str}_{run_start_timestamp}_{group_idx}"
-                if send_routing_key
-                else None
-            )
-            for prompt_idx in tqdm(
-                range(prompts_per_group), desc="Generating questions", leave=False
-            ):
-                turn_questions = questions[group_idx][prompt_idx]
-                turn_prompts = [
-                    f"{system_prompt}\n\n{turn_questions[0]}"
-                ] + turn_questions[1:]
-                full_prompt = turn_prompts[0] if num_turns == 1 else turn_prompts
-                prompt_len = (
-                    1 if fast_prepare else len(tokenizer.encode(turn_prompts[0]))
-                )
-                output_len_val = int(output_lens[group_idx, prompt_idx])
-
-                input_requests.append(
-                    DatasetRow(
-                        prompt=full_prompt,
-                        prompt_len=prompt_len,
-                        output_len=output_len_val,
-                        routing_key=routing_key,
-                    )
-                )
-                total_input_tokens += prompt_len
-                total_output_tokens += output_len_val
+        )
+        total_input_tokens += prompt_len
+        total_output_tokens += output_len_val
 
     if not ordered:
         random.shuffle(input_requests)

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -1,11 +1,18 @@
+import argparse
 import asyncio
 import json
+import pickle
+import random
+import subprocess
+import sys
 import tempfile
 import unittest
+from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import numpy as np
 from PIL import Image
 from tokenizers import Tokenizer
 from tokenizers.models import WordLevel
@@ -16,6 +23,10 @@ from sglang.benchmark.datasets import DATASET_MAPPING, get_dataset
 from sglang.benchmark.datasets.common import DatasetRow
 from sglang.benchmark.datasets.custom import sample_custom_requests
 from sglang.benchmark.datasets.generated_shared_prefix import (
+    GeneratedSharedPrefixDataset,
+    _finite_positive_float,
+    _zipf_group_probs,
+    get_gen_prefix_cache_path,
     sample_generated_shared_prefix_requests,
 )
 from sglang.benchmark.datasets.image import sample_image_requests
@@ -26,7 +37,7 @@ from sglang.benchmark.datasets.random import sample_random_requests
 from sglang.benchmark.datasets.sharegpt import sample_sharegpt_requests
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=40, suite="base-a-test-cpu")
 register_cpu_ci(est_time=7, suite="base-b-test-cpu")
 
 
@@ -133,6 +144,8 @@ def make_args(**overrides):
         "gsp_send_routing_key": False,
         "gsp_num_turns": 1,
         "gsp_ordered": False,
+        "gsp_group_distribution": "uniform",
+        "gsp_zipf_alpha": None,
         "seed": 1,
         "mooncake_workload": "conversation",
     }
@@ -146,8 +159,19 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.processor = DummyProcessor(self.tokenizer)
         self.tmpdir = tempfile.TemporaryDirectory()
         self.tmpdir_path = Path(self.tmpdir.name)
+        # Redirect ~ for the GSP on-disk cache to the per-test tempdir, so
+        # tests never read/write the real ~/.cache/sglang/benchmark. The Zipf
+        # tests in particular compare freshly generated rows against the
+        # uniform path, and a stale cache file from prior runs would silently
+        # short-circuit the uniform path and break that comparison.
+        self._home_patch = patch(
+            "sglang.benchmark.datasets.generated_shared_prefix.Path.home",
+            return_value=self.tmpdir_path,
+        )
+        self._home_patch.start()
 
     def tearDown(self):
+        self._home_patch.stop()
         self.tmpdir.cleanup()
 
     def _write_sharegpt_json(self):
@@ -433,6 +457,413 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         args = make_args(dataset_name="not-a-dataset")
         with self.assertRaises(ValueError):
             get_dataset(args, self.tokenizer, model_id="dummy-model")
+
+    # ------------------------------------------------------------------
+    # Generated-shared-prefix Zipf sampling
+    # ------------------------------------------------------------------
+
+    def _run_gsp(
+        self,
+        *,
+        mode="uniform",
+        alpha=None,
+        seed=42,
+        num_groups=4,
+        prompts_per_group=5,
+        num_turns=1,
+        send_routing_key=False,
+        ordered=True,
+        range_ratio=1.0,
+        system_prompt_len=4,
+        question_len=3,
+        output_len=2,
+        fast_prepare=True,
+        global_seed=None,
+    ):
+        # GSP's own `seed` kwarg only feeds the cache filename; reproducibility
+        # of compute_random_lens / gen_prompt comes from seeding the module
+        # globals before calling. Tests must seed both random and numpy here.
+        seed_for_globals = global_seed if global_seed is not None else seed
+        random.seed(seed_for_globals)
+        np.random.seed(seed_for_globals)
+        return sample_generated_shared_prefix_requests(
+            num_groups=num_groups,
+            prompts_per_group=prompts_per_group,
+            system_prompt_len=system_prompt_len,
+            question_len=question_len,
+            output_len=output_len,
+            range_ratio=range_ratio,
+            tokenizer=self.tokenizer,
+            seed=seed,
+            send_routing_key=send_routing_key,
+            num_turns=num_turns,
+            fast_prepare=fast_prepare,
+            ordered=ordered,
+            group_distribution=mode,
+            zipf_alpha=alpha,
+        )
+
+    @staticmethod
+    def _row_fields(rows):
+        return [(r.prompt, r.prompt_len, r.output_len, r.routing_key) for r in rows]
+
+    def test_gsp_uniform_default_unchanged(self):
+        # AC-1: uniform mode shape + reproducibility under fixed seed.
+        rows_a = self._run_gsp(
+            mode="uniform", num_groups=3, prompts_per_group=4, seed=7
+        )
+        rows_b = self._run_gsp(
+            mode="uniform", num_groups=3, prompts_per_group=4, seed=7
+        )
+        self.assertEqual(len(rows_a), 3 * 4)
+        self.assertEqual(self._row_fields(rows_a), self._row_fields(rows_b))
+
+    def test_gsp_uniform_cache_path_format_unchanged(self):
+        # AC-1 / AC-6: the uniform-mode cache filename keeps the stable
+        # gen_shared_prefix_<seed>_<N>_<P>_<sysL>_<qL>_<outL>_<TokenizerCls>.pkl
+        # shape. The trailing class name is a transformers/tokenizers internal
+        # detail (TokenizersBackend / PreTrainedTokenizerFast depending on
+        # version), so we only pin the deterministic numeric portion.
+        path = get_gen_prefix_cache_path(
+            seed=7,
+            num_groups=3,
+            prompts_per_group=4,
+            system_prompt_len=16,
+            question_len=8,
+            output_len=4,
+            tokenizer=self.tokenizer,
+        )
+        self.assertTrue(path.name.startswith("gen_shared_prefix_7_3_4_16_8_4_"))
+        self.assertTrue(path.name.endswith(".pkl"))
+        self.assertEqual(path.parent, Path.home() / ".cache" / "sglang" / "benchmark")
+
+    def test_zipf_group_probs_helper(self):
+        # AC-3 positive: rank-based math.
+        probs_n3_a1 = _zipf_group_probs(3, 1.0)
+        expected_n3_a1 = np.array([6.0, 3.0, 2.0]) / 11.0
+        np.testing.assert_allclose(probs_n3_a1, expected_n3_a1, atol=1e-12)
+        self.assertAlmostEqual(float(probs_n3_a1.sum()), 1.0, places=12)
+
+        probs_n4_a15 = _zipf_group_probs(4, 1.5)
+        ranks = np.arange(1, 5, dtype=np.float64)
+        ref = 1.0 / ranks**1.5
+        ref = ref / ref.sum()
+        np.testing.assert_allclose(probs_n4_a15, ref, atol=1e-12)
+        # Three-decimal pin against a hand-computable reference.
+        np.testing.assert_allclose(
+            np.round(probs_n4_a15, 3),
+            np.array([0.598, 0.212, 0.115, 0.075]),
+            atol=1e-3,
+        )
+
+    def test_zipf_group_probs_not_lora_skewed_formula(self):
+        # AC-3 negative: helper must NOT use the LoRA alpha**-i exponential
+        # formula. For alpha=1.5, N=4 the two formulas differ noticeably.
+        actual = _zipf_group_probs(4, 1.5)
+        lora_weights = np.array([1.5**-i for i in range(4)], dtype=np.float64)
+        lora_probs = lora_weights / lora_weights.sum()
+        self.assertFalse(
+            np.allclose(actual, lora_probs, atol=1e-3),
+            "Zipf helper must use rank-based 1/rank**alpha, not LoRA alpha**-i",
+        )
+
+    def test_zipf_reproducible_with_seed(self):
+        # AC-4 positive: same seed + same args -> identical rows (incl. order).
+        kwargs = dict(
+            mode="zipf", alpha=1.7, seed=11, num_groups=4, prompts_per_group=10
+        )
+        rows_a = self._run_gsp(**kwargs)
+        rows_b = self._run_gsp(**kwargs)
+        self.assertEqual(len(rows_a), 4 * 10)
+        self.assertEqual(self._row_fields(rows_a), self._row_fields(rows_b))
+
+        # Also under the shuffled path.
+        rows_c = self._run_gsp(ordered=False, **kwargs)
+        rows_d = self._run_gsp(ordered=False, **kwargs)
+        self.assertEqual(self._row_fields(rows_c), self._row_fields(rows_d))
+
+    def test_zipf_different_seeds_differ(self):
+        # AC-4 negative: different seeds -> at least one differing slot.
+        base = dict(mode="zipf", alpha=1.7, num_groups=4, prompts_per_group=10)
+        rows_a = self._run_gsp(seed=11, **base)
+        rows_b = self._run_gsp(seed=12, **base)
+        self.assertEqual(len(rows_a), len(rows_b))
+        self.assertNotEqual(self._row_fields(rows_a), self._row_fields(rows_b))
+
+    def test_zipf_does_not_perturb_global_random_state(self):
+        # AC-4: the Zipf branch must consume zero draws from the global random
+        # / numpy.random state. Therefore the per-slot generated questions and
+        # system prompts under uniform and Zipf modes for the same args and
+        # the same global seed are byte-equal.
+        common = dict(
+            num_groups=4,
+            prompts_per_group=6,
+            system_prompt_len=4,
+            question_len=3,
+            output_len=2,
+            range_ratio=1.0,
+            seed=99,
+            ordered=True,
+            send_routing_key=False,
+            fast_prepare=True,
+            global_seed=99,
+        )
+        uniform_rows = self._run_gsp(mode="uniform", **common)
+        zipf_rows = self._run_gsp(mode="zipf", alpha=1.3, **common)
+
+        # Slot i in uniform mode pairs system_prompts[i // P] with
+        # questions[i // P][i % P], so the question substring after the
+        # delimiter is exactly the i-th question. Same construction is used by
+        # the Zipf branch (only the system prompt changes per slot), so the
+        # question substrings must match slot-by-slot under the same global
+        # seed.
+        delim = "\n\n"
+
+        def question_of(prompt):
+            return prompt.split(delim, 1)[1]
+
+        uniform_questions = [question_of(r.prompt) for r in uniform_rows]
+        zipf_questions = [question_of(r.prompt) for r in zipf_rows]
+        self.assertEqual(uniform_questions, zipf_questions)
+
+        # The set of system prompts (which the gen_prompt path generates) must
+        # also match between modes (set equality, since Zipf reuses prefixes).
+        def system_of(prompt):
+            return prompt.split(delim, 1)[0]
+
+        self.assertEqual(
+            set(system_of(r.prompt) for r in uniform_rows),
+            set(system_of(r.prompt) for r in zipf_rows),
+        )
+
+    def test_zipf_deterministic_per_group_counts(self):
+        # AC-5: per-group counts are pinned for a known (N, P, alpha, seed).
+        rows = self._run_gsp(
+            mode="zipf",
+            alpha=2.0,
+            seed=0,
+            num_groups=4,
+            prompts_per_group=25,
+            send_routing_key=True,
+            ordered=True,
+        )
+        self.assertEqual(len(rows), 4 * 25)
+        # routing_key format is "<uuid8>_<timestamp>_<group_idx>".
+        per_group = Counter(int(r.routing_key.rsplit("_", 1)[-1]) for r in rows)
+        # Pinned counts derived from the implementation for
+        # (N=4, P=25, alpha=2.0, seed=0) using numpy.random.default_rng(seed)
+        # and rng.choice over _zipf_group_probs(N, alpha).
+        self.assertEqual(
+            dict(per_group),
+            {0: 63, 1: 18, 2: 12, 3: 7},
+        )
+        # AC-5 independent: rank-1 (hottest) strictly hotter than rank-N.
+        self.assertGreater(per_group[0], per_group[3])
+
+    def test_zipf_bypasses_cache(self):
+        # AC-6: Zipf neither reads nor writes the on-disk cache; uniform mode
+        # still reads and writes it. Patch Path.home so we control the cache.
+        from sglang.benchmark.datasets import generated_shared_prefix as gsp_mod
+
+        fake_home = self.tmpdir_path / "fakehome"
+        fake_home.mkdir()
+
+        common = dict(
+            num_groups=2,
+            prompts_per_group=3,
+            system_prompt_len=4,
+            question_len=3,
+            output_len=2,
+            range_ratio=1.0,
+            seed=5,
+            send_routing_key=False,
+            num_turns=1,
+            fast_prepare=True,
+            ordered=True,
+        )
+
+        with patch.object(gsp_mod.Path, "home", return_value=fake_home):
+            cache_path = get_gen_prefix_cache_path(
+                seed=common["seed"],
+                num_groups=common["num_groups"],
+                prompts_per_group=common["prompts_per_group"],
+                system_prompt_len=common["system_prompt_len"],
+                question_len=common["question_len"],
+                output_len=common["output_len"],
+                tokenizer=self.tokenizer,
+            )
+            self.assertFalse(cache_path.exists())
+
+            # Uniform mode writes the cache.
+            self._run_gsp(mode="uniform", **common)
+            self.assertTrue(cache_path.exists())
+            cached_bytes = cache_path.read_bytes()
+
+            # Overwrite the cache file with a sentinel payload. A subsequent
+            # uniform-mode call would return this sentinel; Zipf must NOT.
+            sentinel = [DatasetRow(prompt="SENTINEL", prompt_len=1, output_len=1)]
+            with open(cache_path, "wb") as f:
+                pickle.dump(sentinel, f)
+            cache_mtime_before = cache_path.stat().st_mtime_ns
+
+            # Zipf mode: cache file must be neither read nor written.
+            zipf_rows = self._run_gsp(mode="zipf", alpha=1.5, **common)
+            self.assertEqual(len(zipf_rows), 2 * 3)
+            self.assertNotEqual(zipf_rows, sentinel)
+            self.assertEqual(cache_path.stat().st_mtime_ns, cache_mtime_before)
+            self.assertEqual(cache_path.read_bytes(), pickle.dumps(sentinel))
+
+            # Restore real uniform cache; uniform mode still reads it back.
+            with open(cache_path, "wb") as f:
+                f.write(cached_bytes)
+            restored_rows = self._run_gsp(mode="uniform", **common)
+            self.assertEqual(
+                self._row_fields(restored_rows),
+                self._row_fields(pickle.loads(cached_bytes)),
+            )
+
+    def test_zipf_total_rows_and_unique_prompts(self):
+        # AC-7: total rows match uniform; prompts are unique.
+        rows = self._run_gsp(
+            mode="zipf",
+            alpha=2.5,
+            seed=3,
+            num_groups=4,
+            prompts_per_group=10,
+            send_routing_key=False,
+        )
+        self.assertEqual(len(rows), 4 * 10)
+        self.assertEqual(len({r.prompt for r in rows}), len(rows))
+
+    def test_zipf_ordered_preserves_generation_order(self):
+        # AC-8 positive: with ordered=True, output mirrors the sampled order.
+        rows = self._run_gsp(
+            mode="zipf",
+            alpha=1.5,
+            seed=21,
+            num_groups=3,
+            prompts_per_group=8,
+            send_routing_key=True,
+            ordered=True,
+        )
+        observed_groups = [int(r.routing_key.rsplit("_", 1)[-1]) for r in rows]
+
+        # Independently reproduce the expected group sequence: an isolated
+        # default_rng(seed) over _zipf_group_probs(N, alpha) sampling
+        # N * P slots.
+        expected_rng = np.random.default_rng(21)
+        expected_probs = _zipf_group_probs(3, 1.5)
+        expected_groups = expected_rng.choice(
+            3, size=3 * 8, replace=True, p=expected_probs
+        ).tolist()
+        self.assertEqual(observed_groups, expected_groups)
+
+    def test_zipf_shuffle_path_matches_uniform_shuffle(self):
+        # AC-8: when ordered=False, both modes go through random.shuffle on a
+        # list of equal length, so the same global RNG seed yields the same
+        # permutation pattern. Verified indirectly: two calls with the same
+        # global seed under Zipf produce identical orderings.
+        kwargs = dict(
+            mode="zipf",
+            alpha=1.2,
+            seed=8,
+            num_groups=4,
+            prompts_per_group=6,
+            send_routing_key=False,
+            ordered=False,
+            global_seed=8,
+        )
+        rows_a = self._run_gsp(**kwargs)
+        rows_b = self._run_gsp(**kwargs)
+        self.assertEqual(self._row_fields(rows_a), self._row_fields(rows_b))
+
+    # ------------------------------------------------------------------
+    # CLI / from_args validation
+    # ------------------------------------------------------------------
+
+    def test_finite_positive_float_validator(self):
+        # AC-2.3 (alpha-bound) at argparse-type level.
+        for good in ["0.001", "0.5", "1.5", "10", "1e3"]:
+            self.assertEqual(_finite_positive_float(good), float(good))
+        for bad in ["0", "-0.5", "nan", "inf", "-inf", "abc", ""]:
+            with self.assertRaises(argparse.ArgumentTypeError):
+                _finite_positive_float(bad)
+
+    def test_from_args_zipf_requires_alpha(self):
+        # AC-2.3
+        args = make_args(
+            dataset_name="generated-shared-prefix",
+            gsp_group_distribution="zipf",
+            gsp_zipf_alpha=None,
+        )
+        with self.assertRaises(ValueError):
+            GeneratedSharedPrefixDataset.from_args(args)
+
+    def test_from_args_uniform_rejects_alpha(self):
+        # AC-2.3
+        args = make_args(
+            dataset_name="generated-shared-prefix",
+            gsp_group_distribution="uniform",
+            gsp_zipf_alpha=1.0,
+        )
+        with self.assertRaises(ValueError):
+            GeneratedSharedPrefixDataset.from_args(args)
+
+    def test_from_args_rejects_bad_alpha(self):
+        # AC-2.3: 0, negative, NaN, inf
+        for bad in [0.0, -0.5, float("nan"), float("inf"), float("-inf")]:
+            args = make_args(
+                dataset_name="generated-shared-prefix",
+                gsp_group_distribution="zipf",
+                gsp_zipf_alpha=bad,
+            )
+            with self.assertRaises(ValueError):
+                GeneratedSharedPrefixDataset.from_args(args)
+
+    def test_from_args_rejects_unknown_distribution(self):
+        args = make_args(
+            dataset_name="generated-shared-prefix",
+            gsp_group_distribution="not-a-distribution",
+            gsp_zipf_alpha=None,
+        )
+        with self.assertRaises(ValueError):
+            GeneratedSharedPrefixDataset.from_args(args)
+
+    def test_bench_serving_help_and_invalid_choice_argparse(self):
+        # AC-2.1 / AC-2.2 / AC-9: subprocess-driven coverage of the live CLI.
+        help_res = subprocess.run(
+            [sys.executable, "-m", "sglang.bench_serving", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        self.assertEqual(help_res.returncode, 0, help_res.stderr)
+        out = help_res.stdout
+        # Both new flags appear.
+        self.assertIn("--gsp-group-distribution", out)
+        self.assertIn("--gsp-zipf-alpha", out)
+        # Rank-based Zipf formula and alpha constraint are documented.
+        self.assertIn("1/rank**alpha", out)
+        self.assertIn("rank starts at 1", out)
+        self.assertIn("finite float", out)
+
+        # Argparse rejects unknown distribution choice.
+        bad_choice_res = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sglang.bench_serving",
+                "--dataset-name",
+                "generated-shared-prefix",
+                "--gsp-group-distribution",
+                "invalid_name",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        self.assertNotEqual(bad_choice_res.returncode, 0)
+        self.assertIn("invalid choice", (bad_choice_res.stderr + bad_choice_res.stdout))
 
 
 if __name__ == "__main__":

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -508,7 +508,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         return [(r.prompt, r.prompt_len, r.output_len, r.routing_key) for r in rows]
 
     def test_gsp_uniform_default_unchanged(self):
-        # AC-1: uniform mode shape + reproducibility under fixed seed.
+        # Uniform mode returns the documented number of rows and is
+        # bit-reproducible under fixed seeding of the global RNGs.
         rows_a = self._run_gsp(
             mode="uniform", num_groups=3, prompts_per_group=4, seed=7
         )
@@ -519,7 +520,7 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertEqual(self._row_fields(rows_a), self._row_fields(rows_b))
 
     def test_gsp_uniform_cache_path_format_unchanged(self):
-        # AC-1 / AC-6: the uniform-mode cache filename keeps the stable
+        # The uniform-mode cache filename keeps its existing
         # gen_shared_prefix_<seed>_<N>_<P>_<sysL>_<qL>_<outL>_<TokenizerCls>.pkl
         # shape. The trailing class name is a transformers/tokenizers internal
         # detail (TokenizersBackend / PreTrainedTokenizerFast depending on
@@ -538,7 +539,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertEqual(path.parent, Path.home() / ".cache" / "sglang" / "benchmark")
 
     def test_zipf_group_probs_helper(self):
-        # AC-3 positive: rank-based math.
+        # Rank-based probability vector: weight(rank) = 1 / rank ** alpha,
+        # normalized to sum to 1, with rank starting at 1.
         probs_n3_a1 = _zipf_group_probs(3, 1.0)
         expected_n3_a1 = np.array([6.0, 3.0, 2.0]) / 11.0
         np.testing.assert_allclose(probs_n3_a1, expected_n3_a1, atol=1e-12)
@@ -557,8 +559,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         )
 
     def test_zipf_group_probs_not_lora_skewed_formula(self):
-        # AC-3 negative: helper must NOT use the LoRA alpha**-i exponential
-        # formula. For alpha=1.5, N=4 the two formulas differ noticeably.
+        # The helper must NOT use the LoRA `skewed` alpha**-i exponential
+        # formula; for alpha=1.5, N=4 the two formulas differ noticeably.
         actual = _zipf_group_probs(4, 1.5)
         lora_weights = np.array([1.5**-i for i in range(4)], dtype=np.float64)
         lora_probs = lora_weights / lora_weights.sum()
@@ -568,7 +570,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         )
 
     def test_zipf_reproducible_with_seed(self):
-        # AC-4 positive: same seed + same args -> identical rows (incl. order).
+        # Same seed + same args -> identical rows, including order, under
+        # both the in-order and shuffled paths.
         kwargs = dict(
             mode="zipf", alpha=1.7, seed=11, num_groups=4, prompts_per_group=10
         )
@@ -583,7 +586,7 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertEqual(self._row_fields(rows_c), self._row_fields(rows_d))
 
     def test_zipf_different_seeds_differ(self):
-        # AC-4 negative: different seeds -> at least one differing slot.
+        # Different seeds -> at least one differing slot under Zipf sampling.
         base = dict(mode="zipf", alpha=1.7, num_groups=4, prompts_per_group=10)
         rows_a = self._run_gsp(seed=11, **base)
         rows_b = self._run_gsp(seed=12, **base)
@@ -591,8 +594,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertNotEqual(self._row_fields(rows_a), self._row_fields(rows_b))
 
     def test_zipf_does_not_perturb_global_random_state(self):
-        # AC-4: the Zipf branch must consume zero draws from the global random
-        # / numpy.random state. Therefore the per-slot generated questions and
+        # The Zipf branch must consume zero draws from the global random /
+        # numpy.random state. Therefore the per-slot generated questions and
         # system prompts under uniform and Zipf modes for the same args and
         # the same global seed are byte-equal.
         common = dict(
@@ -637,7 +640,9 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         )
 
     def test_zipf_deterministic_per_group_counts(self):
-        # AC-5: per-group counts are pinned for a known (N, P, alpha, seed).
+        # The per-group counts are deterministic and pinned for a known
+        # (num_groups, prompts_per_group, alpha, seed) tuple. Any drift in
+        # the Zipf sampling implementation will trip this assertion.
         rows = self._run_gsp(
             mode="zipf",
             alpha=2.0,
@@ -657,12 +662,13 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
             dict(per_group),
             {0: 63, 1: 18, 2: 12, 3: 7},
         )
-        # AC-5 independent: rank-1 (hottest) strictly hotter than rank-N.
+        # Independent skew sanity check: rank-1 (hottest) > rank-N (coldest).
         self.assertGreater(per_group[0], per_group[3])
 
     def test_zipf_bypasses_cache(self):
-        # AC-6: Zipf neither reads nor writes the on-disk cache; uniform mode
-        # still reads and writes it. Patch Path.home so we control the cache.
+        # Zipf neither reads nor writes the on-disk dataset cache; uniform
+        # mode still reads and writes it. Patch Path.home so the test owns
+        # the cache directory.
         from sglang.benchmark.datasets import generated_shared_prefix as gsp_mod
 
         fake_home = self.tmpdir_path / "fakehome"
@@ -723,7 +729,9 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
             )
 
     def test_zipf_total_rows_and_unique_prompts(self):
-        # AC-7: total rows match uniform; prompts are unique.
+        # Total returned row count under Zipf equals num_groups *
+        # prompts_per_group (identical to uniform mode) and every prompt
+        # string is unique even when groups repeat.
         rows = self._run_gsp(
             mode="zipf",
             alpha=2.5,
@@ -736,7 +744,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertEqual(len({r.prompt for r in rows}), len(rows))
 
     def test_zipf_ordered_preserves_generation_order(self):
-        # AC-8 positive: with ordered=True, output mirrors the sampled order.
+        # With ordered=True, output preserves the sampled order and matches
+        # an independently re-derived group sequence from default_rng(seed).
         rows = self._run_gsp(
             mode="zipf",
             alpha=1.5,
@@ -759,10 +768,10 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         self.assertEqual(observed_groups, expected_groups)
 
     def test_zipf_shuffle_path_matches_uniform_shuffle(self):
-        # AC-8: when ordered=False, both modes go through random.shuffle on a
-        # list of equal length, so the same global RNG seed yields the same
-        # permutation pattern. Verified indirectly: two calls with the same
-        # global seed under Zipf produce identical orderings.
+        # When ordered=False, both modes go through random.shuffle on a list
+        # of equal length, so the same global RNG seed yields the same
+        # permutation. Verified indirectly: two Zipf calls with the same
+        # global seed produce identical orderings.
         kwargs = dict(
             mode="zipf",
             alpha=1.2,
@@ -782,7 +791,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
     # ------------------------------------------------------------------
 
     def test_finite_positive_float_validator(self):
-        # AC-2.3 (alpha-bound) at argparse-type level.
+        # The argparse-type validator accepts strictly positive finite floats
+        # and rejects zero, negatives, NaN, infinities, and unparsable input.
         for good in ["0.001", "0.5", "1.5", "10", "1e3"]:
             self.assertEqual(_finite_positive_float(good), float(good))
         for bad in ["0", "-0.5", "nan", "inf", "-inf", "abc", ""]:
@@ -790,7 +800,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
                 _finite_positive_float(bad)
 
     def test_from_args_zipf_requires_alpha(self):
-        # AC-2.3
+        # from_args rejects zipf-without-alpha for in-process callers that
+        # bypass the CLI entry point.
         args = make_args(
             dataset_name="generated-shared-prefix",
             gsp_group_distribution="zipf",
@@ -800,7 +811,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
             GeneratedSharedPrefixDataset.from_args(args)
 
     def test_from_args_uniform_rejects_alpha(self):
-        # AC-2.3
+        # from_args rejects uniform-with-alpha for in-process callers that
+        # bypass the CLI entry point.
         args = make_args(
             dataset_name="generated-shared-prefix",
             gsp_group_distribution="uniform",
@@ -810,7 +822,8 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
             GeneratedSharedPrefixDataset.from_args(args)
 
     def test_from_args_rejects_bad_alpha(self):
-        # AC-2.3: 0, negative, NaN, inf
+        # from_args defensively rejects bad alpha values (0, negative, NaN,
+        # ±inf) even when the CLI type validator is bypassed.
         for bad in [0.0, -0.5, float("nan"), float("inf"), float("-inf")]:
             args = make_args(
                 dataset_name="generated-shared-prefix",
@@ -830,7 +843,9 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
             GeneratedSharedPrefixDataset.from_args(args)
 
     def test_bench_serving_help_and_invalid_choice_argparse(self):
-        # AC-2.1 / AC-2.2 / AC-9: subprocess-driven coverage of the live CLI.
+        # Subprocess-driven coverage of the live CLI: --help advertises both
+        # flags with the rank-based Zipf formula and the alpha constraint,
+        # and argparse rejects an unknown distribution choice.
         help_res = subprocess.run(
             [sys.executable, "-m", "sglang.bench_serving", "--help"],
             capture_output=True,
@@ -864,6 +879,76 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         )
         self.assertNotEqual(bad_choice_res.returncode, 0)
         self.assertIn("invalid choice", (bad_choice_res.stderr + bad_choice_res.stdout))
+
+    def test_bench_serving_cli_rejects_zipf_without_alpha_before_server(self):
+        # Malformed CLI combinations (zipf with no alpha) must fail at
+        # argparse time so users see the GSP-flag error directly, not a
+        # downstream connection or model-fetch failure.
+        res = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sglang.bench_serving",
+                "--dataset-name",
+                "generated-shared-prefix",
+                "--gsp-group-distribution",
+                "zipf",
+                "--ready-check-timeout-sec",
+                "0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        # parser.error() exits with code 2 (argparse convention).
+        self.assertEqual(res.returncode, 2, res.stderr)
+        stderr = res.stderr + res.stdout
+        self.assertIn("--gsp-group-distribution", stderr)
+        self.assertIn("--gsp-zipf-alpha", stderr)
+        # The error must mention the GSP flags directly, not a network or
+        # model-discovery problem masquerading as the failure.
+        for forbidden in [
+            "HTTPConnectionPool",
+            "HTTPSConnectionPool",
+            "Connection refused",
+            "Failed to fetch model",
+            "Traceback",
+        ]:
+            self.assertNotIn(forbidden, stderr)
+
+    def test_bench_serving_cli_rejects_uniform_with_alpha_before_server(self):
+        # The complementary malformation: uniform distribution with an
+        # explicit alpha value. Must also fail at argparse time.
+        res = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "sglang.bench_serving",
+                "--dataset-name",
+                "generated-shared-prefix",
+                "--gsp-group-distribution",
+                "uniform",
+                "--gsp-zipf-alpha",
+                "1.0",
+                "--ready-check-timeout-sec",
+                "0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        self.assertEqual(res.returncode, 2, res.stderr)
+        stderr = res.stderr + res.stdout
+        self.assertIn("--gsp-group-distribution", stderr)
+        self.assertIn("--gsp-zipf-alpha", stderr)
+        for forbidden in [
+            "HTTPConnectionPool",
+            "HTTPSConnectionPool",
+            "Connection refused",
+            "Failed to fetch model",
+            "Traceback",
+        ]:
+            self.assertNotIn(forbidden, stderr)
 
 
 if __name__ == "__main__":

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -22,6 +22,7 @@ from sglang.benchmark.datasets import DATASET_MAPPING, get_dataset
 from sglang.benchmark.datasets.common import DatasetRow
 from sglang.benchmark.datasets.custom import sample_custom_requests
 from sglang.benchmark.datasets.generated_shared_prefix import (
+    GeneratedSharedPrefixDataset,
     _zipf_group_probs,
     get_gen_prefix_cache_path,
     sample_generated_shared_prefix_requests,
@@ -806,6 +807,26 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
     # ------------------------------------------------------------------
     # CLI / from_args validation
     # ------------------------------------------------------------------
+
+    def test_from_args_rejects_invalid_distribution_and_alpha(self):
+        # Defensive validation in from_args protects in-process callers
+        # that build a Namespace by hand and bypass the argparse boundary
+        # in bench_serving.py. Covers: unknown distribution, zipf without
+        # alpha, uniform with alpha, and non-finite/non-positive alpha.
+        cases = [
+            {"gsp_group_distribution": "not-a-distribution", "gsp_zipf_alpha": None},
+            {"gsp_group_distribution": "zipf", "gsp_zipf_alpha": None},
+            {"gsp_group_distribution": "uniform", "gsp_zipf_alpha": 1.0},
+            {"gsp_group_distribution": "zipf", "gsp_zipf_alpha": 0.0},
+            {"gsp_group_distribution": "zipf", "gsp_zipf_alpha": -0.5},
+            {"gsp_group_distribution": "zipf", "gsp_zipf_alpha": float("nan")},
+            {"gsp_group_distribution": "zipf", "gsp_zipf_alpha": float("inf")},
+            {"gsp_group_distribution": "zipf", "gsp_zipf_alpha": float("-inf")},
+        ]
+        for case in cases:
+            args = make_args(dataset_name="generated-shared-prefix", **case)
+            with self.assertRaises(ValueError, msg=f"case={case}"):
+                GeneratedSharedPrefixDataset.from_args(args)
 
     def test_bench_serving_help_and_invalid_choice_argparse(self):
         # Subprocess-driven coverage of the live CLI: --help advertises both

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -1,4 +1,3 @@
-import argparse
 import asyncio
 import json
 import pickle
@@ -23,8 +22,6 @@ from sglang.benchmark.datasets import DATASET_MAPPING, get_dataset
 from sglang.benchmark.datasets.common import DatasetRow
 from sglang.benchmark.datasets.custom import sample_custom_requests
 from sglang.benchmark.datasets.generated_shared_prefix import (
-    GeneratedSharedPrefixDataset,
-    _finite_positive_float,
     _zipf_group_probs,
     get_gen_prefix_cache_path,
     sample_generated_shared_prefix_requests,
@@ -665,10 +662,10 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         # Independent skew sanity check: rank-1 (hottest) > rank-N (coldest).
         self.assertGreater(per_group[0], per_group[3])
 
-    def test_zipf_bypasses_cache(self):
-        # Zipf neither reads nor writes the on-disk dataset cache; uniform
-        # mode still reads and writes it. Patch Path.home so the test owns
-        # the cache directory.
+    def test_zipf_uses_distinct_cache_from_uniform(self):
+        # The on-disk cache key includes group_distribution and zipf_alpha,
+        # so uniform mode, zipf alpha=1.0, and zipf alpha=2.0 each get their
+        # own file. Uniform mode never reads a zipf cache and vice versa.
         from sglang.benchmark.datasets import generated_shared_prefix as gsp_mod
 
         fake_home = self.tmpdir_path / "fakehome"
@@ -689,7 +686,7 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
         )
 
         with patch.object(gsp_mod.Path, "home", return_value=fake_home):
-            cache_path = get_gen_prefix_cache_path(
+            uniform_path = get_gen_prefix_cache_path(
                 seed=common["seed"],
                 num_groups=common["num_groups"],
                 prompts_per_group=common["prompts_per_group"],
@@ -698,35 +695,55 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
                 output_len=common["output_len"],
                 tokenizer=self.tokenizer,
             )
-            self.assertFalse(cache_path.exists())
-
-            # Uniform mode writes the cache.
-            self._run_gsp(mode="uniform", **common)
-            self.assertTrue(cache_path.exists())
-            cached_bytes = cache_path.read_bytes()
-
-            # Overwrite the cache file with a sentinel payload. A subsequent
-            # uniform-mode call would return this sentinel; Zipf must NOT.
-            sentinel = [DatasetRow(prompt="SENTINEL", prompt_len=1, output_len=1)]
-            with open(cache_path, "wb") as f:
-                pickle.dump(sentinel, f)
-            cache_mtime_before = cache_path.stat().st_mtime_ns
-
-            # Zipf mode: cache file must be neither read nor written.
-            zipf_rows = self._run_gsp(mode="zipf", alpha=1.5, **common)
-            self.assertEqual(len(zipf_rows), 2 * 3)
-            self.assertNotEqual(zipf_rows, sentinel)
-            self.assertEqual(cache_path.stat().st_mtime_ns, cache_mtime_before)
-            self.assertEqual(cache_path.read_bytes(), pickle.dumps(sentinel))
-
-            # Restore real uniform cache; uniform mode still reads it back.
-            with open(cache_path, "wb") as f:
-                f.write(cached_bytes)
-            restored_rows = self._run_gsp(mode="uniform", **common)
-            self.assertEqual(
-                self._row_fields(restored_rows),
-                self._row_fields(pickle.loads(cached_bytes)),
+            zipf_path_a = get_gen_prefix_cache_path(
+                seed=common["seed"],
+                num_groups=common["num_groups"],
+                prompts_per_group=common["prompts_per_group"],
+                system_prompt_len=common["system_prompt_len"],
+                question_len=common["question_len"],
+                output_len=common["output_len"],
+                tokenizer=self.tokenizer,
+                group_distribution="zipf",
+                zipf_alpha=1.5,
             )
+            zipf_path_b = get_gen_prefix_cache_path(
+                seed=common["seed"],
+                num_groups=common["num_groups"],
+                prompts_per_group=common["prompts_per_group"],
+                system_prompt_len=common["system_prompt_len"],
+                question_len=common["question_len"],
+                output_len=common["output_len"],
+                tokenizer=self.tokenizer,
+                group_distribution="zipf",
+                zipf_alpha=2.0,
+            )
+            self.assertNotEqual(uniform_path, zipf_path_a)
+            self.assertNotEqual(zipf_path_a, zipf_path_b)
+
+            # Run each mode; each writes its own cache file.
+            self._run_gsp(mode="uniform", **common)
+            self._run_gsp(mode="zipf", alpha=1.5, **common)
+            self._run_gsp(mode="zipf", alpha=2.0, **common)
+            self.assertTrue(uniform_path.exists())
+            self.assertTrue(zipf_path_a.exists())
+            self.assertTrue(zipf_path_b.exists())
+
+            # Sentinel into the uniform cache: zipf must not read it.
+            sentinel = [DatasetRow(prompt="SENTINEL", prompt_len=1, output_len=1)]
+            with open(uniform_path, "wb") as f:
+                pickle.dump(sentinel, f)
+            zipf_rows = self._run_gsp(mode="zipf", alpha=1.5, **common)
+            self.assertNotEqual(zipf_rows, sentinel)
+
+            # Second zipf call with same args must load from cache (no
+            # regeneration). Mutate the zipf cache to a sentinel and confirm.
+            zipf_sentinel = [
+                DatasetRow(prompt="ZIPF_SENTINEL", prompt_len=1, output_len=1)
+            ]
+            with open(zipf_path_a, "wb") as f:
+                pickle.dump(zipf_sentinel, f)
+            reloaded = self._run_gsp(mode="zipf", alpha=1.5, **common)
+            self.assertEqual(reloaded, zipf_sentinel)
 
     def test_zipf_total_rows_and_unique_prompts(self):
         # Total returned row count under Zipf equals num_groups *
@@ -789,58 +806,6 @@ class TestBenchmarkDatasetsAPI(unittest.TestCase):
     # ------------------------------------------------------------------
     # CLI / from_args validation
     # ------------------------------------------------------------------
-
-    def test_finite_positive_float_validator(self):
-        # The argparse-type validator accepts strictly positive finite floats
-        # and rejects zero, negatives, NaN, infinities, and unparsable input.
-        for good in ["0.001", "0.5", "1.5", "10", "1e3"]:
-            self.assertEqual(_finite_positive_float(good), float(good))
-        for bad in ["0", "-0.5", "nan", "inf", "-inf", "abc", ""]:
-            with self.assertRaises(argparse.ArgumentTypeError):
-                _finite_positive_float(bad)
-
-    def test_from_args_zipf_requires_alpha(self):
-        # from_args rejects zipf-without-alpha for in-process callers that
-        # bypass the CLI entry point.
-        args = make_args(
-            dataset_name="generated-shared-prefix",
-            gsp_group_distribution="zipf",
-            gsp_zipf_alpha=None,
-        )
-        with self.assertRaises(ValueError):
-            GeneratedSharedPrefixDataset.from_args(args)
-
-    def test_from_args_uniform_rejects_alpha(self):
-        # from_args rejects uniform-with-alpha for in-process callers that
-        # bypass the CLI entry point.
-        args = make_args(
-            dataset_name="generated-shared-prefix",
-            gsp_group_distribution="uniform",
-            gsp_zipf_alpha=1.0,
-        )
-        with self.assertRaises(ValueError):
-            GeneratedSharedPrefixDataset.from_args(args)
-
-    def test_from_args_rejects_bad_alpha(self):
-        # from_args defensively rejects bad alpha values (0, negative, NaN,
-        # ±inf) even when the CLI type validator is bypassed.
-        for bad in [0.0, -0.5, float("nan"), float("inf"), float("-inf")]:
-            args = make_args(
-                dataset_name="generated-shared-prefix",
-                gsp_group_distribution="zipf",
-                gsp_zipf_alpha=bad,
-            )
-            with self.assertRaises(ValueError):
-                GeneratedSharedPrefixDataset.from_args(args)
-
-    def test_from_args_rejects_unknown_distribution(self):
-        args = make_args(
-            dataset_name="generated-shared-prefix",
-            gsp_group_distribution="not-a-distribution",
-            gsp_zipf_alpha=None,
-        )
-        with self.assertRaises(ValueError):
-            GeneratedSharedPrefixDataset.from_args(args)
 
     def test_bench_serving_help_and_invalid_choice_argparse(self):
         # Subprocess-driven coverage of the live CLI: --help advertises both


### PR DESCRIPTION
## Motivation

`generated-shared-prefix` (GSP) gives every prefix group an equal share of requests, but real cache-oriented serving studies often need a hot-head / long-tail prefix distribution. Add an opt-in Zipfian sampler so users can A/B compare uniform vs. skewed prefix popularity without rescaling other flags.

## Modifications

- **New CLI flags** in `python/sglang/bench_serving.py` (on the existing `--gsp-*` group):
  - `--gsp-group-distribution {uniform,zipf}`, default `uniform`.
  - `--gsp-zipf-alpha FLOAT`, required when distribution is `zipf`, must be omitted otherwise. argparse `type=` validator rejects NaN, ±inf and values ≤ 0. Cross-flag validation runs early via `_validate_parsed_gsp_args` so a malformed combination exits with code 2 *before* server/model/tokenizer setup.
- **Generator** in `python/sglang/benchmark/datasets/generated_shared_prefix.py`:
  - Two new default-valued kwargs (`group_distribution`, `zipf_alpha`) preserve the existing call signature.
  - Module-private `_zipf_group_probs(num_groups, alpha)` returns `1/rank**alpha / sum_k(1/k**alpha)` with rank starting at 1 (group 0 is hottest).
  - Per-slot group assignment is built once as a single `assignment` ndarray: `np.repeat(np.arange(num_groups), prompts_per_group)` for uniform mode, `default_rng(seed).choice(...)` for zipf. A single loop then materializes the `DatasetRow`s, so uniform and zipf share one code path.
  - Zipf branch uses an isolated `numpy.random.default_rng(seed)`. The global `random` / `numpy.random` state used by `compute_random_lens` and `gen_prompt` is untouched, so uniform-mode and Zipf-mode generate byte-equal system-prompt and question pools for the same seed.
  - Total returned row count is `num_groups * prompts_per_group`, identical to uniform mode.
  - On-disk dataset cache key now includes `group_distribution` and `zipf_alpha`, so uniform-mode and zipf-mode runs (and zipf runs at different alpha values) use separate cache files. Uniform-mode filenames are unchanged from the legacy format, so existing on-disk caches remain valid.
  - `--gsp-ordered` keeps the same semantics in both modes; the shuffle path is the same `random.shuffle` call.
  - `GeneratedSharedPrefixDataset.from_args` retains defensive validation for in-process callers that build a Namespace by hand and bypass argparse.
- **Tests** in `test/registered/bench_fn/test_benchmark_datasets_api.py` (CPU-only, deterministic, in the existing dataset suite): uniform regression, helper math + LoRA-formula rejection, reproducibility + isolated RNG, pinned per-group counts under skew, distinct cache key + zipf cache roundtrip, total-rows + unique-prompts, ordered/shuffle semantics, parametrized `from_args` rejection (unknown distribution, zipf w/o alpha, uniform w/ alpha, non-finite alpha), and subprocess coverage of the live CLI (`--help`, invalid choice, and both malformed CLI combos failing before any network/model setup).
- **Docs**: `docs/developer_guide/bench_serving.md` and `docs_new/docs/developer_guide/bench_serving.mdx` gain the two flag entries, a Zipf example command, the formula, the alpha range, the cache-key note, and a non-production-trace disclaimer.

Default GSP behavior with no new flags is byte-equivalent (verified by `test_gsp_uniform_default_unchanged`).

## Example Usage

A/B compare uniform vs Zipfian prefix popularity against the same server (everything else equal):

```bash
# Uniform baseline (existing behavior)
python3 -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --dataset-name generated-shared-prefix \
  --gsp-num-groups 20 --gsp-prompts-per-group 1 \
  --gsp-system-prompt-len 1900 --gsp-question-len 100 --gsp-output-len 100 \
  --gsp-ordered \
  --max-concurrency 4 --warmup-requests 0 --seed 213 \
  --output-file isl2k-osl100-c4-uniform.jsonl

# Zipfian (alpha=1.0, rank-1 group is hottest)
python3 -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --dataset-name generated-shared-prefix \
  --gsp-num-groups 20 --gsp-prompts-per-group 1 \
  --gsp-system-prompt-len 1900 --gsp-question-len 100 --gsp-output-len 100 \
  --gsp-group-distribution zipf --gsp-zipf-alpha 1.0 \
  --gsp-ordered \
  --max-concurrency 4 --warmup-requests 0 --seed 213 \
  --output-file isl2k-osl100-c4-zipf.jsonl
```

Larger `--gsp-zipf-alpha` concentrates more requests on the hottest group; `alpha → 0` approaches uniform. Total request count is `--gsp-num-groups * --gsp-prompts-per-group` regardless of distribution.

## Accuracy Tests

This PR is workload-generation only and does not touch any model forward / kernel code. Workload correctness validated as:

### Distribution shape (CPU, no server)

20 groups, `α=1.0`, 200,000 samples, `seed=213`:

| Metric | Value |
|---|---|
| Max \|observed − theoretical\| across all 20 ranks | **8.8e-4** |
| KL(observed ‖ theoretical) | **5.9e-5** |
| Rank-1 / Rank-20 frequency ratio | 20.58 (theoretical 20.00) |
| Reproducibility under fixed seed | identical counts on repeat runs |

### Deterministic seed-213 sanity check

`gsp_num_groups=20, gsp_prompts_per_group=1, gsp_zipf_alpha=1.0`:

```
assignment = [5, 6, 1, 1, 1, 10, 11, 0, 0, 0, 18, 9, 1, 1, 1, 19, 1, 1, 12, 14]
distinct groups: 11, repeated-prefix slots: 9 ✓
```

### End-to-end radix-cache hit rate — small workload

`Qwen/Qwen3-0.6B` on 1× H200, `--enable-cache-report`. Cache flushed before each run. Hit rate = `Σ usage.prompt_tokens_details.cached_tokens / Σ usage.prompt_tokens`.

20 requests, ISL ≈ 2000, OSL = 100, `seed=213`, `α=1.0`:

| Workload | concurrency | total prompt | total cached | **hit rate** | reconciliation |
|---|---|---|---|---|---|
| GSP Zipf | 4 | 42,370 | 16,128 | **38.06%** | 8 of 9 expected repeats hit; 1 lost to c=4 scheduling overlap. Theoretical 37.76% |
| GSP Zipf | 1 | 42,370 | 18,000 | **42.70%** | All 9 expected repeats hit. Theoretical 42.75% |
| Random (same shape, no shared prefix) | 4 | 42,161 | 0 | **0.00%** | Confirms baseline — no spurious hits |
| `bench_multiturn` (10 clients × 2 rounds, matched ISL/OSL/concurrency) | 4 | ~40,000 | ~20,000 | **50.00%** | Round 1 misses, round 2 hits ≈95.2%; (10×0 + 10×95.2) / 20 ≈ 47.6% |

Zipf c=1 hits the theoretical cold-cache prompt-token reuse rate within rounding noise. Random baseline is exactly 0%, confirming the cache is exercised by prefix sharing rather than by spurious effects. `bench_multiturn` produces a comparable hit rate via a different mechanism (history accumulation per client vs Zipfian cross-request prefix sharing) — Zipf-GSP and `bench_multiturn` are complementary tools, not substitutes.

### End-to-end radix-cache hit rate — large workload (5-seed sweep)

`Qwen/Qwen3-0.6B` on 1× H200, `--enable-cache-report --enable-metrics --mem-fraction-static 0.85 --max-running-requests 40 --context-length 24000`. Cache flushed before each seed. Hit rate = `Σ sglang:cached_tokens_total / Σ sglang:prompt_tokens_total` over the run window.

Workload: `--gsp-num-groups 200 --gsp-prompts-per-group 1 --gsp-system-prompt-len 19000 --gsp-question-len 1000 --gsp-output-len 1000 --gsp-group-distribution zipf --gsp-zipf-alpha 1.0 --max-concurrency 40 --request-rate inf --gsp-ordered`, 200 requests/seed, ISL ≈ 21K, OSL = 1K.

| seed | total prompt tk | total cached tk | **hit rate** | median TTFT |
|---|---|---|---|---|
| 211 | 4,212,870 | 2,397,767 | **56.92%** | 2185 ms |
| 212 | 4,211,765 | 2,578,991 | **61.23%** | 2213 ms |
| 213 | 4,209,419 | 2,274,251 | **54.03%** | 2131 ms |
| 214 | 4,211,905 | 2,138,079 | **50.76%** | 2200 ms |
| 215 | 4,209,394 | 2,138,395 | **50.80%** | 2189 ms |
| **mean** | | | **54.7%** | 2184 ms |

Top-40 of 200 groups carry ~80% of Zipf α=1.0 probability mass; the device KV (1.09M tokens) fits ≈57 system prefixes of 19K each, so the hot head stays cached and the cold tail evicts. The cross-seed 10pp spread reflects sample-to-sample variance in how often the hot prefixes recur.

### Distributional correctness (formal statistical tests)

Beyond shape and integration: a chi-square + KS goodness-of-fit + log-log slope sweep across α ∈ {0.5, 1.0, 1.5, 2.0, 2.5} × 5 seeds confirms the sampler produces *exactly* the Zipf distribution (not a look-alike). Slopes match −α within 3 standard errors at every (α, seed); the LoRA `α^−i` formula is rejected with p ≈ 0 at every α ≠ 1; the bench-driven `routing_key` assignment is byte-identical to the standalone `_zipf_group_probs + rng.choice` primitive.

## Speed Tests and Profiling

No inference-path changes. The Zipf branch only changes how groups are assigned to existing slots; per-request encode / decode behavior is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26553597266](https://github.com/sgl-project/sglang/actions/runs/26553597266)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26553597194](https://github.com/sgl-project/sglang/actions/runs/26553597194)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
