### PR TITLE
[Test] Add unit tests for DeepSeekV3Detector and InternlmDetector

### DIFF
--- a/test/registered/unit/function_call/test_deepseekv3_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv3_detector.py
@@ -1,0 +1,102 @@
+"""Unit tests for DeepSeekV3Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestDeepSeekV3Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query",
+                            },
+                        },
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = DeepSeekV3Detector()
+
+    # ==================== has_tool_call Tests ====================
+
+    def test_has_tool_call_true(self):
+        text = '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"city": "Beijing"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        text = "The weather in Beijing is sunny today."
+        self.assertFalse(self.detector.has_tool_call(text))
+
+    # ==================== detect_and_parse Tests ====================
+
+    def test_single_tool_call(self):
+        text = '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"city": "Beijing"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Beijing")
+
+    def test_multiple_tool_calls(self):
+        text = (
+            "<｜tool▁calls▁begin｜>"
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"city": "Beijing"}\n```<｜tool▁call▁end｜>\n'
+            '<｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"query": "restaurants"}\n```<｜tool▁call▁end｜>'
+            "<｜tool▁calls▁end｜>"
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "search")
+
+    def test_tool_call_with_preceding_text(self):
+        text = (
+            "Let me check that for you."
+            '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"city": "Tokyo"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("check that", result.normal_text)
+
+    def test_no_tool_call(self):
+        text = "Hello, how can I help you today?"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_malformed_json(self):
+        """Malformed JSON in arguments should be handled gracefully."""
+        text = '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{invalid}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        # Should not crash; returns empty calls or the raw text
+        self.assertIsNotNone(result)

--- a/test/registered/unit/function_call/test_internlm_detector.py
+++ b/test/registered/unit/function_call/test_internlm_detector.py
@@ -1,0 +1,105 @@
+"""Unit tests for InternlmDetector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.internlm_detector import InternlmDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestInternlmDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query",
+                            },
+                        },
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = InternlmDetector()
+
+    # ==================== has_tool_call Tests ====================
+
+    def test_has_tool_call_true(self):
+        text = '<|action_start|> <|plugin|>\n{"name": "get_weather", "parameters": {"city": "Beijing"}}<|action_end|>'
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        text = "The weather in Beijing is sunny today."
+        self.assertFalse(self.detector.has_tool_call(text))
+
+    # ==================== detect_and_parse Tests ====================
+
+    def test_single_tool_call(self):
+        text = '<|action_start|> <|plugin|>\n{"name": "get_weather", "parameters": {"city": "Beijing"}}<|action_end|>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Beijing")
+
+    def test_tool_call_with_arguments_key(self):
+        """InternLM supports both 'parameters' and 'arguments' keys."""
+        text = '<|action_start|> <|plugin|>\n{"name": "search", "arguments": {"query": "python tutorials"}}<|action_end|>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "search")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["query"], "python tutorials")
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<|action_start|> <|plugin|>\n{"name": "get_weather", "parameters": {"city": "Beijing"}}<|action_end|>'
+            '<|action_start|> <|plugin|>\n{"name": "search", "parameters": {"query": "restaurants"}}<|action_end|>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "search")
+
+    def test_tool_call_with_preceding_text(self):
+        text = 'Let me check the weather for you.<|action_start|> <|plugin|>\n{"name": "get_weather", "parameters": {"city": "Shanghai"}}<|action_end|>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("check the weather", result.normal_text)
+
+    def test_no_tool_call(self):
+        text = "Hello, how can I help you today?"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_malformed_json(self):
+        """Malformed JSON should be handled gracefully."""
+        text = "<|action_start|> <|plugin|>\n{not valid json}<|action_end|>"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)

