### PR TITLE
[perf][spec decoding] Re-land #26235 (skip EAGLE topk==1 softmax) for CUDA only

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -30,11 +30,14 @@ from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
 from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 from sglang.srt.speculative.spec_utils import fast_topk
 from sglang.srt.utils import (
+    is_hip,
     require_attn_tp_gather,
     require_gathered_buffer,
     require_mlp_sync,
     require_mlp_tp_gather,
 )
+
+_is_hip = is_hip()
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_worker import EAGLEWorker
@@ -401,8 +404,18 @@ class EAGLEDraftExtendCudaGraphRunner:
                 forward_batch.positions,
                 forward_batch,
             )
-            probs = torch.softmax(ret.next_token_logits, dim=-1)
-            ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
+            if self.topk == 1 and not _is_hip:
+                # topk=1 → degenerate single-path tree; skip full-vocab softmax
+                # and use argmax(logits) directly. Gated off on ROCm/HIP because
+                # the MTP draft path is sensitive to whether topk_p is the true
+                # probability or a placeholder; see #26358 (revert) / R108.
+                ret.topk_index = torch.argmax(
+                    ret.next_token_logits, dim=-1, keepdim=True
+                )
+                ret.topk_p = torch.ones_like(ret.topk_index, dtype=torch.float32)
+            else:
+                probs = torch.softmax(ret.next_token_logits, dim=-1)
+                ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
 
             forward_batch.out_cache_loc = output_cache_loc_backup
             forward_batch.spec_info.hidden_states = hidden_states_backup

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -483,8 +483,18 @@ class EagleDraftWorker(BaseDraftWorker):
                     forward_batch, skip_attn_backend_init=True
                 ).logits_output
             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
