### PR TITLE
[AMD] Fix aiter checkout (rocm dockerfile)

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -206,9 +206,14 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=
 # AITER_USE_SYSTEM_TRITON=0 when intentionally testing aiter-managed Triton.
 ENV AITER_USE_SYSTEM_TRITON=1
 RUN pip uninstall -y aiter
+# Use `checkout -f` so the smudge-filter-induced "dirty" working tree from
+# AITER's .gitattributes (*.csv text eol=lf, added in ROCm/aiter#3370) does not
+# block switching to commits that predate that rule (e.g. the current default
+# AITER_COMMIT_DEFAULT). The working tree was just produced by a fresh
+# `git clone` above, so there are no real user changes to preserve.
 RUN git clone ${AITER_REPO} \
  && cd aiter \
- && git checkout ${AITER_COMMIT} \
+ && git checkout -f ${AITER_COMMIT} \
  && git cherry-pick --no-commit b639cb63bcac4672dce33a731fad042a65cb3649 \
  && git submodule update --init --recursive \
  && pip install -r requirements.txt


### PR DESCRIPTION
## Motivation
Any fresh build of `docker/rocm.Dockerfile` (`--build-from-dockerfile`, nightly image rebuild, manual `docker build`, etc.) started May 27, 2026 — and any AITER rebuild whose target commit predates `cb84b78a1` in `ROCm/aiter` — fails at the `git checkout` step with:
```
error: Your local changes to the following files would be overwritten by checkout:
	aiter/configs/model_configs/a8w8_blockscale_tuned_gemm_qwen36_27b.csv
	aiter/configs/model_configs/a8w8_blockscale_tuned_gemm_qwen3_vl_235b.csv
	aiter/configs/model_configs/a8w8_blockscale_tuned_gemm_qwen3_vl_32b.csv
	aiter/configs/model_configs/dsv4_bf16_untuned_gemm.csv
Please commit your changes or stash them before you switch branches.
Aborting
```
Existing pre-built images aren't affected (AITER was already built into them before the regression), so the bug is currently silent for jobs that just pull an image — but the next image rebuild will fail.
## Root cause
ROCm/aiter#3370 ("Normalize CSV line endings for cleaner diffs", commit `cb84b78a1`, merged 2026-05-27 21:04 +08:00) added a top-level `.gitattributes`:
```
*.csv text eol=lf
```
The CSV blobs in the repo were originally stored with **CRLF** line endings, but this new attribute tells git to normalize CSV files to **LF** on checkout. So immediately after a fresh `git clone`:
- the working tree has LF (after the smudge filter), while
- the stored blob still has CRLF,
and `git status` reports those CSV files as `modified` (`warning: CRLF will be replaced by LF in ...`). When the Dockerfile then runs `git checkout ${AITER_COMMIT}` to a commit that predates `cb84b78a1`, git refuses because checking out would "overwrite local changes".
Relevant timeline (current `AITER_COMMIT_DEFAULT` is `32e1e6d76`, 9 days older than the regression):
| Commit | Date | Role |
| --- | --- | --- |
| `32e1e6d76` | 2026-05-18 23:49 +08:00 | `AITER_COMMIT_DEFAULT` in `docker/rocm.Dockerfile` |
| `cb84b78a1` | 2026-05-27 21:04 +08:00 | PR 3370 adds `.gitattributes` |
## Fix
Use `git checkout -f` in the AITER block. The previous line (a fresh `git clone`) guarantees the working tree contains no real user modifications — the only "changes" are the line-ending mirage produced by the smudge filter, which is safe to discard.
```diff
- && git checkout ${AITER_COMMIT} \
+ && git checkout -f ${AITER_COMMIT} \
```
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.











<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #26556755102](https://github.com/sgl-project/sglang/actions/runs/26556755102)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26556755013](https://github.com/sgl-project/sglang/actions/runs/26556755013)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->