### PR TITLE
fix: copy seq_lens in TRTLLM MHA draft decode cuda graph capture

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -324,6 +324,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
                     "cache_seqlens"
                 ][:bs]
+                # Mirror the replay-time copy so the captured kernel sees
+                # cache_seqlens > 0; otherwise softmax over an empty KV set
+                # produces NaN during warmup.
+                metadata.cache_seqlens_int32.copy_(
+                    seq_lens[:bs].to(torch.int32) + self.speculative_step_id + 1
+                )
                 metadata.max_seq_len_k = seq_lens.max().item() + (
                     self.speculative_step_id + 1
                 )

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -324,11 +324,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 metadata.cache_seqlens_int32 = self.decode_cuda_graph_metadata[
                     "cache_seqlens"
                 ][:bs]
-                # Mirror the replay-time copy so the captured kernel sees
-                # cache_seqlens > 0; otherwise softmax over an empty KV set
-                # produces NaN during warmup.
                 metadata.cache_seqlens_int32.copy_(
-                    seq_lens[:bs].to(torch.int32) + self.speculative_step_id + 1
+                    seq_lens + self.speculative_step_id + 1
                 )
                 metadata.max_seq_len_k = seq_lens.max().item() + (
                     self.speculative_step_id + 1


### PR DESCRIPTION
## Motivation

`TRTLLMHAAttnBackend.init_forward_metadata_capture_cuda_graph` re-uses a
pre-allocated, zero-initialized `cache_seqlens` buffer for the draft-decode
branch but never copies the current `seq_lens` into it. As a result, the
captured kernel runs with `cache_seqlens == 0` (empty KV range), which
produces NaN at softmax normalization during CUDA graph warmup.

The normal-decode branch implicitly seeds the buffer via `seq_lens.to(int32)`
(which allocates a new tensor populated from `seq_lens`), and the replay path
explicitly does `metadata.cache_seqlens_int32.copy_(seq_lens + step + 1)`,
so this is a capture-only omission specific to the draft-decode branch.

## Symptom

Reproducible with EAGLE3 + `trtllm_mha` + `SGLANG_SPEC_NAN_DETECTION=1`:

```
Capturing batches (bs=30 ...): 4%|...
/pytorch/aten/src/ATen/native/cuda/TensorCompare.cu:109: _assert_async_cuda_kernel:
  Assertion `NaN detected! draft_forward step 0` failed.
```

Inspection of the dumped `attn_out` of the draft model layer 0 shows the first
3 rows are entirely NaN while the remaining rows are exactly 0 — consistent
with some TRT-LLM MHA tiles short-circuiting empty-KV softmax to 0 and others
returning 0/0 = NaN.

## Fix

Mirror the replay-time copy in the draft-decode capture branch so the captured
graph sees `cache_seqlens > 0` during warmup.

## Verification

After the fix:
- `/health` returns 200, repeated HEALTH_CHECK requests succeed
- `/generate` returns identical output with spec decoding still active
  (accept rate / accept length / verify count unchanged)
- `SGLANG_SPEC_NAN_DETECTION=1` no longer triggers during CG capture

## Original commits

- `f00ec0825`















<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26617321574](https://github.com/sgl-project/sglang/actions/runs/26617321574)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26617321470](https://github.com/sgl-project/sglang/actions/runs/26617321470)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->