### PR TITLE
Allow Optional key/value in unified_attention_with_output split-op (MLA absorb fix)

### DIFF
--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -151,8 +151,8 @@ class RadixAttention(nn.Module):
 @register_split_op()
 def unified_attention_with_output(
     query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
+    key: Optional[torch.Tensor],
+    value: Optional[torch.Tensor],
     output: torch.Tensor,
     save_kv_cache: bool,
     layer_id: int,
@@ -174,8 +174,10 @@ def unified_attention_with_output(
     real_num_tokens = forward_batch.num_token_non_padded_cpu
 
     query = query[:real_num_tokens]
-    key = key[:real_num_tokens]
-    value = value[:real_num_tokens]
+    if key is not None:
+        key = key[:real_num_tokens]
+    if value is not None:
+        value = value[:real_num_tokens]
 
     kwargs = {}
     if q_rope is not None:


### PR DESCRIPTION
## Motivation

`unified_attention_with_output` is the split-op entry point used by the piecewise / breakable CUDA graph runner (PCG/BCG) to dispatch through the active attention backend. MLA's absorb path calls `RadixAttention.forward(q, k=None, v=None, ...)` because compressed latent KV is read from the token-to-kv-pool inside the MLA backend rather than passed in.

### Bug

The split-op required non-None `key` and `value`. When MLA was routed through the split-op (PCG/BCG runner mode) instead of the direct backend call, the `real_num_tokens` slicing dereferenced `None`:

```python
real_num_tokens = forward_batch.num_token_non_padded_cpu
query = query[:real_num_tokens]
key = key[:real_num_tokens]      # TypeError when key is None (MLA absorb)
value = value[:real_num_tokens]  # TypeError when value is None
```

The non-split-op path (direct backend call) didn't hit this — only the PCG/BCG dispatcher trips it.

## Modifications

`python/sglang/srt/layers/radix_attention.py`:

* Change `key` and `value` parameter types from `torch.Tensor` to `Optional[torch.Tensor]` to match `RadixAttention.forward`'s contract.
* Guard the slicing: only slice when not None. Non-MLA backends always pass non-None K/V, so their behavior is unchanged.

## Accuracy Tests

| Fixture | Before | After |
|---|---|---|
| MLA Triton EXTEND under PCG runner | `TypeError: 'NoneType' object is not subscriptable` | passes ≤ atol |
| MLA Triton EXTEND under BCG runner | same | passes ≤ atol |
| Non-MLA EXTEND under PCG / BCG | unchanged | unchanged |

## Speed Tests and Profiling

Two `if not None` checks on the metadata path. No measurable kernel-time impact.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Tests are part of a follow-up consolidated PR that lifts the attention-backend unit-test matrix into `test/registered/attention/unittest/`.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy benchmark results (above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26544504505](https://github.com/sgl-project/sglang/actions/runs/26544504505)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26544504382](https://github.com/sgl-project/sglang/actions/runs/26544504382)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->