### PR TITLE
[1/N] feat(hisparse): support MTP/spec decoding with extra-page draft slots

### DIFF
--- a/python/sglang/jit_kernel/csrc/hisparse.cuh
+++ b/python/sglang/jit_kernel/csrc/hisparse.cuh
@@ -69,23 +69,85 @@ __device__ __forceinline__ int warp_inclusive_scan(int* s_data, int lane_id, int
   return accumulator;
 }
 
+template <int HOT_BUFFER_SIZE, bool IsDsv4Layout>
+__device__ __forceinline__ bool try_get_static_device_loc(
+    int32_t token_idx,
+    const int32_t* __restrict__ req_device_buffer_locs,
+    int64_t page_size,
+    int32_t* __restrict__ out_loc) {
+  if constexpr (IsDsv4Layout) {
+    return false;
+  } else {
+    if (token_idx < 0 || token_idx >= HOT_BUFFER_SIZE) {
+      return false;
+    }
+    const int32_t loc = req_device_buffer_locs[token_idx];
+    if (loc < 0) {
+      return false;
+    }
+    *out_loc = loc;
+    return true;
+  }
+}
+
+template <int HOT_BUFFER_SIZE, bool IsDsv4Layout>
+__device__ __forceinline__ bool try_get_extra_page_device_loc(
+    int32_t token_idx,
+    int64_t seq_len,
+    int64_t step,
+    int64_t num_steps,
+    const int32_t* __restrict__ req_device_buffer_tokens,
+    const int32_t* __restrict__ req_device_buffer_locs,
+    int64_t page_size,
+    int32_t* __restrict__ out_loc) {
+  int64_t slot = -1;
+  if constexpr (IsDsv4Layout) {
+    if (token_idx == seq_len - 1) {
+      slot = HOT_BUFFER_SIZE;
+    }
+  } else if (num_steps > 1) {
+    for (int64_t candidate_slot = HOT_BUFFER_SIZE; candidate_slot < HOT_BUFFER_SIZE + page_size; candidate_slot++) {
+      if (req_device_buffer_tokens[candidate_slot] == token_idx) {
+        slot = candidate_slot;
+        break;
+      }
+    }
+  } else if (token_idx == seq_len - 1) {
+    slot = HOT_BUFFER_SIZE;
+  }
+
+  if (slot < HOT_BUFFER_SIZE || slot >= HOT_BUFFER_SIZE + page_size) {
+    return false;
+  }
+  const int32_t loc = req_device_buffer_locs[slot];
+  if (loc < 0) {
+    return false;
+  }
+  *out_loc = loc;
+  return true;
+}
+
 // Shared memory size calculation for dynamic allocation.
 // Layout: int32_t region (4-byte aligned) followed by int16_t region (2-byte aligned).
 template <int NUM_TOP_K, int HOT_BUFFER_SIZE>
 struct SmemLayout {
   static constexpr int HASH_SIZE = NUM_TOP_K * 2;
   static constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
-  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys + total_hits + newest_hit
-  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 2;
+  // int32_t region: top_k_tokens + chunk offsets + evict offsets + hash keys + scalar counters.
+  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 3;
   // int16_t region: lru_slots_out + hash_vals
   static constexpr int TOTAL_INT16 = HOT_BUFFER_SIZE + HASH_SIZE;
   static constexpr size_t BYTES = TOTAL_INT32 * sizeof(int32_t) + TOTAL_INT16 * sizeof(int16_t);
 };
 
-// Each block processes one request
+// Each block processes one request, looping over num_steps speculative steps.
 // req_pool_indices and seq_lens can each be int32_t or int64_t
 // Layout: [HOT_BUFFER_SIZE slots for LRU] + [page_size slots for newest token]
 // newest_slot is at HOT_BUFFER_SIZE (first position of extra page)
+//
+// Multi-step: top_k_tokens and top_k_device_locs are [num_reqs, num_steps, NUM_TOP_K]
+// (req-major). seq_lens is [num_reqs * num_steps] flat req-major. LRU state is
+// maintained across steps within each block for cross-step cache reuse.
 //
 // IsDsv4Layout selects the miss-copy addressing:
 //   false -> generic byte-stride: device + host both linear, stride = item_size_bytes
@@ -118,15 +180,14 @@ __global__ void load_cache_to_device_buffer_kernel(
     int64_t top_k_tokens_stride,
     int64_t top_k_device_locs_stride,
     int64_t page_size,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    int64_t num_steps) {
   static_assert(!IsDsv4Layout || IsMLA, "DSv4 page-padded layout is K-only (MLA).");
-  // todo hisparse: support page wise sparsity
   constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
   constexpr int NUM_TOKEN_CHUNKS = (NUM_TOP_K + WARP_SIZE - 1) / WARP_SIZE;
   constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
 
   const int bid = blockIdx.x;
-  // Early exit for padded blocks (CUDA graph pads batch to a captured size)
   if (bid >= num_real_reqs[0]) return;
 
   const int tid = threadIdx.x;
@@ -135,268 +196,296 @@ __global__ void load_cache_to_device_buffer_kernel(
   const unsigned int lanes_before = ((unsigned int)1 << lane_id) - 1;
 
   const int64_t rid = req_pool_indices[bid];
-  const int64_t seq_len = seq_lens[bid];
 
-  // Calculate offsets for this request
-  const int32_t* req_top_k_tokens = top_k_tokens + bid * top_k_tokens_stride;
-  int32_t* req_top_k_device_locs = top_k_device_locs + bid * top_k_device_locs_stride;
-
+  // Per-request pointers (invariant across steps)
   const int64_t buffer_offset = rid * buffer_stride_0;
   int32_t* req_device_buffer_tokens = device_buffer_tokens + buffer_offset;
   const int32_t* req_device_buffer_locs = device_buffer_locs + buffer_offset;
   const int64_t* req_host_cache_locs = host_cache_locs + rid * host_stride;
   int16_t* req_lru_slots = lru_slots + rid * lru_slot_stride_0;
 
-  // Fast path: short sequences have all tokens in the device buffer in order.
-  if (seq_len <= HOT_BUFFER_SIZE) {
-    const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
-    for (int i = tid; i < count; i += BLOCK_SIZE) {
-      int32_t token_pos = req_top_k_tokens[i];
-      if (token_pos >= 0) {
-        req_top_k_device_locs[i] = req_device_buffer_locs[token_pos];
-      }
-    }
-    return;
-  }
+  // Base pointers for this request's top_k data (steps are contiguous after)
+  const int32_t* req_top_k_tokens_base = top_k_tokens + bid * top_k_tokens_stride;
+  int32_t* req_top_k_device_locs_base = top_k_device_locs + bid * top_k_device_locs_stride;
 
-  // Dynamic shared memory layout: int32_t arrays first, then int16_t arrays.
+  // Shared memory layout (allocated once, reused across steps)
   extern __shared__ char smem_raw[];
   using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>;
   constexpr int HASH_SIZE = Layout::HASH_SIZE;
 
   int32_t* smem_i32 = reinterpret_cast<int32_t*>(smem_raw);
-  // Top-k token positions; reused as miss-token scratch in the copy phase
   int32_t* s_top_k_tokens = smem_i32;
-  // Prefix-sum offsets for hit counting and miss counting
   int32_t* s_chunk_offset = s_top_k_tokens + NUM_TOP_K;
-  // Prefix-sum offsets for evictable counting
   int32_t* s_evict_chunk_offset = s_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
-  // Open-addressing hash table: top-k token_id -> top-k index (keys)
   int32_t* s_hash_keys = s_evict_chunk_offset + (NUM_BUFFER_CHUNKS + 1);
-  // Scalar counters
   int32_t& s_total_hits = s_hash_keys[HASH_SIZE];
   int32_t& s_newest_hit = s_hash_keys[HASH_SIZE + 1];
+  int32_t& s_total_misses = s_hash_keys[HASH_SIZE + 2];
 
   int16_t* smem_i16 = reinterpret_cast<int16_t*>(smem_i32 + Layout::TOTAL_INT32);
-  // Compacted slot ordering: [hits fwd->  ...  <-evictables bwd]
   int16_t* s_lru_slots_out = smem_i16;
-  // Open-addressing hash table: top-k token_id -> top-k index (values)
   int16_t* s_hash_vals = s_lru_slots_out + HOT_BUFFER_SIZE;
 
-  // Initialize shared memory: counters, hash table, prefix-sum offsets.
-  if (tid == 0) {
-    s_total_hits = 0;
-    s_newest_hit = 0;
-  }
-  for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
-    s_hash_keys[i] = HASH_EMPTY;
-  }
-  for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
-    s_chunk_offset[i] = 0;
-    s_evict_chunk_offset[i] = 0;
-  }
-  __syncthreads();
+  for (int64_t step = 0; step < num_steps; step++) {
+    // Per-step pointers: [num_reqs, num_steps, NUM_TOP_K] req-major layout
+    const int32_t* step_top_k_tokens = req_top_k_tokens_base + step * NUM_TOP_K;
+    int32_t* step_top_k_device_locs = req_top_k_device_locs_base + step * NUM_TOP_K;
+    // seq_lens: [num_reqs * num_steps] flat req-major; index = bid * num_steps + step
+    const int64_t seq_len = static_cast<int64_t>(seq_lens[bid * num_steps + step]);
 
-  const int newest_slot = HOT_BUFFER_SIZE;
-  const int32_t newest_token = seq_len - 1;
-
-  // Insert top-k tokens into shared-memory hash table.
-  for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
-    int32_t token_idx = req_top_k_tokens[i];
-    if (token_idx == newest_token) {
-      // If topk includes the latest token, bind its canonical occurrence to newest_slot (at HOT_BUFFER_SIZE) and mark
-      // it as a hit. newest_slot is at the first position of the extra page, excluded from LRU tracking.
-      s_top_k_tokens[i] = TOKEN_HIT;
-      req_top_k_device_locs[i] = req_device_buffer_locs[newest_slot];
-      s_newest_hit = 1;
-    } else {
-      int slot = hash_slot(token_idx, HASH_SIZE);
-      while (true) {
-        int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
-        if (old == HASH_EMPTY || old == token_idx) {
-          s_hash_vals[slot] = static_cast<int16_t>(i);
-          break;
+    // Fast path: short sequences have all tokens in the device buffer in order.
+    if (seq_len <= HOT_BUFFER_SIZE) {
+      const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
+      for (int i = tid; i < count; i += BLOCK_SIZE) {
+        int32_t token_pos = step_top_k_tokens[i];
+        int32_t loc = -1;
+        if (try_get_static_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_pos, req_device_buffer_locs, page_size, &loc) ||
+            try_get_extra_page_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_pos,
+                seq_len,
+                step,
+                num_steps,
+                req_device_buffer_tokens,
+                req_device_buffer_locs,
+                page_size,
+                &loc)) {
+          step_top_k_device_locs[i] = loc;
         }
-        slot = (slot + 1) % HASH_SIZE;
       }
-      s_top_k_tokens[i] = token_idx;
-    }
-  }
-  __syncthreads();
-
-  constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
-  int total_hit_count = 0;
-  int total_evict_count = 0;
-  for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
-    int chunk_idx = warp_id + iter * NUM_WARPS;
-    bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
-
-    const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
-    const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
-    const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
-    int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
-    int my_found_top_k_idx = -1;
-    if (my_buffer_token >= 0) {
-      int h = hash_slot(my_buffer_token, HASH_SIZE);
-      while (true) {
-        int32_t k = s_hash_keys[h];
-        if (k == my_buffer_token) {
-          my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
-          break;
-        }
-        if (k == HASH_EMPTY) break;
-        h = (h + 1) % HASH_SIZE;
-      }
-    }
-    bool is_hit = my_found_top_k_idx >= 0;
-    bool is_evictable = has_valid_slot && !is_hit;
-
-    // Record hits
-    if (is_hit) {
-      s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
-      req_top_k_device_locs[my_found_top_k_idx] = req_device_buffer_locs[buf_slot];
+      continue;
     }
 
-    int local_hit_offset = 0;
-    int local_evict_offset = 0;
-    if (has_valid_chunk) {
-      const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
-      const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
-      local_hit_offset = __popc(hit_mask & lanes_before);
-      local_evict_offset = __popc(evict_mask & lanes_before);
-      if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
-        s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
-      }
+    // Initialize shared memory for this step
+    if (tid == 0) {
+      s_total_hits = 0;
+      s_newest_hit = 0;
+      s_total_misses = 0;
+    }
+    for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
+      s_hash_keys[i] = HASH_EMPTY;
+    }
+    for (int i = tid; i < NUM_BUFFER_CHUNKS + 1; i += BLOCK_SIZE) {
+      s_chunk_offset[i] = 0;
+      s_evict_chunk_offset[i] = 0;
     }
     __syncthreads();
 
-    if (warp_id == 0) {
-      total_hit_count =
-          warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
-      total_evict_count =
-          warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
-      if (tid == 0) {
-        s_total_hits = total_hit_count;
-      }
-    }
-    __syncthreads();
-
-    // Hits grow forward from index 0
-    if (is_hit) {
-      int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
-      s_lru_slots_out[hit_offset] = buf_slot;
-    }
-    // Evictables grow backward from HOT_BUFFER_SIZE - 1
-    if (is_evictable) {
-      int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
-      s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
-    }
-  }
-  __syncthreads();
-
-  // Reset offsets for the miss counting phase (only NUM_TOKEN_CHUNKS + 1 entries needed).
-  for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
-    s_chunk_offset[i] = 0;
-  }
-  __syncthreads();
-
-  // Third pass to identify misses and their evictable slots
-  int total_misses = 0;
-  constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
-  for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
-    int chunk_idx = warp_id + iter * NUM_WARPS;
-    bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
-
-    const int chunk_token_start = chunk_idx * WARP_SIZE;
-    const int my_token_idx = chunk_token_start + lane_id;
-    const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
-
-    int32_t my_token = 0;
-    bool is_miss = false;
-    int local_miss_offset = 0;
-
-    if (has_valid_token) {
-      is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
-      if (is_miss) {
-        my_token = s_top_k_tokens[my_token_idx];
-      }
-    }
-
-    if (has_valid_chunk) {
-      const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
-      local_miss_offset = __popc(miss_mask & lanes_before);
-      const int warp_miss_count = __popc(miss_mask);
-      if (lane_id == 0) {
-        s_chunk_offset[chunk_idx + 1] = warp_miss_count;
-      }
-    }
-    __syncthreads();
-
-    if (warp_id == 0) {
-      total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
-    }
-    __syncthreads();
-
-    if (is_miss) {
-      int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
-      int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
-      // Reuse s_top_k_tokens as miss scratch: miss_offset < my_token_idx always
-      // holds (hits are skipped), so compacted writes never overrun pending reads.
-      s_top_k_tokens[miss_offset] = my_token;
-      req_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
-      req_device_buffer_tokens[evict_slot] = my_token;
-    }
-  }
-  __syncthreads();
-
-  total_misses = NUM_TOP_K - s_total_hits - s_newest_hit;
-  // Write back LRU order: evictables at front (LRU), hits at back (MRU).
-  {
-    const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
-    for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
-      if (i < total_misses) {
-        // Misses: just loaded from host, place right before hits
-        req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
-      } else if (i < total_evictable) {
-        // Remaining evictables: truly stale, dest at LRU front
-        req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+    // Insert top-k tokens into shared-memory hash table.
+    for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
+      int32_t token_idx = step_top_k_tokens[i];
+      if (token_idx < 0 || token_idx >= seq_len) {
+        s_top_k_tokens[i] = TOKEN_HIT;
+        step_top_k_device_locs[i] = -1;
       } else {
-        // Hits: source at forward end, dest at MRU back
-        req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        int32_t direct_loc = -1;
+        if (try_get_extra_page_device_loc<HOT_BUFFER_SIZE, IsDsv4Layout>(
+                token_idx,
+                seq_len,
+                step,
+                num_steps,
+                req_device_buffer_tokens,
+                req_device_buffer_locs,
+                page_size,
+                &direct_loc)) {
+          s_top_k_tokens[i] = TOKEN_HIT;
+          step_top_k_device_locs[i] = direct_loc;
+          continue;
+        }
+
+        int slot = hash_slot(token_idx, HASH_SIZE);
+        while (true) {
+          int32_t old = atomicCAS(&s_hash_keys[slot], HASH_EMPTY, token_idx);
+          if (old == HASH_EMPTY || old == token_idx) {
+            s_hash_vals[slot] = static_cast<int16_t>(i);
+            break;
+          }
+          slot = (slot + 1) % HASH_SIZE;
+        }
+        s_top_k_tokens[i] = token_idx;
       }
     }
-  }
+    __syncthreads();
 
