### PR TITLE
[AMD] [CI] Add GLM-5.1 MXFP4 TP2 accuracy gate

### DIFF
--- a/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py
@@ -125,10 +125,7 @@ class TestGLM51MXFP4TP2GSM8KMI35x(unittest.TestCase):
             "| Model | TP | Questions | Accuracy | Invalid | Threshold | Status |\n"
             "| ----- | -- | --------- | -------- | ------- | --------- | ------ |\n"
         )
-        passed = (
-            accuracy >= GSM8K_ACCURACY_THRESHOLD
-            and invalid <= GSM8K_INVALID_THRESHOLD
-        )
+        passed = accuracy >= GSM8K_ACCURACY_THRESHOLD and invalid <= GSM8K_INVALID_THRESHOLD
         status = "PASS" if passed else "FAIL"
         summary += (
             f"| {self.model} | 2 | {num_questions} | {accuracy:.3f} | "

--- a/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py
@@ -1,0 +1,145 @@
+"""MI355X GLM-5.1-MXFP4 TP=2 GSM8K accuracy gate.
+
+This is a PR Test (AMD) regression test for the GLM-5.1-MXFP4 TP=2
+accuracy drop seen on MI355X/gfx950 when aiter selected a bad BF16 GEMM path.
+
+Registry: stage-c-test-large-8-gpu-amd-mi35x suite
+"""
+
+import os
+import resource
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+os.environ.setdefault("HF_HOME", "/data2/models/huggingface")
+os.environ.setdefault("HF_HUB_CACHE", "/data2/models/huggingface/hub")
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_gsm8k_eval
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+register_amd_ci(
+    est_time=3600,
+    suite="stage-c-test-large-8-gpu-amd-mi35x",
+)
+
+GLM51_MXFP4_MODEL_ID = "amd/GLM-5.1-MXFP4"
+GLM51_MXFP4_LOCAL_PATHS = (
+    "/data2/models/amd-GLM-5.1-MXFP4",
+    "/data/huggingface/hub/amd/GLM-5.1-MXFP4",
+)
+
+GSM8K_ACCURACY_THRESHOLD = 0.92
+GSM8K_INVALID_THRESHOLD = 0.02
+DEFAULT_NUM_QUESTIONS = 1200
+DEFAULT_PARALLEL = 1200
+
+
+def _raise_nofile_limit() -> None:
+    """GSM8K with high parallelism can exceed the default soft nofile=1024."""
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = 65535 if hard == resource.RLIM_INFINITY else min(hard, 65535)
+    if soft < target:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+
+
+def _get_model_path() -> str:
+    env_path = os.environ.get("GLM51_MXFP4_MODEL_PATH")
+    if env_path:
+        return env_path
+    for path in GLM51_MXFP4_LOCAL_PATHS:
+        if os.path.exists(path):
+            return path
+    return GLM51_MXFP4_MODEL_ID
+
+
+class TestGLM51MXFP4TP2GSM8KMI35x(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _raise_nofile_limit()
+        cls.model = _get_model_path()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            model=cls.model,
+            base_url=cls.base_url,
+            timeout=5400,
+            other_args=[
+                "--tp",
+                "2",
+                "--trust-remote-code",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--watchdog-timeout",
+                "1200",
+                "--mem-fraction-static",
+                "0.85",
+                "--kv-cache-dtype",
+                "fp8_e4m3",
+                "--disable-radix-cache",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true, "num_threads": 8}',
+                "--dsa-prefill-backend",
+                "tilelang",
+                "--dsa-decode-backend",
+                "tilelang",
+                "--tokenizer-worker-num",
+                "4",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k_accuracy(self):
+        num_questions = int(
+            os.environ.get("GLM51_MXFP4_GSM8K_NUM_QUESTIONS", DEFAULT_NUM_QUESTIONS)
+        )
+        parallel = int(os.environ.get("GLM51_MXFP4_GSM8K_PARALLEL", DEFAULT_PARALLEL))
+        url = urlparse(self.base_url)
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=num_questions,
+            max_new_tokens=512,
+            parallel=parallel,
+            host=url.hostname or "127.0.0.1",
+            port=url.port or 30000,
+            temperature=0.0,
+        )
+
+        metrics = run_gsm8k_eval(args)
+        accuracy = metrics["accuracy"]
+        invalid = metrics["invalid"]
+        summary = (
+            "### GLM-5.1-MXFP4 TP=2 GSM8K (MI355X)\n\n"
+            "| Model | TP | Questions | Accuracy | Invalid | Threshold | Status |\n"
+            "| ----- | -- | --------- | -------- | ------- | --------- | ------ |\n"
+        )
+        passed = (
+            accuracy >= GSM8K_ACCURACY_THRESHOLD
+            and invalid <= GSM8K_INVALID_THRESHOLD
+        )
+        status = "PASS" if passed else "FAIL"
+        summary += (
+            f"| {self.model} | 2 | {num_questions} | {accuracy:.3f} | "
+            f"{invalid:.3f} | accuracy >= {GSM8K_ACCURACY_THRESHOLD:.2f} | {status} |\n"
+        )
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        self.assertGreaterEqual(accuracy, GSM8K_ACCURACY_THRESHOLD)
+        self.assertLessEqual(invalid, GSM8K_INVALID_THRESHOLD)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py
@@ -125,7 +125,9 @@ class TestGLM51MXFP4TP2GSM8KMI35x(unittest.TestCase):
             "| Model | TP | Questions | Accuracy | Invalid | Threshold | Status |\n"
             "| ----- | -- | --------- | -------- | ------- | --------- | ------ |\n"
         )
