### PR TITLE
[XPU CI] Add nightly Docker build + reusable start-container script

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -68,7 +68,8 @@ jobs:
     uses: ./.github/workflows/pr-gate.yml
     secrets: inherit
 
-  build-and-test:
+  # ==================== Stage A ==================== #
+  stage-a-test-1-gpu-xpu:
     needs: [check-changes, pr-gate]
     if: needs.check-changes.outputs.main_package == 'true'
     runs-on: intel-bmg
@@ -79,62 +80,91 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
 
-      - name: Build Docker image
-        run: |
-          PR_REPO=${{ github.event.pull_request.head.repo.clone_url }}
-          PR_HEAD_REF=${{ github.head_ref }}
-          docker build \
-            ${PR_REPO:+--build-arg SG_LANG_REPO=$PR_REPO} \
-            ${PR_HEAD_REF:+--build-arg SG_LANG_BRANCH=$PR_HEAD_REF} \
-            --no-cache --progress=plain -f docker/xpu.Dockerfile -t xpu_sglang_main:bmg .
-
-      - name: Run container
-        id: start_container
-        run: |
-          container_id=$(docker run -dt \
-            --group-add 992 \
-            --group-add $(getent group video | cut -d: -f3) \
-            --group-add $(getent group render | cut -d: -f3) \
-            -v $HOME/.cache/huggingface:/root/.cache/huggingface \
-            --device /dev/dri \
-            -v /dev/dri/by-path:/dev/dri/by-path \
-            -e HF_TOKEN="$(cat ~/huggingface_token.txt)" \
-            xpu_sglang_main:bmg)
-          echo "Started container: $container_id"
-          echo "container_id=$container_id" >> "$GITHUB_OUTPUT"
+      - name: Start CI container
+        run: bash scripts/ci/xpu/xpu_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          INTEL_HARBOR_USERNAME: ${{ secrets.INTEL_HARBOR_USERNAME }}
+          INTEL_HARBOR_TOKEN: ${{ secrets.INTEL_HARBOR_TOKEN }}
 
       - name: Install Dependency
         timeout-minutes: 20
         run: |
-          cid="${{ steps.start_container.outputs.container_id }}"
-          docker exec "$cid" /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install --upgrade pip
-          docker exec "$cid" /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install pytest expecttest ray huggingface_hub
-          docker exec "$cid" /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip uninstall -y flashinfer-python
-          docker exec "$cid" /bin/bash -c '/home/sdp/miniforge3/envs/py3.12/bin/hf auth login --token ${HF_TOKEN} '
+          docker exec ci_sglang_xpu /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install --upgrade pip
+          docker exec ci_sglang_xpu /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install pytest expecttest ray huggingface_hub tabulate
+          docker exec ci_sglang_xpu /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip uninstall -y flashinfer-python
+          docker exec ci_sglang_xpu bash -c "cp /sglang-checkout/python/pyproject_xpu.toml /sglang-checkout/python/pyproject.toml && /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install --no-deps /sglang-checkout/python --extra-index-url https://download.pytorch.org/whl/xpu"
+          docker exec ci_sglang_xpu /bin/bash -c '/home/sdp/miniforge3/envs/py3.12/bin/hf auth login --token ${HF_TOKEN} '
 
-
-      - name: Run E2E Bfloat16 tests
-        timeout-minutes: 20
+      - name: Run stage-a tests
+        timeout-minutes: 30
         run: |
-          cid="${{ steps.start_container.outputs.container_id }}"
-          docker exec "$cid" bash -c "source /home/sdp/miniforge3/bin/activate && conda activate py3.12 && cd /home/sdp/sglang/test/srt && python3 run_suite.py --suite per-commit-xpu"
+          docker exec ci_sglang_xpu bash -c "source /home/sdp/miniforge3/bin/activate && conda activate py3.12 && cd /sglang-checkout/test && python3 run_suite.py --hw xpu --suite stage-a-test-1-gpu-xpu"
+
       - name: Cleanup container
         if: always()