-  // each warp copies one miss directly, can be separated into a new kernel if parallelism is a concern
-  for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
-    const int32_t miss_token = s_top_k_tokens[miss_idx];
-    const int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_idx];
+    // Scan device buffer slots in LRU order, marking hits and evictables.
+    constexpr int ITERATIONS_PER_WARP_BUFFER = (NUM_BUFFER_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+    int total_hit_count = 0;
+    int total_evict_count = 0;
+    for (int iter = 0; iter < ITERATIONS_PER_WARP_BUFFER; iter++) {
+      int chunk_idx = warp_id + iter * NUM_WARPS;
+      bool has_valid_chunk = chunk_idx < NUM_BUFFER_CHUNKS;
 
-    const int64_t src_loc = req_host_cache_locs[miss_token];
-    const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+      const int slot_idx = chunk_idx * WARP_SIZE + lane_id;
+      const bool has_valid_slot = has_valid_chunk && (slot_idx < HOT_BUFFER_SIZE);
+      const int16_t buf_slot = has_valid_slot ? req_lru_slots[slot_idx] : -1;
+      int32_t my_buffer_token = (buf_slot >= 0) ? req_device_buffer_tokens[buf_slot] : -1;
+      int my_found_top_k_idx = -1;
+      if (my_buffer_token >= 0) {
+        int h = hash_slot(my_buffer_token, HASH_SIZE);
+        while (true) {
+          int32_t k = s_hash_keys[h];
+          if (k == my_buffer_token) {
+            my_found_top_k_idx = static_cast<int32_t>(s_hash_vals[h]);
+            break;
+          }
+          if (k == HASH_EMPTY) break;
+          h = (h + 1) % HASH_SIZE;
+        }
+      }
+      bool is_hit = my_found_top_k_idx >= 0;
+      bool is_evictable = has_valid_slot && !is_hit;
 
-    if constexpr (IsDsv4Layout) {
-      // DSv4 path: page-padded device layout + linear host layout, K-only.
-      // Uses kvcacheio.cuh's hardcoded constants (kGPUPageSize=64, kCPUItemBytes=584).
-      device::hisparse::transfer_item<device::hisparse::TransferDirection::HostToDevice>(
-          /*dst_cache=*/device_buffer_k,
-          /*src_cache=*/const_cast<void*>(host_cache_k),
-          /*dst_index=*/static_cast<int32_t>(dst_loc),
-          /*src_index=*/static_cast<int32_t>(src_loc));
-    } else {
-      // Generic path: device + host both linear, stride = item_size_bytes.
-      const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
-      auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
-      transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+      if (is_hit) {
+        s_top_k_tokens[my_found_top_k_idx] = TOKEN_HIT;
+        step_top_k_device_locs[my_found_top_k_idx] = req_device_buffer_locs[buf_slot];
+      }
 
-      if constexpr (!IsMLA) {
-        const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
-        auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
-        transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+      int local_hit_offset = 0;
+      int local_evict_offset = 0;
+      if (has_valid_chunk) {
+        const unsigned int hit_mask = __ballot_sync(0xFFFFFFFF, is_hit);
+        const unsigned int evict_mask = __ballot_sync(0xFFFFFFFF, is_evictable);
+        local_hit_offset = __popc(hit_mask & lanes_before);
+        local_evict_offset = __popc(evict_mask & lanes_before);
+        if (lane_id == 0) {
+          s_chunk_offset[chunk_idx + 1] = __popc(hit_mask);
+          s_evict_chunk_offset[chunk_idx + 1] = __popc(evict_mask);
+        }
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        total_hit_count =
+            warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_hit_count);
+        total_evict_count =
+            warp_inclusive_scan(s_evict_chunk_offset, lane_id, chunk_idx + 1, NUM_BUFFER_CHUNKS + 1, total_evict_count);
+        if (tid == 0) {
+          s_total_hits = total_hit_count;
+        }
+      }
+      __syncthreads();
+
+      if (is_hit) {
+        int hit_offset = s_chunk_offset[chunk_idx] + local_hit_offset;
+        s_lru_slots_out[hit_offset] = buf_slot;
+      }
+      if (is_evictable) {
+        int evict_offset = s_evict_chunk_offset[chunk_idx] + local_evict_offset;
+        s_lru_slots_out[HOT_BUFFER_SIZE - 1 - evict_offset] = buf_slot;
       }
     }
-  }
+    __syncthreads();
+
+    // Reset offsets for the miss counting phase.
+    for (int i = tid; i < NUM_TOKEN_CHUNKS + 1; i += BLOCK_SIZE) {
+      s_chunk_offset[i] = 0;
+    }
+    __syncthreads();
+
+    // Identify misses and assign evict slots.
+    int total_misses = 0;
+    constexpr int ITERATIONS_PER_WARP_TOKEN = (NUM_TOKEN_CHUNKS + NUM_WARPS - 1) / NUM_WARPS;
+    for (int iter = 0; iter < ITERATIONS_PER_WARP_TOKEN; iter++) {
+      int chunk_idx = warp_id + iter * NUM_WARPS;
+      bool has_valid_chunk = chunk_idx < NUM_TOKEN_CHUNKS;
+
+      const int chunk_token_start = chunk_idx * WARP_SIZE;
+      const int my_token_idx = chunk_token_start + lane_id;
+      const bool has_valid_token = has_valid_chunk && (my_token_idx < NUM_TOP_K);
+
+      int32_t my_token = 0;
+      bool is_miss = false;
+      int local_miss_offset = 0;
+
+      if (has_valid_token) {
+        is_miss = s_top_k_tokens[my_token_idx] != TOKEN_HIT;
+        if (is_miss) {
+          my_token = s_top_k_tokens[my_token_idx];
+          if (req_host_cache_locs[my_token] < 0) {
+            is_miss = false;
+            s_top_k_tokens[my_token_idx] = TOKEN_HIT;
+            step_top_k_device_locs[my_token_idx] = -1;
+          }
+        }
+      }
+
+      if (has_valid_chunk) {
+        const unsigned int miss_mask = __ballot_sync(0xFFFFFFFF, is_miss);
+        local_miss_offset = __popc(miss_mask & lanes_before);
+        const int warp_miss_count = __popc(miss_mask);
+        if (lane_id == 0) {
+          s_chunk_offset[chunk_idx + 1] = warp_miss_count;
+        }
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        total_misses = warp_inclusive_scan(s_chunk_offset, lane_id, chunk_idx + 1, NUM_TOKEN_CHUNKS + 1, total_misses);
+        if (tid == 0) {
+          s_total_misses = total_misses;
+        }
+      }
+      __syncthreads();
+
+      if (is_miss) {
+        int miss_offset = s_chunk_offset[chunk_idx] + local_miss_offset;
+        int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_offset];
+        s_top_k_tokens[miss_offset] = my_token;
+        step_top_k_device_locs[my_token_idx] = req_device_buffer_locs[evict_slot];
+        req_device_buffer_tokens[evict_slot] = my_token;
+      }
+    }
+    __syncthreads();
+
+    total_misses = s_total_misses;
+
+    // Write back LRU order: evictables at front (LRU), hits at back (MRU).
+    {
+      const int total_evictable = HOT_BUFFER_SIZE - s_total_hits;
+      for (int i = tid; i < HOT_BUFFER_SIZE; i += BLOCK_SIZE) {
+        if (i < total_misses) {
+          req_lru_slots[total_evictable - total_misses + i] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else if (i < total_evictable) {
+          req_lru_slots[i - total_misses] = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - i];
+        } else {
+          req_lru_slots[i] = s_lru_slots_out[i - total_evictable];
+        }
+      }
+    }
+
+    // Copy missed pages from host to device buffer.
+    for (int miss_idx = warp_id; miss_idx < total_misses; miss_idx += NUM_WARPS) {
+      const int32_t miss_token = s_top_k_tokens[miss_idx];
+      const int16_t evict_slot = s_lru_slots_out[HOT_BUFFER_SIZE - 1 - miss_idx];
+
+      const int64_t src_loc = req_host_cache_locs[miss_token];
+      const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
+
+      if constexpr (IsDsv4Layout) {
+        device::hisparse::transfer_item<device::hisparse::TransferDirection::HostToDevice>(
+            /*dst_cache=*/device_buffer_k,
+            /*src_cache=*/const_cast<void*>(host_cache_k),
+            /*dst_index=*/static_cast<int32_t>(dst_loc),
+            /*src_index=*/static_cast<int32_t>(src_loc));
+      } else {
+        const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+        auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
+        transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
+
+        if constexpr (!IsMLA) {
+          const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+          auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
+          transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
+        }
+      }
+    }
+
+    // Ensure global writes (device_buffer_tokens, lru_slots) are visible to next step.
+    if (num_steps > 1) {
+      __threadfence_block();
+      __syncthreads();
+    }
+  }  // end step loop
 }
 
 template <int BLOCK_SIZE, int NUM_TOP_K, int HOT_BUFFER_SIZE, bool IsMLA, bool IsDsv4Layout>
