### PR TITLE
[Spec] Fix DFlash crash when is_extend_in_batch mixes extend+decode t…

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker.py
+++ b/python/sglang/srt/speculative/dflash_worker.py
@@ -959,9 +959,18 @@ class DFlashWorker:
                 draft_input.target_hidden
             )  # [sum(ctx), hidden]
             if ctx_hidden.shape[0] != ctx_cache_loc.numel():
-                raise RuntimeError(
-                    f"DFLASH ctx_hidden/cache_loc mismatch: {ctx_hidden.shape[0]} vs {ctx_cache_loc.numel()}."
+                logger.warning(
+                    "DFLASH ctx_hidden/cache_loc mismatch: %d vs %d "
+                    "(bs=%d, is_extend_in_batch=%s). "
+                    "Skipping KV append to avoid corruption.",
+                    ctx_hidden.shape[0],
+                    ctx_cache_loc.numel(),
+                    bs,
+                    batch.is_extend_in_batch,
                 )
+                draft_input.ctx_lens = torch.zeros_like(ctx_lens)
+                draft_input.target_hidden = draft_input.target_hidden[:0]
+                return
 
             if self._use_fused_kv_materialize and self._fused_kv_helper is not None:
                 try:
@@ -1143,9 +1152,20 @@ class DFlashWorker:
                 return torch.tensor(x, dtype=torch.int32, device=device)
 
             extend_seq_lens = _to_int32_device_tensor(batch.extend_lens)
+
+            # When is_extend_in_batch, hidden_states contains both extend and
+            # decode tokens, but ctx_lens only accounts for extend tokens.
+            # Truncate to the extend-only portion to avoid a shape mismatch
+            # in _append_target_hidden_to_draft_kv.
+            _target_hidden = logits_output.hidden_states
+            if batch.is_extend_in_batch and batch.extend_num_tokens is not None:
+                _ent = int(batch.extend_num_tokens)
+                if _ent < _target_hidden.shape[0]:
+                    _target_hidden = _target_hidden[:_ent]
+
             draft_input = DFlashDraftInput(
                 bonus_tokens=next_token_ids.to(torch.int64),
-                target_hidden=logits_output.hidden_states,
+                target_hidden=_target_hidden,
                 ctx_lens=extend_seq_lens,
                 draft_seq_lens=(
                     torch.zeros_like(extend_seq_lens)


### PR DESCRIPTION
…okens

When the scheduler produces a mixed batch (is_extend_in_batch=True), logits_output.hidden_states contains hidden states for both extend and decode tokens, but ctx_lens only accounts for extend tokens. This causes a shape mismatch in _append_target_hidden_to_draft_kv that raises RuntimeError and crashes the serving process.

Root cause: forward_batch_generation passes the full hidden_states (including decode rows) to DFlashDraftInput.target_hidden while ctx_lens = extend_seq_lens only covers the extend portion. The downstream project_target_hidden produces more rows than ctx_cache_loc has elements, triggering the mismatch.

Fix 1 (root cause): In forward_batch_generation, when is_extend_in_batch=True, truncate target_hidden to batch.extend_num_tokens rows before constructing DFlashDraftInput. This ensures target_hidden.shape[0] == sum(ctx_lens).

Fix 2 (defense-in-depth): In _append_target_hidden_to_draft_kv, replace the raise RuntimeError on ctx_hidden/cache_loc mismatch with a warning + early return (clear ctx_lens and truncate target_hidden). This degrades gracefully—skipping the KV append for that batch rather than crashing. The DFlash verify mechanism discards incorrect draft tokens, so output correctness is preserved.

Verified: 3 rounds × 100 prompts benchmark with Kimi-K2.5 DFlash (TP=16) showing zero crashes. Fix 1 triggered 904 times (active truncation), Fix 2 triggered 1 time (fallback), accept_length=2.36 unchanged.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26504039859](https://github.com/sgl-project/sglang/actions/runs/26504039859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26504039527](https://github.com/sgl-project/sglang/actions/runs/26504039527)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->