### PR TITLE
[lora] opt 1/n Fuse compute_token_lora_mapping into a single Triton kernel

### DIFF
--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -39,6 +39,53 @@ _is_xpu = is_xpu()
 if _is_cuda or _is_hip or _is_xpu:
     from sglang.jit_kernel.moe_lora_align import moe_lora_align_block_size
 
+if _is_cuda or _is_hip:
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _compute_token_lora_mapping_kernel(
+        seg_indptr_ptr,  # int32 [num_reqs + 1]
+        req_to_lora_ptr,  # int32 [num_reqs]
+        output_ptr,  # int32 [num_tokens]
+        num_reqs,
+        num_tokens,
+        MAX_ITERS: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        """Fused mapping: per-token binary-search into seg_indptr, then gather req_to_lora.
+
+        Replaces 3 torch kernels (arange + searchsorted + gather) with one launch.
+        Each program handles BLOCK_SIZE tokens; binary search is unrolled to
+        MAX_ITERS = ceil(log2(num_reqs + 1)) steps.
+        """
+        pid = tl.program_id(0)
+        offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        valid = offs < num_tokens
+        token_pos = offs.to(tl.int32)
+
+        lo = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+        hi = tl.full([BLOCK_SIZE], num_reqs, dtype=tl.int32)
+
+        for _ in range(MAX_ITERS):
+            mid = (lo + hi) // 2
+            # Mirror torch.searchsorted(..., right=True): find first idx where
+            # seg_indptr[idx+1] > token_pos. Clamp mid to last valid slot for safety.
+            safe_mid = tl.minimum(mid, num_reqs - 1)
+            seg_end = tl.load(
+                seg_indptr_ptr + safe_mid + 1, mask=valid, other=num_tokens
+            ).to(tl.int32)
+            go_right = seg_end <= token_pos
+            lo = tl.where(go_right, mid + 1, lo)
+            hi = tl.where(go_right, hi, mid)
+
+        req_idx = lo
+        in_range = valid & (req_idx < num_reqs)
+        lora_id = tl.load(req_to_lora_ptr + req_idx, mask=in_range, other=-1).to(
+            tl.int32
+        )
+        tl.store(output_ptr + offs, lora_id, mask=valid)
+
 
 def _get_moe_lora_block_config(max_lora_rank: int) -> dict:
     """Compute rank-aware block sizes for MoE LoRA kernels.
@@ -207,8 +254,37 @@ def _compute_token_lora_mapping(
     lora_info: LoRAInfo,
 ) -> torch.Tensor:
     """Map each token to its LoRA adapter index (-1 for no LoRA)."""
+    num_tokens = hidden_states.shape[0]
+    if num_tokens == 0:
+        return torch.empty(0, dtype=torch.int32, device=hidden_states.device)
+
+    if (_is_cuda or _is_hip) and hidden_states.is_cuda:
+        num_reqs = lora_info.req_to_lora.shape[0]
+        if num_reqs == 0:
+            return torch.full(
+                (num_tokens,), -1, dtype=torch.int32, device=hidden_states.device
+            )
+
+        output = torch.empty(
+            (num_tokens,), dtype=torch.int32, device=hidden_states.device
+        )
+        BLOCK_SIZE = 256
+        # Unroll depth: ceil(log2(num_reqs + 1)); +1 covers the half-open upper bound.
+        max_iters = max(1, (num_reqs + 1).bit_length())
+        grid = (triton.cdiv(num_tokens, BLOCK_SIZE),)
+        _compute_token_lora_mapping_kernel[grid](
+            lora_info.seg_indptr,
+            lora_info.req_to_lora,
+            output,
+            num_reqs,
+            num_tokens,
+            MAX_ITERS=max_iters,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+        return output
+
     token_positions = torch.arange(
-        hidden_states.shape[0], device=hidden_states.device, dtype=torch.int32
+        num_tokens, device=hidden_states.device, dtype=torch.int32
     )
     req_indices = torch.searchsorted(
         lora_info.seg_indptr[1:].to(torch.int32),


### PR DESCRIPTION
## Motivation

`_compute_token_lora_mapping` (`python/sglang/srt/lora/lora_moe_runners.py`),
used by the MoE virtual-experts LoRA path inside `build_lora_hooks`, is
currently implemented as three torch ops back-to-back:

\`\`\`python
token_positions = torch.arange(num_tokens, ...)
req_indices     = torch.searchsorted(seg_indptr[1:].to(int32), token_positions, right=True)
return req_to_lora.to(int32)[req_indices]
\`\`\`

This costs 3 kernel launches per call. Profiling on Qwen3-30B-A3B shows
\`compute_token_lora_mapping: ~7us, 3 torch kernels\` per MoE layer; the function
runs once per MoE layer per forward, so the launch overhead accumulates across
all layers per step.

## Modifications

Collapse the three torch ops into a single Triton kernel
(\`_compute_token_lora_mapping_kernel\`) that:

- Per token: binary-search over \`seg_indptr\` to find the owning request
  (unrolled to \`ceil(log2(num_reqs + 1))\` iterations, \`constexpr\` so Triton
  specializes the loop).
- Gather \`req_to_lora[req_idx]\` and store the int32 lora id.
- Mask out-of-range tokens to \`-1\` (slightly more defensive than the original,
  which would OOB-gather past \`seg_indptr[-1]\` if upstream invariants slipped).

\`_compute_token_lora_mapping\` now fast-paths through this kernel on CUDA/HIP
and keeps the original torch implementation as a CPU/XPU fallback. Edge cases
(\`num_tokens == 0\`, \`num_reqs == 0\`) are handled without launching anything.

Single-file change, contained in \`python/sglang/srt/lora/lora_moe_runners.py\`.
No kernel signature changes, no behavior changes to non-virtual-experts paths.

## A. Performance

### Kernel microbench (GB300, n=500 iters, warmup=50)

Wall time per call (includes Python launch overhead):

| config              |     M | reqs | fused (us) | ref (us) | speedup |
|---------------------|------:|-----:|-----------:|---------:|--------:|
| decode bs=128       |   128 |  128 |      21.39 |    37.50 |   1.75x |
| decode bs=256       |   256 |  256 |      20.47 |    42.61 |   2.08x |
| prefill 8x256       |  2048 |    8 |      21.40 |    42.04 |   1.96x |
| prefill 128x128     | 16384 |  128 |      23.26 |    37.50 |   1.61x |
| prefill 1x8192      |  8192 |    1 |      19.50 |    38.60 |   1.98x |

Per-call wall time roughly halves; kernel launch count drops 3→1 unconditionally
(profiler's \"3 torch kernels\" line item collapses).

### End-to-end (Qwen3-30B-A3B-Instruct-2507, TP=4, bs=128, in=8192, out=1024)

LoRA backend: triton + \`--experts-shared-outer-loras --lora-use-virtual-experts\`,
max rank 32. Triton attention used in both A/B (env did not support fa4); single
production run each (warmup dropped).

|                         | input_throughput (tok/s) | output_throughput (tok/s) |
|-------------------------|-------------------------:|--------------------------:|
| baseline (HEAD)         |                 29686.79 |                  10980.79 |
| after this patch        |                 29845.53 |                  11122.50 |
| **Δ**                   |              **+158.74** |               **+141.71** |
| **%**                   |              **+0.53%**  |               **+1.29%**  |

The e2e gain is an underestimate of headroom: triton attention dominates step
time in this env, so the LoRA path is a smaller fraction than under fa4. With
fa4 the same kernel-count reduction translates to a larger e2e %.

## B. Accuracy

This is a bit-exact change (the kernel produces int32 indices identical to
the original \`searchsorted + gather\`; downstream LoRA FP arithmetic is therefore
byte-identical to baseline).

### Kernel-level bit-exact sweep (CUDA)

174 shape configurations × 3 \`req_to_lora\` seeds = 522 sub-tests:

- decode bs ∈ {1, 2, 4, 8, 16, 32, 64, 96, 128, 192, 256, 320, 384, 448, 512}
- prefill bs ∈ {1, 4, 16, 64, 128} with random per-seq lens (8 seeds)
- pathological: single 8K/16K request; 64 small + 1 huge request

Result: **522/522 pass**, fused output \`torch.equal(...)\` matches reference.

### End-to-end logprob A/B (Qwen3-30B-A3B-Instruct-2507, TP=4, virtual experts)

Ran \`check_sglang_lora_correctness.py\` twice — once with this patch applied,
once with the patch \`git stash\`ed. Identical seeds, identical configuration.

| metric                  | baseline                | after this patch        |
|-------------------------|-------------------------|-------------------------|
| \`base first5 logprobs\`  | \`[-7.4476156..., -3.8782687..., ...]\` | identical |
| \`lora first5 logprobs\`  | \`[-6.17362642..., -0.10818254..., ...]\` | identical |
| \`KL(sglang, trainer)\`   | \`0.004630160517990589\`  | \`0.004630160517990589\`  |
| \`KL(sglang, orig_sampler)\` | \`0.00547971623018384\` | \`0.00547971623018384\`   |

Two runs are **byte-identical down to all printed decimals**.

## C. To-do (follow-up, separate PR)

After PR #24160 (\`[lora] Share MoE LoRA Info\`) merges, the natural follow-up
is to move this kernel's invocation out of the per-layer \`build_lora_hooks\`
into the per-batch precompute path introduced by that PR. With #24160's
\`MoELoRABatchInfo\` lifecycle, \`token_lora_mapping\` becomes another field
computed **once per batch** and reused across all MoE layers — multiplying
this patch's saving by the number of MoE layers (~48 for Qwen3-30B-A3B).

No work to do in this PR; the Triton kernel introduced here is the same one
that the per-batch hoist will call, so the two changes compose cleanly.

## Checklist

- [x] Format code with pre-commit
- [x] Provide accuracy and speed benchmark results (see A and B above)
- [x] Follow SGLang code style guidance
- [ ] Add unit tests — *no new tests added in this PR; correctness is covered
      by the existing LoRA accuracy harness (\`check_sglang_lora_correctness.py\`)
      and the in-PR bit-exact sweep above. Happy to add a \`test/srt/lora/\` test
      if reviewers prefer.*

Made with [Cursor](https://cursor.com)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26517416903](https://github.com/sgl-project/sglang/actions/runs/26517416903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26517415882](https://github.com/sgl-project/sglang/actions/runs/26517415882)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->