### PR TITLE
[core] Maintain `req_pool_indices_cpu` host mirror (like `seq_lens_cpu`)

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -77,6 +77,10 @@ class ScheduleBatchDisaggregationDecodeMixin:
         self.req_pool_indices = torch.tensor(
             req_pool_indices, dtype=torch.int64, device=self.device
         )
+        # Host mirror of req_pool_indices. Built once here at prebuilt-batch
+        # creation (only when new disagg reqs arrive), then carried/filtered on
+        # the host, so per-decode-iter consumers avoid a D2H.
+        self.req_pool_indices_cpu = self.req_pool_indices.cpu()
         self.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=self.device)
         self.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
         self.orig_seq_lens = torch.tensor(

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -77,8 +77,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
         self.req_pool_indices = torch.tensor(
             req_pool_indices, dtype=torch.int64, device=self.device
         )
-        # Host mirror of req_pool_indices. Built once here at prebuilt-batch
-        # creation (only when new disagg reqs arrive), then carried/filtered on
+        # Host mirror, built once at prebuilt creation (rare) then carried on
         # the host, so per-decode-iter consumers avoid a D2H.
         self.req_pool_indices_cpu = self.req_pool_indices.cpu()
         self.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=self.device)

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -77,9 +77,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
         self.req_pool_indices = torch.tensor(
             req_pool_indices, dtype=torch.int64, device=self.device
         )
-        # Host mirror, built once at prebuilt creation (rare) then carried on
-        # the host, so per-decode-iter consumers avoid a D2H.
-        self.req_pool_indices_cpu = self.req_pool_indices.cpu()
+        self.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
         self.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=self.device)
         self.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
         self.orig_seq_lens = torch.tensor(

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -444,9 +444,8 @@ class HiSparseCoordinator:
         out_cache_loc: torch.Tensor,
         req_pool_indices: torch.Tensor,
         seq_lens_cpu: torch.Tensor,
+        req_pool_indices_cpu: torch.Tensor,
     ) -> None:
-        req_pool_indices_cpu = req_pool_indices.cpu()
-
         self._eager_backup_previous_token(
             seq_lens, req_pool_indices, seq_lens_cpu, req_pool_indices_cpu
         )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1504,11 +1504,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     req_pool_indices: torch.Tensor = None  # shape: [b], int64
     seq_lens: torch.Tensor = None  # shape: [b], int64
     seq_lens_cpu: torch.Tensor = None  # shape: [b], int64
-    # CPU mirror of req_pool_indices, maintained on the schedule batch only
-    # (build / filter / merge). It is intentionally NOT updated inside the spec
-    # draft-extend window, where req_pool_indices is temporarily swapped to the
-    # draft's own slots and restored afterwards. Read it on the schedule path
-    # (e.g. prepare_for_decode, before the forward), never inside a draft forward.
+    # CPU mirror of req_pool_indices; schedule-path only, stale in spec draft window
     req_pool_indices_cpu: torch.Tensor = None  # shape: [b], int64
     # The output locations of the KV cache
     out_cache_loc: torch.Tensor = None  # shape: [b], int64

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1504,6 +1504,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     req_pool_indices: torch.Tensor = None  # shape: [b], int64
     seq_lens: torch.Tensor = None  # shape: [b], int64
     seq_lens_cpu: torch.Tensor = None  # shape: [b], int64
+    req_pool_indices_cpu: torch.Tensor = None  # CPU mirror of req_pool_indices, int64
     # The output locations of the KV cache
     out_cache_loc: torch.Tensor = None  # shape: [b], int64
 
@@ -1847,7 +1848,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_num_tokens = extend_num_tokens
 
         # Allocate memory
-        out_cache_loc, req_pool_indices_tensor, _ = alloc_for_extend(self)
+        out_cache_loc, req_pool_indices_tensor, req_pool_indices_cpu = alloc_for_extend(
+            self
+        )
 
         # Set fields
         input_embeds = []
@@ -2006,6 +2009,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         self.input_ids = input_ids_tensor
         self.req_pool_indices = req_pool_indices_tensor
