### PR TITLE
[GDN] Add MTP cache mode for final-state recompute

### DIFF
--- a/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -364,3 +364,181 @@ def fused_sigmoid_gating_delta_rule_update(
     )
     o = o.squeeze(0)
     return o
+
+
+@triton.jit
+def fused_sigmoid_gating_delta_rule_recover_final_state_kernel(
+    A_log,
+    a,
+    dt_bias,
+    softplus_beta,
+    softplus_threshold,
+    k,
+    v,
+    b,
+    h0_source,
+    h0_indices,
+    accepted_steps,
+    T,
+    stride_a,
+    stride_k,
+    stride_v,
+    stride_b,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_KDA: tl.constexpr,
+):
+    """Recover h_K directly without writing intermediate states or outputs."""
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+
+    bos = i_n * T
+    accepted_step = tl.load(accepted_steps + i_n)
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_k = k + bos * stride_k + i_h * K + o_k
+    p_v = v + bos * stride_v + i_hv * V + o_v
+    p_b = b + bos * stride_b + i_hv
+
+    p_A_log = A_log + i_hv
+    if IS_KDA:
+        p_a = a + bos * stride_a + i_hv * K + o_k
+        p_dt_bias = dt_bias + i_hv * K + o_k
+    else:
+        p_a = a + bos * stride_a + i_hv
+        p_dt_bias = dt_bias + i_hv
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    idx = tl.load(h0_indices + i_n)
+    p_h0 = h0_source + idx * HV * K * V + i_hv * K * V + o_v[None, :] * K + o_k[:, None]
+    b_h = tl.load(p_h0, mask=(idx >= 0) & mask_h, other=0).to(tl.float32)
+
+    b_A_log = tl.load(p_A_log).to(tl.float32)
+    b_A_coeff = -tl.exp(b_A_log)
+    if IS_KDA:
+        b_dt_bias = tl.load(p_dt_bias, mask=mask_k, other=0).to(tl.float32)
+    else:
+        b_dt_bias = tl.load(p_dt_bias).to(tl.float32)
+
+    for step_idx in range(0, T):
+        active = step_idx <= accepted_step
+
+        b_k = tl.load(p_k, mask=active & mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=active & mask_v, other=0).to(tl.float32)
+        b_b = tl.load(p_b, mask=active, other=0).to(tl.float32)
+
+        if IS_KDA:
+            b_a = tl.load(p_a, mask=active & mask_k, other=0).to(tl.float32)
+        else:
+            b_a = tl.load(p_a, mask=active, other=0).to(tl.float32)
+
+        x = b_a + b_dt_bias
+        beta_x = softplus_beta * x
+        softplus_x = tl.where(
+            beta_x <= softplus_threshold,
+            (1.0 / softplus_beta) * tl.log(1.0 + tl.exp(beta_x)),
+            x,
+        )
+        b_g = b_A_coeff * softplus_x
+        b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_k = b_k / (tl.sqrt(tl.sum(b_k * b_k) + 1e-6))
+
+        if IS_KDA:
+            b_h_gated = b_h * tl.exp(b_g[:, None])
+        else:
+            b_h_gated = b_h * tl.exp(b_g)
+
+        b_v_delta = b_v - tl.sum(b_h_gated * b_k[:, None], 0)
+        b_v_delta *= b_beta
+        b_h_next = b_h_gated + b_k[:, None] * b_v_delta[None, :]
+        b_h = tl.where(active, b_h_next, b_h)
+
+        p_k += stride_k
+        p_v += stride_v
+        p_b += stride_b
+        p_a += stride_a
+
+    tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=(idx >= 0) & mask_h)
+
+
+def fused_sigmoid_gating_delta_rule_recover_final_state(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    dt_bias: torch.Tensor,
+    softplus_beta: float,
+    softplus_threshold: float,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    b: torch.Tensor,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    accepted_steps: torch.Tensor,
+    cache_steps: int,
+    use_qk_l2norm_in_kernel: bool = False,
+    is_kda: bool = False,
+):
+    """Recovery-only GDN recurrence for gdn_mtp_cache_mode=none.
+
+    This writes h_{accepted_step} directly back to the SSM state slot and
+    skips output materialization, intermediate state writes, and the follow-up
+    scatter used by the generic target-verify path.
+    """
+    _, total_tokens, H, K = k.shape
+    HV = v.shape[2]
+    V = v.shape[3]
+    T = cache_steps
+    N = accepted_steps.shape[0]
+    assert total_tokens == N * T
+
+    stride_k = k.stride()[1]
+    stride_v = v.stride()[1]
+    stride_b = b.stride()[-2]
+    stride_a = a.stride()[-2]
+
+    BK, BV = triton.next_power_of_2(K), min(triton.next_power_of_2(V), 32)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+
+    fused_sigmoid_gating_delta_rule_recover_final_state_kernel[(NK, NV, N * HV)](
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=softplus_beta,
+        softplus_threshold=softplus_threshold,
+        k=k,
+        v=v,
+        b=b,
+        h0_source=initial_state_source,
+        h0_indices=initial_state_indices,
+        accepted_steps=accepted_steps,
+        T=T,
+        stride_a=stride_a,
+        stride_k=stride_k,
+        stride_v=stride_v,
+        stride_b=stride_b,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_KDA=is_kda,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -930,14 +930,31 @@ class HybridLinearAttnBackend(AttentionBackend):
         intermediate_state_cache = mamba_caches.intermediate_ssm
         intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
 
-        # Use fully fused kernel that handles masking internally
-        # This avoids separate nonzero() and index_select() calls
-        fused_mamba_state_scatter_with_mask(
-            ssm_states,
-            intermediate_state_cache,
-            state_indices_tensor,
-            last_correct_step_indices,
-        )
+        if mamba_track_indices is not None and intermediate_state_cache is None:
+            raise RuntimeError(
+                "--gdn-mtp-cache-mode=none is not supported with mamba radix "
+                "tracking because tracked prefix states require cached "
+                "intermediate SSM states."
+            )
+
+        # SSM state recovery depends on whether per-draft states were cached.
+        if intermediate_state_cache is not None:
+            # mode=full: h_K is already cached per draft-token position.
+            fused_mamba_state_scatter_with_mask(
+                ssm_states,
+                intermediate_state_cache,
+                state_indices_tensor,
+                last_correct_step_indices,
+            )
+        else:
+            # mode=none: rerun recurrence from h_0 over the accepted prefix
+            # and write h_K directly without materializing outputs.
+            self._no_cache_mtp_recompute(
+                accepted_steps=last_correct_step_indices,
+                state_indices_tensor=state_indices_tensor,
+            )
+
+        # Conv-state rollback uses cached conv windows in both modes.
         # conv intermediate uses the deduplicated sliding-window (overlapping)
         # layout, so it needs the strided-read scatter variant.
         fused_conv_window_scatter_with_mask(
@@ -947,7 +964,8 @@ class HybridLinearAttnBackend(AttentionBackend):
             last_correct_step_indices,
         )
 
-        # Track indices used for tracking mamba states for prefix cache
+        # Prefix-cache tracking requires intermediate SSM states, so it runs
+        # only on the full-cache path.
         if mamba_track_indices is not None:
             assert mamba_steps_to_track is not None
             # Use fully fused kernel for track scatter operations
@@ -962,4 +980,63 @@ class HybridLinearAttnBackend(AttentionBackend):
                 intermediate_conv_window_cache,
                 mamba_track_indices,
                 mamba_steps_to_track,
+            )
+
+    def _no_cache_mtp_recompute(
+        self,
+        accepted_steps: torch.Tensor,
+        state_indices_tensor: torch.Tensor,
+    ):
+        """Recover accepted GDN SSM state for gdn_mtp_cache_mode=none.
+
+        Replays the state-update recurrence over stashed post-conv k/v/a/b and
+        writes h_{accepted_step} directly to the request's SSM state slot.
+        """
+        # Local imports to avoid a circular dependency at module load time.
+        from sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent import (
+            fused_sigmoid_gating_delta_rule_recover_final_state,
+        )
+
+        stash_per_layer: dict = getattr(self.linear_attn_backend, "_no_cache_stash", {})
+        if not stash_per_layer:
+            # No GDN layer ran in cache_mode=none for this batch.
+            return
+
+        pool = self.linear_attn_backend.req_to_token_pool
+
+        # Recovery runs outside the captured graph. Derive per-call sizes from
+        # current tensors because the stash spans multiple batch-size captures.
+        batch_size = accepted_steps.shape[0]
+        draft_token_num = self.linear_attn_backend._no_cache_draft_token_num
+        assert draft_token_num is not None, (
+            "draft_token_num not cached — forward_extend was never called "
+            "in target_verify mode before _mamba_verify_update."
+        )
+        actual_seq_len = batch_size * draft_token_num
+        cache_steps = draft_token_num
+        # The kernel expects int32 state indices.
+        state_idx_i32 = state_indices_tensor.to(torch.int32).contiguous()
+        accepted_steps_i32 = accepted_steps.to(torch.int32).contiguous()
+
+        # One launch per GDN layer. Slice persistent buffers to the current
+        # batch size instead of storing per-call sizes in the shared stash.
+        for layer_id, stash in stash_per_layer.items():
+            layer_cache = pool.mamba2_layer_cache(layer_id)
+            layer_ssm_states = layer_cache.temporal  # [size+1, HV, V, K]
+
+            fused_sigmoid_gating_delta_rule_recover_final_state(
+                A_log=stash["A_log"],
+                a=stash["a"][:actual_seq_len],
+                dt_bias=stash["dt_bias"],
+                softplus_beta=1.0,
+                softplus_threshold=20.0,
+                k=stash["k"][:, :actual_seq_len],
+                v=stash["v"][:, :actual_seq_len],
+                b=stash["b"][:actual_seq_len],
+                initial_state_source=layer_ssm_states,
+                initial_state_indices=state_idx_i32,
+                accepted_steps=accepted_steps_i32,
+                cache_steps=cache_steps,
+                use_qk_l2norm_in_kernel=True,
+                is_kda=False,
             )

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 
@@ -287,6 +287,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
         self.verify_intermediate_state_indices = torch.arange(
             self.req_to_token_pool.size, dtype=torch.int32, device=model_runner.device
         )
