### PR TITLE
perf: avoid eagle draft seq_lens sync

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -724,7 +724,7 @@ class EAGLEWorker(TpModelWorker):
             ]
 
         batch.out_cache_loc = out_cache_loc
-        batch.seq_lens_sum = torch.sum(batch.seq_lens).item()
+        batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
         batch.return_hidden_states = False
         spec_info.positions = batch.seq_lens.repeat_interleave(self.topk, dim=0)
         self.token_to_kv_pool_allocator.restore_state(token_to_kv_pool_state_backup)


### PR DESCRIPTION
Motivation
Issue #26171 reports that EAGLE-3 on Blackwell still has avoidable GPU->CPU synchronization in the draft preprocessing path.

One remaining sync point is in `EAGLEWorker._draft_preprocess_decode()`, where we compute `batch.seq_lens_sum` via `torch.sum(batch.seq_lens).item()`:

- `python/sglang/srt/speculative/eagle_worker.py:727`

That forces a scalar readback from the GPU tensor even though the decode batch already maintains a CPU mirror in `batch.seq_lens_cpu`.

The rest of the forward-batch setup already treats the CPU mirror as the canonical source for this sum:

- `python/sglang/srt/model_executor/forward_batch_info.py:493-495`

This is the same class of cleanup as #20266, but on the draft preprocess side instead of `eagle_info.verify()`.

Modifications
Replace the draft preprocess sum with `int(batch.seq_lens_cpu.sum())` so the code reuses the existing CPU-side sequence lengths instead of synchronizing the GPU tensor.

Preserved behavior
`ScheduleBatch` keeps `seq_lens` and `seq_lens_cpu` in lockstep during decode preparation and speculative batch filtering / merging, so this only changes where the scalar is read from, not the value.

Validation
- `python -m compileall python/sglang/srt/speculative/eagle_worker.py`
- diff inspection against `ForwardBatch.init_new()` to confirm the new source matches the existing lazy recomputation path in `python/sglang/srt/model_executor/forward_batch_info.py:493-495`

Checklist
- [ ] Format your code according to the contribution guide.
- [ ] Add/update tests if maintainers want a focused regression test for this path.
- [ ] Run broader speculative decoding performance validation on Blackwell hardware.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26498214362](https://github.com/sgl-project/sglang/actions/runs/26498214362)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26498214389](https://github.com/sgl-project/sglang/actions/runs/26498214389)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->