### PR TITLE
[AMD] [CI] Add DeepSeek-R1-0528 FP8 HiCache GSM8K test on MI35x

### DIFF
--- a/test/registered/amd/test_deepseek_r1_hicache_mi35x.py
+++ b/test/registered/amd/test_deepseek_r1_hicache_mi35x.py
@@ -1,0 +1,171 @@
+"""MI35x DeepSeek-R1-0528 FP8 HiCache PR Test (8-GPU)
+
+Regression guard: launches DeepSeek-R1-0528 (native FP8, MLA, aiter attention
+backend) on MI35x with the full L1+L2+L3 HiCache hierarchy wired up
+(``--enable-hierarchical-cache --hicache-storage-backend file``), then runs
+GSM8K few-shot completion and asserts the accuracy still matches the
+established threshold. The goal is to catch regressions where HiCache
+breaks DSR1-0528 generation correctness, not to stress-test the cascade
+overflow path (that lives in the nightly suite).
+
+Acceptance: GSM8K (200 questions, 5-shot, completion API) score >= 0.93,
+matching ``test_deepseek_r1_eval_mi35x.py`` /
+``test_deepseek_r1_eval_amd.py``.
+
+Registry: stage-c-test-large-8-gpu-amd-mi35x (per-commit PR suite).
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+# MI35x CI runner caches HF models on a fast local volume. We only fall
+# back to this if HF_HOME isn't already set by the runner (e.g. repro_ci.sh
+# points HF_HOME at /sgl-data/hf-cache); never force HF_HUB_CACHE so
+# huggingface_hub keeps deriving it as $HF_HOME/hub.
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+# ~15 min: 5-8 min weight load + ~2-3 min GSM8K + slack.
+register_amd_ci(est_time=900, suite="stage-c-test-large-8-gpu-amd-mi35x")
+
+DEEPSEEK_R1_MODEL_PATH = "deepseek-ai/DeepSeek-R1-0528"
+SERVER_LAUNCH_TIMEOUT = 1500
+
+# Threshold matches the existing nightly AMD DSR1-0528 accuracy tests:
+#   test/registered/amd/accuracy/mi35x/test_deepseek_r1_eval_mi35x.py
+#   test/registered/amd/accuracy/mi30x/test_deepseek_r1_eval_amd.py
+GSM8K_ACCURACY_THRESHOLD = 0.93
+GSM8K_NUM_EXAMPLES = 200
+GSM8K_NUM_SHOTS = 5
+GSM8K_NUM_THREADS = 64
+
+
+class TestDeepSeekR1HiCacheMI35x(CustomTestCase):
+    """DSR1-0528 FP8 + HiCache (L1+L2+L3) GSM8K regression test for MI35x."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_R1_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.l3_storage_dir = tempfile.mkdtemp(prefix="dsr1-hicache-l3-")
+
+        # cascade_dsr1_lite.sh on ROCm DSR1-0528 requires:
+        #   SGLANG_USE_AITER=1                  -> aiter prefill/decode path
+        #   ROCM_QUICK_REDUCE_QUANTIZATION=NONE -> keep allreduce fp16/bf16
+        #   SGLANG_AITER_FP8_PREFILL_ATTN=0     -> disable PR #18528 FP8,
+        #                                          prefill kernel flash_attn_varlen_func
+        #                                          which is incompatible with
+        #                                          DSR1-0528 + page_size=64
+        env = {
+            **os.environ,
+            "SGLANG_USE_AITER": "1",
+            "ROCM_QUICK_REDUCE_QUANTIZATION": "NONE",
+            "SGLANG_AITER_FP8_PREFILL_ATTN": "0",
+            "SAFETENSORS_FAST_GPU": "1",
+            "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.l3_storage_dir,
+        }
+
+        other_args = [
+            "--tp",
+            "8",
+            "--trust-remote-code",
+            "--mem-fraction-static",
+            "0.6",
+            "--kv-cache-dtype",
+            "fp8_e4m3",
+            "--attention-backend",
+            "aiter",
+            "--page-size",
+            "64",
+            "--context-length",
+            "65536",
+            "--chunked-prefill-size",
+            "32768",
+            "--max-prefill-tokens",
+            "32768",
+            "--watchdog-timeout",
+            "1200",
+            "--enable-metrics",
+            "--enable-cache-report",
+            # HiCache hierarchy: L1 (GPU radix) + L2 (host pinned) + L3 (file).
+            # hicache-ratio=2 gives L2 = 2 * L1 (SGLang requires L1 <= L2).
+            "--enable-hierarchical-cache",
+            "--hicache-ratio",
+            "2",
+            "--hicache-io-backend",
+            "kernel",
+            # page_first + kernel io is the recommended pair; page_first_direct
+            # would silently downgrade io to direct (server_args.py:3108-3125).
+            "--hicache-mem-layout",
+            "page_first",
+            "--hicache-write-policy",
+            "write_through",
+            "--hicache-storage-backend",
+            "file",
+            "--hicache-storage-prefetch-policy",
+            "best_effort",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true, "num_threads": 64}',
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            env=env,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            kill_process_tree(cls.process.pid)
+        if getattr(cls, "l3_storage_dir", None):
+            shutil.rmtree(cls.l3_storage_dir, ignore_errors=True)
+
+    def test_gsm8k(self):
+        """GSM8K few-shot completion against the HiCache-enabled DSR1-0528."""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            eval_name="gsm8k",
+            api="completion",
+            num_examples=GSM8K_NUM_EXAMPLES,
+            num_shots=GSM8K_NUM_SHOTS,
+            num_threads=GSM8K_NUM_THREADS,
+            max_tokens=512,
+            temperature=0.0,
+        )
+        metrics = run_eval(args)
+        score = metrics["score"]
+        print(f"GSM8K {metrics=}", flush=True)
+
+        if is_in_ci():
+            write_github_step_summary(
+                "### DeepSeek-R1-0528 FP8 HiCache GSM8K (MI35x)\n\n"
+                f"- score: `{score:.3f}` (threshold `{GSM8K_ACCURACY_THRESHOLD}`)\n"
+                f"- latency: `{metrics.get('latency', 0):.1f}s`\n"
+            )
+
+        self.assertGreater(
+            score,
+            GSM8K_ACCURACY_THRESHOLD,
+            f"DSR1-0528 FP8 + HiCache GSM8K accuracy {score:.3f} "
+            f"below threshold {GSM8K_ACCURACY_THRESHOLD}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add per-commit PR-CI coverage for `deepseek-ai/DeepSeek-R1-0528` (native FP8, MLA, aiter attention backend) running on AMD MI35x with the full **L1 + L2 + L3 HiCache hierarchy** enabled (`--enable-hierarchical-cache --hicache-ratio 2 --hicache-storage-backend file`).

The existing nightly DSR1-0528 AMD eval tests (`test_deepseek_r1_eval_mi35x.py`, `test_deepseek_r1_eval_amd.py`) intentionally pass `--disable-radix-cache`, so any regression that breaks DSR1-0528 generation correctness *under* HiCache has no per-commit coverage today. This PR closes that gap.

## Modifications

- Add `test/registered/amd/test_deepseek_r1_hicache_mi35x.py` (1 new file).
- Register it with `register_amd_ci(est_time=900, suite="stage-c-test-large-8-gpu-amd-mi35x")` (per-commit, `nightly=False`).
- GSM8K 200-question 5-shot completion eval; accuracy threshold **`0.93`** matches the existing nightly DSR1-0528 AMD eval tests exactly (`test/registered/amd/accuracy/mi35x/test_deepseek_r1_eval_mi35x.py`, `test/registered/amd/accuracy/mi30x/test_deepseek_r1_eval_amd.py`).

## Accuracy Tests

Local repro on MI355X (`rocm/sgl-dev:v0.5.12-rocm720-mi35x-20260517` image, `SGLANG_IS_IN_CI=1` / `GPU_ARCHS=gfx950` like `repro_ci.sh` does):

```
Total latency: 22.674 s
Score: 0.955
Output throughput: 907.987 token/s
GSM8K metrics={'score:std': 0.20730, 'score': 0.955, 'latency': 22.674, 'output_throughput': 907.987}
Ran 1 test in 349.273s

OK
```

| Metric | Local repro | Threshold | Result |
|---|---|---|---|
| **GSM8K score** | **0.955** | ≥ 0.93 | **PASS** (+0.025 margin) |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). `pre-commit run --files test/registered/amd/test_deepseek_r1_hicache_mi35x.py` clean (trailing-whitespace, end-of-file-fixer, isort, ruff `F401,F821`, black-jupyter, codespell, check-registered-tests all pass).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). New test file `test/registered/amd/test_deepseek_r1_hicache_mi35x.py`; runs as `python3 test/registered/amd/test_deepseek_r1_hicache_mi35x.py` (has `if __name__ == "__main__": unittest.main()`).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A, CI test registration only.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). See "Accuracy Tests" section above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

## Local repro recipe

For reviewers who want to rerun this on an MI35x box:

```bash
bash ~/SGLang-benchmarks/tools/repro_ci.sh \
    --docker rocm/sgl-dev:v0.5.12-rocm720-mi35x-20260517 \
    --hostname linux-mi35x-gpu-8 \
    --sglang-dir "$HOME/PR/sglang" \
    --single-file registered/amd/test_deepseek_r1_hicache_mi35x.py
```