@@ -415,7 +504,8 @@ void load_cache_to_device_buffer(
     tvm::ffi::TensorView lru_slots,
     tvm::ffi::TensorView num_real_reqs,
     int64_t page_size,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    int64_t num_steps) {
   using namespace host;
 
   const int64_t bs = top_k_tokens.shape()[0];
@@ -426,8 +516,6 @@ void load_cache_to_device_buffer(
   const int64_t top_k_device_locs_stride = top_k_device_locs.strides()[0];
   const auto device = LaunchKernel::resolve_device(top_k_tokens.device());
 
-  // Generic lambda: int32/int64 kernel variants are compiled for both
-  // seq_lens and req_pool_indices; the correct combo is selected at runtime.
   auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr, const auto* req_pool_indices_ptr) {
     constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
     if constexpr (smem_bytes > 48u * 1024u) {
@@ -454,7 +542,8 @@ void load_cache_to_device_buffer(
         top_k_tokens_stride,
         top_k_device_locs_stride,
         page_size,
-        item_size_bytes);
+        item_size_bytes,
+        num_steps);
   };
 
   const auto seq_dtype = seq_lens.dtype();

--- a/python/sglang/jit_kernel/hisparse.py
+++ b/python/sglang/jit_kernel/hisparse.py
@@ -10,6 +10,8 @@ from sglang.jit_kernel.utils import load_jit, make_cpp_args
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
+_HISPARSE_JIT_CACHE_VERSION = 6
+
 
 @functools.cache
 def _jit_sparse_module(
@@ -24,7 +26,13 @@ def _jit_sparse_module(
         block_size, num_top_k, hot_buffer_size, is_mla, is_dsv4_layout
     )
     cache_args = make_cpp_args(
-        item_size_bytes, block_size, num_top_k, hot_buffer_size, is_mla, is_dsv4_layout
+        _HISPARSE_JIT_CACHE_VERSION,
+        item_size_bytes,
+        block_size,
+        num_top_k,
+        hot_buffer_size,
+        is_mla,
+        is_dsv4_layout,
     )
     return load_jit(
         "sparse_cache",
@@ -58,6 +66,7 @@ def _load_cache_to_device_buffer_mla(
     page_size: int,
     block_size: int,
     num_real_reqs: torch.Tensor | None,
+    num_steps: int = 1,
 ) -> None:
     assert (
         hot_buffer_size >= num_top_k
@@ -95,6 +104,7 @@ def _load_cache_to_device_buffer_mla(
         num_real_reqs,
         page_size,
         item_size_bytes,
+        num_steps,
     )
 
 
@@ -115,6 +125,7 @@ def load_cache_to_device_buffer_mla(
     page_size: int = 1,
     block_size: int = 256,
     num_real_reqs: torch.Tensor | None = None,
+    num_steps: int = 1,
 ) -> None:
     """Generic MLA hisparse swap-in: device + host both linear (stride=item_size_bytes)."""
     _load_cache_to_device_buffer_mla(
@@ -135,6 +146,7 @@ def load_cache_to_device_buffer_mla(
         page_size=page_size,
         block_size=block_size,
         num_real_reqs=num_real_reqs,
+        num_steps=num_steps,
     )
 
 
@@ -155,6 +167,7 @@ def load_cache_to_device_buffer_dsv4_mla(
     page_size: int = 1,
     block_size: int = 256,
     num_real_reqs: torch.Tensor | None = None,
+    num_steps: int = 1,
 ) -> None:
     """DSv4 hisparse swap-in: page-padded device + linear host (kvcacheio.cuh layout)."""
     _load_cache_to_device_buffer_mla(
@@ -175,4 +188,5 @@ def load_cache_to_device_buffer_dsv4_mla(
         page_size=page_size,
         block_size=block_size,
         num_real_reqs=num_real_reqs,
+        num_steps=num_steps,
     )

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -32,6 +32,7 @@ class KVArgs:
     kv_data_ptrs: List[int]
     kv_data_lens: List[int]
     kv_item_lens: List[int]
+    target_kv_data_ptr_count: int
     aux_data_ptrs: List[int]
     aux_data_lens: List[int]
     aux_item_lens: List[int]

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -372,15 +372,23 @@ class DecodePreallocQueue:
 
         kv_args.pp_rank = self.pp_rank
         kv_args.system_dp_rank = self.scheduler.ps.dp_rank
-        transfer_kv_pool = (
-            self.scheduler.hisparse_coordinator.mem_pool_host
-            if self.scheduler.enable_hisparse
-            else self.token_to_kv_pool
-        )
-        kv_data_ptrs, kv_data_lens, kv_item_lens = (
-            transfer_kv_pool.get_contiguous_buf_infos()
-        )
-        if self.draft_token_to_kv_pool is not None:
+        if self.scheduler.enable_hisparse:
+            # Direct-to-host: register host pool pointers so P writes to D's host memory
+            host_pool = self.scheduler.hisparse_coordinator.mem_pool_host
+            kv_data_ptrs, kv_data_lens, kv_item_lens = (
+                host_pool.get_contiguous_buf_infos()
+            )
+        else:
+            kv_data_ptrs, kv_data_lens, kv_item_lens = (
+                self.token_to_kv_pool.get_contiguous_buf_infos()
+            )
+        kv_args.target_kv_data_ptr_count = len(kv_data_ptrs)
+        # HiSparse direct-to-host uses host-pool indices for target KV transfer.
+        # Draft KV remains device-indexed and cannot share that destination list.
+        if (
+            self.draft_token_to_kv_pool is not None
+            and not self.scheduler.enable_hisparse
+        ):
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -685,6 +685,55 @@ class MooncakeKVManager(CommonKVManager):
             executor=executor,
         )
 
+    def send_kvcache_hisparse(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        page_index_slice: slice,
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ):
+        """HiSparse transfer: prefill page_size > decode host page_size=1.
+
+        Receives page-level prefill_kv_indices and the full token-level
+        dst_kv_indices.  Expands both to token granularity before transfer.
+        """
+        page_size = self.kv_args.page_size
+        target_kv_ptr_count = getattr(
+            self.kv_args, "target_kv_data_ptr_count", len(self.kv_args.kv_data_ptrs)
+        )
+        src_data_ptrs = self.kv_args.kv_data_ptrs[:target_kv_ptr_count]
+        per_token_item_lens = [
+            il // page_size for il in self.kv_args.kv_item_lens[:target_kv_ptr_count]
+        ]
+
+        # Expand page-level src indices to token-level
+        base = np.repeat(prefill_kv_indices * page_size, page_size)
+        offsets = np.tile(np.arange(page_size, dtype=np.int32), len(prefill_kv_indices))
+        expanded_src = base + offsets
+
+        # Expand page-level index_slice to token-level for dst
+        token_start = page_index_slice.start * page_size
+        token_end = min(page_index_slice.stop * page_size, len(dst_kv_indices))
+        expanded_dst = dst_kv_indices[token_start:token_end]
+
+        # Clip src to match dst length (last page may be partial)
+        expanded_src = expanded_src[: len(expanded_dst)]
+
+        logger.debug(
+            f"Send KVCache for hisparse: {expanded_src.shape} -> {expanded_dst.shape}"
+        )
+        return self._send_kvcache_generic(
+            mooncake_session_id=mooncake_session_id,
+            src_data_ptrs=src_data_ptrs,
+            dst_data_ptrs=dst_kv_ptrs,
+            item_lens=per_token_item_lens,
+            prefill_data_indices=expanded_src,
+            dst_data_indices=expanded_dst,
+            executor=executor,
+        )
+
     def send_kvcache_slice(
         self,
         mooncake_session_id: str,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -152,6 +152,7 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        kv_args.target_kv_data_ptr_count = len(kv_data_ptrs)
 
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -92,6 +92,13 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
     return seqlens_32.contiguous().view(-1, 1)
 
 
+def _uses_hisparse_device_mapping(forward_batch: ForwardBatch) -> bool:
+    translate_loc = getattr(
+        forward_batch.token_to_kv_pool, "translate_loc_to_hisparse_device", None
+    )
+    return callable(translate_loc)
+
+
 # Reuse this workspace buffer across all DSA backend instances
 global_workspace_buffer = None
 
@@ -1026,17 +1033,13 @@ class DeepseekSparseAttnBackend(
                 page_indices, repeats=self.speculative_num_draft_tokens, dim=0
             )
             metadata.page_table_1[:, :max_seqlen_k].copy_(page_indices)
-            extend_seq_lens_cpu = [self.speculative_num_draft_tokens] * bs
-
-            seqlens_expanded = seqlens_expand_triton(
-                torch.tensor(
-                    extend_seq_lens_cpu, dtype=torch.int32, device=self.device
-                ),
-                cache_seqlens,
-                self.speculative_num_draft_tokens * bs,
-                self.speculative_num_draft_tokens,
+            draft_tokens = self.speculative_num_draft_tokens
+            total_len = draft_tokens * bs
+            metadata.dsa_seqlens_expanded[:total_len].view(bs, draft_tokens).copy_(
+                (cache_seqlens - draft_tokens + 1).unsqueeze(1)
+                + self.get_device_int32_arange(draft_tokens).unsqueeze(0)
             )
-            metadata.dsa_seqlens_expanded.copy_(seqlens_expanded)
+            seqlens_expanded = metadata.dsa_seqlens_expanded[:total_len]
             dsa_cache_seqlens = compute_dsa_seqlens(
                 seqlens_expanded, self.dsa_index_topk
             )
@@ -1418,6 +1421,11 @@ class DeepseekSparseAttnBackend(
         if topk_indices is not None:
             topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
 
+        use_device_mapping_without_coordinator = (
+            forward_batch.hisparse_coordinator is None
+            and _uses_hisparse_device_mapping(forward_batch)
+        )
+
         # NOTE(dark): here, we use page size = 1
         topk_transform_method = self.get_topk_transform_method(
             forward_batch.forward_mode
@@ -1446,10 +1454,52 @@ class DeepseekSparseAttnBackend(
                     page_size=1,
                 )
 
-        # todo hisparse: to cover more backends
-        if self.hisparse_coordinator is not None:
-            page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
-                page_table_1
+        if forward_batch.hisparse_coordinator is not None:
+            if forward_batch.forward_mode.is_target_verify():
+                num_reqs = forward_batch.req_pool_indices.shape[0]
+                num_steps = self.speculative_num_draft_tokens
+                assert (
+                    topk_indices is not None
+                ), "topk_indices is None in TARGET_VERIFY/DRAFT_EXTEND_V2"
+                assert topk_indices.shape == (
+                    num_reqs * num_steps,
+                    self.dsa_index_topk,
+                ), (
+                    f"topk_indices shape mismatch: {topk_indices.shape} vs expected "
+                    f"({num_reqs * num_steps}, {self.dsa_index_topk}), "
+                    f"forward_mode={forward_batch.forward_mode}, num_reqs={num_reqs}, num_steps={num_steps}"
+                )
+                page_table_1 = (
+                    forward_batch.hisparse_coordinator.swap_in_selected_pages(
+                        forward_batch.req_pool_indices,
+                        metadata.dsa_seqlens_expanded,
+                        topk_indices.view(num_reqs, num_steps, -1),
+                        layer.layer_id,
+                        token_position_space="full",
+                        num_steps=num_steps,
+                    ).view(num_reqs * num_steps, -1)
+                )
+            elif forward_batch.forward_mode.is_draft_extend(include_v2=True):
+                assert (
+                    topk_indices is not None
+                ), "topk_indices is None in DRAFT_EXTEND/DRAFT_EXTEND_V2"
+                page_table_1 = self._swap_in_hisparse_draft_extend_pages(
+                    forward_batch,
+                    metadata,
+                    topk_indices,
+                    layer.layer_id,
+                )
+            else:
+                page_table_1 = (
+                    forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
+                        page_table_1
+                    )
+                )
+        elif use_device_mapping_without_coordinator:
+            page_table_1 = (
+                forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
+                    page_table_1
+                )
             )
 
         if dsa_impl == "tilelang":
@@ -1603,12 +1653,17 @@ class DeepseekSparseAttnBackend(
         if topk_indices is not None:
             topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
 
-        if self.hisparse_coordinator is not None:
-            page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
+        use_device_mapping_without_coordinator = (
+            forward_batch.hisparse_coordinator is None
+            and _uses_hisparse_device_mapping(forward_batch)
+        )
+        if forward_batch.hisparse_coordinator is not None:
+            page_table_1 = forward_batch.hisparse_coordinator.swap_in_selected_pages(
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
                 topk_indices,
                 layer.layer_id,
+                token_position_space="full",
             )
         elif envs.SGLANG_DSA_FUSE_TOPK.get():
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
@@ -1617,6 +1672,13 @@ class DeepseekSparseAttnBackend(
                 page_table=metadata.page_table_1,
                 topk_indices=topk_indices,
                 page_size=1,
+            )
+
+        if use_device_mapping_without_coordinator:
+            page_table_1 = (
+                forward_batch.token_to_kv_pool.translate_loc_to_hisparse_device(
+                    page_table_1
+                )
             )
 
         if self.dsa_decode_impl == "flashmla_sparse":
@@ -2167,6 +2229,79 @@ class DeepseekSparseAttnBackend(
 
         return out
 
+    def _swap_in_hisparse_draft_extend_pages(
+        self,
+        forward_batch: ForwardBatch,
+        metadata: DSAMetadata,
+        topk_indices: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Swap HiSparse pages for variable-length DRAFT_EXTEND queries."""
+        assert forward_batch.hisparse_coordinator is not None
+
+        extend_lens_cpu = forward_batch.extend_seq_lens_cpu
+        if extend_lens_cpu is None:
+            extend_lens_cpu = metadata.dsa_extend_seq_lens_list
+        extend_lens_cpu = [int(x) for x in extend_lens_cpu]
+
+        num_reqs = forward_batch.req_pool_indices.shape[0]
+        extend_lens_cpu = extend_lens_cpu[:num_reqs]
+        total_extend = sum(extend_lens_cpu)
+        if total_extend == 0:
+            return topk_indices.new_full(topk_indices.shape, -1)
+
+        max_steps = max(extend_lens_cpu)
+        if max_steps == 0:
+            return topk_indices.new_full(topk_indices.shape, -1)
+
+        real_topk = topk_indices[:total_extend]
+        padded_topk = topk_indices.new_full(
+            (num_reqs, max_steps, topk_indices.shape[-1]), -1
+        )
+        padded_seq_lens = metadata.dsa_seqlens_expanded.new_ones((num_reqs, max_steps))
+
+        offset = 0
+        for req_idx, extend_len in enumerate(extend_lens_cpu):
+            if extend_len == 0:
+                continue
+            next_offset = offset + extend_len
+            padded_topk[req_idx, :extend_len].copy_(real_topk[offset:next_offset])
+            padded_seq_lens[req_idx, :extend_len].copy_(
+                metadata.dsa_seqlens_expanded[offset:next_offset]
+            )
+            offset = next_offset
+
+        swapped = forward_batch.hisparse_coordinator.swap_in_selected_pages(
+            forward_batch.req_pool_indices,
+            padded_seq_lens.reshape(-1),
+            padded_topk,
+            layer_id,
+            token_position_space="full",
+            num_steps=max_steps,
+        )
+
+        rows = [
+            swapped[req_idx, :extend_len]
+            for req_idx, extend_len in enumerate(extend_lens_cpu)
+            if extend_len > 0
+        ]
+        page_table_1 = torch.cat(rows, dim=0)
+        if topk_indices.shape[0] > total_extend:
+            page_table_1 = torch.cat(
+                [
+                    page_table_1,
+                    topk_indices.new_full(
+                        (
+                            topk_indices.shape[0] - total_extend,
+                            topk_indices.shape[-1],
+                        ),
+                        -1,
+                    ),
+                ],
+                dim=0,
+            )
+        return page_table_1
+
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int
     ) -> torch.Tensor:
@@ -2270,9 +2405,10 @@ class DeepseekSparseAttnBackend(
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:
-        force_unfused = (
-            self.hisparse_coordinator is not None
-            and forward_batch.forward_mode.is_decode_or_idle()
+        force_unfused = forward_batch.hisparse_coordinator is not None and (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
         )
         return DSAIndexerMetadata(
             attn_metadata=self.forward_metadata,

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1,7 +1,7 @@
 # to be combined with the sparse coordinator class and sparse algorithm family
 
 import logging
-from typing import List, NamedTuple, Union
+from typing import List, Literal, NamedTuple, Optional, Union
 
 import torch
 
@@ -52,6 +52,7 @@ class HiSparseCoordinator:
         device: str,
         tp_group,
         host_to_device_ratio: int = 2,
+        host_allocator_type: str = "default",
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -88,6 +89,7 @@ class HiSparseCoordinator:
                 host_size=0,
                 page_size=self.mem_pool_device.page_size,
                 layout="layer_first",
+                allocator_type=host_allocator_type,
                 override_kv_cache_dim=self.mem_pool_device.kv_cache_dim,
             )
             self.item_size_bytes = self.mem_pool_host.token_stride_size
@@ -155,7 +157,7 @@ class HiSparseCoordinator:
             .contiguous()
         )
         self._device_buffer_arange_i32 = torch.arange(
-            self.device_buffer_size, dtype=torch.int32, device=device
+            self.padded_buffer_size, dtype=torch.int32, device=device
         )
 
         # Pre-allocated output buffer for swap_in_selected_pages (CUDA-graph safe)
@@ -172,6 +174,7 @@ class HiSparseCoordinator:
         # CPU flag: True means "skip backup on the next decode step" because
         # staging already backed up all prefill tokens.  Cleared after one step.
         self._skip_first_backup = [False] * max_num_req_slots
+        self._pending_draft_extend_backup = None
 
     def set_decode_producer_stream(self, stream) -> None:
         self.decode_producer_stream = stream
@@ -328,10 +331,11 @@ class HiSparseCoordinator:
 
         self.req_device_buffer_tokens[
             :, req.req_pool_idx, : self.device_buffer_size
-        ] = self._device_buffer_arange_i32
+        ] = self._device_buffer_arange_i32[: self.device_buffer_size]
         self.req_device_buffer_token_locs[:, req.req_pool_idx, :alloc_size] = (
             buffer_indices[:alloc_size]
         )
+        self._skip_first_backup[req.req_pool_idx] = True
 
     def _grow_device_buffers(
         self,
@@ -398,6 +402,13 @@ class HiSparseCoordinator:
                     chunk = all_new_indices[offset : offset + grow_size]
                     offset += grow_size
                     self.req_to_device_buffer[req_idx, current_cap:new_cap] = chunk
+                    hot_end = min(new_cap, self.device_buffer_size)
+                    if current_cap < hot_end:
+                        self.req_device_buffer_tokens[
+                            :, req_idx, current_cap:hot_end
+                        ] = self._device_buffer_arange_i32[current_cap:hot_end]
+                    if hot_end < new_cap:
+                        self.req_device_buffer_tokens[:, req_idx, hot_end:new_cap] = -1
                     self.req_device_buffer_token_locs[
                         :, req_idx, current_cap:new_cap
                     ] = chunk
@@ -444,8 +455,11 @@ class HiSparseCoordinator:
         out_cache_loc: torch.Tensor,
         req_pool_indices: torch.Tensor,
         seq_lens_cpu: torch.Tensor,
-        req_pool_indices_cpu: torch.Tensor,
+        req_pool_indices_cpu: Optional[torch.Tensor] = None,
     ) -> None:
+        if req_pool_indices_cpu is None:
+            req_pool_indices_cpu = req_pool_indices.cpu()
+
         self._eager_backup_previous_token(
             seq_lens, req_pool_indices, seq_lens_cpu, req_pool_indices_cpu
         )
@@ -458,6 +472,9 @@ class HiSparseCoordinator:
             self.req_device_buffer_token_locs[
                 :, req_pool_indices, self.device_buffer_size
             ] = reserved_buffer_loc.to(torch.int32)
+            self.req_device_buffer_tokens[
+                :, req_pool_indices, self.device_buffer_size
+            ] = (seq_lens.to(torch.int32) - 1)
 
             # No need to clear prior mappings: the only consumer of the mapping
             # for past tokens is the swap-in kernel, and it goes through
@@ -592,6 +609,482 @@ class HiSparseCoordinator:
         self._backup_done_event.wait(device_module.current_stream())
         self._has_pending_backup = False
 
+    def _backup_device_locs_to_host(
+        self, host_locs: torch.Tensor, device_locs: torch.Tensor
+    ) -> None:
+        if host_locs.numel() == 0:
+            return
+        self.wait_for_pending_backup()
+        schedule_stream = device_module.current_stream()
+        device_locs = device_locs.contiguous()
+        with device_module.stream(self.decode_backup_stream):
+            self.decode_backup_stream.wait_stream(schedule_stream)
+            if self.decode_producer_stream is not None:
+                self.decode_backup_stream.wait_stream(self.decode_producer_stream)
+            self.mem_pool_host.backup_from_device_all_layer(
+                self.mem_pool_device,
+                host_locs,
+                device_locs,
+                io_backend="kernel",
+            )
+            if host_locs.is_cuda:
+                host_locs.record_stream(self.decode_backup_stream)
+            if device_locs.is_cuda:
+                device_locs.record_stream(self.decode_backup_stream)
+        event = device_module.Event()
+        event.record(self.decode_backup_stream)
+        device_module.current_stream().wait_event(event)
+
+    def finish_pending_draft_extend_backup(self) -> None:
+        pending = self._pending_draft_extend_backup
+        if pending is None:
+            return
+        self._pending_draft_extend_backup = None
+        host_locs, device_locs, logical_locs_to_clear = pending
+        self._backup_device_locs_to_host(host_locs, device_locs)
+        if logical_locs_to_clear.numel() > 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[logical_locs_to_clear] = 0
+
+    def clear_pending_draft_extend_backup(self) -> None:
+        pending = self._pending_draft_extend_backup
+        if pending is None:
+            return
+        self._pending_draft_extend_backup = None
+        _, _, logical_locs_to_clear = pending
+        if logical_locs_to_clear.numel() > 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[logical_locs_to_clear] = 0
+
+    def supports_hisparse_draft_slots(self) -> bool:
+        return not self.is_dsv4_hisparse
+
+    def _ensure_padded_buffer(self, req_pool_indices: torch.Tensor) -> None:
+        """Grow under-sized buffers to padded_buffer_size so extra-page slots are valid."""
+        req_indices_cpu = req_pool_indices.cpu().tolist()
+        grow_reqs = []
+        total_grow = 0
+        for req_idx in req_indices_cpu:
+            current_cap = int(self.req_device_buffer_size[req_idx])
+            if current_cap >= self.padded_buffer_size:
+                continue
+            grow_reqs.append((req_idx, current_cap))
+            total_grow += self.padded_buffer_size - current_cap
+
+        if total_grow == 0:
+            return
+
+        all_new = self.token_to_kv_pool_allocator.hisparse_attn_allocator.alloc(
+            total_grow
+        )
+        if all_new is None:
+            raise RuntimeError(
+                f"HiSparse: failed to grow buffers for draft slots (need {total_grow})"
+            )
+
+        offset = 0
+        for req_idx, current_cap in grow_reqs:
+            grow_size = self.padded_buffer_size - current_cap
+            chunk = all_new[offset : offset + grow_size]
+            offset += grow_size
+            self.req_to_device_buffer[
+                req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            hot_end = min(self.padded_buffer_size, self.device_buffer_size)
+            if current_cap < hot_end:
+                self.req_device_buffer_tokens[:, req_idx, current_cap:hot_end] = (
+                    self._device_buffer_arange_i32[current_cap:hot_end]
+                )
+            if hot_end < self.padded_buffer_size:
+                self.req_device_buffer_tokens[
+                    :, req_idx, hot_end : self.padded_buffer_size
+                ] = -1
+            self.req_device_buffer_token_locs[
+                :, req_idx, current_cap : self.padded_buffer_size
+            ] = chunk
+            self.req_device_buffer_size[req_idx] = self.padded_buffer_size
+
+    def get_draft_device_slots(
+        self,
+        req_pool_indices: torch.Tensor,
+        num_tokens_per_req: int,
+        start_positions_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return device slots for a uniform draft allocation.
+
+        Draft tokens that still fit in the hot buffer reuse their logical hot
+        slots. Later draft tokens use the per-request extra-page area.
+        """
+        assert self.supports_hisparse_draft_slots()
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Requested {num_tokens_per_req} draft slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1} "
+                f"available (padded_buffer_size={self.padded_buffer_size}, "
+                f"device_buffer_size={self.device_buffer_size})."
+            )
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = req_pool_indices.numel() * num_tokens_per_req
+        row_indices = torch.repeat_interleave(req_pool_indices, num_tokens_per_req)
+        pos_in_segment = torch.arange(total_slots, device=req_pool_indices.device) % (
+            num_tokens_per_req
+        )
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = (
+            torch.repeat_interleave(start_positions, num_tokens_per_req)
+            + pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        if torch.any(col_indices >= self.padded_buffer_size):
+            raise ValueError(
+                "HiSparse draft slots exceed padded buffer: "
+                f"{col_indices.max().item()=} {self.padded_buffer_size=}"
+            )
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def get_draft_device_slots_variable(
+        self,
+        req_pool_indices: torch.Tensor,
+        tokens_per_req_cpu: torch.Tensor,
+        start_positions_cpu: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return device slots when each request needs a different draft count."""
+        assert self.supports_hisparse_draft_slots()
+        if tokens_per_req_cpu.numel() == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        start = self.device_buffer_size + 1
+        max_tokens = int(tokens_per_req_cpu.max().item())
+        if start + max_tokens > self.padded_buffer_size:
+            raise ValueError(
+                f"Max per-request draft slots ({max_tokens}) exceeds extra page "
+                f"capacity ({self.padded_buffer_size - self.device_buffer_size - 1})."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = int(tokens_per_req_cpu.sum().item())
+        if total_slots == 0:
+            return torch.empty(0, dtype=torch.int64, device=req_pool_indices.device)
+
+        tokens_per_req = tokens_per_req_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+
+        # Build fixed-shape gather indices. Zero-repeat requests naturally disappear.
+        row_indices = torch.repeat_interleave(req_pool_indices, tokens_per_req)
+        offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int64, device=tokens_per_req.device),
+                tokens_per_req.cumsum(0),
+            ]
+        )
+        pos_in_segment = torch.arange(total_slots, device=tokens_per_req.device) - (
+            torch.repeat_interleave(offsets[:-1], tokens_per_req)
+        )
+
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = torch.repeat_interleave(start_positions, tokens_per_req) + (
+            pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        if torch.any(col_indices >= self.padded_buffer_size):
+            raise ValueError(
+                "HiSparse variable draft slots exceed padded buffer: "
+                f"{col_indices.max().item()=} {self.padded_buffer_size=}"
+            )
+
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        return self.req_to_device_buffer[row_indices, col_indices]
+
+    def prepare_verify_slots_spec_v2(
+        self,
+        req_pool_indices: torch.Tensor,
+        verify_cache_locs: torch.Tensor,
+        num_tokens_per_req: int,
+        start_positions_cpu: torch.Tensor,
+    ) -> None:
+        """Bind the current spec-v2 target-verify window to extra-page slots."""
+        assert self.supports_hisparse_draft_slots()
+        start = self.device_buffer_size + 1
+        end = start + num_tokens_per_req
+        if end > self.padded_buffer_size:
+            raise ValueError(
+                f"Spec-v2 verify needs {num_tokens_per_req} slots but extra page only "
+                f"has {self.padded_buffer_size - self.device_buffer_size - 1}."
+            )
+
+        self._ensure_padded_buffer(req_pool_indices)
+        self.req_device_buffer_tokens[
+            :, req_pool_indices, start : self.padded_buffer_size
+        ] = -1
+
+        total_slots = req_pool_indices.numel() * num_tokens_per_req
+        if verify_cache_locs.numel() != total_slots:
+            raise ValueError(
+                "HiSparse spec-v2 verify slot mismatch: "
+                f"expected {total_slots} cache locs, got {verify_cache_locs.numel()}."
+            )
+
+        row_indices = torch.repeat_interleave(req_pool_indices, num_tokens_per_req)
+        pos_in_segment = torch.arange(total_slots, device=req_pool_indices.device) % (
+            num_tokens_per_req
+        )
+        start_positions = start_positions_cpu.to(
+            device=req_pool_indices.device, dtype=torch.int64
+        )
+        token_positions = (
+            torch.repeat_interleave(start_positions, num_tokens_per_req)
+            + pos_in_segment
+        )
+        col_indices = torch.where(
+            token_positions < self.device_buffer_size,
+            token_positions,
+            start + pos_in_segment,
+        )
+        device_slots = self.req_to_device_buffer[row_indices, col_indices]
+        self.req_device_buffer_tokens[:, row_indices, col_indices] = token_positions.to(
+            torch.int32
+        ).unsqueeze(0)
+        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping[
+            verify_cache_locs
+        ] = device_slots
+
+    def finalize_accepted_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        accepted_cache_locs: torch.Tensor,
+        draft_cache_locs: torch.Tensor,
+        num_correct_drafts: torch.Tensor,
+        num_correct_drafts_cpu: torch.Tensor,
+        accepted_token_positions: torch.Tensor,
+    ) -> None:
+        """Persist accepted speculative tokens and remap the newest token slot.
+
+        Accepted draft tokens inside the hot buffer keep their hot slots. Tokens
+        beyond the hot buffer are backed up to host, while the last accepted
+        token is copied into the newest-token slot for the next decode step.
+
+        Transactional: if host alloc fails, all mapping mutations are rolled back
+        so the coordinator stays consistent for the next iteration.
+        """
+        assert self.supports_hisparse_draft_slots()
+        if accepted_cache_locs.numel() == 0:
+            return
+        self.clear_pending_draft_extend_backup()
+
+        counts = num_correct_drafts.to(torch.int64) + 1
+        counts_cpu = num_correct_drafts_cpu.to(torch.int64) + 1
+        total_accepted = int(counts_cpu.sum().item())
+        if total_accepted != accepted_cache_locs.numel():
+            raise ValueError(
+                "HiSparse accepted token bookkeeping mismatch: "
+                f"expected {total_accepted} cache locs, got {accepted_cache_locs.numel()}."
+            )
+        if total_accepted != accepted_token_positions.numel():
+            raise ValueError(
+                "HiSparse accepted token position mismatch: "
+                f"expected {total_accepted} positions, "
+                f"got {accepted_token_positions.numel()}."
+            )
+
+        full_to_device_mapping = (
+            self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+        )
+        accepted_token_positions = accepted_token_positions.to(
+            device=accepted_cache_locs.device, dtype=torch.int64
+        )
+        in_hot_buffer = accepted_token_positions < self.device_buffer_size
+
+        # Snapshot mapping values before mutation for rollback.
+        draft_mapping_snapshot = full_to_device_mapping[draft_cache_locs].clone()
+        accepted_device_locs = full_to_device_mapping[accepted_cache_locs].clone()
+
+        full_to_device_mapping[draft_cache_locs] = 0
+        accepted_req_indices = torch.repeat_interleave(req_pool_indices, counts)
+        if torch.any(in_hot_buffer):
+            hot_cache_locs = accepted_cache_locs[in_hot_buffer]
+            hot_positions = accepted_token_positions[in_hot_buffer]
+            hot_req_indices = accepted_req_indices[in_hot_buffer]
+            hot_slots = self.req_to_device_buffer[hot_req_indices, hot_positions]
+            full_to_device_mapping[hot_cache_locs] = hot_slots
+
+        needs_backup = ~in_hot_buffer
+        backup_count = int(needs_backup.sum().item())
+        if backup_count > 0:
+            backup_positions = accepted_token_positions[needs_backup]
+            backup_req_indices = accepted_req_indices[needs_backup]
+            backup_device_locs = accepted_device_locs[needs_backup]
+
+            host_page_size = getattr(self.mem_pool_host, "page_size", 1)
+            host_alloc_count = (
+                (backup_count + host_page_size - 1) // host_page_size
+            ) * host_page_size
+            host_locs_all = self.mem_pool_host.alloc(host_alloc_count)
+            if host_locs_all is None:
+                full_to_device_mapping[draft_cache_locs] = draft_mapping_snapshot
+                logger.error(
+                    "HiSparse: host alloc failed for %d accepted draft tokens, rolled back",
+                    backup_count,
+                )
+                return
+            host_locs = host_locs_all[:backup_count]
+            if host_alloc_count > backup_count:
+                self.mem_pool_host.free(host_locs_all[backup_count:])
+            host_locs = host_locs.to(device=self.device)
+
+            self._backup_device_locs_to_host(host_locs, backup_device_locs)
+            self.req_to_host_pool[backup_req_indices, backup_positions] = host_locs
+            full_to_device_mapping[accepted_cache_locs[needs_backup]] = (
+                backup_device_locs
+            )
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        last_offsets = offsets[1:] - 1
+        last_positions = accepted_token_positions[last_offsets]
+        reserved_positions = last_positions.clamp(max=self.device_buffer_size)
+        newest_slots = self.req_to_device_buffer[req_pool_indices, reserved_positions]
+        last_logical = accepted_cache_locs[last_offsets]
+        last_slots = accepted_device_locs[last_offsets]
+        self.req_device_buffer_tokens[:, req_pool_indices, reserved_positions] = (
+            last_positions.to(torch.int32).unsqueeze(0)
+        )
+        self.req_device_buffer_token_locs[:, req_pool_indices, reserved_positions] = (
+            newest_slots.to(torch.int32)
+        )
+        for idx in req_pool_indices.tolist():
+            self._skip_first_backup[idx] = True
+
+        same_slot = last_slots == newest_slots
+        if torch.any(~same_slot):
+            self.mem_pool_device.transfer_values_on_device(
+                dst_indices=newest_slots[~same_slot],
+                src_indices=last_slots[~same_slot],
+            )
+        full_to_device_mapping[last_logical] = newest_slots
+
+        if backup_count > 0:
+            backup_positions_in_needs = (
+                torch.cumsum(needs_backup.to(torch.int64), dim=0) - 1
+            )
+            last_needs_backup = needs_backup[last_offsets]
+            post_backup_device_locs = backup_device_locs.clone()
+            if torch.any(last_needs_backup):
+                last_backup_offsets = backup_positions_in_needs[
+                    last_offsets[last_needs_backup]
+                ]
+                post_backup_device_locs[last_backup_offsets] = newest_slots[
+                    last_needs_backup
+                ]
+
+            logical_locs_to_clear_mask = needs_backup.clone()
+            logical_locs_to_clear_mask[last_offsets] = False
+            self._pending_draft_extend_backup = (
+                host_locs,
+                post_backup_device_locs,
+                accepted_cache_locs[logical_locs_to_clear_mask],
+            )
+
+    def finalize_accepted_tokens_spec_v2(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        verify_cache_locs: torch.Tensor,
+        accept_index: torch.Tensor,
+    ) -> None:
+        """Commit accepted spec-v2 target-verify KV into HiSparse storage.
+
+        The target verify pass writes all draft-token KV into per-request
+        extra-page slots. accept_index is the source of truth for which slots
+        survive into host/newest-slot metadata.
+        """
+        assert self.supports_hisparse_draft_slots()
+        if verify_cache_locs.numel() == 0:
+            return
+
+        counts = (accept_index != -1).sum(dim=1).to(torch.int64)
+        total_accepted = int(counts.sum().item())
+        if total_accepted == 0:
+            full_to_device_mapping = (
+                self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+            )
+            full_to_device_mapping[verify_cache_locs] = 0
+            return
+
+        flat_accept_index = accept_index.reshape(-1)
+        accepted_offsets = flat_accept_index[flat_accept_index >= 0].to(torch.int64)
+        if accepted_offsets.numel() != total_accepted:
+            raise ValueError(
+                "HiSparse spec-v2 accepted index mismatch: "
+                f"expected {total_accepted} accepted slots, "
+                f"got {accepted_offsets.numel()}."
+            )
+
+        offsets = torch.cat(
+            [torch.zeros(1, dtype=torch.int64, device=counts.device), counts.cumsum(0)]
+        )
+        pos_in_segment = torch.arange(
+            total_accepted, dtype=torch.int64, device=counts.device
+        ) - torch.repeat_interleave(offsets[:-1], counts)
+        accepted_token_positions = (
+            torch.repeat_interleave(seq_lens.to(torch.int64), counts) + pos_in_segment
+        )
+
+        self.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=verify_cache_locs[accepted_offsets],
+            draft_cache_locs=verify_cache_locs,
+            num_correct_drafts=counts - 1,
+            num_correct_drafts_cpu=(counts - 1).cpu(),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+    def get_front_topk_tokens(
+        self,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        top_k_indices = self.req_to_device_buffer[req_pool_indices, : self.top_k].to(
+            torch.int32
+        )
+        topk_col_indices = torch.arange(self.top_k, device=self.device).unsqueeze(0)
+        # Mask out positions beyond each request's seq_len
+        mask = topk_col_indices >= seq_lens.unsqueeze(1)
+        top_k_indices[mask] = -1
+        return top_k_indices
+
     def naive_load_topk(
         self,
         req_pool_indices: torch.Tensor,
@@ -704,11 +1197,8 @@ class HiSparseCoordinator:
         self.token_to_kv_pool_allocator.free_hisparse(allocated_locs)
 
         # Free host memory that was allocated during admit_request_into_staging
-        host_indices = self.mem_pool_host.allocated_host_indices(
-            self.req_to_host_pool,
-            req.req_pool_idx,
-            self.req_to_host_pool_allocated_len[req.req_pool_idx],
-        )
+        host_indices = self.req_to_host_pool[req.req_pool_idx]
+        host_indices = host_indices[host_indices >= 0]
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
         self.req_to_host_pool[req.req_pool_idx, :] = -1
@@ -752,11 +1242,8 @@ class HiSparseCoordinator:
         )
         self.mem_pool_device.full_to_hisparse_device_index_mapping[compressed_locs] = 0
 
-        host_indices = self.mem_pool_host.allocated_host_indices(
-            self.req_to_host_pool,
-            req.req_pool_idx,
-            self.req_to_host_pool_allocated_len[req.req_pool_idx],
-        )
+        host_indices = self.req_to_host_pool[req.req_pool_idx]
+        host_indices = host_indices[host_indices >= 0]
         if host_indices.numel() > 0:
             self.mem_pool_host.free(host_indices)
 
@@ -776,14 +1263,65 @@ class HiSparseCoordinator:
         compressed_seq_lens: torch.Tensor,
         top_k_result: torch.Tensor,
         layer_id: int,
+        token_position_space: Literal["compressed", "full"] = "compressed",
+        num_steps: int = 1,
     ) -> torch.Tensor:
-        """Swap selected top-k tokens into device memory and return their indices."""
-        num_reqs = req_pool_indices.size(0)
+        """Swap selected top-k tokens into device memory and return their indices.
 
-        top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
+        When num_steps > 1 (speculative multi-step):
+            seq_lens shape: [num_reqs * num_steps] flat req-major
+            top_k_result shape: [num_reqs, num_steps, top_k]
+            returns: [num_reqs, num_steps, top_k]
+        """
+        num_reqs = req_pool_indices.size(0)
+        needed = num_reqs * num_steps
+
+        if needed > self.top_k_device_locs_buffer.shape[0]:
+            self.top_k_device_locs_buffer = torch.full(
+                (needed, self.top_k),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+        if num_steps > 1:
+            top_k_indices = self.top_k_device_locs_buffer[:needed].view(
+                num_reqs, num_steps, -1
+            )
+        else:
+            top_k_indices = self.top_k_device_locs_buffer[:num_reqs]
         top_k_indices.fill_(-1)
 
-        # todo, adjustable for performance
+        swap_seq_lens = compressed_seq_lens
+        swap_top_k_result = top_k_result
+        if token_position_space == "full" and self.is_dsv4_hisparse:
+            if num_steps > 1:
+                seq_lens_for_compare = compressed_seq_lens.view(
+                    num_reqs, num_steps
+                ).unsqueeze(2)
+            else:
+                seq_lens_for_compare = compressed_seq_lens.unsqueeze(1)
+            valid_compressed_token = (
+                (top_k_result >= 0)
+                & (top_k_result < seq_lens_for_compare)
+                & ((top_k_result + 1) % self.compress_ratio == 0)
+            )
+            swap_top_k_result = torch.where(
+                valid_compressed_token,
+                top_k_result // self.compress_ratio,
+                torch.full_like(top_k_result, -1),
+            )
+            if num_steps > 1:
+                swap_seq_lens = (
+                    compressed_seq_lens.view(num_reqs, num_steps) // self.compress_ratio
+                ).reshape(-1)
+            else:
+                swap_seq_lens = compressed_seq_lens // self.compress_ratio
+        elif token_position_space != "compressed":
+            assert (
+                token_position_space == "full"
+            ), f"Unsupported token_position_space={token_position_space}"
+
         block_size = 1024
         swap_in_fn = (
             load_cache_to_device_buffer_dsv4_mla
@@ -791,7 +1329,7 @@ class HiSparseCoordinator:
             else load_cache_to_device_buffer_mla
         )
         swap_in_fn(
-            top_k_tokens=top_k_result,
+            top_k_tokens=swap_top_k_result,
             device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
             host_cache_locs=self.req_to_host_pool,
             device_buffer_locs=self.req_device_buffer_token_locs[layer_id],
@@ -799,13 +1337,14 @@ class HiSparseCoordinator:
             device_buffer=self.mem_pool_device.kv_buffer[layer_id],
             top_k_device_locs=top_k_indices,
             req_pool_indices=req_pool_indices,
-            seq_lens=compressed_seq_lens,
+            seq_lens=swap_seq_lens,
             lru_slots=self.lru_slots[layer_id],
             item_size_bytes=self.item_size_bytes,
             num_top_k=self.top_k,
             hot_buffer_size=self.device_buffer_size,
-            page_size=1,
+            page_size=self.mem_pool_device.page_size if num_steps > 1 else 1,
             block_size=block_size,
             num_real_reqs=self.num_real_reqs,
+            num_steps=num_steps,
         )
         return top_k_indices

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -971,6 +971,7 @@ class Req(ReqDllmMixin):
 
         # For hisparse
         self.hisparse_staging = False
+        self.hisparse_spec_info = None
 
     @property
     def seqlen(self) -> int:
@@ -1333,6 +1334,7 @@ class Req(ReqDllmMixin):
         self.kv_committed_len = 0
         self.kv_committed_freed = False
         self.kv_overallocated_freed = False
+        self.hisparse_spec_info = None
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2324,6 +2324,7 @@ class Scheduler(
         batch.input_ids = torch.tensor(
             [r.output_ids[-1] for r in reqs], dtype=torch.int64, device=device
         )
+        batch.input_ids = batch.output_ids
 
         if batch.return_logprob:
             batch.top_logprobs_nums = [r.logprob.top_logprobs_num for r in reqs]
@@ -2332,7 +2333,40 @@ class Scheduler(
         batch.sampling_info = SamplingBatchInfo.from_schedule_batch(
             batch, self.model_config.vocab_size
         )
-        # todo hisparse, maybe other info to contain for the new batch
+
+        if not batch.spec_algorithm.is_none():
+            missing_spec_info_rids = [
+                req.rid
+                for req in reqs
+                if getattr(req, "hisparse_spec_info", None) is None
+            ]
+            if missing_spec_info_rids:
+                raise RuntimeError(
+                    "HiSparse decode batch is missing speculative draft state for requests: "
+                    + ", ".join(missing_spec_info_rids)
+                )
+
+            batch.spec_info = reqs[0].hisparse_spec_info
+            reqs[0].hisparse_spec_info = None
+            for req in reqs[1:]:
+                batch.spec_info.merge_batch(req.hisparse_spec_info)
+                req.hisparse_spec_info = None
+
+            if batch.is_spec_v2:
+                if batch.spec_info.new_seq_lens is None:
+                    raise RuntimeError(
+                        "HiSparse spec-v2 decode batch is missing new_seq_lens for draft state rebuild."
+                    )
+                future_indices = self.future_map.alloc_future_indices(len(reqs))
+                self.future_map.store_to_map_for_new_batch(
+                    future_indices, batch.spec_info
+                )
+                batch.spec_info.future_indices = future_indices
+                batch.spec_info.verify_done = None
+                batch.seq_lens = batch.spec_info.new_seq_lens
+                batch.seq_lens_cpu = batch.seq_lens.cpu()
+                batch.orig_seq_lens = batch.seq_lens.to(dtype=torch.int32)
+                batch.seq_lens_sum = batch.seq_lens_cpu.sum().item()
         return batch
 
     def get_next_batch_to_run(self) -> Optional[ScheduleBatch]:
@@ -2987,6 +3021,12 @@ class Scheduler(
                 if isinstance(batch_result.next_token_ids, torch.Tensor):
                     batch.input_ids = batch_result.next_token_ids.to(torch.int64)
                 self.update_cache_from_scheduler(batch, batch_result)
+                if (
+                    self.enable_hisparse
+                    and batch.is_spec_v2
+                    and batch_result.next_draft_input is not None
+                ):
+                    batch.spec_info = batch_result.next_draft_input
 
             # These 2 values are needed for processing the output, but the values can be
             # modified by overlap schedule. So we have to copy them here so that

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -175,6 +175,17 @@ class SchedulerBatchResultProcessor:
                     elem = elem.copy()
                 req.customized_info[k].append(elem)
 
+    def _stash_hisparse_spec_info(
+        self, batch: ScheduleBatch, batch_index: int, req: Req
+    ) -> None:
+        if not self.server_args.enable_hisparse or batch.spec_info is None:
+            return
+        if not hasattr(batch.spec_info, "slice_single"):
+            raise RuntimeError(
+                f"HiSparse cannot stash speculative state for {type(batch.spec_info).__name__}"
+            )
+        req.hisparse_spec_info = batch.spec_info.slice_single(batch_index)
+
     def process_batch_result_prefill(
         self,
         batch: ScheduleBatch,
@@ -203,6 +214,12 @@ class SchedulerBatchResultProcessor:
                 result.extend_input_len_per_req,
                 result.extend_logprob_start_len_per_req,
             )
+            if (
+                self.server_args.enable_hisparse
+                and batch.spec_info is None
+                and result.next_draft_input is not None
+            ):
+                batch.spec_info = result.next_draft_input
 
             # Move next_token_ids and logprobs to cpu
             next_token_ids = next_token_ids.tolist()
@@ -237,6 +254,7 @@ class SchedulerBatchResultProcessor:
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if self.server_args.enable_hisparse:
+                            self._stash_hisparse_spec_info(batch, i, req)
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
                     self._maybe_collect_customized_info(i, req, logits_output)

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -2,7 +2,7 @@
 
 import logging
 import weakref
-from typing import Optional
+from typing import Optional, Tuple
 
 import psutil
 import torch
@@ -35,6 +35,27 @@ else:
             "HiSparse device KV transfer requires sgl_kernel.kvcacheio (CUDA/ROCm). "
             "It is not available on this backend."
         )
+
+
+def _hisparse_backup_state(
+    logical_allocator, hisparse_allocator, mapping: torch.Tensor
+) -> Tuple:
+    return (
+        logical_allocator.backup_state(),
+        hisparse_allocator.backup_state(),
+        mapping.clone(),
+    )
+
+
+def _hisparse_restore_state(
+    logical_allocator, hisparse_allocator, mapping: torch.Tensor, state: Tuple
+) -> None:
+    logical_state, hisparse_state, mapping_snapshot = state
+    logical_allocator.restore_state(logical_state)
+    hisparse_allocator.restore_state(hisparse_state)
+    mapping[: mapping_snapshot.shape[0]].copy_(mapping_snapshot)
+    if mapping_snapshot.shape[0] < mapping.shape[0]:
+        mapping[mapping_snapshot.shape[0] :] = 0
 
 
 class HiSparseDSATokenToKVPool(DSATokenToKVPool):
@@ -287,6 +308,51 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def get_last_loc_hisparse_device(self, last_locs: torch.Tensor):
         return self._kvcache._translate_loc_to_hisparse_device(last_locs)
 
+    def alloc_extend_with_device_mapping(
+        self,
+        prefix_lens: torch.Tensor,
+        prefix_lens_cpu: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+        device_slots: torch.Tensor,
+        backup_state: bool = False,
+    ):
+        """Allocate logical indices and map them to caller-managed HiSparse slots."""
+        avail = self.logical_attn_allocator.available_size()
+        if avail < extend_num_tokens:
+            raise RuntimeError(
+                f"HiSparse logical alloc: need {extend_num_tokens} tokens but only "
+                f"{avail} are available."
+            )
+
+        logical_state = (
+            self.logical_attn_allocator.backup_state() if backup_state else None
+        )
+        out = self.logical_attn_allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            extend_num_tokens,
+        )
+        if out is None:
+            raise RuntimeError(
+                f"HiSparse logical alloc failed for {extend_num_tokens} tokens. "
+                f"Logical pool available: {self.logical_attn_allocator.available_size()}"
+            )
+
+        self.full_to_hisparse_device_index_mapping[out] = device_slots
+        if backup_state:
+            return out, (logical_state, out.clone())
+        return out
+
+    def clear_device_mapping(self, logical_indices: torch.Tensor):
+        """Clear mappings for caller-managed slots before freeing logical indices."""
+        self.full_to_hisparse_device_index_mapping[logical_indices] = 0
+
     def alloc_extend(
         self,
         prefix_lens: torch.Tensor,
@@ -385,6 +451,26 @@ class HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             <= self.hisparse_attn_allocator.size
         )
 
+    def backup_state(self):
+        return _hisparse_backup_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+        )
+
+    def restore_state(self, state):
+        if len(state) == 2:
+            # Draft extra-page mappings must stay live until accepted tokens are finalized.
+            self.logical_attn_allocator.restore_state(state[0])
+            return
+
+        _hisparse_restore_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+            state,
+        )
+
 
 class DeepSeekV4SingleKVPoolHost(HiSparseHostPoolMixin):
 
@@ -396,7 +482,6 @@ class DeepSeekV4SingleKVPoolHost(HiSparseHostPoolMixin):
         pin_memory: bool = True,
         device: str = "cpu",
     ):
-
         assert host_size > 0, "Host size must be specified and greater than 0"
 
         self.device_pool = device_pool
@@ -502,7 +587,6 @@ class DeepSeekV4SingleKVPoolHost(HiSparseHostPoolMixin):
 
 
 class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
-
     def __init__(
         self,
         logical_attn_allocator: BaseTokenToKVPoolAllocator,
@@ -776,4 +860,19 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert (
             self.hisparse_attn_allocator.available_size()
             <= self.hisparse_attn_allocator.size
+        )
+
+    def backup_state(self):
+        return _hisparse_backup_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+        )
+
+    def restore_state(self, state):
+        _hisparse_restore_state(
+            self.logical_attn_allocator,
+            self.hisparse_attn_allocator,
+            self.full_to_hisparse_device_index_mapping,
+            state,
         )

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -536,6 +536,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             dimensions=batch.dimensions,
             return_pooled_hidden_states=batch.return_pooled_hidden_states,
             return_hidden_states_before_norm=return_hidden_states_before_norm,
+            hisparse_coordinator=batch.hisparse_coordinator,
             rids=[req.rid for req in batch.reqs],
         )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -764,13 +764,26 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         if self.device == "cuda" or self.device == "musa":
             self.init_cublas()
-            if self.enable_hisparse:
+            self.init_attention_backend()
+            self.kernel_warmup()
+            # Init hisparse coordinator (must happen before CUDA graph capture).
+            # Only the target runner owns scheduler-populated staging state.
+            if self.enable_hisparse and not self.is_draft_worker:
                 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
                 from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
                 hisparse_cfg = parse_hisparse_config(self.server_args)
                 hisparse_top_k = getattr(
                     self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
+                )
+                hisparse_host_allocator_type = (
+                    "mooncake"
+                    if (
+                        self.server_args.disaggregation_mode == "decode"
+                        and self.server_args.disaggregation_transfer_backend
+                        == "mooncake"
+                    )
+                    else "default"
                 )
                 self.hisparse_coordinator = HiSparseCoordinator(
                     req_to_token_pool=self.req_to_token_pool,
@@ -784,9 +797,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                         else self.tp_group.cpu_group
                     ),
                     host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                    host_allocator_type=hisparse_host_allocator_type,
                 )
-            self.init_attention_backend()
-            self.kernel_warmup()
             self._pre_initialize_flashinfer_allreduce_workspace()
             self.init_device_graphs()
         elif self.device == "cpu":
@@ -3255,6 +3267,20 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         else:
             ctx_mgr = forward_context(ForwardContext(attn_backend=self.attn_backend))
         with ctx_mgr:
+            active_hisparse_coordinator = self.hisparse_coordinator
+            if (
+                active_hisparse_coordinator is None
+                and forward_batch.hisparse_coordinator is not None
+                and callable(
+                    getattr(
+                        forward_batch.token_to_kv_pool,
+                        "translate_loc_to_hisparse_device",
+                        None,
+                    )
+                )
+            ):
+                active_hisparse_coordinator = forward_batch.hisparse_coordinator
+
             mode_check = (
                 forward_batch.forward_mode.is_cpu_graph
                 if self.device == "cpu"
@@ -3266,13 +3292,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 and self.graph_runner.can_run(forward_batch)
             )
 
-            # Hisparse coordinator — backends now read it from self.model_runner.
+            # Hisparse coordinator
             if (
                 forward_batch.forward_mode.is_decode()
-                and self.hisparse_coordinator is not None
+                and active_hisparse_coordinator is not None
             ):
-                self.hisparse_coordinator.wait_for_pending_backup()
-                self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
+                forward_batch.hisparse_coordinator = active_hisparse_coordinator
+                active_hisparse_coordinator.wait_for_pending_backup()
+                active_hisparse_coordinator.num_real_reqs.fill_(
+                    forward_batch.batch_size
+                )
 
             if self.is_hybrid_swa:
                 self.token_to_kv_pool.invalidate_loc_cache()
@@ -3309,9 +3338,16 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                     server_args=self.server_args,
                 )
 
-            # Hisparse coordinator — backends now read it from self.model_runner.
-            if self.hisparse_coordinator is not None:
-                self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
+            # Use precomputed SWA cache location
+            if forward_batch.out_cache_loc_swa is not None:
+                self.token_to_kv_pool.set_swa_loc(forward_batch.out_cache_loc_swa)
+
+            # Hisparse coordinator
+            forward_batch.hisparse_coordinator = active_hisparse_coordinator
+            if active_hisparse_coordinator is not None:
+                active_hisparse_coordinator.num_real_reqs.fill_(
+                    forward_batch.batch_size
+                )
 
             # Forward without cuda graph
             if forward_batch.forward_mode.is_decode():

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -769,6 +769,18 @@ class ModelRunnerKVCacheMixin:
                 self.token_to_kv_pool.full_to_swa_index_mapping = (
                     swa_allocator.full_to_swa_index_mapping
                 )
+            if self.enable_hisparse:
+                if isinstance(
+                    self.token_to_kv_pool_allocator, HiSparseTokenToKVPoolAllocator
+                ):
+                    self.token_to_kv_pool.full_to_hisparse_device_index_mapping = (
+                        self.token_to_kv_pool_allocator.full_to_hisparse_device_index_mapping
+                    )
+                else:
+                    assert isinstance(
+                        self.token_to_kv_pool_allocator,
+                        DeepSeekV4HiSparseTokenToKVPoolAllocator,
+                    )
 
         # Defensive check: the explicit validation above should reject known
         # unsupported pool families before allocation. Keep this guard here so

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7119,6 +7119,33 @@ class ServerArgs:
 
         validate_hisparse(self)
 
+        if self.enable_hisparse and self.speculative_algorithm is not None:
+            from sglang.srt.configs.model_config import is_deepseek_dsa
+
+            if is_deepseek_dsa(self.get_model_config().hf_config):
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                hisparse_cfg = parse_hisparse_config(self)
+                hisparse_page_size = getattr(hisparse_cfg, "page_size", None)
+                if hisparse_page_size is None:
+                    hisparse_page_size = 64
+                max_draft = self.speculative_num_draft_tokens or 0
+                if max_draft >= hisparse_page_size:
+                    raise ValueError(
+                        f"hiSparse extra page capacity ({hisparse_page_size - 1} slots) "
+                        f"is insufficient for speculative_num_draft_tokens={max_draft}. "
+                        f"Reduce draft tokens or increase hiSparse page_size."
+                    )
+                if (
+                    self.speculative_eagle_topk is not None
+                    and self.speculative_eagle_topk > 1
+                    and self.page_size > 1
+                ):
+                    raise ValueError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 is not yet "
+                        "supported. Use speculative_eagle_topk=1 or page_size=1."
+                    )
+
         assert (
             self.schedule_conservativeness >= 0
         ), "schedule_conservativeness must be non-negative"

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -187,6 +187,26 @@ class EAGLEDraftCudaGraphRunner:
     def _cache_loc_dtype(self):
         return torch.int64
 
+    def _attach_hisparse_coordinator(
+        self, forward_batch: ForwardBatch, num_real_reqs: int
+    ) -> None:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return
+        if not callable(
+            getattr(
+                forward_batch.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        ):
+            return
+        forward_batch.hisparse_coordinator = coordinator
+        coordinator.wait_for_pending_backup()
+        coordinator.num_real_reqs.fill_(num_real_reqs)
+
     def can_run(self, forward_batch: ForwardBatch):
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
@@ -369,6 +389,7 @@ class EAGLEDraftCudaGraphRunner:
             return ret
 
         with forward_context(ForwardContext(attn_backend=self.draft_attn_backend)):
+            self._attach_hisparse_coordinator(forward_batch, num_seqs)
             self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(
                 forward_batch
             )
@@ -464,6 +485,7 @@ class EAGLEDraftCudaGraphRunner:
             buffers.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
+        self._attach_hisparse_coordinator(forward_batch, raw_bs)
         self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
             forward_batch, bs
         )

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -230,6 +230,12 @@ class EAGLEDraftExtendCudaGraphRunner:
             )
 
     def can_run(self, forward_batch: ForwardBatch):
+        if self._uses_target_hisparse_coordinator(forward_batch):
+            # HiSparse draft-extend uses per-request variable accepted-token
+            # counts. The captured graph has a fixed full-row layout, so replay
+            # can reinterpret packed rows incorrectly after verify.
+            return False
+
         if self.require_mlp_tp_gather:
             cuda_graph_bs = (
                 max(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
@@ -256,6 +262,40 @@ class EAGLEDraftExtendCudaGraphRunner:
 
     def _cache_loc_dtype(self):
         return torch.int64
+
+    def _uses_target_hisparse_coordinator(self, forward_batch: ForwardBatch) -> bool:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return False
+        return callable(
+            getattr(
+                forward_batch.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        )
+
+    def _attach_hisparse_coordinator(
+        self, forward_batch: ForwardBatch, num_real_reqs: int
+    ) -> None:
+        target_worker = getattr(self.eagle_worker, "target_worker", None)
+        target_model_runner = getattr(target_worker, "model_runner", None)
+        coordinator = getattr(target_model_runner, "hisparse_coordinator", None)
+        if coordinator is None:
+            return
+        if not callable(
+            getattr(
+                forward_batch.token_to_kv_pool,
+                "translate_loc_to_hisparse_device",
+                None,
+            )
+        ):
+            return
+        forward_batch.hisparse_coordinator = coordinator
+        coordinator.wait_for_pending_backup()
+        coordinator.num_real_reqs.fill_(num_real_reqs)
 
     def _capture_init(self, run_once_fn):
         for _ in range(2):
@@ -423,6 +463,7 @@ class EAGLEDraftExtendCudaGraphRunner:
         with forward_context(
             ForwardContext(attn_backend=self.draft_extend_attn_backend)
         ):
+            self._attach_hisparse_coordinator(forward_batch, bs)
             self.draft_extend_attn_backend.init_forward_metadata_capture_cuda_graph(
                 bs=bs,
                 num_tokens=num_tokens,
@@ -534,6 +575,7 @@ class EAGLEDraftExtendCudaGraphRunner:
             forward_batch.spec_info.num_correct_drafts = buffers.num_correct_drafts[:bs]
             forward_batch.spec_info.num_accept_tokens = buffers.num_accept_tokens[:bs]
 
+        self._attach_hisparse_coordinator(forward_batch, raw_bs)
         self.draft_extend_attn_backend.init_forward_metadata_replay_cuda_graph(
             bs=bs,
             req_pool_indices=buffers.req_pool_indices,

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -21,6 +21,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
@@ -68,6 +69,18 @@ def _draft_runner_of(worker):
     )
 
 
+def _slice_optional_tensor(tensor: Optional[torch.Tensor], sli: slice):
+    return None if tensor is None else tensor[sli]
+
+
+def _cat_optional_tensor(left: Optional[torch.Tensor], right: Optional[torch.Tensor]):
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return torch.cat([left, right], axis=0)
+
+
 @dataclass
 class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
     draft_token: torch.Tensor
@@ -96,6 +109,74 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.draft_token_num, self.draft_token_num
 
+    def slice_single(self, batch_index: int) -> "EagleVerifyInput":
+        sli = slice(batch_index, batch_index + 1)
+        token_sli = slice(
+            batch_index * self.draft_token_num,
+            (batch_index + 1) * self.draft_token_num,
+        )
+        if self.custom_mask is not None and self.seq_lens_cpu is not None:
+            mask_start = (
+                int(
+                    (
+                        self.seq_lens_cpu[:batch_index].sum()
+                        + batch_index * self.draft_token_num
+                    ).item()
+                )
+                * self.draft_token_num
+            )
+            mask_len = (
+                int(self.seq_lens_cpu[batch_index].item()) + self.draft_token_num
+            ) * self.draft_token_num
+            custom_mask = self.custom_mask[mask_start : mask_start + mask_len]
+        else:
+            custom_mask = self.custom_mask
+        return EagleVerifyInput(
+            draft_token=self.draft_token[token_sli],
+            custom_mask=custom_mask,
+            positions=self.positions[token_sli],
+            retrieve_index=self.retrieve_index[sli],
+            retrieve_next_token=self.retrieve_next_token[sli],
+            retrieve_next_sibling=self.retrieve_next_sibling[sli],
+            retrieve_cum_len=_slice_optional_tensor(self.retrieve_cum_len, sli),
+            topk=self.topk,
+            draft_token_num=self.draft_token_num,
+            spec_steps=self.spec_steps,
+            capture_hidden_mode=self.capture_hidden_mode,
+            seq_lens_sum=(
+                int(self.seq_lens_cpu[batch_index].item())
+                if self.seq_lens_cpu is not None
+                else None
+            ),
+            seq_lens_cpu=_slice_optional_tensor(self.seq_lens_cpu, sli),
+            grammar=self.grammar,
+            num_tokens_per_req=self.num_tokens_per_req,
+        )
+
+    def merge_batch(self, spec_info: "EagleVerifyInput"):
+        self.draft_token = torch.cat([self.draft_token, spec_info.draft_token], axis=0)
+        self.custom_mask = _cat_optional_tensor(self.custom_mask, spec_info.custom_mask)
+        self.positions = torch.cat([self.positions, spec_info.positions], axis=0)
+        self.retrieve_index = torch.cat(
+            [self.retrieve_index, spec_info.retrieve_index], axis=0
+        )
+        self.retrieve_next_token = torch.cat(
+            [self.retrieve_next_token, spec_info.retrieve_next_token], axis=0
+        )
+        self.retrieve_next_sibling = torch.cat(
+            [self.retrieve_next_sibling, spec_info.retrieve_next_sibling], axis=0
+        )
+        self.retrieve_cum_len = _cat_optional_tensor(
+            self.retrieve_cum_len, spec_info.retrieve_cum_len
+        )
+        self.seq_lens_cpu = _cat_optional_tensor(
+            self.seq_lens_cpu, spec_info.seq_lens_cpu
+        )
+        if self.seq_lens_sum is None:
+            self.seq_lens_sum = spec_info.seq_lens_sum
+        elif spec_info.seq_lens_sum is not None:
+            self.seq_lens_sum += spec_info.seq_lens_sum
+
     @classmethod
     def create_idle_input(cls, topk: int, spec_steps: int, num_verify_tokens: int):
         return cls(
@@ -121,7 +202,6 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         )
 
     def prepare_for_verify(self, batch: ScheduleBatch, page_size: int):
-
         if batch.forward_mode.is_idle():
             return
 
@@ -149,15 +229,41 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 batch.req_pool_indices,
                 prefix_lens,
             )
-            batch.out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                prefix_lens,
-                prefix_lens_cpu,
-                end_offset,
-                end_offset_cpu,
-                last_loc,
-                len(batch.input_ids),
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    len(batch.input_ids) + len(prefix_lens_cpu) * allocator.page_size,
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots(
+                    batch.req_pool_indices,
+                    self.draft_token_num,
+                    prefix_lens_cpu,
+                )
+                batch.out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                    device_slots,
+                )
+            else:
+                batch.out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    prefix_lens,
+                    prefix_lens_cpu,
+                    end_offset,
+                    end_offset_cpu,
+                    last_loc,
+                    len(batch.input_ids),
+                )
+            self.last_loc = last_loc
 
         bs = batch.batch_size()
         assign_req_to_token_pool_func(
@@ -469,9 +575,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                     try:
                         req.grammar.accept_token(id)
                     except ValueError as e:
-                        logger.info(
-                            f"{i=}, {req=}\n" f"{accept_index=}\n" f"{predict=}\n"
-                        )
+                        logger.info(f"{i=}, {req=}\n{accept_index=}\n{predict=}\n")
                         raise e
                     req.update_finish_state()
                 if req.finished():
@@ -516,6 +620,34 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
         # try to unify the tensor representation and list representation
         num_correct_drafts_list = num_correct_drafts_cpu.tolist()
         num_accept_tokens_list = num_accept_tokens_cpu.tolist()
+
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            counts = num_correct_drafts.to(torch.int64) + 1
+            offsets = torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.int64, device=counts.device),
+                    counts.cumsum(0),
+                ]
+            )
+            pos_in_segment = torch.arange(
+                accept_index.numel(), dtype=torch.int64, device=counts.device
+            ) - torch.repeat_interleave(offsets[:-1], counts)
+            accepted_token_positions = (
+                torch.repeat_interleave(batch.seq_lens.to(torch.int64), counts)
+                + pos_in_segment
+            )
+            hisparse_coordinator.finalize_accepted_tokens(
+                batch.req_pool_indices,
+                batch.out_cache_loc[accept_index],
+                batch.out_cache_loc,
+                num_correct_drafts,
+                num_correct_drafts_cpu,
+                accepted_token_positions,
+            )
 
         if page_size == 1:
             # TODO: boolean array index leads to a device sync. Remove it.
@@ -572,6 +704,14 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
                 token_to_kv_pool_allocator.free(to_free_slots)
 
                 # Copy the kv cache
+                if (
+                    hisparse_coordinator is not None
+                    and hisparse_coordinator.supports_hisparse_draft_slots()
+                ):
+                    raise NotImplementedError(
+                        "HiSparse + speculative topk > 1 + page_size > 1 needs "
+                        "hisparse-aware move_kv_cache translation."
+                    )
                 batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
                     tgt_cache_loc, src_cache_loc
                 )
@@ -738,6 +878,21 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
         return self.num_tokens_per_req, self.num_tokens_for_logprob_per_req
 
+    def prepare_for_extend(self, batch: ScheduleBatch):
+        if batch.forward_mode.is_idle():
+            return
+
+        # Prefill only generate 1 token.
+        assert len(self.bonus_tokens) == len(batch.seq_lens)
+
+        pt = 0
+        for i, extend_len in enumerate(batch.extend_lens):
+            input_ids = batch.input_ids[pt : pt + extend_len]
+            batch.input_ids[pt : pt + extend_len] = torch.cat(
+                (input_ids[1:], self.bonus_tokens[i].reshape(1))
+            )
+            pt += extend_len
+
     @classmethod
     def hidden_size_for(cls, worker) -> Optional[int]:
         """Decode-phase `hidden_states` width: draft self-chain output
@@ -803,6 +958,24 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             if self.hidden_states is not None:
                 self.hidden_states = self.hidden_states[new_indices]
             self.bonus_tokens = self.bonus_tokens[new_indices]
+
+    def slice_single(self, batch_index: int) -> "EagleDraftInput":
+        sli = slice(batch_index, batch_index + 1)
+        future_indices = None
+        if self.future_indices is not None:
+            future_indices = FutureIndices(indices=self.future_indices.indices[sli])
+        return EagleDraftInput(
+            topk_p=_slice_optional_tensor(self.topk_p, sli),
+            topk_index=_slice_optional_tensor(self.topk_index, sli),
+            hidden_states=_slice_optional_tensor(self.hidden_states, sli),
+            capture_hidden_mode=self.capture_hidden_mode,
+            bonus_tokens=_slice_optional_tensor(self.bonus_tokens, sli),
+            future_indices=future_indices,
+            new_seq_lens=_slice_optional_tensor(self.new_seq_lens, sli),
+            verify_done=self.verify_done,
+            num_correct_drafts=_slice_optional_tensor(self.num_correct_drafts, sli),
+            num_accept_tokens=_slice_optional_tensor(self.num_accept_tokens, sli),
+        )
 
     def merge_batch(self, spec_info: "EagleDraftInput"):
         if self.future_indices is not None:
@@ -1007,6 +1180,193 @@ class EagleDraftExtendInput(SpecInput):
             req_to_token.size(1),
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None
+
+    def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
+        if self.future_indices is not None:
+            self.future_indices.indices = self.future_indices.indices[new_indices]
+            if self.new_seq_lens is not None:
+                self.new_seq_lens = self.new_seq_lens[new_indices]
+            if self.hidden_states is not None:
+                self.hidden_states = self.hidden_states[new_indices]
+            if self.verified_id is not None:
+                self.verified_id = self.verified_id[new_indices]
+            if self.num_correct_drafts is not None:
+                self.num_correct_drafts = self.num_correct_drafts[new_indices]
+            if self.num_accept_tokens is not None:
+                self.num_accept_tokens = self.num_accept_tokens[new_indices]
+            if self.num_correct_drafts_cpu is not None:
+                self.num_correct_drafts_cpu = [
+                    self.num_correct_drafts_cpu[i] for i in new_indices.tolist()
+                ]
+            if self.num_accept_tokens_cpu is not None:
+                self.num_accept_tokens_cpu = [
+                    self.num_accept_tokens_cpu[i] for i in new_indices.tolist()
+                ]
+            if self.topk_p is not None:
+                self.topk_p = self.topk_p[new_indices]
+            if self.topk_index is not None:
+                self.topk_index = self.topk_index[new_indices]
+            return
+
+        strict_check = envs.SGLANG_SPEC_ENABLE_STRICT_FILTER_CHECK.get()
+        if has_been_filtered:
+            # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
+            # therefore, we don't need to filter the batch again in scheduler
+            error_msg = f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, this should not happen"
+            if len(new_indices) != len(self.topk_p):
+                if strict_check:
+                    raise ValueError(error_msg)
+                else:
+                    logger.warning(error_msg)
+
+            self.topk_p = self.topk_p[: len(new_indices)]
+            self.topk_index = self.topk_index[: len(new_indices)]
+            self.hidden_states = self.hidden_states[: len(new_indices)]
+            self.verified_id = self.verified_id[: len(new_indices)]
+        else:
+            # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
+            self.topk_p = self.topk_p[new_indices]
+            self.topk_index = self.topk_index[new_indices]
+            self.hidden_states = self.hidden_states[new_indices]
+            self.verified_id = self.verified_id[new_indices]
+
+    def slice_single(self, batch_index: int) -> "EagleDraftInput":
+        sli = slice(batch_index, batch_index + 1)
+        future_indices = None
+        if self.future_indices is not None:
+            future_indices = FutureIndices(indices=self.future_indices.indices[sli])
+        return EagleDraftInput(
+            topk_p=_slice_optional_tensor(self.topk_p, sli),
+            topk_index=_slice_optional_tensor(self.topk_index, sli),
+            hidden_states=_slice_optional_tensor(self.hidden_states, sli),
+            capture_hidden_mode=self.capture_hidden_mode,
+            verified_id=_slice_optional_tensor(self.verified_id, sli),
+            num_correct_drafts=_slice_optional_tensor(self.num_correct_drafts, sli),
+            num_accept_tokens=_slice_optional_tensor(self.num_accept_tokens, sli),
+            num_correct_drafts_cpu=(
+                None
+                if self.num_correct_drafts_cpu is None
+                else self.num_correct_drafts_cpu[batch_index : batch_index + 1]
+            ),
+            num_accept_tokens_cpu=(
+                None
+                if self.num_accept_tokens_cpu is None
+                else self.num_accept_tokens_cpu[batch_index : batch_index + 1]
+            ),
+            seq_lens_for_draft_extend=_slice_optional_tensor(
+                self.seq_lens_for_draft_extend, sli
+            ),
+            seq_lens_for_draft_extend_cpu=_slice_optional_tensor(
+                self.seq_lens_for_draft_extend_cpu, sli
+            ),
+            req_pool_indices_for_draft_extend=_slice_optional_tensor(
+                self.req_pool_indices_for_draft_extend, sli
+            ),
+            future_indices=future_indices,
+            new_seq_lens=_slice_optional_tensor(self.new_seq_lens, sli),
+            verify_done=self.verify_done,
+        )
+
+    def merge_batch(self, spec_info: "EagleDraftInput"):
+        if self.future_indices is not None:
+            assert spec_info.future_indices is not None
+            self.future_indices = FutureIndices(
+                indices=torch.cat(
+                    [self.future_indices.indices, spec_info.future_indices.indices]
+                )
+            )
+            if self.new_seq_lens is None:
+                self.new_seq_lens = spec_info.new_seq_lens
+            elif spec_info.new_seq_lens is not None:
+                self.new_seq_lens = torch.cat(
+                    [self.new_seq_lens, spec_info.new_seq_lens], axis=0
+                )
+            if self.hidden_states is None:
+                self.hidden_states = spec_info.hidden_states
+            elif spec_info.hidden_states is not None:
+                self.hidden_states = torch.cat(
+                    [self.hidden_states, spec_info.hidden_states], axis=0
+                )
+            if self.verified_id is None:
+                self.verified_id = spec_info.verified_id
+            elif spec_info.verified_id is not None:
+                self.verified_id = torch.cat(
+                    [self.verified_id, spec_info.verified_id], axis=0
+                )
+            if self.num_correct_drafts is None:
+                self.num_correct_drafts = spec_info.num_correct_drafts
+            elif spec_info.num_correct_drafts is not None:
+                self.num_correct_drafts = torch.cat(
+                    [self.num_correct_drafts, spec_info.num_correct_drafts], axis=0
+                )
+            if self.num_accept_tokens is None:
+                self.num_accept_tokens = spec_info.num_accept_tokens
+            elif spec_info.num_accept_tokens is not None:
+                self.num_accept_tokens = torch.cat(
+                    [self.num_accept_tokens, spec_info.num_accept_tokens], axis=0
+                )
+            if self.num_correct_drafts_cpu is None:
+                self.num_correct_drafts_cpu = spec_info.num_correct_drafts_cpu
+            elif spec_info.num_correct_drafts_cpu is not None:
+                self.num_correct_drafts_cpu += spec_info.num_correct_drafts_cpu
+            if self.num_accept_tokens_cpu is None:
+                self.num_accept_tokens_cpu = spec_info.num_accept_tokens_cpu
+            elif spec_info.num_accept_tokens_cpu is not None:
+                self.num_accept_tokens_cpu += spec_info.num_accept_tokens_cpu
+            if self.topk_p is None:
+                self.topk_p = spec_info.topk_p
+            elif spec_info.topk_p is not None:
+                self.topk_p = torch.cat([self.topk_p, spec_info.topk_p], axis=0)
+            if self.topk_index is None:
+                self.topk_index = spec_info.topk_index
+            elif spec_info.topk_index is not None:
+                self.topk_index = torch.cat(
+                    [self.topk_index, spec_info.topk_index], axis=0
+                )
+            return
+
+        if self.hidden_states is None:
+            self.hidden_states = spec_info.hidden_states
+            self.verified_id = spec_info.verified_id
+            self.num_correct_drafts = spec_info.num_correct_drafts
+            self.num_accept_tokens = spec_info.num_accept_tokens
+            self.num_correct_drafts_cpu = spec_info.num_correct_drafts_cpu
+            self.num_accept_tokens_cpu = spec_info.num_accept_tokens_cpu
+            self.topk_p = spec_info.topk_p
+            self.topk_index = spec_info.topk_index
+            return
+        if spec_info.hidden_states is None:
+            return
+        self.hidden_states = torch.cat(
+            [self.hidden_states, spec_info.hidden_states], axis=0
+        )
+        self.verified_id = torch.cat([self.verified_id, spec_info.verified_id], axis=0)
+        if (
+            self.num_correct_drafts is not None
+            and spec_info.num_correct_drafts is not None
+        ):
+            self.num_correct_drafts = torch.cat(
+                [self.num_correct_drafts, spec_info.num_correct_drafts], axis=0
+            )
+        if (
+            self.num_accept_tokens is not None
+            and spec_info.num_accept_tokens is not None
+        ):
+            self.num_accept_tokens = torch.cat(
+                [self.num_accept_tokens, spec_info.num_accept_tokens], axis=0
+            )
+        if (
+            self.num_correct_drafts_cpu is not None
+            and spec_info.num_correct_drafts_cpu is not None
+        ):
+            self.num_correct_drafts_cpu += spec_info.num_correct_drafts_cpu
+        if (
+            self.num_accept_tokens_cpu is not None
+            and spec_info.num_accept_tokens_cpu is not None
+        ):
+            self.num_accept_tokens_cpu += spec_info.num_accept_tokens_cpu
+        self.topk_p = torch.cat([self.topk_p, spec_info.topk_p])
+        self.topk_index = torch.cat([self.topk_index, spec_info.topk_index])
 
 
 @dataclass

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -22,6 +22,7 @@ from sglang.srt.managers.utils import get_alloc_len_per_decode
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -152,15 +153,40 @@ class EagleDraftInputV2Mixin:
                 batch.req_pool_indices,
                 cur_kv_lens,
             )
-            out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                cur_kv_lens,
-                cur_kv_lens_cpu,
-                nxt_kv_lens,
-                nxt_kv_lens_cpu,
-                last_loc,
-                num_needed_tokens,
-            )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = batch.tree_cache.token_to_kv_pool_allocator
+                evict_from_tree_cache(
+                    batch.tree_cache,
+                    num_needed_tokens + len(cur_kv_lens_cpu) * allocator.page_size,
+                )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    nxt_kv_lens_cpu - cur_kv_lens_cpu,
+                    cur_kv_lens_cpu,
+                )
+                out_cache_loc = allocator.alloc_extend_with_device_mapping(
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                    device_slots,
+                )
+            else:
+                out_cache_loc = alloc_paged_token_slots_extend(
+                    batch.tree_cache,
+                    cur_kv_lens,
+                    cur_kv_lens_cpu,
+                    nxt_kv_lens,
+                    nxt_kv_lens_cpu,
+                    last_loc,
+                    num_needed_tokens,
+                )
 
         assign_req_to_token_pool_func(
             batch.req_pool_indices,
@@ -287,6 +313,17 @@ class EagleVerifyInputV2Mixin:
                 draft_token_num=self.draft_token_num,
                 device=device,
             )
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                hisparse_coordinator.prepare_verify_slots_spec_v2(
+                    req_pool_indices=batch.req_pool_indices,
+                    verify_cache_locs=batch.out_cache_loc,
+                    num_tokens_per_req=self.draft_token_num,
+                    start_positions_cpu=batch.seq_lens_cpu,
+                )
 
             if get_global_server_args().enable_mamba_extra_buffer():
                 set_mamba_track_indices_from_reqs(batch)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -23,6 +23,7 @@ from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.mem_cache.common import (
     alloc_paged_token_slots_extend,
     alloc_token_slots,
+    evict_from_tree_cache,
     get_last_loc,
 )
 from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
@@ -533,6 +534,7 @@ class EAGLEWorker(TpModelWorker):
                     next_draft_input = self.forward_draft_extend_after_decode(batch)
                     batch.spec_info = next_draft_input
                 else:
+                    self._clear_hisparse_pending_draft_extend_backup(batch)
                     # All reqs finished and dp_attention isn't forcing extend.
                     # Install an idle EagleDraftInput so next iter's scheduler
                     # ops (merge_batch / filter_batch) see well-typed empty
@@ -555,6 +557,40 @@ class EAGLEWorker(TpModelWorker):
                 num_correct_drafts_per_req_cpu=verify_output.num_correct_drafts_per_req_cpu,
                 can_run_cuda_graph=verify_output.can_run_cuda_graph,
             )
+
+    def check_forward_draft_extend_after_decode(self, verify_output: EagleVerifyOutput):
+        local_need_forward = verify_output.draft_extend_input.input_ids.shape[0] > 0
+        if not self.server_args.enable_dp_attention:
+            return local_need_forward
+
+        global_need_forward = torch.tensor(
+            [
+                (local_need_forward),
+            ],
+            dtype=torch.int64,
+        )
+        torch.distributed.all_reduce(
+            global_need_forward, group=get_tp_group().cpu_group
+        )
+        global_need_forward_cnt = global_need_forward[0].item()
+        need_forward = global_need_forward_cnt > 0
+        return need_forward
+
+    def _finish_hisparse_pending_draft_extend_backup(self, batch: ScheduleBatch):
+        hisparse_coordinator = getattr(batch, "hisparse_coordinator", None)
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            hisparse_coordinator.finish_pending_draft_extend_backup()
+
+    def _clear_hisparse_pending_draft_extend_backup(self, batch: ScheduleBatch):
+        hisparse_coordinator = getattr(batch, "hisparse_coordinator", None)
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+        ):
+            hisparse_coordinator.clear_pending_draft_extend_backup()
 
     def forward_target_extend(
         self, batch: ScheduleBatch
@@ -666,18 +702,46 @@ class EAGLEWorker(TpModelWorker):
                 )
                 extend_num_tokens = torch.sum((seq_lens_cpu - prefix_lens_cpu)).item()
 
-            out_cache_loc, token_to_kv_pool_state_backup = (
-                alloc_paged_token_slots_extend(
+            hisparse_coordinator = batch.hisparse_coordinator
+            if (
+                hisparse_coordinator is not None
+                and hisparse_coordinator.supports_hisparse_draft_slots()
+            ):
+                allocator = self.token_to_kv_pool_allocator
+                evict_from_tree_cache(
                     batch.tree_cache,
-                    prefix_lens,
-                    prefix_lens_cpu,
-                    seq_lens,
-                    seq_lens_cpu,
-                    last_loc,
-                    extend_num_tokens,
-                    backup_state=True,
+                    extend_num_tokens + len(prefix_lens_cpu) * allocator.page_size,
                 )
-            )
+                device_slots = hisparse_coordinator.get_draft_device_slots_variable(
+                    batch.req_pool_indices,
+                    seq_lens_cpu - prefix_lens_cpu,
+                    prefix_lens_cpu,
+                )
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    allocator.alloc_extend_with_device_mapping(
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        device_slots,
+                        backup_state=True,
+                    )
+                )
+            else:
+                out_cache_loc, token_to_kv_pool_state_backup = (
+                    alloc_paged_token_slots_extend(
+                        batch.tree_cache,
+                        prefix_lens,
+                        prefix_lens_cpu,
+                        seq_lens,
+                        seq_lens_cpu,
+                        last_loc,
+                        extend_num_tokens,
+                        backup_state=True,
+                    )
+                )
 
         if self.page_size > 1 and self.topk > 1:
             last_page_lens_cumsum = torch.cumsum(last_page_lens, dim=0)
@@ -1157,6 +1221,7 @@ class EAGLEWorker(TpModelWorker):
             else CaptureHiddenMode.LAST
         )
         if draft_extend_input.input_ids.shape[0] == 0:
+            self._clear_hisparse_pending_draft_extend_backup(batch)
             # Single source for hidden_size via hidden_size_for(self) (incl.
             # EAGLE-3 aux widening). Two stub origins from verify(): fully-idle
             # batch (DP attn rank w/o reqs) and active batch with all reqs
@@ -1233,6 +1298,7 @@ class EAGLEWorker(TpModelWorker):
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
             hidden_states = logits_output.hidden_states
 
+        self._finish_hisparse_pending_draft_extend_backup(batch)
         maybe_detect_nan(
             logits_output.next_token_logits,
             f"draft_extend_after_decode (cuda_graph={can_cuda_graph})",

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1108,6 +1108,19 @@ class EAGLEWorkerV2(BaseSpecWorker):
         ) = verify_input.sample(batch, logits_output, vocab_mask)
         new_seq_lens = batch.seq_lens + accept_lens
 
+        hisparse_coordinator = batch.hisparse_coordinator
+        if (
+            hisparse_coordinator is not None
+            and hisparse_coordinator.supports_hisparse_draft_slots()
+            and not batch.forward_mode.is_idle()
+        ):
+            hisparse_coordinator.finalize_accepted_tokens_spec_v2(
+                req_pool_indices=batch.req_pool_indices,
+                seq_lens=batch.seq_lens,
+                verify_cache_locs=batch.out_cache_loc,
+                accept_index=accept_index,
+            )
+
         # Update mamba state for hybrid GDN models after verification
         if (
             self.target_worker.model_runner.hybrid_gdn_config is not None

--- a/test/registered/unit/disaggregation/test_mooncake_hisparse.py
+++ b/test/registered/unit/disaggregation/test_mooncake_hisparse.py
@@ -1,0 +1,51 @@
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="stage-a-test-cpu")
+
+
+class TestMooncakeHiSparseTransfer(unittest.TestCase):
+    def test_hisparse_transfer_uses_only_target_kv_group(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.kv_args = SimpleNamespace(
+            page_size=4,
+            kv_data_ptrs=[100, 200, 300],
+            kv_item_lens=[40, 80, 120],
+            target_kv_data_ptr_count=2,
+        )
+        captured = {}
+
+        def capture_send(**kwargs):
+            captured.update(kwargs)
+            return 0
+
+        manager._send_kvcache_generic = capture_send
+
+        ret = manager.send_kvcache_hisparse(
+            mooncake_session_id="session",
+            prefill_kv_indices=np.array([5], dtype=np.int32),
+            dst_kv_ptrs=[1000, 2000],
+            dst_kv_indices=np.array([10, 11, 12, 13], dtype=np.int32),
+            page_index_slice=slice(0, 1),
+            executor=None,
+        )
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(captured["src_data_ptrs"], [100, 200])
+        self.assertEqual(captured["dst_data_ptrs"], [1000, 2000])
+        self.assertEqual(captured["item_lens"], [10, 20])
+        np.testing.assert_array_equal(
+            captured["prefill_data_indices"], np.array([20, 21, 22, 23])
+        )
+        np.testing.assert_array_equal(
+            captured["dst_data_indices"], np.array([10, 11, 12, 13])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -170,6 +170,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self.coordinator.lru_slots[:] = self.coordinator._lru_init.view(1, 1, -1)
         self.coordinator.ack_staging_queue.clear()
         self.coordinator._has_pending_backup = False
+        self.coordinator._pending_draft_extend_backup = None
         for i in range(len(self.coordinator._skip_first_backup)):
             self.coordinator._skip_first_backup[i] = False
 
@@ -425,6 +426,62 @@ class TestHiSparseUnit(unittest.TestCase):
 
         self._cleanup_req(req, kv_loc, logical_only=True)
         self._assert_sizes_restored(initial, "long_seq")
+
+    def test_map_last_loc_records_newest_token_for_multistep_swap(self):
+        """Multi-step verify can resolve the newest-token extra-page slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE + self.page_size
+        req = _make_req("newest-token-metadata", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        seq_lens = torch.tensor([fill_len], dtype=torch.int64, device="cuda")
+        seq_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+
+        self.coordinator.map_last_loc_to_buffer(
+            seq_lens=seq_lens,
+            out_cache_loc=kv_loc[-1:],
+            req_pool_indices=req_pool_indices,
+            seq_lens_cpu=seq_lens_cpu,
+        )
+
+        newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ]
+                == fill_len - 1
+            )
+        )
+        self.assertEqual(
+            int(
+                self.allocator.full_to_hisparse_device_index_mapping[kv_loc[-1]].item()
+            ),
+            int(newest_slot.item()),
+        )
+
+        topk = torch.full((1, 4, TOP_K), -1, dtype=torch.int32, device="cuda")
+        topk[0, 0, 0] = fill_len - 1
+        self.coordinator.num_real_reqs[0] = 1
+        locs = self.coordinator.swap_in_selected_pages(
+            req_pool_indices=req_pool_indices,
+            compressed_seq_lens=torch.full(
+                (4,), fill_len, dtype=torch.int32, device="cuda"
+            ),
+            top_k_result=topk,
+            layer_id=0,
+            token_position_space="full",
+            num_steps=4,
+        )
+        self.assertEqual(int(locs[0, 0, 0].item()), int(newest_slot.item()))
+
+        self._cleanup_req(req, kv_loc)
+        self._assert_sizes_restored(initial, "newest_token_metadata")
 
     # ==================================================================
     # Test: Kernel LRU replacement across multiple decode steps
@@ -755,6 +812,364 @@ class TestHiSparseUnit(unittest.TestCase):
             self._cleanup_req(req, kv_locs[i], logical_only=is_long)
 
         self._assert_sizes_restored(initial, "batch_multiple")
+
+    # ==================================================================
+    # Test: HiSparse MTP draft slots
+    # ==================================================================
+    def test_draft_slots_use_extra_page_after_newest_slot(self):
+        """Uniform draft slots start after the newest-token slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE
+        draft_num = 3
+        req = _make_req("draft-slots-uniform", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        extra_start = DEVICE_BUFFER_SIZE + 1
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([DEVICE_BUFFER_SIZE], dtype=torch.int64)
+
+        hot_tokens_before = self.coordinator.req_device_buffer_tokens[
+            :, req_idx, :DEVICE_BUFFER_SIZE
+        ].clone()
+        newest_token_sentinel = torch.full(
+            (LAYER_NUM,), 777, dtype=torch.int32, device="cuda"
+        )
+        self.coordinator.req_device_buffer_tokens[:, req_idx, DEVICE_BUFFER_SIZE] = (
+            newest_token_sentinel
+        )
+
+        device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        expected_slots = self.coordinator.req_to_device_buffer[
+            req_idx, extra_start : extra_start + draft_num
+        ]
+        expected_token_positions = torch.arange(
+            DEVICE_BUFFER_SIZE,
+            DEVICE_BUFFER_SIZE + draft_num,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        self.assertTrue(torch.equal(device_slots, expected_slots))
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, :DEVICE_BUFFER_SIZE
+                ],
+                hot_tokens_before,
+            ),
+            "Draft slots must not rewrite hot-buffer token metadata",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ],
+                newest_token_sentinel,
+            ),
+            "Draft slots must not overwrite the newest-token slot",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, extra_start : extra_start + draft_num
+                ],
+                expected_token_positions.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+
+        self._cleanup_req(req, kv_loc)
+        self._assert_sizes_restored(initial, "draft_slots_uniform")
+
+    def test_draft_slots_variable_respect_per_request_counts(self):
+        """Variable draft slots only populate each request's actual token count."""
+        initial = self._get_initial_sizes()
+        reqs = [
+            _make_req("draft-slots-variable-0"),
+            _make_req("draft-slots-variable-1"),
+        ]
+        for req in reqs:
+            self._alloc_req_slot(req)
+
+        req_pool_indices = torch.tensor(
+            [req.req_pool_idx for req in reqs], dtype=torch.int64, device="cuda"
+        )
+        tokens_per_req_cpu = torch.tensor([1, 3], dtype=torch.int64)
+        start_positions_cpu = torch.tensor(
+            [DEVICE_BUFFER_SIZE, DEVICE_BUFFER_SIZE], dtype=torch.int64
+        )
+        extra_start = DEVICE_BUFFER_SIZE + 1
+
+        device_slots = self.coordinator.get_draft_device_slots_variable(
+            req_pool_indices,
+            tokens_per_req_cpu,
+            start_positions_cpu,
+        )
+
+        expected_slots = torch.cat(
+            [
+                self.coordinator.req_to_device_buffer[
+                    reqs[0].req_pool_idx, extra_start : extra_start + 1
+                ],
+                self.coordinator.req_to_device_buffer[
+                    reqs[1].req_pool_idx, extra_start : extra_start + 3
+                ],
+            ]
+        )
+        self.assertTrue(torch.equal(device_slots, expected_slots))
+
+        req0_expected = torch.tensor(
+            [DEVICE_BUFFER_SIZE, -1, -1], dtype=torch.int32, device="cuda"
+        )
+        req1_expected = torch.arange(
+            DEVICE_BUFFER_SIZE,
+            DEVICE_BUFFER_SIZE + 3,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, reqs[0].req_pool_idx, extra_start : extra_start + 3
+                ],
+                req0_expected.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                self.coordinator.req_device_buffer_tokens[
+                    :, reqs[1].req_pool_idx, extra_start : extra_start + 3
+                ],
+                req1_expected.unsqueeze(0).expand(LAYER_NUM, -1),
+            )
+        )
+
+        for req in reqs:
+            self.coordinator.request_finished(req)
+            self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "draft_slots_variable")
+
+    def test_finalize_accepted_tokens_remaps_newest_and_clears_rejected(self):
+        """Accepted MTP tokens move the last accepted KV to newest slot."""
+        initial = self._get_initial_sizes()
+        fill_len = DEVICE_BUFFER_SIZE
+        draft_num = 4
+        req = _make_req("finalize-accepted", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        draft_device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        device = self.allocator.device
+        prefix_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens = torch.tensor(
+            [fill_len + draft_num], dtype=torch.int64, device=device
+        )
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        last_loc = kv_loc[-1:].to(device=device)
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            draft_num,
+            draft_device_slots,
+        )
+        self.req_to_token_pool.write(
+            (req_idx, slice(fill_len, fill_len + draft_num)), draft_cache_locs
+        )
+        req.kv_allocated_len = fill_len + draft_num
+        req.kv_committed_len = fill_len + draft_num
+
+        for lid in range(LAYER_NUM):
+            for i in range(draft_num):
+                self.device_pool.kv_buffer[lid][draft_device_slots[i]] = (
+                    self._kv_pattern(lid, fill_len + i)
+                )
+
+        accepted_cache_locs = draft_cache_locs[:2]
+        accepted_token_positions = torch.tensor(
+            [fill_len, fill_len + 1], dtype=torch.int64, device="cuda"
+        )
+        self.coordinator.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=accepted_cache_locs,
+            draft_cache_locs=draft_cache_locs,
+            num_correct_drafts=torch.tensor([1], dtype=torch.int64, device="cuda"),
+            num_correct_drafts_cpu=torch.tensor([1], dtype=torch.int64),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+        mapping = self.allocator.full_to_hisparse_device_index_mapping
+        newest_slot = self.coordinator.req_to_device_buffer[req_idx, DEVICE_BUFFER_SIZE]
+
+        self.assertEqual(
+            int(mapping[accepted_cache_locs[0]].item()),
+            int(draft_device_slots[0].item()),
+        )
+        self.assertEqual(int(mapping[accepted_cache_locs[-1]].item()), int(newest_slot))
+        self.assertTrue(torch.all(mapping[draft_cache_locs[2:]] == 0))
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[
+                    :, req_idx, DEVICE_BUFFER_SIZE
+                ]
+                == fill_len + 1
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_to_host_pool[req_idx, accepted_token_positions]
+                >= 0
+            )
+        )
+        for lid in range(LAYER_NUM):
+            expected = self._kv_pattern(lid, fill_len + 1)
+            actual = self.device_pool.kv_buffer[lid][newest_slot.long()]
+            self.assertTrue(
+                torch.allclose(
+                    actual.float(),
+                    torch.full_like(actual.float(), expected),
+                    atol=1e-2,
+                ),
+                f"Layer {lid}: newest slot was not updated from last accepted token",
+            )
+
+        self.coordinator.finish_pending_draft_extend_backup()
+        self.assertEqual(int(mapping[accepted_cache_locs[0]].item()), 0)
+        self.assertEqual(int(mapping[accepted_cache_locs[-1]].item()), int(newest_slot))
+
+        self.coordinator.request_finished(req)
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "finalize_accepted_tokens")
+
+    def test_finalize_accepted_tokens_keeps_short_last_token_in_hot_slot(self):
+        """Short-context accepted tokens use the hot slot read by the fast path."""
+        initial = self._get_initial_sizes()
+        fill_len = self.page_size
+        draft_num = 4
+        req = _make_req("finalize-accepted-short", list(range(fill_len)))
+        self._alloc_req_slot(req)
+
+        kv_loc = self._alloc_kv(req, fill_len)
+        self.coordinator.alloc_device_buffer(req)
+
+        req_idx = req.req_pool_idx
+        req_pool_indices = torch.tensor([req_idx], dtype=torch.int64, device="cuda")
+        start_positions_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        draft_device_slots = self.coordinator.get_draft_device_slots(
+            req_pool_indices,
+            draft_num,
+            start_positions_cpu,
+        )
+
+        device = self.allocator.device
+        prefix_lens = torch.tensor([fill_len], dtype=torch.int64, device=device)
+        prefix_lens_cpu = torch.tensor([fill_len], dtype=torch.int64)
+        seq_lens = torch.tensor(
+            [fill_len + draft_num], dtype=torch.int64, device=device
+        )
+        seq_lens_cpu = torch.tensor([fill_len + draft_num], dtype=torch.int64)
+        last_loc = kv_loc[-1:].to(device=device)
+        draft_cache_locs = self.allocator.alloc_extend_with_device_mapping(
+            prefix_lens,
+            prefix_lens_cpu,
+            seq_lens,
+            seq_lens_cpu,
+            last_loc,
+            draft_num,
+            draft_device_slots,
+        )
+        self.req_to_token_pool.write(
+            (req_idx, slice(fill_len, fill_len + draft_num)), draft_cache_locs
+        )
+        req.kv_allocated_len = fill_len + draft_num
+        req.kv_committed_len = fill_len + draft_num
+
+        accepted_cache_locs = draft_cache_locs[:2]
+        accepted_token_positions = torch.tensor(
+            [fill_len, fill_len + 1], dtype=torch.int64, device="cuda"
+        )
+        self.coordinator.finalize_accepted_tokens(
+            req_pool_indices=req_pool_indices,
+            accepted_cache_locs=accepted_cache_locs,
+            draft_cache_locs=draft_cache_locs,
+            num_correct_drafts=torch.tensor([1], dtype=torch.int64, device="cuda"),
+            num_correct_drafts_cpu=torch.tensor([1], dtype=torch.int64),
+            accepted_token_positions=accepted_token_positions,
+        )
+
+        mapping = self.allocator.full_to_hisparse_device_index_mapping
+        last_hot_slot = self.coordinator.req_to_device_buffer[req_idx, fill_len + 1]
+        extra_newest_slot = self.coordinator.req_to_device_buffer[
+            req_idx, DEVICE_BUFFER_SIZE
+        ]
+
+        self.assertEqual(
+            int(mapping[accepted_cache_locs[-1]].item()), int(last_hot_slot.item())
+        )
+        self.assertNotEqual(int(last_hot_slot.item()), int(extra_newest_slot.item()))
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_tokens[:, req_idx, fill_len + 1]
+                == fill_len + 1
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                self.coordinator.req_device_buffer_token_locs[:, req_idx, fill_len + 1]
+                == last_hot_slot.to(torch.int32)
+            )
+        )
+        self.assertIsNone(self.coordinator._pending_draft_extend_backup)
+
+        self.coordinator.request_finished(req)
+        self.allocator.free(torch.cat([kv_loc, draft_cache_locs]))
+        self._free_req_slot(req)
+        self._assert_sizes_restored(initial, "finalize_accepted_tokens_short")
+
+    def test_draft_extend_cuda_graph_disabled_for_hisparse(self):
+        """Draft-extend graph replay is skipped when HiSparse owns KV mapping."""
+        from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+            EAGLEDraftExtendCudaGraphRunner,
+        )
+
+        runner = EAGLEDraftExtendCudaGraphRunner.__new__(
+            EAGLEDraftExtendCudaGraphRunner
+        )
+        runner.eagle_worker = SimpleNamespace(
+            target_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(hisparse_coordinator=object())
+            )
+        )
+        forward_batch = SimpleNamespace(
+            token_to_kv_pool=SimpleNamespace(
+                translate_loc_to_hisparse_device=lambda loc: loc
+            )
+        )
+
+        self.assertTrue(runner._uses_target_hisparse_coordinator(forward_batch))
+        self.assertFalse(runner.can_run(forward_batch))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
@@ -516,6 +517,49 @@ class TestNgramExternalSamArgs(CustomTestCase):
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
         self.assertIn("external-corpus-max-tokens", str(context.exception))
