### PR TITLE
Fix FlashInfer SWA EXTEND-with-prefix correctness in merge_state path

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -864,12 +864,21 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
 
             else:
+                swa_window_left = (
+                    layer.sliding_window_size
+                    if not (
+                        self.forward_metadata.multi_item_params
+                        and self.forward_metadata.multi_item_params.is_enabled()
+                    )
+                    else -1
+                )
                 o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
                     q.view(-1, layer.tp_q_head_num, layer.head_dim),
                     k.view(-1, layer.tp_k_head_num, layer.head_dim),
                     v.view(-1, layer.tp_v_head_num, layer.head_dim),
                     causal=causal,
                     sm_scale=layer.scaling,
+                    window_left=swa_window_left,
                     logits_soft_cap=logits_soft_cap,
                 )
                 o2, s2 = prefill_wrapper_paged.forward_return_lse(
@@ -877,6 +886,7 @@ class FlashInferAttnBackend(AttentionBackend):
                     self.token_to_kv_pool.get_kv_buffer(layer.layer_id),
                     causal=False,
                     sm_scale=layer.scaling,
+                    window_left=swa_window_left,
                     logits_soft_cap=logits_soft_cap,
                 )
 
@@ -1309,19 +1319,34 @@ class FlashInferIndicesUpdaterPrefill:
         cross_attention_custom_mask: Optional[torch.Tensor] = None,
     ):
         for wrapper_id in range(2):
+            swa_paged_custom_mask = None
             if wrapper_id == 0:
-                # window attention use paged only
-                paged_kernel_lens = torch.minimum(
-                    seq_lens,
-                    torch.tensor(self.sliding_window_size) + seq_lens - prefix_lens,
-                )
-                paged_kernel_lens_sum = paged_kernel_lens.sum().item()
+                if use_ragged:
+                    # K for extend tokens is written after the paged wrapper runs, so
+                    # the paged wrapper sees prefix-only. Trim to the last `window` tokens
+                    # (required for SWATokenToKVPoolAllocator; also keeps mask O(window)).
+                    effective_start = torch.clamp(
+                        prefix_lens - self.sliding_window_size, min=0
+                    )
+                    paged_kernel_lens = prefix_lens - effective_start
+                    paged_kernel_lens_sum = paged_kernel_lens.sum().item()
+                    kv_start_idx = effective_start
+                    swa_paged_custom_mask = self._build_swa_prefix_custom_mask(
+                        prefix_lens, seq_lens, effective_start
+                    )
+                else:
+                    # window attention use paged only
+                    paged_kernel_lens = torch.minimum(
+                        seq_lens,
+                        torch.tensor(self.sliding_window_size) + seq_lens - prefix_lens,
+                    )
+                    paged_kernel_lens_sum = paged_kernel_lens.sum().item()
+                    kv_start_idx = seq_lens - paged_kernel_lens
             else:
                 # full attention
                 paged_kernel_lens = seq_lens
                 paged_kernel_lens_sum = seq_lens_sum
-
-            kv_start_idx = seq_lens - paged_kernel_lens
+                kv_start_idx = seq_lens - paged_kernel_lens
             use_sliding_window_kv_pool = wrapper_id == 0 and isinstance(
                 self.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator
             )
@@ -1341,7 +1366,49 @@ class FlashInferIndicesUpdaterPrefill:
                 spec_info,
                 use_sliding_window_kv_pool=use_sliding_window_kv_pool,
                 multi_item_params=multi_item_params,
+                cross_attention_custom_mask=swa_paged_custom_mask,
             )