-        passed = accuracy >= GSM8K_ACCURACY_THRESHOLD and invalid <= GSM8K_INVALID_THRESHOLD
+        passed = (
+            accuracy >= GSM8K_ACCURACY_THRESHOLD and invalid <= GSM8K_INVALID_THRESHOLD
+        )
         status = "PASS" if passed else "FAIL"
         summary += (
             f"| {self.model} | 2 | {num_questions} | {accuracy:.3f} | "


### PR DESCRIPTION
## Motivation

GLM-5.1-MXFP4 on MI355X/gfx950 regressed specifically at TP=2: GSM8K dropped from the healthy ~0.94 range to ~0.58-0.62 with a high invalid rate. TP=8 stayed healthy, so the gap was not covered by the existing GLM-5.1 MI35x 8-GPU coverage.
Related Issue: https://github.com/sgl-project/sglang/issues/25742

This PR adds a PR Test (AMD) accuracy gate for `amd/GLM-5.1-MXFP4` at TP=2 so future aiter/SGLang changes cannot silently reintroduce this regression.

## Modifications

- Add `test/registered/amd/accuracy/mi35x/test_glm51_mxfp4_tp2_gsm8k_mi35x.py`.
- Register the test in the existing `stage-c-test-large-8-gpu-amd-mi35x` PR Test (AMD) suite.
- Launch `amd/GLM-5.1-MXFP4` with TP=2, DSA tilelang prefill/decode, FP8 KV cache, and GLM parsers.
- Run GSM8K with 1200 questions and require:
  - accuracy >= 0.92
  - invalid <= 0.02
- Raise the process `RLIMIT_NOFILE` before the high-parallel GSM8K run to avoid local `Too many open files` failures.

## Accuracy Tests

Local MI355X/gfx950 run in a ROCm 7.2 MI35x container with the model mounted from `/data`:

```text
python3 -m unittest registered.amd.accuracy.mi35x.test_glm51_mxfp4_tp2_gsm8k_mi35x

Ran 1 test in 249.338s
OK
Accuracy: 0.943
Invalid: 0.001
Latency: 128.114 s
Output throughput: 998.955 token/s
```

A 50-question smoke run also verified that the server launch and model path wiring work, but it was not used for the threshold because the sample size is too small and noisy.

## Speed Tests and Profiling

N/A. This PR adds an accuracy regression gate only; it does not change model, kernel, scheduler, or serving code.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). N/A, test-only PR.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26445270323](https://github.com/sgl-project/sglang/actions/runs/26445270323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26445270191](https://github.com/sgl-project/sglang/actions/runs/26445270191)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->