+        run: docker rm -f ci_sglang_xpu || true
+
+  # ==================== Wait for Stage A ==================== #
+  wait-for-stage-a:
+    needs: [stage-a-test-1-gpu-xpu]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stage-a passed"
+
+  # ==================== Stage B ==================== #
+  stage-b-test-1-gpu-xpu:
+    needs: [check-changes, pr-gate, wait-for-stage-a]
+    if: needs.check-changes.outputs.main_package == 'true'
+    runs-on: intel-bmg
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Start CI container
+        run: bash scripts/ci/xpu/xpu_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          INTEL_HARBOR_USERNAME: ${{ secrets.INTEL_HARBOR_USERNAME }}
+          INTEL_HARBOR_TOKEN: ${{ secrets.INTEL_HARBOR_TOKEN }}
+
+      - name: Install Dependency
+        timeout-minutes: 20
         run: |
-          cid="${{ steps.start_container.outputs.container_id }}"
-          docker rm -f "$cid" || true
+          docker exec ci_sglang_xpu /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install --upgrade pip
+          docker exec ci_sglang_xpu /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install pytest expecttest ray huggingface_hub tabulate
+          docker exec ci_sglang_xpu /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip uninstall -y flashinfer-python
+          docker exec ci_sglang_xpu bash -c "cp /sglang-checkout/python/pyproject_xpu.toml /sglang-checkout/python/pyproject.toml && /home/sdp/miniforge3/envs/py3.12/bin/python3 -m pip install --no-deps /sglang-checkout/python --extra-index-url https://download.pytorch.org/whl/xpu"
+          docker exec ci_sglang_xpu /bin/bash -c '/home/sdp/miniforge3/envs/py3.12/bin/hf auth login --token ${HF_TOKEN} '
+
+      - name: Run stage-b tests
+        timeout-minutes: 60
+        run: |
+          docker exec ci_sglang_xpu bash -c "source /home/sdp/miniforge3/bin/activate && conda activate py3.12 && cd /sglang-checkout/test && python3 run_suite.py --hw xpu --suite stage-b-test-1-gpu-xpu"
+
+      - name: Cleanup container
+        if: always()
+        run: docker rm -f ci_sglang_xpu || true
 
   finish:
     if: always()
-    needs: [build-and-test, pr-gate]
+    needs: [stage-a-test-1-gpu-xpu, stage-b-test-1-gpu-xpu, pr-gate]
     runs-on: ubuntu-latest
     steps:
       - name: Check job status
         run: |
-          result="${{ needs.build-and-test.result }}"
-          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
-            echo "Job failed with result: $result"
+          stage_a="${{ needs.stage-a-test-1-gpu-xpu.result }}"
+          stage_b="${{ needs.stage-b-test-1-gpu-xpu.result }}"
+          if [ "$stage_a" != "success" ] && [ "$stage_a" != "skipped" ]; then
+            echo "stage-a failed with result: $stage_a"
             exit 1
           fi
-          echo "All jobs completed successfully (result: $result)"
+          if [ "$stage_b" != "success" ] && [ "$stage_b" != "skipped" ]; then
+            echo "stage-b failed with result: $stage_b"
+            exit 1
+          fi
+          echo "All jobs completed successfully"
           exit 0

