### PR TITLE
feat(reasoning-parser): add Qwen3-Coder detector with tool-call interruption

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -264,6 +264,52 @@ class Qwen3Detector(BaseReasoningFormatDetector):
         )
 
 
+class Qwen3CoderReasoningDetector(BaseReasoningFormatDetector):
+    """
+    Reasoning detector for Qwen3-Coder family thinking variants
+    (e.g., Qwen3.6-Coder, Qwen3-Coder thinking SKUs).
+
+    Assumes reasoning format:
+      (<think>)*(.*)</think>
+
+    Qwen3-Coder uses ``<tool_call>`` as the function-call boundary token (matched
+    by ``function_call.qwen3_coder_detector.Qwen3CoderDetector``). In long
+    agentic loops the model frequently switches from reasoning to a tool call
+    without first emitting ``</think>``. Without ``tool_start_token`` the
+    parser would keep buffering everything as ``reasoning_content``, dropping
+    the tool call from ``normal_text`` and breaking the agent loop.
+
+    This detector mirrors :class:`Glm45Detector` (which uses the same ``<think>``
+    / ``<tool_call>`` convention) but is registered under the dedicated
+    ``qwen3-coder`` model_type so existing ``qwen3`` thinking deployments are
+    unaffected.
+
+    Note: this is the *reasoning* detector. The tool-call payload itself is
+    parsed by the separate :class:`sglang.srt.function_call.qwen3_coder_detector.Qwen3CoderDetector`.
+
+    Args:
+        stream_reasoning (bool): If False, accumulates reasoning content until the end tag.
+            If True, streams reasoning content as it arrives.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+    ):
+        super().__init__(
+            "<think>",
+            "</think>",
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            tool_start_token="<tool_call>",
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+        )
+
+
 class KimiDetector(BaseReasoningFormatDetector):
     """
     Detector for Kimi Thinking model.
@@ -620,6 +666,7 @@ class ReasoningParser:
         "mimo": _MimoDetector,
         "poolside_v1": _PoolsideV1Detector,
         "qwen3": Qwen3Detector,
+        "qwen3-coder": Qwen3CoderReasoningDetector,
         "qwen3-thinking": Qwen3Detector,
         "minimax": Qwen3Detector,
         "minimax-append-think": MiniMaxAppendThinkDetector,

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -11,6 +11,7 @@ from sglang.srt.parser.reasoning_parser import (
     KimiDetector,
     KimiK2Detector,
     Nemotron3Detector,
+    Qwen3CoderReasoningDetector,
     Qwen3Detector,
     ReasoningParser,
     StreamingParseResult,
@@ -520,6 +521,140 @@ class TestGlm45Detector(CustomTestCase):
         self.assertEqual(result.normal_text, "<tool_call>tool call")
 
 
+class TestQwen3CoderReasoningDetector(CustomTestCase):
+    """Test cases for Qwen3-Coder reasoning detector with tool interruption support."""
+
+    def setUp(self):
+        self.detector = Qwen3CoderReasoningDetector()
+
+    def test_init(self):
+        """Test Qwen3CoderReasoningDetector initialization."""
+        self.assertEqual(self.detector.think_start_token, "<think>")
+        self.assertEqual(self.detector.think_end_token, "</think>")
+        self.assertEqual(self.detector.tool_start_token, "<tool_call>")
+        self.assertFalse(self.detector._in_reasoning)
+        self.assertTrue(self.detector.stream_reasoning)
+
+    def test_detect_and_parse_normal_reasoning(self):
+        """Test parsing a normal reasoning block followed by content."""
+        text = "<think>Let me plan the refactor</think>Here is the patch."
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "Let me plan the refactor")
+        self.assertEqual(result.normal_text, "Here is the patch.")
+
+    def test_detect_and_parse_tool_interrupt(self):
+        """
+        Primary regression test for the agent-loop bug.
+
+        Qwen3-Coder thinking variants frequently jump straight to a tool call
+        without emitting </think> when the reasoning budget is tight. Without
+        tool_start_token wiring, everything would be swallowed as
+        reasoning_content and the tool call would never reach the function-call
+        parser.
+        """
+        text = "<think>I should read the file<tool_call>{\"name\":\"read_file\"}"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "I should read the file")
+        self.assertEqual(
+            result.normal_text, "<tool_call>{\"name\":\"read_file\"}"
+        )
+
+    def test_detect_and_parse_multiple_tool_calls_find(self):
+        """Multiple <tool_call> tokens: split at the first occurrence."""
+        text = (
+            "<think>plan<tool_call>first<tool_call>second<tool_call>third"
+        )
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "plan")
+        self.assertEqual(
+            result.normal_text,
+            "<tool_call>first<tool_call>second<tool_call>third",
+        )
+
+    def test_detect_and_parse_truncated_reasoning(self):
+        """Truncated reasoning with no end tag and no tool call."""
+        text = "<think>thinking but cut off"
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "thinking but cut off")
+        self.assertEqual(result.normal_text, "")
+
+    def test_detect_and_parse_normal_text_only(self):
+        """Plain content with no reasoning block."""
+        text = "Direct answer with no thinking."
+        result = self.detector.detect_and_parse(text)
+        self.assertEqual(result.normal_text, text)
+        self.assertEqual(result.reasoning_text, "")
+
+    def test_streaming_normal_flow(self):
+        """Streaming with a fully-closed reasoning block."""
+        result1 = self.detector.parse_streaming_increment("<think>")
+        self.assertEqual(result1.normal_text, "")
+        self.assertEqual(result1.reasoning_text, "")
+        self.assertTrue(self.detector._in_reasoning)
+
+        result2 = self.detector.parse_streaming_increment("planning...")
+        self.assertEqual(result2.normal_text, "")
+        self.assertEqual(result2.reasoning_text, "planning...")
+
+        result3 = self.detector.parse_streaming_increment("</think>answer")
+        self.assertEqual(result3.normal_text, "answer")
+        self.assertEqual(result3.reasoning_text, "")
+        self.assertFalse(self.detector._in_reasoning)
+
+    def test_streaming_tool_interrupt_split_tokens(self):
+        """Streaming with mid-thought tool-call interruption (no </think>)."""
+        self.detector.parse_streaming_increment("<think>")
+
+        result1 = self.detector.parse_streaming_increment("planning")
+        self.assertEqual(result1.reasoning_text, "planning")
+
+        result2 = self.detector.parse_streaming_increment("<tool_call>")
+        self.assertEqual(result2.reasoning_text, "")
+        self.assertEqual(result2.normal_text, "<tool_call>")
+        self.assertFalse(self.detector._in_reasoning)
+
+        result3 = self.detector.parse_streaming_increment("{\"name\":\"x\"}")
+        self.assertEqual(result3.reasoning_text, "")
+        self.assertEqual(result3.normal_text, "{\"name\":\"x\"}")
+
+    def test_streaming_no_stream_reasoning(self):
+        """stream_reasoning=False still flushes on tool interruption."""
+        detector = Qwen3CoderReasoningDetector(stream_reasoning=False)
+
+        detector.parse_streaming_increment("<think>")
+
+        result = detector.parse_streaming_increment("planning")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "")
+
+        # Mirrors Glm45Detector behavior: <think> tag remains in self._buffer
+        # in the non-streaming path and is flushed on tool interruption.
+        result = detector.parse_streaming_increment("<tool_call>do_thing")
+        self.assertEqual(result.reasoning_text, "<think>planning")
+        self.assertEqual(result.normal_text, "<tool_call>do_thing")
+
+    def test_streaming_empty_reasoning_with_tool(self):
+        """Empty reasoning block immediately followed by a tool call."""
+        self.detector.parse_streaming_increment("<think>")
+        result = self.detector.parse_streaming_increment("<tool_call>noop")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "<tool_call>noop")
+
+    def test_forced_reasoning_mode(self):
+        """force_reasoning=True still honors tool interruption."""
+        detector = Qwen3CoderReasoningDetector(force_reasoning=True)
+
+        text = "Implicit reasoning"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "Implicit reasoning")
+        self.assertEqual(result.normal_text, "")
+
+        text = "More reasoning<tool_call>act"
+        result = detector.detect_and_parse(text)
+        self.assertEqual(result.reasoning_text, "More reasoning")
+        self.assertEqual(result.normal_text, "<tool_call>act")
+
+
 class TestHunyuanDetector(CustomTestCase):
     """Test cases for Hunyuan detector with tool interruption support."""
 
