### PR TITLE
fix(hicache): decouple mamba-clamped pages from KV prefetch admission gate

### DIFF
--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -1751,11 +1751,17 @@ class HiMambaRadixCache(MambaRadixCache):
         if self.mamba_host_lru_list.in_list(last_host_node):
             self.mamba_host_lru_list.remove_node(last_host_node)
 
+        last_hash_for_prefetch = (
+            last_host_node.hash_value[-1]
+            if last_host_node is not self.root_node
+            and last_host_node.hash_value
+            else last_hash
+        )
         operation = self.cache_controller.prefetch(
             req_id,
             host_indices,
             new_input_tokens,
-            last_hash,
+            last_hash_for_prefetch,
             prefix_keys,
             extra_pools=extra_pools,
         )

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -578,7 +578,7 @@ class HybridCacheController(BaseHiCacheController):
                 kv_hit_pages=kv_hit_count, extra_pool_hit_pages={}
             )
 
-        kv_hit_pages = hit_result.kv_hit_pages
+        kv_hit_pages = hit_result.extra_pool_hit_pages.get(PoolName.KV, hit_result.kv_hit_pages)
         operation.pool_storage_result.update_kv_hit_pages(kv_hit_pages)
 
         if kv_hit_pages > 0 and operation.pool_transfers:

--- a/test/registered/unit/mem_cache/test_hicache_prefetch_gate.py
+++ b/test/registered/unit/mem_cache/test_hicache_prefetch_gate.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for two hicache prefetch gate fixes:
+
+  Patch A (hybrid_cache_controller.py): decouple KV prefetch admission gate
+  from the mamba-clamped final_pages. The gate now reads from
+  hit_result.extra_pool_hit_pages[PoolName.KV] so absent mamba companions
+  don't zero-out the KV hit count and revoke all L3 prefetches.
+
+  Patch B (hi_mamba_radix_cache.py): align the prefetch last_hash seed with
+  the write-side hash chain by deriving last_hash_for_prefetch from
+  last_host_node.hash_value[-1] rather than always using the caller-supplied
+  last_hash (which defaults to None).
+"""
+import unittest
+
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransferResult
+from sglang.srt.mem_cache.mamba_radix_cache import TreeNode
+
+
+class TestExtraPoolHitPagesGate(unittest.TestCase):
+    """Patch A: kv_hit_pages must come from extra_pool_hit_pages[PoolName.KV]."""
+
+    def _resolve(self, result: PoolTransferResult) -> int:
+        """Replicate the one-liner from hybrid_cache_controller._storage_hit_query."""
+        return result.extra_pool_hit_pages.get(PoolName.KV, result.kv_hit_pages)
+
+    def test_extra_pool_kv_wins_over_zero_kv_hit_pages(self):
+        """extra_pool_hit_pages[KV]=100 must win even when kv_hit_pages=0.
+
+        Before the fix, kv_hit_pages=0 caused the prefetch gate to revoke
+        every L3 read when mamba companion files were absent.
+        """
+        result = PoolTransferResult(
+            kv_hit_pages=0, extra_pool_hit_pages={PoolName.KV: 100}
+        )
+        self.assertEqual(self._resolve(result), 100)
+
+    def test_fallback_to_kv_hit_pages_when_extra_empty(self):
+        """When batch_exists returns no extra_pool_hit_pages, fall back to kv_hit_pages."""
+        result = PoolTransferResult(kv_hit_pages=50, extra_pool_hit_pages={})
+        self.assertEqual(self._resolve(result), 50)
+
+    def test_extra_pool_kv_zero_does_not_mask_nonzero_kv_hit_pages(self):
+        """An explicit KV=0 entry in extra_pool_hit_pages overrides kv_hit_pages."""
+        result = PoolTransferResult(
+            kv_hit_pages=30, extra_pool_hit_pages={PoolName.KV: 0}
+        )
+        self.assertEqual(self._resolve(result), 0)
+
+    def test_non_kv_pool_entry_does_not_affect_kv_count(self):
+        """An extra entry for a non-KV pool must not influence KV hit pages."""
+        result = PoolTransferResult(kv_hit_pages=20, extra_pool_hit_pages={})
+        self.assertEqual(self._resolve(result), 20)
+
+
+class TestPrefetchLastHashAlignment(unittest.TestCase):
+    """Patch B: prefetch_from_storage derives last_hash from last_host_node.hash_value[-1]."""
+
+    def _compute(self, cache_root, last_host_node, caller_last_hash):
+        """Replicate the exact expression added to prefetch_from_storage."""
+        return (
+            last_host_node.hash_value[-1]
+            if last_host_node is not cache_root and last_host_node.hash_value
+            else caller_last_hash
+        )
+
+    def setUp(self):
+        self.root = TreeNode()
+
+    def test_non_root_with_hash_uses_last_page_hash(self):
+        """A non-root host node with hash_value should seed prefetch with its last page hash."""
+        node = TreeNode()
+        node.hash_value = ["page_0_hash", "page_1_hash", "page_2_hash"]
+        result = self._compute(self.root, node, "caller")
+        self.assertEqual(result, "page_2_hash")
+
+    def test_single_page_node_returns_only_hash(self):
+        node = TreeNode()
+        node.hash_value = ["only_page_hash"]
+        result = self._compute(self.root, node, "caller")
+        self.assertEqual(result, "only_page_hash")
+
+    def test_root_node_falls_back_to_caller_hash(self):
+        """The root node has no prefix to seed from — fall back to caller-supplied last_hash."""
+        self.root.hash_value = ["root_hash"]
+        result = self._compute(self.root, self.root, "caller_hash")
+        self.assertEqual(result, "caller_hash")
+
+    def test_non_root_with_empty_hash_value_falls_back(self):
+        """Empty hash_value list on a non-root node falls back to caller hash."""
+        node = TreeNode()
+        node.hash_value = []
+        result = self._compute(self.root, node, "caller_hash")
+        self.assertEqual(result, "caller_hash")
+
+    def test_non_root_with_none_hash_value_falls_back(self):
+        """None hash_value on a non-root node falls back to caller hash."""
+        node = TreeNode()
+        node.hash_value = None
+        result = self._compute(self.root, node, "caller_hash")
+        self.assertEqual(result, "caller_hash")
+
+    def test_caller_hash_none_and_root_returns_none(self):
+        """When caller_last_hash is None and node is root, result is None (dense RadixCache compat)."""
+        result = self._compute(self.root, self.root, None)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two small fixes that unblock the L3 (file-storage) prefetch read path for hybrid Mamba+Attention models.

### Patch A — decouple prefetch gate from mamba clamp (`hybrid_cache_controller.py`, 1 line)

`HybridCacheController._storage_hit_query` was sourcing `kv_hit_pages` from `hit_result.final_pages` — the mamba-clamped value. When companion `.mamba_*.bin` files are absent (e.g. first run after a restart), the mamba clamp zeros `final_pages`, which makes `storage_hit_count < prefetch_threshold` always true and revokes every L3 prefetch before `.get()` is even dispatched. With this fix the gate reads from `hit_result.extra_pool_hit_pages[PoolName.KV]` — the raw KV-only prefix count — so absent mamba companions no longer suppress KV prefetches.

### Patch B — align prefetch `last_hash` with write-side hash chain (`hi_mamba_radix_cache.py`, 7 lines)

`HiMambaRadixCache.prefetch_from_storage` was passing `last_hash=None` (the default) to `cache_controller.prefetch`, while the write side seeded `write_storage` from `last_host_node.hash_value[-1]`. The mismatch meant `batch_exists_v2` always saw 0 hit pages on the mamba boundary and the prefetch gate revoked every read. Fix: compute `last_hash_for_prefetch` from `last_host_node.hash_value[-1]` (with root-node and empty-chain guards) before calling `prefetch`. Dense `RadixCache` backward-compat preserved via the guard fallback to the caller-provided `last_hash`.

## Impact

Together these two patches make cross-session L3 cache reuse actually work end-to-end on hybrid Mamba+Attention models. Without them, `LRUHiCacheFile` stats show `get_miss=0 / get_hit=0` regardless of how much data is stored in L3.















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26495084628](https://github.com/sgl-project/sglang/actions/runs/26495084628)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26495084546](https://github.com/sgl-project/sglang/actions/runs/26495084546)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->