--- a/.github/workflows/release-docker-xpu-nightly.yml
+++ b/.github/workflows/release-docker-xpu-nightly.yml
@@ -1,0 +1,109 @@
+name: Release Docker Images Nightly XPU (Intel)
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: intel-bmg
+    environment: 'prod'
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu_arch: ['bmg']
+        build_type: ['all']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git describe to find tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: "Set Date"
+        run: |
+          echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
+
+      - name: Get version from latest tag
+        id: version
+        run: |
+          # Use the shared helper so stable/post releases sort above rc tags.
+          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version from git tags"
+            exit 1
+          fi
+
+          # Get short commit hash of current HEAD
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+
+          # Compose pretend version for setuptools_scm: e.g., 0.5.8.dev20260129+g1a2b3c4
+          PRETEND_VERSION="${VERSION}.dev${{ env.DATE }}+g${COMMIT_HASH}"
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "pretend_version=${PRETEND_VERSION}" >> $GITHUB_OUTPUT
+          echo "Detected version: ${VERSION}"
+          echo "Pretend version for pip: ${PRETEND_VERSION}"
+
+      - name: Login to Intel Harbor (gar-registry.caas.intel.com)
+        uses: docker/login-action@v2
+        with:
+          registry: gar-registry.caas.intel.com
+          username: ${{ secrets.INTEL_HARBOR_USERNAME }}
+          password: ${{ secrets.INTEL_HARBOR_TOKEN }}
+
+      - name: Build and Push to gar-registry.caas.intel.com/sglang/sglang-xpu
+        run: |
+          version=${{ steps.version.outputs.version }}
+          pretend_version=${{ steps.version.outputs.pretend_version }}
+          echo "Version: ${version}"
+          echo "Pretend version: ${pretend_version}"
+
+          if [ "${{ matrix.gpu_arch }}" = "bmg" ]; then
+            xpu_tag="xpu-bmg"
+          else
+            echo "Unsupported xpu arch: ${{ matrix.gpu_arch }}"
+            exit 1
+          fi
+
+          tag=v${version}-${xpu_tag}
+          echo "IMAGE_TAG=${tag}-${{ env.DATE }}" >> $GITHUB_ENV
+
+          image="gar-registry.caas.intel.com/sglang/sglang-xpu:${tag}-${{ env.DATE }}"
+
+          docker build . \
+            -f docker/xpu.Dockerfile \
+            --build-arg SG_LANG_BRANCH=${{ github.ref_name }} \
+            --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} \
+            -t "${image}" \
+            --no-cache --progress=plain
+          docker push "${image}"
+
+      # Persist the tag right after the push succeeds so a downstream mirror or
+      # cache job can read exactly the tag that landed on the registry, even if
+      # a later step in this job fails.
+      - name: Save published image tag
+        run: |
+          mkdir -p image-tag
+          echo "${{ env.IMAGE_TAG }}" > "image-tag/${{ matrix.gpu_arch }}.txt"
+
+      - name: Upload image tag artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-tag-${{ matrix.gpu_arch }}
+          path: image-tag/${{ matrix.gpu_arch }}.txt
+          retention-days: 1

