### PR TITLE
fix(metrics_reporter): flush num_running_reqs gauge on active→idle transition

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -1049,7 +1049,7 @@ class SchedulerMetricsReporter:
             self.fwd_occupancy = float("nan")
 
     def _maybe_log_idle_metrics(self):
-        """Collect and log metrics on entry to idle, then every 30 s during idle.
+        """Flush on each active→idle transition, then throttle to 30 s during idle.
 
         The active path (report_prefill_stats / report_decode_stats) logs
         ``num_running_reqs = len(batch.reqs)`` *before* finished requests are
@@ -1057,8 +1057,10 @@ class SchedulerMetricsReporter:
         the gauge sits at the last batch size for up to 30 s after the server
         becomes idle, which trips clients that poll in-flight counters to
         detect server idleness. ``_idle_flush_pending`` is set by the active
-        path on every emit, so the first idle iteration after active work
-        bypasses the throttle; subsequent idle iterations throttle as before.
+        path on every emit and cleared here, so the first idle iteration
+        after each active→idle transition bypasses the throttle; subsequent
+        idle iterations throttle as before. The flag is single-writer /
+        single-reader on the scheduler main loop, so no lock is needed.
         """
         if not self.current_scheduler_metrics_enabled:
             return

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -126,6 +126,11 @@ class SchedulerMetricsReporter:
         self.last_input_throughput: float = 0.0
         self.step_time_dict = defaultdict(list)  # Dict[batch size -> step time]
         self.stats = SchedulerStats()
+        # Set by the active path (report_prefill_stats / report_decode_stats)
+        # whenever it emits a log_stats. The first idle iteration after that
+        # flushes the gauge bypassing the 30 s throttle so the post-finish
+        # drop to 0 is visible to Prometheus scrapers immediately.
+        self._idle_flush_pending = False
         self._graph_backend_label = {
             "cpu": "cpu graph",
             "npu": "npu graph",
@@ -657,6 +662,7 @@ class SchedulerMetricsReporter:
             self._update_lora_metrics()
             self._log_hicache_stats()
             self.metrics_collector.log_stats(self.stats)
+            self._idle_flush_pending = True
             self.scheduler.kv_events_publisher.emit_kv_metrics()
         self.scheduler.kv_events_publisher.publish_kv_events()
 
@@ -875,6 +881,7 @@ class SchedulerMetricsReporter:
             self._update_lora_metrics()
             self._log_hicache_stats()
             self.metrics_collector.log_stats(self.stats)
+            self._idle_flush_pending = True
             self.scheduler.kv_events_publisher.emit_kv_metrics()
         self.scheduler.kv_events_publisher.publish_kv_events()
 
@@ -1042,10 +1049,22 @@ class SchedulerMetricsReporter:
             self.fwd_occupancy = float("nan")
 
     def _maybe_log_idle_metrics(self):
-        """Collect and log metrics every 30 seconds during idle."""
+        """Collect and log metrics on entry to idle, then every 30 s during idle.
+
+        The active path (report_prefill_stats / report_decode_stats) logs
+        ``num_running_reqs = len(batch.reqs)`` *before* finished requests are
+        filtered out by ``get_next_batch_to_run``. Without a transition flush
+        the gauge sits at the last batch size for up to 30 s after the server
+        becomes idle, which trips clients that poll in-flight counters to
+        detect server idleness. ``_idle_flush_pending`` is set by the active
+        path on every emit, so the first idle iteration after active work
+        bypasses the throttle; subsequent idle iterations throttle as before.
+        """
+        if not self.current_scheduler_metrics_enabled:
+            return
         if (
-            not self.current_scheduler_metrics_enabled
-            or time.perf_counter() <= self.metrics_collector.last_log_time + 30
+            not self._idle_flush_pending
+            and time.perf_counter() <= self.metrics_collector.last_log_time + 30
         ):
             return
 
@@ -1083,3 +1102,4 @@ class SchedulerMetricsReporter:
                 self.scheduler.disagg_decode_transfer_queue.queue, priority_enabled
             )
         self.metrics_collector.log_stats(self.stats)
+        self._idle_flush_pending = False

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -661,8 +661,11 @@ class SchedulerMetricsReporter:
             self.stats.fwd_occupancy = self.fwd_occupancy
             self._update_lora_metrics()
             self._log_hicache_stats()
-            self.metrics_collector.log_stats(self.stats)
+            # Mark the flush invariant before emitting so a log_stats
+            # exception cannot leave the next idle iteration throttled
+            # back to the 30 s stale-gauge state.
             self._idle_flush_pending = True
+            self.metrics_collector.log_stats(self.stats)
             self.scheduler.kv_events_publisher.emit_kv_metrics()
         self.scheduler.kv_events_publisher.publish_kv_events()
 
@@ -880,8 +883,11 @@ class SchedulerMetricsReporter:
             self.stats.fwd_occupancy = self.fwd_occupancy
             self._update_lora_metrics()
             self._log_hicache_stats()
-            self.metrics_collector.log_stats(self.stats)
+            # See report_prefill_stats — flag the flush invariant before
+            # emitting so an exception in log_stats does not regress to
+            # the 30 s stale-gauge throttle.
             self._idle_flush_pending = True
+            self.metrics_collector.log_stats(self.stats)
             self.scheduler.kv_events_publisher.emit_kv_metrics()
         self.scheduler.kv_events_publisher.publish_kv_events()
 

--- a/test/manual/test_metrics_reporter_idle_flush.py
+++ b/test/manual/test_metrics_reporter_idle_flush.py
@@ -1,0 +1,85 @@
+"""Manual unit test for _maybe_log_idle_metrics idle-flush behavior.
+
+Verifies that the active→idle transition flush bypasses the 30 s idle
+throttle on the first idle iteration, but subsequent idle iterations
+still throttle as before. Pure mock-based (no GPU, no scheduler loop).
+
+Usage:
+    python3 -m unittest test/manual/test_metrics_reporter_idle_flush.py
+    python3 test/manual/test_metrics_reporter_idle_flush.py
+"""
+
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.scheduler_components.metrics_reporter import (
+    SchedulerMetricsReporter,
+)
+
+
+def _make_reporter():
+    """Stub with just enough state for _maybe_log_idle_metrics to run."""
+    r = MagicMock(spec=SchedulerMetricsReporter)
+    r._idle_flush_pending = False
+    r.current_scheduler_metrics_enabled = True
+    r.metrics_collector = MagicMock()
+    r.metrics_collector.last_log_time = time.perf_counter()
+    r.scheduler = MagicMock()
+    r.scheduler.disaggregation_mode = None  # neither PREFILL nor DECODE branch
+    r.scheduler.enable_priority_scheduling = False
+    r.scheduler.running_batch = MagicMock(reqs=[])
+    r.scheduler.waiting_queue = []
+    r.scheduler.grammar_manager = []
+    pool_stats = MagicMock()
+    pool_stats.update_scheduler_stats = MagicMock()
+    r.scheduler.pool_stats_observer = MagicMock()
+    r.scheduler.pool_stats_observer.get_pool_stats.return_value = pool_stats
+    r.scheduler.pool_stats_observer.streaming_session_count.return_value = 0
+    r.scheduler.pool_stats_observer.session_held_tokens.return_value = 0
+    r.stats = MagicMock()
+    return r
+
+
+class TestIdleMetricFlush(unittest.TestCase):
+    def test_throttle_blocks_when_no_flush_pending(self):
+        r = _make_reporter()
+        r._idle_flush_pending = False
+        SchedulerMetricsReporter._maybe_log_idle_metrics(r)
+        r.metrics_collector.log_stats.assert_not_called()
+
+    def test_pending_flag_bypasses_throttle(self):
+        r = _make_reporter()
+        r._idle_flush_pending = True
+        SchedulerMetricsReporter._maybe_log_idle_metrics(r)
+        r.metrics_collector.log_stats.assert_called_once()
+        self.assertFalse(
+            r._idle_flush_pending,
+            "flag should be cleared after the transition flush",
+        )
+
+    def test_throttle_expires_after_30s(self):
+        r = _make_reporter()
+        r._idle_flush_pending = False
+        r.metrics_collector.last_log_time = time.perf_counter() - 31  # 31 s ago
+        SchedulerMetricsReporter._maybe_log_idle_metrics(r)
+        r.metrics_collector.log_stats.assert_called_once()
+
+    def test_disabled_metrics_short_circuits(self):
+        r = _make_reporter()
+        r._idle_flush_pending = True
+        r.current_scheduler_metrics_enabled = False
+        SchedulerMetricsReporter._maybe_log_idle_metrics(r)
+        r.metrics_collector.log_stats.assert_not_called()
+
+    def test_second_idle_iter_after_flush_throttled(self):
+        r = _make_reporter()
+        r._idle_flush_pending = True
+        SchedulerMetricsReporter._maybe_log_idle_metrics(r)  # first flush
+        r.metrics_collector.log_stats.reset_mock()
+        SchedulerMetricsReporter._maybe_log_idle_metrics(r)  # immediately again
+        r.metrics_collector.log_stats.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_metrics_reporter_idle_flush.py
+++ b/test/registered/unit/managers/test_metrics_reporter_idle_flush.py
@@ -1,13 +1,14 @@
-"""Manual unit test for _maybe_log_idle_metrics idle-flush behavior.
+"""Unit tests for SchedulerMetricsReporter._maybe_log_idle_metrics idle flush.
 
 Verifies that the active→idle transition flush bypasses the 30 s idle
 throttle on the first idle iteration, but subsequent idle iterations
-still throttle as before. Pure mock-based (no GPU, no scheduler loop).
-
-Usage:
-    python3 -m unittest test/manual/test_metrics_reporter_idle_flush.py
-    python3 test/manual/test_metrics_reporter_idle_flush.py
+still throttle as before. Mock-based — no scheduler loop, no GPU,
+no server process.
 """
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import time
 import unittest
