### PR TITLE
Fixed incorrect indexing for slot 0 compatibility

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -383,10 +383,11 @@ def prepare_extend_inputs_for_correctness_test(
 ):
     for i in range(len(reqs)):
         req: Req = reqs[i]
-        req.fill_ids += input_ids[i][bench_args.cut_len :]
+        req.fill_ids.extend(input_ids[i][bench_args.cut_len :])
         if model_runner is not None:
+            # Use req.req_pool_idx instead of i to handle slot 0 padding correctly
             req.prefix_indices = model_runner.req_to_token_pool.req_to_token[
-                i, : bench_args.cut_len
+                req.req_pool_idx, : bench_args.cut_len
             ].to(req.prefix_indices.dtype)
             req.logprob_start_len = -1
             req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))


### PR DESCRIPTION
## Motivation

Fixes bench_one_batch.py to work correctly with the slot 0 padding scheme introduced in commit cb8fbd53f (PR #24243).

## Modifications
Fixed 2 issues:
1. Fixed TypeError
```
 # Line 386: Fix TypeError
 # Before: req.fill_ids += input_ids[i][bench_args.cut_len :]
 # After: req.fill_ids.extend(input_ids[i][bench_args.cut_len :])
```
2. Fixed slot 0 compatibility
  After PR #24243 reserved slot 0 as padding in req_to_token pools for CUDA graph compatibility, bench_one_batch.py was  using incorrect indices:

    - The test harness used loop index i (0, 1, 2, ...) to index into req_to_token_pool.req_to_token
    - However, actual allocated pool indices now start from 1 (slot 0 is reserved)
    - This caused indexing mismatches and incorrect prefix_indices lookups

## Accuracy Tests
The below test works fine after the fix.
python -m sglang.bench_one_batch --model meta-llama/Llama-3.1-8B-Instruct --batch-size 1  --output-len 128  --trust-remote-code  --attention-backend intel_xpu --mem-fraction-static 0.75  --dtype bfloat16 --device xpu --correctness-test

## Speed Tests and Profiling


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26506598166](https://github.com/sgl-project/sglang/actions/runs/26506598166)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #26549272498](https://github.com/sgl-project/sglang/actions/runs/26549272498)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->