-            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
-            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            if self.topk == 1 and not _is_hip:
+                # topk=1 → degenerate single-path tree; skip full-vocab softmax
+                # and use argmax(logits) directly. Gated off on ROCm/HIP because
+                # the MTP draft path is sensitive to whether topk_p is the true
+                # probability or a placeholder; see #26358 (revert) / R108.
+                topk_index = torch.argmax(
+                    logits_output.next_token_logits, dim=-1, keepdim=True
+                )
+                topk_p = torch.ones_like(topk_index, dtype=torch.float32)
+            else:
+                probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+                topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
             maybe_detect_oob(
                 topk_index,
                 0,
@@ -651,8 +661,18 @@ class EagleDraftWorker(BaseDraftWorker):
             draft_logits_output.hidden_states = draft_logits_output.hidden_states[
                 select_index
             ]
-        probs = torch.softmax(draft_logits_output.next_token_logits, dim=-1)
-        ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
+        if self.topk == 1 and not _is_hip:
+            # topk=1 → degenerate single-path tree; skip full-vocab softmax
+            # and use argmax(logits) directly. Gated off on ROCm/HIP because
+            # the MTP draft path is sensitive to whether topk_p is the true
+            # probability or a placeholder; see #26358 (revert) / R108.
+            ret_topk_index = torch.argmax(
+                draft_logits_output.next_token_logits, dim=-1, keepdim=True
+            )
+            ret_topk_p = torch.ones_like(ret_topk_index, dtype=torch.float32)
+        else:
+            probs = torch.softmax(draft_logits_output.next_token_logits, dim=-1)
+            ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
         ret_hidden_states = draft_logits_output.hidden_states
 
         # Construct the return values


### PR DESCRIPTION
## Motivation

Re-lands the perf optimization from #26235 (by @Qiaolin-Yu) — which skips the full-vocab softmax + `fast_topk` when `self.topk == 1` and uses `argmax(logits)` with a placeholder `topk_p = ones` — but **gates it off on ROCm/HIP**, where it was the cause of [R108](https://github.com/bingxche/sglang-ci-bot/issues/84) (DSv3.2 + MTP gsm8k accuracy collapse to 0.035 with ~96% invalid output).

#26235 was reverted in #26358 (merged 2026-05-26 09:47 UTC) to recover AMD nightly. This PR brings back the CUDA perf benefit without re-breaking AMD.

## Why gate (rather than fix the AMD path)

Per verification on the revert PR ([#26358](https://github.com/sgl-project/sglang/pull/26358)), the AMD MTP draft path consumes `topk_p` somewhere downstream in a way that depends on it being the actual softmax probability, not a placeholder. The exact downstream read site has not been identified.

Gating off on HIP is the **zero-correctness-risk** way to preserve the CUDA perf win while keeping AMD safe. A future PR can identify the read site and re-enable the optimization on HIP once a more surgical fix is available — likely along the lines suggested by the gemini-code-assist reviewer on #26358 (compute the top-1 probability directly via the softmax-with-known-max identity, which keeps `topk_p` numerically correct on both backends without the bandwidth cost).

## Modifications

Three call sites (the same three #26235 touched) now look like:

```python
if self.topk == 1 and not _is_hip:
    # topk=1 → degenerate single-path tree; skip full-vocab softmax
    # and use argmax(logits) directly. Gated off on ROCm/HIP because
    # the MTP draft path is sensitive to whether topk_p is the true
    # probability or a placeholder; see #26358 (revert) / R108.
    ret.topk_index = torch.argmax(
        ret.next_token_logits, dim=-1, keepdim=True
    )
    ret.topk_p = torch.ones_like(ret.topk_index, dtype=torch.float32)
else:
    probs = torch.softmax(ret.next_token_logits, dim=-1)
    ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
```

- `python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py`
  - Added `is_hip` to the existing `from sglang.srt.utils import (...)`
  - Added module-scope `_is_hip = is_hip()`
  - Gated the `run_once` softmax+fast_topk site
- `python/sglang/srt/speculative/eagle_worker_v2.py`
  - `_is_hip` was already module-scope (line 89), no new imports
  - Gated the `draft_forward` step site (~line 486)
  - Gated the `_draft_extend_for_decode` site (~line 654)

Net: +39/-6 across 2 files. No behavior change on AMD (runtime path becomes identical to current main).

## Verification plan

- **CUDA**: PR's auto-triggered `pr-test` should re-validate the perf path. EAGLE/MTP tests on CUDA should be ≥ pre-revert baseline.
- **AMD ROCm**: this PR is a runtime no-op on HIP, so the AMD CI behavior should match origin/main exactly. Will additionally request a targeted dispatch of `nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp{,-rocm720}` against this branch to prove the gate keeps R108 clear.

## References

- Original PR (reverted): #26235 ([author](https://github.com/Qiaolin-Yu))
- Revert PR (merged 2026-05-26): #26358
- R108 evidence on revert verify: https://github.com/sgl-project/sglang/actions/runs/26438872740/job/77828088922 (0.975 PASS on revert branch, was 0.035)
- CI tracker: https://github.com/bingxche/sglang-ci-bot/issues/84 (cluster R108)

cc @Qiaolin-Yu — this preserves your CUDA optimization while keeping AMD safe. Open to suggestions for a follow-up that re-enables the optimization on HIP once the downstream read site is identified.

## Checklist

- [x] Format your code — lint clean, no new diagnostics
- [x] Add unit tests — N/A (re-lands existing optimization with backend gate; existing EAGLE tests cover both paths)
- [ ] Update documentation — N/A
- [x] Provide accuracy and speed benchmark results — see Evidence in [#26358 PR body](https://github.com/sgl-project/sglang/pull/26358) (0.035 → 0.975 on AMD MTP-rocm720 from removing the optimization)
- [x] Follow the SGLang code style guidance









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26451630790](https://github.com/sgl-project/sglang/actions/runs/26451630790)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26451630335](https://github.com/sgl-project/sglang/actions/runs/26451630335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->