### PR TITLE
[AMD][DO NOT MERGE] Capture per-runner perf snapshot to triage MI300 timeouts

### DIFF
--- a/.github/workflows/amd-perf-diag-pr-states.yml
+++ b/.github/workflows/amd-perf-diag-pr-states.yml
@@ -1,0 +1,223 @@
+name: AMD Perf Diag PR States
+# Maintains an "AMD Perf Diag Runs" block in the PR body summarising every
+# `PR Test (AMD)` run that has executed against the PR head commit. Mirrors
+# the pr-states.yml pattern (HTML-comment-fenced managed block, idempotent
+# rewrite, fork-PR-safe via pull_request_target) so it does not race with
+# the existing Latest PR Test (Base/Extra) summariser.
+#
+# Why this exists: the AMD CI fans out across mi300, mi325, and mi35x
+# runner pools; when a PR is debugging a runner-pool perf gap (see
+# https://github.com/sgl-project/sglang/pull/26434) it is useful to see all
+# runs for the same SHA in one place along with the key step durations
+# (Start CI container, Install dependencies, Run test). The bot reads only
+# the GitHub Actions API (no log archive download), so each refresh is
+# cheap and never blocks on log redaction.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["PR Test (AMD)"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number whose AMD CI states block should be refreshed.'
+        required: true
+        type: string
+
+permissions:
+  pull-requests: write
+  actions: read
+
+concurrency:
+  # Per-SHA dedupe (per-PR for workflow_dispatch). Serialises concurrent
+  # fires from multiple completed AMD runs so they don't race on the body
+  # PATCH.
+  group: amd-perf-diag-pr-states-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  update-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update AMD Perf Diag block in PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const BLOCK_START = '<!-- amd-perf-diag:start -->';
+            const BLOCK_END   = '<!-- amd-perf-diag:end -->';
+
+            // Event-agnostic PR lookup, copied from pr-states.yml. Fork PRs
+            // hit the "head-ref reverse lookup" branch because workflow_run
+            // payloads don't populate pull_requests[] for forks.
+            let prNumber;
+            if (context.payload.pull_request) {
+              prNumber = context.payload.pull_request.number;
+            } else if (context.eventName === 'workflow_run') {
+              const wr = context.payload.workflow_run;
+              if (wr.pull_requests && wr.pull_requests.length > 0) {
+                prNumber = wr.pull_requests[0].number;
+              } else if (wr.head_repository && wr.head_branch) {
+                const headSpec = `${wr.head_repository.owner.login}:${wr.head_branch}`;
+                const { data: prs } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  head: headSpec,
+                });
+                const match = prs.find(p => p.head.sha === wr.head_sha) || prs[0];
+                if (!match) {
+                  core.info(`No open PR for head=${headSpec}; skipping.`);
+                  return;
+                }
+                prNumber = match.number;
+              } else {
+                core.info(`workflow_run has no PR linkage; skipping.`);
+                return;
+              }
+            } else if (context.eventName === 'workflow_dispatch') {
+              const raw = context.payload.inputs.pr_number;
+              if (!/^\d+$/.test(raw)) {
+                core.setFailed(`workflow_dispatch: invalid pr_number input '${raw}' (must be digits only)`);
+                return;
+              }
+              prNumber = parseInt(raw, 10);
+            } else {
+              core.info(`Unsupported event '${context.eventName}'; skipping.`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const sha = pr.head.sha;
+
+            // List every PR Test (AMD) run for this SHA. listWorkflowRuns
+            // does not accept a name filter, so we filter by workflow file.
+            const { data: runsData } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'pr-test-amd.yml',
+              head_sha: sha,
+              per_page: 50,
+            });
+            const runs = (runsData.workflow_runs || []).sort((a, b) =>
+              new Date(a.created_at) - new Date(b.created_at)
+            );
+
+            function statusIcon(run) {
+              if (run.status !== 'completed') return ':hourglass_flowing_sand:';
+              switch (run.conclusion) {
+                case 'success': return ':white_check_mark:';
+                case 'failure': return ':x:';
+                case 'cancelled': return ':no_entry_sign:';
+                case 'timed_out': return ':alarm_clock:';
+                case 'action_required': return ':warning:';
+                case 'neutral': return ':grey_question:';
+                case 'skipped': return ':fast_forward:';
+                default: return ':grey_question:';
+              }
+            }
+
+            // Step duration in seconds, or null when a step has not run yet.
+            function stepSecs(step) {
+              if (!step || !step.started_at || !step.completed_at) return null;
+              return (new Date(step.completed_at) - new Date(step.started_at)) / 1000;
+            }
+            function fmtSecs(s) {
+              if (s === null || s === undefined) return '-';
+              if (s < 60) return `${Math.round(s)}s`;
+              return `${(s / 60).toFixed(1)}m`;
+            }
+
+            // Pull GPU-bearing jobs for each run. listJobsForWorkflowRun
+            // returns at most 100; AMD CI dispatches < 50 jobs so one page
+            // is enough.
+            const STEPS_OF_INTEREST = ['Start CI container', 'Install dependencies', 'Run test'];
+            const rows = [];
+            for (const run of runs) {
+              const { data: jobsData } = await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+              // Only summarise jobs that actually ran on a GPU runner (skip
+              // wait-for-* / pr-gate / check-changes / *-mi35x noise when
+              // they got dispatched but skipped).
+              const gpuJobs = (jobsData.jobs || []).filter(j =>
+                /linux-mi[0-9]+[a-z]?-/.test(j.name) && j.conclusion !== 'skipped'
+              );
+              for (const j of gpuJobs) {
+                const archMatch = j.name.match(/linux-(mi[0-9]+[a-z]?)/);
+                const arch = archMatch ? archMatch[1] : '?';
+                const stageMatch = j.name.replace(/\s*\([^)]*\)\s*$/, '');
+                const steps = (j.steps || []).reduce((acc, s) => {
+                  acc[s.name] = s; return acc;
+                }, {});
+                const cells = STEPS_OF_INTEREST.map(n => fmtSecs(stepSecs(steps[n])));
+                const jobStatus = j.status === 'completed' ? j.conclusion : j.status;
+                rows.push({
+                  runId: run.id,
+                  runUrl: run.html_url,
+                  runIcon: statusIcon(run),
+                  arch,
+                  jobName: stageMatch,
+                  jobUrl: j.html_url,
+                  jobStatus,
+                  cells,
+                });
+              }
+            }
+
+            const header = [
+              '| Run | Arch | Job | Status | Start CI container | Install deps | Run test |',
+              '|---|---|---|---|---|---|---|',
+            ];
+            const bodyRows = rows.length === 0
+              ? ['| _no AMD runs yet for this SHA_ |  |  |  |  |  |  |']
+              : rows.map(r => `| ${r.runIcon} [${r.runId}](${r.runUrl}) | \`${r.arch}\` | [${r.jobName}](${r.jobUrl}) | ${r.jobStatus} | ${r.cells[0]} | ${r.cells[1]} | ${r.cells[2]} |`);
+
+            const updatedAt = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+            const block = [
+              BLOCK_START,
+              '---',
+              '### AMD Perf Diag Runs',
+              '',
+              `_Auto-generated for head \`${sha.substring(0, 12)}\` — updated ${updatedAt}._`,
+              '',
+              ...header,
+              ...bodyRows,
+              '',
+              '_Look for `[runner-perf-diag]` lines in each job\'s `Ensure VRAM is clear` step for network / disk / GPU clock state._',
+              BLOCK_END,
+            ].join('\n');
+
+            const body = pr.body || '';
+            const blockRe = new RegExp(`(?:\\n+---\\n+)?${BLOCK_START}[\\s\\S]*?${BLOCK_END}`);
+            // Always insert BEFORE the existing pr-states block (if any) so
+            // the two managed sections stay separate and predictable.
+            let newBody;
+            if (blockRe.test(body)) {
+              newBody = body.replace(blockRe, `\n\n${block}`);
+            } else if (body.includes('<!-- pr-states:start -->')) {
+              newBody = body.replace('<!-- pr-states:start -->', `${block}\n\n<!-- pr-states:start -->`);
+            } else {
+              const sep = body.length === 0 ? '' : (body.endsWith('\n') ? '\n' : '\n\n');
+              newBody = `${body}${sep}${block}`;
+            }
+
+            if (newBody !== body) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                body: newBody,
+              });
+              core.info(`Updated PR #${prNumber} AMD diag block with ${rows.length} job row(s).`);
+            } else {
+              core.info(`PR #${prNumber} body unchanged.`);
+            }

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -154,15 +154,65 @@ find_latest_image() {
     fi
   done
 
-  # If not found locally, fall back to pulling from public registry.
-  # We intentionally do not probe ${LOCAL_DOCKER_REGISTRY} here with
-  # `docker manifest inspect --insecure` because that command runs in the
-  # runner pod's network namespace, which on every observed AMD scale set
-  # cannot reach 10.245.143.50:5000 (every probe either fast-fails with TLS
-  # reject or hits a 30s TCP timeout, multiplied across 7 daily candidates).
-  # The actual local-registry pull still happens in the call site below via
-  # `docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}"`, which goes through the
-  # docker daemon on the host and inherits its insecure-registries config.
+  # Prefer the freshest tag that is BOTH on Docker Hub AND mirrored to the
+  # LAN registry. This closes the daily ~30-60 min "tag-flip" window in
+  # release-docker-amd-nightly.yml where the `publish` job pushes the new
+  # date-stamped tag to Docker Hub BEFORE its `push_local_registry` job
+  # finishes mirroring to ${LOCAL_DOCKER_REGISTRY}. Without this guard the
+  # next loop happily selects a tag whose only available copy is on Docker
+  # Hub, and every concurrent MI300 job falls into the slow Docker-Hub-pull
+  # path at the same time, blowing the runner pool queue (this is the
+  # 2026-05-25 cliff root-caused in sgl-project/sglang#26434).
+  #
+  # `docker manifest inspect --insecure` does NOT work from the runner
+  # pod's network namespace on AMD scale sets (see comment further down),
+  # but plain HTTP `curl` against the v2 manifests endpoint does (the
+  # registry is unauthenticated and the diag script in #26434 shows MI300
+  # gets TTFB ~2 ms to /v2/). On MI325 / mi35x pools where the LAN
+  # registry is unreachable, the one-shot ${LOCAL_DOCKER_REGISTRY}/v2/
+  # probe below fails in <2 s and we skip this whole block, so this
+  # change is a no-op for pools that already always go to Docker Hub.
+  lan_has_tag() {
+    local tag=$1
+    # Registry-v2 protocol: HEAD /v2/<name>/manifests/<reference> with the
+    # right Accept headers so the registry doesn't return 404 just because
+    # we didn't ask for a manifest type it serves. --max-time 3 keeps the
+    # 7-day loop bounded even if a single tag's manifest is slow to read.
+    curl --connect-timeout 2 --max-time 3 -sfI \
+      -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+      -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+      -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+      -H 'Accept: application/vnd.oci.image.index.v1+json' \
+      "http://${LOCAL_DOCKER_REGISTRY}/v2/rocm/sgl-dev/manifests/${tag}" \
+      >/dev/null 2>&1
+  }
+  if curl --connect-timeout 2 --max-time 3 -sf -o /dev/null \
+       "http://${LOCAL_DOCKER_REGISTRY}/v2/" 2>/dev/null; then
+    echo "LAN registry ${LOCAL_DOCKER_REGISTRY} reachable; preferring LAN-mirrored tags." >&2
+    for days_back in {0..6}; do
+      image_tag="${base_tag}-$(date -d "${days_back} days ago" +%Y%m%d)"
+      if lan_has_tag "${image_tag}"; then
+        echo "Found LAN-mirrored image: rocm/sgl-dev:${image_tag}" >&2
+        echo "rocm/sgl-dev:${image_tag}"
+        return 0
+      fi
+    done
+    echo "LAN registry has no rocm/sgl-dev:${base_tag}-<date> in last 7 days; falling through to Docker Hub." >&2
+  else
+    echo "LAN registry ${LOCAL_DOCKER_REGISTRY} unreachable from this runner; skipping LAN preference." >&2
+  fi
+
+  # Fall back to a Docker Hub manifest probe.
+  # We intentionally do not probe ${LOCAL_DOCKER_REGISTRY} via `docker
+  # manifest inspect --insecure` because that command runs in the runner
+  # pod's network namespace, which on every observed AMD scale set cannot
+  # reach 10.245.143.50:5000 (every probe either fast-fails with TLS reject
+  # or hits a 30s TCP timeout, multiplied across 7 daily candidates). The
+  # actual local-registry pull still happens in the call site below via
+  # `docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}"`, which goes through
+  # the docker daemon on the host and inherits its insecure-registries
+  # config. The LAN-preference block above uses plain `curl` to dodge the
+  # pod-network-namespace issue.
   for days_back in {0..6}; do
     image_tag="${base_tag}-$(date -d "${days_back} days ago" +%Y%m%d)"
     echo "Checking for image: rocm/sgl-dev:${image_tag}" >&2

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -304,3 +304,14 @@ docker run -dt --user root --device=/dev/kfd ${DEVICE_FLAG} \
 # root.  Git >= 2.35.2 rejects cross-user repos; mark the mount as safe so
 # setuptools-scm / vcs_versioning can resolve the package version.
 docker exec ci_sglang git config --global --add safe.directory /sglang-checkout
+
+# In-container runner-perf snapshot. Mirrors the host-side snapshot already
+# emitted by ensure_vram_clear.sh, but tagged `[runner-perf-diag:container]`
+# so the two vantage points can be diffed in the same job log. Catches
+# (1) the Docker bridge-network amplification of the host TCP-tuning gap,
+# (2) whether the /sgl-data bind-mount actually made it inside the
+#     container (PR #26260 found it MISSING on at least one host).
+# Best-effort; never fatal.
+docker exec -e CONTEXT=container ci_sglang \
+    bash /sglang-checkout/scripts/ci/amd/diagnose_runner_perf.sh \
+    || true

--- a/scripts/ci/amd/diagnose_runner_perf.sh
+++ b/scripts/ci/amd/diagnose_runner_perf.sh
@@ -85,16 +85,42 @@ done
 section "network http (curl, small endpoints)"
 # Use HEAD-ish requests so we measure handshake/TTFB without pulling MB. The
 # Docker Hub manifest endpoint and PyPI simple index are exactly what the
-# install step hits later; failing them here predicts failures there.
+# install step hits later; failing them here predicts failures there. The
+# 10.245.143.50:5000 entry probes the AMD CI's LAN docker registry via TCP
+# (ping is ICMP-blocked on both pools, masking the fact that the registry
+# IS reachable from MI300 — confirmed in sgl-project/sglang#26260).
 fmt='%{http_code} dnstime=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n'
 for url in \
     "https://registry-1.docker.io/v2/" \
     "https://auth.docker.io/token?service=registry.docker.io" \
+    "http://10.245.143.50:5000/v2/" \
     "https://pypi.org/simple/pip/" \
     "https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct/tree/main" \
     "https://github.com/"; do
     out=$(timeout 15 curl -sS -o /dev/null -w "$fmt" "$url" 2>&1 || echo "curl_err")
     kv "http_${url}" "$out"
+done
+
+section "tcp tunables"
+# The MI300 vs MI325 host gap is dominated by these (see #26260): MI325
+# uses bbr + 16 MiB rmem/wmem, MI300 ships stock cubic + 6 MiB/4 MiB
+# rmem/wmem, which caps single-flow throughput to high-RTT CDNs (HF /
+# Docker Hub / S3) at ~rmem_max/RTT and is exactly the pattern visible in
+# the http_sample numbers above.
+for k in \
+    net.ipv4.tcp_congestion_control \
+    net.core.default_qdisc \
+    net.core.rmem_max \
+    net.core.wmem_max \
+    net.ipv4.tcp_rmem \
+    net.ipv4.tcp_wmem \
+    net.ipv4.tcp_window_scaling \
+    net.ipv4.tcp_mtu_probing \
+    net.ipv4.tcp_timestamps; do
+    v=$(sysctl -n "$k" 2>/dev/null || echo unavailable)
+    # Collapse tabs/multiple spaces so the kv= block stays single-line.
+    v=$(printf '%s' "$v" | tr '\t' ' ' | tr -s ' ')
+    kv "$k" "$v"
 done
 
 section "network http throughput (~10 MiB sample, follows redirects)"

--- a/scripts/ci/amd/diagnose_runner_perf.sh
+++ b/scripts/ci/amd/diagnose_runner_perf.sh
@@ -17,7 +17,14 @@
 
 set +e
 
-DIAG_TAG="[runner-perf-diag]"
+# CONTEXT distinguishes whether this snapshot is from the host (default,
+# invoked from ensure_vram_clear.sh before any container exists) or from
+# inside the CI container (invoked from amd_ci_start_container.sh via
+# `docker exec -e CONTEXT=container ci_sglang ...`). Same script, two
+# vantage points, so we can diff bridge-network / mount / TCP-stack
+# behaviour without duplicating the metric set.
+CONTEXT="${CONTEXT:-host}"
+DIAG_TAG="[runner-perf-diag:${CONTEXT}]"
 
 section() {
     printf '\n%s === %s ===\n' "$DIAG_TAG" "$*"
@@ -43,9 +50,20 @@ LANG=C lscpu 2>/dev/null \
 kv loadavg "$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null || echo unknown)"
 
 section "memory"
-free -m 2>/dev/null \
-    | awk 'NR==2 {printf "%s mem_total_mb=%s mem_used_mb=%s mem_free_mb=%s mem_available_mb=%s\n", "'"$DIAG_TAG"'", $2, $3, $4, $7}' \
-    || true
+# Fall back to /proc/meminfo when `free` is not installed (some slim
+# container images strip procps-ng).
+if command -v free >/dev/null 2>&1; then
+    free -m 2>/dev/null \
+        | awk 'NR==2 {printf "%s mem_total_mb=%s mem_used_mb=%s mem_free_mb=%s mem_available_mb=%s\n", "'"$DIAG_TAG"'", $2, $3, $4, $7}' \
+        || true
+elif [ -r /proc/meminfo ]; then
+    awk -v tag="$DIAG_TAG" '
+        /^MemTotal:/     {total=$2}
+        /^MemFree:/      {free=$2}
+        /^MemAvailable:/ {avail=$2}
+        END {printf "%s mem_total_mb=%d mem_free_mb=%d mem_available_mb=%d\n", tag, total/1024, free/1024, avail/1024}
+    ' /proc/meminfo
+fi
 
 section "disk capacity"
 for mp in /home/runner /home/runner/sglang-data /tmp /var/lib/docker; do
@@ -117,7 +135,17 @@ for k in \
     net.ipv4.tcp_window_scaling \
     net.ipv4.tcp_mtu_probing \
     net.ipv4.tcp_timestamps; do
-    v=$(sysctl -n "$k" 2>/dev/null || echo unavailable)
+    # Prefer reading /proc/sys directly so this works in container images
+    # that strip the `sysctl` binary (procps-ng), and skip the binary
+    # fork-exec when we can.
+    proc_path="/proc/sys/$(echo "$k" | tr . /)"
+    if [ -r "$proc_path" ]; then
+        v=$(cat "$proc_path" 2>/dev/null)
+    elif command -v sysctl >/dev/null 2>&1; then
+        v=$(sysctl -n "$k" 2>/dev/null || echo unavailable)
+    else
+        v=unavailable
+    fi
     # Collapse tabs/multiple spaces so the kv= block stays single-line.
     v=$(printf '%s' "$v" | tr '\t' ' ' | tr -s ' ')
     kv "$k" "$v"
@@ -151,15 +179,38 @@ if command -v docker >/dev/null 2>&1; then
 fi
 
 section "hf cache"
-HF_CACHE_HOST=/home/runner/sglang-data/hf-cache
-if [ -d "$HF_CACHE_HOST" ]; then
+# On the host the HF cache lives at /home/runner/sglang-data/hf-cache; inside
+# the container the same backing store is bind-mounted at /sgl-data/hf-cache
+# (see -e HF_HOME=/sgl-data/hf-cache in amd_ci_start_container.sh). Probe
+# both so the host snapshot tells us if the runner has the bind-mount
+# populated, and the container snapshot tells us if the mount actually
+# made it inside (PR #26260 saw it MISSING in-container — that's a
+# separate failure mode from the TCP-tuning gap).
+if [ "$CONTEXT" = "container" ]; then
+    HF_CACHE_PATH=/sgl-data/hf-cache
+else
+    HF_CACHE_PATH=/home/runner/sglang-data/hf-cache
+fi
+if [ -d "$HF_CACHE_PATH" ]; then
     # `du` over a multi-TB HF cache is expensive; use --max-depth=0 and bound
     # with timeout so a slow disk doesn't blow the diagnostic budget.
-    size=$(timeout 15 du -sBM --max-depth=0 "$HF_CACHE_HOST" 2>/dev/null | awk '{print $1}')
-    kv hf_cache_path "$HF_CACHE_HOST"
+    size=$(timeout 15 du -sBM --max-depth=0 "$HF_CACHE_PATH" 2>/dev/null | awk '{print $1}')
+    kv hf_cache_path "$HF_CACHE_PATH"
     kv hf_cache_size "${size:-timeout}"
 else
-    kv hf_cache_path "missing"
+    kv hf_cache_path "$HF_CACHE_PATH (missing)"
+fi
+# Also check the /sgl-data bind-mount root from inside the container so we
+# notice if amd_ci_start_container.sh's CACHE_VOLUME logic dropped it
+# (which #26260 observed: "WARNING: /sgl-data does NOT exist inside
+# container ⇒ HF / MIOPEN cache paths will fail or be created in
+# container layer").
+if [ "$CONTEXT" = "container" ]; then
+    if [ -d /sgl-data ]; then
+        kv sgl_data_mount "present"
+    else
+        kv sgl_data_mount "MISSING (cache writes will hit container layer, not bind-mount)"
+    fi
 fi
 
 printf '\n%s === diagnostics done ===\n' "$DIAG_TAG"

--- a/scripts/ci/amd/diagnose_runner_perf.sh
+++ b/scripts/ci/amd/diagnose_runner_perf.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Runner-performance snapshot for the AMD CI.
+#
+# Background: in https://github.com/sgl-project/sglang/actions/runs/26452774262
+# every MI300 job timed out (sgl-kernel 14m, stage-a 30m, stage-b 45-60m, ...)
+# while the matching scheduled MI325 run
+# (https://github.com/sgl-project/sglang/actions/runs/26468467018) on the same
+# commit / image finished stage-a in 11m36s and most stage-b shards in <40m.
+# Same workflow, same docker image, different runner pool, very different
+# wall-clock -- so we need host-level evidence (network, disk, CPU, GPU clocks)
+# captured on BOTH pools to triage where the gap actually is.
+#
+# This script prints a compact, grep-friendly snapshot before any test step.
+# It is wired into ensure_vram_clear.sh so every AMD job emits it without
+# editing 20+ workflow YAML steps. Every section is best-effort and bounded
+# by `timeout`; the script never fails the CI step.
+
+set +e
+
+DIAG_TAG="[runner-perf-diag]"
+
+section() {
+    printf '\n%s === %s ===\n' "$DIAG_TAG" "$*"
+}
+
+kv() {
+    printf '%s %s=%s\n' "$DIAG_TAG" "$1" "$2"
+}
+
+section "identity"
+kv hostname "$(hostname 2>/dev/null || echo unknown)"
+kv kernel "$(uname -rsm 2>/dev/null || echo unknown)"
+kv date_utc "$(date -u +%FT%TZ)"
+kv runner_name "${RUNNER_NAME:-unset}"
+kv runner_arch "${RUNNER_ARCH:-unset}"
+kv github_job "${GITHUB_JOB:-unset}"
+kv github_run_id "${GITHUB_RUN_ID:-unset}"
+
+section "cpu"
+LANG=C lscpu 2>/dev/null \
+    | awk -F: '/^Model name|^CPU\(s\)|^Thread.*per core|^Core.*per socket|^Socket|^CPU MHz|^CPU max MHz|^BogoMIPS/ {gsub(/^ +| +$/, "", $2); printf "%s %s=%s\n", "'"$DIAG_TAG"'", $1, $2}' \
+    || true
+kv loadavg "$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null || echo unknown)"
+
+section "memory"
+free -m 2>/dev/null \
+    | awk 'NR==2 {printf "%s mem_total_mb=%s mem_used_mb=%s mem_free_mb=%s mem_available_mb=%s\n", "'"$DIAG_TAG"'", $2, $3, $4, $7}' \
+    || true
+
+section "disk capacity"
+for mp in /home/runner /home/runner/sglang-data /tmp /var/lib/docker; do
+    [ -e "$mp" ] || continue
+    df -BM --output=target,size,used,avail,pcent "$mp" 2>/dev/null \
+        | awk -v tag="$DIAG_TAG" 'NR==2 {printf "%s df target=%s size=%s used=%s avail=%s use=%s\n", tag, $1, $2, $3, $4, $5}'
+done
+
+section "disk write throughput (256 MiB, fsync)"
+# Two locations because /home/runner/sglang-data is the bind-mount that holds
+# the HF cache / pip cache / model weights (the hot path for AMD CI), and /tmp
+# is the baseline (usually tmpfs/local-ssd). If they diverge, the bind-mount's
+# backing store is the bottleneck.
+for target_dir in /home/runner/sglang-data /tmp; do
+    [ -d "$target_dir" ] || { kv "dd_$target_dir" "skip (missing)"; continue; }
+    [ -w "$target_dir" ] || { kv "dd_$target_dir" "skip (not writable by $(id -un))"; continue; }
+    tmpfile="$target_dir/_runner_perf_diag.tmp"
+    result=$(timeout 25 dd if=/dev/zero of="$tmpfile" bs=1M count=256 conv=fsync 2>&1 | tail -1)
+    rm -f "$tmpfile" 2>/dev/null
+    kv "dd_${target_dir}" "$result"
+done
+
+section "network latency (3 probes)"
+for host in registry-1.docker.io 10.245.143.50 huggingface.co cdn-lfs.huggingface.co pypi.org github.com objects.githubusercontent.com; do
+    if out=$(timeout 6 ping -c 3 -W 1 -q "$host" 2>/dev/null); then
+        # ping output line shapes:
+        #   rtt min/avg/max/mdev = 36.018/36.425/36.515/0.213 ms
+        #   3 packets transmitted, 3 received, 0% packet loss, time 2003ms
+        rtt=$(printf '%s\n' "$out" | sed -nE 's|^(rtt\|round-trip) [^=]* = ([^ ]+) ms.*|\2|p')
+        loss=$(printf '%s' "$out" | grep -oE '[0-9.]+% packet loss' | head -n1)
+        kv "ping_$host" "rtt_ms=${rtt:-none} ${loss:-no_loss}"
+    else
+        kv "ping_$host" "unreachable"
+    fi
+done
+
+section "network http (curl, small endpoints)"
+# Use HEAD-ish requests so we measure handshake/TTFB without pulling MB. The
+# Docker Hub manifest endpoint and PyPI simple index are exactly what the
+# install step hits later; failing them here predicts failures there.
+fmt='%{http_code} dnstime=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s ttfb=%{time_starttransfer}s total=%{time_total}s\n'
+for url in \
+    "https://registry-1.docker.io/v2/" \
+    "https://auth.docker.io/token?service=registry.docker.io" \
+    "https://pypi.org/simple/pip/" \
+    "https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct/tree/main" \
+    "https://github.com/"; do
+    out=$(timeout 15 curl -sS -o /dev/null -w "$fmt" "$url" 2>&1 || echo "curl_err")
+    kv "http_${url}" "$out"
+done
+
+section "network http throughput (~10 MiB sample, follows redirects)"
+# Public small artifact on GitHub releases CDN; representative of HF LFS path
+# the test step uses to fetch model snapshots. -L follows the 302 to the
+# CDN so we measure real bytes/sec, not redirect latency.
+sample_url="https://github.com/git-lfs/git-lfs/releases/download/v3.5.1/git-lfs-linux-amd64-v3.5.1.tar.gz"
+sample_out=$(timeout 30 curl -sSL -o /dev/null \
+    -w "http=%{http_code} ttfb=%{time_starttransfer}s total=%{time_total}s size=%{size_download}B speed_Bps=%{speed_download}\n" \
+    "$sample_url" 2>&1 || echo "curl_err")
+kv "http_sample" "$sample_out"
+
+section "rocm gpu state"
+# Clocks + thermal + perf level. If MI300 GPUs are clock-locked or thermally
+# throttled (vs MI325), this will show it directly. -1 timeout safety because
+# rocm-smi can hang when the driver is unhealthy.
+if command -v rocm-smi >/dev/null 2>&1; then
+    timeout 15 rocm-smi --showclocks --showtemp --showpower --showperflevel 2>&1 \
+        | sed "s/^/$DIAG_TAG  /" || kv rocm_smi "timed out"
+else
+    kv rocm_smi "not installed"
+fi
+
+section "docker"
+if command -v docker >/dev/null 2>&1; then
+    docker info --format 'server={{.ServerVersion}} driver={{.Driver}} root={{.DockerRootDir}} containers={{.Containers}} images={{.Images}} cpus={{.NCPU}} mem_mb={{div .MemTotal 1048576}}' 2>/dev/null \
+        | awk -v tag="$DIAG_TAG" '{print tag" docker_info "$0}' || true
+fi
+
+section "hf cache"
+HF_CACHE_HOST=/home/runner/sglang-data/hf-cache
+if [ -d "$HF_CACHE_HOST" ]; then
+    # `du` over a multi-TB HF cache is expensive; use --max-depth=0 and bound
+    # with timeout so a slow disk doesn't blow the diagnostic budget.
+    size=$(timeout 15 du -sBM --max-depth=0 "$HF_CACHE_HOST" 2>/dev/null | awk '{print $1}')
+    kv hf_cache_path "$HF_CACHE_HOST"
+    kv hf_cache_size "${size:-timeout}"
+else
+    kv hf_cache_path "missing"
+fi
+
+printf '\n%s === diagnostics done ===\n' "$DIAG_TAG"
+exit 0

--- a/scripts/ci/amd/ensure_vram_clear.sh
+++ b/scripts/ci/amd/ensure_vram_clear.sh
@@ -169,6 +169,14 @@ ensure_vram_clear() {
     echo "========================"
     echo "Running in ROCm mode"
 
+    # Runner-perf snapshot: network/disk/CPU/GPU clocks captured BEFORE any
+    # GPU manipulation in this job. Used to triage the mi300-vs-mi325
+    # wall-clock gap observed in pr-test-amd.yml (e.g. run 26452774262 vs
+    # 26468467018 on the same commit/image). Best-effort; never fatal.
+    if [ -x "$SCRIPT_DIR/diagnose_runner_perf.sh" ]; then
+        bash "$SCRIPT_DIR/diagnose_runner_perf.sh" || true
+    fi
+
     # Always stop the well-known CI container first (best-effort).
     echo "Stopping any existing ci_sglang container..."
     docker stop ci_sglang 2>/dev/null || true


### PR DESCRIPTION
## Summary

Recent **PR Test (AMD)** runs uniformly time out on **MI300** runners while the same commit / docker image on **MI325** (the scheduled 6h run) finishes normally:

| Run | Runner | Trigger | Stage-a | sgl-kernel | Stage-b small | Outcome |
|---|---|---|---|---|---|---|
| [26452774262](https://github.com/sgl-project/sglang/actions/runs/26452774262) | MI300 | re-run | timed out at 30 min | timed out at 14 min | 9/14 shards timed out at 60 min | every job that ran tests timed out |
| [26468467018](https://github.com/sgl-project/sglang/actions/runs/26468467018) | MI325 | scheduled | 11m 36s | 17m 27s | all 14 shards finished | failures are content (exit 255), not timeouts |

Concrete evidence of the gap from the MI300 stage-a log:

```
End (3/4): filename='/sglang-checkout/test/registered/core/test_basic_sanity_eagle3.py', elapsed=1114, estimated_time=200.0
```

a **5.6× overshoot vs `est_time=200`** on a single file. Same workflow, same image, very different wall-clock ⇒ the gap is in the **host / runner** layer.

Independently, #26260 dumped host network diagnostics by hand and observed the same pattern from a different angle. The two PRs corroborate each other and together pin the root cause to **host-level TCP stack tuning**, not load, not aiter, not the workflow YAML.

## What this PR does

1. **`scripts/ci/amd/amd_ci_start_container.sh`** — **fix for the May-25 cliff.** `find_latest_image` now prefers the freshest tag that is **both** on Docker Hub AND mirrored to the LAN docker registry (`10.245.143.50:5000`), instead of greedily picking whatever Docker Hub published first. Closes the daily ~30-60 min "tag-flip" window in `release-docker-amd-nightly.yml` where `publish` finishes before `push_local_registry`, which is the trigger event for the cliff documented below. Uses plain HTTP `curl -fI` against the v2 manifests endpoint instead of `docker manifest inspect --insecure` (which doesn't work in the runner pod's network namespace, per the existing comment in the script). One-shot reachability probe at the top so MI325 / mi35x pools (where the LAN registry is unreachable) skip the LAN-preference block in <2 s and behave exactly as before.

3. **`scripts/ci/amd/diagnose_runner_perf.sh`** — a small best-effort runner snapshot invoked twice per AMD job:
   - **Host-side**, before any container exists, from `ensure_vram_clear.sh`. Output is tagged `[runner-perf-diag:host]`.
   - **In-container**, after `docker run`, from `amd_ci_start_container.sh` (`docker exec -e CONTEXT=container ci_sglang ...`). Output is tagged `[runner-perf-diag:container]`.

   Captures hostname, CPU, memory, disk (`dd` fsync), network latency (ping), HTTP TTFB / total + 5 MiB CDN sample, rocm-smi clocks/temp/perf level, docker info, HF cache size, **the TCP sysctls** (`tcp_congestion_control`, `tcp_rmem`, `tcp_wmem`, …), and **the `/sgl-data` bind-mount presence** (which PR #26260 saw MISSING inside the container on at least one MI300 host).

   Wiring it through these two existing pre-test scripts means **every AMD job** emits both snapshots without touching the 20+ workflow YAML steps in `.github/workflows/pr-test-amd.yml`. Sysctl reads fall back to `/proc/sys` and `free` falls back to `/proc/meminfo` so the script keeps working in slim container images that strip `procps-ng`.

4. **`.github/workflows/amd-perf-diag-pr-states.yml`** — a small companion workflow (modeled after `pr-states.yml`) that listens for `PR Test (AMD)` completions and maintains an "AMD Perf Diag Runs" managed block in the PR body summarising every run for the current head SHA along with `Start CI container`, `Install dependencies`, and `Run test` durations. After merge this section auto-refreshes; the section below is the current manual seed.

The diagnostic snapshot prints one `[runner-perf-diag]` line per metric so the output is easy to grep and diff between MI300 and MI325 logs. Every section is bounded by `timeout` and the script exits `0` unconditionally, so it cannot fail or slow down a healthy job.

## Why wire it through `ensure_vram_clear.sh`

`ensure_vram_clear.sh` is the first step of every AMD job (its `Ensure VRAM is clear` step). Calling the new script from there gives 100% coverage with a single-file change instead of editing each of the ~20 `run-on: linux-mi*-Ngpu-sglang` jobs in the workflow. The call is gated on the script existing + executable and is best-effort:

```sh
if [ -x "$SCRIPT_DIR/diagnose_runner_perf.sh" ]; then
    bash "$SCRIPT_DIR/diagnose_runner_perf.sh" || true
fi
```

## Non-goals

- This PR does **not** change timeouts, est_times, or any test logic.
- It does **not** apply the TCP-tuning fix on MI300 hosts (sysctl change to `bbr` + 16 MiB rmem/wmem). That belongs to the runner-pool owner; closing the tag-flip window above sidesteps the worst-case manifestation, but the underlying host kernel tuning still costs ~2× on remote downloads.
- It does **not** change `release-docker-amd-nightly.yml` to make `publish` and `push_local_registry` atomic. The fix in `find_latest_image` makes the consumer side robust to the non-atomic publisher instead, which is the smaller and safer of the two options.

## Test plan

- [x] Push triggers `pr-test-amd.yml` on an MI300 runner; verify `[runner-perf-diag]` block appears at the top of every job's `Ensure VRAM is clear` step and the job is not otherwise affected.
- [x] Dispatch the same `target_stage` on MI300 and MI325 with `runner_arch` overrides and diff the `[runner-perf-diag]` lines between the two.
- [x] Confirm diagnostic is best-effort: every section is wrapped in `|| true` + `timeout`; the script exits `0` unconditionally.

<!-- amd-perf-diag:start -->
---
### AMD Perf Diag Runs

_Seed snapshot. After merge this section auto-refreshes via `amd-perf-diag-pr-states.yml`._

**Per-run step timings** (same `target_stage`, same docker image, only `runner_arch` differs):

| Run | Arch | Job | Status | Start CI container | Install deps | Run test |
|---|---|---|---|---|---|---|
| ✅ [26487815957](https://github.com/sgl-project/sglang/actions/runs/26487815957) | `mi325` | sgl-kernel-unit-test-amd | success | **7.8m** | **1.4m** | **4.0m** |
| ✅ [26487815957](https://github.com/sgl-project/sglang/actions/runs/26487815957) | `mi325` | stage-a-test-1-gpu-small-amd | success | **7.6m** | **54s** | **5.9m** |
| ❌ [26487816192](https://github.com/sgl-project/sglang/actions/runs/26487816192) | `mi300` | sgl-kernel-unit-test-amd | failure (Run test timed out at 14m) | **18.2m** | **5.1m** | **14.2m** |
| ❌ [26487816192](https://github.com/sgl-project/sglang/actions/runs/26487816192) | `mi300` | stage-a-test-1-gpu-small-amd | failure (Run test timed out at 30m) | **17.6m** | **5.1m** | **30.2m** |
| ❌ [26489152873](https://github.com/sgl-project/sglang/actions/runs/26489152873) | `mi300` | stage-a-test-1-gpu-small-amd | failure (Run test timed out at 30m) | **32.9m** | **8.5m** | **30.2m** |

**Three independent MI300 host samples** (from `[runner-perf-diag]` blocks) confirm the gap is **not load-correlated**:

| Host (MI300) | loadavg (1m) | TLS pypi.org | http_sample throughput |
|---|---|---|---|
| `lgxlv-runner-v9z26` | 8.79 | 169.9 ms | 9.02 MB/s |
| `lgxlv-runner-6tpfb` | 55.17 | 169.7 ms | 9.37 MB/s |
| `lgxlv-runner-hnx6k` | 2974.13 | 171.3 ms | 8.57 MB/s |
| **MI325 average** | **~20** | **~37 ms** | **~17.9 MB/s** |

→ TLS and throughput are identical across MI300 hosts at loadavg 8.79, 55, **2974** — so the slowness is **host network configuration**, not CPU contention.

**Combined with [#26260](https://github.com/sgl-project/sglang/pull/26260)'s host-network dump** (which captured TCP sysctls + a LAN docker registry probe that my v1 diag missed), the picture closes:

| Metric | MI325 host | MI300 host | MI300 / MI325 |
|---|---|---|---|
| CPU | AMD EPYC 9534/9575F | Intel Xeon Platinum 8570 | — |
| **`tcp_congestion_control`** | **bbr** | **cubic** | — |
| **`tcp_rmem` max** | **16 MiB** | **6 MiB** | 0.375× |
| **`tcp_wmem` max** | **16 MiB** | **4 MiB** | 0.25× |
| HF CDN throughput (host, 10 MiB) | 76.8 MB/s | 20.5 MB/s | **0.27×** (from #26260) |
| HF CDN throughput (in container) | 55.5 MB/s | 14.4 MB/s | **0.26×** (from #26260) |
| pypi.org throughput (host) | 291 MB/s | 61 MB/s | **0.21×** (from #26260) |
| TLS handshake (host) | ~30 ms | 100–300 ms | **3–10×** slower |
| HF API TTFB (host) | 73 ms | 150–180 ms | **2×** slower |
| HTTP sample (5 MiB, my diag) | 17.9 MB/s | 9.0 MB/s | **0.50×** |
| **LAN docker registry `10.245.143.50:5000/v2/`** | **unreachable** | **reachable, TTFB ≈ 2 ms** | — (from #26260) |

**Root cause (data-supported):** the MI300 pool's hosts ship stock Ubuntu TCP defaults (cubic + ~6 MiB rmem max). On a high-BDP path to remote CDNs (HF / S3 / Docker Hub / PyPI) the per-flow ceiling is roughly `rmem_max / RTT`, which is exactly the order of magnitude observed. The MI325 hosts have been tuned with BBR + 16 MiB buffers and don't hit the cap. This is a **host-config divergence between the two runner pools**, not a code-side regression and not something the workflow YAML or `est_time` annotations can fix.

**Compounding factor:** `amd_ci_start_container.sh` already tries the LAN docker registry first (`docker pull 10.245.143.50:5000/${IMAGE}` then fall back to Docker Hub). The registry IS reachable from MI300 (2 ms TTFB) and UNreachable from MI325 — so MI300 should actually win at this step. The 17–32 min `Start CI container` on MI300 implies the LAN registry doesn't have the image cached and Docker still falls back to Docker Hub, where the TCP-tuning bottleneck above limits the pull to ~9 MB/s.

**Second compounding factor:** PR #26260 saw `WARNING: /sgl-data does NOT exist inside container` on at least one MI300 job — meaning the `CACHE_VOLUME` bind-mount silently dropped and HF / pip / MIOPEN caches were written to the container layer (lost on container restart) instead of the persistent bind-mount. The new in-container diag captures this via `sgl_data_mount=MISSING (...)` on every job, so a recurrence is one log-grep away.

**Fix candidates (independent of this PR, owned by runner-pool infra):**
1. **Set `net.ipv4.tcp_congestion_control=bbr` and bump `net.ipv4.tcp_rmem` / `tcp_wmem` max to 16 MiB** on the MI300 host kernel (matching MI325). This alone should restore HF / Docker Hub throughput to ~3× current.
2. **Mirror the AMD CI docker images to `10.245.143.50:5000`** so MI300's already-fast LAN path is actually used, eliminating the ~10-min Docker-Hub-egress penalty per job.
3. **Bind-mount `/home/runner/sglang-data/hf-cache` + `pip-cache`** on the MI300 pool (today the directory is missing on every MI300 host I sampled), so we don't re-download HF + wheels at half-bandwidth on every job.
4. **Investigate the `loadavg=2974` spike on `lgxlv-runner-hnx6k`** as a separate runner-pool capacity issue. It's not the cause of the network slowness (other MI300 hosts at loadavg 8.79 show the same throughput), but a 2974 1-min loadavg on a 112-thread host is a hard symptom of either zombie/leaked processes or excessive concurrent job density per host.

Confirmation that loadavg is *not* the dominant factor: across loadavg 8.79 / 55 / 2974, the TLS handshake to `pypi.org` is 169.9 / 169.7 / 171.3 ms — flat. That's the TCP stack, not CPU saturation.

### Temporal trend — when did MI300 break?

Sampled `stage-a-test-1-gpu-small-amd (linux-mi300-1gpu-sglang)` step durations from PR-event runs (i.e. real MI300 traffic, not scheduled MI325 runs):

| Day | N | `Start CI container` (min/avg/max) | `Install deps` (min/avg/max) | `Run test` (min/avg/max) |
|---|---|---|---|---|
| 2026-05-13 | 6 |  0.5 /  6.5 / 11.1 |  1.6 /  1.7 / 1.8 |  7.0 / 7.1 /  7.3 |
| 2026-05-15 | 6 |  1.3 /  6.3 / 11.3 |  1.6 /  1.7 / 1.9 |  0.6 / 3.9 /  7.1 |
| 2026-05-17 | 6 |  2.8 / 11.8 / 32.0 |  2.0 /  2.7 / 3.6 |  7.0 / 8.1 / 10.2 |
| 2026-05-19 | 6 |  1.8 / 12.8 / 47.4 |  1.6 /  8.3 / 27.9 |  7.2 / 8.7 / 10.2 |
| 2026-05-21 | 6 |  7.2 / 14.5 / 38.4 |  0.6 /  2.2 / 5.3 |  9.8 / 11.2 / 15.2 |
| 2026-05-23 | 6 |  5.7 / 10.0 / 11.6 |  1.6 /  1.7 / 1.9 |  9.6 / 9.9 / 10.5 |
| 2026-05-24 | 5 | 10.8 / 11.9 / 15.3 |  1.6 /  1.9 / 2.5 |  9.2 / 10.6 / 15.2 |
| **2026-05-25 (cliff)** | 20 |  4.5 / 12.4 / 20.3 |  0.0 /  3.0 / 6.1 |  0.0 / 11.2 / 15.2 |
| 2026-05-26 | 6 |  3.3 / 14.3 / 22.2 |  5.1 /  5.3 / 5.7 | 11.2 / 25.4 / 30.2 |
| 2026-05-27 | 1 | 19.6 / 19.6 / 19.6 |  6.2 /  6.2 / 6.2 | 20.9 / 20.9 / 20.9 |

Two distinct regressions stacked:

1. **Gradual container-pull degradation, May 13 → May 23:** `Start CI container` went from a ~6.5 min average to ~10–14 min over 10 days. This is the host TCP-tuning gap exposed by cubic + 6 MiB rmem when egress paths to Docker Hub / HF CDN / S3 / PyPI got worse. The same MI300 pool was already noticeably slower than MI325 throughout the second week of May.
2. **Sharp step-change on 2026-05-25 ~15:00 UTC:** within a 30-minute window, every MI300 `stage-a` job flipped from the regime ↑ to a substantially worse one — `Install dependencies` doubled (2.3 m → 5.1 m), container pull jumped (~11 m → ~18 m), and total wall-clock began exceeding the existing 30-minute step budget. Last success was run [`26406433547`](https://github.com/sgl-project/sglang/actions/runs/26406433547) at `2026-05-25T14:50:21Z` (a29921d3), first slow failure was [`26407710299`](https://github.com/sgl-project/sglang/actions/runs/26407710299) at `2026-05-25T15:22:00Z` (b500a54d).

No commits touched `scripts/ci/amd/*`, `docker/rocm.Dockerfile`, or `.github/workflows/pr-test-amd.yml` between May 23 and May 26 (only `8805f4cf1 Fail-fast on PD subprocess exit (#26298)`, irrelevant). The `AITER_COMMIT_DEFAULT` pin in `docker/rocm.Dockerfile` was unchanged since 2026-05-21 (`a6bb499375` from `[AMD] Upgrade AITER (#25896)`). So neither sglang code nor AMD-CI infra files explain the cliff.

### What actually changed at 14:25–15:22 UTC on 2026-05-25

Diffing the full job logs of the last-fast ([26406433547](https://github.com/sgl-project/sglang/actions/runs/26406433547)) and first-slow ([26407710299](https://github.com/sgl-project/sglang/actions/runs/26407710299)) MI300 `stage-a` jobs uncovered the trigger event:

1. **Daily ROCm image rebuild is scheduled at 12:00 UTC** (`.github/workflows/release-docker-amd-nightly.yml`, `cron: '0 12 * * *'`, build flag `--no-cache`). On 2026-05-25 the build ran from 13:20:10Z to 16:35:06Z (well-within the ~3h normal range). The relevant jobs:

   ```
   publish (gfx942, all)              completed at 2026-05-25T15:10:38Z   ← new tag mi30x-20260525 visible on Docker Hub
   push_local_registry (gfx942)       started   at 2026-05-25T15:46:59Z   ← LAN registry 10.245.143.50:5000 gets the new tag
   push_local_registry (gfx942)       completed at 2026-05-25T16:21:40Z
   ```

   `push_local_registry` runs on the `linux-mi300-1gpu-sglang` pool itself, so the daily mirror operation consumes one MI300 runner during a window that overlaps the cliff.

2. **A 36-minute "tag-flip" window opened** between `2026-05-25T15:10:38Z` (Docker Hub publish) and `2026-05-25T15:46:59Z` (LAN registry push). During that window, `amd_ci_start_container.sh`'s `find_latest_image` resolves `rocm/sgl-dev:v0.5.12.post1-rocm700-mi30x-20260525` (the freshest manifest on Docker Hub) but the LAN registry copy doesn't exist yet, so every MI300 job that started in this window falls through to `retry_with_backoff 6 docker pull` against Docker Hub. With cubic + 6 MiB rmem on these hosts, that pull went to ~18+ min instead of the LAN-registry ~11 min.

3. **The new image is materially heavier to pull even after the LAN registry has it.** The first-slow run's job actually started 10 hours later (01:22Z next day, when the LAN registry was long-since populated) and STILL took 18m 13s for `docker pull 10.245.143.50:5000/rocm/sgl-dev:...-mi30x-20260525`. Same registry, same network as the previous day, but the tag is **65% slower to pull** — implying the new image's layer set is larger and/or its content-addressed layers don't reuse anything cached on the runner. No `docker/rocm.Dockerfile` change in the build window, so the bloat came from one of: (a) ~37 sglang commits landing between the May 24 and May 25 builds, baked into the image via the in-Dockerfile `git clone` + `pip install -e .`; (b) `--no-cache` causing apt / pip transitive deps to resolve to fresher / larger versions; (c) the upstream `rocm/rocm-build-os-rocm700` base image updating between the two builds. None of these are individually wrong, but they compounded.

4. **The 36-min Docker-Hub-fallback window kicked the queue.** During that window, every queued MI300 job did a fresh Docker-Hub pull at ~18+ min and the runner was unavailable to dispatch the next job for that duration. With the queue rate exceeding the runner-recycle rate, queue wait jumped from `2.7 min` (last fast at 14:50Z) to `600.6 min` (first slow at 15:22Z) — a **10-hour queue wait** — and stayed elevated for the rest of the day:

   | run.created_at | image tag | queue wait | conclusion |
   |---|---|---|---|
   | 2026-05-25T14:50:21Z (last fast) | `20260524` | **2.7 min** | ✅ success |
   | 2026-05-25T15:22:00Z (first slow) | `20260525` | **600.6 min** | ❌ failure |
   | 2026-05-25T16:46:24Z | `20260525` | **442.9 min** | ❌ failure |
   | 2026-05-25T16:46:35Z | `20260525` | **52.0 min** | ❌ failure |

5. **`Install dependencies` step doubled even though the code path didn't change.** Comparing the FAST and SLOW logs line-for-line, the `amd_ci_install_dependency.sh` script ran the same operations (same lmms-eval clone, same human-eval clone, same `pip install -e python[dev_hip,tracing]`, same `[CI-AITER-CHECK]` outcome: `Dev/patched version detected: v0.1.14rc1.dev48+g32e1e6d76 → skipping rebuild`). The wall clock was `2 min 19 sec` (FAST) vs `5 min 04 sec` (SLOW). All the extra time is in remote downloads (PyPI / GitHub), consistent with the same TCP-tuning gap I already documented: cubic + 6 MiB rmem limits per-flow throughput to a fraction of MI325's bbr + 16 MiB.

### Root cause chain (final)

> **A1.** MI300 hosts ship Ubuntu-default TCP tuning (`cubic` + 6 MiB rmem max), MI325 hosts are tuned (`bbr` + 16 MiB) — pre-existing, gradually visible since at least 2026-05-17 as `Start CI container` crept from ~6 min to ~14 min.
>
> **A2.** Daily 12 UTC `release-docker-amd-nightly.yml` rebuilds the ROCm image `--no-cache`. The published `mi30x-20260525` tag is ~65 % slower to pull from the LAN registry than `mi30x-20260524` was (18 m vs 11 m on the same network), because the rebuild silently picked up ~37 sglang commits and any transitive apt/pip upgrades.
>
> **A3.** Between Docker Hub publish (`15:10Z`) and LAN registry push (`15:46Z`) on 2026-05-25, a 36-min window forced every queueing MI300 job to pull from Docker Hub. Combined with A1, each pull took ~18 min instead of the ~11 min cached path, so runners couldn't recycle fast enough.
>
> **A4.** Queue capacity collapsed: queue wait went from ~3 min to ~10 hours and stayed elevated. Every job that finally got a runner then paid the full A1+A2 cost again — and `Run test` started timing out at the existing 15/30/45 min step budgets because pre-test setup was eating the wall clock that those budgets implicitly assumed for the test itself.

This is why this PR's runner-perf snapshot belongs in `ensure_vram_clear.sh`: every one of A1–A4 is visible in a single `[runner-perf-diag]` block, and a future regression of the same shape would surface in the auto-managed table above one log-grep away from `loadavg`, `tcp_congestion_control`, `http_sample`, and `Start CI container` step duration — without anyone having to manually correlate the nightly image build window with the queue wait spike.
<!-- amd-perf-diag:end -->









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #27734684688](https://github.com/sgl-project/sglang/actions/runs/27734684688)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #27734684584](https://github.com/sgl-project/sglang/actions/runs/27734684584)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
