### PR TITLE
fix: guard zero-token chunk in bench_serving retokenized ITL

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1009,6 +1009,8 @@ def calculate_metrics(
                             outputs[i].text_chunks[k], add_special_tokens=False
                         )
                     )
+                    if num_tokens == 0:
+                        continue
                     adjusted_itl = itl / num_tokens
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
             else:


### PR DESCRIPTION
## Summary

When EAGLE / MTP is enabled and `bench_serving` runs against `sglang-oai`, `calculate_metrics` retokenizes each streamed `text_chunk` to compute an adjusted ITL. Some streamed chunks (whitespace-only, empty, or special-marker-only) retokenize to **zero tokens**, which causes a `ZeroDivisionError` at:

```python
adjusted_itl = itl / num_tokens
```

This PR adds a guard that skips chunks retokenizing to zero tokens — they carry no ITL signal, so dropping them is safe and matches the spirit of the surrounding loop.

## Reproducer

DeepSeek-R1 + EAGLE/MTP, `bench_serving --backend sglang-oai`:

```
File "python/sglang/bench_serving.py", line 1009, in calculate_metrics
    adjusted_itl = itl / num_tokens
                   ~~~~^~~~~~~~~~~~
ZeroDivisionError: float division by zero
```

## Change

```diff
                     num_tokens = len(
                         tokenizer.encode(
                             outputs[i].text_chunks[k], add_special_tokens=False
                         )
                     )
+                    if num_tokens == 0:
+                        continue
                     adjusted_itl = itl / num_tokens
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
```

## Checklist

- [x] Bug only triggers on the combination `accept_length > 0` (EAGLE/MTP) + `backend in {sglang-oai, sglang-oai-chat}`
- [x] Fix is a strict superset of the previous behavior — non-zero-token chunks are unchanged
- [x] Reported TTFT / TPOT / E2E latency unchanged for runs that did not previously crash
- [x] Retokenized ITL distribution differs only by the now-skipped zero-token chunks







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26530264204](https://github.com/sgl-project/sglang/actions/runs/26530264204)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26530264392](https://github.com/sgl-project/sglang/actions/runs/26530264392)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->