### PR TITLE
Add sliding-window mask support to TorchNativeAttnBackend

### DIFF
--- a/python/sglang/srt/layers/attention/torch_native_backend.py
+++ b/python/sglang/srt/layers/attention/torch_native_backend.py
@@ -24,6 +24,21 @@ class TorchNativeAttnBackend(AttentionBackend):
         self.req_to_token_pool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
 
+    @staticmethod
+    def _make_sliding_window_mask(
+        *,
+        q_len: int,
+        kv_len: int,
+        sliding_window_size: int,
+        device: torch.device,
+        query_offset: int = 0,
+    ) -> torch.Tensor:
+        q_pos = torch.arange(
+            query_offset, query_offset + q_len, device=device
+        ).unsqueeze(1)
+        k_pos = torch.arange(kv_len, device=device).unsqueeze(0)
+        return (k_pos <= q_pos) & (k_pos >= q_pos - sliding_window_size)
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
         pass
@@ -44,6 +59,7 @@ class TorchNativeAttnBackend(AttentionBackend):
         enable_gqa=False,
         causal=False,
         is_cross_attn=False,
+        sliding_window_size: Optional[int] = None,
     ):
         """Run the extend forward by using torch native sdpa op.
 
@@ -114,14 +130,26 @@ class TorchNativeAttnBackend(AttentionBackend):
                 per_req_key = per_req_key.to(per_req_query.dtype)
                 per_req_value = per_req_value.to(per_req_query.dtype)
 
+            attn_mask = None
+            is_causal = causal
+            if sliding_window_size is not None and sliding_window_size > -1:
+                attn_mask = self._make_sliding_window_mask(
+                    q_len=seq_len_kv,
+                    kv_len=seq_len_kv,
+                    sliding_window_size=sliding_window_size,
+                    device=per_req_query.device,
+                )
+                is_causal = False
+
             per_req_out_redudant = (
                 scaled_dot_product_attention(
                     per_req_query_redudant.unsqueeze(0),
                     per_req_key.unsqueeze(0),
                     per_req_value.unsqueeze(0),
+                    attn_mask=attn_mask,
                     enable_gqa=enable_gqa,
                     scale=scaling,
-                    is_causal=causal,
+                    is_causal=is_causal,
                 )
                 .squeeze(0)
                 .movedim(query.dim() - 2, 0)
@@ -144,6 +172,7 @@ class TorchNativeAttnBackend(AttentionBackend):
         enable_gqa=False,
         causal=False,
         is_cross_attn=False,
+        sliding_window_size: Optional[int] = None,
     ):
         """Run the decode forward by using torch native sdpa op.
 
@@ -202,14 +231,27 @@ class TorchNativeAttnBackend(AttentionBackend):
                 per_req_key = per_req_key.to(per_req_query.dtype)
                 per_req_value = per_req_value.to(per_req_query.dtype)
 
+            attn_mask = None
+            is_causal = causal
+            if sliding_window_size is not None and sliding_window_size > -1:
+                attn_mask = self._make_sliding_window_mask(
+                    q_len=seq_len_q,
+                    kv_len=seq_len_kv,
+                    sliding_window_size=sliding_window_size,
+                    device=per_req_query.device,
+                    query_offset=seq_len_kv - seq_len_q,
+                )
+                is_causal = False
+
             per_req_out = (
                 scaled_dot_product_attention(
                     per_req_query.unsqueeze(0),
                     per_req_key.unsqueeze(0),
                     per_req_value.unsqueeze(0),
+                    attn_mask=attn_mask,
                     enable_gqa=enable_gqa,
                     scale=scaling,
-                    is_causal=causal,
+                    is_causal=is_causal,
                 )
                 .squeeze(0)
                 .movedim(query.dim() - 2, 0)
@@ -265,6 +307,14 @@ class TorchNativeAttnBackend(AttentionBackend):
             enable_gqa=use_gqa,
             causal=causal,
             is_cross_attn=layer.is_cross_attention,
+            sliding_window_size=(
+                layer.sliding_window_size
+                if causal
+                and not layer.is_cross_attention
+                and layer.sliding_window_size is not None
+                and layer.sliding_window_size > -1
+                else None
+            ),
         )
         return o
 
@@ -317,6 +367,13 @@ class TorchNativeAttnBackend(AttentionBackend):
             enable_gqa=use_gqa,
             causal=False,
             is_cross_attn=layer.is_cross_attention,
+            sliding_window_size=(
+                layer.sliding_window_size
+                if not layer.is_cross_attention
+                and layer.sliding_window_size is not None
+                and layer.sliding_window_size > -1
+                else None
+            ),
         )
 
         return o


### PR DESCRIPTION
## Motivation

`TorchNativeAttnBackend._run_sdpa_forward_extend` and `_run_sdpa_forward_decode` previously ignored `layer.sliding_window_size` and always passed `is_causal=True` to `scaled_dot_product_attention`. Models that require sliding-window attention (e.g. Mistral, Gemma) on the `torch_native` backend therefore produced incorrect outputs — every query attended to the full prefix regardless of the requested window.

### Bug

The backend's two SDPA forwards never consulted the layer's `sliding_window_size`. Output for SWA layers was full-prefix-attended.

## Modifications

`python/sglang/srt/layers/attention/torch_native_backend.py`:

* New `_make_sliding_window_mask(q_len, kv_len, sliding_window_size, device, query_offset)` helper builds a `(q_len, kv_len)` boolean mask where `mask[q, k] = (k <= q + query_offset) & (k >= q + query_offset - sliding_window_size)`. `query_offset` is the absolute position of the first query in the K sequence (decode: `kv_len - q_len`).

* `_run_sdpa_forward_extend` and `_run_sdpa_forward_decode` accept a new `sliding_window_size: Optional[int]` kwarg. When `sliding_window_size > -1` they pass `attn_mask=` to SDPA and set `is_causal=False` (SDPA cannot combine `is_causal=True` with a custom `attn_mask`).

* Non-SWA models (`sliding_window_size is None` or `-1`) take the existing `is_causal=True` path unchanged.

## Accuracy Tests

| Fixture | Before | After |
|---|---|---|
| torch_native SWA EXTEND below-window | full-prefix attend (incorrect) | matches HF reference |
| torch_native SWA EXTEND with-prefix | full-prefix attend | matches HF reference |
| torch_native SWA DECODE within window | full-prefix attend | matches HF reference |
| torch_native SWA DECODE above window | full-prefix attend | matches HF reference |
| torch_native MHA/GQA (non-SWA) | unchanged | unchanged |

## Speed Tests and Profiling

The mask build is a CPU-side O(q_len × kv_len) bool allocation per request — negligible vs the SDPA call itself. No measurable change for non-SWA paths.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Tests are part of a follow-up consolidated PR that lifts the attention-backend unit-test matrix into `test/registered/attention/unittest/`.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy benchmark results (above).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26544528360](https://github.com/sgl-project/sglang/actions/runs/26544528360)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26544528279](https://github.com/sgl-project/sglang/actions/runs/26544528279)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->