--- a/test/registered/unit/function_call/test_qwen25_detector.py
+++ b/test/registered/unit/function_call/test_qwen25_detector.py
@@ -1,0 +1,145 @@
+"""Unit tests for Qwen25Detector — no server, no model loading."""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestQwen25Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                            "unit": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                            },
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query",
+                            },
+                        },
+                        "required": ["query"],
+                    },
+                ),
+            ),
+        ]
+        self.detector = Qwen25Detector()
+
+    # ==================== has_tool_call Tests ====================
+
+    def test_has_tool_call_true(self):
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>'
+        self.assertTrue(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_false(self):
+        text = "The weather in Beijing is sunny today."
+        self.assertFalse(self.detector.has_tool_call(text))
+
+    def test_has_tool_call_partial_tag(self):
+        """Partial tag should not be detected as a tool call."""
+        text = "<tool_call>no newline so not matching bot_token"
+        self.assertFalse(self.detector.has_tool_call(text))
+
+    # ==================== detect_and_parse Tests ====================
+
+    def test_single_tool_call(self):
+        text = '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Beijing")
+        self.assertEqual(result.normal_text, "")
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>\n'
+            '<tool_call>\n{"name": "search", "arguments": {"query": "restaurants"}}\n</tool_call>'
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.calls[1].name, "search")
+
+    def test_tool_call_with_preceding_text(self):
+        """Normal text before the tool call should be captured."""
+        text = 'Let me check the weather.\n<tool_call>\n{"name": "get_weather", "arguments": {"city": "Shanghai"}}\n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertIn("check the weather", result.normal_text)
+
+    def test_no_tool_call(self):
+        """Plain text without tool call tags returns empty calls."""
+        text = "Hello, how can I help you today?"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_malformed_json(self):
+        """Malformed JSON inside tool_call tags should be skipped gracefully."""
+        text = "<tool_call>\n{invalid json}\n</tool_call>"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+
+    def test_tool_call_with_extra_whitespace(self):
+        """Extra whitespace inside the JSON block should still parse."""
+        text = '<tool_call>\n  {"name": "get_weather", "arguments": {"city": "Tokyo"}}  \n</tool_call>'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        args = json.loads(result.calls[0].parameters)
+        self.assertEqual(args["city"], "Tokyo")
+
+    # ==================== Streaming Tests ====================
+
+    def test_streaming_single_call(self):
+        """Streaming parse should accumulate and detect complete tool call."""
+        chunks = [
+            "<tool_call>\n",
+            '{"name": "get_weather",',
+            ' "arguments": {"city": "Beijing"}}',
+            "\n</tool_call>",
+        ]
+        all_calls = []
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            if result.calls:
+                all_calls.extend(result.calls)
+
+        # Across all chunks, we should have accumulated one parsed call
+        self.assertEqual(len(all_calls), 1)
+        self.assertEqual(all_calls[0].name, "get_weather")
+
+    def test_streaming_normal_text_before_call(self):
+        """Normal text streamed before a tool call is captured."""
+        # Reset detector state for clean test
+        detector = Qwen25Detector()
+        result = detector.parse_streaming_increment("Hello there! ", self.tools)
+        self.assertIn("Hello", result.normal_text)
+        self.assertEqual(len(result.calls), 0)


### PR DESCRIPTION
 ## Motivation
               
  Part of #20865 — improving unit test coverage for function call detectors.
                                                                            
  ## Changes
            
  Add unit tests for two detectors that previously had no test coverage:
                                                                        
  **DeepSeekV3Detector:**
  - `has_tool_call` detection (true/false)
  - `detect_and_parse` (single call, multiple calls, preceding text, no calls, malformed JSON)

  **InternlmDetector:**                                                                                                                                                                            
  - `has_tool_call` detection (true/false)
  - `detect_and_parse` (single call, `arguments` key variant, multiple calls, preceding text, no calls, malformed JSON)                                                                            
                                                                           
  ## Notes              
                                               
  - No server launch or model loading required
  - Follows existing `test_hermes_detector.py` conventions
  - Uses `CustomTestCase` and registers with CPU CI