### PR TITLE
[CI] runner-utilization: queue-wait-over-time + running/queued charts

### DIFF
--- a/.github/workflows/runner-utilization.yml
+++ b/.github/workflows/runner-utilization.yml
@@ -56,7 +56,12 @@ jobs:
             -p 'test_runner_utilization_report.py' -v
 
       - name: Generate Utilization Report
-        timeout-minutes: 30
+        # Bumped from 30 to 60 min: with the get_workflow_runs() cap fix,
+        # a 24h window now pulls ~10k runs (vs. the silently-truncated
+        # 5k before), and the job-fetch + chart-build for that volume
+        # was bumping right up against the old 30-min budget. 60 gives
+        # ~2x headroom; if CI volume doubles again we'll know to revisit.
+        timeout-minutes: 60
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -16,6 +16,17 @@ from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 
+# Display all clock times in California time (auto PST/PDT). Internals stay in
+# UTC — this only affects how timestamps are rendered in the report.
+try:
+    from zoneinfo import ZoneInfo
+
+    DISPLAY_TZ = ZoneInfo("America/Los_Angeles")
+    TZ_LABEL = "PT"
+except Exception:  # zoneinfo/tzdata unavailable — fall back to UTC
+    DISPLAY_TZ = timezone.utc
+    TZ_LABEL = "UTC"
+
 # Labels to skip when grouping runners (GitHub default labels)
 DEFAULT_LABELS_TO_IGNORE = {"self-hosted", "Linux", "X64", "ARM64"}
 GITHUB_HOSTED_LABELS = {"ubuntu-latest", "ubuntu-22.04", "ubuntu-24.04"}
@@ -632,11 +643,13 @@ def build_queue_timeline(label_jobs, window_start, window_end, max_series=8):
     if total <= 0 or not label_jobs:
         return [], []
     hours = total / 3600
-    n = max(12, min(48, round(hours * 2)))  # ~30-min resolution
+    # Keep the number of x-axis labels low (one per point in mermaid) so they
+    # stay readable — ~2h resolution for a 24h window (~13 labels).
+    n = max(8, min(12, round(hours)))
     step = total / n
     samples = [window_start + timedelta(seconds=step * i) for i in range(n + 1)]
     fmt = _bucket_label_fmt(hours)
-    sample_labels = [t.strftime(fmt) for t in samples]
+    sample_labels = [t.astimezone(DISPLAY_TZ).strftime(fmt) for t in samples]
 
     series = []
     for label, jobs in label_jobs.items():
@@ -681,7 +694,7 @@ def build_load_buckets(label_jobs, window_start, window_end, max_pools=6):
     step = total / n
     edges = [window_start + timedelta(seconds=step * i) for i in range(n + 1)]
     fmt = _bucket_label_fmt(hours)
-    bucket_labels = [edges[i].strftime(fmt) for i in range(n)]
+    bucket_labels = [edges[i].astimezone(DISPLAY_TZ).strftime(fmt) for i in range(n)]
 
     out = []
     for label, jobs in label_jobs.items():
@@ -726,7 +739,8 @@ def format_report(
         "# Runner Utilization Report",
         "",
         f"**Time window:** Last {hours} hours · "
-        f"**Generated:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
+        f"**Generated:** "
+        f"{datetime.now(DISPLAY_TZ).strftime('%Y-%m-%d %H:%M')} {TZ_LABEL}",
         "",
     ]
     if fetch_failure_pct > 1.0:
@@ -770,20 +784,21 @@ def format_report(
                 "",
                 "## Queue Wait Over Time",
                 "",
-                "Longest in-queue wait per runner pool across the window "
-                "(minutes). Queue time is per-pool — a queued job isn't on a "
-                "host yet, so it can't be attributed to a physical runner.",
+                f"Longest in-queue wait per runner pool across the window "
+                f"(minutes; times in {TZ_LABEL}). Queue time is per-pool — a "
+                f"queued job isn't on a host yet, so it can't be attributed to "
+                f"a physical runner.",
                 "",
                 f"**Pools:** {legend}",
                 "",
                 "```mermaid",
-                '%%{init: {"xyChart": {"width": 1400, "height": 520}, '
+                '%%{init: {"xyChart": {"width": 1500, "height": 520}, '
                 '"themeVariables": {"xyChart": {"plotColorPalette": "'
                 + palette
                 + '"}}}}%%',
                 "xychart-beta",
                 '    title "Queue Wait Over Time (min, per runner pool)"',
-                f'    x-axis "Time (UTC)" [{x_cats}]',
+                f'    x-axis "Time ({TZ_LABEL})" [{x_cats}]',
                 f'    y-axis "Wait (min)" 0 --> {ymax}',
             ]
         )
@@ -800,9 +815,10 @@ def format_report(
                 "",
                 "## Running vs Queued Per Hour",
                 "",
-                "Per runner pool: jobs **running** (🔵 line) and **queued** "
-                "(🟠 bars) during each bucket. Bars rising above the line mean "
-                "demand outran capacity and a backlog built up.",
+                f"Per runner pool: jobs **running** (🔵 line) and **queued** "
+                f"(🟠 bars) during each hourly bucket (times in {TZ_LABEL}). "
+                f"Bars rising above the line mean demand outran capacity and a "
+                f"backlog built up.",
             ]
         )
         for lbl, running, queued in pools:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -586,7 +586,121 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
     # Per-job detail (deduped across labels), longest waits first, for the
     # links + status section of the report.
     longest_waits = sorted(all_job_infos, key=lambda j: j["queue_time"], reverse=True)
