### PR TITLE
Clarify Blackwell quantization backend defaults

### DIFF
--- a/docs/advanced_features/quantization.md
+++ b/docs/advanced_features/quantization.md
@@ -68,20 +68,19 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
 | `triton` | All | Fallback; widely compatible |
 | `aiter` | ROCm | AMD AITER backend |
 
-**`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 currently resolves to Triton by default; see `initialize_fp8_gemm_config()` in `python/sglang/srt/layers/quantization/fp8_utils.py`.
+**`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 always resolves to Triton.
 
 ### `--fp4-gemm-backend` (NVFP4 GEMM)
 
 | Backend | Hardware | Description |
 |---------|----------|-------------|
-| `auto` | SM100/120 | Auto-selects: `flashinfer_cudnn` on SM120; `flashinfer_cutedsl` on SM100; `flashinfer_cutlass` otherwise |
+| `auto` | SM100/120 | Auto-selects: `flashinfer_cudnn` on SM120; `flashinfer_cutlass` on SM100 |
 | `cutlass` | SM100/120 | SGLang CUTLASS kernel |
 | `flashinfer_cutlass` | SM100/120 | FlashInfer CUTLASS backend |
 | `flashinfer_cudnn` | SM100/120 (CUDA 13+, cuDNN 9.15+) | FlashInfer cuDNN backend; used on SM120 for performance |
 | `flashinfer_trtllm` | SM100 | FlashInfer TensorRT-LLM backend |
 
 When FlashInfer is unavailable for NVFP4, the SGLang CUTLASS kernel is used as an automatic fallback.
-On SM120 specifically, `auto` prefers `flashinfer_cudnn` because `flashinfer_cutlass` has produced NaNs in dense MLP layers with heterogeneous batches; see `initialize_fp4_gemm_config()` in `python/sglang/srt/layers/quantization/fp4_utils.py`.
 
 ## Offline Quantization
 

--- a/docs/advanced_features/quantization.md
+++ b/docs/advanced_features/quantization.md
@@ -68,19 +68,20 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
 | `triton` | All | Fallback; widely compatible |
 | `aiter` | ROCm | AMD AITER backend |
 
-**`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 always resolves to Triton.
+**`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 currently resolves to Triton by default; see `initialize_fp8_gemm_config()` in `python/sglang/srt/layers/quantization/fp8_utils.py`.
 
 ### `--fp4-gemm-backend` (NVFP4 GEMM)
 
 | Backend | Hardware | Description |
 |---------|----------|-------------|
-| `auto` | SM100/120 | Auto-selects: `flashinfer_cudnn` on SM120; `flashinfer_cutlass` on SM100 |
+| `auto` | SM100/120 | Auto-selects: `flashinfer_cudnn` on SM120; `flashinfer_cutedsl` on SM100; `flashinfer_cutlass` otherwise |
 | `cutlass` | SM100/120 | SGLang CUTLASS kernel |
 | `flashinfer_cutlass` | SM100/120 | FlashInfer CUTLASS backend |
 | `flashinfer_cudnn` | SM100/120 (CUDA 13+, cuDNN 9.15+) | FlashInfer cuDNN backend; used on SM120 for performance |
 | `flashinfer_trtllm` | SM100 | FlashInfer TensorRT-LLM backend |
 
 When FlashInfer is unavailable for NVFP4, the SGLang CUTLASS kernel is used as an automatic fallback.
+On SM120 specifically, `auto` prefers `flashinfer_cudnn` because `flashinfer_cutlass` has produced NaNs in dense MLP layers with heterogeneous batches; see `initialize_fp4_gemm_config()` in `python/sglang/srt/layers/quantization/fp4_utils.py`.
 
 ## Offline Quantization
 

--- a/docs_new/docs/advanced_features/quantization.mdx
+++ b/docs_new/docs/advanced_features/quantization.mdx
@@ -242,7 +242,7 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
   </tbody>
 </table>
 
-**`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 always resolves to Triton.
+**`auto` selection order:** 1) DeepGEMM (SM90/SM100, installed); 2) FlashInfer TRTLLM (SM100, FlashInfer available); 3) CUTLASS (SM90/SM100/120); 4) AITER (AMD); 5) Triton. **Exception:** SM120 currently resolves to Triton by default; see `initialize_fp8_gemm_config()` in `python/sglang/srt/layers/quantization/fp8_utils.py`.
 
 ### `--fp4-gemm-backend` (NVFP4 GEMM)
 
@@ -258,7 +258,7 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
     <tr>
       <td><code>auto</code></td>
       <td>SM100/120</td>
-      <td>Auto-selects: <code>flashinfer_cudnn</code> on SM120; <code>flashinfer_cutlass</code> on SM100</td>
+      <td>Auto-selects: <code>flashinfer_cudnn</code> on SM120; <code>flashinfer_cutedsl</code> on SM100; <code>flashinfer_cutlass</code> otherwise</td>
     </tr>
     <tr>
       <td><code>cutlass</code></td>
@@ -284,6 +284,7 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
 </table>
 
 When FlashInfer is unavailable for NVFP4, the SGLang CUTLASS kernel is used as an automatic fallback.
+On SM120 specifically, <code>auto</code> prefers <code>flashinfer_cudnn</code> because <code>flashinfer_cutlass</code> has produced NaNs in dense MLP layers with heterogeneous batches; see <code>initialize_fp4_gemm_config()</code> in <code>python/sglang/srt/layers/quantization/fp4_utils.py</code>.
 
 ## Offline Quantization
 

--- a/docs_new/docs/advanced_features/quantization.mdx
+++ b/docs_new/docs/advanced_features/quantization.mdx
@@ -273,7 +273,7 @@ Backend selection is supported only for **blockwise FP8** and **NVFP4** GEMM. Wh
     <tr>
       <td><code>flashinfer_cudnn</code></td>
       <td>SM100/120 (CUDA 13+, cuDNN 9.15+)</td>
-      <td>FlashInfer cuDNN backend; used on SM120 for performance</td>
+      <td>FlashInfer cuDNN backend; preferred on SM120 because the CUTLASS path has produced NaNs in dense MLP layers with heterogeneous batches</td>
     </tr>
     <tr>
       <td><code>flashinfer_trtllm</code></td>


### PR DESCRIPTION
This updates the quantization docs to match the current Blackwell backend-selection code paths.

Failure mechanism:
- the FP8 section said SM120 was in the CUTLASS auto path while the implementation currently forces SM120 to Triton in auto mode
- the FP4 auto row said SM100 selects flashinfer_cutlass, but the implementation currently selects flashinfer_cutedsl on SM100 and flashinfer_cudnn on SM120
- the SM120-specific NaN rationale for preferring flashinfer_cudnn in FP4 auto mode was only present in code comments

Semantic change:
- document the current SM120 FP8 auto exception
- align the FP4 auto-selection row with the implementation
- surface the SM120 dense-MLP NaN rationale that explains why FP4 auto currently prefers flashinfer_cudnn

Preserved invariant:
- no runtime behavior changes
- docs now describe the existing code paths in python/sglang/srt/layers/quantization/fp8_utils.py and fp4_utils.py

Testing:
- compared docs/advanced_features/quantization.md against initialize_fp8_gemm_config() and initialize_fp4_gemm_config() in the current tree































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26712187979](https://github.com/sgl-project/sglang/actions/runs/26712187979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26712187940](https://github.com/sgl-project/sglang/actions/runs/26712187940)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->