### PR TITLE
[CI] FA3: ascending cuda-graph capture to avoid varlen workspace IMA (#26532)

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -530,6 +530,18 @@ def set_global_graph_memory_pool(val):
     global_graph_memory_pool = val
 
 
+def _ci_use_ascending_capture_order(server_args) -> bool:
+    """Whether CI + FA3 forces ascending cuda-graph capture (FA3 varlen IMA workaround, #26532)."""
+    if not envs.SGLANG_IS_IN_CI.get():
+        return False
+    prefill_backend, decode_backend = server_args.get_attention_backends()
+    return "fa3" in (
+        prefill_backend,
+        decode_backend,
+        server_args.speculative_draft_attention_backend,
+    )
+
+
 class CudaGraphRunner:
     """A CudaGraphRunner runs the forward pass of a model with cuda graph and torch.compile."""
 
@@ -815,8 +827,6 @@ class CudaGraphRunner:
         if self.enable_profile_cuda_graph:
             profile_context = self._init_profile_context_and_memory_record()
 
-        from sglang.test.test_utils import ci_use_ascending_capture_order
-
         def _capture_one_stream(stream_idx: Optional[int] = None):
             avail_mem = get_available_gpu_memory(
                 self.model_runner.device,
@@ -827,7 +837,7 @@ class CudaGraphRunner:
             # FA3 varlen workspace-slot IMA (#26532).
             bs_seq = (
                 list(self.capture_bs)
-                if ci_use_ascending_capture_order(self.model_runner.server_args)
+                if _ci_use_ascending_capture_order(self.model_runner.server_args)
                 else list(reversed(self.capture_bs))
             )
             capture_range = (

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -815,17 +815,25 @@ class CudaGraphRunner:
         if self.enable_profile_cuda_graph:
             profile_context = self._init_profile_context_and_memory_record()
 
+        from sglang.test.test_utils import ci_use_ascending_capture_order
+
         def _capture_one_stream(stream_idx: Optional[int] = None):
             avail_mem = get_available_gpu_memory(
                 self.model_runner.device,
                 self.model_runner.gpu_id,
                 empty_cache=False,
             )
-            # Reverse the order to enable better memory sharing across cuda graphs.
+            # Reverse for memory sharing; CI+FA3 uses ascending to dodge the
+            # FA3 varlen workspace-slot IMA (#26532).
+            bs_seq = (
+                list(self.capture_bs)
+                if ci_use_ascending_capture_order(self.model_runner.server_args)
+                else list(reversed(self.capture_bs))
+            )
             capture_range = (
-                tqdm.tqdm(list(reversed(self.capture_bs)))
+                tqdm.tqdm(bs_seq)
                 if get_tensor_model_parallel_rank() == 0
-                else reversed(self.capture_bs)
+                else iter(bs_seq)
             )
             for i, bs in enumerate(capture_range):
                 if get_tensor_model_parallel_rank() == 0:

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -184,17 +184,6 @@ def is_in_amd_ci():
     return get_bool_env_var("SGLANG_IS_IN_CI_AMD")
 
 
-def ci_use_ascending_capture_order(server_args) -> bool:
-    """Whether to flip cuda-graph capture to ascending bs order (FA3 varlen IMA workaround, #26532)."""
-    if not is_in_ci():
-        return False
-    return "fa3" in (
-        server_args.attention_backend,
-        server_args.decode_attention_backend,
-        server_args.speculative_draft_attention_backend,
-    )
-
-
 def is_blackwell_system():
     """Same CUDA capability + toolkit semantics as ``sglang.srt.utils.is_blackwell``."""
     return is_blackwell()

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -184,6 +184,17 @@ def is_in_amd_ci():
     return get_bool_env_var("SGLANG_IS_IN_CI_AMD")
 
 
+def ci_use_ascending_capture_order(server_args) -> bool:
+    """Whether to flip cuda-graph capture to ascending bs order (FA3 varlen IMA workaround, #26532)."""
+    if not is_in_ci():
+        return False
+    return "fa3" in (
+        server_args.attention_backend,
+        server_args.decode_attention_backend,
+        server_args.speculative_draft_attention_backend,
+    )
+
+
 def is_blackwell_system():
     """Same CUDA capability + toolkit semantics as ``sglang.srt.utils.is_blackwell``."""
     return is_blackwell()


### PR DESCRIPTION
Workaround for #26532. Under `SGLANG_IS_IN_CI` + FA3 only; production capture order unchanged.

## Validation

Triggered `/rerun-test registered/spec/eagle/test_eagle_infer_b.py` on this PR ([run 26560654779](https://github.com/sgl-project/sglang/actions/runs/26560654779), `conclusion=success`).

Confirmed the gate behaves correctly across test classes in the same run:

| Test class | `attention_backend` | `cuda_graph_max_bs` | Observed capture order | Gate decision |
|---|---|---|---|---|
| `TestEAGLEServerBasic` | (default, non-fa3) | 8 | `bs=8,7,6,5,4,3,2,1` | reversed (unchanged) |
| **`TestEAGLEServerAdditional`** (the originally-flaky config) | **`fa3`** | **5** | **`bs=1,2,3,4,5`** | **ascending (fix active)** |
| Later non-fa3 test class | (default) | 64 | `bs=64,60,...,1` | reversed (unchanged) |

Captured directly from the `Capturing batches (bs=... avail_mem=... GB)` per-bs print in `CudaGraphRunner._capture_one_stream`.

## Memory cost

For `TestEAGLEServerAdditional` (`fa3`, `cuda_graph_max_bs=5`), comparing first-bs vs last-bs `avail_mem` across the three capture phases:

| Capture phase | First-bs `avail_mem` | Last-bs `avail_mem` | Delta |
|---|---|---|---|
| Target decode | 23.42 GB | 23.33 GB | 90 MB |
| Draft decode  | 20.80 GB | 20.73 GB | 70 MB |
| Draft extend  | 20.73 GB | 20.68 GB | 50 MB |

Sum ~0.21 GB for `max_bs=5`. The ascending order ends the per-call FA3 workspace slot sized for `max_bs` (rather than `min_bs`), which is the whole point of the fix; the only marginal cost is the output buffer slot sizing for `max_bs` vs the smaller bs initially, well under 1 % of the cuda-graph footprint.

## Scope

- Helper `_ci_use_ascending_capture_order(server_args)` lives in `cuda_graph_runner.py` (module-level, no test-utils dependency).
- Gate: `envs.SGLANG_IS_IN_CI.get()` AND `"fa3"` in `server_args.get_attention_backends()` (the canonical resolver, accounts for `attention_backend` / `prefill_attention_backend` / `decode_attention_backend` fallback) OR `server_args.speculative_draft_attention_backend == "fa3"`.
- Default (non-CI or non-FA3): reversed order preserved -- the original "better memory sharing across cuda graphs" optimization from #4195 is untouched.

Once the next scheduled CI cycle confirms `test_eagle_infer_b` flakiness drops, we can consider removing the CI gate and applying the change unconditionally (subject to a production memory check at higher `max_bs`).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #26560518918](https://github.com/sgl-project/sglang/actions/runs/26560518918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #26560518864](https://github.com/sgl-project/sglang/actions/runs/26560518864)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->