+
+
+class TestHiSparseMTPServerArgs(unittest.TestCase):
+    def _make_hisparse_mtp_args(self, **overrides) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.served_model_name = "dummy"
+        args.enable_hisparse = True
+        args.disable_radix_cache = True
+        args.speculative_algorithm = "EAGLE"
+        args.speculative_num_draft_tokens = 4
+        args.speculative_eagle_topk = 1
+        args.enable_mixed_chunk = False
+        args.hisparse_config = '{"top_k": 128}'
+        args.kv_cache_dtype = "bfloat16"
+        args.nsa_prefill_backend = "flashmla_sparse"
+        args.nsa_decode_backend = "flashmla_sparse"
+        args.page_size = 1
+        args.chunked_prefill_size = -1
+        args.enable_grpc = False
+        args.grpc_port = None
+        args.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(
+                architectures=["GlmMoeDsaForCausalLM"],
+                index_topk=128,
+            )
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_missing_hisparse_page_size_uses_default_capacity(self):
+        args = self._make_hisparse_mtp_args()
+
+        args.check_server_args()
+
+    def test_explicit_small_hisparse_page_size_still_rejects_draft_tokens(self):
+        args = self._make_hisparse_mtp_args(hisparse_config='{"page_size": 4}')
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "hiSparse extra page capacity \\(3 slots\\) is insufficient",
+        ):
+            args.check_server_args()
 
 
 class TestDeepEPWaterfillArgs(CustomTestCase):


