### PR TITLE
[docs] DeepSeek-V4 cookbook: note cu129 image for GB200 Pro DeepEP backend

### DIFF
--- a/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
+++ b/docs_new/src/snippets/autoregressive/deepseek-v4-deployment.jsx
@@ -909,6 +909,20 @@ export const DeepSeekV4Deployment = () => {
         `#   NVSHMEM_HCA_LIST=<your-hca-list>\n` +
         cmd;
     }
+    // GB200 Pro with MegaMoE disabled runs the DeepEP a2a backend, which is
+    // currently only packaged in the CUDA 12.9 image — the default `:latest`
+    // ships CUDA 13 and does not include a compatible DeepEP build.
+    if (
+      hardware === "gb200" &&
+      isBig &&
+      megamoe === "disabled" &&
+      flags.some((f) => f.includes("--moe-a2a-backend deepep"))
+    ) {
+      cmd =
+        `# NOTE: for the DeepEP backend, use the cu129 docker image\n` +
+        `# (lmsysorg/sglang:latest-cu129) instead of the default \`:latest\`.\n` +
+        cmd;
+    }
     const withMultinode = multinode ? prependMultiNodeNote(cmd, nnodes) : cmd;
 
     // H200 Pro low-latency: show BOTH a single-node (TP=8 marlin) variant


### PR DESCRIPTION
## Summary

- The default `lmsysorg/sglang:latest` image ships CUDA 13 and does not include a compatible DeepEP supported `mnnvl`, so users hit failures unless they swap to `lmsysorg/sglang:latest-cu129`.
- Surface a `# NOTE:` line prepended to the generated command for the `(gb200, big, megamoe=disabled, deepep-in-flags)` combination — same shell-comment style as the existing GB200 multinode env hint right above it.

The check uses `flags.some(...)` so it correctly skips:
- **low-latency** on GB200 Pro (uses `flashinfer_mxfp4`, not DeepEP)
- **W4A8 / W4A4 MegaMoE** (DeepEP gets swapped to `megamoe` at the existing override block)

## Test plan

- [ ] Open the DeepSeek-V4 cookbook page, select **GB200 → Pro → Balanced** (or Max-Throughput / CP) with **MegaMoE = Disabled**: verify the `# NOTE: for the DeepEP backend, use the cu129 docker image ...` lines appear above the `sglang serve` command.
- [ ] Flip **MegaMoE** to **W4A8** or **W4A4**: verify the cu129 note disappears (since DeepEP is no longer in use).
- [ ] Switch recipe to **Low-Latency** on GB200 Pro: verify the cu129 note is not shown (uses `flashinfer_mxfp4`).
- [ ] Switch hardware to B200 / B300 / GB300 / H200 / H100: verify the cu129 note never appears on non-GB200 hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26466300418](https://github.com/sgl-project/sglang/actions/runs/26466300418)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #26466300023](https://github.com/sgl-project/sglang/actions/runs/26466300023)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->