### PR TITLE
feat(server-args,hicache): expose --hicache-prefetch-threshold and --hicache-prefetch-capacity-tokens

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -99,6 +99,9 @@ class DecodeKVCacheOffloadManager:
             storage_backend=server_args.hicache_storage_backend,
             model_name=server_args.served_model_name,
             storage_backend_extra_config=hicache_storage_backend_extra_config,
+            hicache_prefetch_capacity_tokens=getattr(
+                server_args, "hicache_prefetch_capacity_tokens", 0
+            ),
         )
 
         self.ongoing_offload = {}

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -260,6 +260,7 @@ class HiCacheController:
         pp_rank: int = 0,
         pp_size: int = 1,
         enable_storage_metrics: bool = False,
+        hicache_prefetch_capacity_tokens: int = 0,
     ):
         self.tp_group = tp_group
         self.attn_cp_group = attn_cp_group
@@ -282,6 +283,9 @@ class HiCacheController:
         self.pp_rank = pp_rank
         self.pp_size = pp_size
         self.enable_storage_metrics = enable_storage_metrics
+        # Patch F: override for the L3 prefetch in-flight capacity. 0 = auto
+        # (legacy formula + ratio=1.0 fallback). Used in attach_storage_backend.
+        self.hicache_prefetch_capacity_tokens = hicache_prefetch_capacity_tokens
 
         # Draft KV pool support (best-effort piggyback on target L2/L3 ops).
         self.has_draft = False
@@ -332,6 +336,7 @@ class HiCacheController:
                     prefetch_threshold=prefetch_threshold,
                     model_name=model_name,
                     storage_backend_extra_config=storage_backend_extra_config,
+                    hicache_prefetch_capacity_tokens=hicache_prefetch_capacity_tokens,
                 )
             except ValueError as e:
                 # Preserve the historical error shape on init for unknown backends.
@@ -458,6 +463,7 @@ class HiCacheController:
         prefetch_threshold: int = 256,
         model_name: Optional[str] = None,
         storage_backend_extra_config: Optional[dict] = None,
