### PR TITLE
fix(serving): strip residual chat-template marker strings from output stream

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -48,6 +48,10 @@ from sglang.srt.entrypoints.openai.protocol import (
 from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
 from sglang.srt.entrypoints.openai.sse_utils import build_sse_content
 from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.srt.parser.residual_special_token_stripper import (
+    StreamingResidualStringStripper,
+    get_residual_special_token_strings,
+)
 from sglang.srt.entrypoints.openai.utils import (
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
@@ -65,6 +69,10 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.parser.residual_special_token_stripper import (
+    StreamingResidualStringStripper,
+    get_residual_special_token_strings,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.template_manager import TemplateManager
@@ -193,6 +201,33 @@ class OpenAIServingChat(OpenAIServingBase):
         except Exception:
             self._tokenizer_auto_adds_specials = True
 
+        # Residual special-token-string stripping (see
+        # residual_special_token_stripper.py). Some tokenizers register chat-
+        # template role markers (e.g. <|im_start|> for Qwen) as added tokens
+        # with special=True. The model occasionally emits the literal BPE
+        # bytes of those markers — when that happens, skip_special_tokens does
+        # not strip them because it filters by token ID, not string content.
+        # We collect the marker strings here once and reuse them per request.
+        self._residual_marker_strings: List[str] = []
+        tokenizer = getattr(self.tokenizer_manager, "tokenizer", None)
+        if tokenizer is not None:
+            try:
+                self._residual_marker_strings = get_residual_special_token_strings(
+                    tokenizer
+                )
+                if self._residual_marker_strings:
+                    logger.info(
+                        "Residual special-token-string stripping enabled for "
+                        "%d marker(s) (skip_special_tokens=True requests only)",
+                        len(self._residual_marker_strings),
+                    )
+            except Exception as e:  # defensive — never fail server startup
+                logger.warning(
+                    "Could not enumerate residual special-token strings from "
+                    "tokenizer (%s); residual stripping disabled.",
+                    e,
+                )
+
     def _handle_last_assistant_message(
         self,
         messages: List[Dict[str, Any]],
@@ -315,6 +350,7 @@ class OpenAIServingChat(OpenAIServingBase):
         prompt_tokens: Dict[int, int],
         reasoning_tokens: Dict[int, int],
         completion_tokens: Dict[int, int],
+        residual_stripper_dict: Optional[Dict[int, "StreamingResidualStringStripper"]] = None,
     ) -> AsyncGenerator[str, None]:
         """Generate SSE chunks for streaming content."""
         offset = stream_offsets.get(index, 0)
@@ -323,6 +359,18 @@ class OpenAIServingChat(OpenAIServingBase):
         else:
             delta = content["text"][offset:]
             stream_offsets[index] = len(content["text"])
+
+        # Strip residual special-token strings (e.g. literal "<|im_start|>" bytes
+        # hallucinated by the model) before the reasoning/tool parsers see the text.
+        # Stateful per index so markers split across chunks are handled correctly.
+        if residual_stripper_dict is not None:
+            stripper = residual_stripper_dict.get(index)
+            if stripper is None:
+                stripper = StreamingResidualStringStripper(self._residual_marker_strings)
+                residual_stripper_dict[index] = stripper
+            delta = stripper.feed(delta)
+            if finish_reason_type is not None:
+                delta += stripper.flush()
 
         # Handle reasoning content
         if self.reasoning_parser and request.separate_reasoning:
@@ -919,6 +967,13 @@ class OpenAIServingChat(OpenAIServingBase):
         # Parsers for tool calls and reasoning
         parser_dict = {}
         reasoning_parser_dict = {}
+        # Per-request residual special-token-string strippers. Each index
+        # (n>1, parallel sampling) gets its own buffered stripper because the
+        # tokenizer-side state is independent across choices.
+        residual_stripper_dict: Dict[int, StreamingResidualStringStripper] = {}
+        residual_stripping_enabled = bool(
+            self._residual_marker_strings
+        ) and bool(getattr(request, "skip_special_tokens", True))
 
         # State tracking for streaming
         is_firsts = {}
@@ -1027,6 +1082,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_tokens=prompt_tokens,
                     reasoning_tokens=reasoning_tokens,
                     completion_tokens=completion_tokens,
+                    residual_stripper_dict=residual_stripper_dict if residual_stripping_enabled else None,
                 ):
                     yield chunk
 
@@ -1189,6 +1245,17 @@ class OpenAIServingChat(OpenAIServingBase):
             text = self._decode_response(ret_item)
             if isinstance(text, ErrorResponse):
                 return ORJSONResponse(content=text.model_dump(), status_code=text.code)
+
+            # Strip residual special-token strings before parsers see them.
+            # Same rationale as the streaming path; here we can run a one-shot
+            # feed/flush since the full text is available.
+            if self._residual_marker_strings and getattr(
+                request, "skip_special_tokens", True
+            ):
+                _stripper = StreamingResidualStringStripper(
+                    self._residual_marker_strings
+                )
+                text = _stripper.feed(text) + _stripper.flush()
 
             # Handle reasoning content
             reasoning_text = None

--- a/python/sglang/srt/parser/residual_special_token_stripper.py
+++ b/python/sglang/srt/parser/residual_special_token_stripper.py
@@ -1,0 +1,211 @@
+# Copyright 2024-2025 SGLang Team. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Residual special-token-string stripping for streaming output.
+
+Some tokenizers (notably Qwen-family models) register chat-template role
+delimiters such as ``<|im_start|>`` as added tokens with ``special=True``.
+When the model emits the corresponding token ID, ``skip_special_tokens=True``
+strips it during detokenization, as expected.
+
+However, models occasionally hallucinate the *literal byte sequence* of a
+role marker via BPE — typically during long reasoning content or under
+unusual sampling conditions. In that case the detokenizer faithfully decodes
+the bytes (because ``skip_special_tokens`` only filters by token ID), and
+the marker leaks into the response stream. Downstream API consumers that
+treat role markers as a turn-termination signal (Anthropic ``/v1/messages``,
+some OpenAI tool-call routers) then abort the request mid-thought.
+
+This module provides a streaming-safe stripper that removes these residual
+marker strings before they leave the serving layer. Tokens consumed by the
+reasoning parser (``<think>`` / ``</think>``) and tool-call parser
+(``<tool_call>``, ``[TOOL_CALLS]``, …) are intentionally preserved so those
+parsers can still detect them.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+# Marker strings that downstream parsers consume in-band. Stripping these
+# would break reasoning extraction or tool-call routing, so they are excluded
+# from the residual stripper by default. Keep this list narrow — only
+# parser-consumed structural markers belong here.
+_PARSER_CONSUMED_MARKERS: Set[str] = {
+    # Reasoning parsers
+    "<think>",
+    "</think>",
+    "[THINK]",
+    "[/THINK]",
+    # Tool-call parsers
+    "<tool_call>",
+    "</tool_call>",
+    "[TOOL_CALLS]",
+    "[/TOOL_CALLS]",
+    "<|tool_call|>",
+    "<|tool_calls_section_begin|>",
+    "<|tool_calls_section_end|>",
+    "<|tool_call_begin|>",
+    "<|tool_call_end|>",
+    "<|tool_call_argument_begin|>",
+    "<|python_tag|>",
+}
+
+
+def get_residual_special_token_strings(
+    tokenizer,
+    extra_exclude: Optional[Iterable[str]] = None,
+) -> List[str]:
+    """Collect the set of special-token *strings* whose presence in
+    client-visible output indicates a hallucinated role/structural marker.
+
+    Args:
+        tokenizer: A HuggingFace ``PreTrainedTokenizer``-compatible object.
+            Must expose ``added_tokens_decoder`` (a ``Dict[int, AddedToken]``)
+            or, as a fallback, ``all_special_tokens`` plus
+            ``get_added_vocab()``.
+        extra_exclude: Optional iterable of additional marker strings to
+            preserve. Useful when a custom parser consumes a non-standard
+            structural token in-band.
+
+    Returns:
+        Sorted list (descending by length) of marker strings, with parser-
+        consumed markers excluded. Sorting by length ensures that the
+        rolling-buffer stripper matches the longest applicable marker first
+        when two markers share a prefix.
+    """
+    excluded: Set[str] = set(_PARSER_CONSUMED_MARKERS)
+    if extra_exclude:
+        excluded.update(extra_exclude)
+
+    candidates: Set[str] = set()
+
+    added_tokens_decoder = getattr(tokenizer, "added_tokens_decoder", None)
+    if added_tokens_decoder:
+        for token_id, added_token in added_tokens_decoder.items():
+            try:
+                is_special = bool(getattr(added_token, "special", False))
+                content = getattr(added_token, "content", None) or str(added_token)
+            except Exception:  # pragma: no cover — defensive
+                continue
+            if is_special and content:
+                candidates.add(content)
+    else:
+        # Fallback for tokenizer wrappers that do not expose
+        # added_tokens_decoder (older HF versions, custom shims).
+        special_tokens = getattr(tokenizer, "all_special_tokens", []) or []
+        candidates.update(str(t) for t in special_tokens if t)
+
+    # Drop markers consumed by downstream parsers.
+    markers = [m for m in candidates if m and m not in excluded]
+
+    # Longest first so the matcher cannot half-strip a marker whose prefix
+    # is itself another marker (rare in practice, but defends against
+    # tokenizers that register both ``<|im_start|>`` and ``<|im_start|>user``).
+    markers.sort(key=lambda s: (-len(s), s))
+    return markers
+
+
+class StreamingResidualStringStripper:
+    """Incremental, streaming-safe stripper for residual marker strings.
+
+    The stripper buffers the trailing bytes of each chunk that could be the
+    start of a known marker, so a marker split across chunk boundaries is
+    correctly removed rather than half-emitted.
+
+    Usage::
+
+        stripper = StreamingResidualStringStripper(markers)
+        for chunk in stream:
+            client.send(stripper.feed(chunk))
+        client.send(stripper.flush())
+
+    Notes:
+        * ``markers`` may be empty, in which case ``feed`` is a passthrough.
+        * The buffer is bounded by ``max_marker_len - 1`` characters; for a
+          typical model this is well under 100 bytes of memory per stream.
+        * Calling ``flush()`` is required at end-of-stream to release any
+          buffered tail. Subsequent ``flush()`` calls return ``""``.
+    """
+
+    __slots__ = ("_markers", "_max_marker_len", "_buffer")
+
+    def __init__(self, markers: Iterable[str]):
+        self._markers: List[str] = [m for m in markers if m]
+        self._max_marker_len: int = (
+            max((len(m) for m in self._markers), default=0)
+        )
+        self._buffer: str = ""
+
+    @property
+    def active(self) -> bool:
+        """True when at least one marker is registered."""
+        return bool(self._markers)
+
+    def feed(self, chunk: str) -> str:
+        """Append ``chunk`` to the internal buffer and return the prefix
+        that is safe to emit immediately (with complete markers removed)."""
+        if not self._markers:
+            return chunk
+        if not chunk:
+            return ""
+
+        self._buffer += chunk
+
+        # Determine how many trailing characters could still be the start
+        # of a marker. Anything before that boundary can be safely flushed.
+        hold_back = self._suffix_prefix_overlap(self._buffer)
+        safe_end = len(self._buffer) - hold_back
+        safe = self._buffer[:safe_end]
+        self._buffer = self._buffer[safe_end:]
+
+        return self._strip_complete_markers(safe)
+
+    def flush(self) -> str:
+        """Return any buffered tail with complete markers removed."""
+        if not self._buffer:
+            return ""
+        tail = self._buffer
+        self._buffer = ""
+        return self._strip_complete_markers(tail)
+
+    def _strip_complete_markers(self, text: str) -> str:
+        if not text:
+            return text
+        for marker in self._markers:
+            if marker in text:
+                text = text.replace(marker, "")
+        return text
+
+    def _suffix_prefix_overlap(self, text: str) -> int:
+        """Return the largest k such that ``text[-k:]`` is a proper prefix
+        of at least one marker. ``k == 0`` means the buffer can be fully
+        flushed."""
+        if not text or self._max_marker_len <= 1:
+            return 0
+        max_check = min(len(text), self._max_marker_len - 1)
+        best = 0
+        for marker in self._markers:
+            limit = min(max_check, len(marker) - 1)
+            if limit <= best:
+                continue
+            tail = text[-limit:]
+            # Shrink ``tail`` until it is a prefix of ``marker``.
+            for k in range(limit, best, -1):
+                if marker.startswith(tail[-k:]):
+                    best = k
+                    break
+        return best

--- a/test/registered/unit/parser/test_residual_special_token_stripper.py
+++ b/test/registered/unit/parser/test_residual_special_token_stripper.py
@@ -1,0 +1,195 @@
+"""Unit tests for srt/parser/residual_special_token_stripper.py"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.parser.residual_special_token_stripper import (
+    StreamingResidualStringStripper,
+    get_residual_special_token_strings,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _added_token(content: str, special: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(content=content, special=special)
+
+
+class _FakeTokenizer:
+    def __init__(self, added_tokens_decoder):
+        self.added_tokens_decoder = added_tokens_decoder
+
+
+class TestGetResidualSpecialTokenStrings(CustomTestCase):
+    def test_qwen_style_im_start_extracted(self):
+        tok = _FakeTokenizer(
+            {
+                151644: _added_token("<|im_start|>"),
+                151645: _added_token("<|im_end|>"),
+                151643: _added_token("<|endoftext|>"),
+            }
+        )
+        markers = get_residual_special_token_strings(tok)
+        self.assertIn("<|im_start|>", markers)
+        self.assertIn("<|im_end|>", markers)
+        self.assertIn("<|endoftext|>", markers)
+
+    def test_parser_consumed_markers_excluded_by_default(self):
+        tok = _FakeTokenizer(
+            {
+                1: _added_token("<think>"),
+                2: _added_token("</think>"),
+                3: _added_token("<tool_call>"),
+                4: _added_token("</tool_call>"),
+                5: _added_token("<|im_start|>"),
+            }
+        )
+        markers = get_residual_special_token_strings(tok)
+        self.assertEqual(markers, ["<|im_start|>"])
+
+    def test_non_special_tokens_ignored(self):
+        tok = _FakeTokenizer(
+            {
+                1: _added_token("<|im_start|>", special=True),
+                2: _added_token("regular_word", special=False),
+            }
+        )
+        markers = get_residual_special_token_strings(tok)
+        self.assertEqual(markers, ["<|im_start|>"])
+
+    def test_extra_exclude_honored(self):
+        tok = _FakeTokenizer(
+            {
+                1: _added_token("<|im_start|>"),
+                2: _added_token("<|custom_marker|>"),
+            }
+        )
+        markers = get_residual_special_token_strings(
+            tok, extra_exclude={"<|custom_marker|>"}
+        )
+        self.assertEqual(markers, ["<|im_start|>"])
+
+    def test_sorted_longest_first(self):
+        tok = _FakeTokenizer(
+            {
+                1: _added_token("<|a|>"),
+                2: _added_token("<|abc|>"),
+                3: _added_token("<|ab|>"),
+            }
+        )
+        markers = get_residual_special_token_strings(tok)
+        self.assertEqual([len(m) for m in markers], sorted([7, 6, 5], reverse=True))
+
+    def test_fallback_to_all_special_tokens(self):
+        class _OldStyleTokenizer:
+            added_tokens_decoder = None
+            all_special_tokens = ["<|im_start|>", "<think>", "<|im_end|>"]
+
+            def get_added_vocab(self):  # pragma: no cover — unused branch
+                return {}
+
+        markers = get_residual_special_token_strings(_OldStyleTokenizer())
+        self.assertIn("<|im_start|>", markers)
+        self.assertIn("<|im_end|>", markers)
+        self.assertNotIn("<think>", markers)
+
+    def test_empty_tokenizer(self):
+        tok = _FakeTokenizer({})
+        self.assertEqual(get_residual_special_token_strings(tok), [])
+
+
+class TestStreamingResidualStringStripper(CustomTestCase):
+    MARKER = "<|im_start|>"
+
+    def _stream(self, stripper, chunks):
+        out = "".join(stripper.feed(c) for c in chunks)
+        return out + stripper.flush()
+
+    def test_passthrough_when_no_markers(self):
+        stripper = StreamingResidualStringStripper([])
+        self.assertFalse(stripper.active)
+        self.assertEqual(
+            self._stream(stripper, ["hello ", "world"]), "hello world"
+        )
+
+    def test_marker_fully_in_one_chunk(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        self.assertTrue(stripper.active)
+        result = self._stream(
+            stripper, ["thinking... ", f"{self.MARKER}user", " continues"]
+        )
+        self.assertEqual(result, "thinking... user continues")
+
+    def test_marker_split_across_chunks(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        chunks = ["before <|im_", "start|>after"]
+        self.assertEqual(self._stream(stripper, chunks), "before after")
+
+    def test_marker_split_byte_by_byte(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        chunks = ["x"] + list(self.MARKER) + ["y"]
+        self.assertEqual(self._stream(stripper, chunks), "xy")
+
+    def test_multiple_markers_in_one_chunk(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        result = self._stream(
+            stripper, [f"a{self.MARKER}b{self.MARKER}c"]
+        )
+        self.assertEqual(result, "abc")
+
+    def test_marker_at_boundary_then_flush(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        # First chunk ends with a prefix of the marker; second chunk
+        # never completes it. Expect the partial to be flushed at end.
+        chunks = ["okay <|im_", "start"]
+        self.assertEqual(self._stream(stripper, chunks), "okay <|im_start")
+
+    def test_partial_marker_only_flushed_on_close(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        # The model emits text that happens to be a prefix of a marker
+        # but is never completed. We must NOT swallow it.
+        early = stripper.feed("looks like <|im_")
+        self.assertEqual(early, "looks like ")
+        late = stripper.flush()
+        self.assertEqual(late, "<|im_")
+
+    def test_overlapping_markers_longest_match_wins(self):
+        # If two markers share a prefix, longest-first sorting in
+        # get_residual_special_token_strings ensures the longer is
+        # matched. Here we pass both directly to verify the stripper.
+        stripper = StreamingResidualStringStripper(
+            ["<|im_start|>user", "<|im_start|>"]
+        )
+        self.assertEqual(
+            self._stream(stripper, ["pre <|im_start|>user post"]),
+            "pre  post",
+        )
+
+    def test_excluded_markers_preserved(self):
+        # The stripper itself does not know about exclusions — that's the
+        # caller's job. Verify that markers NOT passed in are preserved.
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        result = self._stream(stripper, ["<think>reasoning</think>actual"])
+        self.assertEqual(result, "<think>reasoning</think>actual")
+
+    def test_empty_chunks_are_safe(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        self.assertEqual(stripper.feed(""), "")
+        self.assertEqual(stripper.flush(), "")
+
+    def test_flush_idempotent(self):
+        stripper = StreamingResidualStringStripper([self.MARKER])
+        # End with '<', which is a one-char prefix of the marker, so it
+        # gets buffered until flush.
+        early = stripper.feed("hello<")
+        self.assertEqual(early, "hello")
+        first = stripper.flush()
+        second = stripper.flush()
+        self.assertEqual(first, "<")
+        self.assertEqual(second, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Some tokenizers (Qwen, Llama-3 instruct, Mistral instruct, …) register chat-template role delimiters such as `<|im_start|>` as added tokens with `special=True`. When the model emits the corresponding **token ID**, `skip_special_tokens=True` correctly strips it during detokenization.

However, models occasionally hallucinate the **literal BPE byte sequence** of a role marker — typically during long reasoning content. In that case the detokenizer faithfully decodes the bytes (`skip_special_tokens` filters by token ID, not string content), and the marker leaks into the response stream. Downstream consumers that treat role markers as turn terminators then abort mid-response.

## Changes

**New module** `python/sglang/srt/parser/residual_special_token_stripper.py`:
- `get_residual_special_token_strings(tokenizer, extra_exclude=...)` — enumerates marker strings from `tokenizer.added_tokens_decoder` (filtered to `special=True`), excluding tokens already consumed by the reasoning parser (`<think>`, `</think>`, `[THINK]`, …) and tool-call parser (`<tool_call>`, `[TOOL_CALLS]`, …) so those parsers still see their structural markers.
- `StreamingResidualStringStripper` — rolling-buffer, streaming-safe stripper that removes markers including those split across chunk boundaries. Markers not completed by stream end are released on `flush()`.

**`python/sglang/srt/entrypoints/openai/serving_chat.py`**:
- `__init__`: enumerate markers once at startup from the tokenizer.
- `_generate_stream_content`: run each delta through a per-index `StreamingResidualStringStripper` before the reasoning/tool parsers; flush on `finish_reason`.
- `_build_chat_response`: one-shot feed+flush on the full text for non-streaming requests.
- Gated on `request.skip_special_tokens` (default `True`). When the user opts into seeing special tokens, the stripper stays out of the way.

**New test** `test/registered/unit/parser/test_residual_special_token_stripper.py` — covers: marker fully in one chunk, split across chunks (byte-by-byte), multiple markers per chunk, partial marker held then flushed, overlapping markers (longest-match), parser-consumed marker exclusion, and tokenizer fallback paths.

## No new ServerArgs flag, no model-specific code

Marker discovery is purely tokenizer-driven. Any model with chat-template role tokens benefits automatically.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26494642532](https://github.com/sgl-project/sglang/actions/runs/26494642532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26494642468](https://github.com/sgl-project/sglang/actions/runs/26494642468)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->