### PR TITLE
[Bugfix] Add missing get_contiguous_buf_infos to DeepSeekV4SingleKVPoolHost

### DIFF
--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -2,7 +2,7 @@
 
 import logging
 import weakref
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import psutil
 import torch
@@ -499,6 +499,19 @@ class DeepSeekV4SingleKVPoolHost(HiSparseHostPoolMixin):
     def free(self, indices: torch.Tensor) -> int:
         self.free_slots = torch.cat([self.free_slots, indices.cpu()])
         return len(indices)
+
+    def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        data_ptrs: List[int] = []
+        data_lens: List[int] = []
+        item_lens: List[int] = []
+
+        for buf in self.kv_buffer:
+            assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
+            data_ptrs.append(buf.data_ptr())
+            data_lens.append(buf.nbytes)
+            item_lens.append(buf[0].nbytes)
+
+        return data_ptrs, data_lens, item_lens
 
 
 class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):

--- a/python/sglang/srt/mem_cache/hisparse_memory_pool.py
+++ b/python/sglang/srt/mem_cache/hisparse_memory_pool.py
@@ -509,7 +509,7 @@ class DeepSeekV4SingleKVPoolHost(HiSparseHostPoolMixin):
             assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
             data_ptrs.append(buf.data_ptr())
             data_lens.append(buf.nbytes)
-            item_lens.append(buf[0].nbytes)
+            item_lens.append(self.page_size * buf[0].nbytes)
 
         return data_ptrs, data_lens, item_lens
 

--- a/test/manual/test_bugfix_26289.py
+++ b/test/manual/test_bugfix_26289.py
@@ -62,12 +62,14 @@ class TestDeepSeekV4SingleKVPoolHostGetContiguousBufInfos(unittest.TestCase):
         for i in range(layer_num):
             self.assertEqual(data_lens[i], host_pool.kv_buffer[i].nbytes)
 
-    def test_item_lens_match_row_sizes(self):
-        """Item lengths should match the byte size of one row in each layer."""
-        host_pool = self._make_host_pool(layer_num=2, dim=128)
+    def test_item_lens_match_page_sizes(self):
+        """Item lengths should match the byte size of one page in each layer."""
+        host_pool = self._make_host_pool(layer_num=2, dim=128, page_size=16)
         data_ptrs, data_lens, item_lens = host_pool.get_contiguous_buf_infos()
         for i in range(2):
-            self.assertEqual(item_lens[i], host_pool.kv_buffer[i][0].nbytes)
+            self.assertEqual(
+                item_lens[i], host_pool.page_size * host_pool.kv_buffer[i][0].nbytes
+            )
 
 
 if __name__ == "__main__":

