### PR TITLE
Expose Flex attention causal/decode masks as static methods

### DIFF
--- a/python/sglang/srt/layers/attention/torch_flex_backend.py
+++ b/python/sglang/srt/layers/attention/torch_flex_backend.py
@@ -70,10 +70,12 @@ class TorchFlexAttnBackend(AttentionBackend):
                     )
                 )
 
-    def _causal_mask(self, b, h, q_idx, kv_idx):
+    @staticmethod
+    def _causal_mask(b, h, q_idx, kv_idx):
         return q_idx >= kv_idx
 
-    def _decode_mask(self, b, h, q_idx, kv_idx):
+    @staticmethod
+    def _decode_mask(b, h, q_idx, kv_idx):
         return q_idx <= kv_idx
 
     def _run_flex_forward_extend(


### PR DESCRIPTION
## Motivation

`torch.nn.attention.flex_attention.create_block_mask` expects a plain callable with the signature `(b, h, q_idx, kv_idx) -> bool`. When the mask is passed as a bound method (e.g. `self._causal_mask`), the closure captured by `create_block_mask` includes a reference to the `TorchFlexAttnBackend` instance. Depending on the torch version, this either produces unintended graph captures of the entire backend object or raises at trace time.

### Bug

```python
class TorchFlexAttnBackend(AttentionBackend):
    def _causal_mask(self, b, h, q_idx, kv_idx):
        return q_idx >= kv_idx
    def _decode_mask(self, b, h, q_idx, kv_idx):
        return q_idx <= kv_idx
    # ...
    create_block_mask(self._causal_mask, ...)  # closure captures `self`
```

## Modifications

Mark `_causal_mask` and `_decode_mask` as `@staticmethod`. The two existing call sites (`self._causal_mask` / `self._decode_mask`) continue to work unchanged — Python resolves them to the underlying function for `@staticmethod`.

## Accuracy Tests

| Fixture | Before | After |
|---|---|---|
| Flex dense EXTEND (causal) | crash at `create_block_mask` trace on recent torch | passes ≤ atol |
| Flex dense DECODE | crash at `create_block_mask` trace on recent torch | passes ≤ atol |

## Speed Tests and Profiling

Pure metadata-callable signature change. No measurable kernel-time impact.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Tests are part of a follow-up consolidated PR that lifts the attention-backend unit-test matrix into `test/registered/attention/unittest/`.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy benchmark results (above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26544479771](https://github.com/sgl-project/sglang/actions/runs/26544479771)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26544479634](https://github.com/sgl-project/sglang/actions/runs/26544479634)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->