### PR TITLE
fix(mamba_radix_cache): graceful handling of sub-page and mismatched-length inserts

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -542,6 +542,16 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 token_ids = token_ids[:cache_len]
                 kv_indices = kv_indices[:cache_len]
 
+            # Clamp cache_len to the actual committed kv tensor length. With
+            # extra_buffer enabled, cache_len starts as mamba_last_track_seqlen
+            # (decode-tracker value) which can exceed kv_committed_len when the
+            # commit length comes from the strip_thinking_cache anchor (or its
+            # min(kv_committed_len, len(origin_input_ids)) fallback). Without
+            # this clamp, the cache_len vs page_aligned_len comparison below
+            # reports the pre-slice mamba seqlen instead of the post-slice kv
+            # range, making the warning log misleading.
+            cache_len = min(cache_len, len(kv_indices))
+
             if self.page_size != 1:
                 page_aligned_len = len(kv_indices) // self.page_size * self.page_size
                 page_aligned_kv_indices = kv_indices[:page_aligned_len].to(
@@ -551,9 +561,41 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 page_aligned_len = len(kv_indices)
                 page_aligned_kv_indices = kv_indices.to(dtype=torch.int64, copy=True)
 
-            assert (
-                cache_len == page_aligned_len
-            ), f"It is required {cache_len=}, {page_aligned_len=}, {kv_committed_len=}, {len(req.origin_input_ids)=}, {len(req.output_ids)=} ping @yizhang2077 if you see this"
+            # Sub-page prefix: nothing to insert at page granularity. Short
+            # prompts (len < page_size) produce page_aligned_len == 0 — there
+            # is nothing worth caching at page granularity, so free and return.
+            if page_aligned_len == 0:
+                self.token_to_kv_pool_allocator.free(
+                    kv_indices[req.cache_protected_len :]
+                )
+                self.req_to_token_pool.free_mamba_cache(req)
+                self.dec_lock_ref(req.last_node)
+                return
+
+            # Defensive fallback: if the mamba commit length disagrees with the
+            # page-aligned KV length, skip the insert and free the resources
+            # cleanly so refcounts stay consistent. This avoids crashing the
+            # scheduler (SIGQUIT via running_phase_sigquit_handler) at the cost
+            # of losing one request's prefix-cache contribution. The drift has
+            # been observed with --strip-thinking-cache + extra_buffer when the
+            # prompt-anchor capture misses an edge case.
+            if cache_len != page_aligned_len:
+                logger.warning(
+                    "mamba_radix_cache: cache_len=%d != page_aligned_len=%d "
+                    "[kv_committed_len=%d, origin_input_ids=%d, output_ids=%d]; "
+                    "skipping insert to preserve refcount consistency.",
+                    cache_len,
+                    page_aligned_len,
+                    kv_committed_len,
+                    len(req.origin_input_ids),
+                    len(req.output_ids),
+                )
+                self.token_to_kv_pool_allocator.free(
+                    kv_indices[req.cache_protected_len :]
+                )
+                self.req_to_token_pool.free_mamba_cache(req)
+                self.dec_lock_ref(req.last_node)
+                return
 
             # Radix Cache takes one ref in memory pool
             # insert the token_ids and kv_indices into the radix tree

--- a/test/registered/unit/mem_cache/test_mamba_radix_sub_page.py
+++ b/test/registered/unit/mem_cache/test_mamba_radix_sub_page.py
@@ -1,0 +1,188 @@
+"""
+Unit tests for fix(mamba_radix_cache): graceful handling of sub-page and
+mismatched-length inserts in MambaRadixCache.cache_finished_req.
+
+Before this fix, both cases hit a hard assert that fired SIGQUIT and killed
+the scheduler with all in-flight requests. After this fix:
+
+  Case 1 — sub-page prefix (page_aligned_len == 0): silent early return.
+  Case 2 — mamba/KV commit-length drift: logger.warning + graceful free.
+"""
+import logging
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import torch
+
+from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache, TreeNode
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+def _make_cache(page_size: int = 4) -> MambaRadixCache:
+    """Return a MambaRadixCache with only the attributes needed by cache_finished_req."""
+    cache = object.__new__(MambaRadixCache)
+    cache.page_size = page_size
+    cache.disable = False
+    cache.enable_mamba_extra_buffer = False
+    cache.token_to_kv_pool_allocator = MagicMock()
+    cache.req_to_token_pool = MagicMock()
+    return cache
+
+
+def _make_req(n_tokens: int, cache_protected_len: int = 0) -> MagicMock:
+    """Return a minimal Req mock for cache_finished_req."""
+    req = MagicMock()
+    req.pop_committed_kv_cache.return_value = n_tokens
+    req.origin_input_ids = list(range(n_tokens))
+    req.output_ids = []
+    req.req_pool_idx = 0
+    req.cache_protected_len = cache_protected_len
+    req.mamba_last_track_seqlen = None
+    req.last_node = TreeNode()
+    return req
+
+
+class TestSubPageSkip(unittest.TestCase):
+    """Case 1: prompt shorter than page_size — page_aligned_len == 0."""
+
+    def _call(self, cache, req):
+        with patch.object(cache, "dec_lock_ref"):
+            cache.cache_finished_req(req)
+
+    def test_no_crash_on_sub_page_prompt(self):
+        """cache_finished_req must not raise when kv_committed_len < page_size."""
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=2)  # 2 < 4 → page_aligned_len = 0
+        kv = torch.zeros(2, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+        self._call(cache, req)  # must not raise
+
+    def test_kv_indices_freed_on_sub_page_prompt(self):
+        """All KV indices must be freed when the prompt is sub-page."""
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=2, cache_protected_len=0)
+        kv = torch.zeros(2, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"):
+            cache.cache_finished_req(req)
+
+        cache.token_to_kv_pool_allocator.free.assert_called_once()
+        freed = cache.token_to_kv_pool_allocator.free.call_args[0][0]
+        self.assertEqual(len(freed), 2)
+
+    def test_mamba_cache_freed_on_sub_page_prompt(self):
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=1)
+        kv = torch.zeros(1, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"):
+            cache.cache_finished_req(req)
+
+        cache.req_to_token_pool.free_mamba_cache.assert_called_once_with(req)
+
+    def test_no_insert_into_radix_tree_on_sub_page_prompt(self):
+        """The radix tree insert path must be bypassed — insert method not called."""
+        cache = _make_cache(page_size=4)
+        cache.insert = MagicMock()
+        req = _make_req(n_tokens=3)
+        kv = torch.zeros(3, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"):
+            cache.cache_finished_req(req)
+
+        cache.insert.assert_not_called()
+
+    def test_page_aligned_prompt_does_not_early_return(self):
+        """A prompt that exactly fills one page must NOT early-return (normal path)."""
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=4)  # 4 == page_size → page_aligned_len = 4
+        kv = torch.zeros(4, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        # normal insert path needs more cache internals; just verify no early-return
+        # by checking free is NOT called immediately (it may be called during insert)
+        with patch.object(cache, "dec_lock_ref"):
+            try:
+                cache.cache_finished_req(req)
+            except Exception:
+                pass  # insert path may fail without full tree — that is expected
+
+        # free may be called but not with the full kv tensor from the early-return path
+        for c in cache.token_to_kv_pool_allocator.free.call_args_list:
+            freed = c[0][0]
+            # early-return frees ALL n_tokens; a normal path only frees un-cached tail
+            self.assertNotEqual(
+                len(freed),
+                4,
+                "early-return should not fire for a page-aligned prompt",
+            )
+
+
+class TestDriftWarning(unittest.TestCase):
+    """Case 2: commit-length drift (cache_len != page_aligned_len > 0)."""
+
+    def test_warning_logged_on_drift(self):
+        """A logger.warning must be emitted when cache_len != page_aligned_len > 0."""
+        cache = _make_cache(page_size=4)
+        # 5 tokens → page_aligned_len = 4, cache_len = 5 (drift)
+        req = _make_req(n_tokens=5)
+        kv = torch.zeros(5, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"), self.assertLogs(
+            "sglang.srt.mem_cache.mamba_radix_cache", level=logging.WARNING
+        ) as log_ctx:
+            cache.cache_finished_req(req)
+
+        self.assertTrue(
+            any("mamba_radix_cache" in m for m in log_ctx.output),
+            "Expected a warning from mamba_radix_cache logger",
+        )
+
+    def test_no_raise_on_drift(self):
+        """Scheduler must survive a drift event — no exception."""
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=5)
+        kv = torch.zeros(5, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"), self.assertLogs(
+            "sglang.srt.mem_cache.mamba_radix_cache", level=logging.WARNING
+        ):
+            cache.cache_finished_req(req)  # must not raise
+
+    def test_kv_freed_on_drift(self):
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=5, cache_protected_len=0)
+        kv = torch.zeros(5, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"), self.assertLogs(
+            "sglang.srt.mem_cache.mamba_radix_cache", level=logging.WARNING
+        ):
+            cache.cache_finished_req(req)
+
+        cache.token_to_kv_pool_allocator.free.assert_called_once()
+        cache.req_to_token_pool.free_mamba_cache.assert_called_once_with(req)
+
+    def test_sub_page_does_not_log_drift_warning(self):
+        """page_aligned_len == 0 must NOT log a drift warning — it is a silent skip."""
+        cache = _make_cache(page_size=4)
+        req = _make_req(n_tokens=2)  # sub-page, not drift
+        kv = torch.zeros(2, dtype=torch.int32)
+        cache.req_to_token_pool.req_to_token.__getitem__.return_value = kv
+
+        with patch.object(cache, "dec_lock_ref"):
+            with self.assertNoLogs(
+                "sglang.srt.mem_cache.mamba_radix_cache", level=logging.WARNING
+            ):
+                cache.cache_finished_req(req)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`MambaRadixCache.cache_finished_req` currently has a hard `assert cache_len == page_aligned_len` that fires `SIGQUIT` through `running_phase_sigquit_handler`, killing the entire scheduler process and all in-flight requests. Two cases hit this path:

