### PR TITLE
[NemotronH] Fix weight-loading unit test broken by Puzzle support

### DIFF
--- a/test/registered/unit/models/test_nemotron_h_weight_loading.py
+++ b/test/registered/unit/models/test_nemotron_h_weight_loading.py
@@ -35,7 +35,7 @@ class _FakeParam:
 class TestNemotronHWeightLoading(unittest.TestCase):
     def _make_minimal_model(self, named_parameters=()):
         model = object.__new__(NemotronHForCausalLM)
-        model.config = SimpleNamespace(n_routed_experts=2)
+        model.config = SimpleNamespace(n_routed_experts=2, max_n_routed_experts=2)
         model.model = SimpleNamespace()
         model.pp_group = _FakePPGroup()
         model.remap_prefix = {}


### PR DESCRIPTION
## Motivation

`test/registered/unit/models/test_nemotron_h_weight_loading.py` is failing on `main` (e.g. [this run](https://github.com/sgl-project/sglang/actions/runs/26541311227/job/78184088573)):

```
File "python/sglang/srt/models/nemotron_h.py", line 910, in load_weights
    num_experts=self.config.max_n_routed_experts,
AttributeError: 'types.SimpleNamespace' object has no attribute 'max_n_routed_experts'. Did you mean: 'n_routed_experts'?
```

**Root cause:** PR #24429 (Support `NemotronHPuzzleForCausalLM`) changed `NemotronHForCausalLM.load_weights` to read `self.config.max_n_routed_experts` instead of `n_routed_experts` — correct, because the Puzzle variant has heterogeneous blocks and `max_n_routed_experts` is a property returning the max experts across MoE blocks (for the base `NemotronHConfig` it simply returns `n_routed_experts`). However, the regression test added in #24434 builds a fake `SimpleNamespace` config that only defines `n_routed_experts`, so the test now raises `AttributeError`.

## Modification

Add `max_n_routed_experts=2` to the test's fake config so it mirrors the real `NemotronHConfig`, where the property equals `n_routed_experts`. Production code is unchanged — the bug was purely in the test fixture.

## Checklist

- [x] Reproduced and root-caused the CI failure
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26547289058](https://github.com/sgl-project/sglang/actions/runs/26547289058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26547289056](https://github.com/sgl-project/sglang/actions/runs/26547289056)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->