### PR TITLE
[Bugfix] Fix tensor dump producing no .pt files when modules use .forward() directly

### DIFF
--- a/python/sglang/srt/debug_utils/tensor_dump_forward_hook.py
+++ b/python/sglang/srt/debug_utils/tensor_dump_forward_hook.py
@@ -10,6 +10,7 @@ The file contains a series of key-value pairs, where the keys correspond to oper
 (similar to those in model.safetensors.index.json), and the values are the outputs produced by the respective operators.
 """
 
+import functools
 import logging
 import os
 from pathlib import Path
@@ -119,10 +120,24 @@ class TensorDumper:
                     # self_attn.qkv_proj, self_attn.attn & self_attn.o_proj.
                     # Therefore, we do not need to add output hooks for self_attn,
                     # since the output of self_attn should be the same to self_attn.o_proj.
-                    module.register_forward_hook(
-                        self._dump_hook(cur_name, top_level_model)
-                    )
+                    #
+                    # Use replace_fn mode so the hook fires even when callers
+                    # invoke .forward() directly (as model_runner and some models do).
+                    self._register_hook(module, cur_name, top_level_model)
         return model_top_level_module_matched, len(model._modules.items())
+
+    def _register_hook(self, module, tensor_name, do_dump):
+        """Register a dump hook that fires on both __call__ and .forward()."""
+        hook_fn = self._dump_hook(tensor_name, do_dump)
+        original_forward = module.forward
+
+        @functools.wraps(original_forward)
+        def _wrapped_forward(*args, **kwargs):
+            output = original_forward(*args, **kwargs)
+            hook_fn(module, args, output)
+            return output
+
+        module.forward = _wrapped_forward
 
     def _dump_hook(self, tensor_name, do_dump):
         def inner_dump_hook(module, input, output):

--- a/test/registered/unit/debug_utils/test_tensor_dump_forward_hook.py
+++ b/test/registered/unit/debug_utils/test_tensor_dump_forward_hook.py
@@ -1,0 +1,129 @@
+"""Unit tests for bugfix #26269: tensor dump produces no .pt files when
+submodules are called via .forward() instead of __call__().
+
+The fix changes TensorDumper to monkey-patch module.forward so hooks
+fire regardless of how the module is invoked.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.debug_utils.tensor_dump_forward_hook import (  # noqa: E402
+    register_forward_hook_for_model,
+)
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class SimpleModel(nn.Module):
+    """Minimal model matching the XxxxForCausalLM -> model -> layers layout."""
+
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList([nn.Linear(4, 4) for _ in range(2)])
+        self.lm_head = nn.Linear(4, 8)
+
+    def forward(self, x):
+        for layer in self.model.layers:
+            x = layer.forward(x)
+        return self.lm_head.forward(x)
+
+
+class TestTensorDumpDirectForwardCall(CustomTestCase):
+    """Test that tensor dump hooks fire when modules use .forward() directly."""
+
+    def test_dump_with_direct_forward_call(self):
+        """Hooks should fire and produce .pt files even when .forward() is called directly."""
+        model = SimpleModel()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dumper = register_forward_hook_for_model(
+                model,
+                dump_dir=tmpdir,
+                dump_layers=None,
+                tp_size=1,
+                tp_rank=0,
+                pp_rank=0,
+            )
+            x = torch.randn(2, 4)
+            model.forward(x)
+            dumper.dump_current_tensors()
+
+            pt_files = [
+                f for f in os.listdir(dumper.get_dump_dir()) if f.endswith(".pt")
+            ]
+            self.assertGreater(len(pt_files), 0, "No .pt files produced")
+
+    def test_dump_with_call_operator(self):
+        """Hooks should also work when using __call__ (the normal path)."""
+        model = SimpleModel()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dumper = register_forward_hook_for_model(
+                model,
+                dump_dir=tmpdir,
+                dump_layers=None,
+                tp_size=1,
+                tp_rank=0,
+                pp_rank=0,
+            )
+            x = torch.randn(2, 4)
+            model(x)
+            dumper.dump_current_tensors()
+
+            pt_files = [
+                f for f in os.listdir(dumper.get_dump_dir()) if f.endswith(".pt")
+            ]
+            self.assertGreater(len(pt_files), 0, "No .pt files produced")
+
+    def test_forward_method_is_patched(self):
+        """After hook registration, module.forward should be wrapped."""
+        model = SimpleModel()
+        original_forward = model.model.layers[0].forward
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            register_forward_hook_for_model(
+                model,
+                dump_dir=tmpdir,
+                dump_layers=None,
+                tp_size=1,
+                tp_rank=0,
+                pp_rank=0,
+            )
+
+        patched_forward = model.model.layers[0].forward
+        self.assertIsNot(patched_forward, original_forward)
+
+    def test_output_correctness_with_hooks(self):
+        """Model output should be unchanged after hook registration."""
+        model = SimpleModel()
+        x = torch.randn(2, 4)
+        expected = model(x).detach().clone()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            register_forward_hook_for_model(
+                model,
+                dump_dir=tmpdir,
+                dump_layers=None,
+                tp_size=1,
+                tp_rank=0,
+                pp_rank=0,
+            )
+            actual = model.forward(x).detach()
+
+        self.assertTrue(
+            torch.allclose(expected, actual, atol=1e-6),
+            "Model output changed after hook registration",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #26269

PyTorch's `register_forward_hook` only fires when a module is invoked via `__call__()`. However, `model_runner` and several models (DeepSeek-V4, Nemotron-H, Pixtral) call `.forward()` directly, bypassing the hook dispatch. This causes `--debug-tensor-dump-output-folder` to silently produce zero `.pt` files.

**Root cause:** `register_forward_hook` hooks are dispatched in `__call__`, not in `forward`. Modules that call `layer.forward(x)` instead of `layer(x)` never trigger the hook.

## Modifications

- `python/sglang/srt/debug_utils/tensor_dump_forward_hook.py` (~15 lines): Replace `register_forward_hook` with a monkey-patch approach that wraps each module's `.forward` method. The wrapper ensures the dump hook fires regardless of call style (both `__call__` and direct `.forward()`). Mirrors the existing `replace_fn` pattern in `dumper.py`.
- `test/registered/unit/debug_utils/test_tensor_dump_forward_hook.py` (new): 4 unit tests covering direct `.forward()` calls, `__call__` path, monkey-patch verification, and output correctness.

## Accuracy Tests

N/A — The fix changes only the hook dispatch mechanism. No model weights, computation, or output values are modified. The monkey-patched forward delegates to the original forward after saving tensor snapshots.

## Speed Tests and Profiling

N/A — The monkey-patch adds negligible overhead (one function call wrapper). This is also a debug-only feature enabled only when `--debug-tensor-dump-output-folder` is passed.

## Checklist

- [x] Format with pre-commit (ruff, black, isort all pass)
- [x] Unit tests pass (4 tests, CPU-only, registered in base-a-test-cpu)
- [ ] CI tests (blocked — need run-ci label from admin)