--- a/test/manual/test_bugfix_26289.py
+++ b/test/manual/test_bugfix_26289.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for bugfix #26289: DeepSeekV4SingleKVPoolHost missing get_contiguous_buf_infos.
+
+When --enable-hisparse is used in PD disaggregation mode, the decode path
+calls transfer_kv_pool.get_contiguous_buf_infos(), but DeepSeekV4SingleKVPoolHost
+does not define this method, causing an AttributeError crash at startup.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.hisparse_memory_pool import DeepSeekV4SingleKVPoolHost
+
+
+class TestDeepSeekV4SingleKVPoolHostGetContiguousBufInfos(unittest.TestCase):
+
+    def _make_host_pool(self, layer_num=2, size=256, page_size=16, dim=64):
+        """Create a host pool without going through init_kv_buffer (which requires pin_memory)."""
+        host_pool = object.__new__(DeepSeekV4SingleKVPoolHost)
+        host_pool.layer_num = layer_num
+        host_pool.size = size
+        host_pool.page_size = page_size
+        host_pool.kv_cache_total_dim = dim
+        host_pool.dtype = torch.float16
+        # Create a small kv_buffer directly: shape (layer_num, size+page_size, dim)
+        host_pool.kv_buffer = torch.empty(
+            layer_num, size + page_size, dim, dtype=torch.float16
+        )
+        return host_pool
+
+    def test_get_contiguous_buf_infos_exists(self):
+        """Method should exist and be callable."""
+        host_pool = self._make_host_pool()
+        self.assertTrue(hasattr(host_pool, "get_contiguous_buf_infos"))
+        self.assertTrue(callable(host_pool.get_contiguous_buf_infos))
+
+    def test_get_contiguous_buf_infos_returns_three_lists(self):
+        """Should return (data_ptrs, data_lens, item_lens)."""
+        host_pool = self._make_host_pool(layer_num=2)
+        result = host_pool.get_contiguous_buf_infos()
+        self.assertEqual(len(result), 3)
+        data_ptrs, data_lens, item_lens = result
+        self.assertEqual(len(data_ptrs), 2)
+        self.assertEqual(len(data_lens), 2)
+        self.assertEqual(len(item_lens), 2)
+
+    def test_data_ptrs_are_ints(self):
+        """Data pointers should be integer memory addresses."""
+        host_pool = self._make_host_pool(layer_num=1)
+        data_ptrs, data_lens, item_lens = host_pool.get_contiguous_buf_infos()
+        for ptr in data_ptrs:
+            self.assertIsInstance(ptr, int)
+
+    def test_data_lens_match_buffer_sizes(self):
+        """Data lengths should match the byte size of each layer buffer."""
+        layer_num = 3
+        host_pool = self._make_host_pool(layer_num=layer_num)
+        data_ptrs, data_lens, item_lens = host_pool.get_contiguous_buf_infos()
+        self.assertEqual(len(data_lens), layer_num)
+        for i in range(layer_num):
+            self.assertEqual(data_lens[i], host_pool.kv_buffer[i].nbytes)
+
+    def test_item_lens_match_row_sizes(self):
+        """Item lengths should match the byte size of one row in each layer."""
+        host_pool = self._make_host_pool(layer_num=2, dim=128)
+        data_ptrs, data_lens, item_lens = host_pool.get_contiguous_buf_infos()
+        for i in range(2):
+            self.assertEqual(item_lens[i], host_pool.kv_buffer[i][0].nbytes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsv4_host_pool.py
+++ b/test/registered/unit/mem_cache/test_dsv4_host_pool.py
@@ -1,5 +1,4 @@
-"""
-Unit tests for bugfix #26289: DeepSeekV4SingleKVPoolHost missing get_contiguous_buf_infos.
+"""Unit tests for bugfix #26289: DeepSeekV4SingleKVPoolHost missing get_contiguous_buf_infos.
 
 When --enable-hisparse is used in PD disaggregation mode, the decode path
 calls transfer_kv_pool.get_contiguous_buf_infos(), but DeepSeekV4SingleKVPoolHost
@@ -7,14 +6,22 @@ does not define this method, causing an AttributeError crash at startup.
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.mem_cache.hisparse_memory_pool import DeepSeekV4SingleKVPoolHost
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.hisparse_memory_pool import (  # noqa: E402
+    DeepSeekV4SingleKVPoolHost,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
-class TestDeepSeekV4SingleKVPoolHostGetContiguousBufInfos(unittest.TestCase):
+class TestDeepSeekV4SingleKVPoolHostGetContiguousBufInfos(CustomTestCase):
 
     def _make_host_pool(self, layer_num=2, size=256, page_size=16, dim=64):
         """Create a host pool without going through init_kv_buffer (which requires pin_memory)."""
@@ -24,7 +31,6 @@ class TestDeepSeekV4SingleKVPoolHostGetContiguousBufInfos(unittest.TestCase):
         host_pool.page_size = page_size
         host_pool.kv_cache_total_dim = dim
         host_pool.dtype = torch.float16
-        # Create a small kv_buffer directly: shape (layer_num, size+page_size, dim)
         host_pool.kv_buffer = torch.empty(
             layer_num, size + page_size, dim, dtype=torch.float16
         )


### PR DESCRIPTION
## Motivation

Fixes #26289

`DeepSeekV4SingleKVPoolHost` is used as the `transfer_kv_pool` when `--enable-hisparse` is set in PD disaggregation mode. At startup, the decode path calls `transfer_kv_pool.get_contiguous_buf_infos()` to get buffer metadata for the transfer engine (Mooncake/RDMA), but `DeepSeekV4SingleKVPoolHost` does not define this method, causing an `AttributeError` crash.

Additionally, the `item_lens` in `get_contiguous_buf_infos` must be the page size in bytes (as required by the transfer engine protocol), not the token size. Since `kv_buffer` is token-granular, `buf[0].nbytes` returns the token size, causing incorrect transfer sizing.

## Modifications

- `python/sglang/srt/mem_cache/hisparse_memory_pool.py` (~13 lines): Add `get_contiguous_buf_infos()` method to `DeepSeekV4SingleKVPoolHost` following the same pattern as `DeepSeekV4TokenToKVPool`. Also fix `item_lens` to multiply by `page_size` so the transfer engine receives correct byte counts.
- `test/registered/unit/mem_cache/test_dsv4_host_pool.py` (new): 5 unit tests covering method existence, return structure, data types, buffer sizes, and page-size item_lens.

## Accuracy Tests

N/A — This is a startup crash fix. No runtime model inference code is affected. The method is called once during initialization to register buffer metadata with the transfer engine.

## Speed Tests and Profiling

N/A — Called once at server startup. No runtime performance impact.

## Checklist

- [x] Format with pre-commit (ruff, black, isort all pass)
- [x] Unit tests pass (5 tests, CPU-only, registered in base-a-test-cpu)
- [ ] CI tests (blocked — need run-ci label from admin)