### PR DESCRIPTION
[Feature] Support MTP/speculative decoding with hiSparse extra page draft zone

Based on PR #23239, this PR adapts hiSparse MTP/speculative decoding to the
current tree and keeps the scope focused on the hiSparse + MTP path plus the
direct runtime guards needed by that path.

Base feature (from PR #23239):
- Wire EAGLE draft/verify pipelines to use hiSparse's per-request extra page
  slots instead of the paged KV allocator
- Add get_draft_device_slots / get_draft_device_slots_variable and
  finalize_accepted_tokens to HiSparseCoordinator
- Add alloc_extend_with_device_mapping, clear_device_mapping, backup_state,
  and restore_state to HiSparseTokenToKVPoolAllocator
- Branch EagleVerifyInput / EagleDraftInputV2 / EAGLEWorker allocation paths
  to use hiSparse device slots when the coordinator is present
- Stash, split, merge, and rebuild per-request speculative state across the
  scheduler prefill-to-decode handoff
- Plumb hiSparse device mappings through ModelRunner and draft/draft-extend
  CUDA graph paths
- Extend hiSparse JIT swap-in and NSA attention paths for multi-step
  target_verify and draft_extend top-k lookup

Additional work on top of PR #23239 in this PR:
- Validate unsupported hiSparse speculative draft/topk/page-size combinations,
  including treating a missing hiSparse page_size as the default extra-page
  capacity
- Restrict Mooncake hiSparse direct-to-host transfer to the target KV pointer
  group when draft KV buffers are also registered
- Add unit tests for HiSparse coordinator draft/finalize behavior, server args
  validation, and Mooncake hiSparse target KV transfer

Out of scope for this PR:
- Generic PD prefill admission/status cleanup
- Rust PD router dispatch hardening
- Unused scheduler model-worker batch helper extraction

Cherry-picked from: PR #23239

Co-authored-by: Edward <sonya24yr@gmail.com>
Co-authored-by: BAIDU-AIAK <244673381+BAIDU-AIAK@users.noreply.github.com>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable MTP (Multi-Token Prediction) / speculative decoding with hiSparse KV-cache
offloading. This combines the latency benefits of speculative decoding with
hiSparse's sparse attention memory savings by allocating draft/verify KV slots
from per-request hiSparse extra pages instead of the normal paged KV allocator.

## Modifications

**Core hiSparse MTP integration:**
- Wire EAGLE draft/verify pipelines to use hiSparse's per-request extra page slots instead of the paged KV allocator
- Add `get_draft_device_slots` / `get_draft_device_slots_variable` and `finalize_accepted_tokens` to `HiSparseCoordinator`
- Add `alloc_extend_with_device_mapping`, `clear_device_mapping`, `backup_state`, and `restore_state` to `HiSparseTokenToKVPoolAllocator`
- Branch `EagleVerifyInput` / `EagleDraftInputV2` / `EAGLEWorker` allocation paths to use hiSparse device slots when the coordinator is present
- Stash speculative state per request during prefill staging and rebuild it when hiSparse requests transition to decode
- Propagate `hisparse_coordinator` through `ForwardBatch`, ModelRunner, and EAGLE draft CUDA graph paths
- Extend hiSparse JIT and NSA attention paths for multi-step target verify / draft extend lookup

**Direct runtime guards and transfer fixes:**
- Validate HiSparse + speculative decoding configs so draft tokens fit inside the extra-page capacity
- Reject currently unsupported HiSparse + speculative topk > 1 + paged KV combinations
- Restrict Mooncake hiSparse direct-to-host transfer to target KV pointer groups when draft KV buffers are also registered

**Testing:**
- Add HiSparse coordinator tests for draft slots, accepted-token finalization, newest-token mapping, and draft-extend CUDA graph disabling
- Add server args tests for HiSparse + speculative validation
- Add Mooncake hiSparse transfer test to verify target KV group slicing

**Validation:**
- `PYTHONPATH=python uv run --no-project python -m pytest -q test/registered/unit/managers/test_hisparse_unit.py test/registered/unit/server_args/test_server_args.py test/registered/unit/disaggregation/test_mooncake_hisparse.py`
- Result: `67 passed, 4 subtests passed`

## Deployment Commands

Model: GLM-5.1-FP8, TP16 EP8 across 2 nodes, 202K context

Common environment:
```bash
export SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1
export SGLANG_DG_CACHE_DIR=<CACHE_DIR>
export DG_JIT_CACHE_DIR=<CACHE_DIR>
export SGL_DG_USE_NVRTC=0
export DG_JIT_USE_NVRTC=0

export IB_GID_INDEX=3
export NVSHMEM_IB_GID_INDEX=3
export MC_GID_INDEX=3
export ROCE_GID_INDEX=3
export RDMA_CM_GID_INDEX=3
export SGLANG_HOST_IP=<RDMA_IP>
```

<details>
<summary>DSA mode</summary>

**Prefill node:**
```bash
sglang serve \
  --host 0.0.0.0 --port 30000 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.75 --chunked-prefill-size 32768 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode prefill --dist-init-addr <DIST_INIT_ADDR> \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16
```

**Decode node:**
```bash
sglang serve \
  --host 0.0.0.0 --port 30001 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.8 --chunked-prefill-size 65536 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode decode --dist-init-addr <DIST_INIT_ADDR> \
  --load-balance-method follow_bootstrap_room \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16 \
  --nsa-decode-backend flashmla_sparse
```

</details>

<details>
<summary>DSA+MTP mode</summary>

**Prefill node:** Add EAGLE speculative flags
```bash
sglang serve \
  --host 0.0.0.0 --port 30000 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.75 --chunked-prefill-size 32768 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode prefill --dist-init-addr <DIST_INIT_ADDR> \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4
```

**Decode node:** Add EAGLE speculative flags
```bash
sglang serve \
  --host 0.0.0.0 --port 30001 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.8 --chunked-prefill-size 65536 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode decode --dist-init-addr <DIST_INIT_ADDR> \
  --load-balance-method follow_bootstrap_room \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4
```

</details>

<details>
<summary>DSA+HiSparse mode</summary>

**Prefill node:** Same as DSA mode

**Decode node:** Add HiSparse flags
```bash
sglang serve \
  --host 0.0.0.0 --port 30001 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.8 --chunked-prefill-size 65536 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode decode --dist-init-addr <DIST_INIT_ADDR> \
  --load-balance-method follow_bootstrap_room \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16 \
  --nsa-decode-backend flashmla_sparse \
  --enable-hisparse \
  --hisparse-config '{"top_k": 2048, "device_buffer_size": 4096}'
```

</details>

<details>
<summary>DSA+HiSparse+MTP mode</summary>

**Prefill node:** Add EAGLE speculative flags
```bash
sglang serve \
  --host 0.0.0.0 --port 30000 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.75 --chunked-prefill-size 32768 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode prefill --dist-init-addr <DIST_INIT_ADDR> \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16 \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4
```

**Decode node:** Add HiSparse + EAGLE flags
```bash
sglang serve \
  --host 0.0.0.0 --port 30001 \
  --context-length 202752 \
  --model-path <MODEL_PATH> --served-model-name glm51 --trust-remote-code \
  --tp 16 --ep 8 --dp 1 \
  --mem-fraction-static 0.8 --chunked-prefill-size 65536 --max-running-requests 32 \
  --nnodes 2 --node-rank <NODE_RANK> \
  --disaggregation-mode decode --dist-init-addr <DIST_INIT_ADDR> \
  --load-balance-method follow_bootstrap_room \
  --disaggregation-ib-device 'mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3' \
  --kv-cache-dtype bfloat16 \
  --nsa-decode-backend flashmla_sparse \
  --enable-hisparse \
  --hisparse-config '{"top_k": 2048, "device_buffer_size": 4096}' \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4
```

</details>

<details>
<summary>Benchmark commands</summary>

**Accuracy (GSM8K):**
```bash
python -m sglang.test.run_eval \
  --eval-name gsm8k \
  --num-examples 500 \
  --num-shots 5 \
  --port 8000
```

**Benchmark (ShareGPT):**
```bash
python bench_serving.py \
  --backend sglang \
  --host 127.0.0.1 \
  --port 8000 \
  --model <MODEL_PATH> \
  --dataset-name sharegpt \
  --dataset-path <SHAREGPT_JSON_PATH> \
  --num-prompts 500 \
  --sharegpt-output-len 4096 \
  --max-concurrency 8 \
  --seed 42
```

</details>

## Accuracy Results

Model: GLM-5.1-FP8 (202K context), Eval: GSM8K (500 examples, 5-shot)

| Mode | Score | Latency (s) | Throughput (tok/s) |
|------|-------|-------------|-------------------|
| DSA | 0.982 | 534.87 | 482.78 |
| DSA+MTP | 0.978 | 239.42 | 1069.01 |
| DSA+HiSparse | 0.982 | 524.58 | 487.08 |
| DSA+HiSparse+MTP | 0.978 | 287.74 | 908.87 |

## Benchmark Results

Model: GLM-5.1-FP8, Dataset: ShareGPT (500 prompts, output_len=4096, concurrency=8)

| Mode | Duration (s) | Output Throughput (tok/s) | Mean TTFT (ms) | Mean TPOT (ms) |
|------|-------------|--------------------------|----------------|----------------|
| DSA | 10821.24 | 189.26 | 589.47 | 41.84 |
| DSA+MTP | 5357.14 | 382.29 | 386.30 | 20.69 |
| DSA+HiSparse | 6896.54 | 296.96 | 369.48 | 26.73 |
| DSA+HiSparse+MTP | 6810.06 | 300.73 | 397.18 | 26.24 |

All four modes passed the smoke test (`What is 1+1?` -> `2`). The
DSA+HiSparse+MTP ShareGPT run completed 500/500 requests; its output throughput
was still below the 350 tok/s target noted in the test record.

<details>
<summary>DSA mode raw data</summary>

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     500
Benchmark duration (s):                  10821.24
Total input tokens:                      193761
Total input text tokens:                 193761
Total generated tokens:                  2048000
Total generated tokens (retokenized):    2041161
Request throughput (req/s):              0.05
Input token throughput (tok/s):          17.91
Output token throughput (tok/s):         189.26
Peak output token throughput (tok/s):    465.00
Peak concurrent requests:                16
Total token throughput (tok/s):          207.16
Concurrency:                             7.94
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   171917.29
Median E2E Latency (ms):                 171902.36
P90 E2E Latency (ms):                    172984.00
P99 E2E Latency (ms):                    175397.60
---------------Time to First Token----------------
Mean TTFT (ms):                          589.47
Median TTFT (ms):                        461.96
P99 TTFT (ms):                           1920.03
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          41.84
Median TPOT (ms):                        41.86
P99 TPOT (ms):                           42.41
---------------Inter-Token Latency----------------
Mean ITL (ms):                           41.83
Median ITL (ms):                         41.84
P95 ITL (ms):                            43.12
P99 ITL (ms):                            43.99
Max ITL (ms):                            109.00
==================================================
```

</details>

<details>
<summary>DSA+MTP mode raw data</summary>

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     500
Benchmark duration (s):                  5357.14
Total input tokens:                      193761
Total input text tokens:                 193761
Total generated tokens:                  2048000
Total generated tokens (retokenized):    2039762
Request throughput (req/s):              0.09
Input token throughput (tok/s):          36.17
Output token throughput (tok/s):         382.29
Peak output token throughput (tok/s):    497.00
Peak concurrent requests:                10
Total token throughput (tok/s):          418.46
Concurrency:                             7.94
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   85093.43
Median E2E Latency (ms):                 80614.20
P90 E2E Latency (ms):                    107667.77
P99 E2E Latency (ms):                    122136.85
---------------Time to First Token----------------
Mean TTFT (ms):                          386.30
Median TTFT (ms):                        337.26
P99 TTFT (ms):                           1096.19
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.69
Median TPOT (ms):                        19.56
P99 TPOT (ms):                           29.76
---------------Inter-Token Latency----------------
Mean ITL (ms):                           20.68
Median ITL (ms):                         16.19
P95 ITL (ms):                            33.01
P99 ITL (ms):                            64.92
Max ITL (ms):                            131.15
==================================================
```

Speculative decoding metrics from decode-node logs during the benchmark
(samples: 1519):

| Metric | Average | Min | Max |
|--------|---------|-----|-----|
| accept len | 3.12 | 2.29 | 4.00 |
| accept rate | 0.71 | 0.43 | 1.00 |

</details>

<details>
<summary>DSA+HiSparse mode raw data</summary>

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     500
Benchmark duration (s):                  6896.54
Total input tokens:                      193761
Total input text tokens:                 193761
Total generated tokens:                  2048000
Total generated tokens (retokenized):    1268245
Request throughput (req/s):              0.07
Input token throughput (tok/s):          28.10
Output token throughput (tok/s):         296.96
Peak output token throughput (tok/s):    200.00
Peak concurrent requests:                16
Total token throughput (tok/s):          325.06
Concurrency:                             7.96
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   109846.30
Median E2E Latency (ms):                 175241.92
P90 E2E Latency (ms):                    178818.13
P99 E2E Latency (ms):                    181473.00
---------------Time to First Token----------------
Mean TTFT (ms):                          369.48
Median TTFT (ms):                        315.97
P99 TTFT (ms):                           1739.47
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          26.73
Median TPOT (ms):                        42.71
P99 TPOT (ms):                           43.95
---------------Inter-Token Latency----------------
Mean ITL (ms):                           42.98
Median ITL (ms):                         42.71
P95 ITL (ms):                            44.90
P99 ITL (ms):                            46.00
Max ITL (ms):                            133.72
==================================================
```

</details>

<details>
<summary>DSA+HiSparse+MTP mode raw data</summary>

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     500
Benchmark duration (s):                  6810.06
Total input tokens:                      193761
Total input text tokens:                 193761
Total generated tokens:                  2048000
Total generated tokens (retokenized):    2043121
Request throughput (req/s):              0.07
Input token throughput (tok/s):          28.45
Output token throughput (tok/s):         300.73
Peak output token throughput (tok/s):    425.00
Peak concurrent requests:                10
Total token throughput (tok/s):          329.18
Concurrency:                             7.92
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   107868.99
Median E2E Latency (ms):                 105054.80
P90 E2E Latency (ms):                    137158.28
P99 E2E Latency (ms):                    153617.25
---------------Time to First Token----------------
Mean TTFT (ms):                          397.18
Median TTFT (ms):                        340.57
P99 TTFT (ms):                           1051.47
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          26.24
Median TPOT (ms):                        25.57
P99 TPOT (ms):                           37.41
---------------Inter-Token Latency----------------
Mean ITL (ms):                           26.24
Median ITL (ms):                         21.35
P95 ITL (ms):                            46.08
P99 ITL (ms):                            86.40
Max ITL (ms):                            222.74
==================================================
```

Speculative decoding metrics from decode-node logs during the benchmark
(tmux `ag:1.2`, latest `mise r deploy:eval:bench` run, window
`14:08:19..16:01:49`, samples: 2128):

| Metric | Average | Min | Max |
|--------|---------|-----|-----|
| accept len | 3.06 | 2.10 | 3.86 |
| accept rate | 0.69 | 0.37 | 0.95 |

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26494358573](https://github.com/sgl-project/sglang/actions/runs/26494358573)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26494358609](https://github.com/sgl-project/sglang/actions/runs/26494358609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->