### Case 1 — sub-page prefix (silent skip, no warning)

A short prompt with fewer tokens than `page_size` (e.g. a 29-token request with `page_size=32`) produces `page_aligned_len = 0`. There is nothing worth caching at page granularity; the assert is a false alarm. Fix: early-return before the assert when `page_aligned_len == 0`, freeing KV and mamba resources cleanly.

### Case 2 — genuine mamba/KV commit-length drift (warning + graceful skip)

Observed with `--strip-thinking-cache` + `--mamba-scheduler-strategy extra_buffer` when the prompt-anchor capture misses an edge case (mamba state captured on first decode step rather than end of prefill). `cache_len` ends up non-zero but differs from `page_aligned_len`. Fix: replace the assert with a `logger.warning` that logs the exact lengths for diagnosis, then frees resources and returns — same as case 1 but with a visible log line.

## Impact

- Short-prompt requests no longer crash the scheduler.
- Under `--strip-thinking-cache` + `extra_buffer`, a single invariant violation loses one request's prefix-cache contribution instead of killing all in-flight requests.
- No change to the happy path (the two early-returns are guarded conditions; normal inserts proceed as before).

## Files changed

- `python/sglang/srt/mem_cache/mamba_radix_cache.py` — replace assert with two guarded handlers















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26495085045](https://github.com/sgl-project/sglang/actions/runs/26495085045)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26495084624](https://github.com/sgl-project/sglang/actions/runs/26495084624)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->