### PR TITLE
Enable Kimi-K2.5 piecewise CUDA graph

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -178,6 +178,7 @@ def _forward_with_allreduce_fusion(
                     residual=residual,
                     weight=weight,
                     eps=norm_module.variance_epsilon,
+                    max_token_num=max(x.shape[0], 2048),
                     use_attn_tp_group=use_attn_tp_group,
                 )
                 if fused_result[0] is not None:

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -674,6 +674,22 @@ class KimiK25ForConditionalGeneration(nn.Module):
             self.vision_tower = self.vision_tower.to(dtype=target_dtype)
             self.mm_projector = self.mm_projector.to(dtype=target_dtype)
 
+    @property
+    def model(self):
+        # Alias .model to .language_model so this class satisfies the piecewise
+        # CUDA graph gate, which checks `hasattr(model, "model")`.
+        return self.language_model
+
+    def __setattr__(self, name, value):
+        # Block writes to "model" so the runner's
+        # `self.model.model = resolve_language_model(self.model)` is a no-op
+        # instead of duplicate nn.Module registration. nn.Module.__setattr__
+        # bypasses @property setters for Module values, so the guard must live
+        # here to keep state_dict and loading paths unchanged.
+        if name == "model":
+            return
+        super().__setattr__(name, value)
+
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         device = self.vision_tower.device
         target_dtype = self.vision_tower.patch_embed.proj.weight.dtype

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -681,11 +681,8 @@ class KimiK25ForConditionalGeneration(nn.Module):
         return self.language_model
 
     def __setattr__(self, name, value):
-        # Block writes to "model" so the runner's
-        # `self.model.model = resolve_language_model(self.model)` is a no-op
-        # instead of duplicate nn.Module registration. nn.Module.__setattr__
-        # bypasses @property setters for Module values, so the guard must live
-        # here to keep state_dict and loading paths unchanged.
+        # Skip redundant self.model.model assignment in runner to avoid duplicate
+        # nn.Module registration.
         if name == "model":
             return
         super().__setattr__(name, value)


### PR DESCRIPTION
## Summary

This PR enables piecewise CUDA graph for the Kimi-K2.5 multimodal wrapper.

Root cause: `KimiK25ForConditionalGeneration` wraps the language model as `language_model`, but the generic piecewise CUDA graph setup checks the common `.model` wrapper path. Without that alias, startup logs report `Disable piecewise CUDA graph because the model is not a language model`, and prefill runs without piecewise CUDA graph.

Changes:
- Add a `.model` property alias that returns `self.language_model`.
- Ignore writes to `.model` during ModelRunner piecewise CUDA graph setup so we do not register a duplicate `nn.Module` alias or perturb state dict / loading paths.
- Pass the runtime token count with a `2048` floor, `max_token_num=max(x.shape[0], 2048)`, to FlashInfer allreduce residual RMSNorm fusion.

## Retest on B200

Re-tested on `ion-b200` on 2026-05-26 with the same Kimi-K2.5 command and workload for both rows. The patched row was re-tested after the Gemini follow-up at head `625b07d03`.

Server shape:
- Model: `/tmp/models/Kimi-K2.5`
- GPUs: B200 `CUDA_VISIBLE_DEVICES=4,5,6,7`, `--tp 4`
- Key flags: `--enable-multimodal --schedule-policy lpm --enable-mixed-chunk --enable-cache-report --keep-mm-feature-on-device --enforce-piecewise-cuda-graph --piecewise-cuda-graph-max-tokens 4096`
- Env: `SGLANG_MM_FEATURE_CACHE_MB=1024`, `SGLANG_USE_CUDA_IPC_TRANSPORT=1`

Probe shape:
- `synthetic-text`, `--synthetic-words 512`, `--limit 256`, `--concurrency 32`, `--max-tokens 20`, `--no-thinking`
- Metrics below use the second warm run after prefix cache is populated.

| Build | Piecewise CUDA graph evidence | TTFT mean | TTFT p50 | TTFT p90 | TTFT p99 | TPOT mean | E2E mean | Cache read tokens |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| `origin/main` | disabled: `not a language model`; prefill `cuda graph: False` | 0.479s | 0.495s | 0.528s | 0.546s | 12.5ms | 0.722s | 131,072 |
| this PR | enabled: `Capture piecewise CUDA graph end`; prefill `cuda graph: True` | 0.147s | 0.133s | 0.216s | 0.243s | 17.7ms | 0.488s | 131,072 |

TTFT mean drops from `0.479s` to `0.147s` on this workload.

Relevant log evidence:

```text
# origin/main
Disable piecewise CUDA graph because the model is not a language model
Prefill batch ... cuda graph: False

# this PR
Capture piecewise CUDA graph end. Time elapsed: 87.16 s.
Prefill batch ... cuda graph: True
```

## Checks

- `git diff --check`
- `ruff check --select F401,F821 python/sglang/srt/layers/layernorm.py python/sglang/srt/models/kimi_k25.py`
- `python3 -m py_compile python/sglang/srt/layers/layernorm.py python/sglang/srt/models/kimi_k25.py`
- Verified a dummy `@model.setter` on `nn.Module` still registers duplicate `model.*` state_dict keys for `Module` values, so `__setattr__` is intentional here.
- Remote B200 launch + latency probes above









































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26488537007](https://github.com/sgl-project/sglang/actions/runs/26488537007)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26488536942](https://github.com/sgl-project/sglang/actions/runs/26488536942)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->