+        hicache_prefetch_capacity_tokens: int = 0,
     ):
         """Attach (enable) storage backend at runtime.
 
@@ -504,8 +510,23 @@ class HiCacheController:
             self.enable_storage = True
             # todo: threshold policy for prefetching
             self.prefetch_threshold = max(prefetch_threshold, self.page_size)
-            self.prefetch_capacity_limit = max(
-                0, int(0.8 * (self.mem_pool_host.size - self.mem_pool_device.size))
+            # Patch F: explicit override wins; otherwise auto-resolve with a
+            # two-branch fallback so hicache-ratio=1.0 does not clamp to 0
+            # (which silently kills L3 reads via prefetch_rate_limited()).
+            if hicache_prefetch_capacity_tokens > 0:
+                self.prefetch_capacity_limit = hicache_prefetch_capacity_tokens
+            elif self.mem_pool_host.size > self.mem_pool_device.size:
+                self.prefetch_capacity_limit = int(
+                    0.8 * (self.mem_pool_host.size - self.mem_pool_device.size)
+                )
+            else:
+                self.prefetch_capacity_limit = int(0.5 * self.mem_pool_device.size)
+            logger.info(
+                "HiCache prefetch capacity_limit=%d (host=%d device=%d override=%d)",
+                self.prefetch_capacity_limit,
+                self.mem_pool_host.size,
+                self.mem_pool_device.size,
+                hicache_prefetch_capacity_tokens,
             )
             # granularity of batch storage IO operations, in number of pages
             self.storage_batch_size = 128

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -131,6 +131,9 @@ class HiMambaRadixCache(MambaRadixCache):
         self.enable_storage_metrics = self.enable_storage and params.enable_metrics
         self.extra_metric_labels = server_args.extra_metric_labels
 
+        # Stash for _parse_storage_backend_extra_config (Patch D): used as the
+        # fallback default when extra_config does not pin prefetch_threshold.
+        self._server_args_prefetch_threshold = server_args.hicache_prefetch_threshold
         (
             extra_config,
             prefetch_threshold,
@@ -1542,7 +1545,11 @@ class HiMambaRadixCache(MambaRadixCache):
                 raise e
 
         defaults = PrefetchTimeoutConfig()
-        prefetch_threshold = extra_config.pop("prefetch_threshold", 256)
+        prefetch_threshold = extra_config.pop(
+            "prefetch_threshold",
+            getattr(self, "_server_args_prefetch_threshold", 256),
+        )
+        prefetch_threshold = max(prefetch_threshold, self.page_size)
         prefetch_timeout_base = extra_config.pop("prefetch_timeout_base", defaults.base)
         prefetch_timeout_per_ki_token = extra_config.pop(
             "prefetch_timeout_per_ki_token", defaults.per_ki_token

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -111,6 +111,9 @@ class HiRadixCache(RadixCache):
         self.enable_storage_metrics = self.enable_storage and params.enable_metrics
         self.extra_metric_labels = server_args.extra_metric_labels
 
+        # Stash for _parse_storage_backend_extra_config (Patch D): used as the
+        # fallback default when extra_config does not pin prefetch_threshold.
+        self._server_args_prefetch_threshold = server_args.hicache_prefetch_threshold
         (
             extra_config,
             prefetch_threshold,
@@ -584,7 +587,11 @@ class HiRadixCache(RadixCache):
                 raise e
 
         defaults = PrefetchTimeoutConfig()
-        prefetch_threshold = extra_config.pop("prefetch_threshold", 256)  # tokens
+        prefetch_threshold = extra_config.pop(
+            "prefetch_threshold",
+            getattr(self, "_server_args_prefetch_threshold", 256),
+        )  # tokens
+        prefetch_threshold = max(prefetch_threshold, self.page_size)
         prefetch_timeout_base = extra_config.pop(
             "prefetch_timeout_base", defaults.base
         )  # seconds

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -157,6 +157,9 @@ class HiRadixCache(RadixCache):
                 pp_rank=self.pp_rank,
                 pp_size=self.pp_size,
                 enable_storage_metrics=self.enable_storage_metrics,
+                hicache_prefetch_capacity_tokens=getattr(
+                    server_args, "hicache_prefetch_capacity_tokens", 0
+                ),
             )
         self._apply_storage_runtime_config(
             storage_backend=server_args.hicache_storage_backend,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -172,6 +172,7 @@ class HybridCacheController(BaseHiCacheController):
         pp_size: int = 1,
         transfer_layer_num: Optional[int] = None,
         enable_storage_metrics: bool = False,
+        hicache_prefetch_capacity_tokens: int = 0,
     ):
         startup_storage_backend = storage_backend
         self.extra_host_mem_release_queues: dict[PoolName, Queue] = {}
@@ -192,6 +193,7 @@ class HybridCacheController(BaseHiCacheController):
             pp_rank=pp_rank,
             pp_size=pp_size,
             enable_storage_metrics=enable_storage_metrics,
+            hicache_prefetch_capacity_tokens=hicache_prefetch_capacity_tokens,
         )
         # Override layer_num: hybrid models transfer all layers (For example, Linear Model (KV + Mamba)),
         # not just the full attention layers reported by full_kv_pool.
@@ -206,6 +208,7 @@ class HybridCacheController(BaseHiCacheController):
                 model_name=model_name,
                 storage_backend_extra_config=storage_backend_extra_config,
                 host_pools=getattr(mem_pool_host, "entries", None),
+                hicache_prefetch_capacity_tokens=hicache_prefetch_capacity_tokens,
             )
 
     def _start_storage_threads(self):
@@ -219,12 +222,14 @@ class HybridCacheController(BaseHiCacheController):
         model_name: Optional[str] = None,
         storage_backend_extra_config: Optional[dict] = None,
         host_pools: Optional[list[PoolEntry]] = None,
+        hicache_prefetch_capacity_tokens: int = 0,
     ):
         super().attach_storage_backend(
             storage_backend=storage_backend,
             prefetch_threshold=prefetch_threshold,
             model_name=model_name,
             storage_backend_extra_config=storage_backend_extra_config,
+            hicache_prefetch_capacity_tokens=hicache_prefetch_capacity_tokens,
         )
 
         for entry in host_pools or []:

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -516,6 +516,7 @@ def build_hybrid_mamba_stack(
     pp_rank: int = 0,
     pp_size: int = 1,
     enable_storage_metrics: bool = False,
+    hicache_prefetch_capacity_tokens: int = 0,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping | mamba_layer_mapping)
     kv_host_pool = build_kv_host_pool(
@@ -569,6 +570,7 @@ def build_hybrid_mamba_stack(
         pp_size=pp_size,
         transfer_layer_num=transfer_layer_num,
         enable_storage_metrics=enable_storage_metrics,
+        hicache_prefetch_capacity_tokens=hicache_prefetch_capacity_tokens,
     )
     return host_pool_group, cache_controller
 
@@ -595,6 +597,7 @@ def build_anchor_sidecar_stack(
     pp_rank: int = 0,
     pp_size: int = 1,
     enable_storage_metrics: bool = False,
+    hicache_prefetch_capacity_tokens: int = 0,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping)
     kv_host_pool = build_kv_host_pool(
@@ -641,6 +644,7 @@ def build_anchor_sidecar_stack(
         pp_size=pp_size,
         transfer_layer_num=transfer_layer_num,
         enable_storage_metrics=enable_storage_metrics,
+        hicache_prefetch_capacity_tokens=hicache_prefetch_capacity_tokens,
     )
     return host_pool_group, cache_controller
 
@@ -1181,6 +1185,9 @@ def attach_hybrid_dsa_pool_to_hiradix_cache(
             pp_rank=radix_cache.pp_rank,
             pp_size=radix_cache.pp_size,
             enable_storage_metrics=enable_storage_metrics,
+            hicache_prefetch_capacity_tokens=getattr(
+                server_args, "hicache_prefetch_capacity_tokens", 0
+            ),
         )
         radix_cache.full_kv_pool_host = host_pool_group.get_pool(PoolName.KV)
         radix_cache.token_to_kv_pool_host = host_pool_group
@@ -1238,6 +1245,9 @@ def attach_hybrid_pool_to_mamba_cache(
             pp_rank=params.pp_rank,
             pp_size=params.pp_size,
             enable_storage_metrics=enable_storage_metrics,
+            hicache_prefetch_capacity_tokens=getattr(
+                server_args, "hicache_prefetch_capacity_tokens", 0
+            ),
         )
         mamba_cache.full_kv_pool_host = host_pool_group.get_pool(PoolName.KV)
         mamba_cache.mamba_pool_host = host_pool_group.get_pool(PoolName.MAMBA)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -672,6 +672,14 @@ class ServerArgs:
     # _parse_storage_backend_extra_config semantics).
     hicache_prefetch_threshold: int = 256
 
+    # Override for the L3 prefetch in-flight capacity (tokens). 0 = auto:
+    # uses 0.8*(host-device) if host > device, else 0.5*device_size.
+    # When the auto formula clamps to 0 (e.g. hicache-ratio=1.0 where
+    # host == device), L3 reads are effectively disabled because
+    # prefetch_rate_limited() returns True immediately. Set to a positive
+    # integer (e.g. 65536) to unblock cross-session reuse on ratio=1.0.
+    hicache_prefetch_capacity_tokens: int = 0
+
     # Hierarchical sparse attention
     enable_hisparse: bool = False
     hisparse_config: Optional[str] = None
@@ -5919,6 +5927,16 @@ class ServerArgs:
                 "in-config-blob default. Lower (e.g. 16) lets smoke-test prompts "
                 "exercise the L3 read path; raise to suppress lookup spam on "
                 "trivially-short prompts."
+            ),
+        )
+        parser.add_argument(
+            "--hicache-prefetch-capacity-tokens",
+            type=int,
+            default=ServerArgs.hicache_prefetch_capacity_tokens,
+            help=(
+                "Override the L3 prefetch in-flight capacity (tokens). "
+                "0 = auto: uses 0.8*(host-device) if host>device, else "
+                "0.5*device_size."
             ),
         )
         parser.add_argument(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -665,6 +665,12 @@ class ServerArgs:
     hicache_storage_backend: Optional[str] = None
     hicache_storage_prefetch_policy: str = "timeout"
     hicache_storage_backend_extra_config: Optional[str] = None
+    # Token-count threshold below which prefetch_from_storage skips the L3
+    # lookup. Lower-bounded internally to page_size. Override via
+    # --hicache-prefetch-threshold or via hicache_storage_backend_extra_config
+    # JSON key `prefetch_threshold` (the JSON key wins if both are set, per
+    # _parse_storage_backend_extra_config semantics).
+    hicache_prefetch_threshold: int = 256
 
     # Hierarchical sparse attention
     enable_hisparse: bool = False
@@ -5901,6 +5907,19 @@ class ServerArgs:
             type=int,
             default=ServerArgs.mamba_track_interval,
             help="The interval to track the mamba state during decode.",
+        )
+        parser.add_argument(
+            "--hicache-prefetch-threshold",
+            type=int,
+            default=ServerArgs.hicache_prefetch_threshold,
+            help=(
+                "Minimum page-aligned new-input token count required for "
+                "prefetch_from_storage to dispatch an L3 lookup. Lower-bounded "
+                "internally to page_size. Default 256 matches the historical "
+                "in-config-blob default. Lower (e.g. 16) lets smoke-test prompts "
+                "exercise the L3 read path; raise to suppress lookup spam on "
+                "trivially-short prompts."
+            ),
         )
         parser.add_argument(
             "--mamba-backend",

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -617,5 +617,37 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
             ServerArgs(**self._base_kwargs(kv_cache_dtype="fp4_e2m1"))
 
 
+class TestHiCachePrefetchServerArgs(unittest.TestCase):
+    """Tests for --hicache-prefetch-threshold and --hicache-prefetch-capacity-tokens."""
+
+    def test_hicache_prefetch_threshold_default(self):
+        args = ServerArgs(model_path="dummy")
+        self.assertEqual(args.hicache_prefetch_threshold, 256)
+
+    def test_hicache_prefetch_capacity_tokens_default(self):
+        args = ServerArgs(model_path="dummy")
+        self.assertEqual(args.hicache_prefetch_capacity_tokens, 0)
+
+    @patch("sglang.srt.server_args.get_device", return_value="cuda")
+    def test_hicache_prefetch_threshold_cli(self, _):
+        args = prepare_server_args(
+            ["--model-path", "dummy", "--hicache-prefetch-threshold", "16"]
+        )
+        self.assertEqual(args.hicache_prefetch_threshold, 16)
+
+    @patch("sglang.srt.server_args.get_device", return_value="cuda")
+    def test_hicache_prefetch_capacity_tokens_cli(self, _):
+        args = prepare_server_args(
+            ["--model-path", "dummy", "--hicache-prefetch-capacity-tokens", "4096"]
+        )
+        self.assertEqual(args.hicache_prefetch_capacity_tokens, 4096)
+
+    @patch("sglang.srt.server_args.get_device", return_value="cuda")
+    def test_hicache_prefetch_capacity_tokens_zero_means_auto(self, _):
+        """Default 0 means the controller auto-computes from host/device pool sizes."""
+        args = prepare_server_args(["--model-path", "dummy"])
+        self.assertEqual(args.hicache_prefetch_capacity_tokens, 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two operator-tunable knobs for the HiCache L3 storage prefetch path, both previously only configurable via the opaque `--hicache-storage-backend-extra-config` JSON blob.

### `--hicache-prefetch-threshold N` (default 256)

Minimum page-aligned new-input token count required for `prefetch_from_storage` to dispatch an L3 lookup. Already existed as a hardcoded default inside `_parse_storage_backend_extra_config`; this PR promotes it to a first-class `ServerArgs` field so it can be set on the command line. The JSON-blob key `prefetch_threshold` still wins when both are provided (existing semantics preserved). Lower-bounded internally to `page_size`.

**Use case:** Set `--hicache-prefetch-threshold 16` in staging to exercise the L3 read path on short test prompts; raise to suppress lookup spam on trivially-short generation deltas.

### `--hicache-prefetch-capacity-tokens N` (default 0 = auto)

Overrides the `prefetch_capacity_limit` computed by `HiCacheController.attach_storage_backend`. The previous auto formula was `max(0, 0.8 * (host_size - device_size))`, which silently clamps to 0 when `hicache-ratio=1.0` (host == device). A clamped-to-zero capacity makes `prefetch_rate_limited()` return `True` on every call, killing all L3 reads even after the prefetch gate fixes in the companion PR.

The new resolver:
1. Explicit positive override wins.
2. `host > device` → legacy `0.8 * (host - device)`.
3. `host <= device` → `0.5 * device_size` (new safe fallback).

An INFO log at `attach_storage_backend` time makes the resolved value observable at boot.

## Files changed

- `python/sglang/srt/server_args.py` — two new fields + CLI args
- `python/sglang/srt/mem_cache/hiradix_cache.py` — thread new arg through dense builder
- `python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py` — 3-branch capacity resolver
- `python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py` — thread new arg through hybrid builder
- `python/sglang/srt/managers/cache_controller.py` — forward new arg
- `python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py` — forward new arg















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26495084370](https://github.com/sgl-project/sglang/actions/runs/26495084370)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26495084274](https://github.com/sgl-project/sglang/actions/runs/26495084274)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->