### PR TITLE
[Fix] mm processor double bos

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -201,6 +201,12 @@ class BaseMultimodalProcessor(ABC):
         else:
             self._tokenizer = self._processor
 
+        # Same guard as in serving_chat.py against double BOS.
+        try:
+            self._tokenizer_auto_adds_specials = len(self._tokenizer.encode("")) > 0
+        except Exception:
+            self._tokenizer_auto_adds_specials = False
+
         # FIXME: not accurate, model and image specific
         self.NUM_TOKEN_PER_FRAME = 330
 
@@ -453,6 +459,12 @@ class BaseMultimodalProcessor(ABC):
 
                 npu_apply_qwen_image_preprocess_patch()
                 kwargs["device"] = "npu"
+
+        # Avoid double BOS when the chat template already wrote one.
+        if self._tokenizer_auto_adds_specials and isinstance(input_text, str):
+            bos = getattr(self._tokenizer, "bos_token", None)
+            if bos and input_text.startswith(bos):
+                kwargs.setdefault("add_special_tokens", False)
 
         result = processor.__call__(
             text=[input_text],

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -132,6 +132,8 @@ class TestProcessMmDataKwargs(unittest.TestCase):
 
         proc.server_args = server_args
         proc._processor = mock_processor
+        proc._tokenizer = MagicMock()
+        proc._tokenizer_auto_adds_specials = False
         proc.image_config = mm_process_config.get("image", {})
         proc.video_config = mm_process_config.get("video", {})
         proc.audio_config = mm_process_config.get("audio", {})
@@ -284,6 +286,49 @@ class TestOverrideProcessorsConfigInjection(unittest.TestCase):
         audio_kw = call_kwargs.kwargs.get("audio_kwargs", {})
         # User config can override truncation if they explicitly set it
         self.assertTrue(audio_kw.get("truncation"))
+
+
+class TestDoubleBosGuard(unittest.TestCase):
+    """Regression test for the multimodal double-BOS bug.
+
+    Repro condition (Cohere2 / Llama3-LLaVA-Next family):
+      - tokenizer.encode("") returns [bos_id]  (auto-adds specials), AND
+      - chat template renders the BOS string as a literal at the start.
+
+    Without the guard in BaseMultimodalProcessor, the inner processor.__call__
+    on the rendered prompt would auto-prepend a second BOS, producing 2 leading
+    BOS tokens vs the HF reference's 1.
+    """
+
+    def test_guard_passes_add_special_tokens_false_on_bug_condition(self):
+        from sglang.srt.multimodal.processors.base_processor import (
+            BaseMultimodalProcessor,
+        )
+
+        server_args = MagicMock()
+        server_args.mm_process_config = {}
+        server_args.disable_fast_image_processor = True
+        server_args.keep_mm_feature_on_device = True
+
+        mock_hf_processor = MagicMock()
+        mock_hf_processor.__class__.__name__ = "TestProcessor"
+        mock_hf_processor.__call__ = MagicMock(return_value={})
+        mock_hf_processor.tokenizer.encode = MagicMock(return_value=[2])
+        mock_hf_processor.tokenizer.bos_token = "<BOS>"
+
+        with patch.object(BaseMultimodalProcessor, "__abstractmethods__", set()):
+            proc = BaseMultimodalProcessor(
+                hf_config=MagicMock(),
+                server_args=server_args,
+                _processor=mock_hf_processor,
+                transport_mode=None,
+            )
+        proc.FEATURE_NAMES = []
+
+        proc.process_mm_data("<BOS>hello", images=["img1"])
+
+        call_kwargs = mock_hf_processor.__call__.call_args.kwargs
+        self.assertEqual(call_kwargs.get("add_special_tokens"), False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

For multimodal requests where the chat template renders a literal BOS string (e.g. `<BOS_TOKEN>` for Cohere2, `<|begin_of_text|>` for Llama3-LLaVA-Next) and the tokenizer also auto-adds BOS on encode, `BaseMultimodalProcessor.process_mm_data` was producing 2 leading BOS tokens vs the HF reference's 1. 

We mirror the existing guard in `serving_chat.py`, detect the auto-add behavior in `__init__` and pass `add_special_tokens=False` to the inner processor call when the rendered input already starts with the BOS literal.

Note that, the existing guard in `serving_chat.py` only covers its own tokenize step; the multimodal path forwards the rendered prompt string to `BaseMultimodalProcessor` (discarding `prompt_ids`), which re-tokenizes via `processor.__call__` with no guard, so the fix has to live at the multimodal processor layer.

A unit test is added for this fix.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Before fix:

```
[text-only OpenAI chat]
  [A] HF ref     len=120  BOS=1  first5=[2, 255000, 255004, 255012, 8928]
  [B] sglang     len=120  BOS=1  first5=[2, 255000, 255004, 255012, 8928]

[multimodal OpenAI chat (with image)]
  [A] HF ref     len=377  BOS=1  first5=[2, 255000, 255004, 255012, 8928]
  [B] sglang     len=378  BOS=2  first5=[2, 2, 255000, 255004, 255012]
```

After fix:

```
[text-only OpenAI chat]
  [A] HF ref     len=120  BOS=1  first5=[2, 255000, 255004, 255012, 8928]
  [B] sglang     len=120  BOS=1  first5=[2, 255000, 255004, 255012, 8928]

[multimodal OpenAI chat (with image)]
  [A] HF ref     len=377  BOS=1  first5=[2, 255000, 255004, 255012, 8928]
  [B] sglang     len=377  BOS=1  first5=[2, 255000, 255004, 255012, 8928]
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26540140252](https://github.com/sgl-project/sglang/actions/runs/26540140252)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26540140213](https://github.com/sgl-project/sglang/actions/runs/26540140213)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->