### PR TITLE
Remove DeepGEMM for indexer GEMM in piecewise NSA path

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -162,12 +162,7 @@ if _is_cuda:
         softmax_scale: float,
         q_scale: torch.Tensor,
     ) -> torch.Tensor:
-        from sglang.srt.layers.deep_gemm_wrapper import entrypoint as deep_gemm_wrapper
-
-        out = torch.empty(
-            (x.shape[0], weight.shape[0]), dtype=torch.float32, device=x.device
-        )
-        deep_gemm_wrapper.gemm_nt_bf16bf16f32(x, weight, out)
+        out = torch.mm(x, weight.t(), out_dtype=torch.float32)
         weights = out * n_heads_inv_sqrt
         weights = weights.unsqueeze(-1) * q_scale * softmax_scale
         return weights


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Remove it in piecewise CUDA graph path, which seems to be accidentally reintroduced in https://github.com/sgl-project/sglang/pull/23351 due to PRs merging at different times. Additionally, it will increase the warmup time
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Remove it.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
It's already been validated in https://github.com/sgl-project/sglang/pull/23856
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
Unit benchmark with CUPTI. 
Results: (only N = 64 and N = 32 are relevant for indexer for DSV3.2 and GLM-5), the rest are Deepseek V4 shapes, which shows we could remove it from Deepseek V4 path later (currently not used on default path anyway)
<img width="8365" height="3267" alt="image" src="https://github.com/user-attachments/assets/94cc7082-8a55-4c6e-a76c-cce5b8cc50dd" />









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26527866613](https://github.com/sgl-project/sglang/actions/runs/26527866613)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26527866300](https://github.com/sgl-project/sglang/actions/runs/26527866300)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->