+
+    def _build_swa_prefix_custom_mask(
+        self,
+        prefix_lens: torch.Tensor,
+        seq_lens: torch.Tensor,
+        kv_start_idx: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        """Custom SWA mask for the paged wrapper in the ragged merge_state EXTEND path.
+
+        Paged KV covers absolute positions [kv_start_idx[i], prefix_lens[i]).
+        Returns None when every key is in-window for every extend query.
+        """
+        window = self.sliding_window_size
+        if window is None or window < 0:
+            return None
+
+        prefix_lens_cpu = prefix_lens.detach().cpu().tolist()
+        extend_lens_cpu = (seq_lens - prefix_lens).detach().cpu().tolist()
+        kv_start_cpu = kv_start_idx.detach().cpu().tolist()
+        if all(p == 0 for p in prefix_lens_cpu):
+            return None
+
+        device = prefix_lens.device
+        mask_parts: List[torch.Tensor] = []
+        need_mask = False
+        for prefix_len, extend_len, kv_start in zip(
+            prefix_lens_cpu, extend_lens_cpu, kv_start_cpu
+        ):
+            paged_len = int(prefix_len - kv_start)  # = min(prefix_len, window)
+            if paged_len == 0 or extend_len == 0:
+                continue
+            q_abs = torch.arange(extend_len, device=device).view(-1, 1) + prefix_len
+            k_abs = torch.arange(paged_len, device=device).view(1, -1) + kv_start
+            block = (k_abs >= (q_abs - window)).to(torch.uint8)
+            if not bool(block.all()):
+                need_mask = True
+            mask_parts.append(block.view(-1))
+
+        if not need_mask or not mask_parts:
+            return None
+        return torch.cat(mask_parts)
 
     def update_cross_attention(
         self,


### PR DESCRIPTION
## Motivation

The FlashInfer SWA EXTEND path with nonzero prefix and `use_ragged=True` (the merge_state branch) returned incorrect outputs. Surfaced under module-level tests as ~0.2 max abs diff vs an HF-style PyTorch reference; under server-level SWA workloads with prefix caching, this produces silently-wrong tokens.

### Bug

When `extend_no_prefix=False` and `use_ragged=True`, `forward_extend` runs **two** FlashInfer wrappers and combines them with `merge_state`:
* a ragged wrapper over Q vs **extend K/V**
* a paged wrapper over Q vs **cached prefix K/V**

Two issues combined:

1. **`window_left` not passed to `forward_return_lse`**: both wrappers ran without per-query sliding-window masking. The `use_ragged=False` branch above already supplied `window_left` (with a multi-item-scoring guard); this branch did not.

2. **`update_sliding_window` reading uninitialized cache positions**: it set `paged_kernel_lens = min(seq_lens, window + extend_lens)`, but K for the extend tokens is written to the KV cache **after** the paged wrapper runs. Positions `[prefix_len, seq_len)` therefore hold stale/uninitialized data when the paged wrapper executes.

## Modifications

`python/sglang/srt/layers/attention/flashinfer_backend.py`:

* Pass `window_left = layer.sliding_window_size` (with the same multi-item-scoring guard) to both `forward_return_lse` calls in the `use_ragged=True` branch of `forward_extend`.

* In `FlashInferIndicesUpdaterPrefill.update_sliding_window`, branch on `use_ragged`:
  - **`use_ragged=True`**: read prefix-only from offset 0 (`paged_kernel_lens = prefix_lens`, `kv_start_idx = 0`). Supply a per-(q, k) custom mask `k >= prefix_len + q - window_left` via `cross_attention_custom_mask` so each extend query gates to prefix keys inside its window.
  - **`use_ragged=False`**: existing behavior unchanged.

The custom mask is required because FlashInfer's built-in `window_left` anchors Q at the end of `kv_len` (i.e. `kv_len - qo_len + qo_idx`), which doesn't express the correct prefix-vs-extend offset when the paged wrapper sees prefix-only K.

## Accuracy Tests

| Fixture | Before | After |
|---|---|---|
| FlashInfer SWA EXTEND `prefix=8, extend=8, window=12` (within-window) | ~0.2 max abs diff vs HF reference | ≤ atol |
| FlashInfer SWA EXTEND `prefix=16, extend=2` (cross-window) | ~0.2 max abs diff | ≤ atol |
| FlashInfer SWA DECODE within window | already correct | unchanged |
| Non-SWA `use_ragged=True` EXTEND | unchanged | unchanged |

## Speed Tests and Profiling

The fix adds one `kv_start_idx` tensor zero-fill and an additional custom-mask build under SWA + prefix. Both are O(num_requests) and dominated by the existing FlashInfer wrapper launch cost. No measurable kernel-time change.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Tests are part of a follow-up consolidated PR that lifts the attention-backend unit-test matrix into `test/registered/attention/unittest/`.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy benchmark results (above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26561797711](https://github.com/sgl-project/sglang/actions/runs/26561797711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26561797569](https://github.com/sgl-project/sglang/actions/runs/26561797569)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->