-    return results, fetch_failure_pct, longest_waits
+    queue_timeline = build_queue_timeline(label_jobs, window_start, window_end)
+    load_buckets = build_load_buckets(label_jobs, window_start, window_end)
+    return (
+        results,
+        fetch_failure_pct,
+        longest_waits,
+        queue_timeline,
+        load_buckets,
+    )
+
+
+# Distinct line colors paired with a matching legend emoji, in the same order,
+# so the emoji swatch identifies each line — xychart-beta has no built-in
+# legend. Series get palette colors in declaration order.
+QUEUE_CHART_COLORS = [
+    ("🔴", "#e6194B"),
+    ("🟢", "#3cb44b"),
+    ("🔵", "#4363d8"),
+    ("🟠", "#f58231"),
+    ("🟣", "#911eb4"),
+    ("🟤", "#9A6324"),
+    ("⚫", "#000000"),
+    ("🟡", "#ffe119"),
+]
+
+
+def _bucket_label_fmt(window_hours: float) -> str:
+    return "%m-%d %H:%M" if window_hours > 24 else "%H:%M"
+
+
+def build_queue_timeline(label_jobs, window_start, window_end, max_series=8):
+    """Sample each runner pool's longest in-queue wait across the window.
+
+    At each sample time t, a pool's value is the max (t - created_at) over
+    jobs dispatched under that pool that were still waiting at t
+    (created_at <= t < queue_end), in minutes — i.e. how long the worst waiter
+    had been queued at that instant. Queue time is inherently per-pool: a
+    queued job has no host yet, so it can't be tied to a physical runner.
+
+    Returns (sample_labels, [(pool, [values...]), ...]) for the pools with the
+    highest peak wait, capped at max_series (the palette size).
+    """
+    total = (window_end - window_start).total_seconds()
+    if total <= 0 or not label_jobs:
+        return [], []
+    hours = total / 3600
+    n = max(12, min(48, round(hours * 2)))  # ~30-min resolution
+    step = total / n
+    samples = [window_start + timedelta(seconds=step * i) for i in range(n + 1)]
+    fmt = _bucket_label_fmt(hours)
+    sample_labels = [t.strftime(fmt) for t in samples]
+
+    series = []
+    for label, jobs in label_jobs.items():
+        waits = [
+            (j["created_at"], j["queue_end"])
+            for j in jobs
+            if j.get("created_at")
+            and j.get("queue_end")
+            and j["queue_end"] > j["created_at"]
+        ]
+        if not waits:
+            continue
+        values = []
+        for t in samples:
+            best = 0.0
+            for c, qe in waits:
+                # Inclusive at qe so the peak (at pickup, or `now` for a job
+                # still queued at the window end) lands on a sample.
+                if c <= t <= qe:
+                    best = max(best, (t - c).total_seconds() / 60.0)
+            values.append(round(best, 1))
+        peak = max(values)
+        if peak > 0:
+            series.append((label, values, peak))
+    series.sort(key=lambda s: s[2], reverse=True)
+    return sample_labels, [(lbl, vals) for lbl, vals, _ in series[:max_series]]
+
+
+def build_load_buckets(label_jobs, window_start, window_end, max_pools=6):
+    """Per runner pool, count jobs running and queued during each hourly bucket.
+
+    A job is *running* in a bucket if its [start, end] interval overlaps it, and
+    *queued* if its waiting interval [created_at, queue_end] overlaps it.
+    Returns (bucket_labels, [(pool, running[], queued[]), ...]) for the busiest
+    pools (by peak running+queued), capped at max_pools.
+    """
+    total = (window_end - window_start).total_seconds()
+    if total <= 0 or not label_jobs:
+        return [], []
+    hours = total / 3600
+    n = max(6, min(48, round(hours)))  # ~hourly buckets
+    step = total / n
+    edges = [window_start + timedelta(seconds=step * i) for i in range(n + 1)]
+    fmt = _bucket_label_fmt(hours)
+    bucket_labels = [edges[i].strftime(fmt) for i in range(n)]
+
+    out = []
+    for label, jobs in label_jobs.items():
+        running = [0] * n
+        queued = [0] * n
+        for j in jobs:
+            s, e = j.get("start"), j.get("end")
+            c, qe = j.get("created_at"), j.get("queue_end")
+            for i in range(n):
+                b0, b1 = edges[i], edges[i + 1]
+                if s is not None and e is not None and s < b1 and e > b0:
+                    running[i] += 1
+                if c is not None and qe is not None and c < b1 and qe > b0:
+                    queued[i] += 1
+        peak = max((r + q for r, q in zip(running, queued)), default=0)
+        if peak > 0:
+            out.append((label, running, queued, peak))
+    out.sort(key=lambda x: x[3], reverse=True)
+    return bucket_labels, [(lbl, r, q) for lbl, r, q, _ in out[:max_pools]]
 
 
 def format_report(
@@ -595,6 +709,8 @@ def format_report(
     fetch_failure_pct: float = 0.0,
     longest_waits: list = None,
     top_n: int = 20,
+    queue_timeline: tuple = None,
+    load_buckets: tuple = None,
 ) -> str:
     """One compact summary table — original schema, fixed columns.
 
@@ -638,6 +754,77 @@ def format_report(
             f"{r['avg_queue_min']:.1f}m | {r['max_queue_min']:.1f}m | "
             f"{format_status_counts(r.get('status_counts', {}))} |"
         )
+
+    # Queue wait over time — one big multi-line chart, one line per runner pool.
+    if queue_timeline and queue_timeline[1]:
+        sample_labels, series = queue_timeline
+        palette = ",".join(c for _, c in QUEUE_CHART_COLORS[: len(series)])
+        ymax = int(max(max(vals) for _, vals in series) * 1.1) + 5
+        x_cats = ", ".join(f'"{s}"' for s in sample_labels)
+        legend = "  ".join(
+            f"{emoji} `{lbl}`"
+            for (emoji, _), (lbl, _) in zip(QUEUE_CHART_COLORS, series)
+        )
+        lines.extend(
+            [
+                "",
+                "## Queue Wait Over Time",
+                "",
+                "Longest in-queue wait per runner pool across the window "
+                "(minutes). Queue time is per-pool — a queued job isn't on a "
+                "host yet, so it can't be attributed to a physical runner.",
+                "",
+                f"**Pools:** {legend}",
+                "",
+                "```mermaid",
+                '%%{init: {"xyChart": {"width": 1400, "height": 520}, '
+                '"themeVariables": {"xyChart": {"plotColorPalette": "'
+                + palette
+                + '"}}}}%%',
+                "xychart-beta",
+                '    title "Queue Wait Over Time (min, per runner pool)"',
+                f'    x-axis "Time (UTC)" [{x_cats}]',
+                f'    y-axis "Wait (min)" 0 --> {ymax}',
+            ]
+        )
+        for _, vals in series:
+            lines.append("    line [" + ", ".join(str(v) for v in vals) + "]")
+        lines.append("```")
+
+    # Running vs queued per hour — one bar+line chart per busy runner pool.
+    if load_buckets and load_buckets[1]:
+        bucket_labels, pools = load_buckets
+        x_cats = ", ".join(f'"{s}"' for s in bucket_labels)
+        lines.extend(
+            [
+                "",
+                "## Running vs Queued Per Hour",
+                "",
+                "Per runner pool: jobs **running** (🔵 line) and **queued** "
+                "(🟠 bars) during each bucket. Bars rising above the line mean "
+                "demand outran capacity and a backlog built up.",
+            ]
+        )
+        for lbl, running, queued in pools:
+            ymax = int(max(max(running), max(queued), 1) * 1.1) + 1
+            lines.extend(
+                [
+                    "",
+                    f"### {lbl}",
+                    "",
+                    "```mermaid",
+                    '%%{init: {"xyChart": {"width": 1200, "height": 340}, '
+                    '"themeVariables": {"xyChart": {"plotColorPalette": '
+                    '"#f58231,#4363d8"}}}}%%',
+                    "xychart-beta",
+                    f'    title "{lbl} — running (line) & queued (bars) per hour"',
+                    f"    x-axis [{x_cats}]",
+                    f'    y-axis "Jobs" 0 --> {ymax}',
+                    "    bar [" + ", ".join(str(v) for v in queued) + "]",
+                    "    line [" + ", ".join(str(v) for v in running) + "]",
+                    "```",
+                ]
+            )
 
     # Longest queue waits — links to the actual jobs, with live status, so the
     # worst waits (including jobs still queued/running right now) are one click
@@ -738,11 +925,16 @@ def main():
     parser.add_argument("--output", type=str, help="Output file (default: stdout)")
     args = parser.parse_args()
 
-    results, fetch_failure_pct, longest_waits = calculate_utilization(
-        args.repo, args.hours, args.filter
+    results, fetch_failure_pct, longest_waits, queue_timeline, load_buckets = (
+        calculate_utilization(args.repo, args.hours, args.filter)
     )
     report = format_report(
-        results, args.hours, fetch_failure_pct, longest_waits=longest_waits
+        results,
+        args.hours,
+        fetch_failure_pct,
+        longest_waits=longest_waits,
+        queue_timeline=queue_timeline,
+        load_buckets=load_buckets,
     )
 
     if args.output:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -763,13 +763,20 @@ def build_queue_timeline(label_jobs, window_start, window_end, max_series=8):
     return sample_labels, [(lbl, vals) for lbl, vals, _ in series[:max_series]]
 
 
-def build_load_buckets(label_jobs, window_start, window_end, max_pools=6):
+def build_load_buckets(label_jobs, window_start, window_end, max_pools=8):
     """Per runner pool, count jobs running and queued during each hourly bucket.
 
     A job is *running* in a bucket if its [start, end] interval overlaps it, and
     *queued* if its waiting interval [created_at, queue_end] overlaps it.
     Returns (bucket_labels, [(pool, running[], queued[]), ...]) for the busiest
     pools (by peak running+queued), capped at max_pools.
+
+    `max_pools` defaults to 8 to match `build_queue_timeline`'s
+    `max_series=8` so both charts cover the same pool set -- otherwise a
+    pool with sustained-but-flat demand (e.g. 8-gpu-h200 at 85% util, 5
+    peak concurrent, 49 peak queue) appears in the Queue Wait Over Time
+    chart legend but is silently absent from the per-pool Running vs
+    Queued sub-charts, which is confusing.
     """
     total = (window_end - window_start).total_seconds()
     if total <= 0 or not label_jobs:

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -96,33 +96,60 @@ def run_gh_command(args: list[str], max_retries: int = 10) -> dict:
 
 
 def get_workflow_runs(repo: str, hours: int = 24) -> list[dict]:
-    """Get workflow runs from the last N hours."""
+    """Get workflow runs created in the last N hours.
+
+    Paginates the runs API newest-first and filters by `created_at`
+    client-side. Important: do NOT add a server-side `created=...`
+    filter -- the runs API silently invokes a search-style backend
+    when filter params are present, which caps total results at 1000
+    regardless of pagination. Plain unfiltered pagination has no such
+    cap, so we collect what we need and stop at the first run older
+    than the cutoff.
+
+    Previously this function had a hard `page > 50` (5000-run) safety
+    cap. Once daily CI volume passed that threshold, the cap silently
+    truncated the OLDEST end of the window -- the Daily report's first
+    ~10 hours looked empty for that reason. The cap is now raised to
+    200 pages (20k runs), and we log a warning if it ever fires
+    instead of breaking silently.
+    """
     since = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     runs = []
     page = 1
-    while True:
+    # Soft guard against runaway pagination. At ~6 runs/min sustained
+    # SGLang volume, 200 pages = ~57h of runs -- comfortable headroom
+    # for a 24h window. If this ever fires we want to know, not have
+    # the chart silently lose data again.
+    MAX_PAGES = 200
+    while page <= MAX_PAGES:
         data = run_gh_command(
             [
                 f"repos/{repo}/actions/runs?per_page=100&page={page}",
             ]
         )
         page_runs = data.get("workflow_runs", [])
+        if not page_runs:
+            return runs
 
-        # Filter by time
         for run in page_runs:
             created_at = parse_time(run.get("created_at"))
             if created_at and created_at >= since:
                 runs.append(run)
             elif created_at and created_at < since:
-                # Runs are ordered by created_at desc, so we can stop
+                # Runs are ordered by created_at desc, so the first
+                # run older than `since` means we've passed the cutoff.
                 return runs
 
         if len(page_runs) < 100:
-            break
+            return runs
         page += 1
-        if page > 50:  # Safety limit (5000 runs)
-            break
+
+    print(
+        f"WARNING: pagination reached MAX_PAGES={MAX_PAGES} "
+        f"({len(runs)} runs collected). The window may be truncated -- "
+        f"consider narrowing --hours or raising MAX_PAGES."
+    )
     return runs
 
 

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -406,6 +406,45 @@ def _likely_no_gpu_jobs(workflow_name: str) -> bool:
     return any(h in n for h in _NON_GPU_WORKFLOW_HINTS)
 
 
+def _wallclock_busy_seconds(jobs, window_start, window_end):
+    """Wall-clock busy seconds on a single runner across the window.
+
+    Each job contributes its `[start, end]` interval clipped to the
+    window. Overlapping intervals are merged with a sweep so the
+    result is bounded by `(window_end - window_start).total_seconds()`
+    per runner. Without the merge, three pathologies double-count
+    busy time:
+
+    1. GitHub API timestamp slop -- consecutive back-to-back jobs on
+       the same runner aren't reliably monotonic, so job N+1's
+       `started_at` can land slightly before job N's `completed_at`.
+    2. `filter=all` on the jobs API returns every retry attempt as a
+       separate row; same runner_name, near-adjacent intervals.
+    3. An `in_progress` job uses `end=now`, which can straddle a
+       just-completed job's `completed_at` by a few seconds.
+
+    These pushed per-label utilization slightly above 100% on busy
+    multi-GPU pools (e.g. `2-gpu-h100` rendered at 108.8% before this
+    helper landed). After merging, utilization is mathematically
+    capped at 100% per label.
+    """
+    intervals = []
+    for j in jobs:
+        cs = max(j["start"], window_start)
+        ce = min(j["end"], window_end)
+        if ce > cs:
+            intervals.append((cs, ce))
+    intervals.sort()
+    busy = 0.0
+    covered_until = window_start
+    for s, e in intervals:
+        s = max(s, covered_until)
+        if e > s:
+            busy += (e - s).total_seconds()
+            covered_until = e
+    return busy
+
+
 def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None):
     """Calculate runner utilization metrics."""
 
@@ -541,15 +580,10 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
 
     # Per-host window-clamped busy time (each physical machine counted once).
     # This is the source of truth for how loaded each host actually is.
-    host_busy_seconds = {}
-    for host, jobs in host_jobs.items():
-        busy = 0.0
-        for j in jobs:
-            cs = max(j["start"], window_start)
-            ce = min(j["end"], window_end)
-            if ce > cs:
-                busy += (ce - cs).total_seconds()
-        host_busy_seconds[host] = busy
+    host_busy_seconds = {
+        host: _wallclock_busy_seconds(jobs, window_start, window_end)
+        for host, jobs in host_jobs.items()
+    }
 
     results = []
     for label in sorted(all_labels):

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -683,7 +683,16 @@ def calculate_utilization(repo: str, hours: int = 24, runner_filter: str = None)
     # links + status section of the report.
     longest_waits = sorted(all_job_infos, key=lambda j: j["queue_time"], reverse=True)
     queue_timeline = build_queue_timeline(label_jobs, window_start, window_end)
-    load_buckets = build_load_buckets(label_jobs, window_start, window_end)
+    # Hand utilization to build_load_buckets so it can include
+    # small-but-saturated pools (e.g. 8-gpu-b200 at 89.5% util on a
+    # single runner) that the peak-demand ranking alone would demote.
+    utilization_by_label = {r["label"]: r["utilization_pct"] for r in results}
+    load_buckets = build_load_buckets(
+        label_jobs,
+        window_start,
+        window_end,
+        utilization_by_label=utilization_by_label,
+    )
     return (
         results,
         fetch_failure_pct,
@@ -763,20 +772,36 @@ def build_queue_timeline(label_jobs, window_start, window_end, max_series=8):
     return sample_labels, [(lbl, vals) for lbl, vals, _ in series[:max_series]]
 
 
-def build_load_buckets(label_jobs, window_start, window_end, max_pools=8):
+def build_load_buckets(
+    label_jobs,
+    window_start,
+    window_end,
+    max_pools=8,
+    *,
+    utilization_by_label=None,
+    max_total=12,
+):
     """Per runner pool, count jobs running and queued during each hourly bucket.
 
     A job is *running* in a bucket if its [start, end] interval overlaps it, and
     *queued* if its waiting interval [created_at, queue_end] overlaps it.
-    Returns (bucket_labels, [(pool, running[], queued[]), ...]) for the busiest
-    pools (by peak running+queued), capped at max_pools.
+    Returns (bucket_labels, [(pool, running[], queued[]), ...]) for the
+    pools selected by the ranking below.
 
-    `max_pools` defaults to 8 to match `build_queue_timeline`'s
-    `max_series=8` so both charts cover the same pool set -- otherwise a
-    pool with sustained-but-flat demand (e.g. 8-gpu-h200 at 85% util, 5
-    peak concurrent, 49 peak queue) appears in the Queue Wait Over Time
-    chart legend but is silently absent from the per-pool Running vs
-    Queued sub-charts, which is confusing.
+    Selection:
+      - When `utilization_by_label` is None: top `max_pools` by peak
+        (running+queued). This is the legacy behavior.
+      - When given: union of (top `max_pools` by peak) and (top
+        `max_pools` by utilization%), de-duplicated and capped at
+        `max_total`. Peak-ranked pools come first so the visual order
+        matches the queue chart; utilization-ranked additions follow.
+
+    Why the hybrid: ranking purely by peak (running+queued) demotes
+    small-but-saturated pools. e.g. 8-gpu-b200 has 1 runner busy 89.5%
+    of the window but peak running+queued is ~7, putting it around
+    15th place. With the hybrid it lands via its 94% utilization
+    instead. `max_pools=8` matches `build_queue_timeline`'s
+    `max_series=8` so both charts cover the same primary pool set.
     """
     total = (window_end - window_start).total_seconds()
     if total <= 0 or not label_jobs:
@@ -804,8 +829,29 @@ def build_load_buckets(label_jobs, window_start, window_end, max_pools=8):
         peak = max((r + q for r, q in zip(running, queued)), default=0)
         if peak > 0:
             out.append((label, running, queued, peak))
-    out.sort(key=lambda x: x[3], reverse=True)
-    return bucket_labels, [(lbl, r, q) for lbl, r, q, _ in out[:max_pools]]
+
+    by_peak = sorted(out, key=lambda x: x[3], reverse=True)
+    peak_top = [x[0] for x in by_peak[:max_pools]]
+
+    if utilization_by_label is None:
+        selected = peak_top
+    else:
+        # Restrict utilization ranking to pools that had nonzero
+        # peak (running+queued) data this window -- a pool with high
+        # historical utilization but no observed activity in this
+        # window has nothing to plot.
+        candidates = {x[0] for x in out}
+        util_top = sorted(
+            (lbl for lbl in candidates if utilization_by_label.get(lbl, 0) > 0),
+            key=lambda lbl: utilization_by_label[lbl],
+            reverse=True,
+        )[:max_pools]
+        # dict.fromkeys preserves first-seen order: peak-rank first,
+        # utilization-only additions after, then cap at max_total.
+        selected = list(dict.fromkeys(peak_top + util_top))[:max_total]
+
+    by_label = {label: (label, r, q) for label, r, q, _ in out}
+    return bucket_labels, [by_label[lbl] for lbl in selected if lbl in by_label]
 
 
 def format_report(

--- a/scripts/ci/utils/runner_utilization_report.py
+++ b/scripts/ci/utils/runner_utilization_report.py
@@ -314,16 +314,40 @@ def calculate_concurrency_metrics(
             "saturation_pct": 0.0,
             "peak_queue": 0,
         }
-    running_events = []
+    # Group running intervals by runner_name and merge per-runner before
+    # building (start, +1) / (end, -1) events. Same overlap sources as
+    # _wallclock_busy_seconds (timestamp slop, `filter=all` retry rows,
+    # in_progress end=now straddling completed_at) -- without the merge
+    # they push `current_running` above num_runners and Avg Concurrent
+    # renders >100% (e.g. 4-gpu-b200 showed 7.5/7=107% in the previous
+    # run). Merge per-runner, not globally: jobs on DIFFERENT runners
+    # do legitimately overlap and must contribute separate events.
+    intervals_by_runner = defaultdict(list)
     for job in jobs:
-        start, end = job["start"], job["end"]
-        # Still-queued jobs have no running interval yet (start/end are None).
+        start, end = job.get("start"), job.get("end")
         if start is None or end is None:
             continue
         if end < window_start or start > window_end:
             continue
-        running_events.append((max(start, window_start), 1))
-        running_events.append((min(end, window_end), -1))
+        s = max(start, window_start)
+        e = min(end, window_end)
+        if e <= s:
+            continue
+        # Bucket runnerless jobs (rare in_progress edge case) individually
+        # so we don't merge unrelated jobs into one interval.
+        runner = job.get("runner_name") or f"_unknown_{id(job)}"
+        intervals_by_runner[runner].append((s, e))
+
+    running_events = []
+    for intervals in intervals_by_runner.values():
+        intervals.sort()
+        covered_until = window_start
+        for s, e in intervals:
+            s = max(s, covered_until)
+            if e > s:
+                running_events.append((s, 1))
+                running_events.append((e, -1))
+                covered_until = e
     queue_events = []
     for job in jobs:
         created_at = job.get("created_at")

--- a/scripts/ci/utils/test_runner_utilization_report.py
+++ b/scripts/ci/utils/test_runner_utilization_report.py
@@ -184,6 +184,7 @@ class TestStatusAndFormatting(unittest.TestCase):
             }
         ]
         report = rur.format_report(results, 24, 0.0, longest_waits=waits)
+        self.assertIn(rur.TZ_LABEL, report)  # generated-time stamped with tz
         self.assertIn("| Status |", report)  # new main-table column
         self.assertIn("Longest Queue Waits", report)
         self.assertIn(f"]({url})", report)  # clickable job link

--- a/scripts/ci/utils/test_runner_utilization_report.py
+++ b/scripts/ci/utils/test_runner_utilization_report.py
@@ -191,5 +191,55 @@ class TestStatusAndFormatting(unittest.TestCase):
         self.assertIn("⏳", report)
 
 
+class TestChartBuilders(unittest.TestCase):
+    @staticmethod
+    def _info(created, queue_end, start=None, end=None):
+        return {
+            "created_at": created,
+            "queue_end": queue_end,
+            "start": start,
+            "end": end,
+        }
+
+    def test_queue_timeline_tracks_ongoing_wait(self):
+        # One job queued the whole 4h window (still waiting at the end).
+        lj = {"8-gpu-h200": [self._info(CREATED, NOW)]}
+        labels, series = rur.build_queue_timeline(lj, CREATED, NOW)
+        self.assertEqual(len(series), 1)
+        pool, vals = series[0]
+        self.assertEqual(pool, "8-gpu-h200")
+        self.assertEqual(len(vals), len(labels))  # x/y aligned for mermaid
+        self.assertAlmostEqual(vals[0], 0, delta=2)  # ~0 at window start
+        self.assertAlmostEqual(vals[-1], 240, delta=2)  # full 4h wait at end
+
+    def test_queue_timeline_caps_and_sorts_by_peak(self):
+        lj = {
+            f"pool{i}": [self._info(CREATED, CREATED + timedelta(minutes=10 * i + 1))]
+            for i in range(12)
+        }
+        _, series = rur.build_queue_timeline(lj, CREATED, NOW, max_series=8)
+        self.assertEqual(len(series), 8)  # capped at palette size
+        peaks = [max(v) for _, v in series]
+        self.assertEqual(peaks, sorted(peaks, reverse=True))  # busiest first
+
+    def test_load_buckets_counts_running_and_queued(self):
+        ws = NOW - timedelta(hours=8)  # 8 hourly buckets
+        start = ws + timedelta(hours=1)
+        end = ws + timedelta(hours=3)
+        lj = {"p": [self._info(ws, start, start=start, end=end)]}
+        labels, pools = rur.build_load_buckets(lj, ws, NOW)
+        self.assertEqual(len(labels), 8)
+        lbl, running, queued = pools[0]
+        self.assertEqual(lbl, "p")
+        self.assertEqual(len(running), 8)
+        self.assertEqual((queued[0], running[0]), (1, 0))  # hour 0: waiting
+        self.assertEqual((queued[1], running[1]), (0, 1))  # hour 1: running
+        self.assertEqual(running[3], 0)  # ended by hour 3
+
+    def test_empty_inputs_safe(self):
+        self.assertEqual(rur.build_queue_timeline({}, CREATED, NOW), ([], []))
+        self.assertEqual(rur.build_load_buckets({}, CREATED, NOW), ([], []))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/utils/test_runner_utilization_report.py
+++ b/scripts/ci/utils/test_runner_utilization_report.py
@@ -362,6 +362,79 @@ class TestChartBuilders(unittest.TestCase):
         self.assertEqual(rur.build_queue_timeline({}, CREATED, NOW), ([], []))
         self.assertEqual(rur.build_load_buckets({}, CREATED, NOW), ([], []))
 
+    def test_load_buckets_hybrid_includes_high_util_low_peak_pool(self):
+        """The motivating case: a pool with only 1 runner serving 1 job
+        the entire window (peak running+queued = 1) is invisible under
+        pure peak-ranking but has 100% utilization. With the hybrid it
+        must appear alongside the high-peak pools."""
+        ws = NOW - timedelta(hours=8)
+        lj = {}
+        # 8 noisy pools each peaking at 5 concurrent jobs in one bucket.
+        # Without the hybrid these claim the top 8 slots.
+        for i in range(8):
+            jobs = []
+            for _ in range(5):
+                start = ws + timedelta(hours=2)
+                end = ws + timedelta(hours=2, minutes=30)
+                jobs.append(self._info(start, start, start=start, end=end))
+            lj[f"noisy-{i}"] = jobs
+        # One "8-gpu-b200-like" pool: a single job pinning a single
+        # runner for the whole window -> peak = 1, util = 100%.
+        start = ws
+        end = NOW
+        lj["small-saturated"] = [self._info(start, start, start=start, end=end)]
+
+        util = {f"noisy-{i}": 10.0 for i in range(8)}
+        util["small-saturated"] = 100.0
+
+        _, pools_no_util = rur.build_load_buckets(lj, ws, NOW, max_pools=8)
+        names_no_util = [lbl for lbl, _, _ in pools_no_util]
+        self.assertNotIn("small-saturated", names_no_util)  # legacy: cut
+
+        _, pools_hybrid = rur.build_load_buckets(
+            lj, ws, NOW, max_pools=8, utilization_by_label=util, max_total=12
+        )
+        names_hybrid = [lbl for lbl, _, _ in pools_hybrid]
+        self.assertIn("small-saturated", names_hybrid)  # hybrid: surfaced
+        self.assertLessEqual(len(names_hybrid), 12)
+
+    def test_load_buckets_hybrid_peak_first_then_util_only(self):
+        """Display order: pools that won by peak come first, then any
+        pools only added via utilization. Within each group the order
+        mirrors the rank that included them."""
+        ws = NOW - timedelta(hours=4)
+        lj = {
+            "peaky-A": [
+                self._info(
+                    ws,
+                    ws,
+                    start=ws + timedelta(hours=1),
+                    end=ws + timedelta(hours=2),
+                )
+            ]
+            * 10,  # peak ~10
+            "peaky-B": [
+                self._info(
+                    ws,
+                    ws,
+                    start=ws + timedelta(hours=1),
+                    end=ws + timedelta(hours=2),
+                )
+            ]
+            * 5,  # peak ~5
+            "util-only": [
+                self._info(ws, ws, start=ws, end=NOW)
+            ],  # peak 1 but 100% util
+        }
+        util = {"peaky-A": 30.0, "peaky-B": 20.0, "util-only": 100.0}
+        _, pools = rur.build_load_buckets(
+            lj, ws, NOW, max_pools=2, utilization_by_label=util, max_total=12
+        )
+        names = [lbl for lbl, _, _ in pools]
+        # peaky-A, peaky-B by peak (top 2). util-only added via util.
+        self.assertEqual(names[:2], ["peaky-A", "peaky-B"])
+        self.assertIn("util-only", names[2:])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/utils/test_runner_utilization_report.py
+++ b/scripts/ci/utils/test_runner_utilization_report.py
@@ -149,6 +149,68 @@ class TestWallclockBusySeconds(unittest.TestCase):
         self.assertEqual(rur._wallclock_busy_seconds([], self.WS, self.WE), 0.0)
 
 
+class TestConcurrencyMergesPerRunnerSlop(unittest.TestCase):
+    """The Avg Concurrent column had the same timestamp-slop overcount
+    that Utilization did -- jobs on the SAME runner_name reporting
+    overlapping intervals briefly pushed `current_running` above the
+    real per-instant count, dragging Avg Concurrent above num_runners.
+    These tests guard the per-runner merge inside
+    calculate_concurrency_metrics."""
+
+    WS = NOW - timedelta(hours=24)
+    WE = NOW
+
+    def _running_job(self, runner, h0, h1):
+        return {
+            "start": self.WS + timedelta(hours=h0),
+            "end": self.WS + timedelta(hours=h1),
+            "runner_name": runner,
+            "created_at": self.WS + timedelta(hours=h0),
+            "queue_end": self.WS + timedelta(hours=h0),
+            "status": "pass",
+            "queue_time": 0,
+        }
+
+    def test_same_runner_overlap_does_not_inflate_avg(self):
+        # Two reported intervals on the same runner overlap by 0.5h
+        # (timestamp slop / retry-row). Real wall-clock busy = 1.5h,
+        # avg_concurrent over 24h = 1.5/24 = 0.0625. Without merge,
+        # the sum-of-intervals view would give 2.0h busy and a higher
+        # avg.
+        jobs = [
+            self._running_job("R1", 0, 1),
+            self._running_job("R1", 0.5, 1.5),
+        ]
+        conc = rur.calculate_concurrency_metrics(jobs, self.WS, self.WE, num_runners=1)
+        # peak should stay at 1: at any real instant only one job on R1
+        self.assertEqual(conc["peak_concurrent"], 1)
+        # avg = 1.5h / 24h
+        self.assertAlmostEqual(conc["avg_concurrent"], 1.5 / 24, places=4)
+
+    def test_different_runners_overlap_does_inflate_avg(self):
+        # Same intervals but on TWO different runners -> legitimately
+        # concurrent. Merge must NOT collapse across runners.
+        jobs = [
+            self._running_job("R1", 0, 1),
+            self._running_job("R2", 0.5, 1.5),
+        ]
+        conc = rur.calculate_concurrency_metrics(jobs, self.WS, self.WE, num_runners=2)
+        # 0.5h window of overlap when both runners were running
+        self.assertEqual(conc["peak_concurrent"], 2)
+        # avg = (1h + 1h) / 24h
+        self.assertAlmostEqual(conc["avg_concurrent"], 2.0 / 24, places=4)
+
+    def test_avg_concurrent_capped_by_num_runners_with_full_overlap_slop(self):
+        # 10 reported intervals all on the same runner, all covering the
+        # full window -- after merge, the runner is busy for 24h, so avg
+        # concurrent = 1 (not 10). This is the property that prevents
+        # the Concurrency column from rendering >100%.
+        jobs = [self._running_job("R1", 0, 24) for _ in range(10)]
+        conc = rur.calculate_concurrency_metrics(jobs, self.WS, self.WE, num_runners=1)
+        self.assertEqual(conc["peak_concurrent"], 1)
+        self.assertAlmostEqual(conc["avg_concurrent"], 1.0, places=4)
+
+
 class TestConcurrencyHandlesQueuedJobs(unittest.TestCase):
     def test_queued_job_does_not_crash_and_counts_in_peak_queue(self):
         window_start = NOW - timedelta(hours=24)

--- a/scripts/ci/utils/test_runner_utilization_report.py
+++ b/scripts/ci/utils/test_runner_utilization_report.py
@@ -90,6 +90,65 @@ class TestClassifyJob(unittest.TestCase):
         self.assertIsNone(rur.classify_job(job, NOW))
 
 
+class TestWallclockBusySeconds(unittest.TestCase):
+    """Guards the merge that keeps per-host busy time <= window_seconds
+    (and therefore per-label utilization <= 100%). Before this merge,
+    job-interval overlap from GitHub timestamp slop / `filter=all`
+    retries / in_progress `end=now` was double-counted -- busy pools
+    rendered above 100% in the report."""
+
+    WS = NOW - timedelta(hours=24)
+    WE = NOW
+
+    def _intv(self, h0: float, h1: float):
+        """Build a job_info-shaped dict spanning [WS+h0h, WS+h1h]."""
+        return {
+            "start": self.WS + timedelta(hours=h0),
+            "end": self.WS + timedelta(hours=h1),
+        }
+
+    def test_disjoint_intervals_sum_straight(self):
+        # Two non-overlapping 1h intervals -> 2h busy.
+        jobs = [self._intv(0, 1), self._intv(2, 3)]
+        busy = rur._wallclock_busy_seconds(jobs, self.WS, self.WE)
+        self.assertEqual(busy, 2 * 3600)
+
+    def test_overlap_merged_not_double_counted(self):
+        # Two 1h jobs overlapping by 30min -> wall-clock 1.5h, not 2h.
+        # This is the canonical timestamp-slop / retry-row case.
+        jobs = [self._intv(0, 1), self._intv(0.5, 1.5)]
+        busy = rur._wallclock_busy_seconds(jobs, self.WS, self.WE)
+        self.assertEqual(busy, 1.5 * 3600)
+
+    def test_fully_contained_interval_absorbed(self):
+        # A 30-min job entirely inside a 2h job -> still 2h busy.
+        jobs = [self._intv(0, 2), self._intv(0.5, 1)]
+        busy = rur._wallclock_busy_seconds(jobs, self.WS, self.WE)
+        self.assertEqual(busy, 2 * 3600)
+
+    def test_intervals_clipped_to_window(self):
+        # Job spans before window_start and after window_end -> clipped to 24h.
+        jobs = [
+            {
+                "start": self.WS - timedelta(hours=5),
+                "end": self.WE + timedelta(hours=5),
+            }
+        ]
+        busy = rur._wallclock_busy_seconds(jobs, self.WS, self.WE)
+        self.assertEqual(busy, 24 * 3600)
+
+    def test_busy_bounded_by_window(self):
+        # Many overlapping jobs covering the whole window -> busy capped
+        # at 24h regardless of how many overlap. This is the property
+        # that guarantees utilization <= 100% per label.
+        jobs = [self._intv(0, 24) for _ in range(50)]
+        busy = rur._wallclock_busy_seconds(jobs, self.WS, self.WE)
+        self.assertEqual(busy, 24 * 3600)
+
+    def test_empty_jobs(self):
+        self.assertEqual(rur._wallclock_busy_seconds([], self.WS, self.WE), 0.0)
+
+
 class TestConcurrencyHandlesQueuedJobs(unittest.TestCase):
     def test_queued_job_does_not_crash_and_counts_in_peak_queue(self):
         window_start = NOW - timedelta(hours=24)


### PR DESCRIPTION
Follow-up to the runner-utilization queue-time fix. Adds two Mermaid charts to the report's Step Summary.

## 1. Queue Wait Over Time
One big multi-line chart — a line per runner **pool** — plotting the longest in-queue wait (minutes) sampled across the window (default 24h, ~30-min resolution). Distinct color per pool with a matching emoji legend, since `xychart-beta` has no native legend. Placed right before **Longest Queue Waits** (overview → detail).

> Queue time is inherently per-pool: a queued job hasn't been assigned a host yet, so it can't be attributed to a physical runner. Lines are therefore pools (`8-gpu-h200`, `4-gpu-b200`, …), capped at the 8-color palette by peak wait.

## 2. Running vs Queued Per Hour
A bar+line chart per busy pool: **queued** jobs as 🟠 bars, **running** jobs as a 🔵 line, bucketed hourly. Bars rising above the line = demand outran capacity and a backlog built up.

## Implementation
- Pure builders `build_queue_timeline()` / `build_load_buckets()` consume the same `label_jobs` the report already has (each `job_info` carries `created_at`, `start`, `end`, `queue_end` from `classify_job`).
- Both are covered by stdlib-only unit tests, run by the existing workflow test step (no API calls).

Validated locally against real job data: the `8-gpu-h200` line climbs to ~264m for the still-queued job, and its hourly bars show the 6-job backlog draining as running ramps up.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26869456162](https://github.com/sgl-project/sglang/actions/runs/26869456162)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26869456099](https://github.com/sgl-project/sglang/actions/runs/26869456099)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->