### PR TITLE
Avoid calling filter_batch with chunked_req_to_exclude being things unrelated to chunked reqs

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2280,7 +2280,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         for idx in range(len(self.reqs)):
             self.release_req(idx, len(self.reqs) - idx, server_args)
 
-        self.filter_batch(retracted_reqs)
+        self.reqs = []
         return retracted_reqs
 
     def retract_decode(


### PR DESCRIPTION
## What

In `ScheduleBatch.retract_all`, replace the terminal `self.filter_batch(retracted_reqs)` call with `self.reqs = []`. Behavior is unchanged.

## Why

`retract_all` was passing `retracted_reqs` (which is just an alias for `self.reqs`) as `filter_batch`'s `chunked_req_to_exclude` parameter. That parameter is meant to identify *chunked* prefill requests to exclude from the kept set — using it as "exclude every req in the batch" is a misuse of the API, and it makes the call read as if some non-trivial filtering is happening when really the only effect is clearing `self.reqs`.

## Trace

In `retract_all`:

```python
retracted_reqs = self.reqs                       # alias, not a copy
for idx in range(len(self.reqs)):
    self.release_req(idx, len(self.reqs) - idx, server_args)
self.filter_batch(retracted_reqs)                # <-- the call in question
```

Inside `filter_batch(retracted_reqs)`:

1. `keep_indices is None`, so it enters the compute branch.
2. `chunked_req_to_exclude` is a `list` (it's `self.reqs` itself), so the `isinstance(..., Req)` and `is None` branches are skipped.
3. `keep_indices = [i for i in range(len(self.reqs)) if not self.reqs[i].finished() and self.reqs[i] not in chunked_req_to_exclude]`. Since `chunked_req_to_exclude is self.reqs`, every `self.reqs[i]` is in it, so the condition is False for all `i` → `keep_indices = []`.
4. The `len(keep_indices) == 0` early-return fires: it sets `self.reqs = []` and returns, without touching `req_pool_indices` / `seq_lens` / `sampling_info` / `spec_info` / etc.

So the net effect of the whole `filter_batch` call is exactly `self.reqs = []`. Writing it that way makes the intent explicit and stops abusing `chunked_req_to_exclude` for something that has nothing to do with chunked requests.

## Notes

- Order matters: `retracted_reqs = self.reqs` must happen *before* clearing, so the returned list still points at the original reqs. Preserved as-is.
- No other batch state is reset here; that was also true of the previous `filter_batch` path (it early-returned before touching anything else).







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #26558826362](https://github.com/sgl-project/sglang/actions/runs/26558826362)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26558826122](https://github.com/sgl-project/sglang/actions/runs/26558826122)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->