@@ -16,6 +17,7 @@ from unittest.mock import MagicMock
 from sglang.srt.managers.scheduler_components.metrics_reporter import (
     SchedulerMetricsReporter,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_reporter():
@@ -41,7 +43,7 @@ def _make_reporter():
     return r
 
 
-class TestIdleMetricFlush(unittest.TestCase):
+class TestIdleMetricFlush(CustomTestCase):
     def test_throttle_blocks_when_no_flush_pending(self):
         r = _make_reporter()
         r._idle_flush_pending = False


### PR DESCRIPTION
## Motivation

The `sglang:num_running_reqs` Prometheus gauge can stay frozen at the last batch's running-request count for up to 30 seconds after the scheduler becomes idle. This trips any downstream consumer that polls the gauge to detect server idleness — for example, orchestration code that waits for `num_running_reqs == 0` before tearing down metric pollers will block for the full throttle window even though the scheduler is already idle.

I verified the gap concretely on a GB300 disaggregated dynamo + SGLang DeepSeek-V4-Flash run:

| Time (UTC) | scheduler state | gauge value |
|---|---|---|
| `18:11:10` | last `Decode batch` log emitted | 24 |
| `18:11:11` | scheduler enters `on_idle()` | 24 (stuck) |
| `18:11:11 – 18:11:40` | idle (no decode events) | 24 (stuck) |
| `18:11:41` | first idle-path flush after throttle | 0 |

i.e. exactly the throttle interval, ~30 s late.

## Root cause

There are two pieces working against each other in `scheduler_components/metrics_reporter.py`:

1. **Active path** (`report_prefill_stats` / `report_decode_stats`) logs the gauge as `num_running_reqs = len(batch.reqs)` **before** finished requests are filtered out by `get_next_batch_to_run` on the next iteration. So the *last* active-path emit always reports the pre-finish batch size.

2. **Idle path** (`_maybe_log_idle_metrics`, called from `Scheduler.on_idle()`) throttles all emits to once per 30 s during idle to keep the metric stream quiet:

   ```python
   if (
       not self.current_scheduler_metrics_enabled
       or time.perf_counter() <= self.metrics_collector.last_log_time + 30
   ):
       return
   ```

   The throttle is reasonable in steady idle, but it also gates the *first* idle iteration after work completes — which is exactly the iteration where the gauge needs to flip from the last batch size to 0.

## Fix

Track an `_idle_flush_pending` flag that the active path sets after each successful emit, and let `_maybe_log_idle_metrics` bypass the throttle (just once) when that flag is set. The throttle is preserved for subsequent idle iterations:

- Active emits: `self._idle_flush_pending = True`
- First idle emit after active work: bypass throttle, flush, then clear the flag.
- Subsequent idle emits: throttle as before.

Effect: at the moment the scheduler transitions from active → idle, the first `on_idle()` iteration recomputes the queue counts (`running_batch.reqs` now empty) and emits them immediately — gauge flips to 0 within the next scrape interval. Steady-idle behavior is unchanged.

_Companion gauges (`num_queue_reqs`, `num_prefill_inflight_queue_reqs`, `num_decode_prealloc_queue_reqs`, `gen_throughput`, `streaming_session_held_tokens`, …) ride the same `log_stats(self.stats)` call and are re-emitted at the transition along with `num_running_reqs`. Counter-type metrics (`increment_realtime_tokens` etc.) are unaffected — they're monotonic and don't have the stale-gauge problem._

## Validation

End-to-end run on the same GB300 dsv4-flash workload, with the patch in:

| Transition | Before patch | After patch |
|---|---|---|
| warmup last sample → idle first sample | gauge `24 → 24` (stuck 30 s) | gauge `11 → 0` (next 1 s scrape) |
| benchmark last sample → idle first sample | gauge `24 → 20` (stuck 30 s) | gauge `5 → 0` (next 1 s scrape) |

Downstream BTK polling that previously observed a phantom 30 s tail now closes cleanly with the final scrape at 0. No regression in steady-state polling rate.

## Alternatives considered

- **Lower the throttle (30 s → 1 s)** — simplest one-liner, but defeats the noise-reduction intent and increases idle scrape volume 30×.
- **Filter finished requests inside `report_decode_stats` before `len(batch.reqs)`** — addresses the count itself rather than the emit cadence. More invasive (touches the batch lifecycle inside `process_batch_result`), with risk of side effects on speculative-decoding and disagg paths.
- **Event-driven flush via an explicit scheduler signal on idle entry** — cleanest in principle, but requires plumbing across `scheduler.py` and `metrics_reporter.py`. Larger diff for the same observable behavior.

The flag-based approach keeps the change local to the existing throttle and preserves the original `_maybe_log_idle_metrics` semantics outside the transition iteration.

## Test plan

- [x] Manual end-to-end run on GB300 disaggregated dynamo + SGLang DeepSeek-V4-Flash, confirmed gauge transitions to 0 on the first idle scrape rather than 30 s later.
- [x] Verified active steady-state polling rate unchanged.
- [x] CI: existing metrics_reporter tests pass.



























































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #28498357137](https://github.com/sgl-project/sglang/actions/runs/28498357137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28498357034](https://github.com/sgl-project/sglang/actions/runs/28498357034)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->