--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get version from git tags
+SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are found
+
+# Fetch tags from origin to ensure we have the latest
+if git fetch --tags origin; then
+  # Use the shared helper so stable/post releases sort above rc tags.
+  VERSION_FROM_TAG=$(python3 python/tools/get_version_tag.py --tag-only || true)
+  if [ -n "$VERSION_FROM_TAG" ]; then
+    SGLANG_VERSION="$VERSION_FROM_TAG"
+    echo "Using SGLang version from git tags: $SGLANG_VERSION"
+  else
+    echo "Warning: No version tags found; using default $SGLANG_VERSION" >&2
+  fi
+else
+  echo "Warning: Failed to fetch tags from origin; using default $SGLANG_VERSION" >&2
+fi
+
+
+# Default base tags (can be overridden by command line arguments)
+XPU_REGISTRY="gar-registry.caas.intel.com/sglang/sglang-xpu"
+DEFAULT_BMG_BASE_TAG="${SGLANG_VERSION}-xpu-bmg"
+
+# Parse command line arguments
+BMG_BASE_TAG="${DEFAULT_BMG_BASE_TAG}"
+CUSTOM_IMAGE=""
+BUILD_FROM_DOCKERFILE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --bmg-base-tag) BMG_BASE_TAG="$2"; shift 2;;
+    --custom-image) CUSTOM_IMAGE="$2"; shift 2;;
+    --build-from-dockerfile) BUILD_FROM_DOCKERFILE="1"; shift;;
+    -h|--help)
+      echo "Usage: $0 [OPTIONS]"
+      echo "Options:"
+      echo "  --bmg-base-tag TAG         Override BMG base image tag"
+      echo "  --custom-image IMAGE       Use a specific Docker image directly"
+      echo "  --build-from-dockerfile    Build image from docker/xpu.Dockerfile"
+      exit 0
+      ;;
+    *) echo "Unknown option $1"; exit 1;;
+  esac
+done
+
+
+# Detect GPU architecture (single-arch today, but kept for parity with AMD)
+GPU_ARCH="bmg"
+
+# Retry a command with exponential backoff. Usage: retry_with_backoff <max_attempts> <cmd...>
+retry_with_backoff() {
+  local max_attempts=$1; shift
+  local attempt=1
+  local wait_secs=30
+  # Add jitter (0-30s) so concurrent jobs don't all retry at the same instant
+  local jitter=$(( RANDOM % 30 ))
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if (( attempt >= max_attempts )); then
+      echo "Error: '$*' failed after ${max_attempts} attempts" >&2
+      return 1
+    fi
+    local sleep_time=$(( wait_secs + jitter ))
+    echo "Attempt ${attempt}/${max_attempts} failed. Retrying in ${sleep_time}s…" >&2
+    sleep "${sleep_time}"
+    (( attempt++ ))
+    (( wait_secs = wait_secs * 2 > 300 ? 300 : wait_secs * 2 ))
+    jitter=$(( RANDOM % 30 ))
+  done
+}
+
+# Authenticate to the Intel Harbor registry to avoid anonymous pull issues.
+# Credentials are optional; when absent we fall back to unauthenticated pulls.
+if [[ -n "${INTEL_HARBOR_USERNAME:-}" && -n "${INTEL_HARBOR_TOKEN:-}" ]]; then
+  echo "Logging in to gar-registry.caas.intel.com…"
+  if retry_with_backoff 6 sh -c 'echo "${INTEL_HARBOR_TOKEN}" | docker login gar-registry.caas.intel.com -u "${INTEL_HARBOR_USERNAME}" --password-stdin >/dev/null 2>&1'; then
+    echo "Intel Harbor login successful"
+  else
+    echo "Warning: Intel Harbor login failed after retries; continuing with unauthenticated pulls" >&2
+  fi
+fi
+
+# Find the latest image
+find_latest_image() {
+  local gpu_arch=$1
+  local base_tag days_back image_tag image_id
+
+  case "${gpu_arch}" in
+      bmg)   base_tag="${BMG_BASE_TAG}" ;;
+      *)     echo "Error: unsupported GPU architecture '${gpu_arch}'" >&2; return 1 ;;
+  esac
+
+  # First, check local cache on the runner.
+  for days_back in {0..6}; do
+    image_tag="${base_tag}-$(date -d "${days_back} days ago" +%Y%m%d)"
+    image_id=$(docker images -q "${XPU_REGISTRY}:${image_tag}")
+    if [[ -n "$image_id" ]]; then
+      echo "Found cached image locally: ${XPU_REGISTRY}:${image_tag}" >&2
+      echo "${XPU_REGISTRY}:${image_tag}"
+      return 0
+    fi
+  done
+
+  # If not found locally, probe the remote registry by manifest.
+  for days_back in {0..6}; do
+    image_tag="${base_tag}-$(date -d "${days_back} days ago" +%Y%m%d)"
+    echo "Checking for image: ${XPU_REGISTRY}:${image_tag}" >&2
+    if docker manifest inspect "${XPU_REGISTRY}:${image_tag}" >/dev/null 2>&1; then
+      echo "Found available image: ${XPU_REGISTRY}:${image_tag}" >&2
+      echo "${XPU_REGISTRY}:${image_tag}"
+      return 0
+    fi
+  done
+
+  echo "No recent images found. Searching any cached local images matching ${gpu_arch}…" >&2
+  local any_local
+  any_local=$(docker images --format '{{.Repository}}:{{.Tag}}' --filter "reference=${XPU_REGISTRY}:*xpu-${gpu_arch}*" | sort -r | head -n 1)
+  if [[ -n "$any_local" ]]; then
+      echo "Using cached fallback image: ${any_local}" >&2
+      echo "${any_local}"
+      return 0
+  fi
+
+  echo "Error: no ${gpu_arch} image found in the last 7 days for base ${base_tag}" >&2
+  return 1
+}
+
+# Determine which image to use
+if [[ -n "${CUSTOM_IMAGE}" ]]; then
+  # Use explicitly provided custom image
+  IMAGE="${CUSTOM_IMAGE}"
+  echo "Using custom image: ${IMAGE}"
+  retry_with_backoff 6 docker pull "${IMAGE}"
+elif [[ -n "${BUILD_FROM_DOCKERFILE}" ]]; then
+  # Build image from Dockerfile
+  DOCKERFILE_DIR="${GITHUB_WORKSPACE:-$PWD}/docker"
+  DOCKERFILE="${DOCKERFILE_DIR}/xpu.Dockerfile"
+
+  if [[ ! -f "${DOCKERFILE}" ]]; then
+    echo "Error: Dockerfile not found at ${DOCKERFILE}" >&2
+    exit 1
+  fi
+
+  IMAGE="sglang-xpu-ci:${GPU_ARCH}-$(date +%Y%m%d)"
+  echo "Building Docker image from ${DOCKERFILE}..."
+
+  PR_REPO="${PR_REPO:-}"
+  PR_HEAD_REF="${PR_HEAD_REF:-}"
+  docker build \
+    ${PR_REPO:+--build-arg SG_LANG_REPO=$PR_REPO} \
+    ${PR_HEAD_REF:+--build-arg SG_LANG_BRANCH=$PR_HEAD_REF} \
+    -t "${IMAGE}" \
+    -f "${DOCKERFILE}" \
+    --no-cache --progress=plain \
+    "${GITHUB_WORKSPACE:-$PWD}"
+  echo "Successfully built image: ${IMAGE}"
+else
+  # Find the latest pre-built image
+  IMAGE=$(find_latest_image "${GPU_ARCH}")
+  retry_with_backoff 6 docker pull "${IMAGE}"
+fi
+
+# HF token can be provided via env or via the token file used by pr-test-xpu.yml.
+if [[ -z "${HF_TOKEN:-}" && -f "$HOME/huggingface_token.txt" ]]; then
+  HF_TOKEN="$(cat "$HOME/huggingface_token.txt")"
+fi
+
+echo "Launching container: ci_sglang_xpu"
+docker run -dt \
+  --group-add 992 \
+  --group-add "$(getent group video | cut -d: -f3)" \
+  --group-add "$(getent group render | cut -d: -f3)" \
+  --device /dev/dri \
+  -v /dev/dri/by-path:/dev/dri/by-path \
+  -v "${GITHUB_WORKSPACE:-$PWD}:/sglang-checkout" \
+  -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
+  --shm-size 32g \
+  --cap-add=SYS_PTRACE \
+  -e HF_TOKEN="${HF_TOKEN:-}" \
+  -e HF_HUB_ETAG_TIMEOUT=300 \
+  -e HF_HUB_DOWNLOAD_TIMEOUT=300 \
+  --security-opt seccomp=unconfined \
+  -w /sglang-checkout \
+  --name ci_sglang_xpu \
+  "${IMAGE}"
+
+# Mark the mounted checkout safe so setuptools-scm / vcs_versioning can resolve
+# the package version (the runner mount is owned by a non-root user but the
+# container may run as root for some operations).
+docker exec ci_sglang_xpu git config --global --add safe.directory /sglang-checkout


### PR DESCRIPTION
## Motivation

Improve the XPU CI pipeline reliability and reduce per-PR build times by switching from building Docker images on every PR to pulling pre-built nightly images. Also introduces a staged test pipeline for better failure isolation.

## Modifications

- **New workflow: `release-docker-xpu-nightly.yml`** — Builds and pushes XPU BMG Docker images to Intel Harbor registry on a daily schedule (cron `0 12 * * *`)
- **Refactored `pr-test-xpu.yml`** — Split the single `build-and-test` job into a staged pipeline (Stage A → Stage B) that runs tests sequentially with fast-fail
- **New script: `scripts/ci/xpu/xpu_ci_start_container.sh`** — Reusable container startup script that:
  - Discovers the latest nightly image (checks local cache, then remote registry, with 7-day lookback)
  - Authenticates to Intel Harbor with retry/exponential backoff
  - Supports three modes: nightly image pull (default), custom image, or build from Dockerfile
  - Mounts the PR checkout into the container at `/sglang-checkout` for live code testing

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26442885124](https://github.com/sgl-project/sglang/actions/runs/26442885124)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26442884976](https://github.com/sgl-project/sglang/actions/runs/26442884976)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->