+        # Per-layer persistent buffers used by gdn_mtp_cache_mode=none recovery.
+        # Values are stable tensors or parameters; per-call sizes are derived
+        # from runtime tensors because the dict spans multiple CUDA graph captures.
+        self._no_cache_stash: Dict[int, Dict[str, torch.Tensor]] = {}
+        # Cached once on first forward; stable across calls.
+        self._no_cache_draft_token_num: Optional[int] = None
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         super().init_forward_metadata(forward_batch)
@@ -401,6 +407,8 @@ class GDNAttnBackend(MambaAttnBackendBase):
         ssm_states = mamba_cache_params.temporal
         if is_target_verify:
             assert isinstance(mamba_cache_params, MambaPool.SpeculativeState)
+            # In cache_mode=none, target verify skips intermediate SSM writes;
+            # accepted h_K is recovered after verification.
             intermediate_state_cache = mamba_cache_params.intermediate_ssm
             intermediate_conv_window_cache = (
                 mamba_cache_params.intermediate_conv_window[0]
@@ -474,6 +482,58 @@ class GDNAttnBackend(MambaAttnBackendBase):
             value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
 
         if is_target_verify:
+            # In cache_mode=none, keep post-conv GDN inputs for accepted-state
+            # recovery. Persistent buffers give CUDA graph replay stable addresses.
+            if intermediate_state_cache is None:
+                # Target layout: [1, max_tokens, heads, dim] where
+                # max_tokens = pool.size * draft_token_num covers any
+                # batch size SGLang may capture a CUDA graph for.
+                draft_token_num = forward_batch.spec_info.draft_token_num
+                max_tokens = self.req_to_token_pool.size * draft_token_num
+                actual_seq_len = query.shape[1]
+
+                stash_entry = self._no_cache_stash.get(layer.layer_id)
+                if stash_entry is None or stash_entry["k"].shape[1] < max_tokens:
+                    # Allocate outside inference_mode so buffers can be updated
+                    # across forward invocations.
+                    with torch.inference_mode(False):
+                        stash_entry = {
+                            "k": torch.empty(
+                                (key.shape[0], max_tokens, *key.shape[2:]),
+                                dtype=key.dtype,
+                                device=key.device,
+                            ),
+                            "v": torch.empty(
+                                (value.shape[0], max_tokens, *value.shape[2:]),
+                                dtype=value.dtype,
+                                device=value.device,
+                            ),
+                            "a": torch.empty(
+                                (max_tokens, *a.shape[1:]),
+                                dtype=a.dtype,
+                                device=a.device,
+                            ),
+                            "b": torch.empty(
+                                (max_tokens, *b.shape[1:]),
+                                dtype=b.dtype,
+                                device=b.device,
+                            ),
+                            "A_log": layer.A_log,
+                            "dt_bias": layer.dt_bias,
+                        }
+                    self._no_cache_stash[layer.layer_id] = stash_entry
+                # In-place slice copy with no new allocation; captured replays
+                # refresh the stable buffer slice for that graph's batch size.
+                stash_entry["k"][:, :actual_seq_len].copy_(key)
+                stash_entry["v"][:, :actual_seq_len].copy_(value)
+                stash_entry["a"][:actual_seq_len].copy_(a)
+                stash_entry["b"][:actual_seq_len].copy_(b)
+                # Do not store per-call sizes or tensor aliases in the stash;
+                # eager recovery derives them from current runtime tensors.
+                if self._no_cache_draft_token_num is None:
+                    self._no_cache_draft_token_num = (
+                        forward_batch.spec_info.draft_token_num
+                    )
             core_attn_out = self.kernel_dispatcher.target_verify(
                 A_log=layer.A_log,
                 dt_bias=layer.dt_bias,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -111,7 +111,9 @@ def conv_window_dedup_enabled(
     )
 
 
-def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
+def get_tensor_size_bytes(t: Optional[Union[torch.Tensor, List[torch.Tensor]]]):
+    if t is None:
+        return 0
     if isinstance(t, list):
         return sum(get_tensor_size_bytes(x) for x in t)
     return np.prod(t.shape) * t.dtype.itemsize
@@ -309,7 +311,9 @@ class MambaPool:
             for f in fields(self):
                 name = f.name
                 v = getattr(self, name)
-                if name in ("conv", "intermediate_conv_window"):
+                if v is None:
+                    kwargs[name] = None
+                elif name in ("conv", "intermediate_conv_window"):
                     kwargs[name] = [conv[layer] for conv in v]
                 else:
                     kwargs[name] = v[layer]
@@ -324,8 +328,10 @@ class MambaPool:
 
     @dataclass(frozen=True, kw_only=True)
     class SpeculativeState(State):
-        intermediate_ssm: torch.Tensor
-        intermediate_conv_window: List[torch.Tensor]
+        # None in gdn_mtp_cache_mode=none; recovery reconstructs h_K after verify.
+        intermediate_ssm: Optional[torch.Tensor] = None
+        # Kept in both modes for accepted conv-state rollback.
+        intermediate_conv_window: Optional[List[torch.Tensor]] = None
 
     def __init__(
         self,
@@ -401,20 +407,12 @@ class MambaPool:
                         temporal_state_shape[-1],
                         temporal_state_shape[-2],
                     )
-                # Cache intermediate SSM states per draft token during target verify
-                # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
-                intermediate_ssm_state_cache = torch.zeros(
-                    size=(
-                        num_mamba_layers,
-                        spec_state_size + 1,
-                        speculative_num_draft_tokens,
-                        temporal_state_shape[0],
-                        temporal_state_shape[1],
-                        temporal_state_shape[2],
-                    ),
-                    dtype=ssm_dtype,
-                    device="cuda",
-                )
+                # gdn_mtp_cache_mode controls only the SSM intermediate cache.
+                # Conv windows stay cached for accepted conv-state rollback.
+                from sglang.srt.server_args import get_global_server_args
+
+                cache_mode = get_global_server_args().gdn_mtp_cache_mode
+
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
                 #
@@ -495,22 +493,56 @@ class MambaPool:
                         for conv_shape in conv_state_shape
                     ]
                     self._intermediate_conv_window_phys = intermediate_conv_window_cache
-                self.mamba_cache = self.SpeculativeState(
-                    conv=conv_state,
-                    temporal=temporal_state,
-                    intermediate_ssm=intermediate_ssm_state_cache,
-                    intermediate_conv_window=intermediate_conv_window_cache,
-                )
-                logger.info(
-                    f"Mamba Cache is allocated. "
-                    f"max_mamba_cache_size: {size}, "
-                    f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
-                    f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
-                    f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
-                    # Report the deduplicated PHYSICAL conv-window buffers (the view
-                    # over-reports its logical, un-deduplicated size).
-                    f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
-                )
+
+                if cache_mode == "none":
+                    # Skip intermediate_ssm, the dominant speculative MTP state cache.
+                    # Recovery reconstructs h_K from committed h_0 after verify.
+                    self.mamba_cache = self.SpeculativeState(
+                        conv=conv_state,
+                        temporal=temporal_state,
+                        intermediate_ssm=None,
+                        intermediate_conv_window=intermediate_conv_window_cache,
+                    )
+                    logger.info(
+                        f"Mamba Cache is allocated (gdn_mtp_cache_mode=none). "
+                        f"max_mamba_cache_size: {size}, "
+                        f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
+                        f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
+                        f"intermediate_ssm_state_cache: SKIPPED "
+                        # Report the deduplicated PHYSICAL conv-window buffers.
+                        f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
+                    )
+                else:
+                    # "full" (default): cache intermediate SSM states per draft token.
+                    # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
+                    intermediate_ssm_state_cache = torch.zeros(
+                        size=(
+                            num_mamba_layers,
+                            spec_state_size + 1,
+                            speculative_num_draft_tokens,
+                            temporal_state_shape[0],
+                            temporal_state_shape[1],
+                            temporal_state_shape[2],
+                        ),
+                        dtype=ssm_dtype,
+                        device="cuda",
+                    )
+                    self.mamba_cache = self.SpeculativeState(
+                        conv=conv_state,
+                        temporal=temporal_state,
+                        intermediate_ssm=intermediate_ssm_state_cache,
+                        intermediate_conv_window=intermediate_conv_window_cache,
+                    )
+                    logger.info(
+                        f"Mamba Cache is allocated. "
+                        f"max_mamba_cache_size: {size}, "
+                        f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
+                        f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
+                        f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
+                        # Report the deduplicated PHYSICAL conv-window buffers (the view
+                        # over-reports its logical, un-deduplicated size).
+                        f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
+                    )
             else:
                 self.mamba_cache = self.State(conv=conv_state, temporal=temporal_state)
                 logger.info(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -316,6 +316,12 @@ MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
 
 LINEAR_ATTN_KERNEL_BACKEND_CHOICES = ["triton", "cutedsl", "flashinfer"]
 
+# GDN MTP intermediate-state cache mode.
+# - "full": cache h-state at every draft token position (default behavior).
+# - "none": skip intermediate caching; reconstruct h_K by rerunning the
+#   recurrence from the committed h_0 over the accepted draft prefix.
+GDN_MTP_CACHE_MODE_CHOICES = ["full", "none"]
+
 
 # Allow external code to add more choices
 def add_load_format_choices(choices):
@@ -1800,6 +1806,18 @@ class ServerArgs:
         int,
         "The interval to track the mamba state during decode.",
     ] = 256
+    gdn_mtp_cache_mode: A[
+        str,
+        Arg(
+            help="Intermediate h-state cache mode for GDN MTP verify. "
+            "'full' (default) caches h at every draft-token position. "
+            "'none' skips intermediate caching and reconstructs h_K after verify by "
+            "re-running the GDN recurrence from the committed h_0 over the accepted "
+            "draft prefix. 'none' trades extra post-verify recovery compute for "
+            "freeing the intermediate_ssm buffer.",
+            choices=["full", "none"],
+        ),
+    ] = "full"
     enable_int8_mamba_checkpoint: A[
         bool,
         "Store radix-cached linear-attn (mamba) states in int8 (separate checkpoint pool) for ~2x cached-prefix capacity at fixed memory.",


### PR DESCRIPTION
## Motivation

This PR adds `--gdn-mtp-cache-mode none` for GDN MTP serving. The default `full` mode keeps the existing behavior: cache every intermediate SSM state during target verify. The new `none` mode skips that persistent intermediate SSM cache and reconstructs the accepted final GDN state after verify.

## Modifications

- Add `--gdn-mtp-cache-mode {full,none}` plumbing through server args and the req-to-token pool.
- Allow the speculative Mamba/GDN pool to skip `intermediate_ssm` allocation in `none` mode while keeping conv-window rollback state.
- Stash post-conv GDN inputs during target verify for `none` mode.
- Add a recovery-only GDN recurrence kernel that writes the accepted final SSM state after verify.
- Keep `full` as the default mode to preserve existing behavior.
- Reject unsupported `cache=none + mamba_track_indices` before mutating recovered state.

## Accuracy Tests

Clean-stack same-time GSM8K, Qwen3.5-397B-A17B-FP8, 4xGB200, `num_examples=1319`, `num_shots=8`, `num_threads=256`, `max_tokens=16384`, `temperature=0.6`, `top_p=0.95`, `top_k=20`.

SGLang's GSM8K evaluator reserves the first 8 test rows as the few-shot prompt and evaluates the remaining 1311 rows.

| Mode | Job | Score | Output throughput | Latency |
| --- | ---: | ---: | ---: | ---: |
| `full` | `1970141` | `0.978642` | `6867.26 tok/s` | `460.61 s` |
| `none` | `1970142` | `0.976354` | `6802.76 tok/s` | `467.91 s` |

Repro commands:

```bash
export MODEL_PATH=/path/to/Qwen3.5-397B-A17B-FP8
export PORT=30000
export GDN_MTP_CACHE_MODE=none  # or full

CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_ENABLE_SPEC_V2=1 \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 \
python3 -m sglang.launch_server \
  --model-path ${MODEL_PATH} \
  --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port ${PORT} \
  --attention-backend trtllm_mha \
  --quantization fp8 \
  --kv-cache-dtype fp8_e4m3 \
  --tensor-parallel-size 4 \
  --expert-parallel-size 1 \
  --mamba-ssm-dtype bfloat16 \
  --moe-runner-backend flashinfer_trtllm \
  --linear-attn-decode-backend flashinfer \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --disable-radix-cache \
  --mamba-scheduler-strategy no_buffer \
  --max-running-requests 256 \
  --mem-fraction-static 0.8 \
  --chunked-prefill-size 16384 \
  --max-prefill-tokens 16384 \
  --cuda-graph-max-bs 256 \
  --gdn-mtp-cache-mode ${GDN_MTP_CACHE_MODE} \
  --decode-log-interval 1 \
  --stream-interval 50 \
  --reasoning-parser qwen3

python3 -m sglang.test.run_eval \
  --base-url http://127.0.0.1:${PORT} \
  --eval-name gsm8k \
  --num-examples 1319 \
  --num-threads 256 \
  --max-tokens 16384 \
  --num-shots 8 \
  --temperature 0.6 \
  --top-p 0.95 \
  --top-k 20
```

## Speed Tests and Profiling

Historical same-time c256 SA-Bench A/B, kept for context but superseded because the two runs had different accept lengths:

| Mode | Job | Completed requests | Failed requests | Output throughput | Mean TPOT | Median accept len |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `none` | `1927795` | `2560` | `0` | ~~`5520.90 tok/s`~~ | ~~`45.07 ms`~~ | `3.40` |
| `full` | `1927796` | `2560` | `0` | ~~`4492.85 tok/s`~~ | ~~`55.52 ms`~~ | `2.27` |

~~Perf gain from `none` vs `full`:~~

- ~~Output throughput: `+22.9%`~~
- ~~Mean TPOT: `-18.8%`~~

These numbers are not apple-to-apple: the `none` run accepted many more draft tokens per iteration (`3.40` vs `2.27`), so the e2e throughput delta mainly reflects acceptance divergence rather than the cache-mode compute path itself.

Apple-to-apple c256 result after fixing the full-cache accept-length issue, with both modes around the same accept length:

| Mode | Job | Output throughput | Mean TPOT | Median accept len |
| --- | --- | ---: | ---: | ---: |
| `none` | `1960698` | `10537.37 tok/s` | `19.64 ms` | `2.92` |
| `full` + source-index fix | `1960961` | `10810.43 tok/s` | `18.77 ms` | `2.89` |

Apple-to-apple delta for `none` vs fixed `full`:

- Output throughput: `-2.5%`
- Mean TPOT: `+4.6%`

Interpretation: after matching accept length, `cache=none` is not an e2e throughput win at c256. It should be viewed as a memory/cache-mode tradeoff that removes the persistent intermediate SSM cache and full-cache scatter dependency, but adds final-state recompute work.

Repro commands:

```bash
export MODEL_PATH=/path/to/Qwen3.5-397B-A17B-FP8
export PORT=30000
export GDN_MTP_CACHE_MODE=none  # or full

CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_ENABLE_SPEC_V2=1 \
FLASHINFER_DISABLE_VERSION_CHECK=1 \
SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 \
python3 -m sglang.launch_server \
  --model-path ${MODEL_PATH} \
  --served-model-name Qwen/Qwen3.5-397B-A17B-FP8 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port ${PORT} \
  --attention-backend trtllm_mha \
  --quantization fp8 \
  --kv-cache-dtype fp8_e4m3 \
  --tensor-parallel-size 4 \
  --expert-parallel-size 1 \
  --mamba-ssm-dtype bfloat16 \
  --moe-runner-backend flashinfer_trtllm \
  --linear-attn-decode-backend flashinfer \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --disable-radix-cache \
  --mamba-scheduler-strategy no_buffer \
  --max-running-requests 256 \
  --mem-fraction-static 0.8 \
  --context-length 4096 \
  --chunked-prefill-size 16384 \
  --max-prefill-tokens 16384 \
  --cuda-graph-max-bs 256 \
  --gdn-mtp-cache-mode ${GDN_MTP_CACHE_MODE} \
  --decode-log-interval 10 \
  --stream-interval 50

python3 -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 \
  --port ${PORT} \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --dataset-name random \
  --num-prompts 2560 \
  --random-input-len 1000 \
  --random-output-len 1000 \
  --random-range-ratio 1.0 \
  --request-rate inf \
  --max-concurrency 256
```

The `none` run reports `intermediate_ssm_state_cache: SKIPPED`; the `full` run allocates the intermediate SSM cache.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->