+        self.req_pool_indices_cpu = req_pool_indices_cpu
         self.orig_seq_lens = orig_seq_lens_tensor
         self.out_cache_loc = out_cache_loc
         self.input_embeds = (
@@ -2379,6 +2383,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.orig_seq_lens = torch.empty(0, dtype=torch.int32, device=self.device)
         self.out_cache_loc = torch.empty(0, dtype=torch.int64, device=self.device)
         self.req_pool_indices = torch.empty(0, dtype=torch.int64, device=self.device)
+        self.req_pool_indices_cpu = torch.empty(0, dtype=torch.int64)
         self.seq_lens_sum = 0
         self.extend_num_tokens = 0
         self.sampling_info = SamplingBatchInfo.from_schedule_batch(
@@ -2471,6 +2476,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 self.out_cache_loc,
                 self.req_pool_indices,
                 self.seq_lens_cpu,
+                self.req_pool_indices_cpu,
             )
 
         if get_global_server_args().enable_mamba_extra_buffer():
@@ -2530,6 +2536,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         if self.multimodal_inputs is not None:
             self.multimodal_inputs = [self.multimodal_inputs[i] for i in keep_indices]
         self.req_pool_indices = self.req_pool_indices[keep_indices_device]
+        self.req_pool_indices_cpu = self.req_pool_indices_cpu[keep_indices]
         self.seq_lens = self.seq_lens[keep_indices_device]
         self.seq_lens_cpu = self.seq_lens_cpu[keep_indices]
         self.orig_seq_lens = self.orig_seq_lens[keep_indices_device]
@@ -2581,6 +2588,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.encoder_lens_cpu.extend(other.encoder_lens_cpu)
         self.req_pool_indices = torch.cat(
             [self.req_pool_indices, other.req_pool_indices]
+        )
+        self.req_pool_indices_cpu = torch.cat(
+            [self.req_pool_indices_cpu, other.req_pool_indices_cpu]
         )
         self.seq_lens = torch.cat([self.seq_lens, other.seq_lens])
         self.seq_lens_cpu = torch.cat([self.seq_lens_cpu, other.seq_lens_cpu])

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1504,7 +1504,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     req_pool_indices: torch.Tensor = None  # shape: [b], int64
     seq_lens: torch.Tensor = None  # shape: [b], int64
     seq_lens_cpu: torch.Tensor = None  # shape: [b], int64
-    req_pool_indices_cpu: torch.Tensor = None  # CPU mirror of req_pool_indices, int64
+    # CPU mirror of req_pool_indices, maintained on the schedule batch only
+    # (build / filter / merge). It is intentionally NOT updated inside the spec
+    # draft-extend window, where req_pool_indices is temporarily swapped to the
+    # draft's own slots and restored afterwards. Read it on the schedule path
+    # (e.g. prepare_for_decode, before the forward), never inside a draft forward.
+    req_pool_indices_cpu: torch.Tensor = None  # shape: [b], int64
     # The output locations of the KV cache
     out_cache_loc: torch.Tensor = None  # shape: [b], int64
 

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -428,14 +428,14 @@ def alloc_req_slots(
 
 def alloc_for_extend(
     batch: ScheduleBatch,
-) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Allocate KV cache for extend batch and write to req_to_token_pool.
 
     Returns:
         out_cache_loc: allocated cache locations
-        req_pool_indices_device: request pool indices at a device tensor
-        req_pool_indices: request pool indices as list
+        req_pool_indices_device: request pool indices as a device tensor
+        req_pool_indices_cpu: request pool indices as a CPU tensor (host mirror)
     """
     # free out-of-window swa tokens
     batch.maybe_evict_swa()
@@ -489,7 +489,7 @@ def alloc_for_extend(
         batch.req_to_token_pool,
     )
 
-    return out_cache_loc, req_pool_indices_device, req_pool_indices
+    return out_cache_loc, req_pool_indices_device, req_pool_indices_cpu
 
 
 def alloc_paged_token_slots_decode(


### PR DESCRIPTION
Maintain a CPU mirror of `req_pool_indices` on `ScheduleBatch`, built/filtered/merged on the host exactly like `seq_lens_cpu` (source already exists in `alloc_for_extend`). Use it in HiSparse `map_last_loc_to_buffer` to drop a per-decode `req_pool_indices.cpu()` D2H. Also unblocks host-side index use in overlap scheduling.



















































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26482327282](https://github.com/sgl-project/sglang/actions/runs/26482327282)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26482327139](https://github.com/sgl-project/sglang/actions/runs/26482327139)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->