### PR TITLE
[gRPC] OpenAIServing.stream_chunks: skip SSE round-trip for non-HTTP transports (WIP)

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -1,0 +1,697 @@
+"""Python-side bridge between the Rust gRPC server and TokenizerManager.
+
+The RuntimeHandle exposes synchronous methods that Rust can call via PyO3
+(with a brief GIL acquisition). Response chunks are pushed into Rust-side
+channels via callback objects while all async work stays on the
+TokenizerManager's event loop.
+"""
+
+import asyncio
+import dataclasses
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MockRequest:
+    """Lightweight stand-in for fastapi.Request when called from gRPC.
+
+    The OpenAI serving classes expect a fastapi.Request for disconnect
+    detection and routing key extraction. This satisfies that interface
+    without importing FastAPI.
+    """
+
+    def __init__(self, headers: Optional[Dict[str, str]] = None):
+        self.headers = headers or {}
+        self.url = type("URL", (), {"path": "/grpc"})()
+        self.state = type("State", (), {})()
+        self.app = type("App", (), {"state": type("AppState", (), {})()})()
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class RuntimeHandle:
+    """Thin Python handle that the Rust gRPC server calls into.
+
+    Provides synchronous ``submit_*``, ``abort``, and info methods.
+    Each submit method receives a ``chunk_callback`` (a Rust-side PyO3 object)
+    that it invokes with ``(chunk_dict, finished, error)`` for each response
+    chunk produced by TokenizerManager.
+    """
+
+    def __init__(
+        self,
+        tokenizer_manager,
+        template_manager,
+        server_args,
+        scheduler_info: Optional[Dict] = None,
+    ):
+        self.tokenizer_manager = tokenizer_manager
+        self.template_manager = template_manager
+        self.server_args = server_args
+        self.scheduler_info = scheduler_info or {}
+
+        self._openai_serving_classes = None
+
+    @property
+    def _tm_loop(self):
+        """Return the tokenizer_manager's event loop (uvicorn loop).
+
+        Communicator-based async methods (flush_cache, get_load, etc.) use
+        asyncio.Event internally, which only works within a single event
+        loop. These must run on the same loop as handle_loop(), i.e. the
+        tokenizer_manager's event_loop.
+        """
+        loop = getattr(self.tokenizer_manager, "event_loop", None)
+        if loop is None:
+            raise RuntimeError(
+                "TokenizerManager event loop not ready - server still starting"
+            )
+        return loop
+
+    def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
+        try:
+            chunk_callback(payload, finished=finished, error=error)
+        except Exception:
+            pass
+
+    def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
+        try:
+            loop = self._tm_loop
+        except RuntimeError as e:
+            self._safe_callback(
+                chunk_callback, empty_response, finished=True, error=str(e)
+            )
+            return
+        asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+
+    def _get_openai_serving(self):
+        """Lazily initialize OpenAI serving classes."""
+        if self._openai_serving_classes is not None:
+            return self._openai_serving_classes
+
+        from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+        from sglang.srt.entrypoints.openai.serving_classify import (
+            OpenAIServingClassify,
+        )
+        from sglang.srt.entrypoints.openai.serving_completions import (
+            OpenAIServingCompletion,
+        )
+        from sglang.srt.entrypoints.openai.serving_embedding import (
+            OpenAIServingEmbedding,
+        )
+        from sglang.srt.entrypoints.openai.serving_rerank import OpenAIServingRerank
+        from sglang.srt.entrypoints.openai.serving_score import OpenAIServingScore
+
+        self._openai_serving_classes = {
+            "chat": OpenAIServingChat(self.tokenizer_manager, self.template_manager),
+            "completion": OpenAIServingCompletion(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "embedding": OpenAIServingEmbedding(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "classify": OpenAIServingClassify(
+                self.tokenizer_manager, self.template_manager
+            ),
+            "score": OpenAIServingScore(self.tokenizer_manager),
+            "rerank": OpenAIServingRerank(
+                self.tokenizer_manager, self.template_manager
+            ),
+        }
+        return self._openai_serving_classes
+
+    # ------------------------------------------------------------------
+    # Consolidated request submission (generate / embed / classify)
+    # ------------------------------------------------------------------
+
+    def submit_request(self, *, req_type: str, req_dict: dict, chunk_callback):
+        """Submit a generate or embed request from a pre-built dict.
+
+        The Rust gRPC server builds ``req_dict`` directly from proto fields,
+        mapping them to GenerateReqInput / EmbeddingReqInput field names.
+        Python just does ``**dict`` unpacking - no JSON parsing needed.
+
+        Args:
+            req_type: "generate" or "embed" (classify uses "embed").
+            req_dict: Dict matching the dataclass constructor kwargs.
+            chunk_callback: Rust-side PyO3 callback object.
+        """
+        if req_type == "generate":
+            from sglang.srt.managers.io_struct import GenerateReqInput
+
+            obj = GenerateReqInput(**req_dict)
+            stream = req_dict.get("stream", False)
+            self._submit_on_tm_loop(
+                lambda: self._run_generate(obj, chunk_callback, stream),
+                chunk_callback,
+                empty_response={},
+            )
+        else:
+            from sglang.srt.managers.io_struct import EmbeddingReqInput
+
+            obj = EmbeddingReqInput(**req_dict)
+            self._submit_on_tm_loop(
+                lambda: self._run_embed(obj, chunk_callback),
+                chunk_callback,
+                empty_response={},
+            )
+
+    async def _run_generate(self, obj, chunk_callback, stream: bool):
+        try:
+            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            if stream:
+                async for chunk in gen:
+                    finished = (
+                        chunk.get("meta_info", {}).get("finish_reason") is not None
+                    )
+                    chunk_callback(chunk, finished=finished)
+                    if finished:
+                        return
+            else:
+                result = await gen.__anext__()
+                chunk_callback(result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+
+    async def _run_embed(self, obj, chunk_callback):
+        try:
+            gen = self.tokenizer_manager.generate_request(obj, request=None)
+            result = await gen.__anext__()
+            chunk_callback(result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
+            self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Abort
+    # ------------------------------------------------------------------
+
+    def abort(self, rid: str = "", abort_all: bool = False):
+        """Abort a request by request ID or abort all active requests."""
+        try:
+            loop = self._tm_loop
+        except RuntimeError:
+            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            return
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._abort_async(rid, abort_all),
+            loop,
+        )
+        future.result()
+
+    async def _abort_async(self, rid: str, abort_all: bool) -> None:
+        self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+
+    # ------------------------------------------------------------------
+    # Info RPCs (synchronous, small data)
+    # ------------------------------------------------------------------
+
+    def get_model_info(self) -> str:
+        """Return model info as a JSON string."""
+        model_config = self.tokenizer_manager.model_config
+        result = {
+            "model_path": self.tokenizer_manager.model_path,
+            "tokenizer_path": self.server_args.tokenizer_path,
+            "is_generation": self.tokenizer_manager.is_generation,
+            "weight_version": self.server_args.weight_version,
+            "model_type": getattr(model_config.hf_config, "model_type", None),
+            "architectures": getattr(model_config.hf_config, "architectures", None),
+        }
+        return json.dumps(result, default=str)
+
+    def get_server_info(self) -> str:
+        """Return server info as a JSON string."""
+        result: Dict[str, Any] = {}
+        try:
+            sa = self.server_args
+            if hasattr(sa, "model_config"):
+                sa = dataclasses.replace(sa)
+                if hasattr(sa, "model_config"):
+                    delattr(sa, "model_config")
+            result.update(dataclasses.asdict(sa))
+        except Exception:
+            pass
+        result.update(self.scheduler_info)
+        return json.dumps(result, default=str)
+
+    def health_check(self) -> bool:
+        """Return True if the server is healthy."""
+        from sglang.srt.managers.tokenizer_manager import ServerStatus
+
+        if self.tokenizer_manager.gracefully_exit:
+            return False
+        if self.tokenizer_manager.server_status == ServerStatus.Starting:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Tokenize / Detokenize (local ops, no inference)
+    # ------------------------------------------------------------------
+
+    def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
+        """Tokenize text and return result as JSON string."""
+        tokenizer = self.tokenizer_manager.tokenizer
+        tokens = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+        result = {
+            "tokens": tokens,
+            "count": len(tokens),
+            "max_model_len": self.tokenizer_manager.model_config.context_len,
+            "input_text": text,
+        }
+        return json.dumps(result)
+
+    def detokenize(self, tokens: List[int]) -> str:
+        """Detokenize token IDs and return result as JSON string."""
+        tokenizer = self.tokenizer_manager.tokenizer
+        text = tokenizer.decode(tokens)
+        return json.dumps({"text": text})
+
+    # ------------------------------------------------------------------
+    # List models
+    # ------------------------------------------------------------------
+
+    def list_models(self) -> str:
+        """Return the list of served models as JSON string."""
+        served_model_name = self.tokenizer_manager.served_model_name
+        models = [
+            {
+                "id": served_model_name,
+                "root": served_model_name,
+                "max_model_len": self.tokenizer_manager.model_config.context_len,
+            }
+        ]
+        if self.server_args.enable_lora and hasattr(
+            self.tokenizer_manager, "lora_registry"
+        ):
+            lora_registry = self.tokenizer_manager.lora_registry
+            for _, lora_ref in lora_registry.get_all_adapters().items():
+                models.append(
+                    {
+                        "id": lora_ref.lora_name,
+                        "root": lora_ref.lora_path,
+                        "parent": served_model_name,
+                    }
+                )
+        return json.dumps(models)
+
+    # ------------------------------------------------------------------
+    # Get load
+    # ------------------------------------------------------------------
+
+    def get_load(self, chunk_callback, dp_rank: Optional[int] = None) -> None:
+        """Return load info via chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._get_load_async(chunk_callback, dp_rank),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _get_load_async(
+        self, chunk_callback, dp_rank: Optional[int] = None
+    ) -> None:
+        try:
+            result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
+            data = json.dumps([dataclasses.asdict(r) for r in result], default=str)
+            chunk_callback(data.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC get_load error: %s", e)
+            data = json.dumps({"error": str(e)})
+            chunk_callback(data.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Flush cache
+    # ------------------------------------------------------------------
+
+    def flush_cache(self, chunk_callback) -> None:
+        """Flush the radix cache. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._flush_cache_async(chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _flush_cache_async(self, chunk_callback) -> None:
+        try:
+            ret = await self.tokenizer_manager.flush_cache()
+            result = json.dumps({"success": ret.success, "message": "Cache flushed."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC flush_cache error: %s", e)
+            result = json.dumps({"success": False, "message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Pause / Continue generation
+    # ------------------------------------------------------------------
+
+    def pause_generation(self, mode: str, chunk_callback) -> None:
+        """Pause generation. Sends result through chunk_callback."""
+        from sglang.srt.managers.io_struct import PauseGenerationReqInput
+
+        obj = PauseGenerationReqInput(mode=mode)
+        self._submit_on_tm_loop(
+            lambda: self._pause_generation_async(obj, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _pause_generation_async(self, obj, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.pause_generation(obj)
+            result = json.dumps({"message": f"Generation paused (mode={obj.mode})."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC pause_generation error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    def continue_generation(self, chunk_callback) -> None:
+        """Continue generation. Sends result through chunk_callback."""
+        from sglang.srt.managers.io_struct import ContinueGenerationReqInput
+
+        obj = ContinueGenerationReqInput()
+        self._submit_on_tm_loop(
+            lambda: self._continue_generation_async(obj, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _continue_generation_async(self, obj, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.continue_generation(obj)
+            result = json.dumps({"message": "Generation continued."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC continue_generation error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Profile (admin)
+    # ------------------------------------------------------------------
+
+    def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
+        """Start profiling. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._start_profile_async(output_dir, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _start_profile_async(self, output_dir, chunk_callback) -> None:
+        try:
+            kwargs = {}
+            if output_dir:
+                kwargs["output_dir"] = output_dir
+            await self.tokenizer_manager.start_profile(**kwargs)
+            result = json.dumps({"message": "Profiling started."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC start_profile error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    def stop_profile(self, chunk_callback) -> None:
+        """Stop profiling. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._stop_profile_async(chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _stop_profile_async(self, chunk_callback) -> None:
+        try:
+            await self.tokenizer_manager.stop_profile()
+            result = json.dumps({"message": "Profiling stopped."})
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC stop_profile error: %s", e)
+            result = json.dumps({"message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Update weights from disk (admin)
+    # ------------------------------------------------------------------
+
+    def update_weights_from_disk(
+        self, model_path: str, load_format: Optional[str], chunk_callback
+    ) -> None:
+        """Update weights from disk. Sends result through chunk_callback."""
+        self._submit_on_tm_loop(
+            lambda: self._update_weights_async(model_path, load_format, chunk_callback),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    async def _update_weights_async(
+        self, model_path: str, load_format: Optional[str], chunk_callback
+    ) -> None:
+        try:
+            from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
+
+            obj = UpdateWeightFromDiskReqInput(
+                model_path=model_path,
+                load_format=load_format,
+            )
+            success, message, num_paused = (
+                await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
+            )
+            result = json.dumps(
+                {
+                    "success": success,
+                    "message": message,
+                    "num_paused_requests": num_paused,
+                }
+            )
+            chunk_callback(result.encode("utf-8"), finished=True)
+        except Exception as e:
+            logger.error("gRPC update_weights error: %s", e)
+            result = json.dumps({"success": False, "message": str(e)})
+            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+
+    # ------------------------------------------------------------------
+    # OpenAI-compatible RPCs (JSON pass-through)
+    # ------------------------------------------------------------------
+
+    def submit_openai_chat(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI chat completion (JSON pass-through)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "chat",
+                json_body,
+                chunk_callback,
+                streaming=True,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_complete(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI completion (JSON pass-through)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "completion",
+                json_body,
+                chunk_callback,
+                streaming=True,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_embed(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI embedding (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "embedding",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_classify(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI classify (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "classify",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_score(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI score (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "score",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def submit_openai_rerank(
+        self,
+        *,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Submit OpenAI rerank (JSON pass-through, unary)."""
+        self._submit_on_tm_loop(
+            lambda: self._run_openai_request(
+                "rerank",
+                json_body,
+                chunk_callback,
+                streaming=False,
+                trace_headers=trace_headers,
+            ),
+            chunk_callback,
+            empty_response=b"",
+        )
+
+    def _get_openai_request_class(self, serving_key: str):
+        """Return the Pydantic request class for a given serving key."""
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionRequest,
+            ClassifyRequest,
+            CompletionRequest,
+            EmbeddingRequest,
+            ScoringRequest,
+            V1RerankReqInput,
+        )
+
+        return {
+            "chat": ChatCompletionRequest,
+            "completion": CompletionRequest,
+            "embedding": EmbeddingRequest,
+            "classify": ClassifyRequest,
+            "score": ScoringRequest,
+            "rerank": V1RerankReqInput,
+        }[serving_key]
+
+    async def _run_openai_request(
+        self,
+        serving_key: str,
+        json_body: bytes,
+        chunk_callback,
+        streaming: bool,
+        trace_headers: Optional[Dict[str, str]] = None,
+    ):
+        """Generic OpenAI pass-through handler.
+
+        Delegates to the appropriate OpenAIServing* class, sending response
+        data back through the Rust chunk_callback.
+        """
+        try:
+            serving = self._get_openai_serving()[serving_key]
+            request_dict = json.loads(json_body)
+            mock_request = MockRequest(headers=trace_headers)
+
+            request_cls = self._get_openai_request_class(serving_key)
+            request_obj = request_cls(**request_dict)
+
+            result = await serving.handle_request(request_obj, mock_request)
+
+            if hasattr(result, "body_iterator"):
+                async for raw_chunk in result.body_iterator:
+                    if isinstance(raw_chunk, bytes):
+                        raw_chunk = raw_chunk.decode("utf-8", errors="replace")
+                    if (
+                        raw_chunk.startswith("data: ")
+                        and raw_chunk.strip() != "data: [DONE]"
+                    ):
+                        json_chunk = raw_chunk[len("data: ") :].strip()
+                        if json_chunk:
+                            chunk_callback(json_chunk.encode("utf-8"), finished=False)
+                chunk_callback(b"", finished=True)
+            else:
+                if hasattr(result, "model_dump"):
+                    resp_bytes = json.dumps(result.model_dump()).encode("utf-8")
+                elif hasattr(result, "body"):
+                    resp_bytes = result.body
+                elif isinstance(result, (dict, list)):
+                    resp_bytes = json.dumps(result).encode("utf-8")
+                else:
+                    resp_bytes = str(result).encode("utf-8")
+                status_code = int(getattr(result, "status_code", 200))
+                chunk_callback(resp_bytes, finished=True, status_code=status_code)
+
+        except Exception as e:
+            logger.error("gRPC OpenAI %s error: %s", serving_key, e)
+            error_body = json.dumps({"error": {"message": str(e)}}).encode("utf-8")
+            if streaming:
+                self._safe_callback(
+                    chunk_callback, error_body, finished=True, error=str(e)
+                )
+            else:
+                try:
+                    chunk_callback(
+                        error_body,
+                        finished=True,
+                        status_code=int(getattr(e, "status_code", 500)),
+                    )
+                except Exception:
+                    pass

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -646,6 +646,22 @@ class RuntimeHandle:
                 is_disconnected_fn=is_disconnected_fn,
             )
 
+            # Streaming endpoints can opt into the pre-SSE hook
+            # ``OpenAIServingBase.stream_chunks`` — the generator yields
+            # already-JSON-encoded bytes so we skip the SSE round-trip.
+            # Serving classes raise NotImplementedError from the default
+            # impl; we fall back to the SSE re-parser below.
+            if streaming:
+                try:
+                    async for chunk_bytes in serving.stream_chunks(
+                        request_obj, mock_request
+                    ):
+                        chunk_callback(chunk_bytes, finished=False)
+                    chunk_callback(b"", finished=True)
+                    return
+                except NotImplementedError:
+                    pass  # fall through to SSE re-parser
+
             result = await serving.handle_request(request_obj, mock_request)
 
             if hasattr(result, "body_iterator"):
@@ -654,8 +670,6 @@ class RuntimeHandle:
                 # currently emits one `data: <json>\n\n` per yield, but a
                 # naive `startswith("data: ")` filter silently drops anything
                 # else — multi-line data, comments, future event/id usage.
-                # See follow-up: replace SSE round-trip with a (dict,
-                # finished) hook on OpenAIServing*.
                 data_buf: List[str] = []
 
                 def _flush_event() -> None:

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -10,27 +10,56 @@ import asyncio
 import dataclasses
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, List, Optional
+
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
 
-class MockRequest:
-    """Lightweight stand-in for fastapi.Request when called from gRPC.
+class _CaseInsensitiveHeaders:
+    """Minimal read-only header view with case-insensitive lookup.
 
-    The OpenAI serving classes expect a fastapi.Request for disconnect
-    detection and routing key extraction. This satisfies that interface
-    without importing FastAPI.
+    Mirrors the only Starlette ``Headers`` surface the OpenAI serving classes
+    use (``.get(name)``), without importing Starlette or FastAPI.
     """
 
+    __slots__ = ("_data",)
+
     def __init__(self, headers: Optional[Dict[str, str]] = None):
-        self.headers = headers or {}
-        self.url = type("URL", (), {"path": "/grpc"})()
-        self.state = type("State", (), {})()
-        self.app = type("App", (), {"state": type("AppState", (), {})()})()
+        self._data = {k.lower(): v for k, v in (headers or {}).items()}
+
+    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        return self._data.get(name.lower(), default)
+
+
+class MockRequest:
+    """Stand-in for ``fastapi.Request`` when serving classes are called from gRPC.
+
+    Implements the three surfaces the OpenAI serving classes actually touch:
+      * ``headers.get(name)`` — case-insensitive, matches HTTP semantics
+      * ``state.<attr>`` — attribute namespace for downstream mutations
+      * ``await is_disconnected()`` — client-cancellation probe
+
+    ``is_disconnected_fn`` is an optional sync callable the Rust side can pass
+    that reads its Tonic ``CancellationToken``. When omitted, the request is
+    treated as always-connected (current Rust behaviour).
+    """
+
+    def __init__(
+        self,
+        headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
+    ):
+        self.headers = _CaseInsensitiveHeaders(headers)
+        self.state = SimpleNamespace()
+        self._is_disconnected_fn = is_disconnected_fn
 
     async def is_disconnected(self) -> bool:
-        return False
+        if self._is_disconnected_fn is None:
+            return False
+        return bool(self._is_disconnected_fn())
 
 
 class RuntimeHandle:
@@ -56,21 +85,25 @@ class RuntimeHandle:
 
         self._openai_serving_classes = None
 
+        # Ensure the handle_loop task exists before any gRPC RPC is dispatched.
+        # auto_create_handle_loop is idempotent (no-op if the loop is already
+        # running) and uses get_or_create_event_loop on the calling thread, so
+        # constructing RuntimeHandle from the launcher's main thread pins the
+        # loop where handle_loop's signal handlers expect it.
+        self.tokenizer_manager.auto_create_handle_loop()
+        self._event_loop = self.tokenizer_manager.event_loop
+
     @property
     def _tm_loop(self):
-        """Return the tokenizer_manager's event loop (uvicorn loop).
+        """Return the tokenizer_manager's event loop.
 
         Communicator-based async methods (flush_cache, get_load, etc.) use
         asyncio.Event internally, which only works within a single event
         loop. These must run on the same loop as handle_loop(), i.e. the
-        tokenizer_manager's event_loop.
+        tokenizer_manager's event_loop. Cached at construction time so RPCs
+        never race the loop's creation.
         """
-        loop = getattr(self.tokenizer_manager, "event_loop", None)
-        if loop is None:
-            raise RuntimeError(
-                "TokenizerManager event loop not ready - server still starting"
-            )
-        return loop
+        return self._event_loop
 
     def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
         try:
@@ -79,14 +112,7 @@ class RuntimeHandle:
             pass
 
     def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
-        try:
-            loop = self._tm_loop
-        except RuntimeError as e:
-            self._safe_callback(
-                chunk_callback, empty_response, finished=True, error=str(e)
-            )
-            return
-        asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+        asyncio.run_coroutine_threadsafe(coro_factory(), self._tm_loop)
 
     def _get_openai_serving(self):
         """Lazily initialize OpenAI serving classes."""
@@ -197,11 +223,7 @@ class RuntimeHandle:
 
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
-        try:
-            loop = self._tm_loop
-        except RuntimeError:
-            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
-            return
+        loop = self._tm_loop
 
         try:
             running_loop = asyncio.get_running_loop()
@@ -498,6 +520,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI chat completion (JSON pass-through)."""
         self._submit_on_tm_loop(
@@ -507,6 +530,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=True,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -518,6 +542,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI completion (JSON pass-through)."""
         self._submit_on_tm_loop(
@@ -527,6 +552,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=True,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -538,6 +564,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI embedding (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -547,6 +574,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -558,6 +586,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI classify (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -567,6 +596,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -578,6 +608,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI score (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -587,6 +618,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -598,6 +630,7 @@ class RuntimeHandle:
         json_body: bytes,
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Submit OpenAI rerank (JSON pass-through, unary)."""
         self._submit_on_tm_loop(
@@ -607,6 +640,7 @@ class RuntimeHandle:
                 chunk_callback,
                 streaming=False,
                 trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
             ),
             chunk_callback,
             empty_response=b"",
@@ -639,6 +673,7 @@ class RuntimeHandle:
         chunk_callback,
         streaming: bool,
         trace_headers: Optional[Dict[str, str]] = None,
+        is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         """Generic OpenAI pass-through handler.
 
@@ -647,11 +682,30 @@ class RuntimeHandle:
         """
         try:
             serving = self._get_openai_serving()[serving_key]
-            request_dict = json.loads(json_body)
-            mock_request = MockRequest(headers=trace_headers)
 
-            request_cls = self._get_openai_request_class(serving_key)
-            request_obj = request_cls(**request_dict)
+            # JSON parse + Pydantic validation are client errors. Surface
+            # them with status_code=400 so the Rust side maps them to
+            # INVALID_ARGUMENT instead of INTERNAL. They always happen
+            # before any stream chunks are emitted, so it is safe to send a
+            # single status-bearing chunk even on streaming endpoints.
+            try:
+                request_dict = json.loads(json_body)
+                request_cls = self._get_openai_request_class(serving_key)
+                request_obj = request_cls(**request_dict)
+            except (json.JSONDecodeError, ValidationError) as e:
+                error_body = json.dumps(
+                    {"error": {"message": str(e), "type": "BadRequest"}}
+                ).encode("utf-8")
+                try:
+                    chunk_callback(error_body, finished=True, status_code=400)
+                except Exception:
+                    pass
+                return
+
+            mock_request = MockRequest(
+                headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
+            )
 
             result = await serving.handle_request(request_obj, mock_request)
 

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -11,7 +11,7 @@ import dataclasses
 import json
 import logging
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from pydantic import ValidationError
 
@@ -105,14 +105,50 @@ class RuntimeHandle:
         """
         return self._event_loop
 
-    def _safe_callback(self, chunk_callback, payload, *, finished: bool, error=None):
+    def _safe_callback(self, chunk_callback, payload, **kwargs) -> None:
         try:
-            chunk_callback(payload, finished=finished, error=error)
+            chunk_callback(payload, **kwargs)
         except Exception:
             pass
 
-    def _submit_on_tm_loop(self, coro_factory, chunk_callback, *, empty_response):
-        asyncio.run_coroutine_threadsafe(coro_factory(), self._tm_loop)
+    def _submit_on_tm_loop(self, coro: Awaitable) -> None:
+        asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
+
+    def _submit_json_unary(
+        self,
+        op_name: str,
+        payload_coro_factory: Callable[[], Awaitable[Any]],
+        chunk_callback,
+        *,
+        error_payload_fn: Optional[Callable[[Exception], Any]] = None,
+    ) -> None:
+        """Schedule a unary op whose result is JSON-encoded and sent via chunk_callback.
+
+        ``payload_coro_factory`` is a zero-arg callable returning a coroutine
+        that awaits the operation and returns the success payload (dict/list).
+        ``error_payload_fn`` maps a caught exception to the payload sent on
+        the error path; defaults to ``{"message": str(e)}``.
+        """
+        error_fn = error_payload_fn or (lambda e: {"message": str(e)})
+
+        async def _run() -> None:
+            try:
+                payload = await payload_coro_factory()
+                self._safe_callback(
+                    chunk_callback,
+                    json.dumps(payload, default=str).encode("utf-8"),
+                    finished=True,
+                )
+            except Exception as e:
+                logger.error("gRPC %s error: %s", op_name, e)
+                self._safe_callback(
+                    chunk_callback,
+                    json.dumps(error_fn(e), default=str).encode("utf-8"),
+                    finished=True,
+                    error=str(e),
+                )
+
+        self._submit_on_tm_loop(_run())
 
     def _get_openai_serving(self):
         """Lazily initialize OpenAI serving classes."""
@@ -150,10 +186,6 @@ class RuntimeHandle:
         }
         return self._openai_serving_classes
 
-    # ------------------------------------------------------------------
-    # Consolidated request submission (generate / embed / classify)
-    # ------------------------------------------------------------------
-
     def submit_request(self, *, req_type: str, req_dict: dict, chunk_callback):
         """Submit a generate or embed request from a pre-built dict.
 
@@ -171,20 +203,12 @@ class RuntimeHandle:
 
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
-            self._submit_on_tm_loop(
-                lambda: self._run_generate(obj, chunk_callback, stream),
-                chunk_callback,
-                empty_response={},
-            )
+            self._submit_on_tm_loop(self._run_generate(obj, chunk_callback, stream))
         else:
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
             obj = EmbeddingReqInput(**req_dict)
-            self._submit_on_tm_loop(
-                lambda: self._run_embed(obj, chunk_callback),
-                chunk_callback,
-                empty_response={},
-            )
+            self._submit_on_tm_loop(self._run_embed(obj, chunk_callback))
 
     async def _run_generate(self, obj, chunk_callback, stream: bool):
         try:
@@ -217,10 +241,6 @@ class RuntimeHandle:
             logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
             self._safe_callback(chunk_callback, {}, finished=True, error=str(e))
 
-    # ------------------------------------------------------------------
-    # Abort
-    # ------------------------------------------------------------------
-
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
         loop = self._tm_loop
@@ -242,10 +262,6 @@ class RuntimeHandle:
 
     async def _abort_async(self, rid: str, abort_all: bool) -> None:
         self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
-
-    # ------------------------------------------------------------------
-    # Info RPCs (synchronous, small data)
-    # ------------------------------------------------------------------
 
     def get_model_info(self) -> str:
         """Return model info as a JSON string."""
@@ -285,10 +301,6 @@ class RuntimeHandle:
             return False
         return True
 
-    # ------------------------------------------------------------------
-    # Tokenize / Detokenize (local ops, no inference)
-    # ------------------------------------------------------------------
-
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         """Tokenize text and return result as JSON string."""
         tokenizer = self.tokenizer_manager.tokenizer
@@ -306,10 +318,6 @@ class RuntimeHandle:
         tokenizer = self.tokenizer_manager.tokenizer
         text = tokenizer.decode(tokens)
         return json.dumps({"text": text})
-
-    # ------------------------------------------------------------------
-    # List models
-    # ------------------------------------------------------------------
 
     def list_models(self) -> str:
         """Return the list of served models as JSON string."""
@@ -335,184 +343,126 @@ class RuntimeHandle:
                 )
         return json.dumps(models)
 
-    # ------------------------------------------------------------------
-    # Get load
-    # ------------------------------------------------------------------
-
     def get_load(self, chunk_callback, dp_rank: Optional[int] = None) -> None:
         """Return load info via chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._get_load_async(chunk_callback, dp_rank),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _get_load_async(
-        self, chunk_callback, dp_rank: Optional[int] = None
-    ) -> None:
-        try:
+        async def _payload():
             result = await self.tokenizer_manager.get_loads(dp_rank=dp_rank)
-            data = json.dumps([dataclasses.asdict(r) for r in result], default=str)
-            chunk_callback(data.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC get_load error: %s", e)
-            data = json.dumps({"error": str(e)})
-            chunk_callback(data.encode("utf-8"), finished=True, error=str(e))
+            return [dataclasses.asdict(r) for r in result]
 
-    # ------------------------------------------------------------------
-    # Flush cache
-    # ------------------------------------------------------------------
+        self._submit_json_unary(
+            "get_load",
+            _payload,
+            chunk_callback,
+            error_payload_fn=lambda e: {"error": str(e)},
+        )
 
     def flush_cache(self, chunk_callback) -> None:
         """Flush the radix cache. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._flush_cache_async(chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _flush_cache_async(self, chunk_callback) -> None:
-        try:
+        async def _payload():
             ret = await self.tokenizer_manager.flush_cache()
-            result = json.dumps({"success": ret.success, "message": "Cache flushed."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC flush_cache error: %s", e)
-            result = json.dumps({"success": False, "message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {"success": ret.success, "message": "Cache flushed."}
 
-    # ------------------------------------------------------------------
-    # Pause / Continue generation
-    # ------------------------------------------------------------------
+        self._submit_json_unary(
+            "flush_cache",
+            _payload,
+            chunk_callback,
+            error_payload_fn=lambda e: {"success": False, "message": str(e)},
+        )
 
     def pause_generation(self, mode: str, chunk_callback) -> None:
         """Pause generation. Sends result through chunk_callback."""
-        from sglang.srt.managers.io_struct import PauseGenerationReqInput
 
-        obj = PauseGenerationReqInput(mode=mode)
-        self._submit_on_tm_loop(
-            lambda: self._pause_generation_async(obj, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
+        async def _payload():
+            from sglang.srt.managers.io_struct import PauseGenerationReqInput
 
-    async def _pause_generation_async(self, obj, chunk_callback) -> None:
-        try:
-            await self.tokenizer_manager.pause_generation(obj)
-            result = json.dumps({"message": f"Generation paused (mode={obj.mode})."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC pause_generation error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            await self.tokenizer_manager.pause_generation(
+                PauseGenerationReqInput(mode=mode)
+            )
+            return {"message": f"Generation paused (mode={mode})."}
+
+        self._submit_json_unary("pause_generation", _payload, chunk_callback)
 
     def continue_generation(self, chunk_callback) -> None:
         """Continue generation. Sends result through chunk_callback."""
-        from sglang.srt.managers.io_struct import ContinueGenerationReqInput
 
-        obj = ContinueGenerationReqInput()
-        self._submit_on_tm_loop(
-            lambda: self._continue_generation_async(obj, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
+        async def _payload():
+            from sglang.srt.managers.io_struct import ContinueGenerationReqInput
 
-    async def _continue_generation_async(self, obj, chunk_callback) -> None:
-        try:
-            await self.tokenizer_manager.continue_generation(obj)
-            result = json.dumps({"message": "Generation continued."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC continue_generation error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            await self.tokenizer_manager.continue_generation(
+                ContinueGenerationReqInput()
+            )
+            return {"message": "Generation continued."}
 
-    # ------------------------------------------------------------------
-    # Profile (admin)
-    # ------------------------------------------------------------------
+        self._submit_json_unary("continue_generation", _payload, chunk_callback)
 
     def start_profile(self, output_dir: Optional[str], chunk_callback) -> None:
         """Start profiling. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._start_profile_async(output_dir, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _start_profile_async(self, output_dir, chunk_callback) -> None:
-        try:
-            kwargs = {}
-            if output_dir:
-                kwargs["output_dir"] = output_dir
+        async def _payload():
+            kwargs = {"output_dir": output_dir} if output_dir else {}
             await self.tokenizer_manager.start_profile(**kwargs)
-            result = json.dumps({"message": "Profiling started."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC start_profile error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {"message": "Profiling started."}
+
+        self._submit_json_unary("start_profile", _payload, chunk_callback)
 
     def stop_profile(self, chunk_callback) -> None:
         """Stop profiling. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._stop_profile_async(chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _stop_profile_async(self, chunk_callback) -> None:
-        try:
+        async def _payload():
             await self.tokenizer_manager.stop_profile()
-            result = json.dumps({"message": "Profiling stopped."})
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC stop_profile error: %s", e)
-            result = json.dumps({"message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {"message": "Profiling stopped."}
 
-    # ------------------------------------------------------------------
-    # Update weights from disk (admin)
-    # ------------------------------------------------------------------
+        self._submit_json_unary("stop_profile", _payload, chunk_callback)
 
     def update_weights_from_disk(
         self, model_path: str, load_format: Optional[str], chunk_callback
     ) -> None:
         """Update weights from disk. Sends result through chunk_callback."""
-        self._submit_on_tm_loop(
-            lambda: self._update_weights_async(model_path, load_format, chunk_callback),
-            chunk_callback,
-            empty_response=b"",
-        )
 
-    async def _update_weights_async(
-        self, model_path: str, load_format: Optional[str], chunk_callback
-    ) -> None:
-        try:
+        async def _payload():
             from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
 
             obj = UpdateWeightFromDiskReqInput(
-                model_path=model_path,
-                load_format=load_format,
+                model_path=model_path, load_format=load_format
             )
             success, message, num_paused = (
                 await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
             )
-            result = json.dumps(
-                {
-                    "success": success,
-                    "message": message,
-                    "num_paused_requests": num_paused,
-                }
-            )
-            chunk_callback(result.encode("utf-8"), finished=True)
-        except Exception as e:
-            logger.error("gRPC update_weights error: %s", e)
-            result = json.dumps({"success": False, "message": str(e)})
-            chunk_callback(result.encode("utf-8"), finished=True, error=str(e))
+            return {
+                "success": success,
+                "message": message,
+                "num_paused_requests": num_paused,
+            }
 
-    # ------------------------------------------------------------------
-    # OpenAI-compatible RPCs (JSON pass-through)
-    # ------------------------------------------------------------------
+        self._submit_json_unary(
+            "update_weights",
+            _payload,
+            chunk_callback,
+            error_payload_fn=lambda e: {"success": False, "message": str(e)},
+        )
+
+    def _submit_openai(
+        self,
+        serving_key: str,
+        streaming: bool,
+        json_body: bytes,
+        chunk_callback,
+        trace_headers: Optional[Dict[str, str]],
+        is_disconnected_fn: Optional[Callable[[], bool]],
+    ) -> None:
+        """Schedule an OpenAI pass-through request on the tokenizer_manager loop."""
+        self._submit_on_tm_loop(
+            self._run_openai_request(
+                serving_key,
+                json_body,
+                chunk_callback,
+                streaming=streaming,
+                trace_headers=trace_headers,
+                is_disconnected_fn=is_disconnected_fn,
+            )
+        )
 
     def submit_openai_chat(
         self,
@@ -521,19 +471,10 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
-        """Submit OpenAI chat completion (JSON pass-through)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "chat",
-                json_body,
-                chunk_callback,
-                streaming=True,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
-            chunk_callback,
-            empty_response=b"",
+    ) -> None:
+        """Submit OpenAI chat completion (JSON pass-through, streaming)."""
+        self._submit_openai(
+            "chat", True, json_body, chunk_callback, trace_headers, is_disconnected_fn
         )
 
     def submit_openai_complete(
@@ -543,19 +484,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
-        """Submit OpenAI completion (JSON pass-through)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "completion",
-                json_body,
-                chunk_callback,
-                streaming=True,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+    ) -> None:
+        """Submit OpenAI completion (JSON pass-through, streaming)."""
+        self._submit_openai(
+            "completion",
+            True,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def submit_openai_embed(
@@ -565,19 +502,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI embedding (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "embedding",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+        self._submit_openai(
+            "embedding",
+            False,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def submit_openai_classify(
@@ -587,19 +520,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI classify (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "classify",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+        self._submit_openai(
+            "classify",
+            False,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def submit_openai_score(
@@ -609,19 +538,10 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI score (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "score",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
-            chunk_callback,
-            empty_response=b"",
+        self._submit_openai(
+            "score", False, json_body, chunk_callback, trace_headers, is_disconnected_fn
         )
 
     def submit_openai_rerank(
@@ -631,19 +551,15 @@ class RuntimeHandle:
         chunk_callback,
         trace_headers: Optional[Dict[str, str]] = None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
-    ):
+    ) -> None:
         """Submit OpenAI rerank (JSON pass-through, unary)."""
-        self._submit_on_tm_loop(
-            lambda: self._run_openai_request(
-                "rerank",
-                json_body,
-                chunk_callback,
-                streaming=False,
-                trace_headers=trace_headers,
-                is_disconnected_fn=is_disconnected_fn,
-            ),
+        self._submit_openai(
+            "rerank",
+            False,
+            json_body,
             chunk_callback,
-            empty_response=b"",
+            trace_headers,
+            is_disconnected_fn,
         )
 
     def _get_openai_request_class(self, serving_key: str):
@@ -696,10 +612,9 @@ class RuntimeHandle:
                 error_body = json.dumps(
                     {"error": {"message": str(e), "type": "BadRequest"}}
                 ).encode("utf-8")
-                try:
-                    chunk_callback(error_body, finished=True, status_code=400)
-                except Exception:
-                    pass
+                self._safe_callback(
+                    chunk_callback, error_body, finished=True, status_code=400
+                )
                 return
 
             mock_request = MockRequest(
@@ -741,11 +656,9 @@ class RuntimeHandle:
                     chunk_callback, error_body, finished=True, error=str(e)
                 )
             else:
-                try:
-                    chunk_callback(
-                        error_body,
-                        finished=True,
-                        status_code=int(getattr(e, "status_code", 500)),
-                    )
-                except Exception:
-                    pass
+                self._safe_callback(
+                    chunk_callback,
+                    error_body,
+                    finished=True,
+                    status_code=int(getattr(e, "status_code", 500)),
+                )

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -108,11 +108,30 @@ class RuntimeHandle:
     def _safe_callback(self, chunk_callback, payload, **kwargs) -> None:
         try:
             chunk_callback(payload, **kwargs)
-        except Exception:
-            pass
+        except Exception as e:
+            # Most often: Rust receiver dropped (client disconnect, channel
+            # closed). Log at warning so it's visible without spamming on
+            # every normal cancellation.
+            logger.warning("gRPC chunk_callback failed: %s", e)
 
     def _submit_on_tm_loop(self, coro: Awaitable) -> None:
-        asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
+        future = asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
+        future.add_done_callback(self._log_unhandled_future_exception)
+
+    @staticmethod
+    def _log_unhandled_future_exception(future) -> None:
+        # All RuntimeHandle coroutines wrap their bodies in try/except and
+        # route errors through chunk_callback, so this is a defence in depth:
+        # if anything ever escapes (or a new caller forgets the wrap), we
+        # surface it instead of silently hanging the gRPC stream.
+        try:
+            future.result()
+        except Exception as e:
+            logger.error(
+                "gRPC scheduled coroutine raised unhandled exception: %s",
+                e,
+                exc_info=True,
+            )
 
     def _submit_json_unary(
         self,
@@ -204,11 +223,15 @@ class RuntimeHandle:
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
             self._submit_on_tm_loop(self._run_generate(obj, chunk_callback, stream))
-        else:
+        elif req_type == "embed":
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
             obj = EmbeddingReqInput(**req_dict)
             self._submit_on_tm_loop(self._run_embed(obj, chunk_callback))
+        else:
+            raise ValueError(
+                f"Unknown req_type: {req_type!r} (expected 'generate' or 'embed')"
+            )
 
     async def _run_generate(self, obj, chunk_callback, stream: bool):
         try:
@@ -297,9 +320,10 @@ class RuntimeHandle:
 
         if self.tokenizer_manager.gracefully_exit:
             return False
-        if self.tokenizer_manager.server_status == ServerStatus.Starting:
-            return False
-        return True
+        return self.tokenizer_manager.server_status not in (
+            ServerStatus.Starting,
+            ServerStatus.UnHealthy,
+        )
 
     def tokenize(self, text: str, add_special_tokens: bool = True) -> str:
         """Tokenize text and return result as JSON string."""
@@ -625,16 +649,43 @@ class RuntimeHandle:
             result = await serving.handle_request(request_obj, mock_request)
 
             if hasattr(result, "body_iterator"):
+                # Parse SSE events per WHATWG spec (data:/event:/id: fields,
+                # `:` comments, blank-line event boundaries). OpenAIServing*
+                # currently emits one `data: <json>\n\n` per yield, but a
+                # naive `startswith("data: ")` filter silently drops anything
+                # else — multi-line data, comments, future event/id usage.
+                # See follow-up: replace SSE round-trip with a (dict,
+                # finished) hook on OpenAIServing*.
+                data_buf: List[str] = []
+
+                def _flush_event() -> None:
+                    if not data_buf:
+                        return
+                    body = "\n".join(data_buf)
+                    data_buf.clear()
+                    if body == "[DONE]" or not body:
+                        return
+                    chunk_callback(body.encode("utf-8"), finished=False)
+
                 async for raw_chunk in result.body_iterator:
                     if isinstance(raw_chunk, bytes):
                         raw_chunk = raw_chunk.decode("utf-8", errors="replace")
-                    if (
-                        raw_chunk.startswith("data: ")
-                        and raw_chunk.strip() != "data: [DONE]"
-                    ):
-                        json_chunk = raw_chunk[len("data: ") :].strip()
-                        if json_chunk:
-                            chunk_callback(json_chunk.encode("utf-8"), finished=False)
+                    for line in raw_chunk.split("\n"):
+                        line = line.rstrip("\r")
+                        if not line:
+                            _flush_event()
+                        elif line.startswith(":"):
+                            continue  # SSE comment / heartbeat
+                        elif line.startswith("data:"):
+                            value = line[5:]
+                            if value.startswith(" "):
+                                value = value[1:]
+                            data_buf.append(value)
+                        # event:, id:, retry:, unknown fields: ignored
+
+                # Defensive: emit a trailing event if the stream ended
+                # without a final blank line.
+                _flush_event()
                 chunk_callback(b"", finished=True)
             else:
                 if hasattr(result, "model_dump"):
@@ -645,7 +696,14 @@ class RuntimeHandle:
                     resp_bytes = json.dumps(result).encode("utf-8")
                 else:
                     resp_bytes = str(result).encode("utf-8")
-                status_code = int(getattr(result, "status_code", 200))
+                # ErrorResponse uses ``code``; Starlette/FastAPI Response
+                # uses ``status_code``. Honour whichever is present so error
+                # responses don't ship as HTTP 200 with an error body.
+                status_code = int(
+                    getattr(result, "status_code", None)
+                    or getattr(result, "code", None)
+                    or 200
+                )
                 chunk_callback(resp_bytes, finished=True, status_code=status_code)
 
         except Exception as e:

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -4,7 +4,7 @@ import json
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, AsyncIterator, List, Optional, Tuple, Union
 
 import orjson
 from fastapi import HTTPException, Request
@@ -201,6 +201,33 @@ class OpenAIServingBase(ABC):
             err_type="NotImplementedError",
             status_code=501,
         )
+
+    async def stream_chunks(
+        self,
+        request: OpenAIServingRequest,
+        raw_request: Request,
+    ) -> AsyncIterator[bytes]:
+        """Pre-SSE streaming hook.
+
+        Yield each chunk as already-JSON-encoded ``bytes``. The generator
+        ending signals end-of-stream — no ``[DONE]`` sentinel, no SSE
+        framing, no callers having to re-parse SSE on the receiving side.
+
+        Used by transports that want JSON chunks directly (e.g. the gRPC
+        bridge in :mod:`sglang.srt.entrypoints.grpc_bridge`). The HTTP
+        path keeps using :meth:`_handle_streaming_request` which wraps
+        chunks as SSE for the client.
+
+        Default raises NotImplementedError; override in serving classes
+        that support streaming.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement stream_chunks; "
+            "the gRPC bridge will fall back to SSE re-parsing until it does."
+        )
+        # The unreachable yield below makes this an async generator so
+        # `hasattr(serving, "stream_chunks")` checks work uniformly.
+        yield b""  # pragma: no cover
 
     def _validate_request(self, _: OpenAIServingRequest) -> Optional[str]:
         """Validate request"""


### PR DESCRIPTION
## Summary

Follow-up to [PR #23507](https://github.com/sgl-project/sglang/pull/23507)'s review (Kangyan's C5 + structural concern). The gRPC bridge currently emits SSE on the OpenAIServing* side and re-parses it on the bridge side, just to forward JSON chunks to a gRPC client that doesn't speak SSE. This PR replaces that with a pre-encoding hook so streaming transports get JSON bytes directly.

## Plan

- **API**: `OpenAIServingBase.stream_chunks(request, raw_request) -> AsyncIterator[bytes]`. Yields already-JSON-encoded bytes. Generator ending = stream done (no `[DONE]` sentinel, no SSE wrapping).
- **HTTP path**: `_handle_streaming_request` keeps returning `StreamingResponse`, but the body iterator becomes a thin SSE wrapper over `stream_chunks` (`f\"data: {body.decode()}\\n\\n\"` + final `\"data: [DONE]\\n\\n\"`).
- **gRPC path**: `grpc_bridge._run_openai_request` consumes `stream_chunks` directly and forwards each `bytes` payload via `chunk_callback(..., finished=False)`, then one final `chunk_callback(b\"\", finished=True)`.

## Status

This commit is the **scaffold only**:
- [x] Add `stream_chunks` to `OpenAIServingBase` (default: raise `NotImplementedError`)
- [x] Wire `grpc_bridge._run_openai_request` to try `stream_chunks` first, fall back to the SSE re-parser on `NotImplementedError`
- [ ] Implement `stream_chunks` on `OpenAIServingChat` (refactor `_generate_chat_stream` to yield encoded chunks)
- [ ] Implement `stream_chunks` on `OpenAIServingCompletion`
- [ ] Rewrite `_handle_streaming_request` on chat/completion as a thin SSE wrapper
- [ ] Tests: HTTP parity (existing SSE clients keep working), gRPC bypasses re-parser

## Why follow-up, not in PR #23507

The original review explicitly flagged this as a follow-up: \"file separately, do not block this PR.\" The serving-class refactor touches ~500 lines of streaming logic across chat + completions and has real HTTP-regression risk; doing it incrementally on its own branch keeps blast radius scoped.

## Test plan

- [ ] All existing OpenAI HTTP streaming tests pass (chat + completions)
- [ ] gRPC streaming returns the same payload sequence as HTTP (modulo SSE framing)
- [ ] Multi-line data, comments, and `[DONE]` are gone from the bridge code path
- [ ] No regression in token throughput on a streaming chat benchmark

## Dependencies

Based on `alexnails/grpc-phase1/python-bridge` (PR #23507). Will rebase onto main after #23507 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->