### PR TITLE
Fix optional output alignment in mixed batches

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -34,6 +34,27 @@ logger = logging.getLogger(__name__)
 DEFAULT_FORCE_STREAM_INTERVAL = envs.SGLANG_FORCE_STREAM_INTERVAL.get()
 
 
+def _append_optional_per_request_field(
+    field: Optional[List[Any]],
+    should_return: bool,
+    value: Any,
+    emitted_count: int,
+) -> Optional[List[Any]]:
+    """Append an optional per-request output while preserving batch alignment.
+
+    `None` means the field is absent for the whole batch. Once any request in a
+    batch enables the field, previous and later requests without that field must
+    occupy a `None` slot so the list stays aligned with `rids`.
+    """
+    if field is None:
+        if not should_return:
+            return None
+        field = [None] * (emitted_count - 1)
+
+    field.append(value if should_return else None)
+    return field
+
+
 @dataclass(kw_only=True, slots=True)
 class SchedulerOutputStreamer:
     send_to_detokenizer: zmq.Socket
@@ -256,9 +277,9 @@ class _GenerationStreamAccumulator:
     spec_num_correct_drafts: list = field(default_factory=list)
     spec_correct_drafts_histogram: list = field(default_factory=list)
     retraction_counts: list = field(default_factory=list)
-    output_hidden_states: list = field(default_factory=list)
-    routed_experts: list = field(default_factory=list)
-    indexer_topk: list = field(default_factory=list)
+    output_hidden_states: Optional[list] = None
+    routed_experts: Optional[list] = None
+    indexer_topk: Optional[list] = None
     customized_info: dict = field(default_factory=dict)
     time_stats: list = field(default_factory=list)
     input_token_logprobs_val: Optional[list] = None
@@ -434,12 +455,24 @@ class _GenerationStreamAccumulator:
                 self.output_token_ids_logprobs_val.append([])
                 self.output_token_ids_logprobs_idx.append([])
 
-        if req.return_hidden_states:
-            self.output_hidden_states.append(req.hidden_states)
-        if req.return_routed_experts:
-            self.routed_experts.append(req.routed_experts)
-        if req.return_indexer_topk:
-            self.indexer_topk.append(req.indexer_topk)
+        self.output_hidden_states = _append_optional_per_request_field(
+            self.output_hidden_states,
+            req.return_hidden_states,
+            req.hidden_states,
+            len(self.rids),
+        )
+        self.routed_experts = _append_optional_per_request_field(
+            self.routed_experts,
+            req.return_routed_experts,
+            req.routed_experts,
+            len(self.rids),
+        )
+        self.indexer_topk = _append_optional_per_request_field(
+            self.indexer_topk,
+            req.return_indexer_topk,
+            req.indexer_topk,
+            len(self.rids),
+        )
 
         if req.customized_info is not None:
             for k, v in req.customized_info.items():
@@ -486,9 +519,9 @@ class _GenerationStreamAccumulator:
             output_token_ids_logprobs_val=self.output_token_ids_logprobs_val,
             output_token_ids_logprobs_idx=self.output_token_ids_logprobs_idx,
             output_token_entropy_val=None,
-            output_hidden_states=self.output_hidden_states or None,
-            routed_experts=self.routed_experts or None,
-            indexer_topk=self.indexer_topk or None,
+            output_hidden_states=self.output_hidden_states,
+            routed_experts=self.routed_experts,
+            indexer_topk=self.indexer_topk,
             customized_info=self.customized_info,
             placeholder_tokens_idx=None,
             placeholder_tokens_val=None,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1773,7 +1773,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     ]
 
             if getattr(recv_obj, "output_hidden_states", None):
-                meta_info["hidden_states"] = recv_obj.output_hidden_states[i]
+                val = recv_obj.output_hidden_states[i]
+                if val is not None:
+                    meta_info["hidden_states"] = val
             if getattr(recv_obj, "routed_experts", None):
                 val = recv_obj.routed_experts[i]
                 if val is not None:

--- a/test/registered/unit/managers/test_output_streamer.py
+++ b/test/registered/unit/managers/test_output_streamer.py
@@ -1,0 +1,40 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_components.output_streamer import (  # noqa: E402
+    _append_optional_per_request_field,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestOutputStreamerOptionalFields(CustomTestCase):
+    def test_optional_field_stays_absent_when_no_request_returns_it(self):
+        field = None
+        field = _append_optional_per_request_field(field, False, "ignored", 1)
+        field = _append_optional_per_request_field(field, False, "ignored", 2)
+
+        self.assertIsNone(field)
+
+    def test_optional_field_backfills_prior_requests(self):
+        field = None
+        field = _append_optional_per_request_field(field, False, "ignored", 1)
+        field = _append_optional_per_request_field(field, True, "routed-b", 2)
+
+        self.assertEqual(field, [None, "routed-b"])
+
+    def test_optional_field_appends_none_for_later_disabled_requests(self):
+        field = None
+        field = _append_optional_per_request_field(field, True, "routed-a", 1)
+        field = _append_optional_per_request_field(field, False, "ignored", 2)
+        field = _append_optional_per_request_field(field, True, "routed-c", 3)
+
+        self.assertEqual(field, ["routed-a", None, "routed-c"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why?

A mixed generation batch can contain requests that ask for optional per-request outputs, such as `routed_experts`, alongside requests that do not, such as `/health_generate` or other ordinary requests. The output accumulator previously appended `routed_experts`, `indexer_topk`, and `output_hidden_states` only for opted-in requests, so those lists could become shorter than `rids`.

That malformed batch breaks multi-tokenizer / multi-detokenizer fanout, which splits responses by request index. In the routed-experts case, fanout can index past the end of the shorter list and crash with `IndexError`; if only length-checked at the splitter, it could also assign one request's optional output to another request.

## How?

- Keep optional per-request generation fields aligned with `rids` by backfilling and appending `None` placeholders once any request in the batch enables that field.
- Preserve the existing "field absent for the whole batch" behavior by leaving the field as `None` until the first opted-in request appears.
- Skip `None` hidden-state placeholders when assembling tokenizer `meta_info`, matching the existing routed-experts and indexer-topk behavior.
- Add a CPU unit test for absent, backfilled, and later-disabled optional field cases.

## Test plan

- `python3 -m py_compile python/sglang/srt/managers/scheduler_components/output_streamer.py python/sglang/srt/managers/tokenizer_manager.py test/registered/unit/managers/test_output_streamer.py`
- Not run locally: `test/registered/unit/managers/test_output_streamer.py` requires SGLang dependencies that are not installable in this macOS arm64 environment (`orjson` missing in bare Python; `sgl-deep-gemm` wheel unavailable via uv on macOS arm64).

Generated with Cursor (https://cursor.com)

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26472752969](https://github.com/sgl-project/sglang/actions/runs/26472752969)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26472752504](https://github.com/sgl-project/sglang/actions/runs/26472752504)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->