@@ -833,6 +968,9 @@ class TestReasoningParser(CustomTestCase):
 
         parser = ReasoningParser("glm45")
         self.assertIsInstance(parser.detector, Glm45Detector)
+
+        parser = ReasoningParser("qwen3-coder")
+        self.assertIsInstance(parser.detector, Qwen3CoderReasoningDetector)
 
         parser = ReasoningParser("hunyuan")
         self.assertIsInstance(parser.detector, HunyuanDetector)


### PR DESCRIPTION
## Summary

Qwen3-Coder thinking variants use the same reasoning convention as plain Qwen3 (`<think>...</think>`) but jump directly to a `<tool_call>` boundary **without first emitting `</think>`** when the reasoning budget is tight on long agentic loops. The shared `Qwen3Detector` does not set `tool_start_token`, so in that case the parser keeps buffering everything as `reasoning_content` and the tool call never reaches the function-call parser — breaking the agent loop silently.

This PR adds a dedicated `Qwen3CoderReasoningDetector` with `tool_start_token="<tool_call>"`, registered under the new `qwen3-coder` model_type. The design mirrors the existing `Glm45ReasoningDetector` / `KimiK2ReasoningDetector` pattern.

## Changes

- `python/sglang/srt/parser/reasoning_parser.py` — new `Qwen3CoderReasoningDetector` class + `qwen3-coder` registration; existing `qwen3` / `qwen3-thinking` mappings are **unchanged** (no regression risk for current deployments)
- `test/registered/unit/parser/test_reasoning_parser.py` — `TestQwen3CoderDetector` covering: init, normal/closed reasoning, mid-thought tool interruption (the regression case), multiple tool calls, truncated reasoning, plain content, streaming flows, `stream_reasoning=False`, and `force_reasoning=True`

## Usage

```bash
python -m sglang.launch_server --model Qwen/Qwen3-Coder-480B-A35B-Instruct \
    --reasoning-parser qwen3-coder
```

The tool-call payload itself continues to be parsed by the existing `function_call.qwen3_coder_detector.Qwen3CoderDetector`; this PR only adds the *reasoning* detector.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26494627413](https://github.com/sgl-project/sglang/actions/runs/26494627413)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26494627287](https://github.com/sgl-project/sglang/actions/runs/26494627287)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->