### PR TITLE
fix: use req.req_pool_idx instead of loop variable for req_to_token i…

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -386,7 +386,7 @@ def prepare_extend_inputs_for_correctness_test(
         req.fill_ids += input_ids[i][bench_args.cut_len :]
         if model_runner is not None:
             req.prefix_indices = model_runner.req_to_token_pool.req_to_token[
-                i, : bench_args.cut_len
+                req.req_pool_idx, : bench_args.cut_len
             ].to(req.prefix_indices.dtype)
             req.logprob_start_len = -1
             req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In bench_one_batch.py prepare_extend_inputs_for_correctness_test, the loop variable i was incorrectly used to index into req_to_token_pool. When requests are not stored in contiguous order, this causes a  silent index mismatch — the wrong prefix indices are assigned, leading to incorrect correctness test results.

## Modifications

- python/sglang/bench_one_batch.py: replace i with req.req_pool_idx when indexing into model_runner.req_to_token_pool.req_to_token so each request retrieves its own prefix indices correctly.

## Accuracy Tests

  Command:
```bash
  python3 -m sglang.bench_one_batch \
    --model-path Qwen3-8B \
    --correct \
    --batch-size 1 \
    --output-len 128
```

  **Input (same before/after the fix):**
  input_ids=[[785, 6722, 315, 9625, 374], [785, 6722, 315, 279, 3639, 16840, 316, 374], [15364, 374, 264, 39698, 1899, 323, 358, 1075]]

  **Before fix — garbled output due to wrong prefix KV cache**

```
  The loop variable i was used to index into req_to_token_pool, causing each request to load another request's prefix KV cache. The generated outputs are mismatched with the inputs:

  ========== Prompt 0 ==========
  The capital of France is, the sum of the first n terms of a geometric sequence
  is given by the formula: S_n = a_1 * (1 - r^n) / (1 - r)...

  ========== Prompt 1 ==========
  The capital of the United Kindom is Paris...  (incorrectly starts with "Paris")

  ========== Prompt 2 ==========
  Today is a sunny day and I like it. The food is good, the service is friendly...
  (mixed with a restaurant review from a different request)
```

  **After fix — correct output**

  Using req.req_pool_idx ensures each request retrieves its own prefix KV cache. Outputs are coherent and match their respective inputs:

```
  ========== Prompt 0 ==========
  The capital of France is Paris. The capital of Italy is Rome. The capital of
  Spain is Madrid. The capital of Germany is Berlin...

  ========== Prompt 1 ==========
  The capital of the United Kindom is London. The capital of France is Paris.
  The capital of Germany is Berlin. The capital of Italy is Rome...

  ========== Prompt 2 ==========
  Today is a sunny day and I like to go out for a walk. I have a choice between
  two paths: one is a straight path to the park...
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #26553269103](https://github.com/sgl-project/sglang/actions/runs/26553269103)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26553269021](https://github.com/sgl-project/sglang/actions/runs/26553269021)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->