### PR TITLE
[Bugfix] Add protocol sampling parameter range validation

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -134,6 +134,27 @@ class AnthropicMessagesRequest(BaseModel):
             raise ValueError("max_tokens must be positive")
         return v
 
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature_range(cls, v):
+        if v is not None and not 0.0 <= v <= 1.0:
+            raise ValueError(f"temperature must be in [0, 1], got {v}")
+        return v
+
+    @field_validator("top_p")
+    @classmethod
+    def validate_top_p_range(cls, v):
+        if v is not None and not 0.0 <= v <= 1.0:
+            raise ValueError(f"top_p must be in [0, 1], got {v}")
+        return v
+
+    @field_validator("top_k")
+    @classmethod
+    def validate_top_k_range(cls, v):
+        if v is not None and not 0 <= v <= 500:
+            raise ValueError(f"top_k must be in [0, 500], got {v}")
+        return v
+
 
 class AnthropicDelta(BaseModel):
     """Delta for streaming responses"""

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -65,6 +65,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL_NAME = "default"
 
 
+def _validate_temperature_range(v):
+    if v is not None and not 0.0 <= v <= 2.0:
+        raise ValueError(f"temperature must be in [0, 2], got {v}")
+    return v
+
+
 class ModelCard(BaseModel):
     """Model cards."""
 
@@ -382,6 +388,11 @@ class CompletionRequest(BaseModel):
         if v is not None and v <= 0:
             raise ValueError("max_tokens must be positive")
         return v
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature_range(cls, v):
+        return _validate_temperature_range(v)
 
 
 class SglExt(BaseModel):
@@ -758,6 +769,11 @@ class ChatCompletionRequest(BaseModel):
     @classmethod
     def _handle_deprecated_dp_rank(cls, values):
         return _migrate_deprecated_dp_rank(values)
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature_range(cls, v):
+        return _validate_temperature_range(v)
 
     @model_validator(mode="before")
     @classmethod
@@ -1355,6 +1371,11 @@ class ResponsesRequest(BaseModel):
         "min_p": 0.0,
         "repetition_penalty": 1.0,
     }
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature_range(cls, v):
+        return _validate_temperature_range(v)
 
     def to_sampling_params(
         self, default_max_tokens: int, default_params: Optional[Dict] = None

--- a/test/registered/unit/entrypoints/anthropic/test_protocol.py
+++ b/test/registered/unit/entrypoints/anthropic/test_protocol.py
@@ -1,0 +1,58 @@
+"""Tests for Anthropic API protocol models"""
+
+import unittest
+
+from pydantic import ValidationError
+
+from sglang.srt.entrypoints.anthropic.protocol import AnthropicMessagesRequest
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+
+
+class TestAnthropicMessagesRequest(unittest.TestCase):
+    def _make_request(self, **kwargs):
+        data = {
+            "model": "claude-test",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 16,
+        }
+        data.update(kwargs)
+        return AnthropicMessagesRequest(**data)
+
+    def test_temperature_range(self):
+        self._make_request(temperature=0.0)
+        self._make_request(temperature=1.0)
+        self._make_request(temperature=None)
+
+        with self.assertRaises(ValidationError):
+            self._make_request(temperature=-0.1)
+
+        with self.assertRaises(ValidationError):
+            self._make_request(temperature=1.1)
+
+    def test_top_p_range(self):
+        self._make_request(top_p=0.0)
+        self._make_request(top_p=1.0)
+        self._make_request(top_p=None)
+
+        with self.assertRaises(ValidationError):
+            self._make_request(top_p=-0.1)
+
+        with self.assertRaises(ValidationError):
+            self._make_request(top_p=1.1)
+
+    def test_top_k_range(self):
+        self._make_request(top_k=0)
+        self._make_request(top_k=500)
+        self._make_request(top_k=None)
+
+        with self.assertRaises(ValidationError):
+            self._make_request(top_k=-1)
+
+        with self.assertRaises(ValidationError):
+            self._make_request(top_k=501)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -27,6 +27,7 @@ from sglang.srt.entrypoints.openai.protocol import (
     Function,
     ModelCard,
     ModelList,
+    ResponsesRequest,
     Tool,
     UsageInfo,
 )
@@ -82,6 +83,16 @@ class TestCompletionRequest(unittest.TestCase):
         self.assertFalse(request.stream)  # default
         self.assertFalse(request.echo)  # default
 
+    def test_completion_request_temperature_range(self):
+        CompletionRequest(model="test-model", prompt="Hello", temperature=0.0)
+        CompletionRequest(model="test-model", prompt="Hello", temperature=2.0)
+
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", temperature=-0.1)
+
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", temperature=2.1)
+
     def test_completion_request_sglang_extensions(self):
         """Test completion request with SGLang-specific extensions"""
         request = CompletionRequest(
@@ -124,6 +135,22 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertEqual(request.temperature, None)  # default
         self.assertFalse(request.stream)  # default
         self.assertEqual(request.tool_choice, "none")  # default when no tools
+
+    def test_chat_completion_temperature_range(self):
+        messages = [{"role": "user", "content": "Hello"}]
+        ChatCompletionRequest(model="test-model", messages=messages, temperature=0.0)
+        ChatCompletionRequest(model="test-model", messages=messages, temperature=2.0)
+        ChatCompletionRequest(model="test-model", messages=messages, temperature=None)
+
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model", messages=messages, temperature=-0.1
+            )
+
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(
+                model="test-model", messages=messages, temperature=2.1
+            )
 
     def test_sampling_param_build(self):
         req = ChatCompletionRequest(
@@ -325,6 +352,19 @@ class TestChatCompletionRequest(unittest.TestCase):
         strict = json_format.strict
         self.assertEqual(name, "VoiceNote")
         self.assertEqual(strict, True)
+
+
+class TestResponsesRequest(unittest.TestCase):
+    def test_responses_request_temperature_range(self):
+        ResponsesRequest(input="Hello", temperature=0.0)
+        ResponsesRequest(input="Hello", temperature=2.0)
+        ResponsesRequest(input="Hello", temperature=None)
+
+        with self.assertRaises(ValidationError):
+            ResponsesRequest(input="Hello", temperature=-0.1)
+
+        with self.assertRaises(ValidationError):
+            ResponsesRequest(input="Hello", temperature=2.1)
 
 
 class TestModelSerialization(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Protocol request models should reject sampling parameters outside each API's documented ranges before forwarding requests to SGLang's internal sampling layer.

## Modifications

- Add OpenAI protocol-level `temperature` range validation for:
  - `CompletionRequest`: [0, 2]
  - `ChatCompletionRequest`: [0, 2]
  - `ResponsesRequest`: [0, 2]
- Add Anthropic Messages protocol-level range validation for:
  - `temperature`: [0, 1]
  - `top_p`: [0, 1]
  - `top_k`: [0, 500]
- Keep SGLang's internal `SamplingParams` validation unchanged so native/non-protocol paths are not affected.
- Add unit coverage for lower/upper boundary values, `None` values where applicable, and out-of-range values.

## Accuracy Tests

Not needed; this is request validation only and does not change model outputs for valid requests.

## Speed Tests and Profiling

Not needed; this adds only Pydantic request validation.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [ ] Update documentation (not needed for this validation-only change)
- [ ] Provide accuracy and speed benchmark results (not needed for this validation-only change)
- [x] Follow the SGLang code style guidance





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26526088272](https://github.com/sgl-project/sglang/actions/runs/26526088272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26526088168](https://github.com/sgl-project/sglang/actions/runs/26526088168)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->