### PR TITLE
fix: partial write_backup for aux components

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2654,17 +2654,23 @@ class HostPoolGroup:
         io_backend,
         pool_transfers: Optional[list] = None,
     ) -> None:
-        # 1. Anchor (KV) backup
-        self.anchor_entry.host_pool.backup_from_device_all_layer(
-            self.anchor_entry.device_pool,
-            host_indices,
-            device_indices,
-            io_backend,
-        )
+        # 1. Anchor (KV) backup. Skip when host_indices is empty: partial
+        # backup paths (FULL already on host, only aux components missing)
+        # call us with a zero-length KV slice and we must not invoke the KV
+        # kernel on it.
+        if host_indices is not None and host_indices.numel() > 0:
+            self.anchor_entry.host_pool.backup_from_device_all_layer(
+                self.anchor_entry.device_pool,
+                host_indices,
+                device_indices,
+                io_backend,
+            )
         # 2. Extra pool backup
         for transfer in pool_transfers or []:
             entry = self.entry_map.get(transfer.name)
             if entry is None or transfer.host_indices is None:
+                continue
+            if transfer.host_indices.numel() == 0:
                 continue
             entry.host_pool.backup_from_device_all_layer(
                 entry.device_pool,

--- a/python/sglang/srt/mem_cache/unified_cache_components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/full_component.py
@@ -296,7 +296,15 @@ class FullComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             if transfers and transfers[0].host_indices is not None:
-                node.component_data[ct].host_value = transfers[0].host_indices.clone()
+                cd = node.component_data[ct]
+                # Caller (write_backup) must gate this on cd.host_value is None
+                # via full_needs_backup. Overwriting here would orphan the
+                # previous host slot and leak it.
+                assert cd.host_value is None, (
+                    "FullComponent BACKUP_HOST commit on a node that already "
+                    "has host_value would leak the previous host slot."
+                )
+                cd.host_value = transfers[0].host_indices.clone()
 
         elif phase == CacheTransferPhase.LOAD_BACK:
             if not transfers or transfers[0].device_indices is None:

--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -370,7 +370,10 @@ class MambaComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             cd = node.component_data[ct]
-            if cd.value is None:
+            # Skip when device value is missing or host value already exists,
+            # so partial write_backup does not re-back-up an already-backed-up
+            # component (which would leak the previous host slot).
+            if cd.value is None or cd.host_value is not None:
                 return None
             return [
                 PoolTransfer(

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -489,7 +489,10 @@ class SWAComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             cd = node.component_data[ct]
-            if cd.value is None:
+            # Skip when device value is missing or host value already exists.
+            # The latter prevents re-backing-up a component that survived a
+            # device-evict cycle; partial write_backup relies on this filter.
+            if cd.value is None or cd.host_value is not None:
                 return None
             # cd.value already holds SWA-pool indices (translated at insert time).
             # Host pool indexing wants int64.

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -353,9 +353,14 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             ct: UnifiedLRUList(ct, self.tree_components, use_host_ptr=True)
             for ct in self.tree_components
         }
+        # Keyed by a monotonic op_id (not node.id) so concurrent partial
+        # backups on the same node each register a distinct in-flight entry
+        # without colliding. Each entry's lock_params is released when the
+        # matching ack arrives, regardless of arrival order.
         self.ongoing_write_through: dict[
             int, tuple[UnifiedTreeNode, Optional[DecLockRefParams]]
         ] = {}
+        self._next_write_op_id: int = 0
         self.ongoing_load_back: dict[int, tuple[UnifiedTreeNode, DecLockRefParams]] = {}
         self.enable_storage = False
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
@@ -1389,9 +1394,12 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         an evict-then-restore path reinstates an aux device value while
         FULL.host_value still exists.
 
-        Returns the number of newly backed-up tokens (FULL + aux). 0 means
-        nothing was backed up (already complete, conditions not met, or a
-        backup for this node is already in flight).
+        Reentry on the same node is supported: each call allocates a fresh
+        op_id and registers an independent entry in ``ongoing_write_through``,
+        so its lock is released independently when the matching ack arrives.
+
+        Returns the number of newly backed-up tokens (FULL + aux); 0 means
+        nothing was backed up (already complete or controller refused).
         """
         if self.cache_controller is None:
             return 0
@@ -1402,13 +1410,6 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         ):
             if self.write_backup(node.parent) <= 0:
                 return 0
-
-        # Same-node reentry: bail out. Re-issuing while a previous backup is
-        # still in flight would overwrite ongoing_write_through[node.id] and
-        # lose the first lock, leaving the node permanently locked. Commit 2
-        # will lift this restriction.
-        if node.id in self.ongoing_write_through:
-            return 0
 
         cd_full = node.component_data[BASE_COMPONENT_TYPE]
         full_needs_backup = cd_full.value is not None and cd_full.host_value is None
@@ -1457,9 +1458,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 (0,), dtype=torch.int64, device=self.token_to_kv_pool_allocator.device
             )
         )
+        # Allocate a fresh op_id so concurrent partial backups on the same
+        # node never collide on the same dict key.
+        op_id = self._next_write_op_id
+        self._next_write_op_id = (self._next_write_op_id + 1) & 0x3FFFFFFF
         host_indices = self.cache_controller.write(
             write_device_indices,
-            node_id=node.id,
+            node_id=op_id,
             extra_pools=aux_xfers or None,
         )
         if host_indices is None:
@@ -1483,7 +1488,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         lock_params = None
         if not write_back:
             lock_params = self.inc_lock_ref(node).to_dec_params()
-        self.ongoing_write_through[node.id] = (node, lock_params)
+        self.ongoing_write_through[op_id] = (node, lock_params)
 
         backed_up = len(host_indices)
         for xfers in comp_xfers.values():
@@ -2665,12 +2670,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                 )
 
         # ── PART 5: Ongoing Operations ──
-        for nid, (n, _) in self.ongoing_write_through.items():
+        for op_id, (n, _) in self.ongoing_write_through.items():
             if n not in all_node_set:
-                E(f"[Ongoing] write_through node {nid} not in tree")
+                E(f"[Ongoing] write_through op {op_id} (node {n.id}) not in tree")
             elif n.component_data[FCT].lock_ref <= 0:
                 E(
-                    f"[Ongoing] write_through node {nid} lock_ref={n.component_data[FCT].lock_ref}"
+                    f"[Ongoing] write_through op {op_id} (node {n.id}) "
+                    f"lock_ref={n.component_data[FCT].lock_ref}"
                 )
         for nid, (n, _) in self.ongoing_load_back.items():
             if n not in all_node_set:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2449,6 +2449,19 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
                     E(f"node {nid} {ct} device present but Full.value=None")
                 if cd.host_value is not None and not full_hst:
                     E(f"node {nid} {ct} host present but Full.host_value=None")
+                # write-through invariant: once Full is backed up, any aux
+                # device value must also have a host backup. Violations point
+                # to evict-then-restore paths that fail to re-trigger backup.
+                if (
+                    not write_back
+                    and full_hst
+                    and cd.value is not None
+                    and cd.host_value is None
+                ):
+                    E(
+                        f"node {nid} {ct} device present and Full backed up "
+                        f"but {ct} host backup missing"
+                    )
 
             # Every node must keep Full data on at least one layer.
             if not full_dev and not full_hst:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -99,6 +99,17 @@ class UnifiedTreeNode:
         return self.component_data[ComponentType.FULL].host_value is not None
 
     @property
+    def fully_backuped(self) -> bool:
+        """Every component that holds device value also has a host backup.
+        Stricter than ``backuped`` (which only inspects FULL): used by
+        ``_inc_hit_count`` to decide whether write_backup must run again to
+        cover aux components restored after evict-then-restore paths."""
+        for cd in self.component_data:
+            if cd.value is not None and cd.host_value is None:
+                return False
+        return True
+
+    @property
     def evicted(self) -> bool:
         """Tree-level: Full KV not on device (non-root with value=None)."""
         return (
@@ -1370,7 +1381,18 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     # ---- HiCache: Backup / LoadBack ----
 
     def write_backup(self, node: UnifiedTreeNode, write_back: bool = False) -> int:
-        """Backup a node's data from device to host (D->H)."""
+        """Backup a node's data from device to host (D->H).
+
+        Only the components that are still missing a host backup contribute
+        to the transfer. If FULL is already backuped, only aux components
+        get backed up (partial backup); this fills the gap that arises when
+        an evict-then-restore path reinstates an aux device value while
+        FULL.host_value still exists.
+
+        Returns the number of newly backed-up tokens (FULL + aux). 0 means
+        nothing was backed up (already complete, conditions not met, or a
+        backup for this node is already in flight).
+        """
         if self.cache_controller is None:
             return 0
 
@@ -1381,10 +1403,18 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             if self.write_backup(node.parent) <= 0:
                 return 0
 
-        device_value = node.component_data[BASE_COMPONENT_TYPE].value
-        kv_xfer = PoolTransfer(name=PoolName.KV, device_indices=device_value)
+        # Same-node reentry: bail out. Re-issuing while a previous backup is
+        # still in flight would overwrite ongoing_write_through[node.id] and
+        # lose the first lock, leaving the node permanently locked. Commit 2
+        # will lift this restriction.
+        if node.id in self.ongoing_write_through:
+            return 0
 
-        # Build aux transfers, keyed per component.
+        cd_full = node.component_data[BASE_COMPONENT_TYPE]
+        full_needs_backup = cd_full.value is not None and cd_full.host_value is None
+
+        # Build aux transfers, keyed per component. Components that already
+        # have host_value are filtered by their build_hicache_transfers hook.
         comp_xfers: dict[ComponentType, list] = {}
         for comp in self._components_tuple:
             if comp.component_type == BASE_COMPONENT_TYPE:
@@ -1392,34 +1422,57 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             t = comp.build_hicache_transfers(node, CacheTransferPhase.BACKUP_HOST)
             if t:
                 comp_xfers[comp.component_type] = t
+
+        if not full_needs_backup and not comp_xfers:
+            return 0
+
+        # Sidecar transfers may piggy-back on KV indices, so build them with
+        # whatever KV slot we are about to use (None if KV is not transferred).
+        device_value = cd_full.value if full_needs_backup else None
+        kv_xfer = PoolTransfer(name=PoolName.KV, device_indices=device_value)
         sidecar_xfers = self._build_sidecar_transfers(
             CacheTransferPhase.BACKUP_HOST, kv_xfer, comp_xfers
         )
 
         # Pre-evict host if insufficient
-        kv_tokens = len(device_value)
-        host_avail = self.cache_controller.mem_pool_host.available_size()
-        if host_avail < kv_tokens:
-            needed = kv_tokens - host_avail
-            evicted = self.evict_host(needed)
-            if evicted < needed:
-                return 0
+        if full_needs_backup:
+            kv_tokens = len(device_value)
+            host_avail = self.cache_controller.mem_pool_host.available_size()
+            if host_avail < kv_tokens:
+                needed = kv_tokens - host_avail
+                evicted = self.evict_host(needed)
+                if evicted < needed:
+                    return 0
 
         aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
         aux_xfers.extend(sidecar_xfers)
+
+        # When FULL already has host backup, pass an empty device_indices
+        # tensor so the controller path is exercised without re-allocating
+        # KV host slots and without re-running the KV kernel.
+        write_device_indices = (
+            device_value
+            if full_needs_backup
+            else torch.empty(
+                (0,), dtype=torch.int64, device=self.token_to_kv_pool_allocator.device
+            )
+        )
         host_indices = self.cache_controller.write(
-            device_value, node_id=node.id, extra_pools=aux_xfers or None
+            write_device_indices,
+            node_id=node.id,
+            extra_pools=aux_xfers or None,
         )
         if host_indices is None:
             return 0
 
         # Commit
-        kv_xfer = PoolTransfer(name=PoolName.KV, host_indices=host_indices)
-        self.components[BASE_COMPONENT_TYPE].commit_hicache_transfer(
-            node,
-            CacheTransferPhase.BACKUP_HOST,
-            transfers=[kv_xfer],
-        )
+        if full_needs_backup:
+            kv_xfer = PoolTransfer(name=PoolName.KV, host_indices=host_indices)
+            self.components[BASE_COMPONENT_TYPE].commit_hicache_transfer(
+                node,
+                CacheTransferPhase.BACKUP_HOST,
+                transfers=[kv_xfer],
+            )
         for ct, xfers in comp_xfers.items():
             self.components[ct].commit_hicache_transfer(
                 node,
@@ -1431,7 +1484,13 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         if not write_back:
             lock_params = self.inc_lock_ref(node).to_dec_params()
         self.ongoing_write_through[node.id] = (node, lock_params)
-        return len(host_indices)
+
+        backed_up = len(host_indices)
+        for xfers in comp_xfers.values():
+            for xfer in xfers:
+                if xfer.host_indices is not None:
+                    backed_up += len(xfer.host_indices)
+        return backed_up
 
     def load_back(
         self,
@@ -1581,7 +1640,7 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         node.hit_count += 1
         if (
             self.cache_controller is not None
-            and not node.backuped
+            and not node.fully_backuped
             and node.hit_count >= self.write_through_threshold
         ):
             self.write_backup(node)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3316,27 +3316,65 @@ class UnifiedRadixCacheSuite:
         )
         tree.sanity_check()
 
-    def test_partial_backup_reentry_returns_zero(self):
-        """Same-node reentry while a previous backup is in flight is rejected."""
+    def test_partial_backup_reentry_independent_op_ids(self):
+        """Same-node reentry while a previous backup is in flight registers a
+        second independent entry under a fresh op_id without losing the first
+        lock; both entries drain on writing_check."""
         if self._skip_unsupported_hicache_test():
             return
+        aux = self._select_partial_aux()
+        if aux is None:
+            self.skipTest("requires exactly one aux component")
         tree, allocator, req_to_token_pool = self._build_hicache_fixture()
         seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        seq = seq + self._make_seq(100, 2)
         self._insert(tree, allocator, req_to_token_pool, seq)
 
         m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
         node = m.last_device_node
+        # write_back=False requires parent already backuped: back up parent
+        # explicitly so the child write_backup can run with inc_lock_ref.
+        self.assertIsNot(node.parent, tree.root_node)
+        self._backup_node(tree, node.parent)
 
-        first = tree.write_backup(node, write_back=True)
+        def _inflight_for(n):
+            return [
+                op_id
+                for op_id, (entry_node, _) in tree.ongoing_write_through.items()
+                if entry_node is n
+            ]
+
+        # First call: full backup (FULL + aux). Use write_back=False so each
+        # call increments lock_ref — this is the path that previously leaked
+        # the first lock when reentry overwrote the dict entry.
+        full_lock_ref_before = node.component_data[ComponentType.FULL].lock_ref
+        first = tree.write_backup(node, write_back=False)
         self.assertGreater(first, 0)
-        self.assertIn(node.id, tree.ongoing_write_through)
+        first_ops = _inflight_for(node)
+        self.assertEqual(len(first_ops), 1)
+        first_lock_ref = node.component_data[ComponentType.FULL].lock_ref
+        self.assertGreater(first_lock_ref, full_lock_ref_before)
 
-        # Second call before writing_check completes the first must bail out.
-        second = tree.write_backup(node, write_back=True)
-        self.assertEqual(second, 0)
+        # Drop aux host backup to create a gap and re-issue. Reentry must
+        # register a second entry under a distinct op_id and take its own lock.
+        node.component_data[aux].host_value = None
+        second = tree.write_backup(node, write_back=False)
+        self.assertGreater(second, 0)
+        second_ops = _inflight_for(node)
+        self.assertEqual(len(second_ops), 2)
+        self.assertEqual(set(first_ops) & set(second_ops), set(first_ops))
+        self.assertNotEqual(set(first_ops), set(second_ops))
+        self.assertGreater(
+            node.component_data[ComponentType.FULL].lock_ref, first_lock_ref
+        )
 
         tree.writing_check(write_back=True)
-        self.assertNotIn(node.id, tree.ongoing_write_through)
+        self.assertEqual(len(_inflight_for(node)), 0)
+        # Both locks released — back to baseline.
+        self.assertEqual(
+            node.component_data[ComponentType.FULL].lock_ref, full_lock_ref_before
+        )
         tree.sanity_check()
 
     def test_partial_backup_inc_hit_count_triggers_after_restore(self):

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3241,6 +3241,140 @@ class UnifiedRadixCacheSuite:
 
         tree.sanity_check()
 
+    # ================================================================
+    # Partial write_backup tests (aux-only backup after evict-restore)
+    # ================================================================
+
+    def _select_partial_aux(self):
+        """Pick a single aux component used by the current cfg, or None."""
+        if self.cfg.has_swa and not self.cfg.has_mamba:
+            return ComponentType.SWA
+        if self.cfg.has_mamba and not self.cfg.has_swa:
+            return ComponentType.MAMBA
+        return None
+
+    def test_partial_backup_aux_only_returns_aux_tokens(self):
+        """write_backup on a fully-backuped node where aux was zeroed only
+        backs up the aux side; FULL host slot count must not change."""
+        if self._skip_unsupported_hicache_test():
+            return
+        aux = self._select_partial_aux()
+        if aux is None:
+            self.skipTest("requires exactly one aux component")
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        node = m.last_device_node
+        self._backup_node(tree, node)
+        self.assertTrue(node.fully_backuped)
+
+        cd_aux = node.component_data[aux]
+        host_avail_before = tree.cache_controller.mem_pool_host.available_size()
+
+        # Drop aux host backup, keep aux device value: this is the gap state
+        # produced by an evict-then-restore path.
+        cd_aux.host_value = None
+        self.assertFalse(node.fully_backuped)
+
+        # Trigger backup again. Only aux should be transferred — FULL is intact.
+        backed_up = tree.write_backup(node, write_back=True)
+        tree.writing_check(write_back=True)
+
+        self.assertGreater(backed_up, 0)
+        self.assertEqual(backed_up, len(cd_aux.value))
+        # FULL host slot count must be unchanged: no additional KV alloc.
+        self.assertEqual(
+            tree.cache_controller.mem_pool_host.available_size(),
+            host_avail_before,
+        )
+        self.assertIsNotNone(cd_aux.host_value)
+        self.assertTrue(node.fully_backuped)
+        tree.sanity_check()
+
+    def test_partial_backup_skip_when_already_fully_backuped(self):
+        """write_backup on a fully-backuped node returns 0 with no transfer."""
+        if self._skip_unsupported_hicache_test():
+            return
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        node = m.last_device_node
+        self._backup_node(tree, node)
+        self.assertTrue(node.fully_backuped)
+
+        write_queue_len_before = len(tree.cache_controller.ack_write_queue)
+        backed_up = tree.write_backup(node, write_back=True)
+        self.assertEqual(backed_up, 0)
+        self.assertEqual(
+            len(tree.cache_controller.ack_write_queue),
+            write_queue_len_before,
+            "no controller op should be enqueued for a fully-backuped node",
+        )
+        tree.sanity_check()
+
+    def test_partial_backup_reentry_returns_zero(self):
+        """Same-node reentry while a previous backup is in flight is rejected."""
+        if self._skip_unsupported_hicache_test():
+            return
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        node = m.last_device_node
+
+        first = tree.write_backup(node, write_back=True)
+        self.assertGreater(first, 0)
+        self.assertIn(node.id, tree.ongoing_write_through)
+
+        # Second call before writing_check completes the first must bail out.
+        second = tree.write_backup(node, write_back=True)
+        self.assertEqual(second, 0)
+
+        tree.writing_check(write_back=True)
+        self.assertNotIn(node.id, tree.ongoing_write_through)
+        tree.sanity_check()
+
+    def test_partial_backup_inc_hit_count_triggers_after_restore(self):
+        """An evict-then-restore sequence that re-introduces aux device value
+        on a Full-backuped node must let _inc_hit_count fire write_backup
+        again and close the gap."""
+        if self._skip_unsupported_hicache_test():
+            return
+        aux = self._select_partial_aux()
+        if aux is None:
+            self.skipTest("requires exactly one aux component")
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        seq = self._make_seq(1, 2)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+
+        m = tree.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
+        node = m.last_device_node
+        # Back up the whole path so write_back=False parent invariant holds.
+        self._backup_tree(tree)
+        self.assertTrue(node.fully_backuped)
+
+        # Simulate evict-restore that left the aux gap: aux device kept,
+        # aux host gone, Full both layers intact.
+        node.component_data[aux].host_value = None
+        self.assertFalse(node.fully_backuped)
+        # Lower the threshold so a single _inc_hit_count call fires backup.
+        tree.write_through_threshold = 1
+        node.hit_count = 0
+
+        # Trigger a hit through match_prefix's _inc_hit_count path, which is
+        # the same hook _insert_helper drives after recover_after_unevict.
+        tree._inc_hit_count(node)
+        tree.writing_check(write_back=True)
+
+        self.assertTrue(node.fully_backuped)
+        self.assertIsNotNone(node.component_data[aux].host_value)
+        tree.sanity_check()
+
 
 class UnifiedLRUListBoundedRefreshTest(CustomTestCase):
 


### PR DESCRIPTION
## Motivation

When a node's FULL host_value is intact but an aux component's device value
    was restored after a previous host backup (evict-then-restore path),
    write_backup must back up only the aux side without re-allocating KV host
    slots. 

## Modifications

    Changes:
    - UnifiedTreeNode.fully_backuped: stricter property — every component with
      device value must have a host backup. Used by _inc_hit_count to retry
      write_backup after the gap appears.
    - write_backup: skip components already backuped via the per-component
      build_hicache_transfers filter; pass an empty KV device_indices when
      FULL is already on host so the controller path runs without re-allocating
      KV host slots; sum aux host slots into the returned token count.
    - FullComponent.commit_hicache_transfer (BACKUP_HOST): idempotency guard —
      never overwrite an existing host_value (would orphan the previous slot).
    - SWAComponent / MambaComponent.build_hicache_transfers (BACKUP_HOST):
      return None when host_value already exists, so partial backup never
      re-runs an already-completed component.
    - HostPoolGroup.run_backup: skip the anchor KV kernel and per-pool kernel
      when host_indices is zero-length (empty-tensor partial path).


































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->