### PR TITLE
[CI] /rerun-test: support glob wildcard patterns

### DIFF
--- a/.claude/skills/ci-workflow-guide/SKILL.md
+++ b/.claude/skills/ci-workflow-guide/SKILL.md
@@ -387,7 +387,7 @@ group: pr-test-{event_name}-{branch}-{pr_sha}-{stage}
 | `/tag-and-rerun-ci` | Adds `run-ci` label + reruns failed |
 | `/tag-and-rerun-ci extra` | Adds both `run-ci` and `run-ci-extra` labels + reruns failed |
 | `/rerun-stage <stage>` | Deprecated; posts deprecation notice |
-| `/rerun-test <test-file> [<test-file> ...]` | Reruns specific test file(s) via `rerun-test.yml`. A file arg containing a glob metacharacter (`*`, `?`, `[...]`) expands against `test/registered/` and the multimodal test dir to every matching `test_*.py` (e.g. `/rerun-test test_*backend*.py`); matches are deduped, grouped by dispatch shape, and can't carry a `::test` selector |
+| `/rerun-test <test-file> [<test-file> ...]` | Reruns specific test file(s) via `rerun-test.yml`. A file arg containing a glob metacharacter (`*`, `?`, `[...]`) expands against `test/registered/` and the multimodal test dir to every matching `test_*.py` (e.g. `/rerun-test test_*backend*.py` — wrap in backticks so GitHub doesn't italicize the `*`); matches are deduped, grouped by dispatch shape, and can't carry a `::test` selector. No match → single ⛔ reply, nothing dispatched. Each reply echoes its originating command (`Results for …`) so concurrent commands stay distinguishable |
 | `/rerun-group <group> [<group> ...]` | Expands registered test groups, then reuses `/rerun-test` |
 
 Handled by `scripts/ci/utils/slash_command_handler.py` → `.github/workflows/slash-command-handler.yml`.

--- a/.claude/skills/ci-workflow-guide/SKILL.md
+++ b/.claude/skills/ci-workflow-guide/SKILL.md
@@ -387,7 +387,7 @@ group: pr-test-{event_name}-{branch}-{pr_sha}-{stage}
 | `/tag-and-rerun-ci` | Adds `run-ci` label + reruns failed |
 | `/tag-and-rerun-ci extra` | Adds both `run-ci` and `run-ci-extra` labels + reruns failed |
 | `/rerun-stage <stage>` | Deprecated; posts deprecation notice |
-| `/rerun-test <test-file>` | Reruns a specific test file via `rerun-test.yml` |
+| `/rerun-test <test-file> [<test-file> ...]` | Reruns specific test file(s) via `rerun-test.yml`. A file arg containing a glob metacharacter (`*`, `?`, `[...]`) expands against `test/registered/` and the multimodal test dir to every matching `test_*.py` (e.g. `/rerun-test test_*backend*.py`); matches are deduped, grouped by dispatch shape, and can't carry a `::test` selector |
 | `/rerun-group <group> [<group> ...]` | Expands registered test groups, then reuses `/rerun-test` |
 
 Handled by `scripts/ci/utils/slash_command_handler.py` → `.github/workflows/slash-command-handler.yml`.

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -486,6 +486,72 @@ def resolve_test_group_specs(group_name):
     return [os.path.relpath(path, "test") for path in test_files], None
 
 
+# A spec is treated as a wildcard pattern (expanding to many files) when its
+# file part contains a glob metacharacter. Plain specs keep the existing
+# single-file resolution, which requires a unique match.
+_GLOB_METACHARS = ("*", "?", "[")
+
+
+def _is_glob_pattern(file_part):
+    return any(ch in file_part for ch in _GLOB_METACHARS)
+
+
+def expand_glob_spec(file_part):
+    """
+    Expand a wildcard file_part into matching test files (repo-relative paths).
+
+    Globs are matched against the same locations resolve_test_file() searches
+    — test/registered/ and the multimodal_gen test dir — so e.g.
+    `test_*backend*.py` reruns every backend test without hand-enumerating
+    each file. Two constraints keep a broad pattern from pulling in non-tests:
+    a match must live under a known test root and be named `test_*.py`.
+
+    glob's `*` matches path separators only via `**`, so a bare pattern is
+    searched recursively under each root; a path-ful pattern is anchored.
+
+    Returns (sorted_repo_relative_paths, error). On success error is None.
+    """
+    pat = file_part
+    if pat.startswith("test/"):
+        pat = pat[len("test/") :]
+
+    matches = set()
+    if "/" in pat:
+        # Path-ful pattern. Glob from the repo root (handles fully qualified
+        # multimodal paths like python/sglang/multimodal_gen/test/**/test_*.py)
+        # and under test/ (handles test/-relative patterns like
+        # registered/attention/test_*.py).
+        for base in (".", "test"):
+            matches.update(glob.glob(os.path.join(base, pat), recursive=True))
+    else:
+        # Bare pattern: search recursively under each known test root.
+        for root in ("test/registered", MULTIMODAL_TEST_DIR):
+            matches.update(glob.glob(os.path.join(root, "**", pat), recursive=True))
+
+    def _under_test_root(path):
+        return path.startswith("test/registered/") or path.startswith(
+            MULTIMODAL_TEST_DIR + "/"
+        )
+
+    files = sorted(
+        {
+            os.path.normpath(p)
+            for p in matches
+            if os.path.isfile(p)
+            and os.path.basename(p).startswith("test_")
+            and p.endswith(".py")
+            and _under_test_root(os.path.normpath(p))
+        }
+    )
+    if not files:
+        return [], (
+            f"No test files matched wildcard `{file_part}` under "
+            f"`test/registered/` or `{MULTIMODAL_TEST_DIR}/` "
+            f"(patterns only match files named `test_*.py`)."
+        )
+    return files, None
+
+
 def resolve_test_file(file_part):
     """
     Resolve a user-provided file path to a path relative to test/ or full path for multimodal.
@@ -907,7 +973,8 @@ def handle_rerun_test(
             "- `/rerun-test test/registered/core/test_srt_endpoint.py::TestSRTEndpoint.test_simple_decode`\n"
             "- `/rerun-test registered/core/test_srt_endpoint.py::TestSRTEndpoint`\n"
             "- `/rerun-test test_srt_endpoint.py`\n"
-            "- `/rerun-test test_a.py test_b.py test_c.py` (multiple tests)"
+            "- `/rerun-test test_a.py test_b.py test_c.py` (multiple tests)\n"
+            "- `/rerun-test test_*backend*.py` (wildcard — reruns every matching file)"
         )
         return False
 
@@ -917,10 +984,46 @@ def handle_rerun_test(
         pr.create_issue_comment(gate_msg)
         return False
 
+    # Phase 0: Expand wildcard specs into concrete test files. A spec whose
+    # file part contains a glob metacharacter (* ? [) expands to every
+    # matching file; plain specs pass through to single-file resolution.
+    # De-dupe so an explicit file and a glob that also matches it (or two
+    # overlapping globs) don't dispatch the same file twice.
+    resolve_failures = []
+    expanded_specs = []
+    seen_specs = set()
+    for spec in test_specs:
+        # Quotes are never meaningful here (the command isn't shell-parsed),
+        # so strip them — it lets a habitually quoted `'test_*.py'` still match.
+        file_part = spec.split("::", 1)[0].strip().strip("'\"")
+        if not _is_glob_pattern(file_part):
+            if spec not in seen_specs:
+                seen_specs.add(spec)
+                expanded_specs.append(spec)
+            continue
+        if "::" in spec:
+            resolve_failures.append(
+                {
+                    "spec": spec,
+                    "error": (
+                        "Wildcard patterns can't be combined with a `::test` "
+                        "selector — drop the `::...` to rerun whole files."
+                    ),
+                }
+            )
+            continue
+        matched, err = expand_glob_spec(file_part)
+        if err:
+            resolve_failures.append({"spec": spec, "error": err})
+            continue
+        for m in matched:
+            if m not in seen_specs:
+                seen_specs.add(m)
+                expanded_specs.append(m)
+
     # Phase 1: Resolve all specs
     resolved = []
-    resolve_failures = []
-    for spec in test_specs:
+    for spec in expanded_specs:
         r = _resolve_test_spec(spec)
         if r.get("error"):
             resolve_failures.append(r)

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -995,11 +995,20 @@ def handle_rerun_test(
     # Phase 0: Expand wildcard specs into concrete test files. A spec whose
     # file part contains a glob metacharacter (* ? [) expands to every
     # matching file; plain specs pass through to single-file resolution.
-    # De-dupe so an explicit file and a glob that also matches it (or two
-    # overlapping globs) don't dispatch the same file twice.
     resolve_failures = []
+    seen_failures = set()
+
+    def _record_failure(spec, error):
+        # De-dupe failures by canonical path so the same un-dispatchable file
+        # reported two ways (explicit + glob, or two globs) yields one line.
+        key = spec.strip().strip("\"'`")
+        if key.startswith("test/"):
+            key = key[len("test/") :]
+        if key not in seen_failures:
+            seen_failures.add(key)
+            resolve_failures.append({"spec": spec, "error": error})
+
     expanded_specs = []
-    seen_specs = set()
     for spec in test_specs:
         # Quotes/backticks are never meaningful here (the command isn't
         # shell-parsed), so strip them. Backtick-wrapping is in fact the
@@ -1008,38 +1017,38 @@ def handle_rerun_test(
         # either way the handler reads the raw body, so the `*` survives.
         file_part = spec.split("::", 1)[0].strip().strip("\"'`")
         if not _is_glob_pattern(file_part):
-            if spec not in seen_specs:
-                seen_specs.add(spec)
-                expanded_specs.append(spec)
+            expanded_specs.append(spec)
             continue
         if "::" in spec:
-            resolve_failures.append(
-                {
-                    "spec": spec,
-                    "error": (
-                        "Wildcard patterns can't be combined with a `::test` "
-                        "selector — drop the `::...` to rerun whole files."
-                    ),
-                }
+            _record_failure(
+                spec,
+                "Wildcard patterns can't be combined with a `::test` "
+                "selector — drop the `::...` to rerun whole files.",
             )
             continue
         matched, err = expand_glob_spec(file_part)
         if err:
-            resolve_failures.append({"spec": spec, "error": err})
+            _record_failure(spec, err)
             continue
-        for m in matched:
-            if m not in seen_specs:
-                seen_specs.add(m)
-                expanded_specs.append(m)
+        expanded_specs.extend(matched)
 
-    # Phase 1: Resolve all specs
+    # Phase 1: Resolve all specs, de-duping by the *resolved* identity. A glob
+    # expands to `test/`-prefixed paths while an explicit spec keeps the form
+    # the user typed, so the same file requested both ways resolves to two
+    # different raw strings — keying de-dup on the resolved (mode, test_command)
+    # is what collapses them into a single dispatch instead of running twice.
     resolved = []
+    seen_commands = set()
     for spec in expanded_specs:
         r = _resolve_test_spec(spec)
         if r.get("error"):
-            resolve_failures.append(r)
-        else:
-            resolved.append(r)
+            _record_failure(r["spec"], r["error"])
+            continue
+        key = (r["mode"], r["test_command"])
+        if key in seen_commands:
+            continue
+        seen_commands.add(key)
+        resolved.append(r)
 
     # Phase 2: Group by dispatch shape.
     groups = {}

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -953,7 +953,14 @@ def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name
 
 
 def handle_rerun_test(
-    gh_repo, pr, comment, user_perms, test_specs, token, skip_permission_check=False
+    gh_repo,
+    pr,
+    comment,
+    user_perms,
+    test_specs,
+    token,
+    skip_permission_check=False,
+    command_label=None,
 ):
     """
     Handles the /rerun-test command. Resolves all test specs, groups them by
@@ -974,7 +981,8 @@ def handle_rerun_test(
             "- `/rerun-test registered/core/test_srt_endpoint.py::TestSRTEndpoint`\n"
             "- `/rerun-test test_srt_endpoint.py`\n"
             "- `/rerun-test test_a.py test_b.py test_c.py` (multiple tests)\n"
-            "- `/rerun-test test_*backend*.py` (wildcard — reruns every matching file)"
+            "- `/rerun-test test_*backend*.py` (wildcard — reruns every matching "
+            "file; wrap the pattern in backticks so GitHub keeps the `*` literal)"
         )
         return False
 
@@ -993,9 +1001,12 @@ def handle_rerun_test(
     expanded_specs = []
     seen_specs = set()
     for spec in test_specs:
-        # Quotes are never meaningful here (the command isn't shell-parsed),
-        # so strip them — it lets a habitually quoted `'test_*.py'` still match.
-        file_part = spec.split("::", 1)[0].strip().strip("'\"")
+        # Quotes/backticks are never meaningful here (the command isn't
+        # shell-parsed), so strip them. Backtick-wrapping is in fact the
+        # recommended way to write a glob: plain `*backend*` renders as italics
+        # in a GitHub comment, but `` `test_*backend*.py` `` stays literal — and
+        # either way the handler reads the raw body, so the `*` survives.
+        file_part = spec.split("::", 1)[0].strip().strip("\"'`")
         if not _is_glob_pattern(file_part):
             if spec not in seen_specs:
                 seen_specs.add(spec)
@@ -1045,7 +1056,8 @@ def handle_rerun_test(
     # Phase 3a: Create placeholder reply comment so we have its ID before
     # dispatching workflows. This lets each dispatched run write its
     # success/failure result back to the right line in this comment.
-    reply_comment = pr.create_issue_comment("🚀 Dispatching rerun-test workflow(s)...")
+    dispatching = f"`{command_label}`" if command_label else "rerun-test workflow(s)"
+    reply_comment = pr.create_issue_comment(f"🚀 Dispatching {dispatching}...")
 
     # Phase 3b: Dispatch one workflow per group, with a unique per-batch
     # marker each. The marker is an HTML comment that the writeback step
@@ -1100,6 +1112,11 @@ def handle_rerun_test(
         lines.append(f"⛔ `{r['spec']}`: {r['error']}")
 
     body = "\n\n".join(lines)
+    # Echo the originating command so each reply is self-identifying when
+    # several /rerun-test commands are in flight at once. Backtick-wrapping
+    # also keeps any `*` in the pattern from rendering as italics.
+    if command_label:
+        body = f"Results for `{command_label}`:\n\n{body}"
 
     successes = [dr for dr in dispatch_results if dr["success"]]
     if successes:
@@ -1111,7 +1128,9 @@ def handle_rerun_test(
     return len(successes) > 0
 
 
-def handle_rerun_group(gh_repo, pr, comment, user_perms, group_names, token):
+def handle_rerun_group(
+    gh_repo, pr, comment, user_perms, group_names, token, command_label=None
+):
     """
     Handles the /rerun-group command. Expands one or more registered test
     groups into test file specs, then reuses /rerun-test dispatch behavior.
@@ -1158,6 +1177,7 @@ def handle_rerun_group(gh_repo, pr, comment, user_perms, group_names, token):
         test_specs,
         token,
         skip_permission_check=True,
+        command_label=command_label,
     )
 
 
@@ -1268,11 +1288,27 @@ def main():
 
     elif first_line.startswith("/rerun-group"):
         group_names = first_line.split()[1:]
-        handle_rerun_group(repo, pr, comment, user_perms, group_names or None, token)
+        handle_rerun_group(
+            repo,
+            pr,
+            comment,
+            user_perms,
+            group_names or None,
+            token,
+            command_label=first_line,
+        )
 
     elif first_line.startswith("/rerun-test"):
         test_specs = first_line.split()[1:]
-        handle_rerun_test(repo, pr, comment, user_perms, test_specs or None, token)
+        handle_rerun_test(
+            repo,
+            pr,
+            comment,
+            user_perms,
+            test_specs or None,
+            token,
+            command_label=first_line,
+        )
 
     else:
         print(f"Unknown or ignored command: {first_line}")


### PR DESCRIPTION
## Motivation

`/rerun-test` already accepts multiple files and groups them by dispatch shape, but a wildcard arg silently fails today: `resolve_test_file()` globs and then rejects any multi-match as *"Ambiguous filename"*. When rerunning a whole family of tests (e.g. while building out a batch of new unit tests), hand-enumerating every file is tedious.

## Change

Add a glob-expansion phase in front of the existing resolution pipeline in `scripts/ci/utils/slash_command_handler.py`. A file arg containing a glob metacharacter (`*`, `?`, `[...]`) is expanded against the same roots `resolve_test_file()` already searches — `test/registered/` and the multimodal_gen test dir — to every matching `test_*.py`.

```
/rerun-test test_*backend*.py
/rerun-test registered/attention/test_*.py
/rerun-test test_intel_amx_attention_backend_[ab].py
```

Details:
- **Two safety constraints** keep a broad pattern from pulling in non-tests: a match must live under a known test root **and** be named `test_*.py`.
- Expanded files flow through the unchanged resolve → group-by-dispatch-shape → dispatch path, so a pattern matching both CUDA and CPU tests splits into separate runs automatically.
- Matches are **deduped** (an explicit file + an overlapping glob won't dispatch twice).
- A glob **can't carry a `::test` selector** (rejected with a clear message); surrounding quotes are stripped since the comment isn't shell-parsed.
- Plain (non-glob) specs keep the existing unique-match behavior — **fully backward compatible**.

## Testing

Validated `expand_glob_spec()` locally against the real `test/registered/` tree:

| Pattern | Result |
|---|---|
| `test_*backend*.py` | 20 files across `attention/`, `backends/`, `cpu/`, `hicache/`, `lora/`, … |
| `registered/attention/test_*.py` | 16 files (anchored to dir) |
| `test/registered/attention/test_*attention_backend.py` | 2 files (full path) |
| `test_intel_amx_attention_backend_[ab].py` | 2 files (char class) |
| `test_does_not_exist_*.py` | clean "no match" error |
| `python/sglang/multimodal_gen/test/**/test_*.py` | 46 multimodal files |

Confirmed expanded paths hand off cleanly to the existing resolver (correct CUDA vs CPU runner/mode), and that a `::selector` + glob is rejected.

Will live-test the three example patterns on this PR before merge.















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26543881541](https://github.com/sgl-project/sglang/actions/runs/26543881541)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26543881404](https://github.com/sgl-project/sglang/actions/runs/26543881404)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->